### PR TITLE
[master] Remove sear method from Cache facade

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -443,20 +443,6 @@ class Repository implements ArrayAccess, CacheContract
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
-    public function sear($key, Closure $callback)
-    {
-        return $this->rememberForever($key, $callback);
-    }
-
-    /**
-     * Get an item from the cache, or execute the given Closure and store the result forever.
-     *
-     * @template TCacheValue
-     *
-     * @param  string  $key
-     * @param  \Closure(): TCacheValue  $callback
-     * @return TCacheValue
-     */
     public function rememberForever($key, Closure $callback)
     {
         $value = $this->get($key);

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -86,17 +86,6 @@ interface Repository extends CacheInterface
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
-    public function sear($key, Closure $callback);
-
-    /**
-     * Get an item from the cache, or execute the given Closure and store the result forever.
-     *
-     * @template TCacheValue
-     *
-     * @param  string  $key
-     * @param  \Closure(): TCacheValue  $callback
-     * @return TCacheValue
-     */
     public function rememberForever($key, Closure $callback);
 
     /**

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -30,7 +30,6 @@ namespace Illuminate\Support\Facades;
  * @method static int|bool decrement(string $key, mixed $value = 1)
  * @method static bool forever(string $key, mixed $value)
  * @method static mixed remember(string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
- * @method static mixed sear(string $key, \Closure $callback)
  * @method static mixed rememberForever(string $key, \Closure $callback)
  * @method static mixed flexible(string $key, array $ttl, callable $callback, array|null $lock = null)
  * @method static bool forget(string $key)

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -18,7 +18,7 @@ assertType('mixed', $cache->pull('cache', 28));
 assertType('mixed', $cache->pull('cache', function (): int {
     return 30;
 }));
-assertType('33', $cache->sear('cache', function (): int {
+assertType('33', $cache->rememberForever('cache', function (): int {
     return 33;
 }));
 assertType('36', $cache->remember('cache', now(), function (): int {

--- a/types/Contracts/Cache/Repository.php
+++ b/types/Contracts/Cache/Repository.php
@@ -18,7 +18,7 @@ assertType('28', $cache->pull('cache', 28));
 assertType('30', $cache->pull('cache', function (): int {
     return 30;
 }));
-assertType('33', $cache->sear('cache', function (): int {
+assertType('33', $cache->rememberForever('cache', function (): int {
     return 33;
 }));
 assertType('36', $cache->remember('cache', now(), function (): int {

--- a/types/Support/Facades/Cache.php
+++ b/types/Support/Facades/Cache.php
@@ -15,7 +15,7 @@ assertType('mixed', Cache::pull('cache', 28));
 assertType('mixed', Cache::pull('cache', function (): int {
     return 30;
 }));
-assertType('mixed', Cache::sear('cache', function (): int {
+assertType('mixed', Cache::rememberForever('cache', function (): int {
     return 33;
 }));
 assertType('mixed', Cache::remember('cache', now(), function (): int {


### PR DESCRIPTION
**Description:**
The `sear` method in the Cache facade is a shortcut for `rememberForever`, but its naming is not intuitive and lacks documentation. The term `sear` does not clearly convey its purpose, making `rememberForever` the more readable and self-explanatory alternative.

Given that `rememberForever` already provides a clear and well-documented way to achieve the same functionality, this PR removes `sear` to improve code clarity and maintainability.

Since there is no official documentation referencing `sear`, its removal should have minimal impact.