### PR TITLE
Support using null-safe operator with `null` value

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -866,7 +866,7 @@ class Builder implements BuilderContract
         // where null clause to the query. So, we will allow a short-cut here to
         // that method for convenience so the developer doesn't have to check.
         if (is_null($value)) {
-            return $this->whereNull($column, $boolean, $operator !== '=');
+            return $this->whereNull($column, $boolean, ! in_array($operator, ['=', '<=>'], true));
         }
 
         $type = 'Basic';
@@ -958,7 +958,7 @@ class Builder implements BuilderContract
     protected function invalidOperatorAndValue($operator, $value)
     {
         return is_null($value) && in_array($operator, $this->operators) &&
-             ! in_array($operator, ['=', '<>', '!=']);
+             ! in_array($operator, ['=', '<=>', '<>', '!=']);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5030,6 +5030,10 @@ SQL;
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', '<>', null);
         $this->assertSame('select * from "users" where "foo" is not null', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', '<=>', null);
+        $this->assertSame('select * from "users" where "foo" is null', $builder->toSql());
     }
 
     public function testDynamicWhere()


### PR DESCRIPTION
This fixes the case when the MySQL null-safe operator `<=>` is used in a where condition with a RHS value of `null`. While the null-safe operator is already considered a valid operator, it is not currently considered valid by `invalidOperatorAndValue` when combined with a `null` value. This PR marks the combination as valid and expands the null convenience shortcut to convert it to `is null`/`is not null` .

I came across this when doing a comparison of a nullable column to a variable input which could also be `null`. I ended up using the null-safe operator so that the comparison would work as expected when the `null` values are encountered, since all other operators (`=`, `!=`, `<>`) return `null` instead of `0`/`1` when either side of the comparison is `null`.