### PR TITLE
Make `db:seed` command prohibitable

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,7 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'db:seed')]
 class SeedCommand extends Command
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The console command name.
@@ -55,8 +56,9 @@ class SeedCommand extends Command
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
-            return 1;
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed()) {
+            return Command::FAILURE;
         }
 
         $this->components->info('Seeding database.');


### PR DESCRIPTION
I think it is generally undesirable and potentially unsafe to execute seeders in production databases. This change allows users fine-grained control to prohibit `db:seed` from running.

This is a follow-up from https://github.com/laravel/framework/pull/55231, but only adds the `Prohibitable` trait without changing `DB::prohibitDestructiveCommands`.

Now, I have to do something like this:

```php
// DBServiceProvider.php
DB::prohibitDestructiveCommands();
$this->app->extend(SeedCommand::class, fn (): ProhibitableSeedCommand => new ProhibitableSeedCommand($this->app->make(ConnectionResolverInterface::class)));
ProhibitableSeedCommand::prohibit();

// ProhibitableSeedCommand.php
use Illuminate\Console\Prohibitable;
use Illuminate\Database\Console\Seeds\SeedCommand;

final class ProhibitableSeedCommand extends SeedCommand
{
    use Prohibitable;

    public function handle(): int
    {
        if ($this->isProhibited()) {
            return self::FAILURE;
        }

        return parent::handle();
    }
}
```

With this pull request, this simply becomes this, without the need for any class overrides:

```php
DB::prohibitDestructiveCommands();
SeedCommand::prohibit();
```