### PR TITLE
[13.x] Add #[\Override] to the BatchFake class methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -67,6 +67,7 @@ class BatchFake extends Batch
      *
      * @return self
      */
+    #[\Override]
     public function fresh()
     {
         return $this;
@@ -78,6 +79,7 @@ class BatchFake extends Batch
      * @param  \Illuminate\Support\Enumerable|object|array  $jobs
      * @return self
      */
+    #[\Override]
     public function add($jobs)
     {
         $jobs = Collection::wrap($jobs);
@@ -97,6 +99,7 @@ class BatchFake extends Batch
      * @param  string  $jobId
      * @return void
      */
+    #[\Override]
     public function recordSuccessfulJob(string $jobId)
     {
         //
@@ -108,6 +111,7 @@ class BatchFake extends Batch
      * @param  string  $jobId
      * @return void
      */
+    #[\Override]
     public function decrementPendingJobs(string $jobId)
     {
         //
@@ -120,6 +124,7 @@ class BatchFake extends Batch
      * @param  \Throwable  $e
      * @return void
      */
+    #[\Override]
     public function recordFailedJob(string $jobId, $e)
     {
         //
@@ -131,6 +136,7 @@ class BatchFake extends Batch
      * @param  string  $jobId
      * @return \Illuminate\Bus\UpdatedBatchJobCounts
      */
+    #[\Override]
     public function incrementFailedJobs(string $jobId)
     {
         return new UpdatedBatchJobCounts;
@@ -141,6 +147,7 @@ class BatchFake extends Batch
      *
      * @return void
      */
+    #[\Override]
     public function cancel()
     {
         $this->cancelledAt = Carbon::now();
@@ -151,6 +158,7 @@ class BatchFake extends Batch
      *
      * @return void
      */
+    #[\Override]
     public function delete()
     {
         $this->deleted = true;


### PR DESCRIPTION
Marks the overridden methods with the proper PHP attribute.