### PR TITLE
[12.x] Add `withoutAppends` scope builder to exclude appends from model query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1956,6 +1956,25 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Exclude all appends from the model's array attributes.
+     *
+     * @param  string|array<array-key,string>  $excepts
+     * @return $this
+     */
+    public function withoutAppends(string|array $excepts = []): static
+    {
+        $this->model::$withoutAppends = true;
+
+        if (! is_array($excepts)) {
+            $excepts = func_get_args();
+        }
+
+        $this->model::$exceptAppends = array_merge($this->model::$exceptAppends ?? [], $excepts);
+
+        return $this;
+    }
+
+    /**
      * Get the "limit" value from the query or null if it's not set.
      *
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -139,6 +139,27 @@ trait HasAttributes
     protected $appends = [];
 
     /**
+     * The attributes of appends that should be hidden for arrays.
+     *
+     * @var bool
+     */
+    public static $withoutAppends = false;
+
+    /**
+     * The appends that should be included despite withoutAppends being true.
+     *
+     * @var array
+     */
+    public static $exceptAppends = [];
+
+    /**
+     * The attributes that save original value of $appends when withoutAppends being true.
+     *
+     * @var array
+     */
+    protected static $originalTempAppends = [];
+
+    /**
      * Indicates whether attributes are snake cased on arrays.
      *
      * @var bool
@@ -355,6 +376,11 @@ trait HasAttributes
      */
     protected function getArrayableAppends()
     {
+        if (static::$withoutAppends) {
+            static::$originalTempAppends = $this->appends;
+            $this->appends = static::$exceptAppends;
+        }
+
         if (! count($this->appends)) {
             return [];
         }
@@ -2339,6 +2365,20 @@ trait HasAttributes
     public function hasAppended($attribute)
     {
         return in_array($attribute, $this->appends);
+    }
+
+    /**
+     * Reset the original appends state.
+     *
+     * @return $this
+     */
+    public function resetOriginalAppends()
+    {
+        static::$withoutAppends = false;
+        static::$exceptAppends = [];
+        $this->appends = static::$originalTempAppends;
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -857,6 +857,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         unset($_SERVER['__eloquent.constrain']);
     }
 
+    public function testWithoutAppends()
+    {
+        $model = new EloquentBuilderTestWithoutAppendsStub;
+        $this->mockConnectionForModel($model, '');
+        $builder = $model->query();
+        $this->assertEquals(['foo' => 'foo', 'bar' => 'bar'], $builder->getModel()->toArray());
+        $this->assertEquals([], $builder->withoutAppends()->getModel()->toArray());
+        $this->assertEquals(['foo' => 'foo', 'bar' => 'bar'], $builder->getModel()->resetOriginalAppends()->toArray());
+        $this->assertEquals(['foo' => 'foo'], $builder->withoutAppends(['foo'])->getModel()->toArray());
+    }
+
     public function testRelationshipEagerLoadProcessForImplicitlyEmpty()
     {
         $queryBuilder = $this->getMockQueryBuilder();
@@ -2856,5 +2867,22 @@ class EloquentBuilderTestWhereBelongsToStub extends Model
     public function parent()
     {
         return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
+    }
+}
+
+class EloquentBuilderTestWithoutAppendsStub extends Model
+{
+    protected $table = 'table';
+
+    protected $appends = ['foo', 'bar'];
+
+    public function getFooAttribute()
+    {
+        return 'foo';
+    }
+
+    public function getBarAttribute()
+    {
+        return 'bar';
     }
 }


### PR DESCRIPTION
I'll provide a description for a pull request that would add the `resetOriginalAppends` method to complement the existing `withoutAppends` method in Laravel's Eloquent Builder.

### Overview
This PR adds a new resetOriginalAppends method to the Eloquent Builder, which allows developers to restore the original appends configuration after using withoutAppends . This provides a more fluent API for controlling model attribute serialization during a query lifecycle.

### Features
1. Existing withoutAppends method : Allows excluding all or specific appends from a model's array attributes
2. New resetOriginalAppends method : Restores the original appends configuration after using withoutAppends
### Use Cases
This feature is particularly useful when:

- You need to temporarily disable appends for a specific query
- You want to exclude certain computed attributes for performance reasons
- You need to restore the original appends configuration after a specific operation
### Example Usage
```php
// Example 1: Exclude all appends for a specific query
$users = User::withoutAppends()->get();

// Example 2: Except specific appends from excludes
$users = User::withoutAppends(['full_name', 'profile_url'])->get();

// Example 3: Reset appends after temporarily disabling them
$users = User::query()
    ->withoutAppends()
    ->get()
    ->map(function ($user) {
        // reuturn all original appends using `resetOriginalAppends`
        return $user->resetOriginalAppends()->toArray();
    });


// Prevent errors of missing attributes after selecting columns in query
class User extends Model
{
   public function getFullNameAttribute()
   {
       return $this->attributes['first_name'] . ' ' . $this->attributes['second_name'];
   }
}

User::select('id', 'first_name')->get();  // ❌ will return error because missing `second_name`
User::select('id', 'first_name')->withoutAppends()->get();  // ✅ Correct
 ```