### PR TITLE
[12.x] Forward only passed arguments into Illuminate\Database\Eloquent\Collection::partition method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -711,7 +711,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function partition($key, $operator = null, $value = null)
     {
-        return parent::partition($key, $operator, $value)->toBase();
+        return parent::partition(...func_get_args())->toBase();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -582,6 +582,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
         $this->assertEquals(BaseCollection::class, get_class($b->flip()));
         $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', '=', 'bar')));
+        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', 'bar')));
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()


### PR DESCRIPTION
This pull request fixes forwarding only provided attributes from `Illuminate\Database\Eloquent\Collection::partition` method to its parent. This method was created in this PR [53304](https://github.com/laravel/framework/pull/53304/files ), but at the moment it is forwarding all the 3 arguments, so if I provide only 2 arguments, the `where operator` in `operatorForWhere` method cannot be guessed correctly.