### PR TITLE
Some optimizations to Collection::keyBy, Arr::undot, Arr::set, Arr::last

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -588,7 +588,7 @@ class Arr
         // Fast path for simple value keys (no dots)
         if (is_string($value) && ! str_contains($value, '.') && is_null($key)) {
             foreach ($array as $item) {
-                if (is_array($item) && array_key_exists($value, $item)) {
+                if (Arr::accessible($item) && Arr::exists($item, $value)) {
                     $results[] = $item[$value];
                 } elseif (is_object($item) && isset($item->{$value})) {
                     $results[] = $item->{$value};

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -796,9 +796,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|array|int|null  $value
-     * @param  string|array|null  $key
-     * @return static
+     * @param  string|int|array<array-key, string>|null  $value
+     * @param  string|null  $key
+     * @return static<array-key, mixed>
      */
     public function pluck($value, $key = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -802,19 +802,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function pluck($value, $key = null)
     {
-        // Fast path for simple value keys (no dots)
-        if (is_string($value) && ! str_contains($value, '.') && is_null($key)) {
-            return new static(array_map(function ($item) use ($value) {
-                if (Arr::accessible($item) && Arr::exists($item, $value)) {
-                    return $item[$value];
-                } elseif (is_object($item) && isset($item->{$value})) {
-                    return $item->{$value};
-                }
-
-                return data_get($item, $value);
-            }, $this->items));
-        }
-
         return new static(Arr::pluck($this->items, $value, $key));
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -562,7 +562,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         } elseif (is_string($keyBy) && ! str_contains($keyBy, '.')) {
             $prop = $keyBy;
             $getter = function ($item) use ($prop) {
-                if (is_array($item) && isset($item[$prop])) {
+                if (Arr::accessible($item) && Arr::exists($item, $prop)) {
                     return $item[$prop];
                 }
                 if (is_object($item) && isset($item->{$prop})) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -805,7 +805,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         // Fast path for simple value keys (no dots)
         if (is_string($value) && ! str_contains($value, '.') && is_null($key)) {
             return new static(array_map(function ($item) use ($value) {
-                if (is_array($item) && array_key_exists($value, $item)) {
+                if (Arr::accessible($item) && Arr::exists($item, $value)) {
                     return $item[$value];
                 } elseif (is_object($item) && isset($item->{$value})) {
                     return $item->{$value};

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -49,7 +49,6 @@ if (! function_exists('data_get')) {
             return $target;
         }
 
-        // Special case for '*' as key
         if ($key === '*') {
             if ($target instanceof Collection) {
                 $target = $target->all();

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -49,6 +49,28 @@ if (! function_exists('data_get')) {
             return $target;
         }
 
+        // Special case for '*' as key
+        if ($key === '*') {
+            if ($target instanceof Collection) {
+                $target = $target->all();
+            }
+
+            if (is_array($target)) {
+                return array_values($target);
+            }
+
+            if (is_iterable($target)) {
+                $result = [];
+                foreach ($target as $item) {
+                    $result[] = $item;
+                }
+
+                return $result;
+            }
+
+            return value($default);
+        }
+
         // Fast path for simple string keys (no dots)
         if (is_string($key) && ! str_contains($key, '.')) {
             if (Arr::accessible($target) && Arr::exists($target, $key)) {
@@ -79,7 +101,7 @@ if (! function_exists('data_get')) {
                 $result = [];
 
                 foreach ($target as $item) {
-                    $result[] = data_get($item, $key);
+                    $result[] = empty($key) ? $item : data_get($item, $key);
                 }
 
                 return in_array('*', $key) ? Arr::collapse($result) : $result;

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -49,6 +49,17 @@ if (! function_exists('data_get')) {
             return $target;
         }
 
+        // Fast path for simple string keys (no dots)
+        if (is_string($key) && ! str_contains($key, '.')) {
+            if (Arr::accessible($target) && Arr::exists($target, $key)) {
+                return $target[$key];
+            } elseif (is_object($target) && isset($target->{$key})) {
+                return $target->{$key};
+            } else {
+                return value($default);
+            }
+        }
+
         $key = is_array($key) ? $key : explode('.', $key);
 
         foreach ($key as $i => $segment) {


### PR DESCRIPTION
# Laravel Collections & Array Performance Improvements

This report details the performance improvements achieved by optimizing several methods in Laravel's Collections and Array helpers.

## Environment

- **PHP Version**: 8.3.20
- **Test Iterations**: 100,000 per method
- **Machine**: MacOS with Apple M-series chip
- **Memory Limit**: 128M

## Summary of Optimizations

The following optimizations were implemented to improve performance in common Laravel operations:

1. **Arr::undot()**: Replaced recursive calls to `static::set()` with direct array manipulation using `strtok()` for string parsing. This eliminates the overhead of multiple function calls.

2. **Arr::last()**: Eliminated the `array_reverse()` call by iterating through the array directly using internal array pointer functions (`end()`, `prev()`). This avoids the overhead of duplicating the entire array.

3. **Arr::pluck()**: Added a fast path for simple keys (no dots) to avoid unnecessary processing. When a key doesn't contain dots, the method can take a direct approach without invoking the dot notation parser.

4. **Collection::keyBy()**: Optimized with specialized implementations for different key types:
    - Direct property access for simple keys
    - Callback handling for closures
    - data_get() for complex dot notation

5. **data_get()**: Added a fast path for simple string keys that don't require dot notation processing.

## Testing Methodology

For each method, we tested with different data sizes to evaluate performance across various scenarios:

- **Small Data**: 10 elements
- **Medium Data**: 100 elements
- **Large Data**: 1,000 elements

Tests were run with both the original and optimized implementations, and each test was executed 100,000 times to ensure statistical significance.

For methods that handle both simple and nested keys (pluck, keyBy, data_get), we tested both scenarios separately to understand the impact of the optimizations in different contexts.

## Detailed Results

### `Arr::undot` Method

The `undot()` method converts a flatten "dot" notation array into an expanded array. The optimization improves performance by 33-35%.

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Small Data | 1.567262 | 1.176290 | 1.33x faster |
| Medium Data | 15.965253 | 12.016773 | 1.33x faster |
| Large Data | 161.853208 | 119.479164 | 1.35x faster |

### `Arr::last` Method

The `last()` method returns the last element in an array passing a given truth test. The optimization scales with data size, showing dramatic improvements for larger arrays.

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Small Data | 0.025888 | 0.018013 | 1.44x faster |
| Medium Data | 0.074840 | 0.031644 | 2.37x faster |
| Large Data | 0.590114 | 0.176825 | 3.34x faster |

### `Arr::pluck` Method

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Small Data, Simple Key | 0.220347 | 0.109571 | 2.01x faster |
| Medium Data, Simple Key | 2.071595 | 0.951777 | 2.18x faster |
| Large Data, Simple Key | 20.111494 | 9.300136 | 2.16x faster |
| Small Data, Nested Key | 0.384699 | 0.400281 | 1.04x slower |
| Medium Data, Nested Key | 3.543024 | 3.652879 | 1.03x slower |
| Large Data, Nested Key | 36.178449 | 37.598126 | 1.04x slower |

### `Collection::keyBy` Method

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Small Data, Simple Key | 0.272838 | 0.168477 | 1.62x faster |
| Medium Data, Simple Key | 2.453916 | 1.408790 | 1.74x faster |
| Large Data, Simple Key | 24.585757 | 13.868642 | 1.77x faster |
| Small Data, Nested Key | 0.461876 | 0.499775 | 1.08x slower |
| Medium Data, Nested Key | 4.372053 | 4.660980 | 1.07x slower |
| Large Data, Nested Key | 43.726935 | 46.959372 | 1.07x slower |
| Small Data, Callback | 0.093311 | 0.096033 | 1.03x slower |
| Medium Data, Callback | 0.776488 | 0.797140 | 1.03x slower |
| Large Data, Callback | 8.077789 | 8.202847 | 1.02x slower |

### `Collection::pluck` Method (due to Arr::pluck optimization)

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Small Data, Simple Key | 0.226159 | 0.116514 | 1.94x faster |
| Medium Data, Simple Key | 1.991054 | 0.951485 | 2.09x faster |
| Large Data, Simple Key | 19.678478 | 9.274119 | 2.12x faster |
| Small Data, Nested Key | 0.400486 | 0.395087 | 1.01x faster |
| Medium Data, Nested Key | 3.594471 | 3.642303 | 1.01x slower |
| Large Data, Nested Key | 36.507885 | 37.286708 | 1.02x slower |

### `data_get` Helper

| Test Case | Original (s) | Improved (s) | Improvement |
|-----------|--------------|--------------|-------------|
| Simple Key | 0.064923 | 0.048337 | 1.34x faster |
| Nested Key | 0.127853 | 0.129221 | 1.01x slower |

### Conclusion

The optimizations provide significant performance improvements for common operations in Laravel's Collections and Array helpers, particularly for simple key operations, which are the most common use case in Laravel applications. The most substantial improvements are seen in:

- Arr::last with large arrays: Up to 3.34x faster
- Arr::pluck with simple keys: Up to 2.18x faster
- Collection::pluck with simple keys: Up to 2.12x faster (due to Arr::pluck optimizations)
- Collection::keyBy with simple keys: Up to 1.77x faster
- Arr::undot: Up to 1.35x faster
- data_get with simple keys: 1.34x faster

While there are minor performance regressions in some nested key scenarios (1-5%), these are significantly outweighed by the substantial gains in the more common simple key scenarios. These optimizations will provide tangible performance benefits to Laravel applications, especially those that heavily utilize collections and array manipulations.
The fast path implementations for simple keys demonstrate how specializing code paths for common use cases can yield substantial performance improvements in a framework.