### PR TITLE
Enhance DetectsLostConnections to Support AWS Aurora Credential Rotation Scenario

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -65,6 +65,7 @@ trait DetectsLostConnections
             'SSL: Handshake timed out',
             'SSL error: sslv3 alert unexpected message',
             'unrecognized SSL error code:',
+            'SQLSTATE[HY000] [1045] Access denied for user',
             'SQLSTATE[HY000] [2002] No connection could be made because the target machine actively refused it',
             'SQLSTATE[HY000] [2002] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond',
             'SQLSTATE[HY000] [2002] Network is unreachable',


### PR DESCRIPTION
### Summary
This pull request adds an additional connection error message to the DetectsLostConnections trait to better handle AWS Aurora database configurations that use AWS Secrets Manager with automatic password rotation.

### Context
When Laravel is used in conjunction with Amazon Aurora and AWS Secrets Manager for managing database credentials, it's common for credentials to rotate automatically (e.g., weekly). If a long-running process (such as a queue worker or a job) is in progress during a credential rotation, any subsequent query attempts may fail with the following error:

`SQLSTATE[HY000] [1045] Access denied for user 'username'@'host' (using password: YES)`

This error is currently not interpreted by Laravel as a "lost connection", even though it effectively is one in this context — since the stored credentials have expired or changed mid-process.

### Solution
This PR explicitly adds the following error message pattern to the DetectsLostConnections trait:

`SQLSTATE[HY000] [1045] Access denied for user`

This helps Laravel detect these kinds of "soft" lost connections that result from credentials rotating behind the scenes.

### Why This Matters
- Ensures Laravel can gracefully handle rotated secrets and attempt reconnects instead of failing fatally.
- Improves DX (developer experience) when using modern cloud-native database setups.
- Aligns with Laravel's principle of building robust and developer-friendly systems that handle real-world cloud infra cases.

### Notes
- This change is backward-compatible and only adds one more string check to the list of known lost connection errors.
- It targets a very specific but increasingly common cloud architecture use case.