### PR TITLE
[12.x]  Add withRelationshipAutoloading method to model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1118,7 +1118,7 @@ trait HasRelationships
     }
 
     /**
-     * Enable relationship autoloading.
+     * Enable relationship autoloading for this model.
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1118,6 +1118,18 @@ trait HasRelationships
     }
 
     /**
+     * Enable relationship autoloading.
+     *
+     * @return $this
+     */
+    public function withRelationshipAutoloading()
+    {
+        $this->newCollection([$this])->withRelationshipAutoloading();
+
+        return $this;
+    }
+
+    /**
      * Duplicate the instance and unset all the loaded relations.
      *
      * @return $this


### PR DESCRIPTION
In the current implementation #53655 Automatic Relation Loading we can only use withRelationshipAutoloading only on collections.

Sometimes we need to enable automatic relation loading for single model

```php
# before
$post->tags->withRelationshipAutoloading();
$post->authors->withRelationshipAutoloading();

# after
$post->withRelationshipAutoloading();
```