### PR TITLE
[13.x] Adapting `blank` to Evaluate Closures

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -50,6 +50,10 @@ if (! function_exists('blank')) {
      */
     function blank($value)
     {
+        if ($value instanceof Closure) {
+            $value = value($value);
+        }
+
         if (is_null($value)) {
             return true;
         }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -65,12 +65,23 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(blank('  '));
         $this->assertTrue(blank(new Stringable('')));
         $this->assertTrue(blank(new Stringable('  ')));
+        $this->assertTrue(blank(fn () => null));
+        $this->assertTrue(blank(fn () => ''));
+        $this->assertTrue(blank(fn () => '  '));
+        $this->assertTrue(blank(fn () => new Stringable('')));
+        $this->assertTrue(blank(fn () => new Stringable('  ')));
         $this->assertFalse(blank(10));
         $this->assertFalse(blank(true));
         $this->assertFalse(blank(false));
         $this->assertFalse(blank(0));
         $this->assertFalse(blank(0.0));
         $this->assertFalse(blank(new Stringable(' FooBar ')));
+        $this->assertFalse(blank(fn () => 10));
+        $this->assertFalse(blank(fn () => true));
+        $this->assertFalse(blank(fn () => false));
+        $this->assertFalse(blank(fn () => 0));
+        $this->assertFalse(blank(fn () => 0.0));
+        $this->assertFalse(blank(fn () => new Stringable(' FooBar ')));
 
         $object = new SupportTestCountable();
         $this->assertTrue(blank($object));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `blank` is an extremely useful helper, but with one flaw: it does not support evaluating closures. With this PR, we have added support for evaluating closures primarily within the scope of the `blank` method so that the `$value` is evaluated right afterward.

Before:

```php
blank(fn () => null); // false
```

After:

```php
blank(fn () => null); // true
```