### PR TITLE
[12.x] Add --json option to EventListCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -55,17 +55,6 @@ class EventListCommand extends Command
             return;
         }
 
-        $this->displayEvents($events);
-    }
-
-    /**
-     * Dispatch to either JSON output or CLI output.
-     *
-     * @param  \Illuminate\Support\Collection  $events
-     * @return void
-     */
-    protected function displayEvents(Collection $events)
-    {
         if ($this->option('json')) {
             $this->displayJson($events);
         } else {
@@ -92,7 +81,7 @@ class EventListCommand extends Command
     }
 
     /**
-     * Display the events and their listeners in the standard CLI format.
+     * Display the events and their listeners for the CLI.
      *
      * @param  \Illuminate\Support\Collection  $events
      * @return void


### PR DESCRIPTION
**Summary**  
This pull request adds an optional `--json` flag to the `event:list` command so that it can return events and listeners in JSON format, similar to other Laravel commands like `route:list`, `about`, `model:show`, and `db:table`.

- Brings `event:list` into parity with other Artisan commands that provide both traditional CLI output and a JSON option. 
- Introduces a `--json` flag to output the event/listener data as JSON.  
- Preserves all existing CLI output and behavior.  
- Non-breaking change: all existing tests pass unchanged, while new tests ensure the JSON output works correctly.  

**Future**  
There are other commands that could similarly use an optional `--json` flag, such as `ListFailedCommand`, `ConfigShowCommand`, `ChannelListCommand`, and `ScheduleListCommand`. I can make separate pull requests for these.

**Testing**  
- Existing tests for `event:list` remain unmodified and still pass.  
- Added new coverage to verify JSON output, including cases for an empty list, a populated list, and usage with filters.  