### PR TITLE
[12.x] Add `percentageDifference` method

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -133,6 +133,28 @@ class Number
     }
 
     /**
+     * Get the percentage difference between two numbers.
+     *
+     * @param int|float $firstNumber
+     * @param int|float $secondNumber
+     * @param int $precision
+     * @param int|null $maxPrecision
+     * @param string|null $locale
+     * @return false|string
+     */
+    public static function percentageDifference(int|float $firstNumber, int|float $secondNumber, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null): false|string
+    {
+        $denominator = ($firstNumber + $secondNumber) / 2;
+
+        if ($denominator === 0) {
+            return static::percentage(0, $precision, $maxPrecision, $locale);
+        }
+
+        $difference = abs($firstNumber - $secondNumber) / $denominator * 100;
+        return static::percentage(round($difference, $precision), $precision, $maxPrecision, $locale);
+    }
+
+    /**
      * Convert the given number to its currency equivalent.
      *
      * @param  int|float  $number

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -138,6 +138,21 @@ class SupportNumberTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
+    public function testToPercentDifference()
+    {
+        $this->assertSame('0%', Number::percentageDifference(0, 0));
+        $this->assertSame('200%', Number::percentageDifference(0, 1));
+        $this->assertSame('200.00%', Number::percentageDifference(1, 0, precision: 2));
+
+        $this->assertSame('67%', Number::percentageDifference(2, 1));
+        $this->assertSame('66.67%', Number::percentageDifference(1, 2, precision: 2));
+
+        $this->assertSame('22%', Number::percentageDifference(1, 1.25));
+        $this->assertSame('22.22%', Number::percentageDifference(1, 1.25, precision: 2));
+        $this->assertSame('22.222%', Number::percentageDifference(1, 1.25, precision: 3));
+    }
+
+    #[RequiresPhpExtension('intl')]
     public function testToCurrency()
     {
         $this->assertSame('$0.00', Number::currency(0));


### PR DESCRIPTION
This pull request adds `percentageDifference` method for `Number` Helper
```php
Number::percentageDifference(1, 2); //67%

Number::percentageDifference(1, 2, precision: 2); //66.67%
```
