### PR TITLE
[12.x] Adds `firstValue()` to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -320,6 +320,27 @@ trait EnumeratesValues
     }
 
     /**
+     * Returns the first value that is not null from the given callback.
+     *
+     * @template TCallbackValue
+     * @template TValueDefault
+     *
+     * @param  callable(TValue, TKey): TCallbackValue|null  $callback
+     * @param  TValueDefault|(\Closure(): TValueDefault)  $default
+     * @return TCallbackValue|TValueDefault
+     */
+    public function firstValue($callback, $default = null)
+    {
+        $value = null;
+
+        $this->each(function ($item, $key) use (&$value, $callback) {
+            return is_null($value = $callback($item, $key));
+        });
+
+        return $value ?? value($default);
+    }
+
+    /**
      * Get a single key's value from the first matching item in the collection.
      *
      * @template TValueDefault

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -334,7 +334,13 @@ trait EnumeratesValues
         $value = null;
 
         $this->each(function ($item, $key) use (&$value, $callback) {
-            return is_null($value = $callback($item, $key));
+            $result = $callback($item, $key);
+
+            if (! is_null($result)) {
+                $value = $result;
+
+                return false;
+            }
         });
 
         return $value ?? value($default);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -74,6 +74,58 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testFirstValueReturnsValue($collection)
+    {
+        $data = new $collection([
+            ['index' => 1, 'value' => 'foo'],
+            ['index' => 2, 'value' => 'bar'],
+            ['index' => 3, 'value' => 'baz'],
+        ]);
+
+        $result = $data->firstValue(function ($item) {
+            if ($item['index'] === 3) {
+                return $item['value'];
+            }
+        });
+
+        $this->assertSame('baz', $result);
+
+        $result = $data->firstValue(function ($item) {
+            if ($item['index'] === 4) {
+                return $item['value'];
+            }
+        });
+
+        $this->assertNull($result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFirstValueWithDefaultReturnsValue($collection)
+    {
+        $data = new $collection([
+            ['index' => 1, 'value' => 'foo'],
+            ['index' => 2, 'value' => 'bar'],
+            ['index' => 3, 'value' => 'baz'],
+        ]);
+
+        $result = $data->firstValue(function ($item) {
+            if ($item['index'] === 3) {
+                return $item['value'];
+            }
+        }, 'default');
+
+        $this->assertSame('baz', $result);
+
+        $result = $data->firstValue(function ($item) {
+            if ($item['index'] === 4) {
+                return $item['value'];
+            }
+        }, 'default');
+
+        $this->assertSame('default', $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists($collection)
     {
         $collection = new $collection([


### PR DESCRIPTION
### What?

This PR enables allows to return a value from the first element given the value is not `null`. 

```php
use App\Models\User;

$users = User::query()->limit(10)->get();

// before
$name = $users->firstWhere(function (User $user) {
    return $user->premium_since->isFuture();
})?->name

// after
$name = $users->firstValue(function (User $user) {
    if ($user->premium_since->isFuture()) {
        return $user->name;
    }
})
```

The idea of this PR is to avoid adding a `?->something` at the end of the `firstWhere`, because sometimes adding a small tail to a code like this may be ignored by mistake. 