### PR TITLE
[12.x] Attribute Casting using Property Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 /.fleet
 /.vscode
 .phpunit.result.cache
+!/phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Thumbs.db
 /.fleet
 /.vscode
 .phpunit.result.cache
-!/phpunit.xml

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -755,7 +755,9 @@ trait HasAttributes
      */
     public function hasAnyGetMutator($key)
     {
-        return $this->hasGetMutator($key) || $this->hasAttributeGetMutator($key);
+        return $this->hasGetMutator($key)
+            || $this->hasPropertyHookGetter($key)
+            || $this->hasAttributeGetMutator($key);
     }
 
     /**
@@ -2540,9 +2542,7 @@ trait HasAttributes
             return [];
         }
 
-        $instance = is_object($class) ? $class : new $class;
-
-        return (new Collection((new ReflectionClass($instance))->getProperties()))
+        return (new Collection((new ReflectionClass($class))->getProperties()))
             ->filter->hasHook(PropertyHookType::Get)->map->name->values()->all();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -666,7 +666,7 @@ trait HasAttributes
      */
     public function hasPropertyHookGetter($key)
     {
-        if (PHP_VERSION_ID < 80400) {
+        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
             return false;
         }
 
@@ -690,7 +690,7 @@ trait HasAttributes
      */
     public function hasPropertyHookSetter($key)
     {
-        if (PHP_VERSION_ID < 80400) {
+        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
             return false;
         }
 
@@ -2537,7 +2537,7 @@ trait HasAttributes
      */
     protected static function getPropertyHookGetters($class)
     {
-        if (PHP_VERSION_ID < 80400) {
+        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
             return [];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -46,7 +46,6 @@ use RuntimeException;
 use ValueError;
 
 use function Illuminate\Support\enum_value;
-use function in_array;
 
 trait HasAttributes
 {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2542,8 +2542,7 @@ trait HasAttributes
 
         $instance = is_object($class) ? $class : new $class;
 
-        return (new Collection((new ReflectionClass($instance))
-            ->getProperties(ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PRIVATE)))
+        return (new Collection((new ReflectionClass($instance))->getProperties()))
             ->filter->hasHook(PropertyHookType::Get)->map->name->values()->all();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -665,7 +665,7 @@ trait HasAttributes
      */
     public function hasPropertyHookGetter($key)
     {
-        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
+        if (PHP_VERSION_ID < 80400) {
             return false;
         }
 
@@ -689,7 +689,7 @@ trait HasAttributes
      */
     public function hasPropertyHookSetter($key)
     {
-        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
+        if (PHP_VERSION_ID < 80400) {
             return false;
         }
 
@@ -2536,7 +2536,7 @@ trait HasAttributes
      */
     protected static function getPropertyHookGetters($class)
     {
-        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
+        if (PHP_VERSION_ID < 80400) {
             return [];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -467,8 +467,8 @@ trait HasAttributes
 
         return array_key_exists($key, $this->attributes) ||
             array_key_exists($key, $this->casts) ||
-            $this->hasGetMutator($key) ||
             $this->hasPropertyHookGetter($key) ||
+            $this->hasGetMutator($key) ||
             $this->hasAttributeMutator($key) ||
             $this->isClassCastable($key);
     }
@@ -1112,10 +1112,10 @@ trait HasAttributes
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // this model, such as "json_encoding" a listing of data for storage.
-        if ($this->hasSetMutator($key)) {
-            return $this->setMutatedAttributeValue($key, $value);
-        } elseif($this->hasPropertyHookSetter($key)) {
+        if ($this->hasPropertyHookSetter($key)) {
             return $this->setPropertyHookValue($key, $value);
+        } elseif ($this->hasSetMutator($key)) {
+            return $this->setMutatedAttributeValue($key, $value);
         } elseif ($this->hasAttributeSetMutator($key)) {
             return $this->setAttributeMarkedMutatedAttributeValue($key, $value);
         }
@@ -2369,10 +2369,10 @@ trait HasAttributes
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.
-        if ($this->hasGetMutator($key)) {
-            return $this->mutateAttribute($key, $value);
-        } elseif ($this->hasPropertyHookGetter($key)) {
+        if ($this->hasPropertyHookGetter($key)) {
             return $this->getPropertyHookValue($key);
+        } elseif ($this->hasGetMutator($key)) {
+            return $this->mutateAttribute($key, $value);
         } elseif ($this->hasAttributeGetMutator($key)) {
             return $this->mutateAttributeMarkedAttribute($key, $value);
         }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -25,6 +25,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('hasAttribute')->passthru();
         $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
+        $model1->shouldReceive('hasPropertyHookGetter')->andReturn(false);
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
         $model1->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model1->shouldReceive('hasRelationAutoloadCallback')->andReturn(false);
@@ -35,6 +36,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('hasAttribute')->passthru();
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
+        $model2->shouldReceive('hasPropertyHookGetter')->andReturn(false);
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
         $model2->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model2->shouldReceive('hasRelationAutoloadCallback')->andReturn(false);

--- a/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
+++ b/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentWithPropertyHooksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            static::markTestSkipped(
+                'Property Hooks are not available to test in PHP ' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION
+            );
+        }
+
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test', function ($table) {
+            $table->increments('id');
+            $table->text('foo_bar');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Model::getConnectionResolver()->connection();
+    }
+
+    public function test_collects_setter_hooks(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            public $fooFoo {
+                get => true;
+            }
+
+            public $barBar {
+                set {
+                    //
+                }
+            }
+
+            public $bazBaz {
+                get => true;
+                set {
+                    //
+                }
+            }
+
+            public $quzQuz;
+
+            public function getCache()
+            {
+                return static::$attributePropertyHookGetterCache[get_class($this)];
+            }
+
+            public function setCache()
+            {
+                return static::$attributePropertyHookSetterCache[get_class($this)];
+            }
+        };
+
+        $this->assertTrue($model->hasPropertyHookGetter('fooFoo'));
+        $this->assertFalse($model->hasPropertyHookSetter('fooFoo'));
+
+        $this->assertFalse($model->hasPropertyHookGetter('barBar'));
+        $this->assertTrue($model->hasPropertyHookSetter('barBar'));
+
+        $this->assertTrue($model->hasPropertyHookGetter('bazBaz'));
+        $this->assertTrue($model->hasPropertyHookSetter('bazBaz'));
+
+        $this->assertFalse($model->hasPropertyHookGetter('quzQuz'));
+        $this->assertFalse($model->hasPropertyHookSetter('quzQuz'));
+
+        $this->assertSame([
+            'fooFoo' => true,
+            'barBar' => false,
+            'bazBaz' => true,
+            'quzQuz' => false,
+        ], $model->getCache());
+
+        $this->assertSame([
+            'fooFoo' => false,
+            'barBar' => true,
+            'bazBaz' => true,
+            'quzQuz' => false,
+        ], $model->setCache());
+    }
+
+
+    public function test_casts_with_property_hooks(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            protected $fooBar {
+                get => isset($this->attributes['foo_bar']) ? strtoupper($this->attributes['foo_bar']) : null;
+                set {
+                    $this->attributes['foo_bar'] = strtolower($value);
+                }
+            }
+        };
+
+        $this->assertNull($model->foo_bar);
+
+        $model->foo_bar = 'bAz';
+
+        $this->assertSame('BAZ', $model->foo_bar);
+        $this->assertSame('baz', $model->getAttributes()['foo_bar']);
+
+        $model->save();
+
+        $model = $model->newQuery()->find(1);
+
+        $this->assertSame('BAZ', $model->foo_bar);
+        $this->assertSame('baz', $model->getAttributes()['foo_bar']);
+    }
+
+    public function test_cast_with_property_hook_get(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            protected $fooBar {
+                get => isset($this->attributes['foo_bar']) ? strtoupper($this->attributes['foo_bar']) : null;
+            }
+        };
+
+        $this->assertNull($model->foo_bar);
+
+        $model->foo_bar = 'bAz';
+
+        $this->assertSame('BAZ', $model->foo_bar);
+        $this->assertSame('bAz', $model->getAttributes()['foo_bar']);
+
+        $model->save();
+
+        $model = $model->newQuery()->find(1);
+
+        $this->assertSame('BAZ', $model->fooBar);
+        $this->assertSame('BAZ', $model->foo_bar);
+        $this->assertSame('bAz', $model->getAttributes()['foo_bar']);
+    }
+
+    public function test_cast_with_property_hook_set(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            protected $fooBar {
+                set {
+                    $this->attributes['foo_bar'] = strtolower($value);
+                }
+            }
+        };
+
+        $this->assertNull($model->foo_bar);
+
+        $model->foo_bar = 'BAZ';
+
+        $this->assertSame('baz', $model->foo_bar);
+        $this->assertSame('baz', $model->getAttributes()['foo_bar']);
+
+        $model->save();
+
+        $model = $model->newQuery()->find(1);
+
+        $this->assertSame('baz', $model->foo_bar);
+        $this->assertSame('baz', $model->getAttributes()['foo_bar']);
+    }
+
+    public function test_property_hook_get_is_appended_using_getters(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            protected $appends = [
+                'baz_quz',
+            ];
+
+            protected $bazQuz {
+                get => 'baz_QUZ';
+            }
+        };
+
+        $model->foo_bar = 'bAz';
+
+        $this->assertSame(['foo_bar' => 'bAz', 'baz_quz' => 'baz_QUZ'], $model->toArray());
+    }
+
+    public function test_property_hook_takes_precedence_over_mutator_and_attribute(): void
+    {
+        $model = new class extends Model {
+            protected $table = 'test';
+
+            protected $bazQuz {
+                get => $this->attributes['foo_bar'];
+                set {
+                    $this->attributes['foo_bar'] = $value;
+                }
+            }
+
+            protected function getBazQuzAttribute()
+            {
+                return 'invalid';
+            }
+
+            protected function setBazQuzAttribute()
+            {
+                return $this->attributes['foo_bar'] = 'invalid';
+            }
+
+            protected function bazQuz(): Attribute
+            {
+                return Attribute::make(fn () => 'invalid', fn() => ['foo_bar' => 'invalid']);
+            }
+        };
+
+        $model->baz_quz = 'valid';
+
+        $this->assertSame('valid', $model->baz_quz);
+    }
+}

--- a/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
+++ b/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
@@ -6,18 +6,20 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use function method_exists;
 
 class DatabaseEloquentWithPropertyHooksTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (PHP_VERSION_ID < 80400) {
-            static::markTestSkipped(
+        parent::setUp();
+
+        if (!method_exists(ReflectionProperty::class, 'hasHook')) {
+            $this->markTestSkipped(
                 'Property Hooks are not available to test in PHP ' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION
             );
         }
-
-        parent::setUp();
 
         $db = new DB;
 

--- a/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
+++ b/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
@@ -20,7 +20,7 @@ class DatabaseEloquentWithPropertyHooksTest extends TestCase
 
         if (PHP_VERSION_ID < 80400) {
             $this->markTestSkipped(
-                'Property Hooks are not available to test in PHP ' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION
+                'Property Hooks are not available to test in PHP '.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             );
         }
 
@@ -35,6 +35,8 @@ class DatabaseEloquentWithPropertyHooksTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
+
+        Model::$snakeAttributes = true;
     }
 
     protected function createSchema()
@@ -156,7 +158,7 @@ class DatabaseEloquentWithPropertyHooksTest extends TestCase
         $this->assertSame('baz', $model->getAttributes()['foo_bar']);
     }
 
-    public function test_property_hook_get_is_appended_using_getters(): void
+    public function test_appends_property_hook_get(): void
     {
         $model = new EloquentModelWithAppendedPropertyHooks();
 

--- a/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
+++ b/tests/Database/DatabaseEloquentWithPropertyHooksTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentModelWithAllPropertyHooks;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentModelWithAppendedPropertyHooks;

--- a/tests/Database/Fixtures/Models/EloquentModelWithAllPropertyHooks.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithAllPropertyHooks.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithAllPropertyHooks extends Model
+{
+    protected $table = 'test';
+
+    public $fooFoo {
+        get => true;
+    }
+
+    public $barBar {
+        set {
+            //
+        }
+    }
+
+    public $bazBaz {
+        get => true;
+        set {
+            //
+        }
+    }
+
+    public $quzQuz;
+
+    public function getCache()
+    {
+        return static::$attributePropertyHookGetterCache[get_class($this)];
+    }
+
+    public function setCache()
+    {
+        return static::$attributePropertyHookSetterCache[get_class($this)];
+    }
+}

--- a/tests/Database/Fixtures/Models/EloquentModelWithAppendedPropertyHooks.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithAppendedPropertyHooks.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithAppendedPropertyHooks extends Model
+{
+    protected $table = 'test';
+
+    protected $appends = [
+        'baz_quz',
+    ];
+
+    protected $bazQuz {
+        get => 'baz_QUZ';
+    }
+}

--- a/tests/Database/Fixtures/Models/EloquentModelWithGetterPropertyHook.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithGetterPropertyHook.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithGetterPropertyHook extends Model
+{
+    protected $table = 'test';
+
+    protected $fooBar {
+        get => isset($this->attributes['foo_bar']) ? strtoupper($this->attributes['foo_bar']) : null;
+    }
+}

--- a/tests/Database/Fixtures/Models/EloquentModelWithPrecedentPropertyHook.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithPrecedentPropertyHook.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class EloquentModelWithPrecedentPropertyHook extends Model
 {

--- a/tests/Database/Fixtures/Models/EloquentModelWithPrecedentPropertyHook.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithPrecedentPropertyHook.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithPrecedentPropertyHook extends Model
+{
+    protected $table = 'test';
+
+    protected $bazQuz {
+        get => $this->attributes['foo_bar'];
+        set {
+            $this->attributes['foo_bar'] = $value;
+        }
+    }
+
+    protected function getBazQuzAttribute()
+    {
+        return 'invalid';
+    }
+
+    protected function setBazQuzAttribute()
+    {
+        return $this->attributes['foo_bar'] = 'invalid';
+    }
+
+    protected function bazQuz(): Attribute
+    {
+        return Attribute::make(fn () => 'invalid', fn() => ['foo_bar' => 'invalid']);
+    }
+}

--- a/tests/Database/Fixtures/Models/EloquentModelWithPropertyHooks.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithPropertyHooks.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithPropertyHooks extends Model
+{
+    protected $table = 'test';
+
+    protected $fooBar {
+        get => isset($this->attributes['foo_bar']) ? strtoupper($this->attributes['foo_bar']) : null;
+        set {
+            $this->attributes['foo_bar'] = strtolower($value);
+        }
+    }
+}

--- a/tests/Database/Fixtures/Models/EloquentModelWithSetterPropertyHook.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithSetterPropertyHook.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithSetterPropertyHook extends Model
+{
+    protected $table = 'test';
+
+    protected $fooBar {
+        set {
+            $this->attributes['foo_bar'] = strtolower($value);
+        }
+    }
+}


### PR DESCRIPTION
## What?

This PR brings compatibility with PHP 8.4 Property Hooks for attribute casting. The way it works is the same as the old and undocumented `get{Name}Attribute()` and `set{Name}Attribute()`, but instead of checking the method names, it will check if a `get` or `set` hooks are declared inside a (preferably non-public) property in _camelCase_.

```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Support\Str;
use App\ValueObjects\Color;

class User extends Model
{
    // Virtual property
    protected string $firstName {
        get => $this->attributes['first_name'];
        set {
            $this->attributes['first_name'] = strtolower($value);
        }
    }
    
    // Read-only property
    protected string $emailDomain {
        get => Str::after($this->attributes['email'], '@');
    }
    
    // Write-only property
    protected int $hexColor {
        set {
            $this->attributes['color'] = Color::fromHex($value)->getName();
        }     
    }
}

$user = new User();

$user->first_name = 'TAYLOR';

echo $user->first_name; // "taylor"
```

> [!CAUTION]
> 
> Because the property hook is native to the language itself, it will take precedence over `get/set{Name}Attribute` and `Attribute` casting.

## Caveats

### Setter with return

One problem of Property Hooks is the setter. If the setter returns a value, that value gets saved into the property of the object itself, duplicating the value the developer would set inside the model attributes array.

For example, assume the following hook setter for the first name.

```php
protected $firstName {
    set => $this->attributes['first_name'] = strtolower($value);
}
```

In the above syntax, the setter is returning the modified value, which is the same syntax as this: 

```php
protected $firstName {
    set {
        return $this->attributes['first_name'] = strtolower($value);
    }
}
```

As it duplicates the value, this will pose a problem for setting object instances. As these become duplicate, these may be not correctly destroyed or garbage collected, as the object reference will still be _alive_ in the object itself.

For this reason, the documentation should encourage developers to, whenever possible, use the `set` hook **without returning a value**, or setting the value of the properly itself.

Currently there is no way to _unset_ a property with hooks, nor execute the closure in isolation without setting the object property value.

## Further work

- Caching an Object could be done by adding an Attribute to the property declaration, with a boolean to disable object caching if needed.
- The setter _could_ be extracted to be executed with the value alone.