### PR TITLE
[12.x] Fix pivot model events not working when using the `withPivotValue`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -470,11 +470,9 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        if (
-            ! empty($this->pivotWheres) ||
+        if (! empty($this->pivotWheres) ||
             ! empty($this->pivotWhereIns) ||
-            ! empty($this->pivotWhereNulls)
-        ) {
+            ! empty($this->pivotWhereNulls)) {
             $records = $this->getCurrentlyAttachedPivotsForIds($ids);
 
             foreach ($records as $record) {
@@ -493,6 +491,16 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Get the pivot models that are currently attached.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getCurrentlyAttachedPivots()
+    {
+        return $this->getCurrentlyAttachedPivotsForIds();
+    }
+
+    /**
      * Get the pivot models that are currently attached, filtered by related model keys.
      *
      * @param  mixed  $ids
@@ -501,7 +509,9 @@ trait InteractsWithPivotTable
     protected function getCurrentlyAttachedPivotsForIds($ids = null)
     {
         return $this->newPivotQuery()
-            ->when(! is_null($ids), fn ($query) => $query->whereIn($this->getQualifiedRelatedPivotKeyName(), $this->parseIds($ids)))
+            ->when(! is_null($ids), fn ($query) => $query->whereIn(
+                $this->getQualifiedRelatedPivotKeyName(), $this->parseIds($ids)
+            ))
             ->get()
             ->map(function ($record) {
                 $class = $this->using ?: Pivot::class;
@@ -512,16 +522,6 @@ trait InteractsWithPivotTable
                     ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
                     ->setRelatedModel($this->related);
             });
-    }
-
-    /**
-     * Get the pivot models that are currently attached.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function getCurrentlyAttachedPivots()
-    {
-        return $this->getCurrentlyAttachedPivotsForIds();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -207,10 +207,7 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
-        if ($this->using &&
-            empty($this->pivotWheres) &&
-            empty($this->pivotWhereIns) &&
-            empty($this->pivotWhereNulls)) {
+        if ($this->using) {
             return $this->updateExistingPivotUsingCustomClass($id, $attributes, $touch);
         }
 
@@ -218,7 +215,7 @@ trait InteractsWithPivotTable
             $attributes = $this->addTimestampsToAttachment($attributes, true);
         }
 
-        $updated = $this->newPivotStatementForId($this->parseId($id))->update(
+        $updated = $this->newPivotStatementForId($id)->update(
             $this->castAttributes($attributes)
         );
 
@@ -239,10 +236,7 @@ trait InteractsWithPivotTable
      */
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
-        $pivot = $this->getCurrentlyAttachedPivots()
-            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
-            ->where($this->relatedPivotKey, $this->parseId($id))
-            ->first();
+        $pivot = $this->getCurrentlyAttachedPivotsForIds($id)->first();
 
         $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
@@ -435,11 +429,7 @@ trait InteractsWithPivotTable
      */
     public function detach($ids = null, $touch = true)
     {
-        if ($this->using &&
-            ! empty($ids) &&
-            empty($this->pivotWheres) &&
-            empty($this->pivotWhereIns) &&
-            empty($this->pivotWhereNulls)) {
+        if ($this->using) {
             $results = $this->detachUsingCustomClass($ids);
         } else {
             $query = $this->newPivotQuery();
@@ -480,14 +470,48 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        foreach ($this->parseIds($ids) as $id) {
-            $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                $this->relatedPivotKey => $id,
-            ], true)->delete();
+        if (
+            ! empty($this->pivotWheres) ||
+            ! empty($this->pivotWhereIns) ||
+            ! empty($this->pivotWhereNulls)
+        ) {
+            $records = $this->getCurrentlyAttachedPivotsForIds($ids);
+
+            foreach ($records as $record) {
+                $results += $record->delete();
+            }
+        } else {
+            foreach ($this->parseIds($ids) as $id) {
+                $results += $this->newPivot([
+                    $this->foreignPivotKey => $this->parent->{$this->parentKey},
+                    $this->relatedPivotKey => $id,
+                ], true)->delete();
+            }
         }
 
         return $results;
+    }
+
+    /**
+     * Get the pivot models that are currently attached, filtered by related model keys.
+     *
+     * @param  mixed  $ids
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getCurrentlyAttachedPivotsForIds($ids = null)
+    {
+        return $this->newPivotQuery()
+            ->when(! is_null($ids), fn ($query) => $query->whereIn($this->getQualifiedRelatedPivotKeyName(), $this->parseIds($ids)))
+            ->get()
+            ->map(function ($record) {
+                $class = $this->using ?: Pivot::class;
+
+                $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
+
+                return $pivot
+                    ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+                    ->setRelatedModel($this->related);
+            });
     }
 
     /**
@@ -497,15 +521,7 @@ trait InteractsWithPivotTable
      */
     protected function getCurrentlyAttachedPivots()
     {
-        return $this->newPivotQuery()->get()->map(function ($record) {
-            $class = $this->using ?: Pivot::class;
-
-            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
-
-            return $pivot
-                ->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
-                ->setRelatedModel($this->related);
-        });
+        return $this->getCurrentlyAttachedPivotsForIds();
     }
 
     /**
@@ -557,7 +573,7 @@ trait InteractsWithPivotTable
      */
     public function newPivotStatementForId($id)
     {
-        return $this->newPivotQuery()->whereIn($this->relatedPivotKey, $this->parseIds($id));
+        return $this->newPivotQuery()->whereIn($this->getQualifiedRelatedPivotKeyName(), $this->parseIds($id));
     }
 
     /**

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -74,6 +74,34 @@ class EloquentPivotEventsTest extends DatabaseTestCase
         $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
     }
 
+    public function testPivotWithPivotValueWillTriggerEventsToBeFired()
+    {
+        $user = PivotEventsTestUser::forceCreate(['email' => 'taylor@laravel.com']);
+        $user2 = PivotEventsTestUser::forceCreate(['email' => 'ralph@ralphschindler.com']);
+        $project = PivotEventsTestProject::forceCreate(['name' => 'Test Project']);
+
+        $project->managers()->attach($user);
+        $this->assertEquals(['saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+        $project->managers()->attach($user2);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->managers()->updateExistingPivot($user->id, ['permissions' => ['foo', 'bar']]);
+        $this->assertEquals(['saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+        $project->managers()->detach($user2);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->managers()->sync([$user2->id]);
+        $this->assertEquals(['deleting', 'deleted', 'saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->managers()->sync([$user->id => ['permissions' => ['foo']], $user2->id => ['permissions' => ['bar']]]);
+        $this->assertEquals(['saving', 'creating', 'created', 'saved', 'saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+
+        PivotEventsTestCollaborator::$eventsCalled = [];
+        $project->managers()->detach($user);
+        $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
+    }
+
     public function testPivotWithPivotCriteriaTriggerEventsToBeFiredOnCreateUpdateNoneOnDetach()
     {
         $user = PivotEventsTestUser::forceCreate(['email' => 'taylor@laravel.com']);
@@ -190,6 +218,13 @@ class PivotEventsTestProject extends Model
         return $this->belongsToMany(PivotEventsTestUser::class, 'project_users', 'project_id', 'user_id')
             ->using(PivotEventsTestCollaborator::class)
             ->wherePivot('role', 'contributor');
+    }
+
+    public function managers()
+    {
+        return $this->belongsToMany(PivotEventsTestUser::class, 'project_users', 'project_id', 'user_id')
+            ->using(PivotEventsTestCollaborator::class)
+            ->withPivotValue('role', 'manager');
     }
 
     public function equipments()


### PR DESCRIPTION
Fixes #55026.

* For `updateExistingPivot`, there is no extra cost in terms of performance; it's already sending a database query for fetching data when using the `updateExistingPivot` method for custom classes. ([InteractsWithPivotTable.php#L242](https://github.com/laravel/framework/blob/a4ba76e06fe6dd02312359f8184ab259900a7780/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L242))
* For `detach`, a query like `updateExistingPivot` will be run before deleting, only if the user uses a custom pivot class and `withPivotValue` (or `wherePivot`), otherwise, it's working exactly as it was working before.
* The previous version of `updateExistingPivot` used the [collection `where` method](https://github.com/laravel/framework/blob/a4ba76e06fe6dd02312359f8184ab259900a7780/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L244) instead of query builder `where` method, so I added a new method to get currently attached pivot models with related keys filter, so the `where` method will run by query builder instead of collection for better performance and not fetching data that is not needed for update/delete pivots.