### PR TITLE
[12.x] Introducing `Rules\Password::appliedRules` Method

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -381,7 +381,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Get the validation rules that should be applied to the password.
+     * Get the validation rules that are defined for validation.
      *
      * @return array
      */

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -381,7 +381,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Get the validation rules that are defined for validation.
+     * Get information about the current state of the password validation rules.
      *
      * @return array
      */

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -379,4 +379,24 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
         return false;
     }
+
+    /**
+     * Get the validation rules that should be applied to the password.
+     *
+     * @return array
+     */
+    public function appliedRules()
+    {
+        return [
+            'min' => $this->min,
+            'max' => $this->max,
+            'mixedCase' => $this->mixedCase,
+            'letters' => $this->letters,
+            'numbers' => $this->numbers,
+            'symbols' => $this->symbols,
+            'uncompromised' => $this->uncompromised,
+            'compromisedThreshold' => $this->compromisedThreshold,
+            'customRules' => $this->customRules,
+        ];
+    }
 }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -339,6 +339,42 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
     }
 
+    public function testCanRetrieveAllRulesApplied()
+    {
+        $password = Password::min(2)
+            ->max(4)
+            ->mixedCase()
+            ->numbers()
+            ->letters()
+            ->symbols();
+
+        $this->assertSame($password->appliedRules(), [
+            'min' => 2,
+            'max' => 4,
+            'mixedCase' => true,
+            'letters' => true,
+            'numbers' => true,
+            'symbols' => true,
+            'uncompromised' => false,
+            'compromisedThreshold' => 0,
+            'customRules' => [],
+        ]);
+
+        $password = Password::min(2);
+
+        $this->assertSame($password->appliedRules(), [
+            'min' => 2,
+            'max' => null,
+            'mixedCase' => false,
+            'letters' => false,
+            'numbers' => false,
+            'symbols' => false,
+            'uncompromised' => false,
+            'compromisedThreshold' => 0,
+            'customRules' => [],
+        ]);
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

We know that the most interesting way to standardize password validation is through `Rules/Password` for backend.

However, when it comes to, for example, displaying the same validation rules from the backend on the frontend, we have a block due to the lack of a method that makes it possible to obtain the rules applied via `AppServiceProvider`.

**This PR introduces the `Rules\Password::appliedRules` method that makes it possible to have an array containing the validation rules and their respective usage statuses**, which allow us to access what was defined in the backend to display the rules that are actually accepted in a given password field.

## Example:

```php
class AppServiceProvider extends ServiceProvider
{
    // ...

    public function boot(): void
    {
        Password::defaults(function () {
            return Password::min(8)
                ->mixedCase()
                ->numbers();
        });
    }
}
```

```php
use Illuminate\Contracts\View\View;
use Illuminate\Validation\Rules\Password;
use Livewire\Component;

class Profile extends Component
{
    // ...

    public function render(): View
    {
        return view('livewire.profile', [
            'appliedRules' => Password::default()->appliedRules(),
        ]);
    }

    public function save(): void
    {
        // ...
    }
}
```

```blade
<div>
    <form wire:submit="save">
        <div>
            <x-input label="Password" />

            <span>{{ __('The password must be at least :min characters long.', ['min' => $appliedRules['min']]) }}</span>

            @if ($appliedRules['mixedCase'] === true)
                <span>{{ __('The password must contain at least one uppercase and one lowercase letter.') }}</span>
            @endif

            @if ($appliedRules['numbers'] === true)
                <span>{{ __('The password must contain at least one number.') }}</span>
            @endif
        </div>
        <x-button type="submit">
            Save
        </x-button>
    </form>
</div>
```