### PR TITLE
[12.x] Fix factory recycle for many to many relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -50,7 +50,10 @@ class BelongsToManyRelationship
      */
     public function createFor(Model $model)
     {
-        Collection::wrap($this->factory instanceof Factory ? $this->factory->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
+        Collection::wrap($this->factory instanceof Factory
+            ? ($this->factory->getRandomRecycledModelsForCount($this->factory->modelName()) ?? $this->factory->create([], $model))
+            : $this->factory
+        )->each(function ($attachable) use ($model) {
             $model->{$this->relationship}()->attach(
                 $attachable,
                 is_callable($this->pivot) ? call_user_func($this->pivot, $model) : $this->pivot

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -740,6 +740,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(1, FactoryTestUser::count());
     }
 
+    public function test_has_method_recycles_models()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $roles = FactoryTestRoleFactory::new()->count(2)->create();
+        $user = FactoryTestUserFactory::new()
+            ->recycle($roles)
+            ->hasRoles(2)
+            ->create();
+
+        $this->assertTrue($roles->pluck('id')->contains($user->roles[0]->id));
+        $this->assertTrue($roles->pluck('id')->contains($user->roles[1]->id));
+    }
+
     public function test_has_method_does_not_reassign_the_parent()
     {
         Factory::guessFactoryNamesUsing(function ($model) {


### PR DESCRIPTION
Let's say we create a user using a factory, and it should get assigned an existing role:
```php
$roles = Role::get();
$user = User::factory()
            ->recycle($roles)
            ->hasRoles()
            ->create();
```

### Original output:
Currently, recycle will only taken into account for a `belongsTo` relationship.
$user will get a newly generated role, ignoring the recycle.

[The docs](https://laravel.com/docs/12.x/eloquent-factories#recycling-an-existing-model-for-relationships) make a mention of this:
> If you have models that share a common relationship with another model, you may use the recycle method to ensure a **single** instance of the related model is recycled for all of the relationships created by the factory.

[HasAttached](https://laravel.com/docs/12.x/eloquent-factories#many-to-many-relationships) makes it pretty clear what it can (not) do, recycle is much more ambiguous. My assumption based on the code only would be that it works for any kind of relationship.

### Suggested output in this PR:
- $user will recycle one of the provided $roles.
- Added a test for this

If this goes forward, I'll send a matching PR for the [docs](https://laravel.com/docs/12.x/eloquent-factories#recycling-an-existing-model-for-relationships).

It might be worth it adding support for one to many (from the owner side, has()) as well.
There's two possibilities there:
- Recycled child already has a value for this relationship. Currently overwritten with a new one (no recycle)
- Recycled child has no value for this relationship. Currently generating a new one (no recycle)
Might need help here, as this situation is more complex with more choices to make in the (testing) approach.

Previous discussion when integrating the for() with recycle [here](https://github.com/laravel/framework/pull/44265).

