### PR TITLE
Speed up operatorForWhere for large collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1087,11 +1087,10 @@ trait EnumeratesValues
 
             $operator = '=';
         }
-
+        $value = enum_value($value);
         return function ($item) use ($key, $operator, $value) {
             $retrieved = enum_value(data_get($item, $key));
-            $value = enum_value($value);
-
+            
             $strings = array_filter([$retrieved, $value], function ($value) {
                 return match (true) {
                     is_string($value) => true,


### PR DESCRIPTION
Move the value retrieval outside the loop, reducing the `enum_value` calls by 50% for large collections

