### PR TITLE
[12.x] Add comprehensive filesystem operation tests to FilesystemTest

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -672,4 +672,42 @@ class FilesystemTest extends TestCase
 
         return (int) base_convert($filePerms, 8, 10);
     }
+
+    public function testFileCreationAndContentVerification()
+    {
+        $files = new Filesystem;
+
+        $testContent = 'This is a test file content';
+        $filePath = self::$tempDir.'/test.txt';
+
+        $files->put($filePath, $testContent);
+
+        $this->assertTrue($files->exists($filePath));
+        $this->assertSame($testContent, $files->get($filePath));
+        $this->assertEquals(strlen($testContent), $files->size($filePath));
+    }
+
+    public function testDirectoryOperationsWithSubdirectories()
+    {
+        $files = new Filesystem;
+
+        $dirPath = self::$tempDir.'/test_dir';
+        $subDirPath = $dirPath.'/sub_dir';
+
+        $this->assertTrue($files->makeDirectory($dirPath));
+        $this->assertTrue($files->isDirectory($dirPath));
+
+        $this->assertTrue($files->makeDirectory($subDirPath));
+        $this->assertTrue($files->isDirectory($subDirPath));
+
+        $filePath = $subDirPath.'/test.txt';
+        $files->put($filePath, 'test content');
+
+        $this->assertTrue($files->exists($filePath));
+
+        $allFiles = $files->allFiles($dirPath);
+
+        $this->assertCount(1, $allFiles);
+        $this->assertEquals('test.txt', $allFiles[0]->getFilename());
+    }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -648,6 +648,19 @@ class FilesystemTest extends TestCase
         $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
+    public function testLastModifiedReturnsTimestamp()
+    {
+        $path = self::$tempDir.'/timestamp.txt';
+        file_put_contents($path, 'test content');
+
+        $filesystem = new Filesystem;
+        $timestamp = $filesystem->lastModified($path);
+
+        $this->assertIsInt($timestamp);
+        $this->assertGreaterThan(0, $timestamp);
+        $this->assertEquals(filemtime($path), $timestamp);
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
This PR adds two new test cases to `FilesystemTest.php` to improve the test coverage of filesystem operations:

1. `testFileCreationAndContentVerification`
   - Tests file creation with content
   - Verifies file existence
   - Validates file content
   - Checks file size

2. `testDirectoryOperationsWithSubdirectories`
   - Tests directory creation
   - Verifies subdirectory operations
   - Tests file creation in sub-directories
   - Validates directory listing functionality