### PR TITLE
[12.x] Adds conditionals to Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasConditions.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasConditions.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use function value;
-
 trait HasConditions
 {
     /**
@@ -55,75 +53,181 @@ trait HasConditions
     }
 
     /**
-     * Save the model to the database if the condition is true
+     * Save the model to the database if the condition is true.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  array  $options
+     * @param  bool  $quietly
+     * @return bool
+     */
+    public function saveWhen($condition, array $options = [], $quietly = false)
+    {
+        if (value($condition, $this)) {
+            return $quietly ? $this->saveQuietly($options) : $this->save($options);
+        }
+
+        return false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  array  $options
+     * @param  bool  $quietly
+     * @return bool
+     */
+    public function saveUnless($condition, array $options = [], $quietly = false)
+    {
+        if (! value($condition, $this)) {
+            return $quietly ? $this->saveQuietly($options) : $this->save($options);
+        }
+
+        return false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
      * @param  array  $options
      * @return bool
      */
-    public function saveWhen($condition, array $options = [])
+    public function saveQuietlyWhen($condition, array $options = [])
     {
-        return value($condition, $this) ? $this->save($options) : false;
+        return $this->saveWhen($condition, $options, true);
     }
 
     /**
-     * Save the model to the database if the condition is true
+     * Save the model to the database if the condition is true.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
      * @param  array  $options
      * @return bool
      */
-    public function saveUnless($condition, array $options = [])
+    public function saveQuietlyUnless($condition, array $options = [])
     {
-        return !value($condition, $this) ? $this->save($options) : false;
+        return $this->saveUnless($condition, $options, true);
     }
 
     /**
-     * Save the model to the database if the condition is true
+     * Save the model to the database if the condition is true.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @param  array  $options
+     * @param  bool  $quietly
+     * @return bool
+     */
+    public function updateWhen($condition, $attributes = [], array $options = [], $quietly = false)
+    {
+        if (value($condition, $this)) {
+            return $quietly
+                ? $this->updateQuietly(value($attributes, $this), $options)
+                : $this->update(value($attributes, $this), $options);
+        }
+
+        return false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @param  array  $options
+     * @param  bool  $quietly
+     * @return bool
+     */
+    public function updateUnless($condition, $attributes = [], array $options = [], $quietly = false)
+    {
+        if (! value($condition, $this)) {
+            return $quietly
+                ? $this->updateQuietly(value($attributes, $this), $options)
+                : $this->update(value($attributes, $this), $options);
+        }
+
+        return false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true, without raising any events.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
      * @param  (\Closure($this):array)|array  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateWhen($condition, $attributes = [], array $options = [])
+    public function updateQuietlyWhen($condition, $attributes = [], array $options = [])
     {
-        return value($condition, $this) ? $this->update(value($attributes, $this), $options) : false;
+        return $this->updateWhen($condition, $attributes, $options, true);
     }
 
     /**
-     * Save the model to the database if the condition is true
+     * Save the model to the database if the condition is true, without raising any events.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
      * @param  (\Closure($this):array)|array  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateUnless($condition, $attributes = [], array $options = [])
+    public function updateQuietlyUnless($condition, $attributes = [], array $options = [])
     {
-        return !value($condition, $this) ? $this->update(value($attributes, $this), $options) : false;
+        return $this->updateUnless($condition, $attributes, $options, true);
     }
 
     /**
      * Delete the model to the database if the condition is truthy.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  bool  $quietly
      * @return bool
      */
-    public function deleteWhen($condition)
+    public function deleteWhen($condition, $quietly = false)
     {
-        return value($condition, $this) ? $this->delete() : false;
+        if (value($condition, $this)) {
+            return $quietly ? $this->deleteQuietly() : $this->delete();
+        }
+
+        return false;
     }
 
     /**
      * Delete the model to the database if the condition is falsy.
      *
      * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  bool  $quietly
      * @return bool
      */
-    public function deleteUnless($condition)
+    public function deleteUnless($condition, $quietly = false)
     {
-        return !value($condition, $this) ? $this->delete() : false;
+        if (! value($condition, $this)) {
+            return $quietly ? $this->deleteQuietly() : $this->delete();
+        }
+
+        return false;
+    }
+
+    /**
+     * Delete the model to the database if the condition is truthy, without raising any events.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function deleteQuietlyWhen($condition)
+    {
+        return $this->deleteWhen($condition, true);
+    }
+
+    /**
+     * Delete the model to the database if the condition is falsy, without raising any events.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function deleteQuietlyUnless($condition)
+    {
+        return $this->deleteUnless($condition, true);
     }
 
     /**
@@ -145,6 +249,6 @@ trait HasConditions
      */
     public function forceDeleteUnless($condition)
     {
-        return !value($condition, $this) ? $this->forceDelete() : false;
+        return ! value($condition, $this) ? $this->forceDelete() : false;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasConditions.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasConditions.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use function value;
+
+trait HasConditions
+{
+    /**
+     * Fill the model with an array of attributes if the condition is truthy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @return $this
+     */
+    public function fillWhen($condition, $attributes = [])
+    {
+        return value($condition, $this) ? $this->fill(value($attributes, $this)) : $this;
+    }
+
+    /**
+     * Fill the model with an array of attributes if the condition is falsy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @return $this
+     */
+    public function fillUnless($condition, $attributes = [])
+    {
+        return ! value($condition, $this) ? $this->fill(value($attributes, $this)) : $this;
+    }
+
+    /**
+     * Fill the model with an array of attributes if the condition is truthy. Force mass assignment.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @return $this
+     */
+    public function forceFillWhen($condition, $attributes = [])
+    {
+        return value($condition, $this) ? $this->forceFill(value($attributes, $this)) : $this;
+    }
+
+    /**
+     * Fill the model with an array of attributes if the condition is falsy. Force mass assignment.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @return $this
+     */
+    public function forceFillUnless($condition, $attributes = [])
+    {
+        return ! value($condition, $this) ? $this->forceFill(value($attributes, $this)) : $this;
+    }
+
+    /**
+     * Save the model to the database if the condition is true
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  array  $options
+     * @return bool
+     */
+    public function saveWhen($condition, array $options = [])
+    {
+        return value($condition, $this) ? $this->save($options) : false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  array  $options
+     * @return bool
+     */
+    public function saveUnless($condition, array $options = [])
+    {
+        return !value($condition, $this) ? $this->save($options) : false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @param  array  $options
+     * @return bool
+     */
+    public function updateWhen($condition, $attributes = [], array $options = [])
+    {
+        return value($condition, $this) ? $this->update(value($attributes, $this), $options) : false;
+    }
+
+    /**
+     * Save the model to the database if the condition is true
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @param  (\Closure($this):array)|array  $attributes
+     * @param  array  $options
+     * @return bool
+     */
+    public function updateUnless($condition, $attributes = [], array $options = [])
+    {
+        return !value($condition, $this) ? $this->update(value($attributes, $this), $options) : false;
+    }
+
+    /**
+     * Delete the model to the database if the condition is truthy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function deleteWhen($condition)
+    {
+        return value($condition, $this) ? $this->delete() : false;
+    }
+
+    /**
+     * Delete the model to the database if the condition is falsy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function deleteUnless($condition)
+    {
+        return !value($condition, $this) ? $this->delete() : false;
+    }
+
+    /**
+     * Force delete the model from the database if the condition is truthy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function forceDeleteWhen($condition)
+    {
+        return value($condition, $this) ? $this->forceDelete() : false;
+    }
+
+    /**
+     * Force delete the model from the database if the condition is falsy.
+     *
+     * @param  (\Closure($this):mixed)|mixed  $condition
+     * @return bool
+     */
+    public function forceDeleteUnless($condition)
+    {
+        return !value($condition, $this) ? $this->forceDelete() : false;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -41,6 +41,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
         Concerns\TransformsToResource,
+        Concerns\HasConditions,
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3670,7 +3670,8 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $model->id = 1;
-        $model->exists = true;$model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model->exists = true;
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldNotReceive('dispatch');
 
         $this->assertNotTrue($model->deleteWhen(false, true));
@@ -3688,7 +3689,8 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $model->id = 1;
-        $model->exists = true;$model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $model->exists = true;
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldNotReceive('dispatch');
 
         $this->assertNotTrue($model->deleteQuietlyWhen(false));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3340,7 +3340,7 @@ class DatabaseEloquentModelTest extends TestCase
         );
 
         $this->assertEmpty(
-            (clone $model)->fillWhen(fn() => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->fillWhen(fn () => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
 
         $this->assertSame(
@@ -3350,7 +3350,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertSame(
             ['name' => 'foo'],
-            (clone $model)->fillWhen(fn() => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->fillWhen(fn () => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
     }
 
@@ -3363,7 +3363,7 @@ class DatabaseEloquentModelTest extends TestCase
         );
 
         $this->assertEmpty(
-            (clone $model)->fillUnless(fn() => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->fillUnless(fn () => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
 
         $this->assertSame(
@@ -3373,7 +3373,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertSame(
             ['name' => 'foo'],
-            (clone $model)->fillUnless(fn() => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->fillUnless(fn () => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
     }
 
@@ -3386,7 +3386,7 @@ class DatabaseEloquentModelTest extends TestCase
         );
 
         $this->assertEmpty(
-            (clone $model)->forceFillWhen(fn() => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->forceFillWhen(fn () => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
 
         $this->assertSame(
@@ -3396,7 +3396,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertSame(
             ['name' => 'foo', 'unfillable' => true],
-            (clone $model)->forceFillWhen(fn() => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->forceFillWhen(fn () => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
     }
 
@@ -3409,7 +3409,7 @@ class DatabaseEloquentModelTest extends TestCase
         );
 
         $this->assertEmpty(
-            (clone $model)->forceFillUnless(fn() => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->forceFillUnless(fn () => 1, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
 
         $this->assertSame(
@@ -3419,18 +3419,18 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertSame(
             ['name' => 'foo', 'unfillable' => true],
-            (clone $model)->forceFillUnless(fn() => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
+            (clone $model)->forceFillUnless(fn () => 0, ['name' => 'foo', 'unfillable' => true])->getAttributes()
         );
     }
 
     public function testSavesConditionallyWhenTruthy()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
-            'newModelQuery', 'updateTimestamps'
+            'newModelQuery', 'updateTimestamps',
         ])->getMock();
 
         $this->assertNotTrue($model->saveWhen(false));
-        $this->assertNotTrue($model->saveWhen(fn() => 0));
+        $this->assertNotTrue($model->saveWhen(fn () => 0));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
@@ -3440,14 +3440,52 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->saveWhen(1));
     }
 
+    public function testSavesConditionallyWhenTruthyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
+            'newModelQuery', 'updateTimestamps',
+        ])->getMock();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->saveWhen(false, [], true));
+        $this->assertNotTrue($model->saveWhen(fn () => 0, [], true));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->saveWhen(1, [], true));
+    }
+
+    public function testSavesConditionallyWhenTruthyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
+            'newModelQuery', 'updateTimestamps',
+        ])->getMock();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->saveQuietlyWhen(false));
+        $this->assertNotTrue($model->saveQuietlyWhen(fn () => 0));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->saveQuietlyWhen(1));
+    }
+
     public function testSavesConditionallyUnlessFalsy()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
-            'newModelQuery', 'updateTimestamps'
+            'newModelQuery', 'updateTimestamps',
         ])->getMock();
 
         $this->assertNotTrue($model->saveUnless(true));
-        $this->assertNotTrue($model->saveUnless(fn() => 1));
+        $this->assertNotTrue($model->saveUnless(fn () => 1));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
@@ -3455,6 +3493,44 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
 
         $this->assertTrue($model->saveUnless(0));
+    }
+
+    public function testSavesConditionallyUnlessFalsyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
+            'newModelQuery', 'updateTimestamps',
+        ])->getMock();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->saveUnless(true, [], true));
+        $this->assertNotTrue($model->saveUnless(fn () => 1, [], true));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->saveUnless(0, [], true));
+    }
+
+    public function testSavesConditionallyUnlessFalsyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods([
+            'newModelQuery', 'updateTimestamps',
+        ])->getMock();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->saveQuietlyUnless(true));
+        $this->assertNotTrue($model->saveQuietlyUnless(fn () => 1));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->saveQuietlyUnless(0));
     }
 
     public function testUpdatesConditionallyWhenTruthy()
@@ -3465,7 +3541,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->syncChanges();
 
         $this->assertNotTrue($model->updateWhen(false, ['name' => 'Taylor']));
-        $this->assertNotTrue($model->updateWhen(fn() => 0, ['name' => 'Taylor']));
+        $this->assertNotTrue($model->updateWhen(fn () => 0, ['name' => 'Taylor']));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
@@ -3473,6 +3549,46 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
 
         $this->assertTrue($model->updateWhen(1, ['name' => 'Taylor']));
+    }
+
+    public function testUpdatesConditionallyWhenTruthyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->syncChanges();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->updateWhen(false, ['name' => 'Taylor'], [], true));
+        $this->assertNotTrue($model->updateWhen(fn () => 0, ['name' => 'Taylor'], [], true));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('update')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->updateWhen(1, ['name' => 'Taylor'], [], true));
+    }
+
+    public function testUpdatesConditionallyWhenTruthyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->syncChanges();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->updateQuietlyWhen(false, ['name' => 'Taylor']));
+        $this->assertNotTrue($model->updateQuietlyWhen(fn () => 0, ['name' => 'Taylor']));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('update')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->updateQuietlyWhen(1, ['name' => 'Taylor']));
     }
 
     public function testUpdatesConditionallyUnlessFalsy()
