### PR TITLE
[12.x] Remove unused var from `DumpCommand`

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -53,7 +53,7 @@ class DumpCommand extends Command
 
         if ($this->option('prune')) {
             (new Filesystem)->deleteDirectory(
-                $path = database_path('migrations'), $preserve = false
+                $path = database_path('migrations'), preserve: false
             );
 
             $info .= ' and pruned';


### PR DESCRIPTION
Was just poking around the `DumpCommand` and saw this unnecessary variable. Changed it to named parameter since I imagine that was what it was originally signaling.