### PR TITLE
[12.x] Add `pipe` method query builders

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -605,7 +605,7 @@ trait BuildsQueries
      * @template TReturn
      *
      * @param  (callable($this): TReturn)  $callback
-     * @return (TReturn is null ? $this : TReturn
+     * @return TReturn is null ? $this : TReturn
      */
     public function pipe($callback)
     {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -598,4 +598,17 @@ trait BuildsQueries
 
         return $this;
     }
+
+    /**
+     * Pass the query to a given callback and return the result.
+     *
+     * @template TReturn
+     *
+     * @param  (callable($this): TReturn)  $callback
+     * @return (TReturn is null ? $this : TReturn
+     */
+    public function pipe($callback)
+    {
+        return $callback($this) ?? $this;
+    }
 }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -587,7 +587,7 @@ trait BuildsQueries
     }
 
     /**
-     * Pass the query to a given callback.
+     * Pass the query to a given callback and then return it.
      *
      * @param  callable($this): mixed  $callback
      * @return $this

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -605,7 +605,7 @@ trait BuildsQueries
      * @template TReturn
      *
      * @param  (callable($this): TReturn)  $callback
-     * @return TReturn is null ? $this : TReturn
+     * @return (TReturn is null|void ? $this : TReturn)
      */
     public function pipe($callback)
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -301,6 +301,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
     }
 
+    public function testPipeCallback()
+    {
+        $query = $this->getBuilder();
+
+        $result = $query->pipe(fn (Builder $query) => 5);
+        $this->assertSame(5, $result);
+
+        $result = $query->pipe(fn (Builder $query) => null);
+        $this->assertSame($query, $result);
+
+        $result = $query->pipe(function (Builder $query) {
+            //
+        });
+        $this->assertSame($query, $result);
+
+        $this->assertCount(0, $query->wheres);
+        $result = $query->pipe(fn (Builder $query) => $query->where('foo', 'bar'));
+        $this->assertSame($query, $result);
+        $this->assertCount(1, $query->wheres);
+    }
+
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -223,6 +223,12 @@ function test(
     assertType('Illuminate\Types\Builder\CommentBuilder', $comment->newQuery()->where('foo', 'bar'));
     assertType('Illuminate\Types\Builder\CommentBuilder', $comment->newQuery()->foo());
     assertType('Illuminate\Types\Builder\Comment', $comment->newQuery()->create(['name' => 'John']));
+    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(function () {
+        //
+    }));
+    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(fn () => null));
+    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(fn ($query) => $query));
+    assertType('int', $query->pipe(fn ($query) => 5));
 }
 
 class User extends Model

--- a/types/Database/Eloquent/Builder.php
+++ b/types/Database/Eloquent/Builder.php
@@ -223,12 +223,12 @@ function test(
     assertType('Illuminate\Types\Builder\CommentBuilder', $comment->newQuery()->where('foo', 'bar'));
     assertType('Illuminate\Types\Builder\CommentBuilder', $comment->newQuery()->foo());
     assertType('Illuminate\Types\Builder\Comment', $comment->newQuery()->create(['name' => 'John']));
-    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(function () {
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->pipe(function () {
         //
     }));
-    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(fn () => null));
-    assertType('\Illuminate\Database\Eloquent\Builder<User>', $query->pipe(fn ($query) => $query));
-    assertType('int', $query->pipe(fn ($query) => 5));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->pipe(fn () => null));
+    assertType('Illuminate\Database\Eloquent\Builder<Illuminate\Types\Builder\User>', $query->pipe(fn ($query) => $query));
+    assertType('5', $query->pipe(fn ($query) => 5));
 }
 
 class User extends Model

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -36,12 +36,6 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazy());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyById());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyByIdDesc());
-    assertType('Illuminate\Database\Query\Builder', $query->pipe(function () {
-        //
-    }));
-    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn () => null));
-    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn ($query) => $query));
-    assertType('int', $query->pipe(fn ($query) => 5));
 
     $query->chunk(1, function ($users, $page) {
         assertType('Illuminate\Support\Collection<int, object>', $users);
@@ -66,4 +60,10 @@ function test(Builder $query, EloquentBuilder $userQuery): void
         assertType('object', $users);
         assertType('int', $page);
     });
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(function () {
+        //
+    }));
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn () => null));
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn ($query) => $query));
+    assertType('int', $query->pipe(fn ($query) => 5));
 }

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -65,5 +65,5 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     }));
     assertType('Illuminate\Database\Query\Builder', $query->pipe(fn () => null));
     assertType('Illuminate\Database\Query\Builder', $query->pipe(fn ($query) => $query));
