### PR TITLE
[12.x] Add `App::shouldSyncLocale()` to keep helpers in line with the app locale

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -231,6 +231,14 @@ interface Application extends Container
     public function setLocale($locale);
 
     /**
+     * Indicate that the app should sync locale changes to the helpers.
+     *
+     * @param  bool  $shouldSyncLocale
+     * @return void
+     */
+    public function shouldSyncLocale($shouldSyncLocale);
+
+    /**
      * Determine if middleware has been disabled for the application.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -22,6 +22,7 @@ use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
+use Illuminate\Support\Number;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -207,6 +208,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @var string[]
      */
     protected $absoluteCachePathPrefixes = ['/', '\\'];
+
+    /**
+     * Indicates if the application's locale should be propagated to helpers.
+     *
+     * @var bool
+     */
+    protected $shouldSyncLocale = false;
 
     /**
      * Create a new Illuminate application instance.
@@ -1584,6 +1592,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         $this['translator']->setLocale($locale);
 
+        if ($this->shouldSyncLocale) {
+            Number::useLocale($locale);
+        }
+
         $this['events']->dispatch(new LocaleUpdated($locale));
     }
 
@@ -1609,6 +1621,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function isLocale($locale)
     {
         return $this->getLocale() == $locale;
+    }
+
+    /**
+     * Indicate that the app should sync locale changes to the helpers.
+     *
+     * @param  bool  $shouldSyncLocale
+     * @return void
+     */
+    public function shouldSyncLocale($shouldSyncLocale = true)
+    {
+        $this->shouldSyncLocale = $shouldSyncLocale;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -93,6 +93,7 @@ namespace Illuminate\Support\Facades;
  * @method static void setLocale(string $locale)
  * @method static void setFallbackLocale(string $fallbackLocale)
  * @method static bool isLocale(string $locale)
+ * @method static void shouldSyncLocale(bool $shouldSyncLocale = true)
  * @method static void registerCoreContainerAliases()
  * @method static void flush()
  * @method static string getNamespace()

--- a/tests/Integration/Foundation/SyncLocaleTest.php
+++ b/tests/Integration/Foundation/SyncLocaleTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Support\Number;
+use Orchestra\Testbench\TestCase;
+
+class SyncLocaleTest extends TestCase
+{
+    public function testItShouldSyncLocale()
+    {
+        $this->app->shouldSyncLocale();
+        $this->app->setLocale('es');
+
+        $this->assertSame('tres', Number::spell(3));
+    }
+}

--- a/tests/Integration/Foundation/SyncLocaleTest.php
+++ b/tests/Integration/Foundation/SyncLocaleTest.php
@@ -7,6 +7,14 @@ use Orchestra\Testbench\TestCase;
 
 class SyncLocaleTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        $this->app->setLocale('en');
+        $this->app->shouldSyncLocale(false);
+
+        parent::tearDown();
+    }
+
     public function testItShouldSyncLocale()
     {
         $this->app->shouldSyncLocale();


### PR DESCRIPTION
When using the Number helper it is possible to specify the locale. The locale's default however, is always English and doesn't change when the app's locale changes. Carbon however, does do this. This leads to the awkward situation where Carbon returns localized results (where applicable), where Number doesn't.

```php
<?php

app()->getLocale(); // "en"
now()->diffForHumans(); // "0 seconds ago"
Number::forHumans(1000); // "1 thousand"

app()->setLocale('nl');
now()->diffForHumans(); // "0 seconden geleden" 🇳🇱 👍
Number::forHumans(1000); // "1 thousand" 🇺🇸 🤔
```

Carbon's service provider listens for the LocaleUpdated event and updates its locale accordingly. This PR proposes a convience method to the Application class to do the same, as enabling this behaviour by default could be considered as a breaking change. Enabling this behaviour by default may be interesting for the next major version.