### PR TITLE
Add `safe_call()` Helper for Safe Callback Execution

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -526,3 +526,28 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (!function_exists('safe_call')) {
+    /**
+     * Execute a callback, returning a default value if an exception occurs.
+     *
+     * @param  callable  $callback
+     * @param  mixed  $default
+     * @param  string[]  $exceptions
+     * @return mixed
+     */
+    function safe_call(callable $callback, $default = null, array $exceptions = [\Throwable::class])
+    {
+        try {
+            return $callback();
+        } catch (\Throwable $e) {
+            foreach ($exceptions as $exception) {
+                if ($e instanceof $exception) {
+                    return $default;
+                }
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1266,6 +1266,27 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testSafeCallReturnsValue()
+    {
+        $result = safe_call(fn () => 'success', 'default');
+    
+        $this->assertEquals('success', $result);
+    }
+    
+    public function testSafeCallReturnsDefaultOnException()
+    {
+        $result = safe_call(fn () => throw new Exception('Test exception'), 'default');
+    
+        $this->assertEquals('default', $result);
+    }
+    
+    public function testSafeCallDoesNotCatchUnspecifiedExceptions()
+    {
+        $this->expectException(InvalidArgumentException::class);
+    
+        safe_call(fn () => throw new InvalidArgumentException('Invalid argument'), 'default', [RuntimeException::class]);
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
**Summary**

This PR introduces a new global helper function, `safe_call()`, to safely execute callbacks and return a default value when an exception occurs. It improves code readability and developer experience by reducing the need for repetitive try/catch blocks in situations where a fallback value is desired.

**Usage Example:**

```php
$result = safe_call(function () {
    return riskyOperation();
}, 'default_value');
```

If `riskyOperation()` throws an exception, the function will return `'default_value'` instead.

**Why?**

While Laravel already provides helpers like `optional()` and `rescue()`, there is still a readability gap for cases where you want a clean and semantic way to safely execute arbitrary callbacks with a fallback value — without wrapping everything in try/catch manually.

The `safe_call()` helper:
- Makes intent clear: safely attempt an operation and return a fallback value if it fails.
- Reduces boilerplate in day-to-day code.
- Can handle specific exception types if desired:
  
```php
$result = safe_call(function () {
    return anotherRiskyOperation();
}, 'default_value', [SpecificException::class]);
```

**Tests**

Unit tests have been added to `SupportHelpersTest.php` to cover:
- Successful execution.
- Exception with fallback value.
- Specific exception filtering.