### PR TITLE
[12.x] Fix Str title null value deprecated warning

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1415,6 +1415,10 @@ class Str
      */
     public static function title($value)
     {
+        if (is_null($value)) {
+            return '';
+        }
+
         return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -40,6 +40,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Jefferson Costella', Str::title('jefferson costella'));
         $this->assertSame('Jefferson Costella', Str::title('jefFErson coSTella'));
 
+        $this->assertSame('', Str::title(null));
         $this->assertSame('', Str::title(''));
         $this->assertSame('123 Laravel', Str::title('123 laravel'));
         $this->assertSame('❤Laravel', Str::title('❤laravel'));


### PR DESCRIPTION
Fix warning when a null value was passed in `Str::title($value)`.

### Error

```
mb_convert_case(): Passing null to parameter #1 ($string) of type string is deprecated
```

