### PR TITLE
[12.x] Adds Cast to Collect into classes or callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Closure;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class AsCollectionMap implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @template TValue
+     *
+     * @param  array{0: class-string<TValue>|(callable(mixed):TValue), 1?: string}  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, TValue>, iterable<TValue>>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            public function __construct(protected array $arguments)
+            {
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                $data = Json::decode($attributes[$key]);
+
+                if (!is_array($data)) {
+                    return null;
+                }
+
+                $this->arguments[0] ??= '';
+
+                if (is_callable($this->arguments[0])) {
+                    return Collection::make($data)->map($this->arguments[0]);
+                }
+
+                [$class, $method] = Str::parseCallback($this->arguments[0]);
+
+                if ($method) {
+                    return Collection::make($data)->map([$class, $method]);
+                }
+
+                if ($class) {
+                    return Collection::make($data)->mapInto($class);
+                }
+
+                throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => Json::encode($value)];
+            }
+        };
+    }
+
+    /**
+     * Specify the class to map into each item in the Collection cast.
+     *
+     * @param  class-string  $class
+     * @return string
+     */
+    public static function into($class)
+    {
+        return static::class.':'.$class;
+    }
+
+    /**
+     * Specify the callable to map each item in the Collection cast.
+     *
+     * @param  callable-string|array{0: class-string, 1: string} $callback
+     * @param  string|null $method
+     * @return string
+     */
+    public static function using($callback, $method = null)
+    {
+        if ($callback instanceof Closure) {
+            throw new InvalidArgumentException('The provided callback should be a callable array or string.');
+        }
+
+        if (is_array($callback) && is_callable($callback)) {
+            [$callback, $method] = [$callback[0], $callback[1]];
+        }
+
+        return $method === null
+            ? static::class.':'.$callback
+            : static::class.':'.$callback.'@'.$method;
+
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
@@ -33,12 +33,9 @@ class AsCollectionMap implements Castable
                     throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
                 }
 
-                if (isset($arguments[1]) && ! is_array($arguments[0])) {
-                    $arguments = [$arguments[0], $arguments[1]];
-                    unset($arguments[1]);
-                }
-
-                $this->callable = $arguments[0];
+                $this->callable = isset($arguments[1]) && ! is_array($arguments[0])
+                    ? [$arguments[0], $arguments[1]]
+                    : $arguments[0];
             }
 
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
@@ -23,8 +23,22 @@ class AsCollectionMap implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments)
+            protected $callable;
+
+            public function __construct(array $arguments)
             {
+                $arguments = array_values($arguments);
+
+                if (empty($arguments) || empty($arguments[0])) {
+                    throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
+                }
+
+                if (isset($arguments[1]) && ! is_array($arguments[0])) {
+                    $arguments = [$arguments[0], $arguments[1]];
+                    unset($arguments[1]);
+                }
+
+                $this->callable = $arguments[0];
             }
 
             public function get($model, $key, $value, $attributes)
@@ -39,23 +53,15 @@ class AsCollectionMap implements Castable
                     return null;
                 }
 
