### PR TITLE
[12.x] only check for soft deletes once when mass-pruning

### DIFF
--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -23,8 +23,10 @@ trait MassPrunable
 
         $total = 0;
 
+        $softDeletable = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)));
+
         do {
-            $total += $count = in_array(SoftDeletes::class, class_uses_recursive(get_class($this)))
+            $total += $count = $softDeletable
                 ? $query->forceDelete()
                 : $query->delete();
 


### PR DESCRIPTION
It's not necessary to repeatedly reflect the traits of a Model to see if it's soft-deletable. This is a very minor optimization.