### PR TITLE
[12.x] Extends `AsCollection` to map items into objects or other values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class AsCollection implements Castable
@@ -21,6 +22,7 @@ class AsCollection implements Castable
         {
             public function __construct(protected array $arguments)
             {
+                $this->arguments = array_pad(array_values($this->arguments), 2, '');
             }
 
             public function get($model, $key, $value, $attributes)
@@ -31,13 +33,29 @@ class AsCollection implements Castable
 
                 $data = Json::decode($attributes[$key]);
 
-                $collectionClass = $this->arguments[0] ?? Collection::class;
+                $collectionClass = empty($this->arguments[0]) ? Collection::class : $this->arguments[0];
 
                 if (! is_a($collectionClass, Collection::class, true)) {
                     throw new InvalidArgumentException('The provided class must extend ['.Collection::class.'].');
                 }
 
-                return is_array($data) ? new $collectionClass($data) : null;
+                if (! is_array($data)) {
+                    return null;
+                }
+
+                $instance = new $collectionClass($data);
+
+                if (! $this->arguments[1]) {
+                    return $instance;
+                }
+
+                if (is_string($this->arguments[1])) {
+                    $this->arguments[1] = Str::parseCallback($this->arguments[1]);
+                }
+
+                return is_callable($this->arguments[1])
+                    ? $instance->map($this->arguments[1])
+                    : $instance->mapInto($this->arguments[1][0]);
             }
 
             public function set($model, $key, $value, $attributes)
@@ -51,10 +69,26 @@ class AsCollection implements Castable
      * Specify the collection for the cast.
      *
      * @param  class-string  $class
+     * @param  array{class-string, string}|class-string  $map
      * @return string
      */
-    public static function using($class)
+    public static function using($class, $map = null)
     {
-        return static::class.':'.$class;
+        if (is_array($map) && is_callable($map)) {
+            $map = $map[0].'@'.$map[1];
+        }
+
+        return static::class.':'.implode(',', [$class, $map]);
+    }
+
+    /**
+     * Specify the callback to map each item.
+     *
+     * @param  array{class-string, string}|class-string  $map
+     * @return string
+     */
+    public static function map($map)
+    {
+        return static::using('', $map);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -45,7 +45,7 @@ class AsCollection implements Castable
 
                 $instance = new $collectionClass($data);
 
-                if (! $this->arguments[1]) {
+                if (! isset($this->arguments[1]) || ! $this->arguments[1]) {
                     return $instance;
                 }
 
@@ -66,7 +66,18 @@ class AsCollection implements Castable
     }
 
     /**
-     * Specify the collection for the cast.
+     * Specify the type of object each item in the collection should be mapped to.
+     *
+     * @param  array{class-string, string}|class-string  $map
+     * @return string
+     */
+    public static function of($map)
+    {
+        return static::using('', $map);
+    }
+
+    /**
+     * Specify the collection type for the cast.
      *
      * @param  class-string  $class
      * @param  array{class-string, string}|class-string  $map
@@ -79,16 +90,5 @@ class AsCollection implements Castable
         }
 
         return static::class.':'.implode(',', [$class, $map]);
-    }
-
-    /**
-     * Specify the callback to map each item.
-     *
-     * @param  array{class-string, string}|class-string  $map
-     * @return string
-     */
-    public static function map($map)
-    {
-        return static::using('', $map);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -40,11 +40,7 @@ class AsEncryptedCollection implements Castable
 
                 $instance = new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));
 
