### PR TITLE
[12.x] Fix the parameter filling order in formatParameters

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -216,13 +216,13 @@ class RouteUrlGenerator
         }
 
         // Match positional parameters to the route parameters that didn't have a value in order...
-        if (count($parameters) == count($routeParametersWithoutDefaultsOrNamedParameters)) {
-            foreach (array_reverse($routeParametersWithoutDefaultsOrNamedParameters) as $name) {
+        if (count($parameters) > 0 && count($routeParametersWithoutDefaultsOrNamedParameters) > 0) {
+            foreach ($routeParametersWithoutDefaultsOrNamedParameters as $name) {
                 if (count($parameters) === 0) {
                     break;
                 }
 
-                $namedParameters[$name] = array_pop($parameters);
+                $namedParameters[$name] = array_shift($parameters);
             }
         }
 


### PR DESCRIPTION
Before Laravel 12.4, when generating a URL with a single parameter (without parameter name), for example:

{{ route('location.show', 'Belgium') }}

for a route defined as:

Route::get('{country}/{city?}', [LocationController::class, 'show'])->name('location.show');

the parameter 'Belgium' was correctly assigned to the first segment ('country').

With the change introduced in Laravel 12.4 (formatParameters), if the number of passed parameters is equal to the number of expected positional parameters, the assignment order was reversed (using array_reverse), which assigned 'Belgium' to 'city' instead of 'country'.