### PR TITLE
[11.x] Respect custom path for cached views by the `AboutCommand`

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -183,7 +183,7 @@ class AboutCommand extends Command
             'Config' => static::format($this->laravel->configurationIsCached(), console: $formatCachedStatus),
             'Events' => static::format($this->laravel->eventsAreCached(), console: $formatCachedStatus),
             'Routes' => static::format($this->laravel->routesAreCached(), console: $formatCachedStatus),
-            'Views' => static::format($this->hasPhpFiles($this->laravel->storagePath('framework/views')), console: $formatCachedStatus),
+            'Views' => static::format($this->hasPhpFiles(config('view.compiled')), console: $formatCachedStatus),
         ]);
 
         static::addToSection('Drivers', fn () => array_filter([

--- a/tests/Integration/Foundation/Console/AboutCommandTest.php
+++ b/tests/Integration/Foundation/Console/AboutCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation\Console;
 
 use Illuminate\Testing\Assert;
+use Orchestra\Testbench\Attributes\WithEnv;
 use Orchestra\Testbench\TestCase;
 
 use function Orchestra\Testbench\remote;
@@ -38,6 +39,18 @@ class AboutCommandTest extends TestCase
                 'queue' => 'database',
                 'session' => 'cookie',
             ], $output['drivers']);
+        });
+    }
+
+    #[WithEnv('VIEW_COMPILED_PATH', __DIR__.'/../../View/templates')]
+    public function testItRespectsCustomPathForCompiledViews(): void
+    {
+        $process = remote('about --json', ['APP_ENV' => 'local'])->mustRun();
+
+        tap(json_decode($process->getOutput(), true), static function (array $output) {
+            Assert::assertArraySubset([
+                'views' => true,
+            ], $output['cache']);
         });
     }
 }


### PR DESCRIPTION
It's possible to customize a path to cached view files via config and `VIEW_COMPILED_PATH` env var. But `AboutCommand` uses a hardcoded `storagePath('framework/views')` path. This PR aims to fix this issue.

BTW: it's the only occurrence of the `framework/views` and `framework.views` in code codebase (except some tests), so, no need to worry about other similar issues.