### PR TITLE
[12.x] Add test coverage for nested array merging behavior

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -390,7 +390,7 @@ class RepositoryTest extends TestCase
         $this->assertSame(2, $this->repository->get('nested.level1.b.y'));
         $this->assertSame(4, $this->repository->get('nested.level1.b.z'));
         $this->assertSame('new', $this->repository->get('nested.level1.c'));
-        
+
         $expected = [
             'level1' => [
                 'a' => 'updated',

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -371,7 +371,7 @@ class RepositoryTest extends TestCase
                 'a' => 'original',
                 'b' => [
                     'x' => 1,
-                    'y' => 2
+                    'y' => 2,
                 ]
             ]
         ]);
@@ -380,9 +380,9 @@ class RepositoryTest extends TestCase
             'a' => 'updated',
             'b' => [
                 'x' => 3,
-                'z' => 4
+                'z' => 4,
             ],
-            'c' => 'new'
+            'c' => 'new',
         ]);
 
         $this->assertSame('updated', $this->repository->get('nested.level1.a'));
@@ -397,9 +397,9 @@ class RepositoryTest extends TestCase
                 'b' => [
                     'x' => 3,
                     'y' => 2,
-                    'z' => 4
+                    'z' => 4,
                 ],
-                'c' => 'new'
+                'c' => 'new',
             ]
         ];
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -363,4 +363,46 @@ class RepositoryTest extends TestCase
 
         $this->repository->float('a.b');
     }
+
+    public function testSetNestedArrayMerging()
+    {
+        $this->repository->set('nested', [
+            'level1' => [
+                'a' => 'original',
+                'b' => [
+                    'x' => 1,
+                    'y' => 2
+                ]
+            ]
+        ]);
+
+        $this->repository->set('nested.level1', [
+            'a' => 'updated',
+            'b' => [
+                'x' => 3,
+                'z' => 4
+            ],
+            'c' => 'new'
+        ]);
+
+        $this->assertSame('updated', $this->repository->get('nested.level1.a'));
+        $this->assertSame(3, $this->repository->get('nested.level1.b.x'));
+        $this->assertSame(2, $this->repository->get('nested.level1.b.y'));
+        $this->assertSame(4, $this->repository->get('nested.level1.b.z'));
+        $this->assertSame('new', $this->repository->get('nested.level1.c'));
+        
+        $expected = [
+            'level1' => [
+                'a' => 'updated',
+                'b' => [
+                    'x' => 3,
+                    'y' => 2,
+                    'z' => 4
+                ],
+                'c' => 'new'
+            ]
+        ];
+
+        $this->assertSame($expected, $this->repository->get('nested'));
+    }
 }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -372,8 +372,8 @@ class RepositoryTest extends TestCase
                 'b' => [
                     'x' => 1,
                     'y' => 2,
-                ]
-            ]
+                ],
+            ],
         ]);
 
         $this->repository->set('nested.level1', [
@@ -400,7 +400,7 @@ class RepositoryTest extends TestCase
                     'z' => 4,
                 ],
                 'c' => 'new',
-            ]
+            ],
         ];
 
         $this->assertSame($expected, $this->repository->get('nested'));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -648,6 +648,19 @@ class FilesystemTest extends TestCase
         $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
+    public function testLastModifiedReturnsTimestamp()
+    {
+        $path = self::$tempDir.'/timestamp.txt';
+        file_put_contents($path, 'test content');
+
+        $filesystem = new Filesystem;
+        $timestamp = $filesystem->lastModified($path);
+
+        $this->assertIsInt($timestamp);
+        $this->assertGreaterThan(0, $timestamp);
+        $this->assertEquals(filemtime($path), $timestamp);
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
This test shows how the Repository handles complex nested data structures and verifies that the merging behavior works correctly when updating nested configuration values. 

### What's being added
- New test case `testSetNestedArrayMerging()` that verifies the Repository's behavior when merging nested configuration arrays
- Comprehensive assertions for both individual path access and complete structure validation

### Why this matters
- Ensures reliable handling of complex nested configurations
- Verifies that existing values are properly preserved during partial updates
- Validates correct merging behavior at multiple levels of nesting
- Helps prevent potential regressions in array merging functionality

