### PR TITLE
[12.x]: Use char(36) for uuid type on MariaDB < 10.7.0

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -31,6 +31,10 @@ class MariaDbGrammar extends MySqlGrammar
      */
     protected function typeUuid(Fluent $column)
     {
+        if (version_compare($this->connection->getServerVersion(), '10.7.0', '<')) {
+            return 'char(36)';
+        }
+
         return 'uuid';
     }
 

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -53,6 +53,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
+        $conn->shouldReceive('getServerVersion')->andReturn('10.7.0');
 
         $blueprint = new Blueprint($conn, 'users');
         $blueprint->create();
@@ -1118,7 +1119,10 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingUuid()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('10.7.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->uuid('foo');
         $statements = $blueprint->toSql();
 
@@ -1126,9 +1130,25 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` uuid not null', $statements[0]);
     }
 
+    public function testAddingUuidOn106()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('10.6.21');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->uuid('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
+    }
+
     public function testAddingUuidDefaultsColumnName()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('10.7.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->uuid();
         $statements = $blueprint->toSql();
 
@@ -1138,7 +1158,10 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingForeignUuid()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('10.7.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $foreignUuid = $blueprint->foreignUuid('foo');
         $blueprint->foreignUuid('company_id')->constrained();
         $blueprint->foreignUuid('laravel_idea_id')->constrained();


### PR DESCRIPTION
Using the new Laravel `mariadb` driver results in an error `General error: 4161 Unknown data type: 'uuid'` on MariaDB < 10.6.x (which is a still supported LTS version till July 2026: https://mariadb.com/kb/en/changes-and-improvements-in-mariadb-10-6/)

`uuid` column types were added in 10.7.0: https://mariadb.com/kb/en/mariadb-1070-release-notes/

This PR adds a version check to use `char(36)` on MariaDB < 10.7.0
