### PR TITLE
[12.x] allow for custom builders in QueriesRelationships closures

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -26,12 +26,13 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @return $this
      *
      * @throws \RuntimeException
@@ -125,10 +126,11 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $boolean
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
@@ -151,9 +153,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -184,9 +187,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -200,9 +204,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @return $this
      */
     public function whereDoesntHave($relation, ?Closure $callback = null)
@@ -214,9 +219,10 @@ trait QueriesRelationships
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|null  $callback
      * @return $this
      */
     public function orWhereDoesntHave($relation, ?Closure $callback = null)
@@ -228,13 +234,14 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $operator
      * @param  int  $count
      * @param  string  $boolean
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
@@ -328,11 +335,12 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $boolean
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
@@ -356,10 +364,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -373,10 +382,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @param  string  $operator
      * @param  int  $count
      * @return $this
@@ -390,10 +400,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -405,10 +416,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
+     * @param  (\Closure(TRelatedModelBuilder) string): mixed)|null  $callback
      * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
@@ -420,9 +432,10 @@ trait QueriesRelationships
      * Add a basic where clause to a relationship query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -461,9 +474,10 @@ trait QueriesRelationships
      * Add an "or where" clause to a relationship query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -483,9 +497,10 @@ trait QueriesRelationships
      * Add a basic count / exists condition to a relationship query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -505,9 +520,10 @@ trait QueriesRelationships
      * Add an "or where" clause to a relationship query.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -527,10 +543,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship condition to the query with a where clause.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -546,10 +563,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship condition to the query with an "or where" clause.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -565,10 +583,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship condition to the query with a doesn't have clause.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -584,10 +603,11 @@ trait QueriesRelationships
      * Add a polymorphic relationship condition to the query with an "or doesn't have" clause.
      *
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TRelatedModelBuilder of \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(TRelatedModelBuilder): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this


### PR DESCRIPTION
The closure types added in #54452 are not accounting for custom query builders, and therefore the following code is triggering a `argument.type` error because the closure expects `Builder<Order>`

```
Parameter #2 $callback of method Illuminate\Database\Eloquent\Builder<OrderItem>::whereHas()  
expects (Closure(Illuminate\Database\Eloquent\Builder<Order>): mixed)|null,                         
Closure(OrderBuilder): OrderBuilder given.  
```

```php
OrderItem::query()->whereHas('order', fn (OrderBuilder $q) => $q->shipped());
```