### PR TITLE
[12.x] Add `Conditionable` Trait to `Fluent` 

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -19,7 +19,7 @@ use JsonSerializable;
  */
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use InteractsWithData, Conditionable,Macroable {
+    use InteractsWithData, Conditionable, Macroable {
         __call as macroCall;
     }
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
@@ -18,7 +19,7 @@ use JsonSerializable;
  */
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use InteractsWithData, Macroable {
+    use InteractsWithData, Conditionable,Macroable {
         __call as macroCall;
     }
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -19,7 +19,7 @@ use JsonSerializable;
  */
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use InteractsWithData, Conditionable, Macroable {
+    use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;
     }
 


### PR DESCRIPTION
This PR adds `when` and `unless` methods to the `Fluent` class, providing a cleaner, more expressive way to conditionally modify values.

### Before:

```php
$data = Fluent::make([
    'name' => 'Michael Nabil',
    'developer' => true,
    'posts' => 25,
]);

if (auth()->isAdmin()) {
    $data = $data->set('role', 'admin');
} else {
    $data = $data->forget('posts');
}
```

### After:

```php
$data = Fluent::make([
    'name' => 'Michael Nabil',
    'developer' => true,
    'posts' => 25,
])->when(auth()->isAdmin(), function (Fluent $input) {
    return $input->set('role', 'admin');
})->unless(auth()->isAdmin(), function (Fluent $input) {
    return $input->forget('posts');
});
```