### PR TITLE
[12.x]  - Redis - Establish connection first, before set the options

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -85,6 +85,8 @@ class PhpRedisConnector implements Connector
                 );
             }
 
+            $this->establishConnection($client, $config);
+
             if (array_key_exists('max_retries', $config)) {
                 $client->setOption(Redis::OPT_MAX_RETRIES, $config['max_retries']);
             }
@@ -100,8 +102,6 @@ class PhpRedisConnector implements Connector
             if (array_key_exists('backoff_cap', $config)) {
                 $client->setOption(Redis::OPT_BACKOFF_CAP, $config['backoff_cap']);
             }
-
-            $this->establishConnection($client, $config);
 
             if (! empty($config['password'])) {
                 if (isset($config['username']) && $config['username'] !== '' && is_string($config['password'])) {


### PR DESCRIPTION
Hi,

PhpRedisConnector try to set 4 options (max_retries,backoff_algorithm,backoff_base,backoff_cap) before
the connection has been established, and so, the options has no effect at all.

With a single line move, creating the connection/client before, the options then is set successfully on client.


