### PR TITLE
[12.x] Add test coverage for nullable parameters in Can validation rule

### DIFF
--- a/tests/Validation/ValidationRuleCanTest.php
+++ b/tests/Validation/ValidationRuleCanTest.php
@@ -90,6 +90,24 @@ class ValidationRuleCanTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidationWithNullableArguments()
+    {
+        $this->gate()->define('process-order', function ($user, $value, $additionalFlag = null) {
+            $this->assertEquals('123', $value);
+            $this->assertNull($additionalFlag);
+
+            return true;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['order' => '123'],
+            ['order' => new Can('process-order', [null])]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     /**
      * Get the Gate instance from the container.
      *


### PR DESCRIPTION
This PR enhances the test coverage for the `Can` validation rule by adding a new test case that verifies the handling of nullable parameters in gate definitions.

### Changes Made
- Added `testValidationWithNullableArguments()` test method
- Validates that optional/nullable parameters are correctly passed to authorization gates
- Ensures proper validation behavior when using null values as additional parameters
