### PR TITLE
chore(tests): align test names with idiomatic naming style

### DIFF
--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -280,7 +280,7 @@ class RepositoryTest extends TestCase
         $this->assertNull($this->repository->get('associate'));
     }
 
-    public function testsItIsMacroable()
+    public function testItIsMacroable()
     {
         $this->repository->macro('foo', function () {
             return 'macroable';

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3223,7 +3223,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->getAttribute('duplicatedAttribute'));
     }
 
-    public function testsCastOnArrayFormatWithOneElement()
+    public function testCastOnArrayFormatWithOneElement()
     {
         $model = new EloquentModelCastingStub;
         $model->setRawAttributes([


### PR DESCRIPTION
While looking at the Config repository's tests, I found a method named `tests...`. To align with the rest of the tests, this PR fixes the naming to `test...`.

I additionally did a full text search over the codebase and found one other test with this out of the ordinary naming and aligned it as well.
