### PR TITLE
[12.x] Fix pivot model observers not working properly when using withPivotValue

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -483,7 +483,14 @@ class BelongsToMany extends Relation
 
         $this->pivotValues[] = compact('column', 'value');
 
-        return $this->wherePivot($column, '=', $value);
+        // Add where clause for filtering but track it separately so it doesn't 
+        // prevent the pivot model observers from working
+        $this->wherePivot($column, '=', $value);
+        
+        // Mark this where clause as coming from withPivotValue
+        $this->pivotWheres[count($this->pivotWheres) - 1]['from_pivot_value'] = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -483,10 +483,10 @@ class BelongsToMany extends Relation
 
         $this->pivotValues[] = compact('column', 'value');
 
-        // Add where clause for filtering but track it separately so it doesn't 
+        // Add where clause for filtering but track it separately so it doesn't
         // prevent the pivot model observers from working
         $this->wherePivot($column, '=', $value);
-        
+
         // Mark this where clause as coming from withPivotValue
         $this->pivotWheres[count($this->pivotWheres) - 1]['from_pivot_value'] = true;
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -572,12 +572,12 @@ trait InteractsWithPivotTable
         foreach ($this->pivotWheres as $arguments) {
             // Clone the arguments to avoid modifying the original array
             $argumentsToApply = $arguments;
-            
+
             // Remove the from_pivot_value flag before applying to the query
             if (isset($argumentsToApply['from_pivot_value'])) {
                 unset($argumentsToApply['from_pivot_value']);
             }
-            
+
             $query->where(...$argumentsToApply);
         }
 

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -166,7 +166,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
         $adminRelation = $project->belongsToMany(
             PivotEventsTestUser::class, 'project_users', 'project_id', 'user_id'
         )->using(PivotEventsTestCollaborator::class)
-        ->withPivotValue('role', 'admin');
+            ->withPivotValue('role', 'admin');
 
         // Update through the relation with withPivotValue
         $adminRelation->updateExistingPivot($user->id, ['permissions' => ['manage']]);


### PR DESCRIPTION
This PR fixes issue #55026 where pivot model observers don't work properly when using the `withPivotValue` method.

## Description
When using a custom pivot model class with observers and calling `withPivotValue` on a relationship, the update and delete events don't fire as expected. This happens because `withPivotValue` adds conditions to `pivotWheres`, which prevents the code from using the custom pivot class path for updates and detaches.

## Solution
- Modified `withPivotValue` to mark where clauses that come from it with a `from_pivot_value` flag
- Added a `getNonPivotValueWhereClauses` method to filter out where clauses that come from `withPivotValue`
- Updated `updateExistingPivot` and `detach` methods to check for non-pivot-value where clauses instead of all where clauses
- Modified `newPivotQuery` to properly apply where clauses but remove the flag before building the query
- Added a test case to verify the fix works correctly

The solution ensures that pivot model observers work properly with `withPivotValue` while maintaining the filtering behavior required by the relation.