### PR TITLE
[12.x] Fix cc/bcc/replyTo address merging in `MailMessage`

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -212,7 +212,7 @@ class MailMessage extends SimpleMessage implements Renderable
     public function replyTo($address, $name = null)
     {
         if ($this->arrayOfAddresses($address)) {
-            $this->replyTo += $this->parseAddresses($address);
+            $this->replyTo = array_merge($this->replyTo, $this->parseAddresses($address));
         } else {
             $this->replyTo[] = [$address, $name];
         }
@@ -230,7 +230,7 @@ class MailMessage extends SimpleMessage implements Renderable
     public function cc($address, $name = null)
     {
         if ($this->arrayOfAddresses($address)) {
-            $this->cc += $this->parseAddresses($address);
+            $this->cc = array_merge($this->cc, $this->parseAddresses($address));
         } else {
             $this->cc[] = [$address, $name];
         }
@@ -248,7 +248,7 @@ class MailMessage extends SimpleMessage implements Renderable
     public function bcc($address, $name = null)
     {
         if ($this->arrayOfAddresses($address)) {
-            $this->bcc += $this->parseAddresses($address);
+            $this->bcc = array_merge($this->bcc, $this->parseAddresses($address));
         } else {
             $this->bcc[] = [$address, $name];
         }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -91,7 +91,7 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([
             ['test@example.com', 'Test'],
             ['test@example.com', null],
-            ['test2@example.com', null]
+            ['test2@example.com', null],
         ], $message->cc);
     }
 
@@ -120,7 +120,7 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([
             ['test@example.com', 'Test'],
             ['test@example.com', null],
-            ['test2@example.com', null]
+            ['test2@example.com', null],
         ], $message->bcc);
     }
 
@@ -149,7 +149,7 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([
             ['test@example.com', 'Test'],
             ['test@example.com', null],
-            ['test2@example.com', null]
+            ['test2@example.com', null],
         ], $message->replyTo);
     }
 

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -83,6 +83,16 @@ class NotificationMailMessageTest extends TestCase
         $message->cc(['test@example.com', 'Test' => 'test@example.com']);
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->cc);
+
+        $message = new MailMessage;
+        $message->cc('test@example.com', 'Test')
+            ->cc(['test@example.com', 'test2@example.com']);
+
+        $this->assertSame([
+            ['test@example.com', 'Test'],
+            ['test@example.com', null],
+            ['test2@example.com', null]
+        ], $message->cc);
     }
 
     public function testBccIsSetCorrectly()
@@ -102,6 +112,16 @@ class NotificationMailMessageTest extends TestCase
         $message->bcc(['test@example.com', 'Test' => 'test@example.com']);
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->bcc);
+
+        $message = new MailMessage;
+        $message->bcc('test@example.com', 'Test')
+            ->bcc(['test@example.com', 'test2@example.com']);
+
+        $this->assertSame([
+            ['test@example.com', 'Test'],
+            ['test@example.com', null],
+            ['test2@example.com', null]
+        ], $message->bcc);
     }
 
     public function testReplyToIsSetCorrectly()
@@ -121,6 +141,16 @@ class NotificationMailMessageTest extends TestCase
         $message->replyTo(['test@example.com', 'Test' => 'test@example.com']);
 
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
+
+        $message = new MailMessage;
+        $message->replyTo('test@example.com', 'Test')
+            ->replyTo(['test@example.com', 'test2@example.com']);
+
+        $this->assertSame([
+            ['test@example.com', 'Test'],
+            ['test@example.com', null],
+            ['test2@example.com', null]
+        ], $message->replyTo);
     }
 
     public function testMetadataIsSetCorrectly()


### PR DESCRIPTION
Address merging in `MailMessage` is broken, when `cc()`, `bcc()`, or `replyTo()` are called multiple times and we're using unnamed address(es) (sequentially indexed), e.g.:

```php
$message = (new MailMessage)
    ->bcc('bcc@example.com', 'Test')
    ->bcc(['bcc2@example.com', 'bcc3@example.com']);
```

results in:

```php
> $message->bcc
= [
    [
      "bcc@example.com",
      "Test",
    ],
    [
      "bcc3@example.com",
      null,
    ],
  ]
```

expected:

```php
> $message->bcc
= [
    [
      "bcc@example.com",
      "Test",
    ],
    [
      "bcc2@example.com",
      null,
    ],
    [
      "bcc3@example.com",
      null,
    ],
  ]
```

The first item of the 2nd `bcc(['bcc2@example.com', 'bcc3@example.com'])` call is lost, as `MailMessage::bcc()` (same in `cc()` and `replyTo()`) uses PHP's `+=` union operator to merge the arrays and in this case does not add the first item as there is already an address with `0` array key present.

Using `array_merge()`  instead fixes it.

For me, this is a common use case, as in my app most notifications are using a `MailMessage` template with an admin recipient set in an initial `bcc()` call, while the notification's `getMailMessage()` method may add one or more bcc recipients, usually unnamed (indexed with int keys).