### PR TITLE
[12.x] Add `forget` Method to Fluent

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -79,6 +79,19 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Remove / unset the attribute on the fluent or object using "dot" notation.
+     *
+     * @param  string|array|int|null  $key
+     * @return $this
+     */
+    public function forget($key)
+    {
+        data_forget($this->attributes, $key);
+
+        return $this;
+    }
+
+    /**
      * Fill the fluent instance with an array of attributes.
      *
      * @param  iterable<TKey, TValue>  $attributes

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -77,6 +77,23 @@ class SupportFluentTest extends TestCase
         $this->assertSame(['color' => 'silver'], $fluent->computer);
     }
 
+    public function testForgetMethod()
+    {
+        $fluent = new Fluent([
+            'name' => 'Michael',
+            'developer' => true,
+            'posts' => 25,
+            'computer' => ['color' => 'silver'],
+        ]);
+
+        $fluent->forget('name');
+        $fluent->forget('developer');
+        $fluent->forget('posts');
+        $fluent->forget('computer');
+
+        $this->assertTrue(empty($fluent->toArray()));
+    }
+
     public function testArrayAccessToAttributes()
     {
         $fluent = new Fluent(['attributes' => '1']);

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -91,7 +91,7 @@ class SupportFluentTest extends TestCase
         $fluent->forget('posts');
         $fluent->forget('computer');
 
-        $this->assertTrue(empty($fluent->toArray()));
+        $this->assertEmpty($fluent->toArray());
     }
 
     public function testArrayAccessToAttributes()


### PR DESCRIPTION
This PR adds a `forget` method to the `Fluent` class, allowing the removal of specific keys from the instance.

### Before

```php
$data = Fluent::make([
    'name' => 'Michael Nabil',
    'developer' => true,
    'posts' => 25,
]);

// No built-in way to remove 'posts' directly
$array = $data->toArray();
unset($array['posts']);
```

### After

```php
$data = Fluent::make([
    'name' => 'Michael Nabil',
    'developer' => true,
    'posts' => 25,
]);

$data->forget('posts');

$data->toArray(); // Output: ['name' => 'Michael Nabil', 'developer' => true]
```