### PR TITLE
Fix factory creation through attributes 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -52,7 +52,7 @@ trait HasFactory
         if ($attributes !== []) {
             $useFactory = $attributes[0]->newInstance();
 
-            $factory = new $useFactory->factoryClass;
+            $factory = $useFactory->factoryClass::new();
 
             $factory->guessModelNamesUsing(fn () => static::class);
 


### PR DESCRIPTION
**Problem**

The `UseFactory` attribute introduced in #54065 instantiates the factory class using `new` instead of calling the `new()` static method. The `new()` static method will call the `configure()` method where factory callbacks may exist. Factories that have callbacks fail to work correctly if using `UseFactory`.

**Solution**

Call `new()` to be consistent with `newFactory()` method and documentation's guidance.