### PR TITLE
cosmetic: include is_array() case in match construct of getArrayableItems

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1046,11 +1046,8 @@ trait EnumeratesValues
      */
     protected function getArrayableItems($items)
     {
-        if (is_array($items)) {
-            return $items;
-        }
-
         return match (true) {
+            is_array($items) => $items,
             $items instanceof WeakMap => throw new InvalidArgumentException('Collections can not be created using instances of WeakMap.'),
             $items instanceof Enumerable => $items->all(),
             $items instanceof Arrayable => $items->toArray(),


### PR DESCRIPTION
getArrayableItems() already makes excellent use of match(true). I would like to include the is_array check (currently a separate if block), to make it more uniform and end up with a single expression and a single return.

The behavior and performance will remain unchanged.