### PR TITLE
Add types to ViewErrorBag

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -14,7 +14,7 @@ class ViewErrorBag implements Countable, Stringable
     /**
      * The array of the view error bags.
      *
-     * @var array
+     * @var array<string, \Illuminate\Contracts\Support\MessageBag>
      */
     protected $bags = [];
 
@@ -43,7 +43,7 @@ class ViewErrorBag implements Countable, Stringable
     /**
      * Get all the bags.
      *
-     * @return array
+     * @return array<string, \Illuminate\Contracts\Support\MessageBag>
      */
     public function getBags()
     {


### PR DESCRIPTION
This PR adds type annotations to the `ViewErrorBag` class to improve static analysis and developer experience.

**Changes include:**
- Updating the `$bags` property docblock to `array<string, \Illuminate\Contracts\Support\MessageBag>`.
- Updating the return type for the `getBags()` methods to reflect the same.

I don't think the failing test has anything to do with what I'm doing here.