### PR TITLE
[12.x] Add `whereRelationAny`, `whereRelationAll` to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -524,6 +524,70 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "whereAny" condition within a relationship query.
+     *
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereRelationAny($relation, $columns, $operator = null, $value = null)
+    {
+        return $this->whereHas($relation, fn ($query) => $query->whereAny($columns, $operator, $value));
+    }
+
+    /**
+     * Add an "orWhereHas" with "whereAny" on a relationship query.
+     *
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereRelationAny($relation, $columns, $operator = null, $value = null)
+    {
+        return $this->orWhereHas($relation, fn ($query) => $query->whereAny($columns, $operator, $value));
+    }
+
+    /**
+     * Add a "whereAll" condition within a relationship query.
+     *
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereRelationAll($relation, $columns, $operator = null, $value = null)
+    {
+        return $this->whereHas($relation, fn ($query) => $query->whereAll($columns, $operator, $value));
+    }
+
+    /**
+     * Add an "orWhereHas" with "whereAll" on a relationship query.
+     *
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereRelationAll($relation, $columns, $operator = null, $value = null)
+    {
+        return $this->orWhereHas($relation, fn ($query) => $query->whereAll($columns, $operator, $value));
+    }
+
+    /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model


### PR DESCRIPTION
This PR introduces four new methods to the Eloquent Builder:

- **`whereRelationAny`**
- **`orWhereRelationAny`**
- **`whereRelationAll`**
- **`orWhereRelationAll`**

These methods are the equivalents of the existing whereAny and whereAll methods available on the base Query Builder.

They allow for more expressive and cleaner filtering when querying related models with multiple conditions, especially when using nested or grouped clauses on relationships.

### **Before:**
```PHP
Post::query()
  ->whereHas('user', fn($query) => 
    $query->whereAny(['first_name', 'last_name', 'username'], $search)
  );
  
// or
 
Post::query()
  ->whereRelation('user', 'first_name', $search)
  ->orWhereRelation('user', 'last_name', $search)
  ->orWhereRelation('user', 'username', $search);
 ```
 
###  **After:**

```PHP
Post::query()
  ->whereRelationAny('user', ['first_name', 'last_name', 'username'], $search);
```

These methods significantly improve readability and developer productivity by avoiding complex closures when applying multiple relationship filters.

Key Benefits:

1. Simplifies Relationship Queries: Reduces nested closures and repetitive whereHas/orWhereHas calls.
2. Consistent Syntax: Matches the existing whereAny/whereAll conventions in the Query Builder.
3. Improved Readability: Clear intent when querying relationships with ANY/ALL logic.

These methods maintain backward compatibility and follow Laravel’s coding standards.