### PR TITLE
[12.x] Fix many to many detach without IDs broken with custom pivot class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -470,21 +470,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        if (! empty($this->pivotWheres) ||
-            ! empty($this->pivotWhereIns) ||
-            ! empty($this->pivotWhereNulls)) {
-            $records = $this->getCurrentlyAttachedPivotsForIds($ids);
+        $records = $this->getCurrentlyAttachedPivotsForIds($ids);
 
-            foreach ($records as $record) {
-                $results += $record->delete();
-            }
-        } else {
-            foreach ($this->parseIds($ids) as $id) {
-                $results += $this->newPivot([
-                    $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                    $this->relatedPivotKey => $id,
-                ], true)->delete();
-            }
+        foreach ($records as $record) {
+            $results += $record->delete();
         }
 
         return $results;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -336,6 +336,49 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertCount(0, $post->tags);
     }
 
+    public function testDetachMethodWithCustomPivot()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+        $tag5 = Tag::create(['name' => Str::random()]);
+        Tag::create(['name' => Str::random()]);
+        Tag::create(['name' => Str::random()]);
+
+        $post->tagsWithCustomPivot()->attach(Tag::all());
+
+        $this->assertEquals(Tag::pluck('name'), $post->tags->pluck('name'));
+
+        $post->tagsWithCustomPivot()->detach($tag->id);
+        $post->load('tagsWithCustomPivot');
+        $this->assertEquals(
+            Tag::whereNotIn('id', [$tag->id])->pluck('name'),
+            $post->tagsWithCustomPivot->pluck('name')
+        );
+
+        $post->tagsWithCustomPivot()->detach([$tag2->id, $tag3->id]);
+        $post->load('tagsWithCustomPivot');
+        $this->assertEquals(
+            Tag::whereNotIn('id', [$tag->id, $tag2->id, $tag3->id])->pluck('name'),
+            $post->tagsWithCustomPivot->pluck('name')
+        );
+
+        $post->tagsWithCustomPivot()->detach(new Collection([$tag4, $tag5]));
+        $post->load('tagsWithCustomPivot');
+        $this->assertEquals(
+            Tag::whereNotIn('id', [$tag->id, $tag2->id, $tag3->id, $tag4->id, $tag5->id])->pluck('name'),
+            $post->tagsWithCustomPivot->pluck('name')
+        );
+
+        $this->assertCount(2, $post->tagsWithCustomPivot);
+        $post->tagsWithCustomPivot()->detach();
+        $post->load('tagsWithCustomPivot');
+        $this->assertCount(0, $post->tagsWithCustomPivot);
+    }
+
     public function testFirstMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
Fixes #55428

This update causes an extra query for detaching without IDs when using a custom pivot class, but it has one benefit.
You may need pivot class data when deleting pivots. The previous implementation was like this:
```php
foreach ($this->parseIds($ids) as $id) {
    $results += $this->newPivot([
        $this->foreignPivotKey => $this->parent->{$this->parentKey},
        $this->relatedPivotKey => $id,
     ], true)->delete();
}
```
The above code only provides the related pivot key and foreign pivot key for listeners that may be problematic in some scenarios when using pivot data in the listeners, but in the new implementation, we also have other pivot data in the listeners.