### PR TITLE
[12.x] Fix translation FileLoader overrides with a missing key

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -102,15 +102,15 @@ class FileLoader implements Loader
     protected function loadNamespaceOverrides(array $lines, $locale, $group, $namespace)
     {
         return (new Collection($this->paths))
-            ->reduce(function ($output, $path) use ($lines, $locale, $group, $namespace) {
+            ->reduce(function ($output, $path) use ($locale, $group, $namespace) {
                 $file = "{$path}/vendor/{$namespace}/{$locale}/{$group}.php";
 
                 if ($this->files->exists($file)) {
-                    $lines = array_replace_recursive($lines, $this->files->getRequire($file));
+                    $output = array_replace_recursive($output, $this->files->getRequire($file));
                 }
 
-                return $lines;
-            }, []);
+                return $output;
+            }, $lines);
     }
 
     /**

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -146,6 +146,20 @@ class TranslationFileLoaderTest extends TestCase
         $this->assertEquals(['foo' => 'override-2', 'baz' => 'boom-2'], $loader->load('en', 'foo', 'namespace'));
     }
 
+    public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverridesWithMultiplePathsWithMissingKey()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), [__DIR__, __DIR__.'/second']);
+        $files->shouldReceive('exists')->once()->with('test-namespace-dir/en/foo.php')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/second/vendor/namespace/en/foo.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with('test-namespace-dir/en/foo.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(['foo' => 'override', 'baz' => 'boom']);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/second/vendor/namespace/en/foo.php')->andReturn(['baz' => 'boom-2']);
+        $loader->addNamespace('namespace', 'test-namespace-dir');
+
+        $this->assertEquals(['foo' => 'override', 'baz' => 'boom-2'], $loader->load('en', 'foo', 'namespace'));
+    }
+
     public function testEmptyArraysReturnedWhenFilesDontExist()
     {
         $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);


### PR DESCRIPTION
This PR will fix the translations FileLoader behaviour when multiple overrides are set up and the last one is missing a translation key:


as in Fileloader → loadNamespaceOverrides() the `$lines` variable is passed to the function through `use`, its value is used every time in `array_replace_recursive()`, instead of using the updated `$output` variable coming from previous iterations of the reduce function

this will cause the last iteration to remove all overrides made in previous ones

I added a failing test for this issue and implemented the fix:

```diff
protected function loadNamespaceOverrides(array $lines, $locale, $group, $namespace)
    {
        return (new Collection($this->paths))
-            ->reduce(function ($output, $path) use ($lines, $locale, $group, $namespace) {
+           ->reduce(function ($output, $path) use ($locale, $group, $namespace) {
                $file = "{$path}/vendor/{$namespace}/{$locale}/{$group}.php";

                if ($this->files->exists($file)) {
-                    $lines = array_replace_recursive($lines, $this->files->getRequire($file));
+                    $output = array_replace_recursive($output, $this->files->getRequire($file));
                }

-                return $lines;
+                return $output;
-            }, []);
+            }, $lines);
    }
```