### PR TITLE
[12.x] Do not require returning a Builder instance from a local scope method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Scope.php
@@ -9,9 +9,6 @@ class Scope
 {
     /**
      * Create a new attribute instance.
-     *
-     * @param  array|string  $classes
-     * @return void
      */
     public function __construct()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2402,9 +2402,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function __callStatic($method, $parameters)
     {
         if (static::isScopeMethodWithAttribute($method)) {
-            $parameters = [$query = static::query(), ...$parameters];
-
-            return (new static)->$method(...$parameters) ?? $query;
+            return (new static)->query()->$method(...$parameters);
         }
 
         return (new static)->$method(...$parameters);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2402,7 +2402,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function __callStatic($method, $parameters)
     {
         if (static::isScopeMethodWithAttribute($method)) {
-            $parameters = [static::query(), ...$parameters];
+            $parameters = [$query = static::query(), ...$parameters];
+
+            return (new static)->$method(...$parameters) ?? $query;
         }
 
         return (new static)->$method(...$parameters);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2402,7 +2402,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function __callStatic($method, $parameters)
     {
         if (static::isScopeMethodWithAttribute($method)) {
-            return (new static)->query()->$method(...$parameters);
+            return static::query()->$method(...$parameters);
         }
 
         return (new static)->$method(...$parameters);

--- a/tests/Integration/Database/EloquentNamedScopeAttributeTest.php
+++ b/tests/Integration/Database/EloquentNamedScopeAttributeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[WithMigration]
 class EloquentNamedScopeAttributeTest extends TestCase
@@ -20,17 +21,27 @@ class EloquentNamedScopeAttributeTest extends TestCase
         );
     }
 
-    public function test_it_can_query_named_scoped_from_the_query_builder()
+    #[DataProvider('namedScopeDataProvider')]
+    public function test_it_can_query_named_scoped_from_the_query_builder(string $methodName)
     {
-        $query = Fixtures\NamedScopeUser::query()->verified(true);
+        $query = Fixtures\NamedScopeUser::query()->{$methodName}(true);
 
         $this->assertSame($this->query, $query->toRawSql());
     }
 
-    public function test_it_can_query_named_scoped_from_static_query()
+    #[DataProvider('namedScopeDataProvider')]
+    public function test_it_can_query_named_scoped_from_static_query(string $methodName)
     {
-        $query = Fixtures\NamedScopeUser::verified(true);
+        $query = Fixtures\NamedScopeUser::{$methodName}(true);
 
         $this->assertSame($this->query, $query->toRawSql());
+    }
+
+    public static function namedScopeDataProvider(): array
+    {
+        return [
+            'scope with return' => ['verified'],
+            'scope without return' => ['verifiedWithoutReturn'],
+        ];
     }
 }

--- a/tests/Integration/Database/Fixtures/NamedScopeUser.php
+++ b/tests/Integration/Database/Fixtures/NamedScopeUser.php
@@ -27,6 +27,12 @@ class NamedScopeUser extends User
         );
     }
 
+    #[NamedScope]
+    protected function verifiedWithoutReturn(Builder $builder, bool $email = true)
+    {
+        $this->verified($builder, $email);
+    }
+
     public function scopeVerifiedUser(Builder $builder, bool $email = true)
     {
         return $builder->when(


### PR DESCRIPTION
To resolve the issue that @JeffreyWay reported on Twitter. https://x.com/jeffrey_way/status/1907138791799709883

Related to: https://github.com/laravel/framework/pull/54450

---
In the current state, a local scope method must return a builder instance when called in a static context. This is counter to how scopes traditionally work, where the return value is essentially ignored.

cc: @shaedrich 