### PR TITLE
[12.x] Fix failing tests on windows OS

### DIFF
--- a/tests/View/Blade/BladeExtendsTest.php
+++ b/tests/View/Blade/BladeExtendsTest.php
@@ -6,8 +6,7 @@ class BladeExtendsTest extends AbstractBladeTestCase
 {
     public function testExtendsAreCompiled()
     {
-        $string = '@extends(\'foo\')
-test';
+        $string = "@extends('foo')\ntest";
         $expected = "test\n".'<?php echo $__env->make(\'foo\', array_diff_key(get_defined_vars(), [\'__data\' => 1, \'__path\' => 1]))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
@@ -18,8 +17,7 @@ test';
 
     public function testSequentialCompileStringCalls()
     {
-        $string = '@extends(\'foo\')
-test';
+        $string = "@extends('foo')\ntest";
         $expected = "test\n".'<?php echo $__env->make(\'foo\', array_diff_key(get_defined_vars(), [\'__data\' => 1, \'__path\' => 1]))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
@@ -31,8 +29,7 @@ test';
 
     public function testExtendsFirstAreCompiled()
     {
-        $string = '@extendsFirst([\'foo\', \'milwad\'])
-test';
+        $string = "@extendsFirst(['foo', 'milwad'])\ntest";
         $expected = "test\n".'<?php echo $__env->first([\'foo\', \'milwad\'], array_diff_key(get_defined_vars(), [\'__data\' => 1, \'__path\' => 1]))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 


### PR DESCRIPTION
The expected strings include new lines within them, and in Windows environments, it translates to `\r\n`
but the blade render always return '\n' regardless of the OS in action.
![image](https://github.com/user-attachments/assets/6a947ae9-e2a6-49a6-b271-4c0986a7a354)
