### PR TITLE
[12.x] fix: throw MissingConditionalCallbackException when callback is null

### DIFF
--- a/src/Illuminate/Conditionable/MissingConditionalCallbackException.php
+++ b/src/Illuminate/Conditionable/MissingConditionalCallbackException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Support;
+
+use RuntimeException;
+
+class MissingConditionalCallbackException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Traits;
 
 use Closure;
 use Illuminate\Support\HigherOrderWhenProxy;
+use Illuminate\Support\MissingConditionalCallbackException;
 
 trait Conditionable
 {
@@ -31,6 +32,10 @@ trait Conditionable
         }
 
         if ($value) {
+            if ($callback === null) {
+                throw new MissingConditionalCallbackException;
+            }
+
             return $callback($this, $value) ?? $this;
         } elseif ($default) {
             return $default($this, $value) ?? $this;
@@ -63,6 +68,10 @@ trait Conditionable
         }
 
         if (! $value) {
+            if ($callback === null) {
+                throw new MissingConditionalCallbackException;
+            }
+
             return $callback($this, $value) ?? $this;
         } elseif ($default) {
             return $default($this, $value) ?? $this;

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HigherOrderWhenProxy;
+use Illuminate\Support\MissingConditionalCallbackException;
 use PHPUnit\Framework\TestCase;
 
 class ConditionableTest extends TestCase
@@ -31,6 +32,8 @@ class ConditionableTest extends TestCase
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(false, null));
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(true, function () {
         }));
+        $this->expectException(MissingConditionalCallbackException::class);
+        TestConditionableModel::query()->when(true, null);
     }
 
     public function testUnless(): void
@@ -41,6 +44,8 @@ class ConditionableTest extends TestCase
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(true, null));
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {
         }));
+        $this->expectException(MissingConditionalCallbackException::class);
+        TestConditionableModel::query()->unless(null, null);
     }
 }
 


### PR DESCRIPTION
This update improves the when() and unless() methods by explicitly throwing a MissingConditionalCallbackException when a truthy condition is passed but no callback is provided. This prevents silent failures and makes the method usage more predictable and developer-friendly.

Useful for catching logic errors where a conditional action is expected but unintentionally omitted