### PR TITLE
Add parameters support to terminable middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -252,12 +252,12 @@ class Kernel implements KernelContract
                 continue;
             }
 
-            [$name] = $this->parseMiddleware($middleware);
+            [$name, $parameters] = $this->parseMiddleware($middleware);
 
             $instance = $this->app->make($name);
 
             if (method_exists($instance, 'terminate')) {
-                $instance->terminate($request, $response);
+                $instance->terminate($request, $response, ...$parameters);
             }
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

We cannot use parameters in terminable middleware. It gives an error if used.

With this PR we can use parameters with terminable middleware.