-    assertType('int', $query->pipe(fn ($query) => 5));
+    assertType('5', $query->pipe(fn ($query) => 5));
 }

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -36,12 +36,12 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazy());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyById());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyByIdDesc());
-    assertType('Illuminate\Database\Query\Builder', $query->tap(function () {
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(function () {
         //
     }));
-    assertType('Illuminate\Database\Query\Builder', $query->tap(fn () => null));
-    assertType('Illuminate\Database\Query\Builder', $query->tap(fn ($query) => $query));
-    assertType('int', $query->tap(fn ($query) => 5));
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn () => null));
+    assertType('Illuminate\Database\Query\Builder', $query->pipe(fn ($query) => $query));
+    assertType('int', $query->pipe(fn ($query) => 5));
 
     $query->chunk(1, function ($users, $page) {
         assertType('Illuminate\Support\Collection<int, object>', $users);

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -36,6 +36,12 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazy());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyById());
     assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyByIdDesc());
+    assertType('Illuminate\Database\Query\Builder', $query->tap(function () {
+        //
+    }));
+    assertType('Illuminate\Database\Query\Builder', $query->tap(fn () => null));
+    assertType('Illuminate\Database\Query\Builder', $query->tap(fn ($query) => $query));
+    assertType('int', $query->tap(fn ($query) => 5));
 
     $query->chunk(1, function ($users, $page) {
         assertType('Illuminate\Support\Collection<int, object>', $users);


### PR DESCRIPTION
This PR introduces a `pipe` method to the base query builder and eloquent query builder. The functionality of this method is the same as the collection `pipe` method.

```php
$records = DB::query()
    ->from('...')
    // ...
    ->tap(new TappableScope) // returns the query
    ->pipe(new ActionScope); // executes the query and returns the result
```

## Why?

Model scopes offer the ability to return the result of a query. Scopes that execute the query and return a result I've personally dubbed _action_ scopes. [My blog post on the idea](https://tim.macdonald.au/query-scopes-meet-action-scopes).

An action scope:

```php
class Voucher extends Model
{
    // ...

    public function scopeExtendUntil(Builder $builder, Carbon $date): int
    {
        return $builder->update(['expires_at' => $date]);
    }
}
```

Usage:

```php
$count = Voucher::query()
    ->whereExpired()
    ->extendUntil(Carbon::now()->addYear());

// $count is now an integer containing the number of extended vouchers.

return "{$count} vouchers have been extended for a year";
```

You can consider native methods things like `count`, `get`, `pluck`, etc., to be built-in action scopes.

---

When using the query builder directly for non-eloquent queries, I very much enjoy using tappable scopes for reusable query filtering.

```php
class ServerFilter
{
    public function __construct(private string $server)
    {
        //
    }

    public function __invoke(Builder $query): void
    {
        if ($this->server) {
            $query->where('server', $this->server);
        }
    }
}
```

Usage:

```php
$result = DB::query()
    ->from('...')
    // ...
    ->tap(new ServerFilter($request->query('server')))
    ->get();
```

There is currently no way to create an _action_ scope using this pattern.

Imagine you have many queries throughout your application's controllers that all have their own unique filtering and always end in a similar pattern: order, paginate, include query string, and map into an value object.

```php
$result = DB::query()
    ->from('...')
    // ...
    ->orderBy('timestamp')
    ->cursorPaginate(100, cursorName: 'c')
    ->withQueryString()
    ->through(fn ($row) => new ValueObject($row));
```

With the `pipe` method, it is possible to wrap this up into a reusable action scope:

```php
class Paginate
{
    /**
     * @param  class-string  $mapInto
     * @param  literal-string  $orderBy
     * @param  non-negative-int  $perPage
     */
    public function __construct(
        private string $mapInto,
        private string $orderBy = 'created_at',
        private int $perPage = 100,
    ) {
        //
    }

    public function __invoke(Builder $query): CursorPaginator
    {
        return $query->orderByDesc($this->orderBy)
                     ->cursorPaginate($this->perPage, cursorName: 'c')
                     ->withQueryString()
                     ->through(fn ($row) => new $this->mapInto($row));
    }
}

```

Query may now be refactored:

```php
$result = DB::query()
    ->from('...')
    // ...
    ->pipe(new Paginate(mapInto: ValueObject));
```

Aside from the above, I often find the `pipe` helper useful when building collection pipelines to inline some more complex logic related to the query that I otherwise would have to split out before the collection call chain.