### PR TITLE
[12.x] Additional password reset token env vars

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -94,8 +94,8 @@ return [
         'users' => [
             'provider' => 'users',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
-            'expire' => 60,
-            'throttle' => 60,
+            'expire' => (int) env('AUTH_PASSWORD_RESET_TOKEN_EXPIRE', 60),
+            'throttle' => (int) env('AUTH_PASSWORD_RESET_TOKEN_THROTTLE', 60),
         ],
     ],
 


### PR DESCRIPTION
This adds optional environment variables to `config/auth.php` for the `passwords` entry, allowing token expiration and reset request throttling to be configured without publishing the config file.