### PR TITLE
[12.x] Add test for Filesystem::lastModified() method

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -648,6 +648,19 @@ class FilesystemTest extends TestCase
         $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
+    public function testLastModifiedReturnsTimestamp()
+    {
+        $path = self::$tempDir.'/timestamp.txt';
+        file_put_contents($path, 'test content');
+
+        $filesystem = new Filesystem;
+        $timestamp = $filesystem->lastModified($path);
+
+        $this->assertIsInt($timestamp);
+        $this->assertGreaterThan(0, $timestamp);
+        $this->assertEquals(filemtime($path), $timestamp);
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
This PR adds a new test case `testLastModifiedReturnsTimestamp()` to verify the functionality of the `lastModified()` method in the Filesystem class.

The test verifies that:
1. The method returns an integer timestamp
2. The timestamp is greater than 0 (valid Unix timestamp)
3. The timestamp matches the one returned by PHP's native filemtime() function

This test helps ensure the reliability of file modification time tracking in the Filesystem class and follows the same testing patterns as other methods in the test suite.
