### PR TITLE
[12.x] Added Arr::groupBy() helper function for array grouping

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1021,4 +1021,29 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Group an associative array by a key or callback.
+     *
+     * @param  array  $array
+     * @param  string|int|callable  $groupBy
+     * @param  bool  $preserveKeys
+     * @return array
+     */
+    public static function groupBy($array, $groupBy, $preserveKeys = false)
+    {
+        $result = [];
+
+        foreach ($array as $key => $item) {
+            $groupKey = is_callable($groupBy) ? $groupBy($item, $key) : static::get($item, $groupBy);
+
+            if ($preserveKeys) {
+                $result[$groupKey][$key] = $item;
+            } else {
+                $result[$groupKey][] = $item;
+            }
+        }
+
+        return $result;
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1601,4 +1601,84 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testGroupBy()
+    {
+        $products = [
+            [
+                'id' => 1,
+                'type' => 'Electronics',
+                'name' => 'Laptop',
+            ],
+            [
+                'id' => 2,
+                'type' => 'Clothing',
+                'name' => 'T-shirt',
+            ],
+            [
+                'id' => 3,
+                'type' => 'Electronics',
+                'name' => 'Smartphone',
+            ],
+        ];
+
+        // Basic grouping
+        $grouped = Arr::groupBy($products, 'type');
+
+        $this->assertEquals([
+            'Electronics' => [
+                [
+                    'id' => 1,
+                    'type' => 'Electronics',
+                    'name' => 'Laptop',
+                ],
+                [
+                    'id' => 3,
+                    'type' => 'Electronics',
+                    'name' => 'Smartphone',
+                ],
+            ],
+            'Clothing' => [
+                [
+                    'id' => 2,
+                    'type' => 'Clothing',
+                    'name' => 'T-shirt',
+                ],
+            ],
+        ], $grouped);
+
+        // With preserved keys
+        $grouped = Arr::groupBy($products, 'type', true);
+
+        $this->assertEquals([
+            'Electronics' => [
+                0 => [
+                    'id' => 1,
+                    'type' => 'Electronics',
+                    'name' => 'Laptop',
+                ],
+                2 => [
+                    'id' => 3,
+                    'type' => 'Electronics',
+                    'name' => 'Smartphone',
+                ],
+            ],
+            'Clothing' => [
+                1 => [
+                    'id' => 2,
+                    'type' => 'Clothing',
+                    'name' => 'T-shirt',
+                ],
+            ],
+        ], $grouped);
+
+        // With callback
+        $grouped = Arr::groupBy($products, function ($item) {
+            return strtolower($item['type']);
+        });
+
+        $this->assertArrayHasKey('electronics', $grouped);
+
+        $this->assertArrayHasKey('clothing', $grouped);
+    }
 }


### PR DESCRIPTION
### Overview

This PR introduces a new `Arr::groupBy()` helper method to the `Illuminate\Support\Arr` class. It provides a convenient way to group associative array by a specified key or a callback, with optional support for preserving the original array keys.

### Example

```php
use Illuminate\Support\Arr;

$products = [
    [
        'id' => 1,
        'type' => 'Electronics',
        'name' => 'Laptop',
    ],
    [
        'id' => 2,
        'type' => 'Clothing',
        'name' => 'T-shirt',
    ],
    [
        'id' => 3,
        'type' => 'Electronics',
        'name' => 'Smartphone',
    ],
];

// Group by type
$grouped = Arr::groupBy($products, 'type');

/*
Output: 
[
    'Electronics' => [
        [
            'id' => 1,
            'type' => 'Electronics',
            'name' => 'Laptop',
        ],
        [
            'id' => 3,
            'type' => 'Electronics',
            'name' => 'Smartphone',
        ],
    ],
    'Clothing' => [
        [
            'id' => 2,
            'type' => 'Clothing',
            'name' => 'T-shirt',
        ],
    ],
]
*/

// With preserved keys
$grouped = Arr::groupBy($products, 'type', true);

/*
Output: 
[
    'Electronics' => [
        0 => [
            'id' => 1,
            'type' => 'Electronics',
            'name' => 'Laptop',
        ],
        2 => [
            'id' => 3,
            'type' => 'Electronics',
            'name' => 'Smartphone',
        ],
    ],
    'Clothing' => [
        1 => [
            'id' => 2,
            'type' => 'Clothing',
            'name' => 'T-shirt',
        ],
    ],
]
*/

// With callback
$grouped = Arr::groupBy($products, function ($item) {
    return strtolower($item['type']);
});

/*
Output:
[
    'electronics' => [
        [
            'id' => 1,
            'type' => 'Electronics',
            'name' => 'Laptop',
        ],
        [
            'id' => 3,
            'type' => 'Electronics',
            'name' => 'Smartphone',
        ],
    ],
    'clothing' => [
        [
            'id' => 2,
            'type' => 'Clothing',
            'name' => 'T-shirt',
        ],
    ],
]
*/
```