-                if (! $this->arguments[1]) {
-                    return $instance;
-                }
-
-                if (! $this->arguments[1]) {
+                if (! isset($this->arguments[1]) || ! $this->arguments[1]) {
                     return $instance;
                 }
 
@@ -69,6 +65,17 @@ class AsEncryptedCollection implements Castable
     }
 
     /**
+     * Specify the type of object each item in the collection should be mapped to.
+     *
+     * @param  array{class-string, string}|class-string  $map
+     * @return string
+     */
+    public static function of($map)
+    {
+        return static::using('', $map);
+    }
+
+    /**
      * Specify the collection for the cast.
      *
      * @param  class-string  $class
@@ -82,16 +89,5 @@ class AsEncryptedCollection implements Castable
         }
 
         return static::class.':'.implode(',', [$class, $map]);
-    }
-
-    /**
-     * Specify the callback to map each item.
-     *
-     * @param  array{class-string, string}|class-string  $map
-     * @return string
-     */
-    public static function map($map)
-    {
-        return static::using('', $map);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class AsEncryptedCollection implements Castable
@@ -22,21 +23,38 @@ class AsEncryptedCollection implements Castable
         {
             public function __construct(protected array $arguments)
             {
+                $this->arguments = array_pad(array_values($this->arguments), 2, '');
             }
 
             public function get($model, $key, $value, $attributes)
             {
-                $collectionClass = $this->arguments[0] ?? Collection::class;
+                $collectionClass = empty($this->arguments[0]) ? Collection::class : $this->arguments[0];
 
                 if (! is_a($collectionClass, Collection::class, true)) {
                     throw new InvalidArgumentException('The provided class must extend ['.Collection::class.'].');
                 }
 
-                if (isset($attributes[$key])) {
-                    return new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));
+                if (! isset($attributes[$key])) {
+                    return null;
                 }
 
-                return null;
+                $instance = new $collectionClass(Json::decode(Crypt::decryptString($attributes[$key])));
+
+                if (! $this->arguments[1]) {
+                    return $instance;
+                }
+
+                if (! $this->arguments[1]) {
+                    return $instance;
+                }
+
+                if (is_string($this->arguments[1])) {
+                    $this->arguments[1] = Str::parseCallback($this->arguments[1]);
+                }
+
+                return is_callable($this->arguments[1])
+                    ? $instance->map($this->arguments[1])
+                    : $instance->mapInto($this->arguments[1][0]);
             }
 
             public function set($model, $key, $value, $attributes)
@@ -54,10 +72,26 @@ class AsEncryptedCollection implements Castable
      * Specify the collection for the cast.
      *
      * @param  class-string  $class
+     * @param  array{class-string, string}|class-string  $map
      * @return string
      */
-    public static function using($class)
+    public static function using($class, $map = null)
     {
-        return static::class.':'.$class;
+        if (is_array($map) && is_callable($map)) {
+            $map = $map[0].'@'.$map[1];
+        }
+
+        return static::class.':'.implode(',', [$class, $map]);
+    }
+
+    /**
+     * Specify the callback to map each item.
+     *
+     * @param  array{class-string, string}|class-string  $map
+     * @return string
+     */
+    public static function map($map)
+    {
+        return static::using('', $map);
     }
 }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -158,7 +158,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithCustomCasts();
         $model->mergeCasts([
-            'collection' => AsCollection::map(Fluent::class),
+            'collection' => AsCollection::of(Fluent::class),
         ]);
 
         $model->setRawAttributes([
@@ -189,7 +189,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithCustomCasts();
         $model->mergeCasts([
-            'collection' => AsCollection::map([FluentWithCallback::class, 'make']),
+            'collection' => AsCollection::of([FluentWithCallback::class, 'make']),
         ]);
 
         $model->setRawAttributes([

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -7,8 +7,10 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Stringable;
 
 class DatabaseCustomCastsTest extends DatabaseTestCase
@@ -151,6 +153,68 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
             $model->array_object_json->toArray()
         );
     }
+
+    public function test_as_collection_with_map_into()
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::map(Fluent::class),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(Fluent::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
+
+    public function test_as_custom_collection_with_map_into()
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::using(CustomCollection::class, Fluent::class),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(CustomCollection::class, $model->collection);
+        $this->assertInstanceOf(Fluent::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
+
+    public function test_as_collection_with_map_callback(): void
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::map([FluentWithCallback::class, 'make']),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(FluentWithCallback::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
+
+    public function test_as_custom_collection_with_map_callback(): void
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::using(CustomCollection::class, [FluentWithCallback::class, 'make']),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(CustomCollection::class, $model->collection);
+        $this->assertInstanceOf(FluentWithCallback::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
 }
 
 class TestEloquentModelWithCustomCasts extends Model
@@ -196,4 +260,16 @@ class TestEloquentModelWithCustomCastsNullable extends Model
         'collection' => AsCollection::class,
         'stringable' => AsStringable::class,
     ];
+}
+
+class FluentWithCallback extends Fluent
+{
+    public static function make(array $array)
+    {
+        return new static($array);
+    }
+}
+
+class CustomCollection extends Collection
+{
 }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -264,9 +264,9 @@ class TestEloquentModelWithCustomCastsNullable extends Model
 
 class FluentWithCallback extends Fluent
 {
-    public static function make(array $array)
+    public static function make($attributes = [])
     {
-        return new static($array);
+        return new static($attributes);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -249,7 +249,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
         $subject = new EncryptedCast;
 
-        $subject->mergeCasts(['secret_collection' => AsEncryptedCollection::map(Fluent::class)]);
+        $subject->mergeCasts(['secret_collection' => AsEncryptedCollection::of(Fluent::class)]);
 
         $subject->secret_collection = new Collection([new Fluent(['key1' => 'value1'])]);
         $subject->secret_collection->push(new Fluent(['key2' => 'value2']));

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Fluent;
 use stdClass;
 
 class EloquentModelEncryptedCastingTest extends DatabaseTestCase
@@ -218,6 +219,58 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Collection::class, $subject->secret_collection);
         $this->assertSame('value1', $subject->secret_collection->get('key1'));
         $this->assertSame('value2', $subject->secret_collection->get('key2'));
+
+        $subject->secret_collection = null;
+        $subject->save();
+
+        $this->assertNull($subject->secret_collection);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_collection' => null,
+        ]);
+
+        $this->assertNull($subject->fresh()->secret_collection);
+    }
+
+    public function testAsEncryptedCollectionMap()
+    {
+        $this->encrypter->expects('encryptString')
+            ->twice()
+            ->with('[{"key1":"value1"}]')
+            ->andReturn('encrypted-secret-collection-string-1');
+        $this->encrypter->expects('encryptString')
+            ->times(12)
+            ->with('[{"key1":"value1"},{"key2":"value2"}]')
+            ->andReturn('encrypted-secret-collection-string-2');
+        $this->encrypter->expects('decryptString')
+            ->once()
+            ->with('encrypted-secret-collection-string-2')
+            ->andReturn('[{"key1":"value1"},{"key2":"value2"}]');
+
+        $subject = new EncryptedCast;
+
+        $subject->mergeCasts(['secret_collection' => AsEncryptedCollection::map(Fluent::class)]);
+
+        $subject->secret_collection = new Collection([new Fluent(['key1' => 'value1'])]);
+        $subject->secret_collection->push(new Fluent(['key2' => 'value2']));
+
+        $subject->save();
+
+        $this->assertInstanceOf(Collection::class, $subject->secret_collection);
+        $this->assertInstanceOf(Fluent::class, $subject->secret_collection->first());
+        $this->assertSame('value1', $subject->secret_collection->get(0)->key1);
+        $this->assertSame('value2', $subject->secret_collection->get(1)->key2);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_collection' => 'encrypted-secret-collection-string-2',
+        ]);
+
+        $subject = $subject->fresh();
+
+        $this->assertInstanceOf(Collection::class, $subject->secret_collection);
+        $this->assertInstanceOf(Fluent::class, $subject->secret_collection->first());
+        $this->assertSame('value1', $subject->secret_collection->get(0)->key1);
+        $this->assertSame('value2', $subject->secret_collection->get(1)->key2);
 
         $subject->secret_collection = null;
         $subject->save();


