### PR TITLE
Differentiate explicit null from default using `__UNSET__` in whenLoaded method

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -256,7 +256,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenLoaded($relationship, $value = null, $default = null)
+    protected function whenLoaded($relationship, $value = '__UNSET__', $default = null)
     {
         if (func_num_args() < 3) {
             $default = new MissingValue;
@@ -276,7 +276,7 @@ trait ConditionallyLoadsAttributes
             return;
         }
 
-        if ($value === null) {
+        if ($value === '__UNSET__') {
             $value = value(...);
         }
 
@@ -291,7 +291,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenCounted($relationship, $value = null, $default = null)
+    public function whenCounted($relationship, $value = '__UNSET__', $default = null)
     {
         if (func_num_args() < 3) {
             $default = new MissingValue;
@@ -311,7 +311,7 @@ trait ConditionallyLoadsAttributes
             return;
         }
 
-        if ($value === null) {
+        if ($value === '__UNSET__') {
             $value = value(...);
         }
 
@@ -328,7 +328,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenAggregated($relationship, $column, $aggregate, $value = null, $default = null)
+    public function whenAggregated($relationship, $column, $aggregate, $value = '__UNSET__', $default = null)
     {
         if (func_num_args() < 5) {
             $default = new MissingValue;
@@ -348,7 +348,7 @@ trait ConditionallyLoadsAttributes
             return;
         }
 
-        if ($value === null) {
+        if ($value === '__UNSET__') {
             $value = value(...);
         }
 


### PR DESCRIPTION
Fixes #55374.

## Description

Due to the PHP 8 named arguments feature, we encountered an ambiguity issue. Previously, when calling methods like `whenLoaded`, explicitly passing a `null` argument was indistinguishable from omitting the argument completely. This ambiguity could cause unexpected results, like unintentionally returning the entire related entity instead of the intended `null` value.

For example, before this fix, the following call:

```php
'value' => $this->whenLoaded('entity', $this->resource->entity->comment),
```

would incorrectly return the whole `'entity'` object if `comment` was `null` in the database (and that's because of the changes intriduced in #51342 because of null verification)

```json
{
  "value": {
    // entity object returned instead of null
  }
}
```

To resolve this ambiguity clearly and effectively, we've introduced a sentinel default value (`'__UNSET__'`) to reliably identify if an argument was explicitly provided as `null` or simply omitted.

### Changes

- **Before**:
  ```php
  protected function whenLoaded($relationship, $value = null, $default = null)
  ```
  (Cannot distinguish an explicitly provided null from omitted parameter)

- **After**:
  ```php
  protected function whenLoaded($relationship, $value = '__UNSET__', $default = null)
  ```
  (Clearly distinguish an explicitly provided null from omitted parameter)

### Impact of this Change

With this fix, explicitly passing `null` will behave correctly and predictably:

- Calling `whenLoaded('relation', null)` explicitly returns `null` as intended.
- Improves internal logic by clearly differentiating between omitted parameters and explicitly provided `null`.

Now, the example above returns the correct result:

```json
{
  "value": null
}
```