### PR TITLE
Add a response timing mechanism to measure it

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -79,7 +79,7 @@ class TestResponse implements ArrayAccess
      * @var float|null
      */
     protected $endTime;
-    
+
     /**
      * Create a new test response instance.
      *
@@ -1899,7 +1899,7 @@ class TestResponse implements ArrayAccess
         return $this->baseResponse->{$method}(...$args);
     }
 
-     /**
+    /**
      * Assert that the response time is less than or equal to a given threshold in milliseconds.
      *
      * @param  int  $milliseconds

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2864,6 +2864,77 @@ class TestResponseTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function testCanGetResponseTime()
+    {
+        define('LARAVEL_START', microtime(true) - 0.1);
+        
+        $baseResponse = new Response([
+            'data' => ['foo' => 'bar'],
+        ]);
+        $response = new TestResponse($baseResponse);
+        
+        $responseTime = $response->getResponseTimeInMs();
+        
+        $this->assertIsFloat($responseTime);
+        $this->assertGreaterThan(0, $responseTime);
+        $this->assertLessThan(200, $responseTime);
+    }
+
+    public function testCanAssertResponseTimeUnder()
+    {
+        define('LARAVEL_START', microtime(true) - 0.1);
+        
+        $baseResponse = new Response([
+            'data' => ['foo' => 'bar'],
+        ]);
+        $response = new TestResponse($baseResponse);
+        
+        $response->assertResponseTimeUnder(200);
+        
+        try {
+            $response->assertResponseTimeUnder(50);
+            $this->fail('Expected assertion to fail');
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+            $this->assertStringContainsString('Response time of', $e->getMessage());
+        }
+    }
+
+    public function testCanAssertResponseTimeUnderOrEqual()
+    {
+        define('LARAVEL_START', microtime(true) - 0.1);
+        
+        $baseResponse = new Response([
+            'data' => ['foo' => 'bar'],
+        ]);
+        $response = new TestResponse($baseResponse);
+        
+        $response->assertResponseTimeUnderOrEqual(200);
+        
+        try {
+            $response->assertResponseTimeUnderOrEqual(50);
+            $this->fail('Expected assertion to fail');
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+            $this->assertStringContainsString('Response time of', $e->getMessage());
+        }
+    }
+
+    public function testResponseTimeRequiresLaravelStart()
+    {
+        $baseResponse = new Response([
+            'data' => ['foo' => 'bar'],
+        ]);
+        $response = new TestResponse($baseResponse);
+        
+        $this->assertNull($response->getResponseTimeInMs());
+        
+        try {
+            $response->assertResponseTimeUnder(100);
+            $this->fail('Expected assertion to fail');
+        } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
+            $this->assertStringContainsString('LARAVEL_START', $e->getMessage());
+        }
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2867,14 +2867,14 @@ class TestResponseTest extends TestCase
     public function testCanGetResponseTime()
     {
         define('LARAVEL_START', microtime(true) - 0.1);
-        
+
         $baseResponse = new Response([
             'data' => ['foo' => 'bar'],
         ]);
         $response = new TestResponse($baseResponse);
-        
+
         $responseTime = $response->getResponseTimeInMs();
-        
+
         $this->assertIsFloat($responseTime);
         $this->assertGreaterThan(0, $responseTime);
         $this->assertLessThan(200, $responseTime);
@@ -2883,14 +2883,14 @@ class TestResponseTest extends TestCase
     public function testCanAssertResponseTimeUnder()
     {
         define('LARAVEL_START', microtime(true) - 0.1);
-        
+
         $baseResponse = new Response([
             'data' => ['foo' => 'bar'],
         ]);
         $response = new TestResponse($baseResponse);
-        
+
         $response->assertResponseTimeUnder(200);
-        
+
         try {
             $response->assertResponseTimeUnder(50);
             $this->fail('Expected assertion to fail');
@@ -2902,14 +2902,14 @@ class TestResponseTest extends TestCase
     public function testCanAssertResponseTimeUnderOrEqual()
     {
         define('LARAVEL_START', microtime(true) - 0.1);
-        
+
         $baseResponse = new Response([
             'data' => ['foo' => 'bar'],
         ]);
         $response = new TestResponse($baseResponse);
-        
+
         $response->assertResponseTimeUnderOrEqual(200);
-        
+
         try {
             $response->assertResponseTimeUnderOrEqual(50);
             $this->fail('Expected assertion to fail');
@@ -2924,9 +2924,9 @@ class TestResponseTest extends TestCase
             'data' => ['foo' => 'bar'],
         ]);
         $response = new TestResponse($baseResponse);
-        
+
         $this->assertNull($response->getResponseTimeInMs());
-        
+
         try {
             $response->assertResponseTimeUnder(100);
             $this->fail('Expected assertion to fail');


### PR DESCRIPTION
Add support for response timing/performance testing, which is currently missing from the framework but would be valuable for developers.

Here's what I propose to add:

1. A response timing mechanism to measure response time
2. Methods to assert response time thresholds
3. Helpful performance-related assertions

Add some test fo

- Tests for getting response time
- Tests for asserting response time thresholds
- Tests for handling missing LARAVEL_START
- Tests for both successful and failing assertions

This enhancement allows developers to write performance tests like:
```PHP
public function test_homepage_loads_quickly()
{
    $response = $this->get('/');
    
    $response->assertOk()
             ->assertResponseTimeUnder(500); // Assert response takes less than 500ms
}
```