### PR TITLE
Use value() helper in 'when' method

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -20,7 +20,7 @@ trait Conditionable
      */
     public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
-        $value = $value instanceof Closure ? $value($this) : $value;
+        $value = value($value, $this);
 
         if (func_num_args() === 0) {
             return new HigherOrderWhenProxy($this);


### PR DESCRIPTION
When using the when method, it first checked if the given value was a Closure and then executed it.  
This is essentially the same logic as value() helper, which was being re-implemented here.  

https://github.com/laravel/framework/blob/17786ca25fa9080f0b4f03af7517e9fc72fa0b4a/src/Illuminate/Collections/helpers.php#L234-L237

This PR replaces that duplicated logic with a direct call to value().


similar in [#54650](https://github.com/laravel/framework/pull/54650)