### PR TITLE
[12.x] Add createMany mass-assignment variants to `HasOneOrMany` relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -437,7 +437,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create a Collection of new instances of the related model. Allow mass-assignment.
+     * Create a Collection of new instances of the related model, allowing mass-assignment.
      *
      * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
@@ -454,8 +454,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create a Collection of new instances of the related model with mass-assignment
-     * and without raising any events to the parent model.
+     * Create a Collection of new instances of the related model, allowing mass-assignment and without raising any events to the parent model.
      *
      * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -455,7 +455,7 @@ abstract class HasOneOrMany extends Relation
 
     /**
      * Create a Collection of new instances of the related model with mass-assignment
-     * and without raising any events to the parent model
+     * and without raising any events to the parent model.
      *
      * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -437,6 +437,35 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create a Collection of new instances of the related model. Allow mass-assignment.
+     *
+     * @param  iterable  $records
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     */
+    public function forceCreateMany(iterable $records)
+    {
+        $instances = $this->related->newCollection();
+
+        foreach ($records as $record) {
+            $instances->push($this->forceCreate($record));
+        }
+
+        return $instances;
+    }
+
+    /**
+     * Create a Collection of new instances of the related model with mass-assignment
+     * and without raising any events to the parent model
+     *
+     * @param  iterable  $records
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     */
+    public function forceCreateManyQuietly(iterable $records)
+    {
+        return Model::withoutEvents(fn () => $this->forceCreateMany($records));
+    }
+
+    /**
      * Set the foreign ID for creating a related model.
      *
      * @param  TRelatedModel  $model


### PR DESCRIPTION
In Eloquent's `HasOneOrMany` relation, we have the following methods: `create()`, `createQuietly()`, `forceCreate()`, and `forceCreateQuietly()`. But to create a collection of new instances of the related model, we only have `createMany()` and `createManyQuietly`. I found myself searching for such mass-assignment variants over and over again.

In data import actions, I do this:

```php
collect($comments)
    ->map(fn (array $comment) => [
        ...$comment,
        // override some attributes here
    ])
    ->each(fn (array $comment) => $post->comments()->forceCreateQuietly($comment));
```

With this PR, we can use use the lovely splat operator `...` to pass all items directly into the `forceCreateManyQuietly()` method:

```php
collect($comments)
    ->map(fn (array $comment) => [
        ...$comment,
        // override some attributes here
    ])
    ->pipe($post->comments()->forceCreateManyQuietly(...));
```

This PR adds the missing `forceCreateMany()` and `forceCreateManyQuietly()` methods.