### PR TITLE
[12.x] Rename test method of failedRequest()

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2362,7 +2362,7 @@ class HttpClientTest extends TestCase
         ]);
     }
 
-    public function testRequestException()
+    public function testFailedRequest()
     {
         $requestException = $this->factory->failedRequest(['code' => 'not_found'], 404, ['X-RateLimit-Remaining' => 199]);
 


### PR DESCRIPTION
This renames the test name to be in line with the function name, that was renamed in https://github.com/laravel/framework/commit/780154c6f0b640602c010c16a0bb872ff75e2fb7. I just noticed it by looking through the resent git history.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
