### PR TITLE
[12.x] Add `limitIncludesEnd` flag to Str::limit

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -689,19 +689,32 @@ class Str
      * @param  int  $limit
      * @param  string  $end
      * @param  bool  $preserveWords
+     * @param  bool  $limitIncludesEnd
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...', $preserveWords = false)
+    public static function limit($value, $limit = 100, $end = '...', $preserveWords = false, $limitIncludesEnd = false)
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+        $valueWidth = mb_strwidth($value, 'UTF-8');
+
+        if ($valueWidth <= $limit) {
             return $value;
         }
 
+        $endWidth = mb_strwidth($end, 'UTF-8');
+
         if (! $preserveWords) {
+            if ($limitIncludesEnd && $valueWidth + $endWidth > $limit) {
+                $limit = max(0, $limit - $endWidth);
+            }
+
             return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
         }
 
         $value = trim(preg_replace('/[\n\r]+/', ' ', strip_tags($value)));
+
+        if ($limitIncludesEnd) {
+            $limit = max(0, $limit - $endWidth);
+        }
 
         $trimmed = rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8'));
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -445,11 +445,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  int  $limit
      * @param  string  $end
      * @param  bool  $preserveWords
+     * @param  bool  $limitIncludesEnd
      * @return static
      */
-    public function limit($limit = 100, $end = '...', $preserveWords = false)
+    public function limit($limit = 100, $end = '...', $preserveWords = false, $limitIncludesEnd = false)
     {
-        return new static(Str::limit($this->value, $limit, $end, $preserveWords));
+        return new static(Str::limit($this->value, $limit, $end, $preserveWords, $limitIncludesEnd));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -675,21 +675,32 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
         $this->assertSame('这是一...', Str::limit('这是一段中文', 6));
         $this->assertSame('Laravel is a...', Str::limit('Laravel is a free, open source PHP web application framework.', 15, preserveWords: true));
+        $this->assertSame('Laravel...', Str::limit('Laravel is a free, open source PHP web application framework.', 10, limitIncludesEnd: true));
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', Str::limit($string, 7));
+        $this->assertSame('The...', Str::limit($string, 7, limitIncludesEnd: true));
         $this->assertSame('The PHP...', Str::limit($string, 10, preserveWords: true));
         $this->assertSame('The PHP', Str::limit($string, 7, ''));
+        $this->assertSame('The PHP', Str::limit($string, 7, '', limitIncludesEnd: true));
         $this->assertSame('The PHP', Str::limit($string, 10, '', true));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
+        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100, limitIncludesEnd: true));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100, preserveWords: true));
         $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true));
+        $this->assertSame('The PHP fram...', Str::limit($string, 15, limitIncludesEnd: true));
+        $this->assertSame('The PHP...', Str::limit($string, 15, preserveWords: true, limitIncludesEnd: true));
+        $this->assertSame('The PHP framework...', Str::limit($string, 20, preserveWords: true, limitIncludesEnd: true));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6, preserveWords: true));
+        $this->assertSame('这...', Str::limit($nonAsciiString, 6, limitIncludesEnd: true));
+        $this->assertSame('这...', Str::limit($nonAsciiString, 6, preserveWords: true, limitIncludesEnd: true));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', true));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', limitIncludesEnd: true));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', true, true));
     }
 
     public function testLength()


### PR DESCRIPTION
## Description

This pull request adds a new parameter to the `Str::limit()` function to make it possible to include the length of the `$end` suffix into the `$limit`.

## Example use case

Say you have a 'notes' table where the title column can be 20 characters long. You include a 'copy' feature where the title gets copied over, but must be suffixed with ' (Copy)'.

```php
$title = 'Laravel is awesome!'; // Length: 19
$copy = Str::limit($title, 20 - 7) . ' (Copy)';
// What we want: 'Laravel is... (Copy)'; Length: 20
// What we get: 'Laravel is aw... (Copy)'; Length: 23 -> Exception, value too long for column
```

## Usage

```php
<?php

Str::limit('Laravel is awesome!', 7, limitIncludesEnd: true) // Laravel
Str::limit('Laravel is awesome!', 12, limitIncludesEnd: true) // Laravel i...
Str::limit('Laravel is awesome!', 12, preserveWords: true, limitIncludesEnd: true) // Laravel...

```

## Testing

The PR includes tests to check multiple scenarios and combinations with the existing $preserveWords parameter

## No Breaking Changes

To not introduce breaking changes, I've opted to set the new parameter to `false` by default to keep the current behavior.


