### PR TITLE
[12.x] Stringable surround with text

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -836,6 +836,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Surround the string with the given values.
+     *
+     * @param  string  $before
+     * @param  string  $after
+     * @param  string  $separator
+     * @return static
+     */
+    public function surround($before, $after, $separator = '')
+    {
+        return new static($before.$separator.$this->value.$separator.$after);
+    }
+
+    /**
      * Convert the given string to upper-case.
      *
      * @return static

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1298,6 +1298,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br><strong>'));
     }
 
+    public function testSurround()
+    {
+        $this->assertSame('beforetextafter', (string) $this->stringable('text')->surround('before', 'after'));
+        $this->assertSame('before*text*after', (string) $this->stringable('text')->surround('before', 'after', '*'));
+    }
+
     public function testReplaceMatches()
     {
         $stringable = $this->stringable('Hello world!');


### PR DESCRIPTION
This PR will add a plain and simple method to surround a Stringable text with a `prefix` and `suffix`:

it will allow to go from:

```php
str('text')->prepend('before text ')->append(' after text'); // before text text after text
```

to

```php
str('text')->surround('before text ', ' after text'); // before text text after text
```

bonus, a separator string can be set, also:

```php
str('text')->surround('before text', 'after text', ' / '); // before text / text / after text
```


A use case? here:

```php
str('text')->surround('<b>', '</b>'); // <b>text</b>
```