### PR TITLE
[12.x] Adds `fromJson()` to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -180,6 +180,19 @@ trait EnumeratesValues
     }
 
     /**
+     * Create a new collection by decoding a JSON string.
+     *
+     * @param  string  $json
+     * @param  int  $depth
+     * @param  int  $flags
+     * @return static<TKey, TValue>
+     */
+    public static function fromJson($json, $depth = 512, $flags = 0)
+    {
+        return new static(json_decode($json, true, $depth, $flags));
+    }
+
+    /**
      * Get the average value of a given key.
      *
      * @param  (callable(TValue): float|int)|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2815,6 +2815,35 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testFromJson($collection)
+    {
+        $json = json_encode($array = ['foo' => 'bar', 'baz' => 'quz']);
+
+        $instance = $collection::fromJson($json);
+
+        $this->assertSame($array, $instance->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFromJsonWithDepth($collection)
+    {
+        $json = json_encode(['foo' => ['baz' => ['quz']], 'bar' => 'baz']);
+
+        $instance = $collection::fromJson($json, 1);
+
+        $this->assertEmpty($instance->toArray());
+        $this->assertSame(JSON_ERROR_DEPTH, json_last_error());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFromJsonWithFlags($collection)
+    {
+        $instance = $collection::fromJson('{"int":99999999999999999999999}', 512, JSON_BIGINT_AS_STRING);
+
+        $this->assertSame(['int' => '99999999999999999999999'], $instance->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testConstructMakeFromObject($collection)
     {
         $object = new stdClass;


### PR DESCRIPTION
## What?

Allows a developer to just issue a JSON string and decode it from the `Collection` class instance throught the `fromJson()` method. It receives a JSON string and accepts depth and flags parameters to pass down to the `json_encode` method.

```php
use Illuminate\Support\Collection;

public function something(string $json)
{
    return Collection::fromJson($json);
}
```

It's left to the developer if the JSON should throw an exception on error (via flag) or not.