### PR TITLE
[13.x] Error exit code for clear command

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -57,7 +57,7 @@ class ClearCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle()
     {
@@ -70,7 +70,9 @@ class ClearCommand extends Command
         $this->flushFacades();
 
         if (! $successful) {
-            return $this->components->error('Failed to clear cache. Make sure you have the appropriate permissions.');
+            $this->components->error('Failed to clear cache. Make sure you have the appropriate permissions.');
+
+            return 1;
         }
 
         $this->laravel['events']->dispatch(


### PR DESCRIPTION
This PR ensures that an unsuccessful cache-clear operation correctly returns an exit code of 1. This change prevents deployments from proceeding if the cache clear fails, stopping a deployment process, for instance.

See https://github.com/laravel/framework/pull/55353. Now targeting master.