### PR TITLE
[12.x] Fix: Make Paginated Queries Consistent Across Pages

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2790,7 +2790,9 @@ class Builder implements BuilderContract
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if (is_null($lastId)) {
+            $this->whereNotNull($column);
+        } else {
             $this->where($column, '<', $lastId);
         }
 
@@ -2810,7 +2812,9 @@ class Builder implements BuilderContract
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if (is_null($lastId)) {
+            $this->whereNotNull($column);
+        } else {
             $this->where($column, '>', $lastId);
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2360,6 +2360,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" limit 0 offset 0', $builder->toSql());
     }
 
+    public function testForPageBeforeId()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->forPageBeforeId(15, null);
+        $this->assertSame('select * from "users" where "id" is not null order by "id" desc limit 15', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->forPageBeforeId(15, 0);
+        $this->assertSame('select * from "users" where "id" < ? order by "id" desc limit 15', $builder->toSql());
+    }
+
+    public function testForPageAfterId()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->forPageAfterId(15, null);
+        $this->assertSame('select * from "users" where "id" is not null order by "id" asc limit 15', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->forPageAfterId(15, 0);
+        $this->assertSame('select * from "users" where "id" > ? order by "id" asc limit 15', $builder->toSql());
+    }
+
     public function testGetCountForPaginationWithBindings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
## Problem
When using `Illuminate\Database\Query\Builder` methods _orderedChunkById_ and _orderedLazyById_ without specifying `$column` and `$alias` property values, where the query includes a join on another table, the query for the first page may work as expected while the query for subsequent pages may throw `Illuminate\Database\QueryException` with the following message:
> SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous...

The cause of this issue is that the query for the first page doesn't include a _where_ clause for the _id_ column, but the subsequent queries do. So it may not be clear that the column is ambiguous until at least the query for the second page is run.

```SQL
-- page 1 passes
select * from users join profiles on profiles.user_id = users.id order by id asc limit 15
```

```SQL
-- page 2 fails due to ambiguity in where clause
select * from users join profiles on profiles.user_id = users.id where id > 15 order by id asc limit 15
```

## Impact
In non-production environments, since it's common to encounter a smaller dataset, use of these methods without the mentioned properties may work without a problem. However, when releasing a feature into an environment with a large enough dataset to cause the paged query to run more than once, suddenly a working, tested change may fail.

## Solution
The PR modifies the _forPageBeforeId_ and _forPageAfterId_ methods in `Illuminate\Database\Query\Builder` to always include a _where_ clause on the given `$column` property; specifically, if property `$lastId` evaluates to `null`, the clause `$this->whereNotNull($column)` is added.

```SQL
-- page 1 fails due to ambiguity in where clause
select * from users join profiles on profiles.user_id = users.id where id is not null order by id asc limit 15
```

```SQL
-- page 2 fails due to ambiguity in where clause
select * from users join profiles on profiles.user_id = users.id where id > 15 order by id asc limit 15
```

## Benefits
The benefit of always including a _where_ clause on the given column name is that any ambiguity in the query is immediately evident, even when used on a small dataset.