### PR TITLE
Remove dead code from ApplicationBuilder

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -30,13 +30,6 @@ class ApplicationBuilder
     protected array $pendingProviders = [];
 
     /**
-     * Any additional routing callbacks that should be invoked while registering routes.
-     *
-     * @var array
-     */
-    protected array $additionalRoutingCallbacks = [];
-
-    /**
      * The Folio / page middleware that have been defined by the user.
      *
      * @var array
@@ -247,10 +240,6 @@ class ApplicationBuilder
                 } else {
                     Route::middleware('web')->group($web);
                 }
-            }
-
-            foreach ($this->additionalRoutingCallbacks as $callback) {
-                $callback();
             }
 
             if (is_string($pages) &&


### PR DESCRIPTION
I was looking for a way to add an additional routing configuration in `bootstrap/app.php` using named arguments in the `withRouting()` syntax. Seems like there's a `$then` parameter that supports a callback to be executed after default configurations. Great.

However I also noticed there's a property `$additionalRoutingCallbacks` defined and being iterated, but I don't see any possible way to actually populate that property.

Because `$then` already achieves the very same, this might be dead code.
Or if the existence of `$additionalRoutingCallbacks` is still applicable, then you might want to review how it can be set.

This is just a heads-up PR.