### PR TITLE
[12.x] Fix adding `setTags` method on new cache flush events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheFlushFailed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushFailed.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Cache\Events;
 
-class CacheFlushed
+class CacheFlushFailed
 {
     /**
      * The name of the cache store.

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -12,13 +12,34 @@ class CacheFlushing
     public $storeName;
 
     /**
+     * The tags that were assigned to the key.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      * @return void
      */
-    public function __construct($storeName)
+    public function __construct($storeName, array $tags = [])
     {
         $this->storeName = $storeName;
+        $this->tags = $tags;
+    }
+
+    /**
+     * Set the tags for the cache event.
+     *
+     * @param  array  $tags
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
+
 class RedisTaggedCache extends TaggedCache
 {
     /**
@@ -105,8 +108,12 @@ class RedisTaggedCache extends TaggedCache
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->flushValues();
         $this->tags->flush();
+
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -7,6 +7,7 @@ use BadMethodCallException;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushFailed;
 use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
@@ -584,6 +585,8 @@ class Repository implements ArrayAccess, CacheContract
 
         if ($result) {
             $this->event(new CacheFlushed($this->getName()));
+        } else {
+            $this->event(new CacheFlushFailed($this->getName()));
         }
 
         return $result;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
@@ -77,7 +79,11 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
+        $this->event(new CacheFlushing($this->getName()));
+
         $this->tags->reset();
+
+        $this->event(new CacheFlushed($this->getName()));
 
         return true;
     }
@@ -104,7 +110,7 @@ class TaggedCache extends Repository
     /**
      * Fire an event for this cache instance.
      *
-     * @param  \Illuminate\Cache\Events\CacheEvent  $event
+     * @param  object  $event
      * @return void
      */
     protected function event($event)

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Events\CacheFlushed;
+use Illuminate\Cache\Events\CacheFlushFailed;
 use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
@@ -242,7 +243,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->clear());
     }
 
-    public function testFlushFailureDoesNotDispatchEvent()
+    public function testFlushFailureDoesDispatchEvent()
     {
         $dispatcher = $this->getDispatcher();
 
@@ -255,6 +256,12 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with(
             $this->assertEventMatches(CacheFlushing::class, [
+                'storeName' => 'array',
+            ])
+        );
+
+        $dispatcher->shouldReceive('dispatch')->once()->with(
+            $this->assertEventMatches(CacheFlushFailed::class, [
                 'storeName' => 'array',
             ])
         );


### PR DESCRIPTION
- Closes #55322
- Closes #55101
- Closes https://github.com/laravel/framework/pull/55142#discussion_r2029396378

 ## Why
 In https://github.com/laravel/framework/pull/55121#issuecomment-2745343350, Taylor [said](https://github.com/laravel/framework/pull/55121#issuecomment-2745343350) that the new `CacheFlushed` or `CacheFlushing` events should not extend `CacheEvent`. This makes sense since the `CacheEvent` is for events with a specific `$key`.
 
 However, that means that we now have cache events that do not share a common ancestor and these events cannot have their tags set in `TaggedCache` (or `RedisTaggedCache`).
 
 ## What
 This PR attempts to fix this issue by adding a `TaggedCacheEvent` abstract class with a `setTags` method and making `CacheEvent`, `CacheFlushing`, and `CacheFlushed` extend it.
 


