### PR TITLE
[12.x] add generics to commonly used methods in Schema/Builder

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -39,12 +39,7 @@ class MySqlProcessor extends Processor
         return is_numeric($id) ? (int) $id : $id;
     }
 
-    /**
-     * Process the results of a columns query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processColumns($results)
     {
         return array_map(function ($result) {
@@ -71,12 +66,7 @@ class MySqlProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of an indexes query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processIndexes($results)
     {
         return array_map(function ($result) {
@@ -92,12 +82,7 @@ class MySqlProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of a foreign keys query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processForeignKeys($results)
     {
         return array_map(function ($result) {

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -30,12 +30,7 @@ class PostgresProcessor extends Processor
         return is_numeric($id) ? (int) $id : $id;
     }
 
-    /**
-     * Process the results of a types query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processTypes($results)
     {
         return array_map(function ($result) {
@@ -79,12 +74,7 @@ class PostgresProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of a columns query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processColumns($results)
     {
         return array_map(function ($result) {
@@ -112,12 +102,7 @@ class PostgresProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of an indexes query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processIndexes($results)
     {
         return array_map(function ($result) {
@@ -133,12 +118,7 @@ class PostgresProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of a foreign keys query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processForeignKeys($results)
     {
         return array_map(function ($result) {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -123,7 +123,7 @@ class Processor
     /**
      * Process the results of an indexes query.
      *
-     * @param  list<array<string, mixed>> $results
+     * @param  list<array<string, mixed>>  $results
      * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
      */
     public function processIndexes($results)

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -39,8 +39,8 @@ class Processor
     /**
      * Process the results of a schemas query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, path?: string, default?: bool}>
      */
     public function processSchemas($results)
     {
@@ -58,8 +58,8 @@ class Processor
     /**
      * Process the results of a tables query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment: string|null, collation: string|null, engine: string|null}>
      */
     public function processTables($results)
     {
@@ -81,8 +81,8 @@ class Processor
     /**
      * Process the results of a views query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, definition: string}>
      */
     public function processViews($results)
     {
@@ -101,8 +101,8 @@ class Processor
     /**
      * Process the results of a types query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, schema: string, type: string, type: string, category: string, implicit: bool}>
      */
     public function processTypes($results)
     {
@@ -112,8 +112,8 @@ class Processor
     /**
      * Process the results of a columns query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
      */
     public function processColumns($results)
     {
@@ -123,8 +123,8 @@ class Processor
     /**
      * Process the results of an indexes query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>> $results
+     * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
      */
     public function processIndexes($results)
     {
@@ -134,8 +134,8 @@ class Processor
     /**
      * Process the results of a foreign keys query.
      *
-     * @param  array  $results
-     * @return array
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string, columns: list<string>, foreign_schema: string, foreign_table: string, foreign_columns: list<string>, on_update: string, on_delete: string}>
      */
     public function processForeignKeys($results)
     {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -82,7 +82,7 @@ class Processor
      * Process the results of a views query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, definition: string}>
+     * @return list<array{name: string, schema: string, schema_qualified_name: string, definition: string}>
      */
     public function processViews($results)
     {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -40,7 +40,7 @@ class Processor
      * Process the results of a schemas query.
      *
      * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string, path?: string, default?: bool}>
+     * @return list<array{name: string, path: string|null, default: bool}>
      */
     public function processSchemas($results)
     {

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -4,13 +4,7 @@ namespace Illuminate\Database\Query\Processors;
 
 class SQLiteProcessor extends Processor
 {
-    /**
-     * Process the results of a columns query.
-     *
-     * @param  array  $results
-     * @param  string  $sql
-     * @return array
-     */
+    /** @inheritDoc */
     public function processColumns($results, $sql = '')
     {
         $hasPrimaryKey = array_sum(array_column($results, 'primary')) === 1;
@@ -57,12 +51,7 @@ class SQLiteProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of an indexes query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processIndexes($results)
     {
         $primaryCount = 0;
@@ -90,12 +79,7 @@ class SQLiteProcessor extends Processor
         return $indexes;
     }
 
-    /**
-     * Process the results of a foreign keys query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processForeignKeys($results)
     {
         return array_map(function ($result) {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -55,12 +55,7 @@ class SqlServerProcessor extends Processor
         return is_object($row) ? $row->insertid : $row['insertid'];
     }
 
-    /**
-     * Process the results of a columns query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processColumns($results)
     {
         return array_map(function ($result) {
@@ -90,12 +85,7 @@ class SqlServerProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of an indexes query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processIndexes($results)
     {
         return array_map(function ($result) {
@@ -111,12 +101,7 @@ class SqlServerProcessor extends Processor
         }, $results);
     }
 
-    /**
-     * Process the results of a foreign keys query.
-     *
-     * @param  array  $results
-     * @return array
-     */
+    /** @inheritDoc */
     public function processForeignKeys($results)
     {
         return array_map(function ($result) {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -149,7 +149,7 @@ class Builder
     /**
      * Get the schemas that belong to the connection.
      *
-     * @return array
+     * @return list<array{name: string, path?: string, default?: bool}>
      */
     public function getSchemas()
     {
@@ -208,7 +208,7 @@ class Builder
      * Get the tables that belong to the connection.
      *
      * @param  string|string[]|null  $schema
-     * @return array
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment: string|null, collation: string|null, engine: string|null}>
      */
     public function getTables($schema = null)
     {
@@ -222,7 +222,7 @@ class Builder
      *
      * @param  string|string[]|null  $schema
      * @param  bool  $schemaQualified
-     * @return array
+     * @return list<string>
      */
     public function getTableListing($schema = null, $schemaQualified = true)
     {
@@ -236,7 +236,7 @@ class Builder
      * Get the views that belong to the connection.
      *
      * @param  string|string[]|null  $schema
-     * @return array
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, definition: string}>
      */
     public function getViews($schema = null)
     {
@@ -249,7 +249,7 @@ class Builder
      * Get the user-defined types that belong to the connection.
      *
      * @param  string|string[]|null  $schema
-     * @return array
+     * @return list<array{name: string, schema: string, type: string, type: string, category: string, implicit: bool}>
      */
     public function getTypes($schema = null)
     {
@@ -276,7 +276,7 @@ class Builder
      * Determine if the given table has given columns.
      *
      * @param  string  $table
-     * @param  array  $columns
+     * @param  array<string>  $columns
      * @return bool
      */
     public function hasColumns($table, array $columns)
@@ -347,7 +347,7 @@ class Builder
      * Get the column listing for a given table.
      *
      * @param  string  $table
-     * @return array
+     * @return list<string>
      */
     public function getColumnListing($table)
     {
@@ -358,7 +358,7 @@ class Builder
      * Get the columns for a given table.
      *
      * @param  string  $table
-     * @return array
+     * @return list<array{name: string, type: string, type_name: string, nullable: bool, default: mixed, auto_increment: bool, comment: string|null, generation: array{type: string, expression: string|null}|null}>
      */
     public function getColumns($table)
     {
@@ -377,7 +377,7 @@ class Builder
      * Get the indexes for a given table.
      *
      * @param  string  $table
-     * @return array
+     * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
      */
     public function getIndexes($table)
     {
@@ -396,7 +396,7 @@ class Builder
      * Get the names of the indexes for a given table.
      *
      * @param  string  $table
-     * @return array
+     * @return list<string>
      */
     public function getIndexListing($table)
     {
@@ -506,7 +506,7 @@ class Builder
      * Drop columns from a table schema.
      *
      * @param  string  $table
-     * @param  string|array  $columns
+     * @param  string|array<string>  $columns
      * @return void
      */
     public function dropColumns($table, $columns)

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -149,7 +149,7 @@ class Builder
     /**
      * Get the schemas that belong to the connection.
      *
-     * @return list<array{name: string, path?: string, default?: bool}>
+     * @return list<array{name: string, path: string|null, default: bool}>
      */
     public function getSchemas()
     {

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -30,12 +30,7 @@ class SQLiteBuilder extends Builder
         return ! File::exists($name) || File::delete($name);
     }
 
-    /**
-     * Get the tables that belong to the connection.
-     *
-     * @param  string|string[]|null  $schema
-     * @return array
-     */
+    /** @inheritDoc */
     public function getTables($schema = null)
     {
         try {
@@ -65,12 +60,7 @@ class SQLiteBuilder extends Builder
         );
     }
 
-    /**
-     * Get the views that belong to the connection.
-     *
-     * @param  string|string[]|null  $schema
-     * @return array
-     */
+    /** @inheritDoc */
     public function getViews($schema = null)
     {
         $schema ??= array_column($this->getSchemas(), 'name');
@@ -86,12 +76,7 @@ class SQLiteBuilder extends Builder
         return $this->connection->getPostProcessor()->processViews($views);
     }
 
-    /**
-     * Get the columns for a given table.
-     *
-     * @param  string  $table
-     * @return array
-     */
+    /** @inheritDoc */
     public function getColumns($table)
     {
         [$schema, $table] = $this->parseSchemaAndTable($table);


### PR DESCRIPTION
I added generics to commonly used methods in `Illuminate/Database/Schema/Builder` (and related Processors) for better static type checking and better code completion when using IDEs.

The methods are

- getSchemas
- getTables
- getTableListing
- getViews
- getTypes
- hasColumns
- getColumnListing
- getColumns
- dropColumns
- getIndexes
- getIndexListing