### PR TITLE
[12.x] Allow Container to build `Migrator` from class name

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -82,6 +82,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
         });
+
         $this->app->bind(Migrator::class, fn ($app) => $app['migrator']);
     }
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class MigrationServiceProvider extends ServiceProvider implements DeferrableProvider
 {

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class MigrationServiceProvider extends ServiceProvider implements DeferrableProvider
 {
@@ -77,12 +78,12 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton(Migrator::class, function ($app) {
+        $this->app->singleton('migrator', function ($app) {
             $repository = $app['migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
         });
-        $this->app->alias(Migrator::class, 'migrator');
+        $this->app->bind(Migrator::class, fn ($app) => $app['migrator']);
     }
 
     /**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -77,11 +77,12 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
+        $this->app->singleton(Migrator::class, function ($app) {
             $repository = $app['migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
         });
+        $this->app->alias(Migrator::class, 'migrator');
     }
 
     /**
@@ -220,7 +221,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     public function provides()
     {
         return array_merge([
-            'migrator', 'migration.repository', 'migration.creator',
+            'migrator', 'migration.repository', 'migration.creator', Migrator::class,
         ], array_values($this->commands));
     }
 }

--- a/tests/Integration/Database/MigrationServiceProviderTest.php
+++ b/tests/Integration/Database/MigrationServiceProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Migrations\Migrator;
+
+class MigrationServiceProviderTest extends DatabaseTestCase
+{
+    public function testContainerCanBuildMigrator()
+    {
+        $fromString = $this->app->make('migrator');
+        $fromClass = $this->app->make(Migrator::class);
+
+        $this->assertSame($fromString, $fromClass);
+    }
+}

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -59,7 +59,6 @@ class MigratorTest extends TestCase
     public function testMigrateWithoutOutput()
     {
         $this->app->forgetInstance('migrator');
-        $this->app->forgetInstance(Migrator::class);
         $this->subject = $this->app->make('migrator');
 
         $this->subject->run([__DIR__.'/fixtures']);

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -59,6 +59,7 @@ class MigratorTest extends TestCase
     public function testMigrateWithoutOutput()
     {
         $this->app->forgetInstance('migrator');
+        $this->app->forgetInstance(Migrator::class);
         $this->subject = $this->app->make('migrator');
 
         $this->subject->run([__DIR__.'/fixtures']);


### PR DESCRIPTION
Writing integration tests that rely on the migrator (such as testing a single migration) requires me to write:

```php
$this->app->make('migrator')
```

Because otherwise, there's a binding resolution exception:
```php
Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Database\Migrations\MigrationRepositoryInterface] is not instantiable while building [Illuminate\Database\Migrations\Migrator].
```

With this change, I will now be able to write tests like this:

```php
$this->app->make(Migrator::class)->run(database_path(''));
```