@@ -3483,7 +3599,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->syncChanges();
 
         $this->assertNotTrue($model->updateUnless(true, ['name' => 'Taylor']));
-        $this->assertNotTrue($model->updateUnless(fn() => 1, ['name' => 'Taylor']));
+        $this->assertNotTrue($model->updateUnless(fn () => 1, ['name' => 'Taylor']));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
@@ -3493,6 +3609,46 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->updateUnless(0, ['name' => 'Taylor']));
     }
 
+    public function testUpdatesConditionallyUnlessFalsyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->syncChanges();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->updateUnless(true, ['name' => 'Taylor'], [], true));
+        $this->assertNotTrue($model->updateUnless(fn () => 1, ['name' => 'Taylor'], [], true));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('update')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->updateUnless(0, ['name' => 'Taylor'], [], true));
+    }
+
+    public function testUpdatesConditionallyUnlessFalsyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->syncChanges();
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->updateQuietlyUnless(true, ['name' => 'Taylor']));
+        $this->assertNotTrue($model->updateQuietlyUnless(fn () => 1, ['name' => 'Taylor']));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('update')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->updateQuietlyUnless(0, ['name' => 'Taylor']));
+    }
+
     public function testDeletesConditionallyWhenTruthy()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
@@ -3500,7 +3656,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = true;
 
         $this->assertNotTrue($model->deleteWhen(false));
