### PR TITLE
[12.x] Refactor Query Builder: Extract shared logic from `whereAny` and `whereAll` into a reusable method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -905,6 +905,25 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where" clause for multiple columns using "or" or "and" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  string  $booleanNested
+     * @return $this
+     */
+    protected function addNestedWhereGroup($columns, $operator = null, $value = null, $boolean = 'and', $booleanNested = 'and')
+    {
+        $callback = fn($query) => array_walk($columns,
+            fn($column) => $query->where($column, $operator, $value, $boolean)
+        );
+
+        return $this->whereNested($callback, $booleanNested);
+    }
+
+    /**
      * Add an array of where clauses to the query.
      *
      * @param  array  $column
@@ -2275,13 +2294,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'and');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addNestedWhereGroup($columns, $operator, $value, 'and', $boolean);
     }
 
     /**
@@ -2312,13 +2325,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'or');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addNestedWhereGroup($columns, $operator, $value, 'or', $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -916,8 +916,8 @@ class Builder implements BuilderContract
      */
     protected function addNestedWhereGroup($columns, $operator = null, $value = null, $boolean = 'and', $booleanNested = 'and')
     {
-        $callback = fn($query) => array_walk($columns,
-            fn($column) => $query->where($column, $operator, $value, $boolean)
+        $callback = fn ($query) => array_walk($columns,
+            fn ($column) => $query->where($column, $operator, $value, $boolean)
         );
 
         return $this->whereNested($callback, $booleanNested);


### PR DESCRIPTION
This PR refactors the `Query\Builder` class to eliminate duplicated logic between the `whereAny` and `whereAll` methods.

Both methods were doing the same thing internally — looping over the columns and applying a where clause — with only the boolean (`or `vs `and`) being different. That repeated logic has now been pulled into a new internal method: `addNestedWhereGroup`.

### Before
Both `whereAny` and `whereAll` had almost identical code blocks for building nested conditions. This made the code harder to maintain and more error-prone when changes were needed.

### After
Now both methods delegate to `addNestedWhereGroup`, which handles the common logic. This keeps things cleaner, more maintainable, and easier to reason about.