### PR TITLE
[12.x] `AbstractPaginator` should implement `CanBeEscapedWhenCastToString`

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -19,7 +19,7 @@ use Traversable;
  *
  * @mixin \Illuminate\Support\Collection<TKey, TValue>
  */
-abstract class AbstractPaginator implements Htmlable, Stringable, CanBeEscapedWhenCastToString
+abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlable, Stringable
 {
     use ForwardsCalls, Tappable;
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Pagination;
 
 use Closure;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -18,7 +19,7 @@ use Traversable;
  *
  * @mixin \Illuminate\Support\Collection<TKey, TValue>
  */
-abstract class AbstractPaginator implements Htmlable, Stringable
+abstract class AbstractPaginator implements Htmlable, Stringable, CanBeEscapedWhenCastToString
 {
     use ForwardsCalls, Tappable;
 
@@ -70,6 +71,13 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      * @var string
      */
     protected $pageName = 'page';
+
+    /**
+     * Indicates that the paginator's string representation should be escaped when __toString is invoked.
+     *
+     * @var bool
+     */
+    protected $escapeWhenCastingToString = false;
 
     /**
      * The number of links to display on each side of current page link.
@@ -797,6 +805,21 @@ abstract class AbstractPaginator implements Htmlable, Stringable
      */
     public function __toString()
     {
-        return (string) $this->render();
+        return $this->escapeWhenCastingToString
+            ? e((string) $this->render())
+            : (string) $this->render();
+    }
+
+    /**
+     * Indicate that the paginator's string representation should be escaped when __toString is invoked.
+     *
+     * @param  bool  $escape
+     * @return $this
+     */
+    public function escapeWhenCastingToString($escape = true)
+    {
+        $this->escapeWhenCastingToString = $escape;
+
+        return $this;
     }
 }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
@@ -799,11 +800,15 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $model = new class extends Model {
         };
 
+        $paginator = new class extends AbstractPaginator {
+        };
+
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));
         $this->assertEquals(e('1'), BladeCompiler::sanitizeComponentAttribute('1'));
         $this->assertEquals(1, BladeCompiler::sanitizeComponentAttribute(1));
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute($class));
         $this->assertSame($model, BladeCompiler::sanitizeComponentAttribute($model));
+        $this->assertSame($paginator, BladeCompiler::sanitizeComponentAttribute($paginator));
     }
 
     public function testItThrowsAnExceptionForNonExistingAliases()


### PR DESCRIPTION
If you pass a paginator to an anonymous blade component, the paginator will be converted to a string in the process, which causes the paginator's `render()` method to be called. The blade component receives the paginator object in the end, but it does not make sense that the paginator is rendered to a string while passing the object from one blade file to another.

This PR fixes that by implementing `CanBeEscapedWhenCastToString` interface on the `AbstractPaginator` class. This is the same as the implementation of that interface on `Model`, `Collection`, ... classes (see https://github.com/laravel/framework/pull/39319)