### PR TITLE
Add mustImplement() and mustExtend() support for MorphTo relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+trait MorphTypeConstraints
+{
+    /**
+     * The interfaces that related models must implement.
+     *
+     * @var array
+     */
+    protected  $requiredInterfaces = [];
+
+    /**
+     * The abstract classes that related models must extend.
+     *
+     * @var array
+     */
+    protected  $requiredAbstractClasses = [];
+
+    /**
+     * Require that all morph-related models implement a specific interface.
+     *
+     * @param  string|array  $interface
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function mustImplement($interface)
+    {
+        $interfaces = is_array($interface) ? $interface : [$interface];
+
+        foreach ($interfaces as $interface) {
+            if (!interface_exists($interface)) {
+                throw new \InvalidArgumentException("Interface [{$interface}] does not exist.");
+            }
+
+            $this->requiredInterfaces[] = $interface;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Require that all morph-related models extend a specific abstract class.
+     *
+     * @param  string|array  $abstractClass
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function mustExtend($abstractClass)
+    {
+        $classes = is_array($abstractClass) ? $abstractClass : [$abstractClass];
+
+        foreach ($classes as $class) {
+            if (!class_exists($class)) {
+                throw new \InvalidArgumentException("Class [{$class}] does not exist.");
+            }
+
+            if (!(new \ReflectionClass($class))->isAbstract()) {
+                throw new \InvalidArgumentException("Class [{$class}] is not abstract.");
+            }
+
+            $this->requiredAbstractClasses[] = $class;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Validate that the related model meets all type constraints.
+     *
+     * @param  mixed  $model
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function validateRelatedModel($model)
+    {
+        if ($model === null) {
+            return;
+        }
+
+        foreach ($this->requiredInterfaces as $interface) {
+            if (!($model instanceof $interface)) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Related model [%s] must implement interface [%s].',
+                        get_class($model),
+                        $interface
+                    )
+                );
+            }
+        }
+
+        foreach ($this->requiredAbstractClasses as $abstractClass) {
+            if (!is_a($model, $abstractClass)) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Related model [%s] must extend abstract class [%s].',
+                        get_class($model),
+                        $abstractClass
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Validate all models in a collection meet the type constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    protected function validateRelatedCollection($models)
+    {
+        foreach ($models as $model) {
+            $this->validateRelatedModel($model);
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
@@ -29,6 +29,7 @@ trait MorphTypeConstraints
     public function mustImplement($interface)
     {
         $this->requiredInterfaces[] = $interface;
+
         return $this;
     }
 
@@ -43,6 +44,7 @@ trait MorphTypeConstraints
     public function mustExtend($class)
     {
         $this->requiredClasses[] = $class;
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
@@ -16,7 +16,7 @@ trait MorphTypeConstraints
      *
      * @var array
      */
-    protected $requiredAbstractClasses = [];
+    protected $requiredClasses = [];
 
     /**
      * Require that all morph-related models implement a specific interface.
@@ -28,43 +28,21 @@ trait MorphTypeConstraints
      */
     public function mustImplement($interface)
     {
-        $interfaces = is_array($interface) ? $interface : [$interface];
-
-        foreach ($interfaces as $interface) {
-            if (! interface_exists($interface)) {
-                throw new \InvalidArgumentException("Interface [{$interface}] does not exist.");
-            }
-
-            $this->requiredInterfaces[] = $interface;
-        }
-
+        $this->requiredInterfaces[] = $interface;
         return $this;
     }
 
     /**
      * Require that all morph-related models extend a specific abstract class.
      *
-     * @param  string|array  $abstractClass
+     * @param  string|array  $class
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
-    public function mustExtend($abstractClass)
+    public function mustExtend($class)
     {
-        $classes = is_array($abstractClass) ? $abstractClass : [$abstractClass];
-
-        foreach ($classes as $class) {
-            if (! class_exists($class)) {
-                throw new \InvalidArgumentException("Class [{$class}] does not exist.");
-            }
-
-            if (! (new \ReflectionClass($class))->isAbstract()) {
-                throw new \InvalidArgumentException("Class [{$class}] is not abstract.");
-            }
-
-            $this->requiredAbstractClasses[] = $class;
-        }
-
+        $this->requiredClasses[] = $class;
         return $this;
     }
 
@@ -94,13 +72,13 @@ trait MorphTypeConstraints
             }
         }
 
-        foreach ($this->requiredAbstractClasses as $abstractClass) {
-            if (! is_a($model, $abstractClass)) {
+        foreach ($this->requiredClasses as $class) {
+            if (! is_a($model, $class)) {
                 throw new \RuntimeException(
                     sprintf(
-                        'Related model [%s] must extend abstract class [%s].',
+                        'Related model [%s] must extend class [%s].',
                         get_class($model),
-                        $abstractClass
+                        $class
                     )
                 );
             }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
@@ -63,6 +63,10 @@ trait MorphTypeConstraints
         }
 
         foreach ($this->requiredInterfaces as $interface) {
+            if (! interface_exists($interface)) {
+                throw new \RuntimeException("Interface [$interface] does not exist.");
+            }
+
             if (! ($model instanceof $interface)) {
                 throw new \RuntimeException(
                     sprintf(
@@ -75,6 +79,9 @@ trait MorphTypeConstraints
         }
 
         foreach ($this->requiredClasses as $class) {
+            if (! class_exists($class)) {
+                throw new \RuntimeException("Class [$class] does not exist.");
+            }
             if (! is_a($model, $class)) {
                 throw new \RuntimeException(
                     sprintf(

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/MorphTypeConstraints.php
@@ -9,14 +9,14 @@ trait MorphTypeConstraints
      *
      * @var array
      */
-    protected  $requiredInterfaces = [];
+    protected $requiredInterfaces = [];
 
     /**
      * The abstract classes that related models must extend.
      *
      * @var array
      */
-    protected  $requiredAbstractClasses = [];
+    protected $requiredAbstractClasses = [];
 
     /**
      * Require that all morph-related models implement a specific interface.
@@ -31,7 +31,7 @@ trait MorphTypeConstraints
         $interfaces = is_array($interface) ? $interface : [$interface];
 
         foreach ($interfaces as $interface) {
-            if (!interface_exists($interface)) {
+            if (! interface_exists($interface)) {
                 throw new \InvalidArgumentException("Interface [{$interface}] does not exist.");
             }
 
@@ -54,11 +54,11 @@ trait MorphTypeConstraints
         $classes = is_array($abstractClass) ? $abstractClass : [$abstractClass];
 
         foreach ($classes as $class) {
-            if (!class_exists($class)) {
+            if (! class_exists($class)) {
                 throw new \InvalidArgumentException("Class [{$class}] does not exist.");
             }
 
-            if (!(new \ReflectionClass($class))->isAbstract()) {
+            if (! (new \ReflectionClass($class))->isAbstract()) {
                 throw new \InvalidArgumentException("Class [{$class}] is not abstract.");
             }
 
@@ -83,7 +83,7 @@ trait MorphTypeConstraints
         }
 
         foreach ($this->requiredInterfaces as $interface) {
-            if (!($model instanceof $interface)) {
+            if (! ($model instanceof $interface)) {
                 throw new \RuntimeException(
                     sprintf(
                         'Related model [%s] must implement interface [%s].',
@@ -95,7 +95,7 @@ trait MorphTypeConstraints
         }
 
         foreach ($this->requiredAbstractClasses as $abstractClass) {
-            if (!is_a($model, $abstractClass)) {
+            if (! is_a($model, $abstractClass)) {
                 throw new \RuntimeException(
                     sprintf(
                         'Related model [%s] must extend abstract class [%s].',

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -19,7 +19,6 @@ class MorphTo extends BelongsTo
 {
     use InteractsWithDictionary,MorphTypeConstraints;
 
-
     /**
      * The type of the polymorphic relation.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -217,7 +217,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, EloquentCollection $results)
     {
         foreach ($results as $result) {
-            if (!empty($this->requiredInterfaces) || !empty($this->requiredAbstractClasses)) {
+            if (! empty($this->requiredInterfaces) || ! empty($this->requiredAbstractClasses)) {
                 $this->validateRelatedModel($result);
             }
             $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -216,7 +216,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, EloquentCollection $results)
     {
         foreach ($results as $result) {
-            if (! empty($this->requiredInterfaces) || ! empty($this->requiredAbstractClasses)) {
+            if (! empty($this->requiredInterfaces) || ! empty($this->requiredClasses)) {
                 $this->validateRelatedModel($result);
             }
             $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Database\Eloquent\Relations\Concerns\MorphTypeConstraints;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -16,7 +17,8 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
  */
 class MorphTo extends BelongsTo
 {
-    use InteractsWithDictionary;
+    use InteractsWithDictionary,MorphTypeConstraints;
+
 
     /**
      * The type of the polymorphic relation.
@@ -215,8 +217,10 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, EloquentCollection $results)
     {
         foreach ($results as $result) {
+            if (!empty($this->requiredInterfaces) || !empty($this->requiredAbstractClasses)) {
+                $this->validateRelatedModel($result);
+            }
             $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
-
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
                     $model->setRelation($this->relationName, $result);

--- a/tests/Database/DatabaseEloquentMorphTypeConstaints.php
+++ b/tests/Database/DatabaseEloquentMorphTypeConstaints.php
@@ -303,7 +303,8 @@ class MorphTypeConstraintsTest extends TestCase
     public function testMorphToWithAbstractClass()
     {
         // Redefine the relationship to require an abstract class
-        $animal = new class extends Animal {
+        $animal = new class extends Animal
+        {
             public function flyable()
             {
                 return $this->morphTo()->mustExtend(Vehicle::class);

--- a/tests/Database/DatabaseEloquentMorphTypeConstaints.php
+++ b/tests/Database/DatabaseEloquentMorphTypeConstaints.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Capsule\Manager as DB;
+use PHPUnit\Framework\TestCase;
 
 // ==================== Interfaces and Abstract Classes ====================
 
@@ -37,7 +37,7 @@ class Bird extends Model implements Flyable, Identifiable
 
     public function getIdentifier()
     {
-        return 'bird-' . $this->id;
+        return 'bird-'.$this->id;
     }
 }
 
@@ -97,7 +97,7 @@ class Feature extends Model implements Identifiable
 
     public function getIdentifier()
     {
-        return 'feature-' . $this->id;
+        return 'feature-'.$this->id;
     }
 
     public function featureable()
@@ -251,7 +251,8 @@ class MorphTypeConstraintsTest extends TestCase
     public function testMorphToMultipleInterfaces()
     {
         // Redefine the relationship to require multiple interfaces
-        $animal = new class extends Animal {
+        $animal = new class extends Animal
+        {
             public function flyable()
             {
                 return $this->morphTo()->mustImplement([Flyable::class, Identifiable::class]);
@@ -421,7 +422,8 @@ class MorphTypeConstraintsTest extends TestCase
     public function testCustomMorphClass()
     {
         // Create a class with a custom morph class name
-        $customBird = new class extends Bird {
+        $customBird = new class extends Bird
+        {
             public function getMorphClass()
             {
                 return 'custom_bird';

--- a/tests/Database/DatabaseEloquentMorphTypeConstaints.php
+++ b/tests/Database/DatabaseEloquentMorphTypeConstaints.php
@@ -412,14 +412,6 @@ class MorphTypeConstraintsTest extends TestCase
         $animal->morphTo()->mustExtend('NonExistentClass');
     }
 
-    public function testNonAbstractClass()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $animal = new Animal();
-        $animal->morphTo()->mustExtend(Bird::class); // Bird is not abstract
-    }
-
     public function testCustomMorphClass()
     {
         // Create a class with a custom morph class name

--- a/tests/Database/DatabaseEloquentMorphTypeConstaints.php
+++ b/tests/Database/DatabaseEloquentMorphTypeConstaints.php
@@ -1,0 +1,442 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Capsule\Manager as DB;
+
+// ==================== Interfaces and Abstract Classes ====================
+
+interface Flyable
+{
+    public function fly();
+}
+
+interface Identifiable
+{
+    public function getIdentifier();
+}
+
+abstract class Vehicle
+{
+    abstract public function getType();
+}
+
+// ==================== Models ====================
+
+class Bird extends Model implements Flyable, Identifiable
+{
+    protected $guarded = [];
+
+    public function fly()
+    {
+        return 'Bird is flying';
+    }
+
+    public function getIdentifier()
+    {
+        return 'bird-' . $this->id;
+    }
+}
+
+class Airplane extends Model implements Flyable
+{
+    protected $guarded = [];
+
+    public function fly()
+    {
+        return 'Airplane is flying';
+    }
+}
+
+class Car extends Vehicle
+{
+    protected $guarded = [];
+
+    public function getType()
+    {
+        return 'Land Vehicle';
+    }
+}
+
+class Boat extends Vehicle
+{
+    protected $guarded = [];
+
+    public function getType()
+    {
+        return 'Water Vehicle';
+    }
+}
+
+class Animal extends Model
+{
+    protected $guarded = [];
+
+    public function flyable()
+    {
+        return $this->morphTo()->mustImplement(Flyable::class);
+    }
+
+    public function features()
+    {
+        return $this->morphMany(Feature::class, 'featureable')->mustImplement(Identifiable::class);
+    }
+
+    public function mainFeature()
+    {
+        return $this->morphOne(Feature::class, 'featureable')->mustImplement(Identifiable::class);
+    }
+}
+
+class Feature extends Model implements Identifiable
+{
+    protected $guarded = [];
+
+    public function getIdentifier()
+    {
+        return 'feature-' . $this->id;
+    }
+
+    public function featureable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Tag extends Model
+{
+    protected $guarded = [];
+
+    public function vehicles()
+    {
+        return $this->morphedByMany(Car::class, 'taggable')
+            ->withPivot('notes')
+            ->withTimestamps()
+            ->mustExtend(Vehicle::class);
+    }
+}
+
+class MorphTypeConstraintsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->setAsGlobal();
+        $db->bootEloquent();
+
+        $this->createSchema();
+        $this->seedData();
+    }
+
+    protected function createSchema()
+    {
+        DB::schema()->create('birds', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        DB::schema()->create('airplanes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        DB::schema()->create('cars', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        DB::schema()->create('boats', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        DB::schema()->create('animals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->morphs('flyable');
+            $table->timestamps();
+        });
+
+        DB::schema()->create('features', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->morphs('featureable');
+            $table->timestamps();
+        });
+
+        DB::schema()->create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        DB::schema()->create('taggables', function (Blueprint $table) {
+            $table->integer('tag_id');
+            $table->morphs('taggable');
+            $table->string('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function seedData()
+    {
+        Bird::create(['name' => 'Eagle']);
+        Bird::create(['name' => 'Sparrow']);
+        Airplane::create(['name' => 'Boeing 747']);
+        Car::create(['name' => 'Ferrari']);
+        Boat::create(['name' => 'Yacht']);
+
+        // Valid relationships with flyable objects
+        Animal::create([
+            'name' => 'Eagle',
+            'flyable_type' => Bird::class,
+            'flyable_id' => 1,
+        ]);
+
+        Animal::create([
+            'name' => 'Boeing',
+            'flyable_type' => Airplane::class,
+            'flyable_id' => 1,
+        ]);
+
+        // Invalid relationship - Car doesn't implement Flyable
+        Animal::create([
+            'name' => 'Ferrari',
+            'flyable_type' => Car::class,
+            'flyable_id' => 1,
+        ]);
+
+        // Features for birds (implements Identifiable)
+        Feature::create([
+            'name' => 'Wings',
+            'featureable_type' => Bird::class,
+            'featureable_id' => 1,
+        ]);
+
+        Feature::create([
+            'name' => 'Beak',
+            'featureable_type' => Bird::class,
+            'featureable_id' => 1,
+        ]);
+
+        // Tags for vehicles
+        $tag = Tag::create(['name' => 'Fast']);
+        $tag->vehicles()->attach(1, ['notes' => 'Very fast car']);
+    }
+
+    // ==================== Tests for MorphTo ====================
+
+    public function testMorphToValidImplementations()
+    {
+        $eagle = Animal::where('name', 'Eagle')->first();
+        $this->assertInstanceOf(Flyable::class, $eagle->flyable);
+        $this->assertEquals('Bird is flying', $eagle->flyable->fly());
+
+        $boeing = Animal::where('name', 'Boeing')->first();
+        $this->assertInstanceOf(Flyable::class, $boeing->flyable);
+        $this->assertEquals('Airplane is flying', $boeing->flyable->fly());
+    }
+
+    public function testMorphToMultipleInterfaces()
+    {
+        // Redefine the relationship to require multiple interfaces
+        $animal = new class extends Animal {
+            public function flyable()
+            {
+                return $this->morphTo()->mustImplement([Flyable::class, Identifiable::class]);
+            }
+        };
+
+        // This should work with Bird (implements both interfaces)
+        $eagle = $animal::where('name', 'Eagle')->first();
+        $this->assertInstanceOf(Flyable::class, $eagle->flyable);
+        $this->assertInstanceOf(Identifiable::class, $eagle->flyable);
+
+        // This should fail with Airplane (only implements Flyable)
+        $this->expectException(\RuntimeException::class);
+        $boeing = $animal::where('name', 'Boeing')->first();
+        $boeing->flyable;
+    }
+
+    public function testMorphToInvalidImplementation()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Related model [Tests\Database\Eloquent\Car] must implement interface [Tests\Database\Eloquent\Flyable]');
+
+        $ferrari = Animal::where('name', 'Ferrari')->first();
+        $ferrari->flyable; // This should throw an exception
+    }
+
+    public function testMorphToEagerLoading()
+    {
+        // This should throw an exception during eager loading due to Car not implementing Flyable
+        $this->expectException(\RuntimeException::class);
+
+        Animal::with('flyable')->get();
+    }
+
+    public function testMorphToWithNullRelationship()
+    {
+        // Create an animal with no flyable relationship
+        $animal = Animal::create([
+            'name' => 'Human',
+            'flyable_type' => null,
+            'flyable_id' => null,
+        ]);
+
+        // This shouldn't throw an exception despite the constraint
+        $this->assertNull($animal->flyable);
+    }
+
+    public function testMorphToWithAbstractClass()
+    {
+        // Redefine the relationship to require an abstract class
+        $animal = new class extends Animal {
+            public function flyable()
+            {
+                return $this->morphTo()->mustExtend(Vehicle::class);
+            }
+        };
+
+        // This should work with Car (extends Vehicle)
+        $ferrari = $animal::where('name', 'Ferrari')->first();
+        $this->assertInstanceOf(Vehicle::class, $ferrari->flyable);
+
+        // This should fail with Bird (doesn't extend Vehicle)
+        $this->expectException(\RuntimeException::class);
+        $eagle = $animal::where('name', 'Eagle')->first();
+        $eagle->flyable;
+    }
+
+    // ==================== Tests for MorphMany ====================
+
+    public function testMorphManyValidImplementations()
+    {
+        $bird = Bird::find(1);
+        Feature::create([
+            'name' => 'Feathers',
+            'featureable_type' => Bird::class,
+            'featureable_id' => $bird->id,
+        ]);
+
+        $animal = Animal::where('name', 'Eagle')->first();
+        $features = $animal->features;
+
+        $this->assertCount(2, $features);
+        foreach ($features as $feature) {
+            $this->assertInstanceOf(Identifiable::class, $feature);
+        }
+    }
+
+    public function testMorphManyEagerLoading()
+    {
+        $bird = Bird::find(1);
+        $birds = Bird::with('features')->get();
+
+        foreach ($birds as $loadedBird) {
+            foreach ($loadedBird->features as $feature) {
+                $this->assertInstanceOf(Identifiable::class, $feature);
+            }
+        }
+    }
+
+    // ==================== Tests for MorphOne ====================
+
+    public function testMorphOneValidImplementation()
+    {
+        $bird = Bird::find(1);
+        $feature = $bird->mainFeature;
+
+        $this->assertInstanceOf(Identifiable::class, $feature);
+        $this->assertEquals('feature-1', $feature->getIdentifier());
+    }
+
+    // ==================== Tests for MorphToMany ====================
+
+    public function testMorphToManyValidImplementation()
+    {
+        $tag = Tag::find(1);
+        $vehicles = $tag->vehicles;
+
+        $this->assertCount(1, $vehicles);
+        foreach ($vehicles as $vehicle) {
+            $this->assertInstanceOf(Vehicle::class, $vehicle);
+        }
+    }
+
+    public function testMorphToManyWithInvalidAbstractClass()
+    {
+        // Create a tag that's incorrectly associated with a Bird
+        DB::table('taggables')->insert([
+            'tag_id' => 1,
+            'taggable_type' => Bird::class,
+            'taggable_id' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // This should throw an exception when loading
+        $this->expectException(\RuntimeException::class);
+        $tag = Tag::find(1);
+        $tag->vehicles()->get();
+    }
+
+    // ==================== Tests for edge cases ====================
+
+    public function testNonExistentInterface()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $animal = new Animal();
+        $animal->morphTo()->mustImplement('NonExistentInterface');
+    }
+
+    public function testNonExistentAbstractClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $animal = new Animal();
+        $animal->morphTo()->mustExtend('NonExistentClass');
+    }
+
+    public function testNonAbstractClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $animal = new Animal();
+        $animal->morphTo()->mustExtend(Bird::class); // Bird is not abstract
+    }
+
+    public function testCustomMorphClass()
+    {
+        // Create a class with a custom morph class name
+        $customBird = new class extends Bird {
+            public function getMorphClass()
+            {
+                return 'custom_bird';
+            }
+        };
+
+        // Create an animal with the custom morph type
+        $animal = Animal::create([
+            'name' => 'CustomBird',
+            'flyable_type' => 'custom_bird',
+            'flyable_id' => 1,
+        ]);
+
+        // This should work without throwing an exception
+        Model::addMorphMap(['custom_bird' => get_class($customBird)]);
+        $this->assertInstanceOf(Flyable::class, $animal->flyable);
+    }
+}


### PR DESCRIPTION
# Summary

This pull request introduces two new methods to the `MorphTo` relation: `mustImplement()` and `mustExtend()`. These allow developers to explicitly require that polymorphic related models conform to specific contracts (interfaces or base classes).

This is especially useful in large applications or packages where it's important to guarantee that a morph relation always returns a model that can be interacted with predictably.

# Motivation

Polymorphic relationships in Laravel are extremely powerful, but they come with a tradeoff: type uncertainty. You can call `$model->morphable`, but unless you add extra logic, you have no assurance of what methods or behavior are present on the related model.

Consider this:

```php
public function flyable()
{
    return $this->morphTo()->mustImplement(FlyableInterface::class);
}
```

By enforcing that the related model implements `FlyableInterface`, we gain:

* **Static confidence:** IDEs and static analyzers can reason about the expected contract.
* **Early runtime validation:** Any misuse (e.g., attaching a model that doesn't fulfill the contract) throws a clear error.
* **Cleaner code:** Less defensive coding or manual `instanceof` checks.

# Example Use Case

```php
interface Flyable {
    public function fly();
}

abstract class Aircraft extends Model implements Flyable {}

class Helicopter extends Aircraft {
    public function fly() { /* ... */ }
}

class Airplane extends Model {
    public function flyable()
    {
        return $this->morphTo()
            ->mustImplement(Flyable::class) // Can also accept interface strings
            ->mustExtend(Aircraft::class);
    }
}
```

If someone accidentally assigns a `Car` model as the morph target for `flyable`, an exception will be thrown when the relation is accessed—avoiding undefined method errors later in the lifecycle.

# Implementation Details

* `mustImplement(string|array $interface)`
    * Stores required interfaces and validates against them when resolving the relation.
* `mustExtend(string|array $abstractClass)`
    * Stores required abstract classes and validates using `is_a()` + reflection check for abstraction.

Validation occurs in:

* `getResults()` (lazy loading)
* `getEager()` (eager loading)

If a related model does not meet the constraints, a `RuntimeException` is thrown with a clear message.

# Why It Belongs in the Core

* Cleanly integrates into Laravel’s existing relation structure.
* Provides significant DX improvements with zero breaking changes.
* Optional and expressive: developers opt-in only when they need stricter contracts.
* No impact on performance unless the methods are explicitly called.
* Aligned with Laravel’s philosophy of expressive, elegant code.
