### PR TITLE
[12.x] Option to disable dispatchAfterResponse in a test

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -56,7 +56,7 @@ class Dispatcher implements QueueingDispatcher
      *
      * @var bool
      */
-    protected $afterResponseDisabled = false;
+    protected $allowsDispatchingAfterResponses = true;
 
     /**
      * Create a new command dispatcher instance.
@@ -259,7 +259,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchAfterResponse($command, $handler = null)
     {
-        if ($this->afterResponseDisabled) {
+        if (! $this->allowsDispatchingAfterResponses) {
             $this->dispatchSync($command);
 
             return;
@@ -268,30 +268,6 @@ class Dispatcher implements QueueingDispatcher
         $this->container->terminating(function () use ($command, $handler) {
             $this->dispatchSync($command, $handler);
         });
-    }
-
-    /**
-     * Disable dispatching after response.
-     *
-     * @return $this
-     */
-    public function disableDispatchingAfterResponse()
-    {
-        $this->afterResponseDisabled = true;
-
-        return $this;
-    }
-
-    /**
-     * Enable dispatching after response.
-     *
-     * @return $this
-     */
-    public function enableDispatchingAfterResponse()
-    {
-        $this->afterResponseDisabled = false;
-
-        return $this;
     }
 
     /**
@@ -316,6 +292,30 @@ class Dispatcher implements QueueingDispatcher
     public function map(array $map)
     {
         $this->handlers = array_merge($this->handlers, $map);
+
+        return $this;
+    }
+
+    /**
+     * Allow dispatching after responses.
+     *
+     * @return $this
+     */
+    public function withDispatchingAfterResponses()
+    {
+        $this->allowsDispatchingAfterResponses = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable dispatching after responses.
+     *
+     * @return $this
+     */
+    public function withoutDispatchingAfterResponses()
+    {
+        $this->allowsDispatchingAfterResponses = false;
 
         return $this;
     }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -52,6 +52,13 @@ class Dispatcher implements QueueingDispatcher
     protected $queueResolver;
 
     /**
+     * Indicates if dispatching after response is disabled.
+     *
+     * @var bool
+     */
+    protected $afterResponseDisabled = false;
+
+    /**
      * Create a new command dispatcher instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
@@ -252,9 +259,39 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchAfterResponse($command, $handler = null)
     {
+        if ($this->afterResponseDisabled) {
+            $this->dispatchSync($command);
+
+            return;
+        }
+
         $this->container->terminating(function () use ($command, $handler) {
             $this->dispatchSync($command, $handler);
         });
+    }
+
+    /**
+     * Disable dispatching after response.
+     *
+     * @return $this
+     */
+    public function disableDispatchingAfterResponse()
+    {
+        $this->afterResponseDisabled = true;
+
+        return $this;
+    }
+
+    /**
+     * Enable dispatching after response.
+     *
+     * @return $this
+     */
+    public function enableDispatchingAfterResponse()
+    {
+        $this->afterResponseDisabled = false;
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\Attributes\WithMigration;
 
@@ -163,6 +164,37 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertNull($events[2]->queue);
         $this->assertInstanceOf(JobQueued::class, $events[3]);
         $this->assertNull($events[3]->queue);
+    }
+
+    public function testCanDisableDispatchingAfterResponse()
+    {
+        Job::dispatchAfterResponse('test');
+
+        $this->assertFalse(Job::$ran);
+
+        $this->app->terminate();
+
+        $this->assertTrue(Job::$ran);
+
+        Bus::disableDispatchingAfterResponse();
+
+        Job::$ran = false;
+        Job::dispatchAfterResponse('test');
+
+        $this->assertTrue(Job::$ran);
+
+        $this->app->terminate();
+
+        Bus::enableDispatchingAfterResponse();
+
+        Job::$ran = false;
+        Job::dispatchAfterResponse('test');
+
+        $this->assertFalse(Job::$ran);
+
+        $this->app->terminate();
+
+        $this->assertTrue(Job::$ran);
     }
 
     /**

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -176,7 +176,7 @@ class JobDispatchingTest extends QueueTestCase
 
         $this->assertTrue(Job::$ran);
 
-        Bus::disableDispatchingAfterResponse();
+        Bus::withoutDispatchingAfterResponses();
 
         Job::$ran = false;
         Job::dispatchAfterResponse('test');
@@ -185,7 +185,7 @@ class JobDispatchingTest extends QueueTestCase
 
         $this->app->terminate();
 
-        Bus::enableDispatchingAfterResponse();
+        Bus::withDispatchingAfterResponses();
 
         Job::$ran = false;
         Job::dispatchAfterResponse('test');


### PR DESCRIPTION
When you use `afterResponse()` on a job in route and you want to test that job, then there is currently no easy way to do this because the job will never be executed in the test.
```php
/** @test */
public function some_job()
{
    dispatch(function () {
         // will not be executed when running the test
    })->afterResponse();
}
```

This PR fixes that by providing an option to disable (similar to `withoutDefer`)
```php
/** @test */
public function some_job()
{
    Bus::disableDispatchingAfterResponse();

    dispatch(function () {
         // will be executed when running the test
    })->afterResponse();
}
```