### PR TITLE
Improved error message for Bcrypt hashing issues

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -85,7 +85,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
         }
 
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
-            throw new RuntimeException('This password does not use the Bcrypt algorithm.');
+            throw new RuntimeException('Authentication failed: The stored password is either missing, not hashed, or the database column is incorrect. Ensure your database has a "password" column with properly hashed values.');
         }
 
         return parent::check($value, $hashedValue, $options);


### PR DESCRIPTION
This update enhances the error message in the BcryptHasher class to provide more informative feedback when there's an issue with password hashing, particularly when the column name is mistakenly written as "Password" (capital 'P') instead of "password" (lowercase 'p').

This will help developers more easily identify and troubleshoot this common issue related to password hashing in Laravel