### PR TITLE
[12.x] Add flag to disable where clauses for `withAttributes` method on Eloquent Builder 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1819,20 +1819,22 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value
-     * @param  array  $pending
+     * @param  bool  $addWheres
      * @return $this
      */
-    public function withAttributes(Expression|array|string $attributes, $value = null, array $pending = [])
+    public function withAttributes(Expression|array|string $attributes, $value = null, $addWheres = true)
     {
         if (! is_array($attributes)) {
             $attributes = [$attributes => $value];
         }
 
-        foreach ($attributes as $column => $value) {
-            $this->where($this->qualifyColumn($column), $value);
+        if ($addWheres) {
+            foreach ($attributes as $column => $value) {
+                $this->where($this->qualifyColumn($column), $value);
+            }
         }
 
-        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes, $pending);
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1819,16 +1819,16 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value
-     * @param  bool  $addWheres
+     * @param  bool  $asConditions
      * @return $this
      */
-    public function withAttributes(Expression|array|string $attributes, $value = null, $addWheres = true)
+    public function withAttributes(Expression|array|string $attributes, $value = null, $asConditions = true)
     {
         if (! is_array($attributes)) {
             $attributes = [$attributes => $value];
         }
 
-        if ($addWheres) {
+        if ($asConditions) {
             foreach ($attributes as $column => $value) {
                 $this->where($this->qualifyColumn($column), $value);
             }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1819,9 +1819,10 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
      * @param  mixed  $value
+     * @param  array  $pending
      * @return $this
      */
-    public function withAttributes(Expression|array|string $attributes, $value = null)
+    public function withAttributes(Expression|array|string $attributes, $value = null, array $pending = [])
     {
         if (! is_array($attributes)) {
             $attributes = [$attributes => $value];
@@ -1831,7 +1832,7 @@ class Builder implements BuilderContract
             $this->where($this->qualifyColumn($column), $value);
         }
 
-        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);
+        $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes, $pending);
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
@@ -218,7 +218,7 @@ class ManyToManyPendingAttributesPost extends Model
     public function metaTags(): BelongsToMany
     {
         return $this->tags()
-            ->withAttributes('visible', true, addWheres: false)
+            ->withAttributes('visible', true, asConditions: false)
             ->withPivotValue('type', 'meta');
     }
 
@@ -231,7 +231,7 @@ class ManyToManyPendingAttributesPost extends Model
                 'pending_attributes_taggables',
                 relatedPivotKey: 'tag_id'
             )
-            ->withAttributes('visible', true, addWheres: false)
+            ->withAttributes('visible', true, asConditions: false)
             ->withPivotValue('type', 'meta');
     }
 }
@@ -250,7 +250,7 @@ class ManyToManyPendingAttributesTag extends Model
                 'pending_attributes_taggables',
                 'tag_id',
             )
-            ->withAttributes('title', 'Title!', addWheres: false)
+            ->withAttributes('title', 'Title!', asConditions: false)
             ->withPivotValue('type', 'meta');
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
@@ -218,7 +218,7 @@ class ManyToManyPendingAttributesPost extends Model
     public function metaTags(): BelongsToMany
     {
         return $this->tags()
-            ->withAttributes([], pending: ['visible' => true])
+            ->withAttributes('visible', true, addWheres: false)
             ->withPivotValue('type', 'meta');
     }
 
@@ -231,7 +231,7 @@ class ManyToManyPendingAttributesPost extends Model
                 'pending_attributes_taggables',
                 relatedPivotKey: 'tag_id'
             )
-            ->withAttributes([], pending: ['visible' => true])
+            ->withAttributes('visible', true, addWheres: false)
             ->withPivotValue('type', 'meta');
     }
 }
@@ -250,7 +250,7 @@ class ManyToManyPendingAttributesTag extends Model
                 'pending_attributes_taggables',
                 'tag_id',
             )
