### PR TITLE
[12.x] Display exception in HTML comment

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
@@ -1,4 +1,13 @@
 @use('Illuminate\Foundation\Exceptions\Renderer\Renderer')
+<!--
+    {{ $exception->class() }} - {{ $exception->title() }}
+
+    {{ $exception->message() }}
+
+@foreach($exception->frames() as $frame)
+    {{ $frame->file() }}:{{ $frame->line() }}
+@endforeach
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
Modify Blade component exception renderers to display useful exception summary as HTML comment.

When working with HTTP proxies/tunnels, such as ngrok, the origin HTTP response body is displayed as text in the summary. Should an Exception or Error occur, the details are embedded deep within the markup and it's challenging to immediately see what the issue is.