### PR DESCRIPTION
## What?

Rework of #55377. This extends `AsCollection` and `AsEncryptedCollection` to accept a class to map each item into, or a callable as `[class, method]` or `class@method` notation, without or without a custom collection class.

For example, I expect the most common to be using the `map()` static method to set a Class to map each item into, using the base Collection class.

```php
use Illuminate\Database\Eloquent\Casts\AsCollection;
use Illuminate\Support\Fluent;

public function casts()
{
    return [
        'colors' => AsCollection::map(Fluent::class)
    ];
}

// Same as
Collection::make($this->attributes['colors'])->mapInto(Fluent::class);
```

If the developer sets an array callable, it gets normalized into `class@method` notation.

```php
use Illuminate\Database\Eloquent\Casts\AsCollection;
use App\ValueObject\Color;

public function casts()
{
    return [
        'colors' => AsCollection::map([Color::class, 'make']),
    ];
}

// Same as
Collection::make($this->attributes['colors'])->map([Color::class, 'make']);
```

If the developer wants to use a custom Collection class, the `using()` can be used with a second parameter and either a class or array callable / `class@method`.

```php
return [
    'colors' => AsCollection::using(CustomCollection::class, [Color::class, 'make']),
];

// Same as
CustomCollection::make($this->attributes['colors'])->map([Color::class, 'make']);
```

> [!CAUTION]
> 
> Because the nature of the casts declaration, there is no support to using a Closure. The developer can use `castUsing()` directly with a Closure if desired.

This logic is also extended to the `AsEncryptedCollection` class, which works in the same way.

```php
use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
use App\ValueObject\Color;

public function casts()
{
    return [
        'colors' => AsEncryptedCollection::map([Color::class, 'make']), 
    ];
}
```