-            ->withAttributes([], pending: ['title' => 'Title!'])
+            ->withAttributes('title', 'Title!', addWheres: false)
             ->withPivotValue('type', 'meta');
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyWithAttributesPendingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        $this->createSchema();
+    }
+
+    public function testCreatesPendingAttributesAndPivotValues(): void
+    {
+        $post = ManyToManyPendingAttributesPost::create();
+        $tag = $post->metaTags()->create(['name' => 'long article']);
+
+        $this->assertSame('long article', $tag->name);
+        $this->assertTrue($tag->visible);
+
+        $pivot = DB::table('pending_attributes_pivot')->first();
+        $this->assertSame('meta', $pivot->type);
+        $this->assertSame($post->id, $pivot->post_id);
+        $this->assertSame($tag->id, $pivot->tag_id);
+    }
+
+    public function testQueriesPendingAttributesAndPivotValues(): void
+    {
+        $post = new ManyToManyPendingAttributesPost(['id' => 2]);
+        $wheres = $post->metaTags()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_pivot.tag_id',
+            'operator' => '=',
+            'value' => 2,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_pivot.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testMorphToManyPendingAttributes(): void
+    {
+        $post = new ManyToManyPendingAttributesPost(['id' => 2]);
+        $wheres = $post->morphedTags()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_type',
+            'operator' => '=',
+            'value' => ManyToManyPendingAttributesPost::class,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_id',
+            'operator' => '=',
+            'value' => 2,
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(3, $wheres);
+
+        $tag = $post->morphedTags()->create(['name' => 'new tag']);
+
+        $this->assertTrue($tag->visible);
+        $this->assertSame('new tag', $tag->name);
+        $this->assertSame($tag->id, $post->morphedTags()->first()->id);
+    }
+
+    public function testMorphedByManyPendingAttributes(): void
+    {
+        $tag = new ManyToManyPendingAttributesTag(['id' => 4]);
+        $wheres = $tag->morphedPosts()->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.type',
+            'operator' => '=',
+            'value' => 'meta',
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.taggable_type',
+            'operator' => '=',
+            'value' => ManyToManyPendingAttributesPost::class,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => 'pending_attributes_taggables.tag_id',
+            'operator' => '=',
+            'value' => 4,
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(3, $wheres);
+
+        $post = $tag->morphedPosts()->create();
+        $this->assertSame('Title!', $post->title);
+        $this->assertSame($post->id, $tag->morphedPosts()->first()->id);
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('pending_attributes_posts', function ($table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('pending_attributes_tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('visible')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('pending_attributes_pivot', function ($table) {
+            $table->integer('post_id');
+            $table->integer('tag_id');
+            $table->string('type');
+        });
+
+        $this->schema()->create('pending_attributes_taggables', function ($table) {
+            $table->integer('tag_id');
+            $table->integer('taggable_id');
+            $table->string('taggable_type');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('pending_attributes_posts');
+        $this->schema()->drop('pending_attributes_tags');
+        $this->schema()->drop('pending_attributes_pivot');
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection($connection = 'default')
+    {
+        return Model::getConnectionResolver()->connection($connection);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+}
+
+class ManyToManyPendingAttributesPost extends Model
+{
+    protected $guarded = [];
+    protected $table = 'pending_attributes_posts';
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            ManyToManyPendingAttributesTag::class,
+            'pending_attributes_pivot',
+            'tag_id',
+            'post_id',
+        );
+    }
+
+    public function metaTags(): BelongsToMany
+    {
+        return $this->tags()
+            ->withAttributes([], pending: ['visible' => true])
+            ->withPivotValue('type', 'meta');
+    }
+
+    public function morphedTags(): MorphToMany
+    {
+        return $this
+            ->morphToMany(
+                ManyToManyPendingAttributesTag::class,
+                'taggable',
+                'pending_attributes_taggables',
+                relatedPivotKey: 'tag_id'
+            )
+            ->withAttributes([], pending: ['visible' => true])
+            ->withPivotValue('type', 'meta');
+    }
+}
+
+class ManyToManyPendingAttributesTag extends Model
+{
+    protected $guarded = [];
+    protected $table = 'pending_attributes_tags';
+
+    public function morphedPosts(): MorphToMany
+    {
+        return $this
+            ->morphedByMany(
+                ManyToManyPendingAttributesPost::class,
+                'taggable',
+                'pending_attributes_taggables',
+                'tag_id',
+            )
+            ->withAttributes([], pending: ['title' => 'Title!'])
+            ->withPivotValue('type', 'meta');
+    }
+}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
@@ -31,7 +31,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -50,7 +50,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasOne(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -69,7 +69,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -89,7 +89,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphOne(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -108,7 +108,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([], pending: [$key => $defaultValue]);
+            ->withAttributes([$key => $defaultValue], addWheres: false);
 
         $relatedModel = $relationship->make([$key => $value]);
 
@@ -127,7 +127,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
             ->where($key, $value)
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -141,9 +141,9 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: ['a' => 'A'])
-            ->withAttributes([], pending: ['b' => 'B'])
-            ->withAttributes([], pending: ['a' => 'AA']);
+            ->withAttributes(['a' => 'A'], addWheres: false)
+            ->withAttributes(['b' => 'B'], addWheres: false)
+            ->withAttributes(['a' => 'AA'], addWheres: false);
 
         $relatedModel = $relationship->make([
             'b' => 'BB',
@@ -163,7 +163,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes($key, $value, addWheres: false);
 
         $relatedModel = $relationship->make();
 
@@ -181,7 +181,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $wheres = $relationship->toBase()->wheres;
 
@@ -213,7 +213,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => null]);
+            ->withAttributes([$key => null], addWheres: false);
 
         $wheres = $relationship->toBase()->wheres;
         $relatedModel = $relationship->make();
@@ -249,7 +249,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: [$key => $value])
+            ->withAttributes([$key => $value], addWheres: false)
             ->one();
 
         $relatedModel = $relationship->make();
@@ -269,7 +269,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([], pending: [$key => $value])
+            ->withAttributes([$key => $value], addWheres: false)
             ->one();
 
         $relatedModel = $relationship->make();
@@ -288,7 +288,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([], pending: ['is_admin' => 1]);
+            ->withAttributes(['is_admin' => 1], addWheres: false);
 
         $relatedModel = $relationship->make();
 

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testHasManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasOne(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphManyAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testMorphOneAddsAttributes(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphOne(RelatedPendingAttributesModel::class, 'relatable')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testPendingAttributesCanBeOverriden(): void
+    {
+        $key = 'a key';
+        $defaultValue = 'a value';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->withAttributes([], pending: [$key => $defaultValue]);
+
+        $relatedModel = $relationship->make([$key => $value]);
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testQueryingDoesNotBreakWither(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->where($key, $value)
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testAttributesCanBeAppended(): void
+    {
+        $parent = new RelatedPendingAttributesModel;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: ['a' => 'A'])
+            ->withAttributes([], pending: ['b' => 'B'])
+            ->withAttributes([], pending: ['a' => 'AA']);
+
+        $relatedModel = $relationship->make([
+            'b' => 'BB',
+            'c' => 'C',
+        ]);
+
+        $this->assertSame('AA', $relatedModel->a);
+        $this->assertSame('BB', $relatedModel->b);
+        $this->assertSame('C', $relatedModel->c);
+    }
+
+    public function testSingleAttributeApi(): void
+    {
+        $parent = new RelatedPendingAttributesModel;
+        $key = 'attr';
+        $value = 'Value';
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testWheresAreNotSet(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => $value]);
+
+        $wheres = $relationship->toBase()->wheres;
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'operator' => '=',
+            'value' => $parentId,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'NotNull',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testNullValueIsAccepted(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => null]);
+
+        $wheres = $relationship->toBase()->wheres;
+        $relatedModel = $relationship->make();
+
+        $this->assertNull($relatedModel->$key);
+
+        $this->assertContains([
+            'type' => 'Basic',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'operator' => '=',
+            'value' => $parentId,
+            'boolean' => 'and',
+        ], $wheres);
+
+        $this->assertContains([
+            'type' => 'NotNull',
+            'column' => $parent->qualifyColumn('parent_id'),
+            'boolean' => 'and',
+        ], $wheres);
+
+        // Ensure no other wheres exist
+        $this->assertCount(2, $wheres);
+    }
+
+    public function testOneKeepsAttributesFromHasMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: [$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testOneKeepsAttributesFromMorphMany(): void
+    {
+        $parentId = 123;
+        $key = 'a key';
+        $value = 'the value';
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
+            ->withAttributes([], pending: [$key => $value])
+            ->one();
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->relatable_id);
+        $this->assertSame($parent::class, $relatedModel->relatable_type);
+        $this->assertSame($value, $relatedModel->$key);
+    }
+
+    public function testHasManyAddsCastedAttributes(): void
+    {
+        $parentId = 123;
+
+        $parent = new RelatedPendingAttributesModel;
+        $parent->id = $parentId;
+
+        $relationship = $parent
+            ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
+            ->withAttributes([], pending: ['is_admin' => 1]);
+
+        $relatedModel = $relationship->make();
+
+        $this->assertSame($parentId, $relatedModel->parent_id);
+        $this->assertSame(true, $relatedModel->is_admin);
+    }
+}
+
+class RelatedPendingAttributesModel extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+    ];
+}

--- a/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php
@@ -31,7 +31,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -50,7 +50,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasOne(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -69,7 +69,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -89,7 +89,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphOne(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -108,7 +108,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([$key => $defaultValue], addWheres: false);
+            ->withAttributes([$key => $defaultValue], asConditions: false);
 
         $relatedModel = $relationship->make([$key => $value]);
 
@@ -127,7 +127,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
             ->where($key, $value)
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -141,9 +141,9 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes(['a' => 'A'], addWheres: false)
-            ->withAttributes(['b' => 'B'], addWheres: false)
-            ->withAttributes(['a' => 'AA'], addWheres: false);
+            ->withAttributes(['a' => 'A'], asConditions: false)
+            ->withAttributes(['b' => 'B'], asConditions: false)
+            ->withAttributes(['a' => 'AA'], asConditions: false);
 
         $relatedModel = $relationship->make([
             'b' => 'BB',
@@ -163,7 +163,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes($key, $value, addWheres: false);
+            ->withAttributes($key, $value, asConditions: false);
 
         $relatedModel = $relationship->make();
 
@@ -181,7 +181,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $wheres = $relationship->toBase()->wheres;
 
@@ -213,7 +213,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([$key => null], addWheres: false);
+            ->withAttributes([$key => null], asConditions: false);
 
         $wheres = $relationship->toBase()->wheres;
         $relatedModel = $relationship->make();
@@ -249,7 +249,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes([$key => $value], addWheres: false)
+            ->withAttributes([$key => $value], asConditions: false)
             ->one();
 
         $relatedModel = $relationship->make();
@@ -269,7 +269,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->morphMany(RelatedPendingAttributesModel::class, 'relatable')
-            ->withAttributes([$key => $value], addWheres: false)
+            ->withAttributes([$key => $value], asConditions: false)
             ->one();
 
         $relatedModel = $relationship->make();
@@ -288,7 +288,7 @@ class DatabaseEloquentHasOneOrManyWithAttributesPendingTest extends TestCase
 
         $relationship = $parent
             ->hasMany(RelatedPendingAttributesModel::class, 'parent_id')
-            ->withAttributes(['is_admin' => 1], addWheres: false);
+            ->withAttributes(['is_admin' => 1], asConditions: false);
 
         $relatedModel = $relationship->make();
 

--- a/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
@@ -33,7 +33,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
         $value = 'the value';
 
         $query = PendingAttributesModel::query()
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $model = $query->make();
 
@@ -46,7 +46,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
         $value = 'the value';
 
         $query = PendingAttributesModel::query()
-            ->withAttributes([$key => $value], addWheres: false);
+            ->withAttributes([$key => $value], asConditions: false);
 
         $wheres = $query->toBase()->wheres;
 
@@ -62,7 +62,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
                 'first_name' => 'FIRST',
                 'last_name' => 'LAST',
                 'type' => PendingAttributesEnum::internal,
-            ], addWheres: false);
+            ], asConditions: false);
 
         $model = $query->make();
 
@@ -89,7 +89,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
                 'first_name' => 'FIRST',
                 'last_name' => 'LAST',
                 'type' => PendingAttributesEnum::internal,
-            ], addWheres: false);
+            ], asConditions: false);
 
         $query->create();
 

