### PR TITLE
feat: register custom casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2386,7 +2386,7 @@ trait HasAttributes
         if (isset(static::$customCastAliasRegistry[$alias]) || in_array($alias, static::$primitiveCastTypes)) {
             throw new \InvalidArgumentException("Custom cast alias '{$alias}' already registered.");
         }
-    
+
         static::$customCastAliasRegistry[$alias] = $class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -125,6 +125,13 @@ trait HasAttributes
     ];
 
     /**
+     * Cast types registered by custom casts.
+     *
+     * @var array
+     */
+    protected static $customCastAliasRegistry = [];
+
+    /**
      * The storage format of the model's date columns.
      *
      * @var string|null
@@ -1725,6 +1732,10 @@ trait HasAttributes
             return false;
         }
 
+        if (isset(static::$customCastAliasRegistry[$castType])) {
+            $castType = static::$customCastAliasRegistry[$castType];
+        }
+
         if (class_exists($castType)) {
             return true;
         }
@@ -1806,6 +1817,10 @@ trait HasAttributes
 
             $castType = $segments[0];
             $arguments = explode(',', $segments[1]);
+        }
+
+        if (isset(static::$customCastAliasRegistry[$castType])) {
+            $castType = static::$customCastAliasRegistry[$castType];
         }
 
         if (is_subclass_of($castType, Castable::class)) {
@@ -2353,6 +2368,26 @@ trait HasAttributes
         }
 
         return static::$mutatorCache[static::class];
+    }
+
+    /**
+     * Register a custom cast type.
+     *
+     * @param  string  $alias
+     * @param  string  $class
+     * @return void
+     */
+    public static function registerCustomCast(string $alias, string $class)
+    {
+        if (! class_exists($class)) {
+            throw new \InvalidArgumentException("Custom cast class '{$class}' not found.");
+        }
+
+        if (isset(static::$customCastAliasRegistry[$alias]) || in_array($alias, static::$primitiveCastTypes)) {
+            throw new \InvalidArgumentException("Custom cast alias '{$alias}' already registered.");
+        }
+    
+        static::$customCastAliasRegistry[$alias] = $class;
     }
 
     /**

--- a/tests/Database/EloquentModelRegisteredCustomCastingTest.php
+++ b/tests/Database/EloquentModelRegisteredCustomCastingTest.php
@@ -2,17 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
-use Brick\Math\BigNumber;
-use GMP;
-use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Database\Schema\Blueprint;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/EloquentModelRegisteredCustomCastingTest.php
+++ b/tests/Database/EloquentModelRegisteredCustomCastingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Brick\Math\BigNumber;
+use GMP;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Blueprint;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('integration')]
+class EloquentModelRegisteredCustomCastingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+        // $this->createSchema();
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        // register custom casts
+        Model::registerCustomCast('uppercase', UppercaseCaster::class);
+        Model::registerCustomCast('uppercase-argument', UppercaseCasterWithArgument::class);
+    }
+
+    public function testBasicCustomCasting()
+    {
+        $model = new TestModel;
+        $model->uppercase = 'vinicius de santana';
+
+        $this->assertSame('VINICIUS DE SANTANA', $model->uppercase);
+        $this->assertSame('VINICIUS DE SANTANA', $model->getAttributes()['uppercase']);
+        $this->assertSame('VINICIUS DE SANTANA', $model->toArray()['uppercase']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->uppercase);
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->getAttributes()['uppercase']);
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->toArray()['uppercase']);
+    }
+
+    public function testCustomCastingWithoutArgument()
+    {
+        $model = new TestModel;
+        $model->uppercase_without_argument = 'vinicius de santana';
+
+        $this->assertSame('VINICIUS DE SANTANA', $model->uppercase_without_argument);
+        $this->assertSame('VINICIUS DE SANTANA', $model->getAttributes()['uppercase_without_argument']);
+        $this->assertSame('VINICIUS DE SANTANA', $model->toArray()['uppercase_without_argument']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->uppercase_without_argument);
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->getAttributes()['uppercase_without_argument']);
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->toArray()['uppercase_without_argument']);
+    }
+
+    public function testCustomCastingWithArgument()
+    {
+        $model = new TestModel;
+        $model->uppercase_with_argument = 'vinicius de santana';
+
+        $this->assertSame('argument', $model->uppercase_with_argument);
+        $this->assertSame('VINICIUS DE SANTANA', $model->getAttributes()['uppercase_with_argument']);
+        $this->assertSame('argument', $model->toArray()['uppercase_with_argument']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertSame('argument', $unserializedModel->uppercase_with_argument);
+        $this->assertSame('VINICIUS DE SANTANA', $unserializedModel->getAttributes()['uppercase_with_argument']);
+        $this->assertSame('argument', $unserializedModel->toArray()['uppercase_with_argument']);
+    }
+}
+
+class TestModel extends Model
+{
+    protected $table = 'test_model';
+    public $timestamps = false;
+    protected $casts = [
+        'uppercase' => 'uppercase',
+        'uppercase_without_argument' => 'uppercase-argument',
+        'uppercase_with_argument' => 'uppercase-argument:argument',
+    ];
+}
+
+class UppercaseCaster implements CastsAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return strtoupper($value);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return [$key => strtoupper($value)];
+    }
+}
+
+class UppercaseCasterWithArgument implements CastsAttributes
+{
+    private $argument;
+
+    public function __construct($argument = null)
+    {
+        $this->argument = $argument;
+    }
+
+    public function get($model, $key, $value, $attributes)
+    {
+        if ($this->argument) {
+            return $this->argument;
+        }
+
+        return strtoupper($value);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return strtoupper($value);
+    }
+}

--- a/tests/Database/EloquentModelRegisteredCustomCastingTest.php
+++ b/tests/Database/EloquentModelRegisteredCustomCastingTest.php
@@ -33,7 +33,7 @@ class EloquentModelRegisteredCustomCastingTest extends TestCase
 
     public function testBasicCustomCasting()
     {
-        $model = new TestModel;
+        $model = new TestRegisteredCustomCastModel;
         $model->uppercase = 'vinicius de santana';
 
         $this->assertSame('VINICIUS DE SANTANA', $model->uppercase);
@@ -49,7 +49,7 @@ class EloquentModelRegisteredCustomCastingTest extends TestCase
 
     public function testCustomCastingWithoutArgument()
     {
-        $model = new TestModel;
+        $model = new TestRegisteredCustomCastModel;
         $model->uppercase_without_argument = 'vinicius de santana';
 
         $this->assertSame('VINICIUS DE SANTANA', $model->uppercase_without_argument);
@@ -65,7 +65,7 @@ class EloquentModelRegisteredCustomCastingTest extends TestCase
 
     public function testCustomCastingWithArgument()
     {
-        $model = new TestModel;
+        $model = new TestRegisteredCustomCastModel;
         $model->uppercase_with_argument = 'vinicius de santana';
 
         $this->assertSame('argument', $model->uppercase_with_argument);
@@ -80,7 +80,7 @@ class EloquentModelRegisteredCustomCastingTest extends TestCase
     }
 }
 
-class TestModel extends Model
+class TestRegisteredCustomCastModel extends Model
 {
     protected $table = 'test_model';
     public $timestamps = false;


### PR DESCRIPTION
A key feature of Eloquent is attribute casting, which allows developers to transform attribute values when they are retrieved from or saved to the database.

For custom casts, this mapping necessitates the use of the fully qualified class name of the caster (e.g., `App\Casts\MyCustomCast::class`). The framework requires string concatenation to achieve this, resulting in syntax like `MyCustomCast::class . ':parameter'`.

This PR proposes a system of string-based aliases for custom cast classes. This enhancement would allow developers to register custom cast classes against simple, descriptive string aliases (e.g., `my-custom`). These aliases could be used within the $casts property of Eloquent models, leading to a more streamlined syntax such as `$casts = ['attribute' => 'my-custom'];`. Furthermore, the passing of parameters could be made more intuitive through a colon-separated format, for example, `$casts = ['attribute' => 'my-custom:param1,param2'];`.

This proposed system aims to simplify the definition of custom casts and improve the overall readability of model definitions.