-        $this->assertNotTrue($model->deleteWhen(fn() => 0));
+        $this->assertNotTrue($model->deleteWhen(fn () => 0));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
@@ -3510,6 +3666,42 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->deleteWhen(1));
     }
 
+    public function testDeletesConditionallyWhenTruthyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;$model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->deleteWhen(false, true));
+        $this->assertNotTrue($model->deleteWhen(fn () => 0), true);
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('delete')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->deleteWhen(1, true));
+    }
+
+    public function testDeletesConditionallyWhenTruthyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;$model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->deleteQuietlyWhen(false));
+        $this->assertNotTrue($model->deleteQuietlyWhen(fn () => 0));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('delete')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->deleteQuietlyWhen(1));
+    }
+
     public function testDeletesConditionallyUnlessFalsy()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
@@ -3517,7 +3709,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = true;
 
         $this->assertNotTrue($model->deleteUnless(true));
-        $this->assertNotTrue($model->deleteUnless(fn() => 1));
+        $this->assertNotTrue($model->deleteUnless(fn () => 1));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
@@ -3527,6 +3719,44 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->deleteUnless(0));
     }
 
+    public function testDeletesConditionallyUnlessFalsyQuietly()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->deleteUnless(true, true));
+        $this->assertNotTrue($model->deleteUnless(fn () => 1), true);
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('delete')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->deleteUnless(0, true));
+    }
+
+    public function testDeletesConditionallyUnlessFalsyQuietlyWithHelper()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
+        $model->id = 1;
+        $model->exists = true;
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldNotReceive('dispatch');
+
+        $this->assertNotTrue($model->deleteQuietlyUnless(true));
+        $this->assertNotTrue($model->deleteQuietlyUnless(fn () => 1));
+
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
+        $query->shouldReceive('delete')->andReturnSelf();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+
+        $this->assertTrue($model->deleteQuietlyUnless(0));
+    }
+
     public function testForceDeletesConditionallyWhenTruthy()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
