### PR TITLE
[12.x]: Use char(36) for uuid type on MariaDB < 10.7.0

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -31,6 +31,10 @@ class MariaDbGrammar extends MySqlGrammar
      */
     protected function typeUuid(Fluent $column)
     {
+        if (version_compare($this->connection->getServerVersion(), '10.7.0', '<')) {
+            return 'char(36)';
+        }
+
         return 'uuid';
     }
 


### PR DESCRIPTION
Using the new Laravel `mariadb` driver results in an error `General error: 4161 Unknown data type: 'uuid'` on MariaDB < 10.6.x (which is a still supported LTS version till July 2026: https://mariadb.com/kb/en/changes-and-improvements-in-mariadb-10-6/)

`uuid` column types were added in 10.7.0: https://mariadb.com/kb/en/mariadb-1070-release-notes/

This PR adds a version check to use `char(36)` on MariaDB < 10.7.0
