### PR TITLE
[12.x] Add whereValueBetweenColumns methods to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1409,6 +1409,25 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where between statement using columns to the query for an arbitrary value.
+     *
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereValueBetweenColumns($value, array $columns, $boolean = 'and', $not = false)
+    {
+        $type = 'valueBetweenColumns';
+
+        $this->wheres[] = compact('type', 'value', 'columns', 'boolean', 'not');
+
+        $this->addBinding($value,'where');
+
+        return $this;
+    }
+
+    /**
      * Add an or where between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1428,6 +1447,17 @@ class Builder implements BuilderContract
     public function orWhereBetweenColumns($column, array $values)
     {
         return $this->whereBetweenColumns($column, $values, 'or');
+    }
+
+    /**
+     * Add an or where between statement using columns to the query for an arbitrary value.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereValueBetweenColumns($value, array $columns)
+    {
+        return $this->whereValueBetweenColumns($value, $columns, 'or');
     }
 
     /**
@@ -1455,6 +1485,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where not between statement using columns to the query for an arbitrary value.
+     *
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereValueNotBetweenColumns($value, array $columns, $boolean = 'and')
+    {
+        return $this->whereValueBetweenColumns($value, $columns, $boolean, true);
+    }
+
+    /**
      * Add an or where not between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1474,6 +1516,17 @@ class Builder implements BuilderContract
     public function orWhereNotBetweenColumns($column, array $values)
     {
         return $this->whereNotBetweenColumns($column, $values, 'or');
+    }
+
+    /**
+     * Add an or where not between statement using columns to the query for an arbitrary value.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereValueNotBetweenColumns($value, array $columns)
+    {
+        return $this->whereValueNotBetweenColumns($value, $columns, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1422,7 +1422,7 @@ class Builder implements BuilderContract
 
         $this->wheres[] = compact('type', 'value', 'columns', 'boolean', 'not');
 
-        $this->addBinding($value,'where');
+        $this->addBinding($value, 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -456,6 +456,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "between" where clause for an arbitrary value.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereValueBetweenColumns(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->wrap(is_array($where['columns']) ? reset($where['columns']) : $where['columns'][0]);
+
+        $max = $this->wrap(is_array($where['columns']) ? end($where['columns']) : $where['columns'][1]);
+
+        return $this->parameter($where['value']).' '.$between.' '.$min.' and '.$max;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1197,7 +1197,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('brackets')->whereValueBetweenColumns('id', ['min_amount', 'max_amount']);
+        $builder->select('*')->from('brackets')->whereValueBetweenColumns(5, ['min_amount', 'max_amount']);
         $this->assertSame('select * from "brackets" where ? between "min_amount" and "max_amount"', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
 
@@ -1233,7 +1233,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('brackets')->whereValueNotBetweenColumns('id', ['min_amount', 'max_amount']);
+        $builder->select('*')->from('brackets')->whereValueNotBetweenColumns(5, ['min_amount', 'max_amount']);
         $this->assertSame('select * from "brackets" where ? not between "min_amount" and "max_amount"', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1189,6 +1189,78 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2], $builder->getBindings());
     }
 
+    public function testWhereValueBetweenColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueBetweenColumns(5, ['brackets.min_amount', 'brackets.max_amount']);
+        $this->assertSame('select * from "brackets" where ? between "brackets"."min_amount" and "brackets"."max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueBetweenColumns('id', ['min_amount', 'max_amount']);
+        $this->assertSame('select * from "brackets" where ? between "min_amount" and "max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueBetweenColumns(5, [new Raw(1), new Raw(2)]);
+        $this->assertSame('select * from "brackets" where ? between 1 and 2', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+    }
+
+    public function testOrWhereValueBetweenColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueBetweenColumns(5, ['brackets.min_amount', 'brackets.max_amount']);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? between "brackets"."min_amount" and "brackets"."max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueBetweenColumns(5, ['min_amount', 'max_amount']);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? between "min_amount" and "max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueBetweenColumns(5, [new Raw(1), new Raw(2)]);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? between 1 and 2', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+    }
+
+    public function testWhereValueNotBetweenColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueNotBetweenColumns(5, ['brackets.min_amount', 'brackets.max_amount']);
+        $this->assertSame('select * from "brackets" where ? not between "brackets"."min_amount" and "brackets"."max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueNotBetweenColumns('id', ['min_amount', 'max_amount']);
+        $this->assertSame('select * from "brackets" where ? not between "min_amount" and "max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->whereValueNotBetweenColumns(5, [new Raw(1), new Raw(2)]);
+        $this->assertSame('select * from "brackets" where ? not between 1 and 2', $builder->toSql());
+        $this->assertEquals([0 => 5], $builder->getBindings());
+    }
+
+    public function testOrWhereValueNotBetweenColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueNotBetweenColumns(5, ['brackets.min_amount', 'brackets.max_amount']);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? not between "brackets"."min_amount" and "brackets"."max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueNotBetweenColumns(5, ['min_amount', 'max_amount']);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? not between "min_amount" and "max_amount"', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('brackets')->where('id', 2)->orWhereValueNotBetweenColumns(5, [new Raw(1), new Raw(2)]);
+        $this->assertSame('select * from "brackets" where "id" = ? or ? not between 1 and 2', $builder->toSql());
+        $this->assertEquals([0 => 2, 1 => 5], $builder->getBindings());
+    }
+
     public function testBasicOrWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
**Update:** added the sql queries generated by the examples for clarity on sql injection and prepared statements.

This PR adds the following methods to the database query builder: 
- `whereValueBetweenColumns`
- `orWhereValueBetweenColumns`
- `whereValueNotBetweenColumns`
- `orWhereValueNotBetweenColumns` 

These allow checking if an arbitrary value is between two columns.

### Problem

There exists the `whereBetweenColumns()` methods for checking if the value of one column (a) is between the values of two other columns (b and c):

```php
$rows = DB::table('sometable')->whereBetweenColumns('column_a',['column_b', 'column_c'])->get();

// generated sql: select * from "sometable" where "column_a" between "column_b" and "column_c";
```

However, these methods do not (directly) support checking if some arbitrary value (a string, number, variable, etc.) is between two columns. In order to do this, you have to either:

1. use two where methods that need to stay grouped together:

```php
// 'where between'
$rows = DB::table('sometable')->where($somevalue, '>=', 'column_b')->where($somevalue, '<=', 'column_c')->get();
// generated sql: select * from "sometable" where ? >= "column_b" and ? <= "column_c";
// params: [$somevalue, $somevalue]

// 'where not between'
$rows = DB::table('sometable')->where($somevalue, '<', 'column_b')->orWhere($somevalue, '>', 'column_c')->get();
// generated sql: select * from "sometable" where ? < "column_b" or ? > "column_c";
// params: [$somevalue, $somevalue]

// 'where not between' with other methods (would have to be in subquery)
$rows = DB::table('sometable')->where('column_a','=',5)
	->where(function (Builder $query) {
		$query->where($somevalue, '<', 'column_b')
			->orWhere($somevalue, '>', 'column_c')
	})
	->get();
// generated sql: select * from "sometable" where "column_a" = ? and (? < "column_b" or ? > "column_c");
// params: [5, $somevalue, $somevalue]
```

2. or risk SQL injection using a raw expression with the `whereBetweenColumns()` method:

```php
$somevalue = '1=1; --  ";
$rows = DB::table('sometable')->whereBetweenColumns(DB::raw($somevalue),['column_b','column_c'])->get();
// generated sql: select * from "sometable" where 1=1; -- between "column_b" and "column_c";
// params: none, not using prepared statement !!!
```

### Solution

With these new `whereValueBetweenColumns()` methods, you can easily and safely check if any value is between two columns:

```php
$rows = DB::table('sometable')->whereValueBetweenColumns($somevalue, ['column_b','column_c'])->get();
// generated sql: select * from "sometable" where ? between "column_b" and "column_c";
// params: [$somevalue]

$rows = DB::table('sometable')->whereValueNotBetweenColumns($somevalue, ['column_b','column_c'])->get();
// generated sql: select * from "sometable" where ? not between "column_b" and "column_c";
// params: [$somevalue]

$rows = DB::table('sometable')->where('id',1)->orWhereValueBetweenColumns($somevalue, ['column_b','column_c'])->get();
// generated sql: select * from "sometable" where  id = ? or ? between "column_b" and "column_c";
// params: [1, $somevalue]

$rows = DB::table('sometable')->where('id',1)->orWhereValueNotBetweenColumns($somevalue, ['column_b','column_c'])->get();
// generated sql: select * from "sometable" where id = ? or ? not between "column_b" and "column_c";
// params: [1, $somevalue]
```

### Some example use cases

All events that are currently happening (datetime):

```php
$now = Carbon()->now();

$events = Event::whereValueBetweenColumns($now,['start_at','end_at'])->get();
// generated sql: select * from "events" where ? between "start_at" and "end_at";
// params: ['2025-04-24 13:45:32']
```

What tax bracket does an income fall under (number):

```php
$income = 50000;

$brackets = TaxBracket::whereValueBetweenColumns($income, ['min_amount','max_amount'])->first();
// generated sql: select * from "tax_brackets" where ? between "min_amount" and "max_amount";
// params: [50000]
```

Scholarship eligibility (number):

```php
$gpa = 3.4;

$scholarships = Scholarship::where('ignore_gpa',true)->orWhereValueBetweenColumns($gpa, ['min_gpa','max_gpa'])->get();
// generated sql: select * from "scholarships" where "ignore_gpa" = ? or ? between "min_gpa" and "max_gpa";
// params: [true, 3.4]
```

Theater seat section (string):

```php
$seat = 'A14'; // 'A' is the row

$section = Section::whereValueBetweenColumns($seat,['start_row','end_row'])->first();
// generated sql: select * from "sections" where ? between "start_row" and "end_row";
// params: ['A14']

// (A14 is in the "Orchestra" section which contains rows A-F)
```

### Notes

- I made them separate methods instead of modifying the existing  `whereBetweenColumns()` methods for the following reasons:
	- It would be unintuitive/confusing to guess if the first parameter is a column name or a value.
	- Adding a boolean parameter like `whereBetweenColumns('somevalue',['column1','column2'], true)` to say its not a column would break backward compatibility by reordering the parameters (there are additional parameters on the existing methods)
	- I don't know how you would name the parameter that both preserves existing functionality but isn't a negative. It would be either  `whereBetweenColumns('somevalue',['column1','column2'], not_column: true)` which looks inverted or `whereBetweenColumns('somevalue',['column1','column2'], column: true)` which breaks backward compatibility.
