### PR TITLE
[12.x] Add typed getters for translations

### DIFF
--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -7,6 +7,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool has(string $key, string|null $locale = null, bool $fallback = true)
  * @method static string|array get(string $key, array $replace = [], string|null $locale = null, bool $fallback = true)
  * @method static string choice(string $key, \Countable|int|float|array $number, array $replace = [], string|null $locale = null)
+ * @method static string string(string $key, array $replace = [], string|null $locale = null, bool $fallback = true)
+ * @method static array array(string $key, array $replace = [], string|null $locale = null, bool $fallback = true)
  * @method static void addLines(array $lines, string $locale, string $namespace = '*')
  * @method static void load(string $namespace, string $group, string $locale)
  * @method static \Illuminate\Translation\Translator handleMissingKeysUsing(callable|null $callback)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -219,6 +219,50 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
+     * Get the specified string translation value for the given key.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return string
+     */
+    public function string($key, array $replace = [], $locale = null, $fallback = true)
+    {
+        $value = $this->get($key, $replace, $locale, $fallback);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Translation value for key [%s] for locale [%s] must be a string, %s given.', $key, $locale, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array translation value for the given key.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return array
+     */
+    public function array($key, array $replace = [], $locale = null, $fallback = true)
+    {
+        $value = $this->get($key, $replace, $locale, $fallback);
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Translation value for key [%s] for locale [%s] must be an array, %s given.', $key, $locale, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the proper locale for a choice operation.
      *
      * @param  string  $key

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -333,6 +333,48 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo'));
     }
 
+    public function testItGetsAsString(): void
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'foo']);
+
+        $this->assertSame('foo', $t->string('foo.bar', [], 'en'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Translation value for key \[foo.bar\] for locale \[en\] must be a string, (.*) given.#');
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => ['foo' => 'foo']]);
+
+        $t->string('foo.bar', [], 'en');
+    }
+
+    public function testItGetsAsArray(): void
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => ['foo' => 'foo']]);
+
+        $this->assertSame(['foo' => 'foo'], $t->array('foo.bar', [], 'en'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonArrayValueAsArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Translation value for key \[foo.bar\] for locale \[en\] must be an array, (.*) given.#');
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'foo']);
+
+        $t->array('foo.bar', [], 'en');
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
This PR adds support for typed getters for translations, identical to the configuration > https://laravel.com/docs/12.x/configuration#accessing-configuration-values

**The problem:**

All of Laravel translation helpers/methods (`__`, `trans`, `Lang::get`) except `trans_choice` and `Lang::choice` return string|array. If we use PHPStan, then something like this:

```php
TextInput::make('name')
    ->label(Lang::get('user.name.label'))
```

throws:

`Parameter #1 $label of method Filament\Forms\Components\Component::label() expects Closure|Illuminate\Contracts\Support\Htmlable|string|null, array|string given.`

**The solution:**

This PR adds 2 new translation retrieval methods: `Lang::string` and `Lang::array`.  If the retrieved translation value does not match the expected type, an exception will be thrown.