### PR TITLE
[12.x] Fix group imports in Blade `@use` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -14,7 +14,7 @@ trait CompilesUseStatements
     {
         $expression = preg_replace('/[()]/', '', $expression);
 
-        // Preserve grouped imports as-is.
+        // Preserve grouped imports as-is...
         if (str_contains($expression, '{')) {
             $use = ltrim(trim($expression, " '\""), '\\');
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -12,7 +12,16 @@ trait CompilesUseStatements
      */
     protected function compileUse($expression)
     {
-        $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
+        $expression = preg_replace('/[()]/', '', $expression);
+
+        // Preserve grouped imports as-is.
+        if (str_contains($expression, '{')) {
+            $use = ltrim(trim($expression, " '\""), '\\');
+
+            return "<?php use \\{$use}; ?>";
+        }
+
+        $segments = explode(',', $expression);
 
         $use = ltrim(trim($segments[0], " '\""), '\\');
         $as = isset($segments[1]) ? ' as '.trim($segments[1], " '\"") : '';

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -47,4 +47,26 @@ class BladeUseTest extends AbstractBladeTestCase
         $string = "Foo @use(\SomeNamespace\SomeClass, Foo) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithBracesAreCompiledCorrectly()
+    {
+        $expected = "Foo <?php use \SomeNamespace\{Foo, Bar}; ?> bar";
+
+        $string = "Foo @use('SomeNamespace\{Foo, Bar}') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(SomeNamespace\{Foo, Bar}) bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementWithBracesAndBackslashAreCompiledCorrectly()
+    {
+        $expected = "Foo <?php use \SomeNamespace\{Foo, Bar}; ?> bar";
+
+        $string = "Foo @use('\SomeNamespace\{Foo, Bar}') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(\SomeNamespace\{Foo, Bar}) bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
PHP natively supports group imports since PHP 7.0:

```php
use MySpace\{Foo, Bar};
```

Currently, the `@use` directive mistakenly treats these as aliases. For example,

```blade
@use(MySpace\{Foo, Bar})
```

Results in:

```php
use MySpace\Foo as Bar.
```

This PR fixes it so that the blade code above, produces output equal to PHP's original feature:

```php
use MySpace\{Foo, Bar};
```
