### PR TITLE
Fix the PhpDoc for DB::prohibitDestructiveCommands and align order

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -122,18 +122,18 @@ class DB extends Facade
     /**
      * Indicate if destructive Artisan commands should be prohibited.
      *
-     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, and migrate:reset
+     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, migrate:reset, migrate:rollback
      *
      * @param  bool  $prohibit
      * @return void
      */
     public static function prohibitDestructiveCommands(bool $prohibit = true)
     {
+        WipeCommand::prohibit($prohibit);
         FreshCommand::prohibit($prohibit);
         RefreshCommand::prohibit($prohibit);
         ResetCommand::prohibit($prohibit);
         RollbackCommand::prohibit($prohibit);
-        WipeCommand::prohibit($prohibit);
     }
 
     /**


### PR DESCRIPTION
This adds the missing docs for `migrate:rollback` and aligns the order of calls with the order in which commands are listed in the PhpDoc.