### PR TITLE
[12.x] Add `Expression` type to param `$value` of `QueryBuilder` `having()` method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2399,7 +2399,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
      * @param  \DateTimeInterface|string|int|float|null  $operator
-     * @param  \DateTimeInterface|\Illuminate\Contracts\Database\Query\Expression|string|int|float|null  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\DateTimeInterface|string|int|float|null  $value
      * @param  string  $boolean
      * @return $this
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2399,7 +2399,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
      * @param  \DateTimeInterface|string|int|float|null  $operator
-     * @param  \DateTimeInterface|string|int|float|null  $value
+     * @param  \DateTimeInterface|\Illuminate\Contracts\Database\Query\Expression|string|int|float|null  $value
      * @param  string  $boolean
      * @return $this
      */


### PR DESCRIPTION
In this PR I added `QueryExpression` type to param `$value` of `QueryBuilder` `having()` method.

```php
$query->having('count', '<', DB::raw('max'));
```

### Static analyser error
![image](https://github.com/user-attachments/assets/2979d414-6fd1-428a-ae27-a26b3bb0bcf7)
