### PR TITLE
[12.x] Allow `fillAndInsert()` usage with HasMany relationships by automatically setting the foreign key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -374,6 +374,33 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Insert into the database after merging the model's default attributes, setting timestamps, and casting values.
+     *
+     * @param  array<int, array<string, mixed>>  $values
+     * @return bool
+     */
+    public function fillAndInsert(array $values)
+    {
+        return $this->query->fillAndInsert($this->fillForInsert($values));
+    }
+
+    protected function fillForInsert(array $values)
+    {
+        if (empty($values)) {
+            return [];
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        return $this->related->unguarded(fn () => array_map(
+            fn ($value) => $this->make($value)->getAttributes(),
+            $values
+        ));
+    }
+
+    /**
      * Create a new instance of the related model without raising any events to the parent model.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -384,6 +384,28 @@ abstract class HasOneOrMany extends Relation
         return $this->query->fillAndInsert($this->fillForInsert($values));
     }
 
+    /**
+     * Insert (ignoring errors) into the database after merging the model's default attributes, setting timestamps, and casting values.
+     *
+     * @param  array<int, array<string, mixed>>  $values
+     * @return int
+     */
+    public function fillAndInsertOrIgnore(array $values)
+    {
+        return $this->query->fillAndInsertOrIgnore($this->fillForInsert($values));
+    }
+
+    /**
+     * Insert a record into the database and get its ID after merging the model's default attributes, setting timestamps, and casting values.
+     *
+     * @param  array<string, mixed>  $values
+     * @return int
+     */
+    public function fillAndInsertGetId(array $values)
+    {
+        return $this->query->fillAndInsertGetId($this->fillForInsert($values)[0]);
+    }
+
     protected function fillForInsert(array $values)
     {
         if (empty($values)) {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2686,7 +2686,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 'name' => 'ship or die',
                 'published_at' => '2025-01-31T22:18:21.000Z',
                 'status' => 3,
-                'status_string' => StringBackedStatus::Published
+                'status_string' => StringBackedStatus::Published,
             ],
             [
                 'id' => 3,


### PR DESCRIPTION
This pull request is a follow-up to #55038 introduced in **v12.6.0** by @cosmastech. While `fillAndInsert()` was successfully added to allow merging attributes before insertion, it can cause errors when used on a **HasMany** relationship if the related table enforces a NOT NULL constraint on the foreign key.

For instance, the following snippet will fail on certain table definitions:

* Repro code
  ```php
  $user->posts()->fillAndInsert([
      [ /* omission */ ]
  ]);
  ```
* Error message
  ```
  Integrity constraint violation: 19
    NOT NULL constraint failed: posts_having_uuids.user_id
  ```
* SQL
  ```sql
  insert into "posts_having_uuids"
    ("created_at", "id", "name", "published_at", "status", "status_string", "updated_at", "uuid")
  values
    /* omission */
  ```

With the current implementation (without this PR), the `user_id` column is not automatically populated, resulting in a constraint violation. This PR ensures that `fillAndInsert()` can correctly handle the foreign key column for HasMany relationships, preventing such errors.

(Above snippet and error details are included within the tests to demonstrate the exact failure under real conditions.)
