### PR TITLE
[12.x] Add `WhereNotAny`, `WhereNotAll` methods to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2335,7 +2335,61 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where not" clause to the query for multiple columns where none of the conditions should be true.
+     * Add a "where not" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotAny($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->whereAny($columns, $operator, $value, $boolean.' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query for multiple columns with "or" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereNotAny($columns, $operator = null, $value = null)
+    {
+        return $this->whereNotAny($columns, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where not" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotAll($columns, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->whereAll($columns, $operator, $value, $boolean.' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query for multiple columns with "and" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereNotAll($columns, $operator = null, $value = null)
+    {
+        return $this->whereNotAll($columns, $operator, $value, 'or');
+    }
+
+    /**
+     * Alias for the "whereNotAny" method.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
      * @param  mixed  $operator
@@ -2345,11 +2399,11 @@ class Builder implements BuilderContract
      */
     public function whereNone($columns, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereAny($columns, $operator, $value, $boolean.' not');
+        return $this->whereNotAny(...func_get_args());
     }
 
     /**
-     * Add an "or where not" clause to the query for multiple columns where none of the conditions should be true.
+     * Alias for the "orWhereNotAny" method.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
      * @param  mixed  $operator
@@ -2358,7 +2412,7 @@ class Builder implements BuilderContract
      */
     public function orWhereNone($columns, $operator = null, $value = null)
     {
-        return $this->whereNone($columns, $operator, $value, 'or');
+        return $this->orWhereNotAny(...func_get_args());
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1565,6 +1565,98 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
     }
 
+    public function testWhereNotAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAny(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where not ("email_verified_at" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testOrWhereNotAny()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" = ? or "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAny(['last_name', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" is null or "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAny(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? or "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
+    public function testWhereNotAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAll(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("email_verified_at" is null and "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? and not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotAll(['email_verified_at', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where not ("email_verified_at" is null and "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testOrWhereNotAll()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAll(['last_name', 'email'], 'like', '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAll(['last_name', 'email'], '%Otwell%');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" = ? and "email" = ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNotAll(['last_name', 'deleted_at'], null);
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" is null and "deleted_at" is null)', $builder->toSql());
+        $this->assertEquals(['%Taylor%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->whereNotAll(['last_name', 'email'], 'like', '%Otwell%', 'or');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("last_name" like ? and "email" like ?)', $builder->toSql());
+        $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+    }
+
     public function testWhereNone()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
 This PR introduces new methods to the Query Builder and refactors existing ones to enhance consistency and clarity:
 
- **`whereNotAny`**: Adds a "where not" clause for multiple columns with "or" conditions between them.
- **`orWhereNotAny`**: Adds an "or where not" clause for multiple columns with "or" conditions between them.
- **`whereNotAll`**: Adds a "where not" clause for multiple columns with "and" conditions between them.
- **`orWhereNotAll`**: Adds an "or where not" clause for multiple columns with "and" conditions between them.

Additionally, the previously existing methods `whereNone` and `orWhereNone` have been refactored to serve as aliases for `whereNotAny` and `orWhereNotAny`, respectively. This change addresses concerns regarding the naming inconsistency and potential confusion associated with the whereNone method, as discussed in [PR #52383](https://github.com/laravel/framework/pull/52383).​

The `whereNone` method's naming did not align with Laravel's established conventions, leading to potential confusion among developers. By introducing `whereNotAny` and `whereNotAll`, we adhere to a more intuitive and consistent naming pattern, enhancing code readability and maintainability. This approach also aligns with the enhancements proposed in [PR #52361](https://github.com/laravel/framework/pull/52361), ensuring a comprehensive and logical set of query builder methods.

To maintain backward compatibility, `whereNone` and `orWhereNone` have been retained as aliases. However, it is recommended that these methods be deprecated in future Laravel releases to encourage developers to adopt the more appropriately named methods.