### PR TITLE
[12.x] Fix relation auto loading with manually set relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -184,7 +184,7 @@ trait HasRelationships
 
         foreach ($models as $model) {
             // Check if relation autoload contexts are different to avoid circular relation autoload...
-            if (is_null($context) || $context !== $model) {
+            if ((is_null($context) || $context !== $model) && is_object($model) && method_exists($model, 'autoloadRelationsUsing')) {
                 $model->autoloadRelationsUsing($callback, $context);
             }
         }


### PR DESCRIPTION
When using `Model::automaticallyEagerLoadRelationships()` the autoRleationsUsing method is called on each entry of the relation.

When setting a relation manually using `->setRelation([['some entry']])` this leads to a server error when trying to call `autoloadRelationsUsing` on array.