### PR TITLE
[12.x] Temporarily prevents PHPUnit 12.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,19 +67,12 @@ jobs:
       - name: Set Framework version
         run: composer config version "12.x-dev"
 
-      - name: Set PHPUnit
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
-
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:^${{ matrix.phpunit }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit --display-deprecation ${{ matrix.stability == 'prefer-stable' && '--fail-on-deprecation' || '' }}
@@ -134,20 +127,12 @@ jobs:
       - name: Set Framework version
         run: composer config version "12.x-dev"
 
-      - name: Set PHPUnit
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^${{ matrix.phpunit }} --dev --no-interaction --no-update
-          shell: bash
-
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:^${{ matrix.phpunit }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "pda/pheanstalk": "^5.0.6",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+        "phpunit/phpunit": "^10.5.35|^11.5.3|~12.0.1",
         "predis/predis": "^2.3",
         "resend/resend-php": "^0.10.0",
         "symfony/cache": "^7.2.0",


### PR DESCRIPTION
Getting following failure with PHPUnit 12.1.0:

```
1) Illuminate\Tests\Integration\View\BladeTest::test_rendering_blade_long_maxpathlen_string_with_exact_length
ErrorException: ini_set(): open_basedir restriction in effect. File() is not within the allowed path(s): (/)

/home/runner/work/framework/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:256
```
