### PR TITLE
[12.x] Test `@use` directive without quotes

### DIFF
--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -6,29 +6,45 @@ class BladeUseTest extends AbstractBladeTestCase
 {
     public function testUseStatementsAreCompiled()
     {
-        $string = "Foo @use('SomeNamespace\SomeClass', 'Foo') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
+
+        $string = "Foo @use('SomeNamespace\SomeClass', 'Foo') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(SomeNamespace\SomeClass, Foo) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testUseStatementsWithoutAsAreCompiled()
     {
-        $string = "Foo @use('SomeNamespace\SomeClass') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
+
+        $string = "Foo @use('SomeNamespace\SomeClass') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(SomeNamespace\SomeClass) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testUseStatementsWithBackslashAtBeginningAreCompiled()
     {
-        $string = "Foo @use('\SomeNamespace\SomeClass') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass; ?> bar";
+
+        $string = "Foo @use('\SomeNamespace\SomeClass') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(\SomeNamespace\SomeClass) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
     public function testUseStatementsWithBackslashAtBeginningAndAliasedAreCompiled()
     {
-        $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
         $expected = "Foo <?php use \SomeNamespace\SomeClass as Foo; ?> bar";
+
+        $string = "Foo @use('\SomeNamespace\SomeClass', 'Foo') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "Foo @use(\SomeNamespace\SomeClass, Foo) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
It is possible to use the `@use` directive both with and without quotes. To ensure we don't break this behaviour in the future, I suggest having both ways in the tests.

https://github.com/search?q=%40use+language%3Ablade&type=code