### PR TITLE
[12.x] Introducing `toArray` to `ComponentAttributeBag` class

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -45,7 +45,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      */
     public function all()
     {
-        return $this->toArray();
+        return $this->attributes;
     }
 
     /**
@@ -505,7 +505,7 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      */
     public function toArray()
     {
-        return $this->attributes;
+        return $this->all();
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use ArrayAccess;
 use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -16,7 +17,7 @@ use JsonSerializable;
 use Stringable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable, Stringable
+class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable, Stringable, Arrayable
 {
     use Conditionable, Macroable;
 
@@ -38,13 +39,13 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
     }
 
     /**
-     * Get all of the attribute values.
+     * Get all the attribute values.
      *
      * @return array
      */
     public function all()
     {
-        return $this->attributes;
+        return $this->toArray();
     }
 
     /**
@@ -493,6 +494,16 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
      * @return mixed
      */
     public function jsonSerialize(): mixed
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Get all the attribute values.
+     *
+     * @return array
+     */
+    public function toArray()
     {
         return $this->attributes;
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -17,7 +17,7 @@ use JsonSerializable;
 use Stringable;
 use Traversable;
 
-class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable, Stringable, Arrayable
+class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable, Stringable
 {
     use Conditionable, Macroable;
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -153,4 +153,15 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertTrue((bool) $bag->isNotEmpty());
     }
+
+    public function testAttributeIsArray()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'class' => 'font-bold',
+        ]);
+
+        $this->assertIsArray($bag->toArray());
+        $this->assertEquals(['name' => 'test', 'class' => 'font-bold'], $bag->toArray());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Being one of the most well-known methods in the framework's core, `toArray` is widely used when interacting with different types of instances of different classes. However, this "pattern" adopted by the framework was absent in the `ComponentAttributeBag` class. Therefore, with this PR, we added `toArray` to the `ComponentAttributeBag` class to **assimilate** the context of this class with the entire framework in general.