### PR TITLE
[12.x] Let Collection `collect()` method accept key to collect

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1243,9 +1243,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Collect the values into a collection.
      *
+     * @param string|null $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    public function collect();
+    public function collect($key);
 
     /**
      * Get the collection of items as a plain array.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1243,7 +1243,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Collect the values into a collection.
      *
-     * @param string|null $key
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function collect($key);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -926,7 +926,7 @@ trait EnumeratesValues
     /**
      * Collect the values into a collection.
      *
-     * @param string|null $key
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function collect($key = null)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -926,11 +926,12 @@ trait EnumeratesValues
     /**
      * Collect the values into a collection.
      *
+     * @param string|null $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    public function collect()
+    public function collect($key = null)
     {
-        return new Collection($this->all());
+        return new Collection($key ? $this->get($key) : $this->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5471,6 +5471,23 @@ class SupportCollectionTest extends TestCase
             'b' => 2,
             'c' => 3,
         ], $data->all());
+		
+		$data = $collection::make([
+			'foos' => [
+				'foo',
+				'bar',
+				'baz',
+			],
+			'a' =>  1,
+		])->collect('foos');
+	    
+	    $this->assertInstanceOf(Collection::class, $data);
+		
+	    $this->assertSame([
+			'foo',
+			'bar',
+			'baz',
+		], $data->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5471,23 +5471,23 @@ class SupportCollectionTest extends TestCase
             'b' => 2,
             'c' => 3,
         ], $data->all());
-		
-		$data = $collection::make([
-			'foos' => [
-				'foo',
-				'bar',
-				'baz',
-			],
-			'a' =>  1,
-		])->collect('foos');
-	    
-	    $this->assertInstanceOf(Collection::class, $data);
-		
-	    $this->assertSame([
-			'foo',
-			'bar',
-			'baz',
-		], $data->all());
+
+        $data = $collection::make([
+            'foos' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'a' => 1,
+        ])->collect('foos');
+
+        $this->assertInstanceOf(Collection::class, $data);
+
+        $this->assertSame([
+            'foo',
+            'bar',
+            'baz',
+        ], $data->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
Sometimes it can be very handy when working with collections if you could select a key and get another collection of that key. This PR allows the `->collect()` to accept a key on Collections.

```php
$collection = collect([
   'foos' => ['foo', 'bar', 'baz'],
   'other-keys' => 'foo',
]);

$foos = $collection->collect('foos');
// Collection [foo/bar/baz]
```

Thanks!

PS: I am not sure if this is considered a breaking change because of the change in the `Enumerable` contract, or if this contract is only supposed for internal use.