### PR TITLE
[12.x] Add `isEmpty` Method to Fluent

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -159,6 +159,16 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Determine if the fluent is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->attributes);
+    }
+
+    /**
      * Get the attributes from the fluent instance.
      *
      * @return array<TKey, TValue>

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -123,6 +123,16 @@ class SupportFluentTest extends TestCase
         $this->assertEquals($array, $fluent->toArray());
     }
 
+    public function testIsEmptyAttribute()
+    {
+        $fluent = new Fluent(['name' => 'Michael', 'age' => 25]);
+
+        unset($fluent->name);
+        unset($fluent->age);
+
+        $this->assertTrue($fluent->isEmpty());
+    }
+
     public function testToJsonEncodesTheToArrayResult()
     {
         $fluent = $this->getMockBuilder(Fluent::class)->onlyMethods(['toArray'])->getMock();


### PR DESCRIPTION
This PR introduces an `isEmpty` method to the `Fluent` class, enabling a straightforward check to determine whether the underlying `attributes` array is empty.

```php
$data = Fluent::make(['name' => 'Michael', 'age' => 25]);

$data->isEmpty(); // false
```