### PR TITLE
[12.x] Fixed a bug in using `illuminate/console` in external apps

### DIFF
--- a/src/Illuminate/Console/Enums/TaskResult.php
+++ b/src/Illuminate/Console/Enums/TaskResult.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Console\Enums;
+
+enum TaskResult: int
+{
+    case Success = 1;
+    case Failure = 2;
+    case Skipped = 3;
+}

--- a/src/Illuminate/Console/Enums/TaskResult.php
+++ b/src/Illuminate/Console/Enums/TaskResult.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Console\Enums;
 
 enum TaskResult: int

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\View\Components;
 
-use Illuminate\Database\Migrations\MigrationResult;
+use Illuminate\Console\Enums\TaskResult;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
@@ -35,10 +35,10 @@ class Task extends Component
 
         $startTime = microtime(true);
 
-        $result = MigrationResult::Failure;
+        $result = TaskResult::Failure->value;
 
         try {
-            $result = ($task ?: fn () => MigrationResult::Success)();
+            $result = ($task ?: fn () => TaskResult::Success->value)();
         } catch (Throwable $e) {
             throw $e;
         } finally {
@@ -55,8 +55,8 @@ class Task extends Component
 
             $this->output->writeln(
                 match ($result) {
-                    MigrationResult::Failure => ' <fg=red;options=bold>FAIL</>',
-                    MigrationResult::Skipped => ' <fg=yellow;options=bold>SKIPPED</>',
+                    TaskResult::Failure->value => ' <fg=red;options=bold>FAIL</>',
+                    TaskResult::Skipped->value => ' <fg=yellow;options=bold>SKIPPED</>',
                     default => ' <fg=green;options=bold>DONE</>'
                 },
                 $verbosity,

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\View\Components;
 
-use Illuminate\Console\Enums\TaskResult;
+use Illuminate\Console\View\TaskResult;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;

--- a/src/Illuminate/Console/View/TaskResult.php
+++ b/src/Illuminate/Console/View/TaskResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Console\Enums;
+namespace Illuminate\Console\View;
 
 enum TaskResult: int
 {

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -245,7 +245,7 @@ class Migrator
             : true;
 
         if (! $shouldRunMigration) {
-            $this->write(Task::class, $name, fn () => MigrationResult::Skipped);
+            $this->write(Task::class, $name, fn () => MigrationResult::Skipped->value);
         } else {
             $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));
 

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -109,17 +109,17 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Success);
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Success->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('DONE', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Failure);
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Failure->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('FAIL', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped);
+        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('SKIPPED', $result);


### PR DESCRIPTION
## Problem

When using the `illuminate/console` package in an external application outside the Laravel Framework, a problem started to appear as the package started to access the `Illuminate\Database\Migrations\MigrationResult` class even though the `illuminate/database` dependency is not set.

This behavior was added in version [12.4.0](https://github.com/laravel/framework/releases/tag/v12.4.0) (https://github.com/laravel/framework/pull/55011).

## Error

```bash
PHP Fatal error:  Uncaught Error: Class "Illuminate\Database\Migrations\MigrationResult" not found in /home/runner/work/lang/lang/vendor/illuminate/console/View/Components/Task.php:38
Stack trace:
#0 /home/runner/work/lang/lang/vendor/illuminate/console/View/Components/Factory.php(59): Illuminate\Console\View\Components\Task->render()
#1 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Helpers/Output.php(42): Illuminate\Console\View\Components\Factory->__call()
#2 /home/runner/work/lang/lang/vendor/dragon-code/support/src/Instances/Call.php(133): LaravelLang\StatusGenerator\Helpers\Output->{closure:LaravelLang\StatusGenerator\Helpers\Output::task():42}()
#3 /home/runner/work/lang/lang/vendor/dragon-code/support/src/Facades/Facade.php(30): DragonCode\Support\Instances\Call->callback()
#4 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Helpers/Output.php(55): DragonCode\Support\Facades\Facade::__callStatic()
#5 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Helpers/Output.php(40): LaravelLang\StatusGenerator\Helpers\Output->when()
#6 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Commands/Command.php(73): LaravelLang\StatusGenerator\Helpers\Output->task()
#7 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Commands/Command.php(49): LaravelLang\StatusGenerator\Commands\Command->handleByProcessor()
#8 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/src/Commands/Command.php(36): LaravelLang\StatusGenerator\Commands\Command->handle()
#9 /home/runner/work/lang/lang/vendor/symfony/console/Command/Command.php(279): LaravelLang\StatusGenerator\Commands\Command->execute()
#10 /home/runner/work/lang/lang/vendor/symfony/console/Application.php(1076): Symfony\Component\Console\Command\Command->run()
#11 /home/runner/work/lang/lang/vendor/symfony/console/Application.php(342): Symfony\Component\Console\Application->doRunCommand()
#12 /home/runner/work/lang/lang/vendor/symfony/console/Application.php([19](https://github.com/Laravel-Lang/lang/actions/runs/14458858865/job/40547605464#step:5:20)3): Symfony\Component\Console\Application->doRun()
#13 /home/runner/work/lang/lang/vendor/laravel-lang/status-generator/bin/lang(50): Symfony\Component\Console\Application->run()
#14 /home/runner/work/lang/lang/vendor/bin/lang(119): include('...')
#15 {main}
  thrown in /home/runner/work/lang/lang/vendor/illuminate/console/View/Components/Task.php on line 38
```

## Solution

Replace the status reference from Illuminate Database with your own.