### PR TITLE
[12.x] Add Route::when() for conditionally defining routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -472,6 +472,22 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Create a route with conditional Callback.
+     *
+     * @param bool $condition
+     * @param Closure $callback
+     * @return $this
+     */
+    public function when(bool $condition, Closure $callback)
+    {
+        if ($condition) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Update the group stack with the given attributes.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -24,6 +24,7 @@ namespace Illuminate\Support\Facades;
  * @method static void apiSingletons(array $singletons, array $options = [])
  * @method static \Illuminate\Routing\PendingSingletonResourceRegistration apiSingleton(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|array|string $routes)
+ * @method static \Illuminate\Routing\Router when(bool $condition, \Closure $closure)
  * @method static array mergeWithLastGroup(array $new, bool $prependExistingPrefix = true)
  * @method static string getLastGroupPrefix()
  * @method static \Illuminate\Routing\Route addRoute(array|string $methods, string $uri, array|string|callable|null $action)

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -24,7 +24,7 @@ namespace Illuminate\Support\Facades;
  * @method static void apiSingletons(array $singletons, array $options = [])
  * @method static \Illuminate\Routing\PendingSingletonResourceRegistration apiSingleton(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\Router group(array $attributes, \Closure|array|string $routes)
- * @method static \Illuminate\Routing\Router when(bool $condition, \Closure $closure)
+ * @method static \Illuminate\Routing\Router when(bool $condition, \Closure $callback)
  * @method static array mergeWithLastGroup(array $new, bool $prependExistingPrefix = true)
  * @method static string getLastGroupPrefix()
  * @method static \Illuminate\Routing\Route addRoute(array|string $methods, string $uri, array|string|callable|null $action)

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -62,6 +62,32 @@ class FluentRoutingTest extends TestCase
 
         $this->assertSame('Hello World', $this->get('public')->content());
     }
+
+    public function test_route_when_executes_callback_when_condition_is_true()
+    {
+        Route::when(true, function () {
+            Route::get('test-when-true', function () {
+                return 'success';
+            });
+        });
+
+        $this->assertSame('success', $this->get('test-when-true')->content());
+        $this->get('test-when-true')->assertStatus(200)->isOk();
+
+    }
+
+    public function test_route_when_does_not_execute_callback_when_condition_is_false()
+    {
+        Route::when(false, function () {
+            Route::get('test-when-false', function () {
+                return 'success';
+            });
+        });
+
+        $this->assertNotSame('success', $this->get('test-when-false')->content());
+        $this->get('test-when-false')->assertNotFound();
+
+    }
 }
 
 class Middleware


### PR DESCRIPTION

**Description:** This PR introduces a new Route::when() method that allows developers to conditionally register routes based on a boolean value or closure. This helps keep route files clean and expressive without relying on verbose if statements or complex logic blocks.

**Example usage:**

```
Route::when(app()->isLocal(), function () {
    Route::get('/debug', DebugController::class); 
});
```
You can also use a closure as the condition:

```
Route::when(fn () => auth()->check(), function () { 
     Route::get('/dashboard', DashboardController::class); 
});
```

If the condition evaluates to true, the callback is executed and routes are registered as normal. If false, the callback is skipped entirely.

This addition will help when working with environment-specific, user-specific, or feature-flagged routes.

Let me know if you'd like tests or implementation adjustments. Happy to iterate.