### PR TITLE
[12.x] Add QueriedBy attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/QueriedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/QueriedBy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class QueriedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Builder<*>>  $builderClass
+     */
+    public function __construct(public string $builderClass)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/HasBuilder.php
+++ b/src/Illuminate/Database/Eloquent/HasBuilder.php
@@ -2,11 +2,21 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
+use ReflectionClass;
+
 /**
  * @template TBuilder of \Illuminate\Database\Eloquent\Builder
  */
 trait HasBuilder
 {
+    /**
+     * The resolved builder class names by model.
+     *
+     * @var array<class-string<static>, class-string<TBuilder>>
+     */
+    protected static array $resolvedBuilderClasses = [];
+
     /**
      * Begin querying the model.
      *
@@ -120,5 +130,23 @@ trait HasBuilder
     public static function with($relations)
     {
         return parent::with($relations);
+    }
+
+    /**
+     * Resolve the builder class name from the QueriedBy attribute.
+     *
+     * @return class-string<TBuilder>|null
+     */
+    public function resolveBuilderFromAttribute()
+    {
+        $reflectionClass = new ReflectionClass(static::class);
+
+        $attributes = $reflectionClass->getAttributes(QueriedBy::class);
+
+        if (! isset($attributes[0]) || ! isset($attributes[0]->getArguments()[0])) {
+            return;
+        }
+
+        return $attributes[0]->getArguments()[0];
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -44,6 +44,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
+    /** @use HasBuilder<\Illuminate\Database\Eloquent\Builder<static>> */
+    use HasBuilder;
 
     /**
      * The connection name for the model.
@@ -1651,7 +1653,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new static::$builder($query);
+        static::$resolvedBuilderClasses[static::class] ??= ($this->resolveBuilderFromAttribute() ?? static::$builder);
+
+        return new static::$resolvedBuilderClasses[static::class]($query);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -17,6 +17,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
@@ -3319,6 +3320,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertInstanceOf(CustomEloquentCollection::class, $collection);
     }
 
+    public function testQueriedByAttribute()
+    {
+        $model = new EloquentModelWithQueriedByAttribute;
+        $builder = $model->newQuery();
+
+        $this->assertInstanceOf(CustomEloquentBuilder::class, $builder);
+    }
+
     public function testUseFactoryAttribute()
     {
         $model = new EloquentModelWithUseFactoryAttribute;
@@ -4177,4 +4186,17 @@ class EloquentModelBootingCallbackTestStub extends Model
 class EloquentChildModelBootingCallbackTestStub extends EloquentModelBootingCallbackTestStub
 {
     public static bool $bootHasFinished = false;
+}
+
+#[QueriedBy(CustomEloquentBuilder::class)]
+class EloquentModelWithQueriedByAttribute extends Model
+{
+    public function newQuery()
+    {
+        return $this->newEloquentBuilder(m::mock(BaseBuilder::class));
+    }
+}
+
+class CustomEloquentBuilder extends Builder
+{
 }

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Types\Model;
 
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+use Illuminate\Database\Eloquent\Attributes\QueriedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\HasBuilder;
 use Illuminate\Database\Eloquent\HasCollection;
 use Illuminate\Database\Eloquent\Model;
 use User;
@@ -38,6 +41,9 @@ function test(User $user, Post $post, Comment $comment, Article $article): void
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->withoutTrashed());
     assertType('Illuminate\Database\Eloquent\Builder<User>', $user->prunable());
     assertType('Illuminate\Database\Eloquent\Relations\MorphMany<Illuminate\Notifications\DatabaseNotification, User>', $user->notifications());
+
+    assertType('Illuminate\Types\Model\ArticleBuilder<Illuminate\Types\Model\Article>', Article::query());
+    assertType('Illuminate\Types\Model\ArticleBuilder<Illuminate\Types\Model\Article>', $article->newQuery());
 
     assertType('Illuminate\Database\Eloquent\Collection<(int|string), User>', $user->newCollection([new User()]));
     assertType('Illuminate\Types\Model\Posts<(int|string), Illuminate\Types\Model\Post>', $post->newCollection(['foo' => new Post()]));
@@ -84,10 +90,14 @@ final class Comments extends Collection
 }
 
 #[CollectedBy(Articles::class)]
+#[QueriedBy(ArticleBuilder::class)]
 class Article extends Model
 {
     /** @use HasCollection<Articles<array-key, static>> */
     use HasCollection;
+
+    /** @use HasBuilder<ArticleBuilder<static>> */
+    use HasBuilder;
 }
 
 /**
@@ -96,5 +106,13 @@ class Article extends Model
  *
  * @extends Collection<TKey, TModel> */
 class Articles extends Collection
+{
+}
+
+/**
+ * @template TModel of Article
+ *
+ * @extends Builder<TModel> */
+class ArticleBuilder extends Builder
 {
 }


### PR DESCRIPTION
This pull request adds a new `QueriedBy` attribute for specifying a custom Builder class for a model.

```php
#[QueriedBy(UserBuilder::class)]
class User extends Model
{
    // ...
}
```

This addition would complement existing attributes like `CollectedBy`, `ScopedBy`, and `ObservedBy` attributes.

Personal notes:
- Looking at [Google Trends](https://trends.google.com/trends/explore), it seems like custom query builders are about as popular as, say, custom collections- so this might be a nice addition to the framework.
- In many projects I’ve been involved with, custom query builders are used frequently.