### PR TITLE
Add types to MessageBag

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -14,7 +14,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * All of the registered messages.
      *
-     * @var array
+     * @var array<string, array<string>>
      */
     protected $messages = [];
 
@@ -28,7 +28,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Create a new message bag instance.
      *
-     * @param  array  $messages
+     * @param  array<string, Arrayable|string|array<string>>  $messages
      */
     public function __construct(array $messages = [])
     {
@@ -42,7 +42,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Get the keys present in the message bag.
      *
-     * @return array
+     * @return array<string>
      */
     public function keys()
     {
@@ -95,7 +95,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Merge a new array of messages into the message bag.
      *
-     * @param  \Illuminate\Contracts\Support\MessageProvider|array  $messages
+     * @param  \Illuminate\Contracts\Support\MessageProvider|array<string, array<string>>  $messages
      * @return $this
      */
     public function merge($messages)
@@ -193,7 +193,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      *
      * @param  string  $key
      * @param  string|null  $format
-     * @return array
+     * @return array<string>|array<string, array<string>>
      */
     public function get($key, $format = null)
     {
@@ -218,7 +218,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      *
      * @param  string  $key
      * @param  string|null  $format
-     * @return array
+     * @return array<string, array<string>>
      */
     protected function getMessagesForWildcardKey($key, $format)
     {
@@ -234,7 +234,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      * Get all of the messages for every key in the message bag.
      *
      * @param  string|null  $format
-     * @return array
+     * @return array<string>
      */
     public function all($format = null)
     {
@@ -276,10 +276,10 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Format an array of messages.
      *
-     * @param  array  $messages
+     * @param  array<string>  $messages
      * @param  string  $format
      * @param  string  $messageKey
-     * @return array
+     * @return array<string>
      */
     protected function transform($messages, $format, $messageKey)
     {
@@ -310,7 +310,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Get the raw messages in the message bag.
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public function messages()
     {
@@ -320,7 +320,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Get the raw messages in the message bag.
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public function getMessages()
     {


### PR DESCRIPTION
This PR adds explicit type annotations to the `MessageBag` class, improving static analysis and overall code clarity.

**Changes include:**
- Specifying `array<string, array<string>>` for the internal `$messages` property.
- Updating docblocks for the constructor and methods like:
  - `keys()`
  - `merge()`
  - `get()`
  - `all()`
  - `transform()`
  - `messages()`
  - `getMessages()`

These updates help IDEs and static analysis tools better understand the structure of the messages.