### PR TITLE
[12.x] Add ability to guess `alter|update` table

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,6 +10,8 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
+        '/^(alter|update)_(\w+)_table$/',
+        '/^(alter|update)_(\w+)$/',
         '/.+_(to|from|in)_(\w+)_table$/',
         '/.+_(to|from|in)_(\w+)$/',
     ];

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,6 +28,14 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('alter_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
@@ -49,6 +57,14 @@ class TableGuesserTest extends TestCase
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('alter_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('update_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
     }


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have added to migrations the ability to guess `alter` and `update` migration commands.

```bash
php artisan make:migration update_users_table
```
```bash
php artisan make:migration alter_users_table
```

After merging this PR, we can use these commands to generate update migrations.