### PR TITLE
[12.x] Add `pendingAttributes` method to Eloquent relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1837,6 +1837,24 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Specify attributes that should be added to any new models created by this builder.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function pendingAttributes(Expression|array|string $attributes, $value = null)
+    {
+        if (! is_array($attributes)) {
+            $attributes = [$attributes => $value];
+        }
+
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
+
+        return $this;
+    }
+
+    /**
      * Apply query-time casts to the model instance.
      *
      * @param  array  $casts

--- a/tests/Database/DatabaseEloquentBelongsToManyPendingAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyPendingAttributesTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyPendingAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->createSchema();
+    }
+
+    public function testCreatesPendingAttributesAndPivotValues(): void
+    {
+        $post = ManyToManyPendingAttributesPost::create();
+        $tag = $post->metaTags()->create(['name' => 'long article']);
+
+        $this->assertSame('long article', $tag->name);
+        $this->assertTrue($tag->visible);
+
+        $pivot = DB::table('pending_attributes_pivot')->first();
+        $this->assertSame('meta', $pivot->type);
+        $this->assertSame($post->id, $pivot->post_id);
+        $this->assertSame($tag->id, $pivot->tag_id);
+    }
+
+    public function testQueriesPendingAttributesAndPivotValues(): void
+    {
+        $post = new ManyToManyPendingAttributesPost(['id' => 2]);
+        $wheres = $post->metaTags()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_pivot.tag_id',
+            'operator' => '=',
+            'value' => 2,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_pivot.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testMorphToManyPendingAttributes(): void
+    {
+        $post = new ManyToManyPendingAttributesPost(['id' => 2]);
+        $wheres = $post->morphedTags()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_type',
+            'operator' => '=',
+            'value' => ManyToManyPendingAttributesPost::class,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_id',
+            'operator' => '=',
+            'value' => 2,
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(3, $wheres);
+
+        $tag = $post->morphedTags()->create(['name' => 'new tag']);
+
+        $this->assertTrue($tag->visible);
+        $this->assertSame('new tag', $tag->name);
+        $this->assertSame($tag->id, $post->morphedTags()->first()->id);
+    }
+
+    public function testMorphedByManyPendingAttributes(): void
+    {
+        $tag = new ManyToManyPendingAttributesTag(['id' => 4]);
+        $wheres = $tag->morphedPosts()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_type',
+            'operator' => '=',
+            'value' => ManyToManyPendingAttributesPost::class,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.tag_id',
+            'operator' => '=',
+            'value' => 4,
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(3, $wheres);
+
+        $post = $tag->morphedPosts()->create();
+        $this->assertSame('Title!', $post->title);
+        $this->assertSame($post->id, $tag->morphedPosts()->first()->id);
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('pending_attributes_posts', function ($table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('pending_attributes_tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('visible')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('pending_attributes_pivot', function ($table) {
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->string('type');
+        });
+
+        $this->schema()->create('pending_attributes_taggables', function ($table) {
+            $table->integer('tag_id');
+            $table->integer('taggable_id');
+            $table->string('taggable_type');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('pending_attributes_posts');
+        $this->schema()->drop('pending_attributes_tags');
+        $this->schema()->drop('pending_attributes_pivot');
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Model::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class ManyToManyPendingAttributesPost extends Model
+{
+    protected $guarded = [];
+    protected $table = 'pending_attributes_posts';
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            ManyToManyPendingAttributesTag::class,
+            'pending_attributes_pivot',
+            'tag_id',
+            'post_id',
+        );
+    }
+
+    public function metaTags(): BelongsToMany
+    {
+        return $this->tags()
+            ->pendingAttributes('visible', true)
+            ->withPivotValue('type', 'meta');
+    }
+
+    public function morphedTags(): MorphToMany
+    {
+        return $this
+            ->morphToMany(
+                ManyToManyPendingAttributesTag::class,
+                'taggable',
+                'pending_attributes_taggables',
+                relatedPivotKey: 'tag_id'
+            )
+            ->pendingAttributes('visible', true)
+            ->withPivotValue('type', 'meta');
+    }
+}
+
+class ManyToManyPendingAttributesTag extends Model
+{
+    protected $guarded = [];
+    protected $table = 'pending_attributes_tags';
+
+    public function morphedPosts(): MorphToMany
+    {
+        return $this
+            ->morphedByMany(
+                ManyToManyPendingAttributesPost::class,
+                'taggable',
+                'pending_attributes_taggables',
+                'tag_id',
+            )
+            ->pendingAttributes('title', 'Title!')
+            ->withPivotValue('type', 'meta');
+    }
+}

--- a/tests/Database/DatabaseEloquentHasOneOrManyPendingAttributesTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyPendingAttributesTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentHasOneOrManyPendingAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testHasManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasOne(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->pendingAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphOne(RelatedPendingAttributesModel::class, 'relatable')
+            ->pendingAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testPendingAttributesCanBeOverriden(): void
+    {
+        $key = 'a key';
+        $defaultValue = 'a value';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->pendingAttributes([$key => $defaultValue]);
+
+        $relatedModel = $relationship->make([$key => $value]);
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testQueryingDoesNotBreakWither(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->where($key, $value)
+            ->pendingAttributes([$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testAttributesCanBeAppended(): void
+    {
+        $parent = new RelatedPendingAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes(['a' => 'A'])
+            ->pendingAttributes(['b' => 'B'])
+            ->pendingAttributes(['a' => 'AA']);
+
+        $relatedModel = $relationship->make([
+            'b' => 'BB',
+            'c' => 'C',
+        ]);
+
+        $this->assertSame('AA', $relatedModel->a);
+        $this->assertSame('BB', $relatedModel->b);
+        $this->assertSame('C', $relatedModel->c);
+    }
+
+    public function testSingleAttributeApi(): void
+    {
+        $parent = new RelatedPendingAttributesModel;
+        $key = 'attr';
+        $value = 'Value';
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes($key, $value);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testWheresAreNotSet(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes([$key => $value]);
+
+        $wheres = $relationship->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'operator' => '=',
+            'value' => $parentId,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'NotNull',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testNullValueIsAccepted(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes([$key => null]);
+
+        $wheres = $relationship->toBase()->wheres;
+        $relatedModel = $relationship->make();
+
+        $this->assertNull($relatedModel->$key);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'operator' => '=',
+            'value' => $parentId,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'NotNull',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testOneKeepsAttributesFromHasMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testOneKeepsAttributesFromMorphMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->pendingAttributes([$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasManyAddsCastedAttributes(): void
+    {
+        $parentId = 123;
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->pendingAttributes(['is_admin' => 1]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame(true, $relatedModel->is_admin);
+    }
+}
+
+class RelatedPendingAttributesModel extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+    ];
+}

--- a/tests/Database/DatabaseEloquentPendingAttributesTest.php
+++ b/tests/Database/DatabaseEloquentPendingAttributesTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Builder;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentPendingAttributesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->dropIfExists((new PendingAttributesModel)->getTable());
+    }
+
+    public function testAddsAttributes(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = PendingAttributesModel::query()
+            ->pendingAttributes([$key => $value]);
+
+        $model = $query->make();
+
+        $this->assertSame($value, $model->$key);
+    }
+
+    public function testDoesNotAddWheres(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = PendingAttributesModel::query()
+            ->pendingAttributes([$key => $value]);
+
+        $wheres = $query->toBase()->wheres;
+
+        // Ensure no wheres exist
+        $this->assertEmpty($wheres);
+    }
+
+    public function testAddsWithCasts(): void
+    {
+        $query = PendingAttributesModel::query()
+            ->pendingAttributes([
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => PendingAttributesEnum::internal,
+            ]);
+
+        $model = $query->make();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(PendingAttributesEnum::internal, $model->type);
+
+        $this->assertEqualsCanonicalizing([
+            'is_admin' => 1,
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'type' => 'int',
+        ], $model->getAttributes());
+    }
+
+    public function testAddsWithCastsViaDb(): void
+    {
+        $this->bootTable();
+
+        $query = PendingAttributesModel::query()
+            ->pendingAttributes([
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => PendingAttributesEnum::internal,
+            ]);
+
+        $query->create();
+
+        $model = PendingAttributesModel::first();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(PendingAttributesEnum::internal, $model->type);
+    }
+
+    protected function bootTable(): void
+    {
+        $this->schema()->create((new PendingAttributesModel)->getTable(), function ($table) {
+            $table->id();
+            $table->boolean('is_admin');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    protected function schema(): Builder
+    {
+        return PendingAttributesModel::getConnectionResolver()->connection()->getSchemaBuilder();
+    }
+}
+
+class PendingAttributesModel extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+        'type' => PendingAttributesEnum::class,
+    ];
+
+    public function setFirstNameAttribute(string $value): void
+    {
+        $this->attributes['first_name'] = strtolower($value);
+    }
+
+    public function getFirstNameAttribute(?string $value): string
+    {
+        return ucfirst($value);
+    }
+
+    protected function lastName(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => ucfirst($value),
+            set: fn (string $value) => strtolower($value),
+        );
+    }
+}
+
+enum PendingAttributesEnum: string
+{
+    case internal = 'int';
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Why
The `withAttributes` method (documented [here](https://laravel.com/docs/12.x/eloquent-relationships#scoped-relationships)) is very helpful for adding attributes to both the `where` clauses as well as the attributes when a model is made from the relationship.

However, I ran into a situation where I needed to set an attribute when the relationship is created, but not constrain the relationship to only rows where the attribute is set to that value.

The `$pendingAttributes` property already exists on the Eloquent builder and all the logic to add the pending attributes to the new models also exist.

## What
This led to me creating the `pendingAttributes` method to do the same thing as `withAttributes` but not touch the `where` clauses.

Implementation:
```php
/**
 * Specify attributes that should be added to any new models created by this builder.
 *
 * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
 * @param  mixed  $value
 * @return $this
 */
public function pendingAttributes(Expression|array|string $attributes, $value = null)
{
    if (! is_array($attributes)) {
        $attributes = [$attributes => $value];
    }

    $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);

    return $this;
}
```

Tests:
- `tests/Database/DatabaseEloquentBelongsToManyPendingAttributesTest.php`<br>Copied from `DatabaseEloquentBelongsToManyWithAttributesTest.php` and made sure only the relational `where` clauses exist
- `tests/Database/DatabaseEloquentHasOneOrManyPendingAttributesTest.php`<br>Copied from `DatabaseEloquentHasOneOrManyWithAttributesTest.php` and made sure only the relational `where` clauses exist
- `tests/Database/DatabaseEloquentPendingAttributesTest.php`<br>Copied from `DatabaseEloquentWithAttributesTest.php` and made sure no `where` clauses