@@ -3534,7 +3764,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = true;
 
         $this->assertNotTrue($model->forceDeleteWhen(false));
-        $this->assertNotTrue($model->forceDeleteWhen(fn() => 0));
+        $this->assertNotTrue($model->forceDeleteWhen(fn () => 0));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();
@@ -3551,7 +3781,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->exists = true;
 
         $this->assertNotTrue($model->forceDeleteUnless(true));
-        $this->assertNotTrue($model->forceDeleteUnless(fn() => 1));
+        $this->assertNotTrue($model->forceDeleteUnless(fn () => 1));
 
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->with('id', '=', 1)->andReturnSelf();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -972,11 +972,11 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         [$taylor, $abigail] = $this->createUsers();
 
         $this->assertNotTrue($taylor->deleteWhen(false));
-        $this->assertNotTrue($taylor->deleteWhen(fn() => 0));
+        $this->assertNotTrue($taylor->deleteWhen(fn () => 0));
         $this->assertTrue($taylor->deleteWhen(1));
 
         $this->assertNotTrue($abigail->forceDeleteWhen(false));
-        $this->assertNotTrue($abigail->forceDeleteWhen(fn() => 0));
+        $this->assertNotTrue($abigail->forceDeleteWhen(fn () => 0));
         $this->assertTrue($abigail->forceDeleteWhen(1));
 
         $this->assertCount(1, $taylor->newQuery()->withoutGlobalScopes()->get());
