### PR TITLE
[12.x] Fix for global autoload relationships not working  in certain cases

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -854,13 +854,9 @@ class Builder implements BuilderContract
             $models = $builder->eagerLoadRelations($models);
         }
 
-        $collection = $builder->getModel()->newCollection($models);
-
-        if (Model::isAutomaticallyEagerLoadingRelationships()) {
-            $collection->withRelationshipAutoloading();
-        }
-
-        return $this->applyAfterQueryCallbacks($collection);
+        return $this->applyAfterQueryCallbacks(
+            $builder->getModel()->newCollection($models)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/HasCollection.php
+++ b/src/Illuminate/Database/Eloquent/HasCollection.php
@@ -27,7 +27,13 @@ trait HasCollection
     {
         static::$resolvedCollectionClasses[static::class] ??= ($this->resolveCollectionFromAttribute() ?? static::$collectionClass);
 
-        return new static::$resolvedCollectionClasses[static::class]($models);
+        $collection = new static::$resolvedCollectionClasses[static::class]($models);
+
+        if (Model::isAutomaticallyEagerLoadingRelationships()) {
+            $collection->withRelationshipAutoloading();
+        }
+
+        return $collection;
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/55438 issue

In the current implementation of [#53655](https://github.com/laravel/framework/pull/53655), `Model::automaticallyEagerLoadRelationships` does not work in certain cases.

For example:
```php
Model::automaticallyEagerLoadRelationships();

class Project extends Model
{
    public function contracts()
    {
        return $this->belongsToMany(Contract::class);
    }
}

# Autoloading works fine here
foreach ($project->contracts as $contract) {
    $contractors[] = $contract->contractor;
}

# Not working — we have an N+1 issue here
foreach ($project->contracts()->get() as $contract) {
    $contractors[] = $contract->contractor;
}
```

After this fix, both scenarios work as expected.