### PR TITLE
[12.x] Fix Closure serialization error in automatic relation loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2501,6 +2501,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->classCastCache = [];
         $this->attributeCastCache = [];
+        $this->relationAutoloadCallback = null;
 
         return array_keys(get_object_vars($this));
     }
@@ -2515,5 +2516,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->bootIfNotBooted();
 
         $this->initializeTraits();
+
+        if (static::isAutomaticallyEagerLoadingRelationships()) {
+            $this->withRelationshipAutoloading();
+        }
     }
 }

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -107,6 +107,8 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         }
 
         $this->assertCount(2, DB::getQueryLog());
+
+        Model::automaticallyEagerLoadRelationships(false);
     }
 
     public function testRelationAutoloadVariousNestedMorphRelations()


### PR DESCRIPTION
In the current implementation of #53655, serializing models with automatic relation loading enabled can cause the error: `Serialization of 'Closure' is not allowed`

This occurs because the closure used for relation loading cannot be serialized. This fix resolves the issue by removing the closure before serialization and reinstating it in the __wakeup method if Model::automaticallyEagerLoadRelationships is enabled.

In the case of opt-in usage, the developer needs to explicitly call withRelationshipAutoloading() again after deserialization to re-enable the feature I this model.

With this fix, the following should now work without errors:
```php
Model::automaticallyEagerLoadRelationships();

$user = Cache::remember('user', 60, fn () => User::find(1));

foreach ($user->comments as $comment) {
    //
}
```