### PR TITLE
[12.x] feat: Add Arr::date helper to retreive Carbon instances 

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -4,8 +4,8 @@ namespace Illuminate\Support;
 
 use ArgumentCountError;
 use ArrayAccess;
-use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
@@ -430,39 +430,35 @@ class Arr
     }
 
     /**
-     * Get a Carbon instance from an array using "dot" notation.
+     * Retrieve an item from an array as a Carbon instance.
      *
      * It will return null values when dates cannot be parsed or keys don't exist.
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key
-     * @param  ?Carbon  $default
-     * @return Carbon|null
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
      */
-    public static function date($array, $key, $default = null): Carbon|null|array
+    public static function date($array, $key, $tz = null)
     {
-        $value = static::get($array, $key, $default);
+        $value = static::get($array, $key);
+
+        if (is_null($value)) {
+            return null;
+        }
 
         if (is_array($value)) {
-            return array_map(function ($segment) {
+            return array_map(function ($segment) use ($tz) {
                 try {
-                    return Carbon::parse($segment);
+                    return Date::parse($segment, $tz);
                 } catch (InvalidFormatException) {
                     return null;
                 }
             }, $value);
         }
 
-        if (is_null($value)) {
-            return null;
-        }
-
-        if ($value instanceof Carbon) {
-            return $value;
-        }
-
         try {
-            return Carbon::parse($value);
+            return Date::parse($value, $tz);
         } catch (InvalidFormatException) {
             return null;
         }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -4,11 +4,11 @@ namespace Illuminate\Support;
 
 use ArgumentCountError;
 use ArrayAccess;
+use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
-use Carbon\Carbon;
-use Carbon\Exceptions\InvalidFormatException;
 
 class Arr
 {
@@ -431,20 +431,19 @@ class Arr
 
     /**
      * Get a Carbon instance from an array using "dot" notation.
-     * 
+     *
      * It will return null values when dates cannot be parsed or keys don't exist.
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key
-     * @param  ?Carbon $default
-     * 
+     * @param  ?Carbon  $default
      * @return Carbon|null
      */
     public static function date($array, $key, $default = null): Carbon|null|array
     {
         $value = static::get($array, $key, $default);
 
-        if (is_array($value)) { 
+        if (is_array($value)) {
             return array_map(function ($segment) {
                 try {
                     return Carbon::parse($segment);
@@ -454,7 +453,7 @@ class Arr
             }, $value);
         }
 
-        if (is_null($value)) { 
+        if (is_null($value)) {
             return null;
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -436,10 +436,11 @@ class Arr
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key
+     * @param  string|null  $format
      * @param  string|null  $tz
      * @return \Illuminate\Support\Carbon|null
      */
-    public static function date($array, $key, $tz = null)
+    public static function date($array, $key, $format = null, $tz = null)
     {
         $value = static::get($array, $key);
 
@@ -448,9 +449,11 @@ class Arr
         }
 
         if (is_array($value)) {
-            return array_map(function ($segment) use ($tz) {
+            return array_map(function ($segment) use ($format, $tz) {
                 try {
-                    return Date::parse($segment, $tz);
+                    return $format
+                        ? Date::createFromFormat($format, $segment, $tz)
+                        : Date::parse($segment, $tz);
                 } catch (InvalidFormatException) {
                     return null;
                 }
@@ -458,7 +461,9 @@ class Arr
         }
 
         try {
-            return Date::parse($value, $tz);
+            return $format
+                ? Date::createFromFormat($format, $value, $tz)
+                : Date::parse($value, $tz);
         } catch (InvalidFormatException) {
             return null;
         }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -7,6 +7,8 @@ use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use Random\Randomizer;
+use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
 
 class Arr
 {
@@ -425,6 +427,46 @@ class Arr
         }
 
         return false;
+    }
+
+    /**
+     * Get a Carbon instance from an array using "dot" notation.
+     * 
+     * It will return null values when dates cannot be parsed or keys don't exist.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  ?Carbon $default
+     * 
+     * @return Carbon|null
+     */
+    public static function date($array, $key, $default = null): Carbon|null|array
+    {
+        $value = static::get($array, $key, $default);
+
+        if (is_array($value)) { 
+            return array_map(function ($segment) {
+                try {
+                    return Carbon::parse($segment);
+                } catch (InvalidFormatException) {
+                    return null;
+                }
+            }, $value);
+        }
+
+        if (is_null($value)) { 
+            return null;
+        }
+
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (InvalidFormatException) {
+            return null;
+        }
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayObject;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Carbon\Carbon as BaseCarbon;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
@@ -599,6 +600,36 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::hasAny($array, 'foo.baz'));
         $this->assertFalse(Arr::hasAny($array, 'foo.bax'));
         $this->assertTrue(Arr::hasAny($array, ['foo.bax', 'foo.baz']));
+    }
+
+    public function testDate()
+    {
+      Carbon::setTestNow('2018-09-01 00:00:00.000000');
+
+      $array = ['date' => '2018-09-01 00:00:00.000000'];
+      $this->assertInstanceOf(BaseCarbon::class, Arr::date($array, 'date'));
+      $this->assertEquals('2018-09-01 00:00:00.000000', Arr::date($array, 'date')->format('Y-m-d H:i:s.u'));
+
+
+      $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null);
+      $this->assertInstanceOf(BaseCarbon::class, $array[0]);
+      $this->assertEquals('2018-09-01 00:00:00.000000', $array[0]->format('Y-m-d H:i:s.u'));
+      $this->assertInstanceOf(BaseCarbon::class, $array[1]);
+      $this->assertEquals('2018-09-02 00:00:00.000000', $array[1]->format('Y-m-d H:i:s.u'));
+      $this->assertNull($array[2]);
+
+      $array = []; 
+      $this->assertNull(Arr::date($array, 'date', null));
+
+      $this->assertEquals(
+        '2018-09-01 00:00:00.000000', 
+        Arr::date($array, 'date', now())->format('Y-m-d H:i:s.u')
+      );
+
+      $array = ['date' => '2222-22-22']; 
+      $this->assertNull(Arr::date($array, 'date', null));
+
+      Carbon::setTestNow();
     }
 
     public function testIsAssoc()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -604,31 +604,31 @@ class SupportArrTest extends TestCase
 
     public function testDate()
     {
-      Carbon::setTestNow('2018-09-01 00:00:00.000000');
+        Carbon::setTestNow('2018-09-01 00:00:00.000000');
 
-      $array = ['date' => '2018-09-01 00:00:00.000000'];
-      $this->assertInstanceOf(BaseCarbon::class, Arr::date($array, 'date'));
-      $this->assertEquals('2018-09-01 00:00:00.000000', Arr::date($array, 'date')->format('Y-m-d H:i:s.u'));
+        $array = ['date' => '2018-09-01 00:00:00.000000'];
+        $this->assertInstanceOf(BaseCarbon::class, Arr::date($array, 'date'));
+        $this->assertEquals('2018-09-01 00:00:00.000000', Arr::date($array, 'date')->format('Y-m-d H:i:s.u'));
 
-      $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null);
-      $this->assertInstanceOf(BaseCarbon::class, $array[0]);
-      $this->assertEquals('2018-09-01 00:00:00.000000', $array[0]->format('Y-m-d H:i:s.u'));
-      $this->assertInstanceOf(BaseCarbon::class, $array[1]);
-      $this->assertEquals('2018-09-02 00:00:00.000000', $array[1]->format('Y-m-d H:i:s.u'));
-      $this->assertNull($array[2]);
+        $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null);
+        $this->assertInstanceOf(BaseCarbon::class, $array[0]);
+        $this->assertEquals('2018-09-01 00:00:00.000000', $array[0]->format('Y-m-d H:i:s.u'));
+        $this->assertInstanceOf(BaseCarbon::class, $array[1]);
+        $this->assertEquals('2018-09-02 00:00:00.000000', $array[1]->format('Y-m-d H:i:s.u'));
+        $this->assertNull($array[2]);
 
-      $array = [];
-      $this->assertNull(Arr::date($array, 'date', null));
+        $array = [];
+        $this->assertNull(Arr::date($array, 'date', null));
 
-      $this->assertEquals(
-        '2018-09-01 00:00:00.000000',
-        Arr::date($array, 'date', now())->format('Y-m-d H:i:s.u')
-      );
+        $this->assertEquals(
+            '2018-09-01 00:00:00.000000',
+            Arr::date($array, 'date', now())->format('Y-m-d H:i:s.u')
+        );
 
-      $array = ['date' => '2222-22-22'];
-      $this->assertNull(Arr::date($array, 'date', null));
+        $array = ['date' => '2222-22-22'];
+        $this->assertNull(Arr::date($array, 'date', null));
 
-      Carbon::setTestNow();
+        Carbon::setTestNow();
     }
 
     public function testIsAssoc()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayObject;
-use Illuminate\Support\Carbon;
 use Carbon\Carbon as BaseCarbon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
@@ -610,7 +610,6 @@ class SupportArrTest extends TestCase
       $this->assertInstanceOf(BaseCarbon::class, Arr::date($array, 'date'));
       $this->assertEquals('2018-09-01 00:00:00.000000', Arr::date($array, 'date')->format('Y-m-d H:i:s.u'));
 
-
       $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null);
       $this->assertInstanceOf(BaseCarbon::class, $array[0]);
       $this->assertEquals('2018-09-01 00:00:00.000000', $array[0]->format('Y-m-d H:i:s.u'));
@@ -618,15 +617,15 @@ class SupportArrTest extends TestCase
       $this->assertEquals('2018-09-02 00:00:00.000000', $array[1]->format('Y-m-d H:i:s.u'));
       $this->assertNull($array[2]);
 
-      $array = []; 
+      $array = [];
       $this->assertNull(Arr::date($array, 'date', null));
 
       $this->assertEquals(
-        '2018-09-01 00:00:00.000000', 
+        '2018-09-01 00:00:00.000000',
         Arr::date($array, 'date', now())->format('Y-m-d H:i:s.u')
       );
 
-      $array = ['date' => '2222-22-22']; 
+      $array = ['date' => '2222-22-22'];
       $this->assertNull(Arr::date($array, 'date', null));
 
       Carbon::setTestNow();

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -622,10 +622,13 @@ class SupportArrTest extends TestCase
         $array = ['date' => '2222-22-22'];
         $this->assertNull(Arr::date($array, 'date'));
 
-        $array = ['date' => '2025-01-22 00:00:00'];
-        $this->assertEquals('CAT', Arr::date($array, 'date', 'CAT')->timezone);
+        $array = ['date' => '01/22/2025 00:00:00'];
+        $this->assertEquals('2025-01-22 00:00:00', Arr::date($array, 'date', 'm/d/Y H:i:s')->format('Y-m-d H:i:s'));
 
-        $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null, 'CAT');
+        $array = ['date' => '2025-01-22 00:00:00'];
+        $this->assertEquals('CAT', Arr::date($array, 'date', null, 'CAT')->timezone);
+
+        $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null, null, 'CAT');
         $this->assertInstanceOf(Carbon::class, $array[0]);
         $this->assertEquals('CAT', $array[0]->timezone);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayObject;
-use Carbon\Carbon as BaseCarbon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -607,26 +606,28 @@ class SupportArrTest extends TestCase
         Carbon::setTestNow('2018-09-01 00:00:00.000000');
 
         $array = ['date' => '2018-09-01 00:00:00.000000'];
-        $this->assertInstanceOf(BaseCarbon::class, Arr::date($array, 'date'));
+        $this->assertInstanceOf(Carbon::class, Arr::date($array, 'date'));
         $this->assertEquals('2018-09-01 00:00:00.000000', Arr::date($array, 'date')->format('Y-m-d H:i:s.u'));
 
         $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null);
-        $this->assertInstanceOf(BaseCarbon::class, $array[0]);
+        $this->assertInstanceOf(Carbon::class, $array[0]);
         $this->assertEquals('2018-09-01 00:00:00.000000', $array[0]->format('Y-m-d H:i:s.u'));
-        $this->assertInstanceOf(BaseCarbon::class, $array[1]);
+        $this->assertInstanceOf(Carbon::class, $array[1]);
         $this->assertEquals('2018-09-02 00:00:00.000000', $array[1]->format('Y-m-d H:i:s.u'));
         $this->assertNull($array[2]);
 
         $array = [];
-        $this->assertNull(Arr::date($array, 'date', null));
-
-        $this->assertEquals(
-            '2018-09-01 00:00:00.000000',
-            Arr::date($array, 'date', now())->format('Y-m-d H:i:s.u')
-        );
+        $this->assertNull(Arr::date($array, 'date'));
 
         $array = ['date' => '2222-22-22'];
-        $this->assertNull(Arr::date($array, 'date', null));
+        $this->assertNull(Arr::date($array, 'date'));
+
+        $array = ['date' => '2025-01-22 00:00:00'];
+        $this->assertEquals('CAT', Arr::date($array, 'date', 'CAT')->timezone);
+
+        $array = Arr::date(['2018-09-01 00:00:00', '2018-09-02 00:00:00', '2222-22-22 99:99:99'], null, 'CAT');
+        $this->assertInstanceOf(Carbon::class, $array[0]);
+        $this->assertEquals('CAT', $array[0]->timezone);
 
         Carbon::setTestNow();
     }


### PR DESCRIPTION
This PR introduces an `Illuminate\Support\Arr::date()` method.

It attempts to match `request()->date('input')` functionality for arrays, using  `Arr::get()` to fetch the key or array and retrieving results as Date instances, or null for invalid values or missing keys. 

Example usage
```php
$array = ['due_date' => '2023-03-12'];

$date = Arr::date(
    array: $array, 
    key: 'due_date', 
    format: 'Y-m-d',
    tz: 'GMT'
 );

// previously I would do something like this.. 
$array = ['due_date' => '2023-03-12'];
try { 
   $dueDate = Carbon::parse(Arr::get($array, 'due_date')));
} catch (InvalidFormatException) { 
   $dueDate = null;
}

// now...
$dueDate = Arr::date($array, 'due_date');

//previously
$array = ['2025-02-12', '2025-03-15'];
$dates = array_map(function($date) {
try { 
   return Carbon::parse(Arr::get($date, 'due_date')));
} catch (InvalidFormatException) { 
   return null;
}}, $arr)

// now...
$array = ['2025-02-12', '2025-03-15'];
$dates = Arr::date($array, null);
```

Looking for opinions on existing easier ways to do this and returning null values vs throwing exceptions?

I guess it would be nice to have something like `Arr::tryDate` which should return null values where this would then throw exceptions?

Thoughts or concerns? 

Have PR'ed something for Carbon too: https://github.com/briannesbitt/Carbon/pull/3179 - can clean up here if that gets added, or add this to the Illuminate/Support/Carbon instance? 



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
