### PR TITLE
Add missing assertFailedWith() included in Laravels documentation

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -148,6 +148,34 @@ trait InteractsWithQueue
     /**
      * Assert that the job was manually failed with a specific exception.
      *
+     * @return $this
+     */
+    public function assertFailedWith(string $expectedExceptionClass)
+    {
+        $this->ensureQueueInteractionsHaveBeenFaked();
+
+        PHPUnit::assertTrue(
+            $this->job->hasFailed(),
+            'Job was expected to be manually failed, but was not.'
+        );
+
+        PHPUnit::assertNotNull(
+            $this->job->failedWith,
+            'Job failed but no exception was recorded.'
+        );
+
+        PHPUnit::assertInstanceOf(
+            $expectedExceptionClass,
+            $this->job->failedWith,
+            "Job was expected to fail with an instance of {$expectedExceptionClass}, but got " . get_class($this->job->failedWith)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the job was manually failed with a specific exception.
+     *
      * @param  \Throwable|string  $exception
      * @return $this
      */

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -164,10 +164,12 @@ trait InteractsWithQueue
             'Job failed but no exception was recorded.'
         );
 
+        $actualClass = get_class($this->job->failedWith);
+
         PHPUnit::assertInstanceOf(
             $expectedExceptionClass,
             $this->job->failedWith,
-            "Job was expected to fail with an instance of {$expectedExceptionClass}, but got " . get_class($this->job->failedWith)
+            "Job was expected to fail with an instance of {$expectedExceptionClass}, but got {$actualClass}"
         );
 
         return $this;


### PR DESCRIPTION
Laravel's documentation says there should be an assertFailedWith method but it doesn't exist:

https://laravel.com/docs/12.x/queues#testing-job-queue-interactions

Example usage of this would be :

```
$job = (new SyncArtworkDetail($artwork->id))->withFakeQueueInteractions();
$job->handle();
$job->assertFailedWith(InvalidArtworkExtensionException::class);
```
