### PR TITLE
[12.x] Add pluckOrDefault to Collection and LazyCollection.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -788,6 +788,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Extract values for a given key from the collection, returning a default value if the key is missing or its value is null.
+     *
+     * This method retrieves the values associated with the specified key from each item in the collection.
+     * If the key does not exist in an item or its value is null, the provided default value is returned instead.
+     * The key can be a simple key or use dot notation for nested structures.
+     *
+     * @param  string|int  $value  The key to extract from each item (supports dot notation for nested data)
+     * @param  mixed  $default  The default value to return if the key is not found or its value is null (optional, defaults to null)
+     * @return static<int|string, mixed> A new collection containing the extracted values
+     */
+    public function pluckOrDefault($value, $default = null)
+    {
+        return $this->map(function ($item) use ($value, $default) {
+            $result = data_get($item, $value);
+
+            return $result === null ? $default : $result;
+        });
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @template TMapValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -795,6 +795,27 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Extract values for a given key from the collection, returning a default value if the key is missing or its value is null.
+     *
+     * This method retrieves the values associated with the specified key from each item in the collection,
+     * yielding them lazily. If the key does not exist in an item or its value is null, the provided default
+     * value is returned instead. The key can use dot notation for nested structures.
+     *
+     * @param  string|int  $value  The key to extract from each item (supports dot notation for nested data)
+     * @param  mixed  $default  The default value to return if the key is not found or its value is null (optional, defaults to null)
+     * @return static<int|string, mixed> A new lazy collection containing the extracted or default values
+     */
+    public function pluckOrDefault($value, $default = null)
+    {
+        return new static(function () use ($value, $default) {
+            foreach ($this as $item) {
+                $itemValue = data_get($item, $value);
+                yield $itemValue === null ? $default : $itemValue;
+            }
+        });
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @template TMapValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2316,6 +2316,72 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithExistingKeys($collection)
+    {
+        $data = new $collection([(object) ['name' => 'John', 'age' => 25], ['name' => 'Jane', 'age' => 30]]);
+        $result = $data->pluckOrDefault('age', 0);
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals([25, 30], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithMissingKeysAndNullValues($collection)
+    {
+        $data = new $collection([(object) ['name' => 'John', 'age' => 25], ['name' => 'Jane'], ['name' => 'Bob', 'age' => null]]);
+        $result = $data->pluckOrDefault('age', 0);
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals([25, 0, 0], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithDotNotation($collection)
+    {
+        $data = new $collection([(object) ['user' => ['age' => 25]], ['user' => ['name' => 'Jane']], ['user' => ['age' => 30]]]);
+        $result = $data->pluckOrDefault('user.age', 18);
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals([25, 18, 30], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithEmptyCollection($collection)
+    {
+        $data = new $collection([]);
+        $result = $data->pluckOrDefault('name', 'Unknown');
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals([], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithNullItems($collection)
+    {
+        $data = new $collection([(object) ['name' => 'John'], null, ['name' => 'Bob']]);
+        $result = $data->pluckOrDefault('name', 'N/A');
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals(['John', 'N/A', 'Bob'], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithDifferentDefaultTypes($collection)
+    {
+        $data = new $collection([(object) ['score' => 100], ['score' => null], []]);
+        $resultA = $data->pluckOrDefault('score', 'N/A');
+        $this->assertEquals([100, 'N/A', 'N/A'], $resultA->all());
+        $resultB = $data->pluckOrDefault('score', 0);
+        $this->assertEquals([100, 0, 0], $resultB->all());
+        $resultC = $data->pluckOrDefault('score', []);
+        $this->assertEquals([100, [], []], $resultC->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPluckOrDefaultWithoutDefault($collection)
+    {
+        $data = new $collection([(object) ['name' => 'John'], []]);
+        $result = $data->pluckOrDefault('name');
+        $this->assertInstanceOf($collection, $result);
+        $this->assertEquals(['John', null], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testHas($collection)
     {
         $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);


### PR DESCRIPTION
This PR adds pluckOrDefault to Illuminate\Support\Collection and Illuminate\Support\LazyCollection, enabling extraction of values with a default fallback for missing keys or null values. The Collection version uses map for eager processing, while LazyCollection uses a generator for lazy evaluation. The original testPluckOrDefault is refactored from one test into seven focused methods for better isolation and clarity, covering scenarios like missing keys, dot notation, and default types, tested against both classes.

```
$collection = collect([['name' => 'John'], ['age' => 25], ['name' => null]]);
$result = $collection->pluckOrDefault('name', 'N/A');
// Returns: ['John', 'N/A', 'N/A']
```