### PR TITLE
[12.x] Improve `Fluent` Constructor Performance by Directly Assigning Attributes

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
+use Traversable;
 
 /**
  * @template TKey of array-key
@@ -36,7 +37,11 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __construct($attributes = [])
     {
-        $this->fill($attributes);
+        if (! $attributes instanceof Traversable) {
+            $attributes = is_object($attributes) ? get_object_vars($attributes) : $attributes;
+        }
+
+        $this->attributes = is_array($attributes) ? $attributes : iterator_to_array($attributes);
     }
 
     /**


### PR DESCRIPTION
This PR optimizes the constructor of the `Fluent` class by assigning the `$attributes` directly to the `$this->attributes` property, rather than using the `fill()` method.

## Benchmark Results:

Version | Execution Time
-- | --
Before | 0.029 ms
After | 0.002 ms

This change results in a <strong>more than 14x performance improvement</strong>, which is particularly beneficial in performance-critical applications where `Fluent` instances are frequently created.

<details>

<summary>The code for `Benchmark` is:</summary>

```php
Benchmark::dd(
   fn() => Fluent::make(array_fill(0, 1000, 'Row')),
   5,
);
```
</details>
