### PR TITLE
[12.x]Use promoted properties and type declarations 

### DIFF
--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -5,19 +5,12 @@ namespace Illuminate\Foundation\Events;
 class LocaleUpdated
 {
     /**
-     * The new locale.
-     *
-     * @var string
-     */
-    public $locale;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $locale
+     * @param  string  $locale  The new locale.
      */
-    public function __construct($locale)
-    {
-        $this->locale = $locale;
+    public function __construct(
+        public string $locale
+    ) {
     }
 }

--- a/src/Illuminate/Foundation/Events/PublishingStubs.php
+++ b/src/Illuminate/Foundation/Events/PublishingStubs.php
@@ -7,20 +7,13 @@ class PublishingStubs
     use Dispatchable;
 
     /**
-     * The stubs being published.
-     *
-     * @var array
-     */
-    public $stubs = [];
-
-    /**
      * Create a new event instance.
      *
-     * @param  array  $stubs
+     * @param  array  $stubs  The stubs being published.
      */
-    public function __construct(array $stubs)
-    {
-        $this->stubs = $stubs;
+    public function __construct(
+        public array $stubs = []
+    ) {
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -5,28 +5,14 @@ namespace Illuminate\Foundation\Events;
 class VendorTagPublished
 {
     /**
-     * The vendor tag that was published.
-     *
-     * @var string
-     */
-    public $tag;
-
-    /**
-     * The publishable paths registered by the tag.
-     *
-     * @var array
-     */
-    public $paths;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $tag
-     * @param  array  $paths
+     * @param  string  $tag  The vendor tag that was published.
+     * @param  array  $paths  The publishable paths registered by the tag.
      */
-    public function __construct($tag, $paths)
-    {
-        $this->tag = $tag;
-        $this->paths = $paths;
+    public function __construct(
+        public string $tag,
+        public array $paths
+    ) {
     }
 }


### PR DESCRIPTION
Add proper type declarations to properties that were previously only typed via docblocks. Also convert to promoted properties.