### PR TITLE
[12.x] Fix adding tags on new cache flush events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheEvent.php
+++ b/src/Illuminate/Cache/Events/CacheEvent.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Cache\Events;
 
-abstract class CacheEvent
+abstract class CacheEvent implements TaggedCacheEvent
 {
     /**
      * The name of the cache store.

--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Cache\Events;
 
-class CacheFlushed
+class CacheFlushed implements TaggedCacheEvent
 {
     /**
      * The name of the cache store.
@@ -12,13 +12,34 @@ class CacheFlushed
     public $storeName;
 
     /**
+     * The tags that were assigned to the cache event.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
-     * @return void
+     * @param  array  $tags
      */
-    public function __construct($storeName)
+    public function __construct($storeName, array $tags = [])
     {
         $this->storeName = $storeName;
+        $this->tags = $tags;
+    }
+
+    /**
+     * Set the tags for the cache event.
+     *
+     * @param  array  $tags
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Cache\Events;
 
-class CacheFlushing
+class CacheFlushing implements TaggedCacheEvent
 {
     /**
      * The name of the cache store.
@@ -12,13 +12,34 @@ class CacheFlushing
     public $storeName;
 
     /**
+     * The tags that were assigned to the cache event.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
-     * @return void
+     * @param  array  $tags
      */
-    public function __construct($storeName)
+    public function __construct($storeName, array $tags = [])
     {
         $this->storeName = $storeName;
+        $this->tags = $tags;
+    }
+
+    /**
+     * Set the tags for the cache event.
+     *
+     * @param  array  $tags
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Cache/Events/TaggedCacheEvent.php
+++ b/src/Illuminate/Cache/Events/TaggedCacheEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+interface TaggedCacheEvent
+{
+    /**
+     * Set the tags for the cache event.
+     *
+     * @param  array  $tags
+     * @return $this
+     */
+    public function setTags($tags);
+}

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
+
 class RedisTaggedCache extends TaggedCache
 {
     /**
@@ -105,8 +108,12 @@ class RedisTaggedCache extends TaggedCache
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->flushValues();
         $this->tags->flush();
+
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -104,7 +104,7 @@ class TaggedCache extends Repository
     /**
      * Fire an event for this cache instance.
      *
-     * @param  \Illuminate\Cache\Events\CacheEvent  $event
+     * @param  \Illuminate\Cache\Events\TaggedCacheEvent  $event
      * @return void
      */
     protected function event($event)

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
@@ -77,7 +79,11 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->tags->reset();
+
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Why
Alternative solution to #55157. Comes from discussion on #55142.

In #55121, Taylor [said](https://github.com/laravel/framework/pull/55121#issuecomment-2745343350) that the new `CacheFlushed` or `CacheFlushing` events should not extend `CacheEvent`. This makes sense since the `CacheEvent` is for events with a specific `$key`.

However, that means that we now have cache events that do not share a common ancestor and these events cannot have their tags set in `TaggedCache` (or `RedisTaggedCache`).

## What

This PR attempts to fix this issue by adding a `TaggedCacheEvent` interface with a `setTags` method and making `CacheEvent`, `CacheFlushing`, and `CacheFlushed` implement it.

An alternative solution to this would be to allow `CacheFlushing` and `CacheFlushed` extend `CacheEvent` with an empty key (see #55157).