### PR TITLE
Bugfix for Cache::memo()->many() returning the wrong value with an integer key type

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -79,7 +79,7 @@ class MemoizedStore implements Store
         foreach ($keys as $key) {
             if (array_key_exists($key, $memoized)) {
                 $result[$key] = $memoized[$key];
-            } elseif (array_key_exists($key, $retrieved)) {
+            } else {
                 $result[$key] = $retrieved[$key];
             }
         }

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -83,7 +83,7 @@ class MemoizedStore implements Store
                 $result[$key] = $retrieved[$key];
             }
         }
-    
+
         return $result;
     }
 

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -76,6 +76,7 @@ class MemoizedStore implements Store
         }
 
         $result = [];
+
         foreach ($keys as $key) {
             if (array_key_exists($key, $memoized)) {
                 $result[$key] = $memoized[$key];

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -70,7 +70,7 @@ class MemoizedStore implements Store
                     ...$this->cache,
                     ...collect($values)->mapWithKeys(fn ($value, $key) => [
                         $this->prefix($key) => $value,
-                    ])->all(),
+                    ]),
                 ];
             });
         }

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -56,14 +56,14 @@ class MemoizedStore implements Store
 
         foreach ($keys as $key) {
             $prefixedKey = $this->prefix($key);
-    
+
             if (array_key_exists($prefixedKey, $this->cache)) {
                 $memoized[$key] = $this->cache[$prefixedKey];
             } else {
                 $missing[] = $key;
             }
         }
-    
+
         if (count($missing) > 0) {
             $retrieved = tap($this->repository->many($missing), function ($values) {
                 $this->cache = [

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -89,6 +89,22 @@ class MemoizedStoreTest extends TestCase
         $this->assertSame(['name.0' => 'Tim', 'name.1' => 'Taylor'], $memoized);
     }
 
+    public function test_it_uses_correct_keys_for_getMultiple()
+    {
+        $data = [
+            'a' => 'string-value',
+            '1.1' => 'float-value',
+            '1' => 'integer-value-as-string',
+            2 => 'integer-value'
+        ];
+        Cache::putMany($data);
+
+        $memoValue = Cache::memo()->many(['a', '1.1', '1', 2]);
+        $cacheValue = Cache::many(['a', '1.1', '1', 2]);
+
+        $this->assertSame($cacheValue, $memoValue);
+    }
+
     public function test_null_values_are_memoized_when_retrieving_mulitple_values()
     {
         $live = Cache::getMultiple(['name.0', 'name.1']);

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -110,7 +110,7 @@ class MemoizedStoreTest extends TestCase
         ], $cacheValue);
         $this->assertSame($cacheValue, $memoValue);
 
-        // ensure correct on the seconds memoized retrieval
+        // ensure correct on the second memoized retrieval
         $memoValue = Cache::memo()->many(['a', '1.1', '1', 2]);
 
         $this->assertSame($cacheValue, $memoValue);

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -110,7 +110,7 @@ class MemoizedStoreTest extends TestCase
         ], $cacheValue);
         $this->assertSame($cacheValue, $memoValue);
 
-        // ensure correct on the seconds memoized retrieval 
+        // ensure correct on the seconds memoized retrieval
         $memoValue = Cache::memo()->many(['a', '1.1', '1', 2]);
 
         $this->assertSame($cacheValue, $memoValue);

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -95,12 +95,23 @@ class MemoizedStoreTest extends TestCase
             'a' => 'string-value',
             '1.1' => 'float-value',
             '1' => 'integer-value-as-string',
-            2 => 'integer-value'
+            2 => 'integer-value',
         ];
         Cache::putMany($data);
 
         $memoValue = Cache::memo()->many(['a', '1.1', '1', 2]);
         $cacheValue = Cache::many(['a', '1.1', '1', 2]);
+
+        $this->assertSame([
+            'a' => 'string-value',
+            '1.1' => 'float-value',
+            '1' => 'integer-value-as-string',
+            2 => 'integer-value',
+        ], $cacheValue);
+        $this->assertSame($cacheValue, $memoValue);
+
+        // ensure correct on the seconds memoized retrieval 
+        $memoValue = Cache::memo()->many(['a', '1.1', '1', 2]);
 
         $this->assertSame($cacheValue, $memoValue);
     }


### PR DESCRIPTION
Bugfix for: https://github.com/laravel/framework/issues/55500

This helps maintain the correct data structure to match the results without `memo()`, even when an integer key type is used.