-                $this->arguments[0] ??= '';
-
-                if (is_callable($this->arguments[0])) {
-                    return Collection::make($data)->map($this->arguments[0]);
+                if (is_callable($this->callable)) {
+                    return Collection::make($data)->map($this->callable);
                 }
 
-                [$class, $method] = Str::parseCallback($this->arguments[0]);
+                [$class, $method] = Str::parseCallback($this->callable);
 
-                if ($method) {
-                    return Collection::make($data)->map([$class, $method]);
-                }
-
-                if ($class) {
-                    return Collection::make($data)->mapInto($class);
-                }
-
-                throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
+                return $method
+                    ? Collection::make($data)->map([$class, $method])
+                    : Collection::make($data)->mapInto($class);
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollectionMap.php
@@ -35,7 +35,7 @@ class AsCollectionMap implements Castable
 
                 $data = Json::decode($attributes[$key]);
 
-                if (!is_array($data)) {
+                if (! is_array($data)) {
                     return null;
                 }
 
@@ -79,8 +79,8 @@ class AsCollectionMap implements Castable
     /**
      * Specify the callable to map each item in the Collection cast.
      *
-     * @param  callable-string|array{0: class-string, 1: string} $callback
-     * @param  string|null $method
+     * @param  callable-string|array{0: class-string, 1: string}  $callback
+     * @param  string|null  $method
      * @return string
      */
     public static function using($callback, $method = null)
@@ -96,6 +96,5 @@ class AsCollectionMap implements Castable
         return $method === null
             ? static::class.':'.$callback
             : static::class.':'.$callback.'@'.$method;
-
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
@@ -32,12 +32,9 @@ class AsEncryptedCollectionMap extends AsCollectionMap
                     throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
                 }
 
-                if (isset($arguments[1]) && ! is_array($arguments[1])) {
-                    $arguments = [$arguments[0], $arguments[1]];
-                    unset($arguments[1]);
-                }
-
-                $this->callable = $arguments[0];
+                $this->callable = isset($arguments[1]) && ! is_array($arguments[0])
+                    ? [$arguments[0], $arguments[1]]
+                    : $arguments[0];
             }
 
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class AsEncryptedCollectionMap extends AsCollectionMap
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @template TValue
+     *
+     * @param  array{class-string<TValue>|(callable(mixed):TValue)}  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, TValue>, iterable<TValue>>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            public function __construct(protected array $arguments)
+            {
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                $data = Json::decode(Crypt::decryptString($attributes[$key]));
+
+                if (!is_array($data)) {
+                    return null;
+                }
+
+                $this->arguments[0] ??= '';
+
+                if (is_callable($this->arguments[0])) {
+                    return Collection::make($data)->map($this->arguments[0]);
+                }
+
+                [$class, $method] = Str::parseCallback($this->arguments[0]);
+
+                if ($method) {
+                    return Collection::make($data)->map([$class, $method]);
+                }
+
+                if ($class) {
+                    return Collection::make($data)->mapInto($class);
+                }
+
+                throw new InvalidArgumentException('No class or callable has been set to map the Collection.');
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (! is_null($value)) {
+                    return [$key => Crypt::encryptString(Json::encode($value))];
+                }
+
+                return null;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
@@ -68,4 +68,37 @@ class AsEncryptedCollectionMap extends AsCollectionMap
             }
         };
     }
