### PR TITLE
Support dot notation for `Request::post()` and `Request::query()`

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -134,7 +134,7 @@ trait InteractsWithInput
      */
     public function query($key = null, $default = null)
     {
-        return $this->retrieveItem('query', $key, $default);
+        return data_get($this->retrieveItem('query', null, $default), $key, $default);
     }
 
     /**
@@ -146,7 +146,7 @@ trait InteractsWithInput
      */
     public function post($key = null, $default = null)
     {
-        return $this->retrieveItem('request', $key, $default);
+        return data_get($this->retrieveItem('request', null, $default), $key, $default);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\InteractsWithData;
 use SplFileInfo;
@@ -146,7 +147,17 @@ trait InteractsWithInput
      */
     public function post($key = null, $default = null)
     {
-        return data_get($this->retrieveItem('request', null, $default), $key, $default);
+        $postValues = $this->retrieveItem('request', null, $default);
+
+        if (is_null($key)) {
+            return $postValues;
+        }
+
+        if (Str::contains($key, '.')) {
+            return $postValues[$key] ?? data_get($postValues, $key, $default);
+        }
+
+        return $postValues[$key] ?? $default;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -976,6 +976,11 @@ class HttpRequestTest extends TestCase
         $this->assertSame(['from' => '2025-04-09', 'to' => '2025-04-10'], $request->query('date'));
         $this->assertSame('2025-04-09', $request->query('date.from'));
         $this->assertSame('2025-04-10', $request->query('date.to'));
+
+        // PHP replaces dots in query parameters witih underscores.
+        $request = Request::create('/?date.from=2025-04-09', 'GET');
+        $this->assertSame(['date_from' => '2025-04-09'], $request->query());
+        $this->assertSame('2025-04-09', $request->query('date_from'));
     }
 
     public function testPostMethod()
@@ -992,6 +997,10 @@ class HttpRequestTest extends TestCase
         $this->assertSame(['from' => '2025-04-09', 'to' => '2025-04-10'], $request->post('date'));
         $this->assertSame('2025-04-09', $request->post('date.from'));
         $this->assertSame('2025-04-10', $request->post('date.to'));
+
+        $request = Request::create('/', 'POST', ['date.from' => '2025-04-09']);
+        $this->assertSame(['date.from' => '2025-04-09'], $request->post());
+        $this->assertSame('2025-04-09', $request->post('date.from'));
     }
 
     public function testCookieMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -971,6 +971,11 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/?hello=world&user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
         $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
         $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
+
+        $request = Request::create('/?date[from]=2025-04-09&date[to]=2025-04-10', 'GET', []);
+        $this->assertSame(['from' => '2025-04-09', 'to' => '2025-04-10'], $request->query('date'));
+        $this->assertSame('2025-04-09', $request->query('date.from'));
+        $this->assertSame('2025-04-10', $request->query('date.to'));
     }
 
     public function testPostMethod()
@@ -982,6 +987,11 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Bob', $request->post('foo', 'Bob'));
         $all = $request->post(null);
         $this->assertSame('Taylor', $all['name']);
+
+        $request = Request::create('/', 'POST', ['date' => ['from' => '2025-04-09', 'to' => '2025-04-10']]);
+        $this->assertSame(['from' => '2025-04-09', 'to' => '2025-04-10'], $request->post('date'));
+        $this->assertSame('2025-04-09', $request->post('date.from'));
+        $this->assertSame('2025-04-10', $request->post('date.to'));
     }
 
     public function testCookieMethod()


### PR DESCRIPTION
This fixes inconsistencies between `Request::input()` and the `post()` and `query()` methods as mentioned in #55337.

Edit: I see that this might be breaking if someone uses actual dots in their query param keys or post keys though. Any thoughts regarding how to deal with that are much appreciated.

Edit 2: upon investigation it seems that dots in query parameters keys are replaced with `_` in PHP (according to https://github.com/symfony/symfony/issues/9009). For `post()` I will make it backwards compatible in case anyone uses actual dots in their keys.