### PR TITLE
[12.x] Feature/support/bugfix foreign string

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1014,6 +1014,21 @@ class Blueprint
     }
 
     /**
+     * Create a new string (8-bit) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignString($column)
+    {
+        return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
+            'type' => 'char',
+            'name' => $column,
+            'length' => Builder::$defaultStringLength,
+        ]));
+    }
+
+    /**
      * Create a foreign ID column for the given model.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
@@ -1057,7 +1058,13 @@ class Blueprint
                 ->referencesModelColumn($model->getKeyName());
         }
 
-        return $this->foreignUuid($column)
+        if (in_array(HasUuids::class, $modelTraits, true)) {
+            return $this->foreignUuid($column)
+                ->table($model->getTable())
+                ->referencesModelColumn($model->getKeyName());
+        }
+
+        return $this->foreignString($column)
             ->table($model->getTable())
             ->referencesModelColumn($model->getKeyName());
     }

--- a/tests/Database/Fixtures/Models/EloquentModelUsingUuid.php
+++ b/tests/Database/Fixtures/Models/EloquentModelUsingUuid.php
@@ -2,30 +2,18 @@
 
 namespace Illuminate\Tests\Database\Fixtures\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
 class EloquentModelUsingUuid extends Model
 {
+    use HasUuids;
     /**
      * The table associated with the model.
      *
      * @var string
      */
     protected $table = 'model';
-
-    /**
-     * The "type" of the primary key ID.
-     *
-     * @var string
-     */
-    protected $keyType = 'string';
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 
     /**
      * Get the default foreign key name for the model.


### PR DESCRIPTION
## ForeignIdFor issue
Hi, when changing Models `$keyType` to `string`, `foreignIdFor()` method does not work as expected.

## Example/Reproduction
### Models
```php 
class Basket extends Model
{
    protected $keyType = 'string';
    public $incrementing = false;
}

class Customer extends Model
{} 
```

### Migrations
```php 
public function up(): void
    {
        Schema::create('customers', function (Blueprint $table) {
            $table->id();
            $table->timestamps();
            $table->foreignIdFor(Basket::class);
        });
    }

public function up(): void
    {
        Schema::create('baskets', function (Blueprint $table) {
            $table->string('id')->primary();
            $table->timestamps();
        });
    }
```

### Tinker
```php 
$customer = new App\Models\Customer()
= App\Models\Customer {#5202}

> $basket = new App\Models\Basket()
= App\Models\Basket {#5211}

> $basket->id = "1"
= "1"

> $customer->basket_id = $basket->id
= "1"

> $basket->save()
= true

> $customer->save()

   Illuminate\Database\QueryException  SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type uuid: "1"
CONTEXT:  unnamed portal parameter $1 = '...' (Connection: pgsql, SQL: insert into "customers" ("basket_id", "updated_at", "created_at") values (1, 2025-04-18 12:26:56, 2025-04-18 12:26:56) returning "id").
```
### Env setup
Setup laravel app with sail and choose pgsql. I tested this issue only for pgsql and mysql (I did not test maria, sqlite, etc.). Mysql works fine but pgsql does not work because it expects UUID (see the code) and not a custom string.

### (Braking) changes
Model will have to `use HasUuids;` if it uses UUID as its primary key when specifying a foreign id using foreignIdFor() method

`foreignString ` method - I am not sure if it should be extracted or the code inside the function should be embedded into `foreignIdFor ` method. 

### Current workaround
when building migrations use foreign()
```php 
$table->string('basket_id');
$table->foreign('basket_id')->references('id')->on('baskets');
```

I had to also reorder (rename timestamps) of  migration files so that previously created migration does not depend on future migrations. When using `foreignIdFor`, the order of running migrations does not matter.

Other possible workaround is using mysql (since it works there) but DB migration is complicated.

### Future work
If this or similar change gets accepted I will update Laravel docs. There is the same problem with morph relations, i could not use `morph` method and instead had to specify custom keys in migrations. 
Feel free to contribute to PR and ask any questions, I will open an issue for this bug/feature if needed.