### PR TITLE
[12.x] Add `Http::requestException()`

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -188,11 +188,7 @@ class Factory
      */
     public static function requestException($body = null, $status = 200, $headers = [])
     {
-        return new RequestException(
-            new Response(
-                static::psr7Response($body, $status, $headers)
-            )
-        );
+        return new RequestException(new Response(static::psr7Response($body, $status, $headers)));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -154,15 +154,45 @@ class Factory
      */
     public static function response($body = null, $status = 200, $headers = [])
     {
+        return Create::promiseFor(
+            static::psr7Response($body, $status, $headers)
+        );
+    }
+
+    /**
+     * Create a new PSR-7 response instance for use during stubbing.
+     *
+     * @param  array|string|null  $body
+     * @param  int  $status
+     * @param  array<string, mixed>  $headers
+     * @return \GuzzleHttp\Psr7\Response
+     */
+    protected static function psr7Response($body = null, $status = 200, $headers = [])
+    {
         if (is_array($body)) {
             $body = json_encode($body);
 
             $headers['Content-Type'] = 'application/json';
         }
 
-        $response = new Psr7Response($status, $headers, $body);
+        return new Psr7Response($status, $headers, $body);
+    }
 
-        return Create::promiseFor($response);
+    /**
+     * Create a new RequestException instance for use during stubbing.
+     *
+     * @param  array|string|null  $body
+     * @param  int  $status
+     * @param  array<string, mixed>  $headers
+     * @return \Illuminate\Http\Client\RequestException
+     */
+    public static function requestException($body = null, $status = 200, $headers = [])
+    {
+        return new RequestException(
+            new Response(
+                static::psr7Response($body, $status, $headers)
+            )
+        );
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -167,7 +167,7 @@ class Factory
      * @param  array<string, mixed>  $headers
      * @return \GuzzleHttp\Psr7\Response
      */
-    protected static function psr7Response($body = null, $status = 200, $headers = [])
+    public static function psr7Response($body = null, $status = 200, $headers = [])
     {
         if (is_array($body)) {
             $body = json_encode($body);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2362,6 +2362,16 @@ class HttpClientTest extends TestCase
         ]);
     }
 
+    public function testRequestException()
+    {
+        $requestException = $this->factory->requestException(['code' => 'not_found'], 404, ['X-RateLimit-Remaining' => 199]);
+
+        $this->assertInstanceOf(RequestException::class, $requestException);
+        $this->assertEqualsCanonicalizing(['code' => 'not_found'], $requestException->response->json());
+        $this->assertEquals(404, $requestException->response->status());
+        $this->assertEquals(199, $requestException->response->header('X-RateLimit-Remaining'));
+    }
+
     public function testFakeConnectionException()
     {
         $this->factory->fake($this->factory->failedConnection('Fake'));


### PR DESCRIPTION
I had a need earlier to throw a RequestException for an exception throwing stub class.

It wasn't super obvious how to do it; I ended up with something like:

## Before
```php
$exception = new RequestException(
    new Response(
        Http::response(['code' => 'not_found', 404)->wait()
    )
);
```

While this is fine, I thought maybe a helper (to go along with the `failedConnection()` method) would be appreciated by others.

## After
```php
$exception = Http::requestException(['code' => 'not_found'], 404);
```