### PR TITLE
Add descriptive error messages to assertViewHas()

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1195,18 +1195,18 @@ class TestResponse implements ArrayAccess
         $actual = Arr::get($this->original->gatherData(), $key);
 
         if (is_null($value)) {
-            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the data contains the key '$key'.");
+            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the data contains the key [{$key}].");
         } elseif ($value instanceof Closure) {
-            PHPUnit::withResponse($this)->assertTrue($value($actual), "Failed asserting that the value at '$key' fulfills the closure.");
+            PHPUnit::withResponse($this)->assertTrue($value($actual), "Failed asserting that the value at [{$key}] fulfills the expectations defined by the closure.");
         } elseif ($value instanceof Model) {
-            PHPUnit::withResponse($this)->assertTrue($value->is($actual), "Failed asserting that the model at '$key' equals the given model.");
+            PHPUnit::withResponse($this)->assertTrue($value->is($actual), "Failed asserting that the model at [{$key}] matches the given model.");
         } elseif ($value instanceof EloquentCollection) {
             PHPUnit::withResponse($this)->assertInstanceOf(EloquentCollection::class, $actual);
             PHPUnit::withResponse($this)->assertSameSize($value, $actual);
 
-            $value->each(fn($item, $index) => PHPUnit::withResponse($this)->assertTrue($actual->get($index)->is($item), "Failed asserting that the collection at '$key.[$index]' matches the given collection."));
+            $value->each(fn ($item, $index) => PHPUnit::withResponse($this)->assertTrue($actual->get($index)->is($item), "Failed asserting that the collection at [{$key}.[{$index}]]' matches the given collection."));
         } else {
-            PHPUnit::withResponse($this)->assertEquals($value, $actual, "Failed asserting that '$key' matches the expected value.");
+            PHPUnit::withResponse($this)->assertEquals($value, $actual, "Failed asserting that [{$key}] matches the expected value.");
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1193,7 +1193,7 @@ class TestResponse implements ArrayAccess
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the view data contains the key '$key'");
+            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the view data contains the key '$key'.");
         } elseif ($value instanceof Closure) {
             PHPUnit::withResponse($this)->assertTrue($value(Arr::get($this->original->gatherData(), $key)), "Failed asserting that the value at '$key' fulfils the closure.");
         } elseif ($value instanceof Model) {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1193,18 +1193,18 @@ class TestResponse implements ArrayAccess
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key));
+            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the view data contains the key '$key'");
         } elseif ($value instanceof Closure) {
-            PHPUnit::withResponse($this)->assertTrue($value(Arr::get($this->original->gatherData(), $key)));
+            PHPUnit::withResponse($this)->assertTrue($value(Arr::get($this->original->gatherData(), $key)), "Failed asserting that the value at '$key' fulfils the closure.");
         } elseif ($value instanceof Model) {
-            PHPUnit::withResponse($this)->assertTrue($value->is(Arr::get($this->original->gatherData(), $key)));
+            PHPUnit::withResponse($this)->assertTrue($value->is(Arr::get($this->original->gatherData(), $key)), "Failed asserting that the model at '$key' equals the given model.");
         } elseif ($value instanceof EloquentCollection) {
             $actual = Arr::get($this->original->gatherData(), $key);
 
             PHPUnit::withResponse($this)->assertInstanceOf(EloquentCollection::class, $actual);
             PHPUnit::withResponse($this)->assertSameSize($value, $actual);
 
-            $value->each(fn ($item, $index) => PHPUnit::withResponse($this)->assertTrue($actual->get($index)->is($item)));
+            $value->each(fn($item, $index) => PHPUnit::withResponse($this)->assertTrue($actual->get($index)->is($item), "Failed asserting that the collection at '$key.[$index]' matches the given collection."));
         } else {
             PHPUnit::withResponse($this)->assertEquals($value, Arr::get($this->original->gatherData(), $key));
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1192,21 +1192,21 @@ class TestResponse implements ArrayAccess
 
         $this->ensureResponseHasView();
 
-        if (is_null($value)) {
-            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the view data contains the key '$key'.");
-        } elseif ($value instanceof Closure) {
-            PHPUnit::withResponse($this)->assertTrue($value(Arr::get($this->original->gatherData(), $key)), "Failed asserting that the value at '$key' fulfils the closure.");
-        } elseif ($value instanceof Model) {
-            PHPUnit::withResponse($this)->assertTrue($value->is(Arr::get($this->original->gatherData(), $key)), "Failed asserting that the model at '$key' equals the given model.");
-        } elseif ($value instanceof EloquentCollection) {
-            $actual = Arr::get($this->original->gatherData(), $key);
+        $actual = Arr::get($this->original->gatherData(), $key);
 
+        if (is_null($value)) {
+            PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the data contains the key '$key'.");
+        } elseif ($value instanceof Closure) {
+            PHPUnit::withResponse($this)->assertTrue($value($actual), "Failed asserting that the value at '$key' fulfills the closure.");
+        } elseif ($value instanceof Model) {
+            PHPUnit::withResponse($this)->assertTrue($value->is($actual), "Failed asserting that the model at '$key' equals the given model.");
+        } elseif ($value instanceof EloquentCollection) {
             PHPUnit::withResponse($this)->assertInstanceOf(EloquentCollection::class, $actual);
             PHPUnit::withResponse($this)->assertSameSize($value, $actual);
 
             $value->each(fn($item, $index) => PHPUnit::withResponse($this)->assertTrue($actual->get($index)->is($item), "Failed asserting that the collection at '$key.[$index]' matches the given collection."));
         } else {
-            PHPUnit::withResponse($this)->assertEquals($value, Arr::get($this->original->gatherData(), $key));
+            PHPUnit::withResponse($this)->assertEquals($value, $actual, "Failed asserting that '$key' matches the expected value.");
         }
 
         return $this;


### PR DESCRIPTION
### Problem Statement:
Currently, when passing multiple key-value pairs to assertViewHasAll() and an error occurs, there is no feedback to which of the many fields caused the assertion to fail. Not even the stacktrace and line numbers provide sufficient information.

**Example:**
```
$response->assertViewHasAll([
    'key_without_value',
    'key_with_value' => 10,
    'key_with_closure' => fn ($value) => $value == 10,
    'key_with_model' => Customer::first(),
    'key_with_collection' => Customer::factory()->count(10)->create(),
]);
```
### Before: 
![image](https://github.com/user-attachments/assets/09ff50c4-3496-4aca-97fb-a1dbae706a54)


### Solution:
This PR adds custom error messages to the underlying assertions to give the user better feedback, which of the fields caused the assertion error.

Please feel free to make any suggestions regarding the exact text that we want to use in the error messages - these are just what I came up with when doing a quick test.

### After:

**key_without_value**:
![image](https://github.com/user-attachments/assets/9d30067c-5188-43fb-95c9-66ada212a9ed)

**key_with_value**
![image](https://github.com/user-attachments/assets/7f51369e-58a8-4078-b01c-b00f5d0ff823)

**key_with_closure**
![image](https://github.com/user-attachments/assets/8d241bb4-a4a9-47bd-a8cc-54498874fa1b)

**key_with_model**
![image](https://github.com/user-attachments/assets/9fdb6995-7efb-4547-a6ac-5f168a9efc88)

**key_with_collection**
![image](https://github.com/user-attachments/assets/7b1a59ee-5621-40b3-b3bb-a1d5fbfdaad1)


