### PR TITLE
[12.x] Add `nestedRelationLoaded()` method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1076,6 +1076,34 @@ trait HasRelationships
     }
 
     /**
+     * Determine if the given nested relations are loaded.
+     *
+     * @param  string  $relationPath
+     * @return bool
+     */
+    public function nestedRelationLoaded(string $relationPath): bool
+    {
+        [$relation, $childRelation] = array_replace(
+            [null, null],
+            explode('.', $relationPath, 2),
+        );
+
+        if (! $this->relationLoaded($relation)) {
+            return false;
+        }
+
+        if ($childRelation) {
+            foreach ($this->$relation as $related) {
+                if (! $related->nestedRelationLoaded($childRelation)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Set the given relationship on the model.
      *
      * @param  string  $relation

--- a/tests/Integration/Database/EloquentModelNestedRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelNestedRelationLoadedTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelNestedRelationLoadedTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelNestedRelationLoadedTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('ones', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('twos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('threes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('two_id');
+            $table->integer('one_id')->nullable();
+        });
+    }
+
+    public function testWhenRelationNotLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()->find($one->id);
+
+        $this->assertFalse($model->nestedRelationLoaded('twos'));
+    }
+
+    public function testWhenRelationLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertTrue($model->nestedRelationLoaded('twos'));
+    }
+
+    public function testWhenChildRelationIsNotLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertTrue($model->nestedRelationLoaded('twos'));
+        $this->assertFalse($model->nestedRelationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos.threes')
+            ->find($one->id);
+
+        $this->assertTrue($model->nestedRelationLoaded('twos'));
+        $this->assertTrue($model->nestedRelationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRecursiveRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create(['one_id' => $one->id]);
+
+        $model = One::query()
+            ->with('twos.threes.one')
+            ->find($one->id);
+
+        $this->assertTrue($model->nestedRelationLoaded('twos'));
+        $this->assertTrue($model->nestedRelationLoaded('twos.threes'));
+        $this->assertTrue($model->nestedRelationLoaded('twos.threes.one'));
+    }
+}
+
+class One extends Model
+{
+    public $table = 'ones';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos(): HasMany
+    {
+        return $this->hasMany(Two::class, 'one_id');
+    }
+}
+
+class Two extends Model
+{
+    public $table = 'twos';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function threes(): HasMany
+    {
+        return $this->hasMany(Three::class, 'two_id');
+    }
+}
+
+class Three extends Model
+{
+    public $table = 'threes';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function two(): BelongsTo
+    {
+        return $this->belongsTo(Two::class, 'two_id');
+    }
+}


### PR DESCRIPTION
# Introduced `nestedRelationLoaded()` method to Eloquent Model (`HasRelationShips` trait)

## Why `nestedRelationLoaded()`?

Current `relationLoaded()` method only checks immediate relation of the Model. Using `nestedRelationLoaded()`, users can check whether the nested relations are loaded.

```
$user->load('posts.comments');
$user->relationLoaded('posts.comments'); // Returns false
$user->nestedRelationLoaded('posts.comments'); // Returns true
```

## Benefits

End users can check whether the nested relation loaded once and load the desired relation.

## reasons it does not break any existing features

Since this method is completely newly introduced and uses nowhere else inside codebase, no existing features will be broken.