### PR TITLE
New: Uri `pathSegments()` helper method

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -155,13 +155,13 @@ class Uri implements Htmlable, Responsable, Stringable
     /**
      * Get the URI's path segments.
      *
-     * Empty or missing paths are returned as an empty array.
+     * Empty or missing paths are returned as an empty collection.
      */
-    public function pathSegments(): array
+    public function pathSegments(): Collection
     {
         $path = $this->path();
 
-        return $path === '/' ? [] : explode('/', $path);
+        return $path === '/' ? collect() : collect(explode('/', $path));
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -152,6 +152,13 @@ class Uri implements Htmlable, Responsable, Stringable
         return $path === '' ? '/' : $path;
     }
 
+    public function pathSegments(): array
+    {
+        $path = $this->path();
+
+        return $path === '/' ? [] : explode('/', $path);
+    }
+
     /**
      * Get the URI's query string.
      */

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -161,7 +161,7 @@ class Uri implements Htmlable, Responsable, Stringable
     {
         $path = $this->path();
 
-        return $path === '/' ? collect() : collect(explode('/', $path));
+        return $path === '/' ? new Collection : new Collection(explode('/', $path));
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -152,6 +152,11 @@ class Uri implements Htmlable, Responsable, Stringable
         return $path === '' ? '/' : $path;
     }
 
+    /**
+     * Get the URI's path segments.
+     *
+     * Empty or missing paths are returned as an empty array.
+     */
     public function pathSegments(): array
     {
         $path = $this->path();

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -205,6 +205,6 @@ class SupportUriTest extends TestCase
 
         $uri = Uri::of('https://laravel.com/one/two/three');
 
-        $this->assertEquals(['one', 'two', 'three'],$uri->pathSegments());
+        $this->assertEquals(['one', 'two', 'three'], $uri->pathSegments());
     }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -206,7 +206,18 @@ class SupportUriTest extends TestCase
         $uri = Uri::of('https://laravel.com/one/two/three');
 
         $this->assertEquals(['one', 'two', 'three'], $uri->pathSegments()->toArray());
-
         $this->assertEquals('one', $uri->pathSegments()->first());
+
+        $uri = Uri::of('https://laravel.com/one/two/three?foo=bar');
+
+        $this->assertEquals(3, $uri->pathSegments()->count());
+
+        $uri = Uri::of('https://laravel.com/one/two/three/?foo=bar');
+
+        $this->assertEquals(3, $uri->pathSegments()->count());
+
+        $uri = Uri::of('https://laravel.com/one/two/three/#foo=bar');
+
+        $this->assertEquals(3, $uri->pathSegments()->count());
     }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -201,10 +201,12 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://laravel.com');
 
-        $this->assertEquals([], $uri->pathSegments());
+        $this->assertEquals([], $uri->pathSegments()->toArray());
 
         $uri = Uri::of('https://laravel.com/one/two/three');
 
-        $this->assertEquals(['one', 'two', 'three'], $uri->pathSegments());
+        $this->assertEquals(['one', 'two', 'three'], $uri->pathSegments()->toArray());
+
+        $this->assertEquals('one', $uri->pathSegments()->first());
     }
 }

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -196,4 +196,15 @@ class SupportUriTest extends TestCase
         $this->assertEquals('https://laravel.com', (string) $uri);
         $this->assertEquals('https://laravel.com', (string) $uri->withQuery([]));
     }
+
+    public function test_path_segments()
+    {
+        $uri = Uri::of('https://laravel.com');
+
+        $this->assertEquals([], $uri->pathSegments());
+
+        $uri = Uri::of('https://laravel.com/one/two/three');
+
+        $this->assertEquals(['one', 'two', 'three'],$uri->pathSegments());
+    }
 }


### PR DESCRIPTION
Recently I ran into a situation where I needed the first path segment from an url, so I have added `pathSegments()` helper method to the Uri class to easily access them.

Calling `pathSegments()` on the Uri class will return an colleciton of all path segments then you can easily access any of them.

So instead of doing something like this:
```php
        $path = Uri::of('https://laravel.com/one/two/three')->path();
        
        $firstSegment = collect(explode('/', $path))->first();
        // result: 'one'
```

You could just do this:
```php
        $firstSegment = Uri::of('https://laravel.com/one/two/three')->pathSegments()->first();
        // result: 'one'
```

I think that this would be a handy to have if you are dealing with path segments. It doesn't break any existing features as it's a new method.