### PR TITLE
Return frozen time for easier testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -15,7 +15,9 @@ trait InteractsWithTime
      */
     public function freezeTime($callback = null)
     {
-        return $this->travelTo(Carbon::now(), $callback);
+        $result = $this->travelTo($now = Carbon::now(), $callback);
+
+        return is_null($callback) ? $now : $result;
     }
 
     /**
@@ -26,7 +28,9 @@ trait InteractsWithTime
      */
     public function freezeSecond($callback = null)
     {
-        return $this->travelTo(Carbon::now()->startOfSecond(), $callback);
+        $result = $this->travelTo($now = Carbon::now()->startOfSecond(), $callback);
+
+        return is_null($callback) ? $now : $result;
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithTimeTest.php
+++ b/tests/Foundation/FoundationInteractsWithTimeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithTime;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class FoundationInteractsWithTimeTest extends TestCase
+{
+    use InteractsWithTime;
+
+    public function testFreezeTimeReturnsFrozenTime()
+    {
+        $actual = $this->freezeTime();
+
+        $this->assertTrue(Carbon::hasTestNow());
+        $this->assertInstanceOf(\DateTimeInterface::class, $actual);
+        $this->assertTrue(Carbon::getTestNow()->eq($actual));
+    }
+
+    public function testFreezeTimeReturnsCallbackResult()
+    {
+        $actual = $this->freezeTime(function () {
+            return 12345;
+        });
+
+        $this->assertSame(12345, $actual);
+        $this->assertFalse(Carbon::hasTestNow());
+    }
+
+    public function testFreezeTimeReturnsCallbackResultEvenWhenNull()
+    {
+        $actual = $this->freezeTime(function () {
+            return null;
+        });
+
+        $this->assertNull($actual);
+        $this->assertFalse(Carbon::hasTestNow());
+    }
+
+    public function testFreezeSecondReturnsFrozenTime()
+    {
+        $actual = $this->freezeSecond();
+
+        $this->assertTrue(Carbon::hasTestNow());
+        $this->assertInstanceOf(\DateTimeInterface::class, $actual);
+        $this->assertTrue(Carbon::getTestNow()->eq($actual));
+        $this->assertSame(0, $actual->milliseconds);
+    }
+
+    public function testFreezeSecondReturnsCallbackResult()
+    {
+        $actual = $this->freezeSecond(function () {
+            return 12345;
+        });
+
+        $this->assertSame(12345, $actual);
+        $this->assertFalse(Carbon::hasTestNow());
+    }
+
+    public function testFreezeSecondReturnsCallbackResultEvenWhenNull()
+    {
+        $actual = $this->freezeSecond(function () {
+            return null;
+        });
+
+        $this->assertNull($actual);
+        $this->assertFalse(Carbon::hasTestNow());
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithTimeTest.php
+++ b/tests/Foundation/FoundationInteractsWithTimeTest.php
@@ -10,6 +10,13 @@ class FoundationInteractsWithTimeTest extends TestCase
 {
     use InteractsWithTime;
 
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow();
+    }
+
     public function testFreezeTimeReturnsFrozenTime()
     {
         $actual = $this->freezeTime();


### PR DESCRIPTION
The following common test setup will often fail due to millisecond differences between "now" and the underlying data.

```php
$now = now();
Carbon::setTestNow($now);

$post->slug = $slug;
$post->save();

$package->refresh();
$this->assertTrue($now->equalTo($post->updated_at));
```

From a [quick Twitter thread](https://x.com/gonedark/status/1909598520010506733), it seems developers have wildly different approaches to get around this. However, both Laravel and Carbon provide ways around this. Just not a unified one.

This PR aims to provide that by updating Laravel's `freezeTime` and `freezeSecond` to return the "frozen time" when not passed a callback.

The above example may now be written as follows and passes out-of-the-box, providing a smoother testing DX free of time _gotchas_.

```php
$now = $this->freezeSecond();

$post->slug = $slug;
$post->save();

$package->refresh();
$this->assertTrue($now->equalTo($post->updated_at));
```


---
This should not be a breaking change as these methods were only returning a meaningful value if a callback were passed. I say _should not_ and _meaningful_ as the developer could be assigning this to a variable that would now be non-null. But that seems like a extremely minimal impact. 