### PR TITLE
[12.x] Log: Add optional keys parameter to `Log::withoutContext` to remove selected context from future logs

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -512,15 +512,16 @@ class LogManager implements LoggerInterface
     }
 
     /**
-     * Flush the log context on all currently resolved channels.
+     * Remove all or passed context keys on all currently resolved channels.
      *
+     * @param  string[]|null  $keys
      * @return $this
      */
-    public function withoutContext()
+    public function withoutContext($keys = null)
     {
         foreach ($this->channels as $channel) {
             if (method_exists($channel, 'withoutContext')) {
-                $channel->withoutContext();
+                $channel->withoutContext($keys);
             }
         }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -512,12 +512,12 @@ class LogManager implements LoggerInterface
     }
 
     /**
-     * Remove all or passed context keys on all currently resolved channels.
+     * Flush the log context on all currently resolved channels.
      *
      * @param  string[]|null  $keys
      * @return $this
      */
-    public function withoutContext($keys = null)
+    public function withoutContext(?array $keys = null)
     {
         foreach ($this->channels as $channel) {
             if (method_exists($channel, 'withoutContext')) {

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -202,13 +202,18 @@ class Logger implements LoggerInterface
     }
 
     /**
-     * Flush the existing context array.
+     * Remove all or passed context keys for future logs.
      *
+     * @param  string[]|null  $keys
      * @return $this
      */
-    public function withoutContext()
+    public function withoutContext($keys = null)
     {
-        $this->context = [];
+        if (is_array($keys)) {
+            $this->context = array_diff_key($this->context, array_flip($keys));
+        } else {
+            $this->context = [];
+        }
 
         return $this;
     }

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -202,12 +202,12 @@ class Logger implements LoggerInterface
     }
 
     /**
-     * Remove all or passed context keys for future logs.
+     * Flush the log context on all currently resolved channels.
      *
      * @param  string[]|null  $keys
      * @return $this
      */
-    public function withoutContext($keys = null)
+    public function withoutContext(?array $keys = null)
     {
         if (is_array($keys)) {
             $this->context = array_diff_key($this->context, array_flip($keys));

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -9,7 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Psr\Log\LoggerInterface driver(string|null $driver = null)
  * @method static \Illuminate\Log\LogManager shareContext(array $context)
  * @method static array sharedContext()
- * @method static \Illuminate\Log\LogManager withoutContext()
+ * @method static \Illuminate\Log\LogManager withoutContext(string[]|null $keys = null)
  * @method static \Illuminate\Log\LogManager flushSharedContext()
  * @method static string|null getDefaultDriver()
  * @method static void setDefaultDriver(string $name)

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -47,6 +47,17 @@ class LogLoggerTest extends TestCase
         $writer->error('foo');
     }
 
+    public function testContextKeysCanBeRemovedForSubsequentLogs()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->withContext(['bar' => 'baz', 'forget' => 'me']);
+        $writer->withoutContext(['forget']);
+
+        $monolog->shouldReceive('error')->once()->with('foo', ['bar' => 'baz']);
+
+        $writer->error('foo');
+    }
+
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);


### PR DESCRIPTION
## Description

This PR adds an optional `$keys` parameter to the `withoutContext` method, allowing to selectively remove specific context keys from the logger instance.
When no keys are provided, existing behaviour is not changed - the method continues to clear all context as before.

Thanks to @slashequip for the inspiration 💜

```php
// Clear all context (existing behavior)
Log::withoutContext();

// Remove specific context keys
Log::withoutContext(['post_id', 'comment_id']);
```

## Benefits

- Provides more granular control over which context keys to remove, without needing to remove all context or update the context value to a null value.
- Allows context to be easily scoped to a specific operation, without impacting context added elsewhere in the lifecycle.
- Maintains backward compatibility with existing `withoutContext` usage

## Example

The `withoutContext` method can now be used to remove specific context keys while preserving others:

```php
class SyncPostWithPlatformAction
{
    public function handle(Post $post): void
    {
        // Add post context
        Log::withContext(['post_id' => $post->id, 'platform' => $post->platform]);

        Log::info('Fetching latest update from platform');

        // do work

        Log::info('Updated post with recent platform changes');
        
        // Removes only the additional context added for the duration of this action, preserving other
        // context added during the whole process, e.g. 'job', 'request_id', 'user_id', etc.
        Log::withoutContext(['post_id', 'platform']);
    }
}
```

## Why?

We want to lean more into using withContext, but can end up polluting the context when using our actions within http requests, queued jobs, commands. It means we usually end up repeating the context throughout more complex actions in order to not pollute other logs created from outside of the action. 