--- a/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
@@ -33,7 +33,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
         $value = 'the value';
 
         $query = PendingAttributesModel::query()
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $model = $query->make();
 
@@ -46,7 +46,7 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
         $value = 'the value';
 
         $query = PendingAttributesModel::query()
-            ->withAttributes([], pending: [$key => $value]);
+            ->withAttributes([$key => $value], addWheres: false);
 
         $wheres = $query->toBase()->wheres;
 
@@ -57,12 +57,12 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
     public function testAddsWithCasts(): void
     {
         $query = PendingAttributesModel::query()
-            ->withAttributes([], pending: [
+            ->withAttributes([
                 'is_admin' => 1,
                 'first_name' => 'FIRST',
                 'last_name' => 'LAST',
                 'type' => PendingAttributesEnum::internal,
-            ]);
+            ], addWheres: false);
 
         $model = $query->make();
 
@@ -84,12 +84,12 @@ class DatabaseEloquentWithAttributesPendingTest extends TestCase
         $this->bootTable();
 
         $query = PendingAttributesModel::query()
-            ->withAttributes([], pending: [
+            ->withAttributes([
                 'is_admin' => 1,
                 'first_name' => 'FIRST',
                 'last_name' => 'LAST',
                 'type' => PendingAttributesEnum::internal,
-            ]);
+            ], addWheres: false);
 
         $query->create();
 

--- a/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
+++ b/tests/Database/DatabaseEloquentWithAttributesPendingTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Builder;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentWithAttributesPendingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schema()->dropIfExists((new PendingAttributesModel)->getTable());
+    }
+
+    public function testAddsAttributes(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = PendingAttributesModel::query()
+            ->withAttributes([], pending: [$key => $value]);
+
+        $model = $query->make();
+
+        $this->assertSame($value, $model->$key);
+    }
+
+    public function testDoesNotAddWheres(): void
+    {
+        $key = 'a key';
+        $value = 'the value';
+
+        $query = PendingAttributesModel::query()
+            ->withAttributes([], pending: [$key => $value]);
+
+        $wheres = $query->toBase()->wheres;
+
+        // Ensure no wheres exist
+        $this->assertEmpty($wheres);
+    }
+
+    public function testAddsWithCasts(): void
+    {
+        $query = PendingAttributesModel::query()
+            ->withAttributes([], pending: [
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => PendingAttributesEnum::internal,
+            ]);
+
+        $model = $query->make();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(PendingAttributesEnum::internal, $model->type);
+
+        $this->assertEqualsCanonicalizing([
+            'is_admin' => 1,
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'type' => 'int',
+        ], $model->getAttributes());
+    }
+
+    public function testAddsWithCastsViaDb(): void
+    {
+        $this->bootTable();
+
+        $query = PendingAttributesModel::query()
+            ->withAttributes([], pending: [
+                'is_admin' => 1,
+                'first_name' => 'FIRST',
+                'last_name' => 'LAST',
+                'type' => PendingAttributesEnum::internal,
+            ]);
+
+        $query->create();
+
+        $model = PendingAttributesModel::first();
+
+        $this->assertSame(true, $model->is_admin);
+        $this->assertSame('First', $model->first_name);
+        $this->assertSame('Last', $model->last_name);
+        $this->assertSame(PendingAttributesEnum::internal, $model->type);
+    }
+
+    protected function bootTable(): void
+    {
+        $this->schema()->create((new PendingAttributesModel)->getTable(), function ($table) {
+            $table->id();
+            $table->boolean('is_admin');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    protected function schema(): Builder
+    {
+        return PendingAttributesModel::getConnectionResolver()->connection()->getSchemaBuilder();
+    }
+}
+
+class PendingAttributesModel extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_admin' => 'boolean',
+        'type' => PendingAttributesEnum::class,
+    ];
+
+    public function setFirstNameAttribute(string $value): void
+    {
+        $this->attributes['first_name'] = strtolower($value);
+    }
+
+    public function getFirstNameAttribute(?string $value): string
+    {
+        return ucfirst($value);
+    }
+
+    protected function lastName(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value) => ucfirst($value),
+            set: fn (string $value) => strtolower($value),
+        );
+    }
+}
+
+enum PendingAttributesEnum: string
+{
+    case internal = 'int';
+}


