### PR TITLE
[12.x] Add possibility to define nested validation rules as array

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -72,7 +72,7 @@ class ValidationRuleParser
                 $rules = $this->explodeWildcardRules($rules, $key, [$rule]);
 
                 unset($rules[$key]);
-            } else if (is_array($rule) && !array_is_list($rule)) {
+            } elseif (is_array($rule) && ! array_is_list($rule)) {
                 $rules = $this->explodeNestedRule($rules, $rule, $key);
 
                 unset($rules[$key]);
@@ -95,7 +95,7 @@ class ValidationRuleParser
     protected function explodeNestedRule($results, $rule, $attribute)
     {
         $input = $this->data[$attribute];
-        $prefix = (is_array($input) && !array_is_list($input)) || is_object($input)
+        $prefix = (is_array($input) && ! array_is_list($input)) || is_object($input)
             ? $attribute.'.'
             : $attribute.'.*.';
         foreach ($rule as $key => $value) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -103,6 +103,12 @@ class ValidationRuleParser
 
         $rules = [];
 
+        if (!array_is_list($rule)) {
+            foreach ($rule as $key => $value) {
+                $rules = array_merge($rules, $this->explodeExplicitRule($value, $key));
+            }
+        }
+
         foreach ($rule as $value) {
             if ($value instanceof Date || $value instanceof Numeric) {
                 $rules = array_merge($rules, explode('|', (string) $value));

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -469,4 +469,52 @@ class ValidationRuleParserTest extends TestCase
             ],
         ], $results->rules);
     }
+
+    public function testNestedValidationRulesObject()
+    {
+        $parser = (new ValidationRuleParser([
+            'numbers' => [
+                'favorite' => 42,
+            ],
+        ]));
+
+        $rules = [
+            'number' => [
+                'favorite' => Rule::numeric()->max(100),
+            ],
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number.favorite' => [
+                'numeric',
+                'max:100',
+            ],
+        ], $results->rules);
+    }
+
+    public function testNestedValidationRulesArray()
+    {
+        $parser = (new ValidationRuleParser([
+            'numbers' => [
+                ['favorite' => 42],
+            ],
+        ]));
+
+        $rules = [
+            'number' => [
+                'favorite' => Rule::numeric()->max(100),
+            ],
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number.*.favorite' => [
+                'numeric',
+                'max:100',
+            ],
+        ], $results->rules);
+    }
 }

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -473,7 +473,7 @@ class ValidationRuleParserTest extends TestCase
     public function testNestedValidationRulesObject()
     {
         $parser = (new ValidationRuleParser([
-            'number' => (object)[
+            'number' => (object) [
                 'favorite' => 42,
             ],
         ]));

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -473,7 +473,7 @@ class ValidationRuleParserTest extends TestCase
     public function testNestedValidationRulesObject()
     {
         $parser = (new ValidationRuleParser([
-            'numbers' => [
+            'number' => (object)[
                 'favorite' => 42,
             ],
         ]));
@@ -494,10 +494,34 @@ class ValidationRuleParserTest extends TestCase
         ], $results->rules);
     }
 
-    public function testNestedValidationRulesArray()
+    public function testNestedValidationRulesAssociativeArray()
     {
         $parser = (new ValidationRuleParser([
-            'numbers' => [
+            'number' => [
+                'favorite' => 42,
+            ],
+        ]));
+
+        $rules = [
+            'number' => [
+                'favorite' => Rule::numeric()->max(100),
+            ],
+        ];
+
+        $results = $parser->explode($rules);
+
+        $this->assertEquals([
+            'number.favorite' => [
+                'numeric',
+                'max:100',
+            ],
+        ], $results->rules);
+    }
+
+    public function testNestedValidationRulesNumericArray()
+    {
+        $parser = (new ValidationRuleParser([
+            'number' => [
                 ['favorite' => 42],
             ],
         ]));


### PR DESCRIPTION
This PR adds the possibility to define nested validation rules using array notation

# Features
* Nested array to dot notation
* Automagically guessing whether the rule applies to an array or an object

# Related features
* This is the _declarative_ approach as compared to [`Rule::forEach()`](https://github.com/laravel/framework/blob/c01bb8d3ea1add70aafaa7f35480ea9d449eec62/src/Illuminate/Validation/Rule.php#L79-L88)'s _imperative_ approach introduced in #40498 by @stevebauman 

# Is this a BC?
TL;DR\
Yeah and no

It is already _possible_ to have this syntax in your code, although _unlikely_ due to it leading to unexpected results. So while these results would change, the syntax wasn't supported by the framework per se. So, I'd be happy to target `master` instead if this is actually considered a BC.