@@ -988,11 +988,11 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         [$taylor, $abigail] = $this->createUsers();
 
         $this->assertNotTrue($taylor->deleteUnless(true));
-        $this->assertNotTrue($taylor->deleteUnless(fn() => 1));
+        $this->assertNotTrue($taylor->deleteUnless(fn () => 1));
         $this->assertTrue($taylor->deleteUnless(0));
 
         $this->assertNotTrue($abigail->forceDeleteUnless(true));
-        $this->assertNotTrue($abigail->forceDeleteUnless(fn() => 1));
+        $this->assertNotTrue($abigail->forceDeleteUnless(fn () => 1));
         $this->assertTrue($abigail->forceDeleteUnless(0));
 
         $this->assertCount(1, $taylor->newQuery()->withoutGlobalScopes()->get());

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -967,6 +967,38 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(1, SoftDeletesTestUser::whereHas('self_referencing')->count());
     }
 
+    public function testForceDeletesConditionallyWhenTruthy()
+    {
+        [$taylor, $abigail] = $this->createUsers();
+
+        $this->assertNotTrue($taylor->deleteWhen(false));
+        $this->assertNotTrue($taylor->deleteWhen(fn() => 0));
+        $this->assertTrue($taylor->deleteWhen(1));
+
+        $this->assertNotTrue($abigail->forceDeleteWhen(false));
+        $this->assertNotTrue($abigail->forceDeleteWhen(fn() => 0));
+        $this->assertTrue($abigail->forceDeleteWhen(1));
+
+        $this->assertCount(1, $taylor->newQuery()->withoutGlobalScopes()->get());
+        $this->assertSame(1, $taylor->newQuery()->withoutGlobalScopes()->first()->id);
+    }
+
+    public function testDeletesConditionallyUnlessFalsy()
+    {
+        [$taylor, $abigail] = $this->createUsers();
+
+        $this->assertNotTrue($taylor->deleteUnless(true));
+        $this->assertNotTrue($taylor->deleteUnless(fn() => 1));
+        $this->assertTrue($taylor->deleteUnless(0));
+
+        $this->assertNotTrue($abigail->forceDeleteUnless(true));
+        $this->assertNotTrue($abigail->forceDeleteUnless(fn() => 1));
+        $this->assertTrue($abigail->forceDeleteUnless(0));
+
+        $this->assertCount(1, $taylor->newQuery()->withoutGlobalScopes()->get());
+        $this->assertSame(1, $taylor->newQuery()->withoutGlobalScopes()->first()->id);
+    }
+
     /**
      * Helpers...
      *


### PR DESCRIPTION
## What?

Adds conditional fill, save, update, delete and force-delete to Models. This way developers don't have to be confused with the `when` and `unless` operations that are proxied to the Eloquent Builder, which are kept as-is and accessible as a static methods from the Model class.

```php

use App\Models\User;

$user = User::find(1);

$user->updateWhen(fn () => 'truthy', ['is_cool' => true]);
```

The methods are:

- `forceFillWhen() | forceFillUnless()`: Accepts the condition and fills the attributes using `fill()` method.
- `fillWhen() | fillUnless()`: Accepts the condition and fills the attributes using `forceFill()` method.
- `saveWhen() | saveUnless()`: Accepts the condition and the options to pass to the `save()` method.
- `updateWhen() | updateUnelss()`: Accepts the condition, the attributes, and the options to pass to the `update()` method.
- `deleteWhen() | deleteUnless()`: Accepts the condition and calls `delete()`.
- `forceDeleteWhen() | forceDeleteUnless()`: Same logic as before but for `forceDelete()`.

Notice that the conditional methods that accept attributes as an array also accept a callback that returns the array of attributes. This is because a developer _may_ have to execute computationally expensive attributes based on the condition, which can be avoided if the condition fails.

```php
// Before

$model->updateWhen($mayBeTrue, [
    // This gets executed even if the condition is falsy.
    'value' => Something::computationallyExpensive()
);
```

```php
// After

$model->updateWhen($mayBeTrue, fn (Model $model) => [
    // This will get executed only after the condition is truthy.
    'value' => Something::computationallyExpensive()
]);
```

These callbacks receive the model instance, allowing the developer to use a callback from _elsewhere_, which can make controllers or other methods grow in size.

```php
$model->updateWhen($mayBeTrue, Payments::modifyModel(...));
```