### PR TITLE
[12.x] fix missing nullable for Query/Grammar::compileInsertGetId

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1203,7 +1203,7 @@ class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  string  $sequence
+     * @param  string|null  $sequence
      * @return string
      */
     public function compileInsertGetId(Builder $query, $values, $sequence)

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -383,7 +383,7 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  string  $sequence
+     * @param  string|null  $sequence
      * @return string
      */
     public function compileInsertGetId(Builder $query, $values, $sequence)


### PR DESCRIPTION
This PR adds `null` to `Illuminate\Database\Query\Grammar::compileInsertGetId`'s `$sequence` argument in phpdoc.

To quickly confirm, you can check this method's caller (`Query\Builder`) and you can see that the default parameter for `$sequence` is `null`.

https://github.com/laravel/framework/blob/c1c6194fb7f7dd4e4436cf67b072fbb3c7e917cb/src/Illuminate/Database/Query/Builder.php#L3761