### PR TITLE
[Feature] Add createMany() to Eloquent\Builder for bulk record creation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1193,6 +1193,21 @@ class Builder implements BuilderContract
         });
     }
 
+    public function createMany(array $records, bool $quiet = false): Collection
+    {
+        $collection = $this->model->newCollection();
+
+        foreach ($records as $record) {
+            $model = $quiet
+                ? $this->createQuietly($record)
+                : $this->create($record);
+
+            $collection->push($model);
+        }
+
+        return $collection;
+    }
+
     /**
      * Save a new model and return the instance without raising model events.
      *


### PR DESCRIPTION
## Description

This PR introduces a `createMany()` method to the `Illuminate\Database\Eloquent\Builder` class. It enables bulk creation of Eloquent models **with support for all Eloquent features**, such as:

- Mass assignment protection
- Model events (`creating`, `created`, etc.)
- Attribute casting
- Automatic timestamps

Currently, the only alternatives for bulk inserts are:

- `Model::insert()`: fast, but skips Eloquent features.
- Looping through `Model::create([...])`: verbose and less expressive.

The proposed `createMany()` method simplifies this use case in a clean and idiomatic way.

---

## Usage Example

```php
$products = Product::query()->createMany([
    ['name' => 'iPhone', 'price' => 999],
    ['name' => 'Galaxy', 'price' => 899],
]);

foreach ($products as $product) {
    echo $product->id; // Model is saved and accessible
}
```

Quiet mode to skip model events:

```php
Product::query()->createMany([
    ['name' => 'Pixel 6', 'price' => 599],
    ['name' => 'OnePlus', 'price' => 699],
], quiet: true);
```

---

## Benefits

✅ **Cleaner Syntax**  
Avoids manual loops for model creation.

✅ **Preserves Eloquent Features**  
Unlike `insert()`, it respects model observers, mutators, casts, timestamps, etc.

✅ **Consistent API**  
Aligns with `HasMany::createMany()` method already available in Eloquent relationships.

---

## Implementation

The method added to `Illuminate\Database\Eloquent\Builder`:

```php
use Illuminate\Database\Eloquent\Collection;

public function createMany(array $records, bool $quiet = false): Collection
{
    $collection = $this->model->newCollection();

    foreach ($records as $record) {
        $model = $quiet
            ? $this->createQuietly($record)
            : $this->create($record);

        $collection->push($model);
    }

    return $collection;
}
```

---

## Backward Compatibility

✅ This feature is fully backward-compatible. It adds a non-breaking method to the builder.



## Final Notes

This method will be helpful in almost every CRUD-based application, allowing developers to maintain clean syntax and leverage Laravel’s expressive API when dealing with batch inserts.

Looking forward to your feedback 🙌