### PR TITLE
[12.x] Add ability to flush state on Vite helper

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -1023,4 +1023,14 @@ class Vite implements Htmlable
     {
         return $this->__invoke($this->entryPoints)->toHtml();
     }
+
+    /**
+     * Flush state.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->preloadedAssets = [];
+    }
 }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1693,6 +1693,18 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testItCanFlushState()
+    {
+        $this->makeViteManifest();
+
+        app(Vite::class)('resources/js/app.js');
+        app()->forgetScopedInstances();
+        $this->assertCount(1, app(Vite::class)->preloadedAssets());
+
+        app(Vite::class)->flush();
+        $this->assertCount(0, app(Vite::class)->preloadedAssets());
+    }
+
     protected function cleanViteManifest($path = 'build')
     {
         if (file_exists(public_path("{$path}/manifest.json"))) {


### PR DESCRIPTION
There is a [memory leak in Octane](https://github.com/laravel/octane/issues/992) as the Vite class is a singleton which collects state on each request.

We cannot make the class a scoped instance, as it needs to store some registered information between requests.

This PR adds a `flush` method that we will then call in Octane to clear the state between executions.

Octane PR: https://github.com/laravel/octane/pull/1016/files#diff-713c2b10a1e78ad1a57b948bbecdeace4afcef924eef6ce3c0899d2fa2fe7134L51-R52