### PR TITLE
Add Env::extend to support custom adapters when loading environment variables

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Closure;
 use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Repository\RepositoryBuilder;
 use PhpOption\Option;
@@ -22,6 +23,13 @@ class Env
      * @var \Dotenv\Repository\RepositoryInterface|null
      */
     protected static $repository;
+
+    /**
+     * The list of custom adapters for loading environment variables.
+     *
+     * @var array<Closure>
+     */
+    protected static $customAdapters = [];
 
     /**
      * Enable the putenv adapter.
@@ -46,6 +54,18 @@ class Env
     }
 
     /**
+     * Register a custom adapter creator Closure.
+     */
+    public static function extend(Closure $callback, ?string $name = null): void
+    {
+        if (! is_null($name)) {
+            static::$customAdapters[$name] = $callback;
+        } else {
+            static::$customAdapters[] = $callback;
+        }
+    }
+
+    /**
      * Get the environment repository instance.
      *
      * @return \Dotenv\Repository\RepositoryInterface
@@ -57,6 +77,10 @@ class Env
 
             if (static::$putenv) {
                 $builder = $builder->addAdapter(PutenvAdapter::class);
+            }
+
+            foreach (static::$customAdapters as $adapter) {
+                $builder = $builder->addAdapter($adapter());
             }
 
             static::$repository = $builder->immutable()->make();


### PR DESCRIPTION
# See #54756.

This adds the same functionality for Laravel 11.x.

---------------------
> # Summary
> This PR introduces a new capability to register one or more additional adapters for reading and loading environment variables during the Kernel's bootstrap process. This allows Laravel applications to retrieve environment variables from external sources such as **AWS Secrets Manager**, HashiCorp Vault, Infisical, encrypted local files, or any other implementation that conforms to the default interface.
> 
> ## Problem
> An application might rely on environment variables ("secrets") that are securely stored in external sources, rather than in a "local" .env file. Additionally, these variables may be dynamically updated (rotated), requiring a reliable way to load them at the right stage of the bootstrapping process.
> 
> There are currently a few ways to handle this, but each has limitations:
> 
> * One approach is to use the `afterLoadingEnvironment` callback to load external secrets. However, if additional environment variables are loaded within this callback, it could lead to the situation where not all environment variables are available yet. As a result, the naming and intended purpose of the callback may become misleading or inaccurate.
> * Another approach is creating a custom Service Provider that retrieves external secrets and updates them via the Configuration Repository with `config([$key => $value])`. However, service providers load late in the request lifecycle, meaning environment variables (and related configuration settings) are updated too late to be useful during early bootstrapping.
> 
> Therefore, both solutions fail to provide external secrets before Laravel compiles the configuration, which is necessary for secure and dynamic environment variable management.
> 
> ## Proposed Solution
> The **Dotenv** library, which Laravel uses to read and load environment variables, supports multiple adapters for reading and writing variables. Currently, Laravel leverages the default **RepositoryBuilder**, which comes with the following adapters:
> 
> * **ServerConstAdapter** (reads from `$_SERVER`)
> * **EnvConstAdapter** (reads from `$_ENV`)
> * **PutenvAdapter** (optional, provides `putenv()` / `getenv()` support)
> 
> Thus, this PR introduces a new method: `Env::extend`, allowing developers to:
> 
> * Register one or more custom adapters that read environment variables from any external source.
> * Load these variables before configuration is compiled, ensuring they are available early in the bootstrapping process.
> * Create custom, secure, and flexible solutions while adhering to Laravel’s existing contract for environment management.
> 
> ### Example
> The perfect place for registering an extra adapter might be in the `bootstrap/app.php` file, right before the application builder, so the **ApplicationBuilder** already has access to all the necessary environment variables.
> 
> ```
> \Illuminate\Support\Env::extend('aws_secrets', fn() => new AwsSecretsManagerAdapter);
> ```
> 
> In theory, this approach could serve as a more direct alternative to how Laravel Vapor currently loads parameters ("secrets") from Amazon EC2 Systems Manager (SSM). For this reason, I’ve added support for multiple adapters, ensuring flexibility in case Vapor adopts this solution and/or if the application needs to integrate with multiple external sources of "secrets".

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
