### PR TITLE
Add setIfExists() to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -797,6 +797,23 @@ class Arr
     }
 
     /**
+     * Set an array item to a given value using "dot" notation only if the array key exists
+     *
+     * @param  array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function setIfExists(&$array, $key, $value)
+    {
+        if (! static::exists($array, $key))) {
+            return $array;
+        }
+
+        return static::set($array, $key, $value);
+    }
+
+    /**
      * Shuffle the given array and return the result.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1044,12 +1044,12 @@ class SupportArrTest extends TestCase
     {
         // key does not exist, nothing is set
         $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::set($array, 'products.desk.currency', 'USD');
+        Arr::setIfExists($array, 'products.desk.currency', 'USD');
         $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
 
         // key exists
         $array = ['products' => ['desk' => ['price' => 100]]];
-        Arr::set($array, 'products.desk.price', 200);
+        Arr::setIfExists($array, 'products.desk.price', 200);
         $this->assertEquals(['products' => ['desk' => ['price' => 200]]], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1040,6 +1040,19 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
     }
 
+    public function testSetIfExists()
+    {
+        // key does not exist, nothing is set
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::set($array, 'products.desk.currency', 'USD');
+        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+
+        // key exists
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::set($array, 'products.desk.price', 200);
+        $this->assertEquals(['products' => ['desk' => ['price' => 200]]], $array);
+    }
+
     public function testShuffleProducesDifferentShuffles()
     {
         $input = range('a', 'z');


### PR DESCRIPTION
# Usage

Example 1:
```php
$person = ['name' => 'Jane'];

Arr::setIfExists($person, 'price', 888);
```

This returns you ['name' => 'Jane'] as it will not be set as the 'price' key does not exist in the array


Example 2:

```php
$people = ['name' => 'Jane'];

Arr::setIfExists($person, 'name', 'Jack');
```

This returns you ['name' => 'Jack'] as the key exist in the original array

I think this method can be quite convenient if you want to iterate over an array to replace certain PIIs with faker data only if the array contain certain json keys but otherwise you do not want to add new keys to the original payload array