+
+    /**
+     * Specify the class to map into each item in the Collection cast.
+     *
+     * @param  class-string  $class
+     * @return string
+     */
+    public static function into($class)
+    {
+        return static::class.':'.$class;
+    }
+
+    /**
+     * Specify the callable to map each item in the Collection cast.
+     *
+     * @param  callable-string|array{0: class-string, 1: string}  $callback
+     * @param  string|null  $method
+     * @return string
+     */
+    public static function using($callback, $method = null)
+    {
+        if ($callback instanceof Closure) {
+            throw new InvalidArgumentException('The provided callback should be a callable array or string.');
+        }
+
+        if (is_array($callback) && is_callable($callback)) {
+            [$callback, $method] = [$callback[0], $callback[1]];
+        }
+
+        return $method === null
+            ? static::class.':'.$callback
+            : static::class.':'.$callback.'@'.$method;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollectionMap.php
@@ -34,7 +34,7 @@ class AsEncryptedCollectionMap extends AsCollectionMap
 
                 $data = Json::decode(Crypt::decryptString($attributes[$key]));
 
-                if (!is_array($data)) {
+                if (! is_array($data)) {
                     return null;
                 }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -15,8 +15,10 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\AsCollectionMap;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
+use Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap;
 use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -2237,11 +2239,11 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
-        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
+        } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class, AsCollectionMap::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
         } elseif ($this->isClassCastable($key) && Str::startsWith($this->getCasts()[$key], [AsEnumArrayObject::class, AsEnumCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+        } elseif ($this->isClassCastable($key) && $original !== null && Str::startsWith($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class, AsEncryptedCollectionMap::class])) {
             if (empty(static::currentEncrypter()->getPreviousKeys())) {
                 return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
             }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -4,12 +4,16 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\AsCollectionMap;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Stringable;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DatabaseCustomCastsTest extends DatabaseTestCase
 {
@@ -151,6 +155,74 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
             $model->array_object_json->toArray()
         );
     }
+
+    public function test_custom_casting_map_into_collection(): void
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+        $model->mergeCasts(['collection' => AsCollectionMap::into(Fluent::class)]);
+        $model->fill([
+            'collection' => [
+                ['name' => 'Taylor']
+            ]
+        ]);
+
+        $fluent = $model->collection->first();
+
+        $this->assertInstanceOf(Fluent::class, $fluent);
+        $this->assertSame('Taylor', $fluent->name);
+    }
+
+    public static function provideMapArguments()
+    {
+        return [
+            [TestCollectionMapCallable::class],
+            [TestCollectionMapCallable::class, 'make'],
+            [TestCollectionMapCallable::class . '@' .'make'],
+        ];
+    }
+
+    #[DataProvider('provideMapArguments')]
+    public function test_custom_casting_map_collection($class, $method = null): void
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+        $model->mergeCasts(['collection' => AsCollectionMap::using($class, $method)]);
+        $model->fill([
+            'collection' => [
+                ['name' => 'Taylor']
+            ]
+        ]);
+
+        $result = $model->collection->first();
+
+        $this->assertInstanceOf(TestCollectionMapCallable::class, $result);
+        $this->assertSame('Taylor', $result->name);
+    }
+
+    public function test_custom_casting_map_collection_throw_when_no_arguments(): void
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+        $model->mergeCasts(['collection' => AsCollectionMap::class]);
+        $model->fill([
+            'collection' => [
+                ['name' => 'Taylor']
+            ]
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No class or callable has been set to map the Collection.');
+
+        $model->collection->first();
+    }
+
+    public function test_custom_casting_map_collection_throw_when_using_closure(): void
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided callback should be a callable array or string.');
+
+        $model->mergeCasts(['collection' => AsCollectionMap::using(TestCollectionMapCallable::make(...))]);
+    }
 }
 
 class TestEloquentModelWithCustomCasts extends Model
@@ -196,4 +268,19 @@ class TestEloquentModelWithCustomCastsNullable extends Model
         'collection' => AsCollection::class,
         'stringable' => AsStringable::class,
     ];
+}
+
+class TestCollectionMapCallable
+{
+    public $name;
+
+    public function __construct($data)
+    {
+        $this->name = $data['name'];
+    }
+
+    public static function make($data)
+    {
+        return new static($data);
+    }
 }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -202,16 +202,15 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithCustomCastsNullable();
         $model->mergeCasts(['collection' => AsCollectionMap::class]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No class or callable has been set to map the Collection.');
+
         $model->fill([
             'collection' => [
                 ['name' => 'Taylor'],
             ],
         ]);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No class or callable has been set to map the Collection.');
-
-        $model->collection->first();
     }
 
     public function test_custom_casting_map_collection_throw_when_using_closure(): void

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -162,8 +162,8 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model->mergeCasts(['collection' => AsCollectionMap::into(Fluent::class)]);
         $model->fill([
             'collection' => [
-                ['name' => 'Taylor']
-            ]
+                ['name' => 'Taylor'],
+            ],
         ]);
 
         $fluent = $model->collection->first();
@@ -177,7 +177,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         return [
             [TestCollectionMapCallable::class],
             [TestCollectionMapCallable::class, 'make'],
-            [TestCollectionMapCallable::class . '@' .'make'],
+            [TestCollectionMapCallable::class.'@'.'make'],
         ];
     }
 
