### PR TITLE
[12.x] Supports `pda/pheanstalk` 7

### DIFF
--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -178,7 +178,15 @@ jobs:
   beanstalkd:
     runs-on: ubuntu-24.04
 
-    name: Beanstalkd Driver
+    strategy:
+      matrix:
+        include:
+          - php: 8.2
+            pheanstalk: 5
+          - php: 8.3
+            pheanstalk: 7
+
+    name: Beanstalkd Driver (pda/pheanstalk:^${{ matrix.pheanstalk }})
 
     steps:
       - name: Checkout code
@@ -198,11 +206,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
-          include:
-            - php: 8.2
-              pheanstalk: 5
-            - php: 8.3
-              pheanstalk: 7
 
       - name: Set Framework version
         run: composer config version "12.x-dev"

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -179,12 +179,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     strategy:
+      fail-fast: true
       matrix:
-        include:
-          - php: 8.2
-            pheanstalk: 5
-          - php: 8.3
-            pheanstalk: 7
+        - php: 8.2
+          pheanstalk: 5
+        - php: 8.3
+          pheanstalk: 7
 
     name: Beanstalkd Driver (pda/pheanstalk:^${{ matrix.pheanstalk }})
 

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -181,10 +181,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        - php: 8.2
-          pheanstalk: 5
-        - php: 8.3
-          pheanstalk: 7
+        include:
+          - php: 8.2
+            pheanstalk: 5
+          - php: 8.3
+            pheanstalk: 7
 
     name: Beanstalkd Driver (pda/pheanstalk:^${{ matrix.pheanstalk }})
 

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -194,10 +194,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
           tools: composer:v2
           coverage: none
+          include:
+            - php: 8.2
+              pheanstalk: 5
+            - php: 8.3
+              pheanstalk: 7
 
       - name: Set Framework version
         run: composer config version "12.x-dev"
@@ -207,7 +212,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress --with="pda/pheanstalk:^${{ matrix.pheanstalk }}"
 
       - name: Daemonize beanstalkd
         run: ./beanstalkd-1.13/beanstalkd &

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
         "orchestra/testbench-core": "^10.0.0",
-        "pda/pheanstalk": "^5.0.6",
+        "pda/pheanstalk": "^5.0.3|^7.0.0",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
         "orchestra/testbench-core": "^10.0.0",
-        "pda/pheanstalk": "^5.0.3|^7.0.0",
+        "pda/pheanstalk": "^5.0.6|^7.0.0",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -45,7 +45,7 @@
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.322.9).",
         "illuminate/redis": "Required to use the Redis queue driver (^12.0).",
-        "pda/pheanstalk": "Required to use the Beanstalk queue driver (^5.0)."
+        "pda/pheanstalk": "Required to use the Beanstalk queue driver (^5.0.6|^7.0.0)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Skipped version 6 (released Jan 2025) since it's mainly removing PHP 8.1 and 8.2 support, while 7 was released shortly in March 2025