### PR TITLE
[12.x] Fix the serve command sometimes fails to destructure the request pool array

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -335,7 +335,7 @@ class ServeCommand extends Command
                 } elseif ((new Stringable($line))->contains(' Closing')) {
                     $requestPort = static::getRequestPortFromLine($line);
 
-                    if (empty($this->requestsPool[$requestPort])) {
+                    if (empty($this->requestsPool[$requestPort]) || count($this->requestsPool[$requestPort] ?? []) !== 3) {
                         $this->requestsPool[$requestPort] = [
                             $this->getDateFromLine($line),
                             false,


### PR DESCRIPTION
The code expects the array to always contain 3 items, but apparently, that's not always true. Sometimes it only contains a single key "1" with the requested file (from what it looks like, it's when PHP serves a file).

I don't know the root cause for this, but this patch seems to work around that.

---

Context:

- This project has an SSE route that hangs the PHP process to deliver events
- I'm using multiple processes, so I set the `--no-reload`  flag on the `artisan serve` command (because of https://github.com/laravel/framework/pull/54972)
- The app works for a while, but then sometimes it runs into this issue after using the app for a little while

<details>
<summary>Error Screenshot</summary>

![image](https://github.com/user-attachments/assets/9ab19332-5489-47cd-a8c5-1d0a767c987b)

</details>

<details>
<summary>Dump of the Pool array right before it throws the error</summary>

```bash
    server   | "[2649104] [Wed Apr 16 00:25:02 2025] Failed to poll event" // vendor/laravel/framework/src/Illuminate/Foundation
    /Console/ServeCommand.php:339
    server   | "[2649101] [Wed Apr 16 00:25:02 2025] 192.168.0.25:51726 [200]: GET /js/controllers/sidebar_controller.js?digest=
    b1990218760a98466584219ada61659ab131aa2a" // vendor/laravel/framework/src/Illuminate/Foundation/Console/ServeCommand.php:339
    server   | "[2649101] [Wed Apr 16 00:25:02 2025] 192.168.0.25:51726 Closing" // vendor/laravel/framework/src/Illuminate/Foun
    dation/Console/ServeCommand.php:339
    server   | array:3 [
    server   |   "pool" => array:12 [
    server   |     42272 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744762989^ {#1800
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007080000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:23:09.0 UTC (+00:00)
    server   |       }
    server   |       1 => "/js/controllers/flash_controller.js?digest=93f221180e0daa0579fc2fa27f8ab03ae83a1bde"
    server   |       2 => 1744773789.3445
    server   |     ]
    server   |     52980 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763049^ {#1806
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "000000000000070e0000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:24:09.0 UTC (+00:00)
    server   |       }
    server   |       1 => "/hotwired-laravel-hotreload/sse"
    server   |       2 => 1744773849.6646
    server   |     ]
    server   |     58360 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763058^ {#1792
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007000000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:24:18.0 UTC (+00:00)
    server   |       }
    server   |       1 => "/js/controllers/bridge/toast_controller.js?digest=fc5ab55b0c5662da875b067353bb96f119f6dce7"
    server   |       2 => 1744773858.7083
    server   |     ]
    server   |     59732 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763069^ {#1809
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007110000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:24:29.0 UTC (+00:00)
    server   |       }
    server   |       1 => "/hotwired-laravel-hotreload/sse"
    server   |       2 => 1744773869.3486
    server   |     ]
    server   |     59704 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763069^ {#1804
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "000000000000070c0000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:24:29.0 UTC (+00:00)
    server   |       }
    server   |       1 => "/js/libs/stimulus.js?digest=c48cb5c3e6fc114fef7383c898bca1ed1[2649104] [Wed Apr 16 00:24:29 2025] 192
    .168.0.25:59680"
    server   |       2 => 1744773869.3483
    server   |     ]
    server   |     51816 => array:1 [
    server   |       1 => "/hotwired-laravel-hotreload/sse"
    server   |     ]
    server   |     51740 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763102^ {#1805
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "000000000000070d0000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:25:02.0 UTC (+00:00)
    server   |       }
    server   |       1 => false
    server   |       2 => 1744773902.9105
    server   |     ]
    server   |     51754 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763102^ {#1810
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007120000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:25:02.0 UTC (+00:00)
    server   |       }
    server   |       1 => false
    server   |       2 => 1744773902.9116
    server   |     ]
    server   |     51758 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763102^ {#1795
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007030000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:25:02.0 UTC (+00:00)
    server   |       }
    server   |       1 => false
    server   |       2 => 1744773902.9121
    server   |     ]
    server   |     51770 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763102^ {#1811
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007130000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:25:02.0 UTC (+00:00)
    server   |       }
    server   |       1 => false
    server   |       2 => 1744773902.9123
    server   |     ]
    server   |     51778 => array:3 [
    server   |       0 => Illuminate\Support\Carbon @1744763102^ {#1799
    server   |         #endOfTime: false
    server   |         #startOfTime: false
    server   |         #constructedObjectId: "00000000000007070000000000000000"
    server   |         -clock: null
    server   |         #localMonthsOverflow: null
    server   |         #localYearsOverflow: null
    server   |         #localStrictModeEnabled: null
    server   |         #localHumanDiffOptions: null
    server   |         #localToStringFormat: null
    server   |         #localSerializer: null
    server   |         #localMacros: null
    server   |         #localGenericMacros: null
    server   |         #localFormatFunction: null
    server   |         #localTranslator: null
    server   |         #dumpProperties: array:3 [
    server   |           0 => "date"
    server   |           1 => "timezone_type"
    server   |           2 => "timezone"
    server   |         ]
    server   |         #dumpLocale: null
    server   |         #dumpDateProperties: null
    server   |         date: 2025-04-16 00:25:02.0 UTC (+00:00)
    server   |       }
    server   |       1 => false
    server   |       2 => 1744773902.9125
    server   |     ]
    server   |     51726 => array:1 [
    server   |       1 => "/js/controllers/sidebar_controller.js?digest=b1990218760a98466584219ada61659ab131aa2a"
    server   |     ]
    server   |   ]
    server   |   "port" => 51726
    server   |   "line" => "[2649101] [Wed Apr 16 00:25:02 2025] 192.168.0.25:51726 Closing"
    server   | ]
```

</details>