### PR TITLE
[12.x] Adds missing return type in migration stub

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create('{{ table }}', function (Blueprint $table): void {
             $table->id();
             $table->timestamps();
         });

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', function (Blueprint $table): void {
             //
         });
     }
@@ -21,7 +21,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', function (Blueprint $table): void {
             //
         });
     }

--- a/tests/Integration/Generators/MigrateMakeCommandTest.php
+++ b/tests/Integration/Generators/MigrateMakeCommandTest.php
@@ -12,7 +12,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foos\', function (Blueprint $table) {',
+            'Schema::table(\'foos\', function (Blueprint $table): void {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -24,7 +24,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::table(\'foobar\', function (Blueprint $table) {',
+            'Schema::table(\'foobar\', function (Blueprint $table): void {',
         ], 'add_bar_to_foos_table.php');
     }
 
@@ -36,7 +36,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
+            'Schema::create(\'foos\', function (Blueprint $table): void {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
     }
@@ -49,7 +49,7 @@ class MigrateMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foobar\', function (Blueprint $table) {',
+            'Schema::create(\'foobar\', function (Blueprint $table): void {',
             'Schema::dropIfExists(\'foobar\');',
         ], 'foos_table.php');
     }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -185,7 +185,7 @@ class ModelMakeCommandTest extends TestCase
         $this->assertMigrationFileContains([
             'use Illuminate\Database\Migrations\Migration;',
             'return new class extends Migration',
-            'Schema::create(\'foos\', function (Blueprint $table) {',
+            'Schema::create(\'foos\', function (Blueprint $table): void {',
             'Schema::dropIfExists(\'foos\');',
         ], 'create_foos_table.php');
 


### PR DESCRIPTION
Minor change to make it more type-safe.
Rector/Phpstan and type-coverage fails if we do not add void return type.