### PR TITLE
[11.x] Fix: withoutEvents disables events for all models inside closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -420,6 +420,10 @@ trait HasEvents
      */
     public static function getEventDispatcher()
     {
+        if (array_key_exists(Model::class, static::$modelDispatchers)) {
+            return static::$modelDispatchers[Model::class];
+        }
+
         if (array_key_exists(static::class, static::$modelDispatchers)) {
             return static::$modelDispatchers[static::class];
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2277,7 +2277,7 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelSaveStub::setEventDispatcher($dispatcher, false);
         EloquentAnotherModelSaveStub::setEventDispatcher($secondDispatcher, false);
 
-        EloquentModelSaveStub::withoutEvents(fn() => true);
+        EloquentModelSaveStub::withoutEvents(fn () => true);
 
         $this->assertSame($dispatcher, EloquentModelSaveStub::getEventDispatcher());
         $this->assertSame($secondDispatcher, EloquentAnotherModelSaveStub::getEventDispatcher());


### PR DESCRIPTION
https://github.com/laravel/framework/issues/55432