@@ -188,8 +188,8 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model->mergeCasts(['collection' => AsCollectionMap::using($class, $method)]);
         $model->fill([
             'collection' => [
-                ['name' => 'Taylor']
-            ]
+                ['name' => 'Taylor'],
+            ],
         ]);
 
         $result = $model->collection->first();
@@ -204,8 +204,8 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model->mergeCasts(['collection' => AsCollectionMap::class]);
         $model->fill([
             'collection' => [
-                ['name' => 'Taylor']
-            ]
+                ['name' => 'Taylor'],
+            ],
         ]);
 
         $this->expectException(InvalidArgumentException::class);

--- a/types/Database/Eloquent/Casts/Castable.php
+++ b/types/Database/Eloquent/Casts/Castable.php
@@ -13,6 +13,21 @@ assertType(
 );
 
 assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([\Post::class]),
+);
+
+assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([fn(): \Post => new \Post]),
+);
+
+assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([\Post::class, 'make']),
+);
+
+assertType(
     'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Database\Eloquent\Casts\ArrayObject<(int|string), mixed>, iterable>',
     \Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject::castUsing([]),
 );
@@ -20,6 +35,21 @@ assertType(
 assertType(
     'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), mixed>, iterable>',
     \Illuminate\Database\Eloquent\Casts\AsEncryptedCollection::castUsing([]),
+);
+
+assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([\Post::class]),
+);
+
+assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([fn(): \Post => new \Post]),
+);
+
+assertType(
+    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([\Post::class, 'make']),
 );
 
 assertType(

--- a/types/Database/Eloquent/Casts/Castable.php
+++ b/types/Database/Eloquent/Casts/Castable.php
@@ -13,17 +13,17 @@ assertType(
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
     \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([\Post::class]),
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
-    \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([fn(): \Post => new \Post]),
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([fn (): \Post => new \Post]),
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
     \Illuminate\Database\Eloquent\Casts\AsCollectionMap::castUsing([\Post::class, 'make']),
 );
 
@@ -38,17 +38,17 @@ assertType(
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
     \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([\Post::class]),
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
-    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([fn(): \Post => new \Post]),
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
+    \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([fn (): \Post => new \Post]),
 );
 
 assertType(
-    '\Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, Post>, iterable<Post>>',
+    'Illuminate\Contracts\Database\Eloquent\CastsAttributes<Illuminate\Support\Collection<(int|string), Post>, iterable<Post>>',
     \Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap::castUsing([\Post::class, 'make']),
 );
 


### PR DESCRIPTION
## What?

This PR adds a new `AsCollectionMap` _castable_ that will allow the developer to create a collection mapped into a class, or to a callback. It's an alternative to use a custom Collection class that would map the items at construction time.

A developer may use this castable to map items into a given class using the `into()` static method:

```php
use Illuminate\Database\Eloquent\Casts\AsCollectionMap;
use Illuminate\Support\Fluent;

public function casts()
{
    return [
        'colors' => AsCollectionMap::into(Fluent::class)
    ];
}
```

It's not limited to class names, but also callbacks that transform the item through the `using()` method. These callbacks should be either a string in `class@method` notation, a callable array, or a class and method set separately.

```php
use Illuminate\Database\Eloquent\Casts\AsCollectionMap;
use App\ValueObject\Color;

public function casts()
{
    return [
        'colors' => AsCollectionMap::using(Color::class, 'make'), 
    ];
}
```

> [!CAUTION]
> 
> Because the nature of the casts declaration, there is no support to using a Closure. If a Closure is set, a descriptive exception will be thrown. Alternatively, the developer can use `castUsing()` directly with a closure.

The whole logic sits after the value decryption, so encryption can work as any monday morning with the `AsEncryptedCollectionMap` class.

```php
use Illuminate\Database\Eloquent\Casts\AsEncryptedCollectionMap;
use App\ValueObject\Color;

public function casts()
{
    return [
        'colors' => AsEncryptedCollectionMap::using(Color::class, 'make'), 
    ];
}
```