### PR DESCRIPTION
## Why
The `withAttributes` method (documented [here](https://laravel.com/docs/12.x/eloquent-relationships#scoped-relationships)) is very helpful for adding attributes to both the `where` clauses as well as the attributes when a model is made from the relationship.

However, I ran into a situation where I needed to set an attribute when the relationship is created, but not constrain the relationship to only rows where the attribute is set to that value.

The `$pendingAttributes` property already exists on the Eloquent builder and all the logic to add the pending attributes to the new models also exist.

## What
A new argument (`$asConditions`, defaults to `true`) was added `withAttributes` method on the Eloquent builder to determine whether the attributes passed into the method will also create where clauses.

### Implementation:
```php
/**
 * Specify attributes that should be added to any new models created by this builder.
 *
 * The given key / value pairs will also be added as where conditions to the query.
 *
 * @param  \Illuminate\Contracts\Database\Query\Expression|array|string  $attributes
 * @param  mixed  $value
 * @param  bool  $asConditions
 * @return $this
 */
public function withAttributes(Expression|array|string $attributes, $value = null, $asConditions = true)
{
    if (! is_array($attributes)) {
        $attributes = [$attributes => $value];
    }

    if ($asConditions) {
        foreach ($attributes as $column => $value) {
            $this->where($this->qualifyColumn($column), $value);
        }
    }

    $this->pendingAttributes = array_merge($this->pendingAttributes, $attributes);

    return $this;
}
```

### Usage:
```php
/**
 * Get the students that the teacher has.
 */
public function students(): HasMany {
    return $this->hasMany(Student::class)->withAttributes('current_teacher_id', $this->id, asConditions: false);
}

```

<details>
<summary>See previous PR content</summary>

## Why
Another attempt at #55178. Instead of adding the `pendingAttributes` method, Taylor said he would rather have this passed as a named argument to `withAttributes` ([see comment](https://github.com/laravel/framework/pull/55178#issuecomment-2761803990)).

---

The `withAttributes` method (documented [here](https://laravel.com/docs/12.x/eloquent-relationships#scoped-relationships)) is very helpful for adding attributes to both the `where` clauses as well as the attributes when a model is made from the relationship.

However, I ran into a situation where I needed to set an attribute when the relationship is created, but not constrain the relationship to only rows where the attribute is set to that value.

The `$pendingAttributes` property already exists on the Eloquent builder and all the logic to add the pending attributes to the new models also exist.

## What
~This led to me creating the `pendingAttributes` method to do the same thing as `withAttributes` but not touch the `where` clauses.~ 

~This led to me adding the `pending` named argument to the `withAttributes` method on the Eloquent builder.~

I added an `$addWheres` flag (probably should be renamed) to the `withAttributes` method on the Eloquent builder to determine whether the attributes passed into the method will also create where clauses. The default value is `true`.

Tests:
- `tests/Database/DatabaseEloquentBelongsToManyWithAttributesPendingTest.php`<br>Copied from `DatabaseEloquentBelongsToManyWithAttributesTest.php` and made sure only the relational `where` clauses exist
- `tests/Database/DatabaseEloquentHasOneOrManyWithAttributesPendingTest.php`<br>Copied from `DatabaseEloquentHasOneOrManyWithAttributesTest.php` and made sure only the relational `where` clauses exist
- `tests/Database/DatabaseEloquentWithAttributesPendingTest.php`<br>Copied from `DatabaseEloquentWithAttributesTest.php` and made sure no `where` clauses exist

## Alternative
**Edit:** Implemented the alternative! Current interface is `withAttributes(Expression|array|string $attributes, $value = null, $addWheres = true)`

One downside to using a named parameter to pass the `pending` attributes, is that the `$attributes` argument is still required, meaning we would need to do `->withAttributes([], pending: ['key' => 'value'])` to use it. After creating this commit, I had the idea that we could simply add a `$applyWhere` or `$addWhere` to `withAttributes` to dictate whether the where clauses are added (`true` by default)

Taylor, if you like the idea of changing `withAttributes` to `withAttributes(Expression|array|string $attributes, $value = null, $addWheres = true)` over `withAttributes(Expression|array|string $attributes, $value = null, array $pending = [])`, please let me know before closing the PR and I will update it.
</details>