### PR TITLE
[12.x] Fix support for adding custom observable events from traits

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -38,9 +38,7 @@ trait HasEvents
      */
     public static function bootHasEvents()
     {
-        static::registerModelEvent('booted', function () {
-            static::observe(static::resolveObserveAttributes());
-        });
+        static::whenBooted(fn () => static::observe(static::resolveObserveAttributes()));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -38,7 +38,9 @@ trait HasEvents
      */
     public static function bootHasEvents()
     {
-        static::observe(static::resolveObserveAttributes());
+        static::registerModelEvent('booted', function () {
+            static::observe(static::resolveObserveAttributes());
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -150,6 +151,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected static $booted = [];
 
+    protected static array $bootedCallbacks = [];
+
     /**
      * The array of trait initializers that will be called on each new instance.
      *
@@ -280,6 +283,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             static::boot();
             static::booted();
 
+            static::$bootedCallbacks[static::class] ??= [];
+
+            foreach (static::$bootedCallbacks[static::class] as $callback) {
+                $callback();
+            }
             $this->fireModelEvent('booted', false);
         }
     }
@@ -334,6 +342,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 );
             }
         }
+    }
+
+    protected static function whenBooted(Closure $callback): void
+    {
+        static::$bootedCallbacks[static::class] ??= [];
+
+        static::$bootedCallbacks[static::class][] = $callback;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -151,7 +151,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected static $booted = [];
 
-    protected static array $bootedCallbacks = [];
+    /**
+     * The callbacks that should be executed after the model has booted.
+     *
+     * @var array
+     */
+    protected static $bootedCallbacks = [];
 
     /**
      * The array of trait initializers that will be called on each new instance.
@@ -288,6 +293,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             foreach (static::$bootedCallbacks[static::class] as $callback) {
                 $callback();
             }
+
             $this->fireModelEvent('booted', false);
         }
     }
@@ -344,13 +350,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
     }
 
-    protected static function whenBooted(Closure $callback): void
-    {
-        static::$bootedCallbacks[static::class] ??= [];
-
-        static::$bootedCallbacks[static::class][] = $callback;
-    }
-
     /**
      * Initialize any initializable traits on the model.
      *
@@ -371,6 +370,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static function booted()
     {
         //
+    }
+
+    /**
+     * Register a closure to be executed after the model has booted.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    protected static function whenBooted(Closure $callback)
+    {
+        static::$bootedCallbacks[static::class] ??= [];
+
+        static::$bootedCallbacks[static::class][] = $callback;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -381,6 +381,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function clearBootedModels()
     {
         static::$booted = [];
+        static::$bootedCallbacks = [];
 
         static::$globalScopes = [];
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2293,6 +2293,35 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(EloquentModelBootingTestStub::isBooted());
     }
 
+    public function testCallbacksCanBeRunAfterBootingHasFinished()
+    {
+        $this->assertFalse(EloquentModelBootingCallbackTestStub::$bootHasFinished);
+
+        $model = new EloquentModelBootingCallbackTestStub();
+
+        $this->assertTrue($model::$bootHasFinished);
+
+        EloquentModelBootingCallbackTestStub::unboot();
+    }
+
+    public function testBootedCallbacksAreSeparatedByClass()
+    {
+        $this->assertFalse(EloquentModelBootingCallbackTestStub::$bootHasFinished);
+
+        $model = new EloquentModelBootingCallbackTestStub();
+
+        $this->assertTrue($model::$bootHasFinished);
+
+        $this->assertFalse(EloquentChildModelBootingCallbackTestStub::$bootHasFinished);
+
+        $model = new EloquentChildModelBootingCallbackTestStub();
+
+        $this->assertTrue($model::$bootHasFinished);
+
+        EloquentModelBootingCallbackTestStub::unboot();
+        EloquentChildModelBootingCallbackTestStub::unboot();
+    }
+
     public function testModelsTraitIsInitialized()
     {
         $model = new EloquentModelStubWithTrait;
@@ -3602,6 +3631,7 @@ class EloquentModelBootingTestStub extends Model
     public static function unboot()
     {
         unset(static::$booted[static::class]);
+        unset(static::$bootedCallbacks[static::class]);
     }
 
     public static function isBooted()
@@ -4120,4 +4150,31 @@ class EloquentModelWithUseFactoryAttributeFactory extends Factory
 class EloquentModelWithUseFactoryAttribute extends Model
 {
     use HasFactory;
+}
+
+trait EloquentTraitBootingCallbackTestStub
+{
+    public static function bootEloquentTraitBootingCallbackTestStub()
+    {
+        static::whenBooted(fn () => static::$bootHasFinished = true);
+    }
+}
+
+class EloquentModelBootingCallbackTestStub extends Model
+{
+    use EloquentTraitBootingCallbackTestStub;
+
+    public static bool $bootHasFinished = false;
+
+    public static function unboot()
+    {
+        unset(static::$booted[static::class]);
+        unset(static::$bootedCallbacks[static::class]);
+        static::$bootHasFinished = false;
+    }
+}
+
+class EloquentChildModelBootingCallbackTestStub extends EloquentModelBootingCallbackTestStub
+{
+    public static bool $bootHasFinished = false;
 }

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelCustomEventsTest;
 
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Event;
@@ -24,6 +25,11 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
         });
+
+        Schema::create('eloquent_model_stub_with_custom_event_from_traits', function (Blueprint $table) {
+            $table->boolean('custom_attribute');
+            $table->boolean('observer_attribute');
+        });
     }
 
     public function testFlushListenersClearsCustomEvents()
@@ -45,6 +51,20 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
 
         $this->assertTrue($_SERVER['fired_event']);
     }
+
+    public function testAddObservableEventFromTrait()
+    {
+        $model = new EloquentModelStubWithCustomEventFromTrait();
+
+        $this->assertNull($model->custom_attribute);
+        $this->assertNull($model->observer_attribute);
+
+        $model->completeCustomAction();
+
+        $this->assertTrue($model->custom_attribute);
+        $this->assertTrue($model->observer_attribute);
+    }
+
 }
 
 class TestModel1 extends Model
@@ -58,4 +78,36 @@ class TestModel1 extends Model
 class CustomEvent
 {
     //
+}
+
+trait CustomEventTrait
+{
+    public function completeCustomAction()
+    {
+        $this->custom_attribute = true;
+
+        $this->fireModelEvent('customEvent');
+    }
+
+    public function initializeCustomEventTrait()
+    {
+        $this->addObservableEvents([
+            'customEvent',
+        ]);
+    }
+}
+
+class CustomObserver
+{
+    public function customEvent(EloquentModelStubWithCustomEventFromTrait $model)
+    {
+        $model->observer_attribute = true;
+    }
+}
+
+#[ObservedBy(CustomObserver::class)]
+class EloquentModelStubWithCustomEventFromTrait extends Model {
+    use CustomEventTrait;
+
+    public $timestamps = false;
 }

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -64,7 +64,6 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
         $this->assertTrue($model->custom_attribute);
         $this->assertTrue($model->observer_attribute);
     }
-
 }
 
 class TestModel1 extends Model
@@ -106,7 +105,8 @@ class CustomObserver
 }
 
 #[ObservedBy(CustomObserver::class)]
-class EloquentModelStubWithCustomEventFromTrait extends Model {
+class EloquentModelStubWithCustomEventFromTrait extends Model
+{
     use CustomEventTrait;
 
     public $timestamps = false;


### PR DESCRIPTION
This delays the `observe` call in the boot method for the `HasEvents` trait until after the model has finished booting so that any custom events registered by other traits are available to be matched up to observer class methods.

This fixes the initial issue that was discussed in #53607 