### PR TITLE
[12.x] Add streamableUri function to FilesystemAdapter class

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -794,6 +794,16 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Determine if streamable URIs can be generated.
+     *
+     * @return bool
+     */
+    public function providesStreamableUris()
+    {
+        return isset($this->config['stream_wrapper']);
+    }
+
+    /**
      * Get a temporary URL for the file at the given path.
      *
      * @param  string  $path
@@ -835,6 +845,32 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         throw new RuntimeException('This driver does not support creating temporary upload URLs.');
+    }
+
+    /**
+     * Get a stream URI for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  array  $options
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function streamableUri($path, array $options = [])
+    {
+        if (! $this->providesStreamableUris()) {
+            throw new RuntimeException('This driver does not support creating stream URIs.');
+        }
+
+        $wrapper = $this->config['stream_wrapper'];
+
+        $availableWrappers = stream_get_wrappers();
+
+        if (! in_array($wrapper, $availableWrappers)) {
+            throw new RuntimeException("The stream wrapper [{$wrapper}] is not available.");
+        }
+
+        return $wrapper . '://' . ltrim($this->path($path), '\\/');
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -870,7 +870,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             throw new RuntimeException("The stream wrapper [{$wrapper}] is not available.");
         }
 
-        return $wrapper . '://' . ltrim($this->path($path), '\\/');
+        return $wrapper.'://'.ltrim($this->path($path), '\\/');
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds two new methods to the `Illuminate/Filesystem/FilesystemAdapter.php` class.

Theese methods are intended to offer a way for developers to set a default PHP stream wrapper prefix in the filesystem configuration, and get a proper URI to directly access a file through PHP default file manipulation functions (`fopen`, `file_get_contents`, etc).

The reasoning behind this PR is to add a convenient way to integrate Laravel filesystems to external file manipulation libraries that work exclusively with resources.

## Usage

A user may define a default stream wrapper in the `filesystems.php` config file:

```php
's3' => [
    'driver' => 's3',
    'stream_wrapper' => 's3',
    ...
],
```

Then, through the `Storage` facade, the user may check if a given filesystem can provide a streamable URI:

```php
Storage::disk('s3')->providesStreamableUris(); // true
```

For getting the actual path, the user can use the following function:

```php
Storage::disk('s3')->streamableUri('path/to/file'); // "s3://path/to/file"
```

## Conclusion

I am open to feedback on this. The feature has been relevant to my workspace, and I believe it could be a good addition to the framework.  
