### PR TITLE
List missing `migrate:rollback` in DB::prohibitDestructiveCommands PhpDoc

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -122,7 +122,7 @@ class DB extends Facade
     /**
      * Indicate if destructive Artisan commands should be prohibited.
      *
-     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, migrate:rollback, and migrate:reset
+     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, migrate:reset, and migrate:rollback
      *
      * @param  bool  $prohibit
      * @return void

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -122,7 +122,7 @@ class DB extends Facade
     /**
      * Indicate if destructive Artisan commands should be prohibited.
      *
-     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, and migrate:reset
+     * Prohibits: db:wipe, migrate:fresh, migrate:refresh, migrate:rollback, and migrate:reset
      *
      * @param  bool  $prohibit
      * @return void


### PR DESCRIPTION
Minimal version of https://github.com/laravel/framework/pull/55239. This adds `migrate:rollback` to the PhpDoc description while maintaining the alphabetical order of the calls within the method.