### PR TITLE
Add Common Table Expressions to the Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -531,15 +531,15 @@ class Builder implements BuilderContract
     /**
      * Add a common table expression clause to the query.
      *
-     * @param string|array $cteAliasName Table alias as a string or an array of the table alias and columns
-     * @param Closure $callback
-     * @param Closure|null $recursiveCallback
-     * @param bool $unionAll
+     * @param  string|array  $cteAliasName  Table alias as a string or an array of the table alias and columns
+     * @param  Closure  $callback
+     * @param  Closure|null  $recursiveCallback
+     * @param  bool  $unionAll
      * @return $this
      */
-    public function commonTableExpression(string|array $cteAliasName, \Closure $callback, \Closure|null $recursiveCallback = null, bool $unionAll = false)
+    public function commonTableExpression(string|array $cteAliasName, \Closure $callback, ?\Closure $recursiveCallback = null, bool $unionAll = false)
     {
-        if (!is_array($this->commonTableExpressions)) {
+        if (! is_array($this->commonTableExpressions)) {
             $this->commonTableExpressions = [];
         }
 
@@ -577,10 +577,10 @@ class Builder implements BuilderContract
     /**
      * Get a new common table expression clause.
      *
-     * @param Builder $parentQuery
-     * @param string $cteName
-     * @param array $cteColumns
-     * @param bool $recursive
+     * @param  Builder  $parentQuery
+     * @param  string  $cteName
+     * @param  array  $cteColumns
+     * @param  bool  $recursive
      * @return CteClause
      */
     protected function newCteClause(self $parentQuery, string $cteName, array $cteColumns, bool $recursive): CteClause

--- a/src/Illuminate/Database/Query/CteClause.php
+++ b/src/Illuminate/Database/Query/CteClause.php
@@ -6,17 +6,15 @@ use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 
 /**
  * Class CteClause
- * Handles a Common Table Expression
- *
- * @package Illuminate\Database\Query
+ * Handles a Common Table Expression.
  */
 class CteClause extends Builder
 {
     /**
-     * @param Builder $parentQuery
-     * @param string $aliasName
-     * @param array $aliasColumns
-     * @param bool $recursive
+     * @param  Builder  $parentQuery
+     * @param  string  $aliasName
+     * @param  array  $aliasColumns
+     * @param  bool  $recursive
      */
     public function __construct(
         protected BuilderContract $parentQuery,

--- a/src/Illuminate/Database/Query/CteClause.php
+++ b/src/Illuminate/Database/Query/CteClause.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
+
+/**
+ * Class CteClause
+ * Handles a Common Table Expression
+ *
+ * @package Illuminate\Database\Query
+ */
+class CteClause extends Builder
+{
+    /**
+     * @param Builder $parentQuery
+     * @param string $aliasName
+     * @param array $aliasColumns
+     * @param bool $recursive
+     */
+    public function __construct(
+        protected BuilderContract $parentQuery,
+        public string $aliasName,
+        public array $aliasColumns = [],
+        public bool $recursive = false
+    ) {
+        parent::__construct(
+            $this->parentQuery->getConnection(),
+            $this->parentQuery->getGrammar(),
+            $this->parentQuery->getProcessor()
+        );
+    }
+
+    /**
+     * Get a new instance of the join clause builder.
+     *
+     * @return static
+     */
+    public function newQuery()
+    {
+        return new static($this->newParentQuery(), $this->recursive);
+    }
+
+    /**
+     * Create a new query instance for sub-query.
+     *
+     * @return Builder
+     */
+    protected function forSubQuery()
+    {
+        return $this->newParentQuery()->newQuery();
+    }
+
+    /**
+     * Create a new parent query instance.
+     *
+     * @return Builder
+     */
+    protected function newParentQuery()
+    {
+        $parentQueryClass = get_class($this->parentQuery);
+
+        return new $parentQueryClass(
+            $this->parentQuery->getConnection(),
+            $this->parentQuery->getGrammar(),
+            $this->parentQuery->getProcessor()
+        );
+    }
+}

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -143,7 +143,7 @@ class Grammar extends BaseGrammar
             $cteSqlBlocks[] = sprintf(
                 '%s%s AS (%s)',
                 $cteClause->aliasName,
-                !empty($cteClause->aliasColumns) ? '(' . implode(', ', $cteClause->aliasColumns) . ')' : '',
+                ! empty($cteClause->aliasColumns) ? '('.implode(', ', $cteClause->aliasColumns).')' : '',
                 $cteClause->toSql()
             );
         }


### PR DESCRIPTION
This PR adds a method for including Common Table Expressions in the Query Builder. Common table expressions are an often overlooked part of SQL, though extremely valuable when performing more complex aggregations of data (like recursively building a hierarchy of rows). This will simplify the usage of common table expressions and remove the current need to write raw SQL, which can be error prone.

Example:
Simple CTE:
```php
$builder = DB::select('*')->from('users');

$builder->commonTableExpression(
    'sessions',
    function (Builder $builder) {
        $builder->select(['id', 'name'])
            ->from('user_sessions')
            ->whereRaw('user_sessions.user_id = users.id');
    }
);
```
will create the following sql:
```sql
with sessions AS (
    select "id", "name"
    from "user_sessions"
     where user_sessions.user_id = users.id
)
select * from "users"
```

Recursive CTE:
```php
$builder = DB::select('*')->from('users');

$builder->commonTableExpression(
    'sessions',
    function ($builder) {
        $builder->select(['id', 'name'])
            ->from('user_sessions')
            ->whereRaw('user_sessions.user_id = users.id');
    },
    function ($builder) {
        $builder->select(['id', 'name'])
            ->from('sessions')
            ->whereRaw('user_sessions.parent_id = sessions.id');
    }
);
```
will create the following sql:
```sql
with recursive sessions AS (
    (select "id", "name" from "user_sessions" where user_sessions.user_id = users.id)
    union
    (select "id", "name" from "sessions" where user_sessions.parent_id = sessions.id)
)
select * from "users"
```

Overall followed the lead of joins, with a simple Builder wrapper class and callbacks for the construction of the sub tables. Only a callback approach to adding the sub table queries is supported, which is a practical limitation to keep the functionality as clean as possible.