### PR TITLE
[12.x] Add `Expression` type to param `$value` of `QueryBuilder` `orHaving()` method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2451,7 +2451,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column
      * @param  \DateTimeInterface|string|int|float|null  $operator
-     * @param  \DateTimeInterface|string|int|float|null  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|\DateTimeInterface|string|int|float|null  $value
      * @return $this
      */
     public function orHaving($column, $operator = null, $value = null)


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/55200 as it's merged, in this PR I added `QueryExpression` type to param `$value` of `QueryBuilder` `orHaving()` method.

```php
$query->orHaving('count', '<', DB::raw('max'));
```

### Static analyser error
![image](https://github.com/user-attachments/assets/39285918-49e9-4e85-b7e4-bb39e9b23279)
