### PR TITLE
add string to array converter method in Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2066,6 +2066,31 @@ class Str
     }
 
     /**
+     * Converts a string to array using the first found separator from the provided list.
+     *
+     * @param  string  $string  The input string to convert
+     * @param  array  $separators  List of possible separators to check
+     */
+    public static function toArray(string $string, array $separators = [',', '-', '|', ';', ':', '/', '\\']): array
+    {
+        // If string is empty, return empty array early
+        if ($string === '') {
+            return [];
+        }
+
+        $result = [$string];
+        foreach ($separators as $separator) {
+            if (str_contains($string, $separator)) {
+                $result = explode($separator, $string);
+                break; // Exit once we find the first separator
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1814,6 +1814,63 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testToArrayWithCommaSeparator(): void
+    {
+        $this->assertEquals(
+            ['1', '2', '3'],
+            Str::toArray('1,2,3')
+        );
+    }
+
+    public function testToArrayWithDashSeparator(): void
+    {
+        $this->assertEquals(
+            ['10', '20', '30'],
+            Str::toArray('10-20-30')
+        );
+    }
+
+    public function testToArrayWithPipeSeparator(): void
+    {
+        $this->assertEquals(
+            ['a', 'b', 'c'],
+            Str::toArray('a|b|c')
+        );
+    }
+
+    public function testToArrayWithSlashSeparator(): void
+    {
+        $this->assertEquals(
+            ['apple', 'banana', 'cherry'],
+            Str::toArray('apple/banana/cherry')
+        );
+    }
+
+    public function testToArrayWithCustomSeparators(): void
+    {
+        $this->assertEquals(
+            ['1', '2', '3'],
+            Str::toArray('1*2*3', ['*'])
+        );
+    }
+
+    public function testToArrayWithNoSeparatorReturnsSingleElementArray(): void
+    {
+        $this->assertEquals(
+            ['single'],
+            Str::toArray('single')
+        );
+    }
+
+    public function testToArrayWithEmptyStringReturnsEmptyStringArray(): void
+    {
+        $this->assertEquals(
+            [],
+            Str::toArray('')
+        );
+    }
+
 }
 
 class StringableObjectStub


### PR DESCRIPTION
This PR introduces a new static method Str::toArray() to the Illuminate\Support\Str class. It provides a convenient way to convert delimited strings into arrays using common separators such as ,, -, |, /, etc.