### PR TITLE
[12.x] Introduce `excludeCan` method

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1101,6 +1101,22 @@ class Route
     }
 
     /**
+     * Specify that the "can" middleware for a specific ability should be removed from the route.
+     *
+     * @param  \UnitEnum|string  $ability
+     * @param  array|string  $models
+     * @return $this
+     */
+    public function excludeCan($ability, $models = [])
+    {
+        $ability = enum_value($ability);
+
+        return empty($models)
+            ? $this->withoutMiddleware(['can:'.$ability])
+            : $this->withoutMiddleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
+    }
+
+    /**
      * Get the middleware for the route's controller.
      *
      * @return array

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -19,6 +19,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route put(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method \Illuminate\Routing\RouteRegistrar can(\UnitEnum|string  $ability, array|string $models = [])
+ * @method \Illuminate\Routing\RouteRegistrar excludeCan(\UnitEnum|string  $ability, array|string $models = [])
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(\BackedEnum|string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
@@ -66,6 +67,7 @@ class RouteRegistrar
     protected $allowedAttributes = [
         'as',
         'can',
+        'excludeCan',
         'controller',
         'domain',
         'middleware',

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -90,6 +90,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar whereIn(array|string $parameters, array $values)
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar can(\UnitEnum|string $ability, array|string $models = [])
+ * @method static \Illuminate\Routing\RouteRegistrar excludeCan(\UnitEnum|string $ability, array|string $models = [])
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method static \Illuminate\Routing\RouteRegistrar domain(\BackedEnum|string $value)
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)


### PR DESCRIPTION
### Why
Consider **a multi-tenant CRM system** where access to routes is controlled by user permissions:

- `manage-company`: Allows access to company-wide settings like billing, domains, etc.
- `manage-users`: Allows access to manage user profiles (e.g., invite, remove, assign roles).

We group routes like this:

```php
Route::can('manage-company')->group(function () {
    Route::get('/company/settings', ...); // Only for those who can manage the company

    Route::excludeCan('manage-company')->can('manage-users')->get('/users', ...);
    // Even if user cannot manage the company, they can manage users if they have that specific permission
});
```
This is useful when you have department heads or team leads who should be allowed to manage their team members but not have access to sensitive company-wide settings.

### Alternative
```php
// Group that requires 'manage-company'
Route::middleware('can:manage-company')->group(function () {
    Route::get('/company/settings', ...);
});

// Group that requires only 'manage-users'
Route::middleware('can:manage-users')->get('/users', ...);
```

While this works, it has two limitations:
1. **Splits route structure**: If `/users` logically belongs within the `/company` section (e.g., in breadcrumbs, navigation), you lose that grouping clarity.
2. **Harder to maintain when nesting deeply**: If you're doing complex nesting (e.g., can:manage-company -> can:manage-users -> exclude parent), this gets messy and repetitive.