### PR TITLE
feat: Add a callback to be called on transaction failure

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -16,12 +16,12 @@ trait ManagesTransactions
      *
      * @param  (\Closure(static): TReturn)  $callback
      * @param  int  $attempts
-     * @param  Closure|null  $onFailureCallback
+     * @param  Closure|null  $onFailure
      * @return TReturn
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailureCallback = null)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailure = null)
     {
         for ($currentAttempt = 1; $currentAttempt <= $attempts; $currentAttempt++) {
             $this->beginTransaction();
@@ -38,7 +38,7 @@ trait ManagesTransactions
             // exception back out, and let the developer handle an uncaught exception.
             catch (Throwable $e) {
                 $this->handleTransactionException(
-                    $e, $currentAttempt, $attempts, $onFailureCallback
+                    $e, $currentAttempt, $attempts, $onFailure
                 );
 
                 continue;
@@ -79,12 +79,12 @@ trait ManagesTransactions
      * @param  \Throwable  $e
      * @param  int  $currentAttempt
      * @param  int  $maxAttempts
-     * @param Closure|null $onFailureCallback
+     * @param Closure|null $onFailure
      * @return void
      *
      * @throws \Throwable
      */
-    protected function handleTransactionException(Throwable $e, $currentAttempt, $maxAttempts, ?Closure $onFailureCallback)
+    protected function handleTransactionException(Throwable $e, $currentAttempt, $maxAttempts, ?Closure $onFailure)
     {
         // On a deadlock, MySQL rolls back the entire transaction so we can't just
         // retry the query. We have to throw this exception all the way out and
@@ -110,8 +110,8 @@ trait ManagesTransactions
             return;
         }
 
-        if ($onFailureCallback !== null) {
-            $onFailureCallback($e);
+        if ($onFailure !== null) {
+            $onFailure($e);
         }
 
         throw $e;

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -131,11 +131,12 @@ interface ConnectionInterface
      *
      * @param  \Closure  $callback
      * @param  int  $attempts
+     * @param  Closure|null  $onFailureCallback
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1);
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailureCallback = null);
 
     /**
      * Start a new database transaction.

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -131,12 +131,12 @@ interface ConnectionInterface
      *
      * @param  \Closure  $callback
      * @param  int  $attempts
-     * @param  Closure|null  $onFailureCallback
+     * @param  Closure|null  $onFailure
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailureCallback = null);
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailure = null);
 
     /**
      * Start a new database transaction.

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -27,16 +27,16 @@ class SqlServerConnection extends Connection
      *
      * @param  \Closure  $callback
      * @param  int  $attempts
-     * @param  Closure|null  $onFailureCallback
+     * @param  Closure|null  $onFailure
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailureCallback = null)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailure = null)
     {
         for ($a = 1; $a <= $attempts; $a++) {
             if ($this->getDriverName() === 'sqlsrv') {
-                return parent::transaction($callback, $attempts, $onFailureCallback);
+                return parent::transaction($callback, $attempts, $onFailure);
             }
 
             $this->getPdo()->exec('BEGIN TRAN');
@@ -56,8 +56,8 @@ class SqlServerConnection extends Connection
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
 
-                if ($a === $attempts && $onFailureCallback !== null) {
-                    $onFailureCallback($e);
+                if ($a === $attempts && $onFailure !== null) {
+                    $onFailure($e);
                 }
 
                 throw $e;

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -27,15 +27,16 @@ class SqlServerConnection extends Connection
      *
      * @param  \Closure  $callback
      * @param  int  $attempts
+     * @param  Closure|null  $onFailureCallback
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailureCallback = null)
     {
         for ($a = 1; $a <= $attempts; $a++) {
             if ($this->getDriverName() === 'sqlsrv') {
-                return parent::transaction($callback, $attempts);
+                return parent::transaction($callback, $attempts, $onFailureCallback);
             }
 
             $this->getPdo()->exec('BEGIN TRAN');
@@ -54,6 +55,10 @@ class SqlServerConnection extends Connection
             // be handled how the developer sees fit for their applications.
             catch (Throwable $e) {
                 $this->getPdo()->exec('ROLLBACK TRAN');
+
+                if ($a === $attempts && $onFailureCallback !== null) {
+                    $onFailureCallback($e);
+                }
 
                 throw $e;
             }

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -105,6 +105,42 @@ class DatabaseTransactionsTest extends DatabaseTestCase
         $this->assertTrue($secondObject->ran);
         $this->assertFalse($thirdObject->ran);
     }
+
+    public function testOnErrorCallbackIsCalled()
+    {
+        $executed = false;
+        try {
+            DB::transaction(function () {
+                throw new \Exception;
+            }, 1, function () use (&$executed) {
+                $executed = true;
+            });
+        } catch (\Throwable) {
+            // Ignore the exception
+        }
+
+        $this->assertTrue($executed);
+    }
+
+    public function testOnErrorCallbackIsCalledWithDeadlockRetry()
+    {
+        $executed = false;
+        $attempts = 0;
+
+        try {
+            DB::transaction(function () use (&$attempts) {
+                $attempts += 1;
+                throw new \Exception('has been chosen as the deadlock victim');
+            }, 3, function () use (&$executed) {
+                $executed = true;
+            });
+        } catch (\Throwable) {
+            // Ignore the exception
+        }
+
+        $this->assertSame(3, $attempts);
+        $this->assertTrue($executed);
+    }
 }
 
 class TestObjectForTransactions


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new argument to `DB::transaction()` that allows you to pass in a callback to be executed when the transaction fails:

```php
DB::transaction(function () {
 // do DB stuff
}, onFailureCallback: function () {
    Notification::send($admin, new SomethingImportantBroke());
});
```