### PR TITLE
[12.x] Add Str::randomLetters method for alphabetic only random strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1103,6 +1103,30 @@ class Str
     }
 
     /**
+     * Generate a random string containing only lowercase alphabetic characters.
+     *
+     * @param  int  $length
+     * @return string
+     */
+    public static function randomLetters($length = 16)
+    {
+        return (static::$randomStringFactory ?? function ($length) {
+            $characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+            $string = '';
+
+            while (($len = strlen($string)) < $length) {
+                $size = $length - $len;
+                $bytesSize = (int) ceil($size / 3) * 3;
+                $bytes = random_bytes($bytesSize);
+
+                $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            }
+
+            return substr(str_shuffle(str_repeat($characters, ceil($length / strlen($characters)))), 0, $length);
+        })($length);
+    }
+
+    /**
      * Set the callable that will be used to generate random strings.
      *
      * @param  callable|null  $factory

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -779,6 +779,15 @@ class SupportStrTest extends TestCase
         }
     }
 
+    public function testRandomLetters()
+    {
+        $this->assertEquals(16, strlen(Str::randomLetters()));
+        $randomInteger = random_int(1, 100);
+        $this->assertEquals($randomInteger, strlen(Str::randomLetters($randomInteger)));
+        $this->assertIsString(Str::randomLetters());
+        $this->assertMatchesRegularExpression('/^[a-zA-Z]+$/', Str::randomLetters());
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));


### PR DESCRIPTION
This adds a new static method to the `Illuminate\Support\Str` class: `Str::randomLetters()`.

It behaves similarly to Str::random(), but limits the generated characters to alphabetic letters only (a–zA–Z). This provides a convenient way to generate random strings without digits. Also the limit is defaulted to 16, same as in the original random function


### Example
```php
Str::randomLetters(6)   // generates: "zsZuoN", "FtqbkH", "MIFEri"

Str::randomLetters()   // generates: "onrchkCpNIDfMOJS", "EHxfohMAarjpicqL"
```

### Open Discussion
I was unsure about lower case only so please feel free to give your thoughts about this.