### PR TITLE
[12.x] Supercharges Seeder

### DIFF
--- a/src/Illuminate/Database/Attributes/SeedTask.php
+++ b/src/Illuminate/Database/Attributes/SeedTask.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class SeedTask
+{
+    /**
+     * Create a new Seed Task instance.
+     */
+    public function __construct(public string $as = '')
+    {
+        //
+    }
+}

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -233,7 +233,7 @@ class SeedCommand extends Command
         return [
             ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
-            ['continue', null, InputOption::VALUE_OPTIONAL, 'Continue from a previous seed operation'],
+            ['continue', null, InputOption::VALUE_OPTIONAL, 'Continue from a previous incomplete seed operation'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];
     }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -129,7 +130,7 @@ class SeedCommand extends Command
             return $files->exists($path) ? $files->json($path) : [];
         }
 
-        throw new RuntimeException('Unable to retrieve continue data. Please install the "illuminate/filesystem" package to use the --continue option.');
+        throw new InvalidArgumentException('Unable to retrieve continue data. Install the "illuminate/filesystem" package to use the --continue option.');
     }
 
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -15,8 +15,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Throwable;
 
-use function json_encode;
-
 #[AsCommand(name: 'db:seed')]
 class SeedCommand extends Command
 {

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Throwable;
+
 use function json_encode;
 
 #[AsCommand(name: 'db:seed')]
@@ -153,13 +154,13 @@ class SeedCommand extends Command
     /**
      * Returns the "continue" file path for the invoked seeder.
      *
-     * @param \Illuminate\Database\Seeder $seeder
+     * @param  \Illuminate\Database\Seeder  $seeder
      * @return string
      */
     protected function continueFilePath($seeder)
     {
         return $this->getLaravel()->storagePath(
-            'framework/database/seeder.' . str_replace('\\', '_', get_class($seeder)) . '.json'
+            'framework/database/seeder.'.str_replace('\\', '_', get_class($seeder)).'.json'
         );
     }
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -101,7 +101,7 @@ class SeedCommand extends Command
             }
         }
 
-        if (! $seeder->useTransactions()) {
+        if (! method_exists($seeder, 'run') && ! $seeder->useTransactions()) {
             $this->components->warn('Transactions are disabled. Errors may yield incomplete records.');
         }
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -7,9 +7,14 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
+use Illuminate\Filesystem\Filesystem;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
+use function json_encode;
 
 #[AsCommand(name: 'db:seed')]
 class SeedCommand extends Command
@@ -67,15 +72,108 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
-        });
+        Model::unguarded($this->seed(...));
 
         if ($previousConnection) {
             $this->resolver->setDefaultConnection($previousConnection);
         }
 
         return 0;
+    }
+
+    /**
+     * Invoke the database seeder.
+     *
+     * @return void
+     */
+    protected function seed()
+    {
+        $seeder = $this->getSeeder();
+
+        $continueFilePath = $this->continueFilePath($seeder);
+
+        if ($this->option('continue')) {
+            if ($list = $this->retrieveContinueData($continueFilePath)) {
+                $this->components->info('Resuming from previous seed operation.');
+                Seeder::setContinue($list);
+            } else {
+                $this->components->warn('No previous seed operation found.');
+            }
+        }
+
+        if (! $seeder->useTransactions()) {
+            $this->components->warn('Transactions are disabled. Errors may yield incomplete records.');
+        }
+
+        try {
+            $seeder->__invoke();
+        } catch (Throwable $e) {
+            $this->storeContinueData($continueFilePath, Seeder::getContinue());
+
+            throw $e;
+        }
+
+        $this->deleteContinueData($continueFilePath);
+    }
+
+    /**
+     * Retrieve the "continue" data list from a JSON file as an array.
+     *
+     * @param  string  $path
+     * @return array
+     */
+    protected function retrieveContinueData($path)
+    {
+        if ($this->getLaravel()->bound(Filesystem::class)) {
+            $files = $this->getLaravel()->make(Filesystem::class);
+
+            return $files->exists($path) ? $files->json($path) : [];
+        }
+
+        throw new RuntimeException('Unable to retrieve continue data. Please install the "illuminate/filesystem" package to use the --continue option.');
+    }
+
+    /**
+     * Store the "continue" data list to a JSON file.
+     *
+     * @param  string  $path
+     * @param  array  $data
+     * @return void
+     */
+    protected function storeContinueData($path, array $data)
+    {
+        if ($this->getLaravel()->bound(Filesystem::class)) {
+            $files = $this->getLaravel()->make(Filesystem::class);
+
+            $files->ensureDirectoryExists(dirname($path));
+            $files->put($path, json_encode($data));
+        }
+    }
+
+    /**
+     * Returns the "continue" file path for the invoked seeder.
+     *
+     * @param \Illuminate\Database\Seeder $seeder
+     * @return string
+     */
+    protected function continueFilePath($seeder)
+    {
+        return $this->getLaravel()->storagePath(
+            'framework/database/seeder.' . str_replace('\\', '_', get_class($seeder)) . '.json'
+        );
+    }
+
+    /**
+     * Delete the "continue" file from the filesystem.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function deleteContinueData($path)
+    {
+        if ($this->getLaravel()->bound(Filesystem::class)) {
+            $this->getLaravel()->make(Filesystem::class)->delete($path);
+        }
     }
 
     /**
@@ -135,6 +233,7 @@ class SeedCommand extends Command
         return [
             ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
+            ['continue', null, InputOption::VALUE_OPTIONAL, 'Continue from a previous seed operation'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];
     }

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -8,9 +8,9 @@ use Illuminate\Database\Seeder;
 class {{ class }} extends Seeder
 {
     /**
-     * Run the database seeds.
+     * Seed the database with records.
      */
-    public function run(): void
+    public function seed(): void
     {
         //
     }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -62,12 +62,11 @@ abstract class Seeder
      */
     public function __invoke(array $parameters = [])
     {
-        $method = match(true) {
+        $method = match (true) {
             method_exists($this, 'run') => 'run',
             method_exists($this, 'runSeedTasks') => 'runSeedTasks',
             default => throw new InvalidArgumentException('Method [run] missing from '.get_class($this))
         };
-
 
         $callback = fn () => isset($this->container)
             ? $this->container->call([$this, $method], $parameters)
@@ -149,8 +148,8 @@ abstract class Seeder
 
                 return $this;
             } catch (Throwable $e) {
-                if (method_exists($seeder, 'finally')) {
-                    $seeder->finally($e);
+                if (method_exists($seeder, 'onError')) {
+                    $seeder->onError($e);
                 }
 
                 throw $e;
@@ -233,7 +232,7 @@ abstract class Seeder
         Collection::make((new ReflectionObject($this))->getMethods())
             ->filter(function (ReflectionMethod $method) {
                 return Str::startsWith($method->name, 'seed')
-                    || !empty($method->getAttributes(Attributes\SeedTask::class));
+                    || ! empty($method->getAttributes(Attributes\SeedTask::class));
             })
             ->map(fn (ReflectionMethod $method) => function () use ($method, $parameters) {
                 $name = $method->getAttributes(Attributes\SeedTask::class)[0]?->newInstance()->as
@@ -369,7 +368,7 @@ abstract class Seeder
      */
     protected function printTwoColumns($first, $second = null)
     {
-        if ($this->silent || !$this->command) {
+        if ($this->silent || ! $this->command) {
             return;
         }
 
@@ -384,7 +383,7 @@ abstract class Seeder
      */
     public function setSilent($silent)
     {
-        $this->silent = $silent || !isset($this->command);
+        $this->silent = $silent || ! isset($this->command);
     }
 
     /**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -2,12 +2,18 @@
 
 namespace Illuminate\Database;
 
+use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
+use ReflectionMethod;
+use ReflectionObject;
+use Throwable;
 
 abstract class Seeder
 {
@@ -26,11 +32,76 @@ abstract class Seeder
     protected $command;
 
     /**
+     * Determine if the seeder should output to the console.
+     *
+     * @var bool
+     */
+    protected $silent = false;
+
+    /**
      * Seeders that have been called at least one time.
      *
      * @var array
      */
     protected static $called = [];
+
+    /**
+     * Seeding registry to continue from if desired by the developer.
+     *
+     * @var array<class-string, string[]>
+     */
+    protected static $continue = [];
+
+    /**
+     * Run the database seeds.
+     *
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __invoke(array $parameters = [])
+    {
+        $method = match(true) {
+            method_exists($this, 'run') => 'run',
+            method_exists($this, 'runSeedTasks') => 'runSeedTasks',
+            default => throw new InvalidArgumentException('Method [run] missing from '.get_class($this))
+        };
+
+
+        $callback = fn () => isset($this->container)
+            ? $this->container->call([$this, $method], $parameters)
+            : $this->{$method}(...$parameters);
+
+        $uses = array_flip(class_uses_recursive(static::class));
+
+        if (isset($uses[WithoutModelEvents::class])) {
+            $callback = $this->withoutModelEvents($callback);
+        }
+
+        return $callback();
+    }
+
+    /**
+     * Determine if the Seeder should wrap each seed task into a database transaction.
+     *
+     * @return bool
+     */
+    public function useTransactions()
+    {
+        return true;
+    }
+
+    /**
+     * Skips the current seed task. Skips the entire seeder if invoked inside the "before" method.
+     *
+     * @param  string  $reason
+     * @return never
+     */
+    protected function skip($reason = '')
+    {
+        throw new SeederSkipped($reason);
+    }
 
     /**
      * Run the given seeder class.
@@ -56,9 +127,34 @@ abstract class Seeder
                 );
             }
 
+            $seeder->setSilent($silent);
+
             $startTime = microtime(true);
 
-            $seeder->__invoke($parameters);
+            try {
+                $seeder->__invoke($parameters);
+            } catch (SeederSkipped $e) {
+                if ($silent === false && isset($this->command)) {
+                    with(new TwoColumnDetail($this->command->getOutput()))->render(
+                        $name,
+                        '<fg=cyan;options=bold>SKIPPED</>'
+                    );
+
+                    if ($e->getMessage()) {
+                        with(new TwoColumnDetail($this->command->getOutput()))->render('🛈 '.$e->getMessage());
+                    }
+                }
+
+                static::$called[] = $class;
+
+                return $this;
+            } catch (Throwable $e) {
+                if (method_exists($seeder, 'finally')) {
+                    $seeder->finally($e);
+                }
+
+                throw $e;
+            }
 
             if ($silent === false && isset($this->command)) {
                 $runTime = number_format((microtime(true) - $startTime) * 1000);
@@ -122,6 +218,79 @@ abstract class Seeder
     }
 
     /**
+     * Execute each seeder's seed tasks.
+     *
+     * @return void
+     */
+    public function runSeedTasks()
+    {
+        if (method_exists($this, 'before')) {
+            $this->container->call([$this, 'before']);
+        }
+
+        $parameters = func_get_args();
+
+        Collection::make((new ReflectionObject($this))->getMethods())
+            ->filter(function (ReflectionMethod $method) {
+                return Str::startsWith($method->name, 'seed')
+                    || !empty($method->getAttributes(Attributes\SeedTask::class));
+            })
+            ->map(fn (ReflectionMethod $method) => function () use ($method, $parameters) {
+                $name = $method->getAttributes(Attributes\SeedTask::class)[0]?->newInstance()->as
+                    ?: Str::ucfirst(Str::snake($method->name, ' '));
+
+                // If the developer has specified to continue the seeding operation, the seed tasks
+                // that have already been run will be set to true in the static::$continue array.
+                // We'll check if this seed task ran, and skip it if it's present in this list.
+                if ($this->hasSeedTaskRan($method->name)) {
+                    $this->printTwoColumns("↳ $name", '<fg=gray;options=bold>CONTINUE</>');
+
+                    return;
+                }
+
+                try {
+                    $result = $this->container->call([$this, $method->name], $parameters[$method->name] ?? []);
+                } catch (SeederSkipped $e) {
+                    $this->printTwoColumns("↳ $name", '<fg=blue;options=bold>SKIPPED</>');
+
+                    if ($e->getMessage()) {
+                        $this->printTwoColumns("🛈 {$e->getMessage()}");
+                    }
+
+                    self::$continue[get_class($this)][$method->name] = true;
+
+                    return;
+                } catch (Throwable $e) {
+                    $this->printTwoColumns("⚠ $name", '<fg=red;options=bold>ERROR</>');
+
+                    throw $e;
+                }
+
+                if ($result instanceof Eloquent\Factories\Factory) {
+                    $result->create();
+                } elseif ($result instanceof Eloquent\Collection) {
+                    $result->each->push();
+                } elseif ($result instanceof Eloquent\Model) {
+                    $result->push();
+                }
+
+                $this->printTwoColumns("↳ $name", '<fg=green;options=bold>DONE</>');
+
+                self::$continue[get_class($this)][$method->name] = true;
+            })
+            ->when($this->useTransactions())->map(function (Closure $callback): Closure {
+                return function () use ($callback): void {
+                    $this->container->make('db.connection')->getConnection()->transaction($callback);
+                };
+            })
+            ->each(fn (Closure $callback) => $callback());
+
+        if (method_exists($this, 'after')) {
+            $this->container->call([$this, 'after']);
+        }
+    }
+
+    /**
      * Resolve an instance of the given seeder class.
      *
      * @param  string  $class
@@ -171,29 +340,61 @@ abstract class Seeder
     }
 
     /**
-     * Run the database seeds.
+     * Returns the list of database seeders and seed tasks called.
      *
-     * @param  array  $parameters
-     * @return mixed
-     *
-     * @throws \InvalidArgumentException
+     * @return array<class-string, string[]>
      */
-    public function __invoke(array $parameters = [])
+    public static function getContinue()
     {
-        if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
+        return self::$continue;
+    }
+
+    /**
+     * Sets the list of database seeders that have been called.
+     *
+     * @param  array<class-string, string[]>  $tasksCalled
+     * @return void
+     */
+    public static function setContinue(array $tasksCalled)
+    {
+        self::$continue = $tasksCalled;
+    }
+
+    /**
+     * Send a two-column detail to the console output.
+     *
+     * @param  string  $first
+     * @param  string|null  $second
+     * @return void
+     */
+    protected function printTwoColumns($first, $second = null)
+    {
+        if ($this->silent || !$this->command) {
+            return;
         }
 
-        $callback = fn () => isset($this->container)
-            ? $this->container->call([$this, 'run'], $parameters)
-            : $this->run(...$parameters);
+        (new TwoColumnDetail($this->command->getOutput()))->render($first, $second);
+    }
 
-        $uses = array_flip(class_uses_recursive(static::class));
+    /**
+     * Makes the seeder not output to the console.
+     *
+     * @param  bool  $silent
+     * @return void
+     */
+    public function setSilent($silent)
+    {
+        $this->silent = $silent || !isset($this->command);
+    }
 
-        if (isset($uses[WithoutModelEvents::class])) {
-            $callback = $this->withoutModelEvents($callback);
-        }
-
-        return $callback();
+    /**
+     * Check if the seed task has been run before.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function hasSeedTaskRan($name)
+    {
+        return isset(self::$continue[get_class($this)][$name]);
     }
 }

--- a/src/Illuminate/Database/SeederSkipped.php
+++ b/src/Illuminate/Database/SeederSkipped.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class SeederSkipped extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -40,7 +40,7 @@
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.24).",
         "illuminate/console": "Required to use the database commands (^12.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^12.0).",
-        "illuminate/filesystem": "Required to use the migrations and continue failed seeding (^12.0).",
+        "illuminate/filesystem": "Required to use the migrations and continue incomplete seeding (^12.0).",
         "illuminate/http": "Required to convert Eloquent models to API resources (^12.0).",
         "illuminate/pagination": "Required to paginate the result set (^12.0).",
         "symfony/finder": "Required to use Eloquent model factories (^7.2)."

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -40,7 +40,7 @@
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.24).",
         "illuminate/console": "Required to use the database commands (^12.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^12.0).",
-        "illuminate/filesystem": "Required to use the migrations (^12.0).",
+        "illuminate/filesystem": "Required to use the migrations and continue failed seeding (^12.0).",
         "illuminate/http": "Required to convert Eloquent models to API resources (^12.0).",
         "illuminate/pagination": "Required to paginate the result set (^12.0).",
         "symfony/finder": "Required to use Eloquent model factories (^7.2)."

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -2,13 +2,17 @@
 
 namespace Illuminate\Tests\Database;
 
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
+use Illuminate\Database\Attributes\SeedTask;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Seeder;
 use Mockery as m;
 use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class TestSeeder extends Seeder
 {
@@ -26,10 +30,163 @@ class TestDepsSeeder extends Seeder
     }
 }
 
+class TestSeedTaskSeeder extends Seeder
+{
+    public function seedFirst()
+    {
+        //
+    }
+
+    public function seedSecond()
+    {
+        //
+    }
+
+    #[SeedTask]
+    public function thirdThing()
+    {
+        //
+    }
+
+    #[SeedTask(as: 'Test name')]
+    public function fourth()
+    {
+        //
+    }
+}
+
+class TestSeedTaskSeederWithBeforeAndAfter extends Seeder
+{
+    public function before()
+    {
+
+    }
+
+    public function seed()
+    {
+
+    }
+
+    public function after()
+    {
+
+    }
+}
+
+class TestSeederSkipsCompletely extends Seeder
+{
+    public function before()
+    {
+        $this->skip('test reason');
+    }
+
+    public function seed()
+    {
+
+    }
+}
+
+class TestSeederSkipsSingleSeedTask extends Seeder
+{
+    public function before()
+    {
+
+    }
+
+    public function seedFirst()
+    {
+
+    }
+
+    public function seedSecond()
+    {
+        $this->skip('test reason');
+
+        throw new Exception('Should not be thrown');
+    }
+
+    public function seedThird()
+    {
+
+    }
+}
+
+class TestSeedTaskSeederWithError extends Seeder
+{
+    public function seedFirst()
+    {
+
+    }
+
+    public function seedSecond()
+    {
+        throw new Exception('test error');
+    }
+
+    public function seedThird()
+    {
+
+    }
+}
+
+class TestSeedTaskSeederWithoutTransactions extends Seeder
+{
+    public function seedFirst()
+    {
+
+    }
+
+    public function useTransactions()
+    {
+        return false;
+    }
+}
+
+class TestSeederCallsSeedTask extends Seeder
+{
+    public function run()
+    {
+        $this->call(TestSeederSkipsCompletely::class);
+    }
+}
+
+class TestSeederCallsFailingSeedTask extends Seeder
+{
+    public function run()
+    {
+        $this->call(TestSeedTaskSeederRunsFinally::class);
+    }
+}
+
+class TestSeedTaskSeederRunsFinally extends Seeder
+{
+    public function seedFirst()
+    {
+        throw new Exception('test error');
+    }
+
+    public function seedSecond()
+    {
+        //
+    }
+
+    public function finally($throwable)
+    {
+        throw new Exception('finally called', 0, $throwable);
+    }
+}
+
 class DatabaseSeederTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Seeder::setContinue([]);
+    }
+
     protected function tearDown(): void
     {
+        Seeder::setContinue([]);
+
         m::close();
     }
 
@@ -45,6 +202,7 @@ class DatabaseSeederTest extends TestCase
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
+        $child->shouldReceive('setSilent')->with(false)->once();
         $child->shouldReceive('__invoke')->once();
 
         $seeder->call('ClassName');
@@ -88,5 +246,354 @@ class DatabaseSeederTest extends TestCase
         $seeder->__invoke(['test1', 'test2']);
 
         $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], ['test1', 'test2']);
+    }
+
+    public function testSeedTasks()
+    {
+        $seeder = new TestSeedTaskSeeder();
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call')->once()->with([$seeder, 'runSeedTasks'], []);
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testSeedsTasksInOrder()
+    {
+        $seeder = new TestSeedTaskSeeder();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed first <fg=gray>..........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed second <fg=gray>.........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Third thing <fg=gray>.........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Test name <fg=gray>...........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->withArgs(function ($callback) {
+            $callback();
+
+            return true;
+        });
+
+        $container = m::mock(Container::class);
+
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedFirst'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedSecond'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'thirdThing'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'fourth'], []);
+
+        $container->shouldReceive('call')->once()->withArgs(function ($callable, $parameters) use ($seeder) {
+            $this->assertSame([$seeder, 'runSeedTasks'], $callable);
+            $this->assertSame([], $parameters);
+
+            $callable();
+
+            return true;
+        })->andReturn();
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testSeedsTasksSeederBeforeAndAfter()
+    {
+        $seeder = new TestSeedTaskSeederWithBeforeAndAfter();
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(function ($callback) {
+            $callback();
+
+            return true;
+        });
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'before']);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seed'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'after']);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testSeedsTasksSeederSkipsCompletely()
+    {
+        $seeder = new TestSeederSkipsCompletely();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  Illuminate\Tests\Database\TestSeederSkipsCompletely <fg=gray>................</> <fg=yellow;options=bold>RUNNING</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  Illuminate\Tests\Database\TestSeederSkipsCompletely <fg=gray>................</> <fg=cyan;options=bold>SKIPPED</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  🛈 test reason <fg=gray>..............................................................</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->never();
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with(TestSeederSkipsCompletely::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'before'])->andReturnUsing(fn ($callback) => $callback());
+        $container->shouldReceive('call')->never()->with([$seeder, 'seed'], []);
+        $container->shouldReceive('call')->never()->with([$seeder, 'after']);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $class = new TestSeederCallsSeedTask();
+        $class->setContainer($container);
+        $class->setCommand($command);
+
+        $container->shouldReceive('call')->with([$class, 'run'], [])->andReturnUsing(fn ($callable) => $callable());
+
+        $class->__invoke();
+    }
+
+    public function testSeedsTaskSeederSkipsSingleTask()
+    {
+        $seeder = new TestSeederSkipsSingleSeedTask();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed first <fg=gray>..........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed second <fg=gray>......................................................</> <fg=blue;options=bold>SKIPPED</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  🛈 test reason <fg=gray>..............................................................</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed third <fg=gray>..........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) =>  $callback());
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'before']);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedFirst'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedSecond'], [])->andReturnUsing(fn ($callback) =>  $callback());
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedThird'], []);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testSeedTaskSeederWithError()
+    {
+        $seeder = new TestSeedTaskSeederWithError();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed first <fg=gray>..........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ⚠ Seed second <fg=gray>........................................................</> <fg=red;options=bold>ERROR</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) =>  $callback());
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedFirst'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedSecond'], [])->andReturnUsing(fn ($callback) =>  $callback());
+        $container->shouldReceive('call')->never()->with([$seeder, 'seedThird'], []);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('test error');
+
+        try {
+            $seeder->__invoke();
+        } catch (Throwable $e) {
+            $this->assertSame([TestSeedTaskSeederWithError::class => ['seedFirst' => true]], $seeder->getContinue());
+
+            throw $e;
+        }
+    }
+
+    public function testSeedTaskSeederContinuesFromPastSeeding()
+    {
+        $seeder = new TestSeedTaskSeeder();
+        $seeder->setContinue([
+            TestSeedTaskSeeder::class => [
+                'seedFirst' => true,
+            ],
+        ]);
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed first <fg=gray>......................................................</> <fg=gray;options=bold>CONTINUE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed second <fg=gray>.........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Third thing <fg=gray>.........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Test name <fg=gray>...........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) =>  $callback());
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->never()->with([$seeder, 'seedFirst'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedSecond'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'thirdThing'], []);
+        $container->shouldReceive('call')->once()->with([$seeder, 'fourth'], []);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(function ($callable) {
+            return $callable();
+        });
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testWithoutTransactions()
+    {
+        $seeder = new TestSeedTaskSeederWithoutTransactions();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  ↳ Seed first <fg=gray>..........................................................</> <fg=green;options=bold>DONE</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->never();
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedFirst'], []);
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $seeder->__invoke();
+    }
+
+    public function testSeedTaskSeederCallsFinally()
+    {
+        $seeder = new TestSeedTaskSeederRunsFinally();
+
+        $output = m::mock(OutputInterface::class);
+        $output->shouldReceive('writeln')->with(
+            '  Illuminate\Tests\Database\TestSeedTaskSeederRunsFinally <fg=gray>............</> <fg=yellow;options=bold>RUNNING</>  ',
+            32,
+        );
+        $output->shouldReceive('writeln')->with(
+            '  ⚠ Seed first <fg=gray>.........................................................</> <fg=red;options=bold>ERROR</>  ',
+            32,
+        );
+
+        $command = m::mock(Command::class);
+        $command->shouldReceive('getOutput')->andReturn($output);
+
+        $seeder->setCommand($command);
+
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) => $callback());
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with(TestSeedTaskSeederRunsFinally::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with('db.connection')->andReturn($connection);
+        $container->shouldReceive('call')->once()->with([$seeder, 'seedFirst'], [])->andReturnUsing(fn ($callback) => $callback());
+        $container->shouldReceive('call')->with([$seeder, 'runSeedTasks'], [])->andReturnUsing(fn ($callback) => $callback());
+
+        $seeder->setContainer($container);
+
+        $class = new TestSeederCallsFailingSeedTask();
+        $class->setContainer($container);
+        $class->setCommand($command);
+
+        $container->shouldReceive('call')->with([$class, 'run'], [])->andReturnUsing(fn ($callable) => $callable());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('finally called');
+
+        try {
+            $class->__invoke();
+        } catch (Throwable $e) {
+            $this->assertSame('test error', $e->getPrevious()->getMessage());
+
+            throw $e;
+        }
     }
 }

--- a/tests/Database/DatabaseSeederTestOn.php
+++ b/tests/Database/DatabaseSeederTestOn.php
@@ -288,7 +288,7 @@ class DatabaseSeederTest extends TestCase
         $seeder->setCommand($command);
 
         $connection = m::mock(ConnectionInterface::class);
-        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback)  => $callback());
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) => $callback());
 
         $container = m::mock(Container::class);
 
@@ -318,7 +318,7 @@ class DatabaseSeederTest extends TestCase
         $seeder = new TestSeedTaskSeederWithBeforeAndAfter();
 
         $connection = m::mock(ConnectionInterface::class);
-        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback)  => $callback());
+        $connection->shouldReceive('getConnection->transaction')->andReturnUsing(fn ($callback) => $callback());
 
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('db.connection')->andReturn($connection);

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Testing\Assert;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -161,8 +162,8 @@ class SeedCommandTest extends TestCase
         // call run to set up IO, then fire manually.
         $command->run($input, $output);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to retrieve continue data. Please install the "illuminate/filesystem" package to use the --continue option.');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to retrieve continue data. Install the "illuminate/filesystem" package to use the --continue option.');
 
         Assert::assertSame(Command::FAILURE, $command->handle());
     }

--- a/tests/Integration/Generators/SeederMakeCommandTest.php
+++ b/tests/Integration/Generators/SeederMakeCommandTest.php
@@ -17,7 +17,7 @@ class SeederMakeCommandTest extends TestCase
             'namespace Database\Seeders;',
             'use Illuminate\Database\Seeder;',
             'class FooSeeder extends Seeder',
-            'public function run()',
+            'public function seed()',
         ], 'database/seeders/FooSeeder.php');
     }
 }


### PR DESCRIPTION
## What?

This PR supercharges the default seeder while keeping compatibility with classic seeders, enabling the following out-of-the-box:

- Run logic before/after the seeding is executed (great to skip or prepare records).
- Separate seeding into methods called automatically (seed tasks).
- Dependency Injection into each _seed task_.
- Skipping seeding completely or per _seed task_.
- Seeding errors tied to the seed task (to know _where_ it failed).
- Use a DB Transaction on each seed task to avoid orphaned records.
- Continue incomplete seeding.

## Why?

I do, more often than not, make seeders more handy in terms of programmatical seeding. For example, some tasks I do are:

- Use Dependency Injection for additional seeding tasks for a model.
- Skip the seeder if it detects some records already seeded.
- Wrapping seeding into transactions to speed up SQLite (try to seed 1000 records outside it!).
- Having different seeding sets.

The main idea that [I implemented on a project](https://larawiz.github.io/docs/model-properties/seeders.html) was to enable these tasks to run seamlessly, with less code, while separating seeding operations into more purposeful tasks than all-in-one method.

Once models and relations start to grow left and right, it becomes chaotic when seeders start to account for the multiple permutations and conditions, and all of these must be accounted by the developer with a class that doesn't help too much apart from calling other seeders.

## Give me the details

Okay. Let's start with each part from the easiest to understand at the core of the seeder: the seed task.

### Seed tasks

Each seeder, when executed, will find all methods that start with the `seed` name or have the `#[SeedTask]` attribute (like PHPUnit does for tests), and call them (through the container) in the order these are declared in the class. There is no care for visibility, but `public` is preferred just in case the developer wants to call a seeder outside a command lifecycle.

```php
namespace Database\Seeders;

use Illuminate\Database\Attributes\SeedTask;
use Illuminate\Database\Seeder;
use Database\Factories\UserFactory;

class DatabaseSeeder extends Seeder
{
    public function run()
    {
        $this->call(UserSeeder::class);
    }
}

class UserSeeder extends Seeder
{
    public function seedNormalUsers(UserFactory $factory)
    {
        return $factory->count(5);
    }
    
    public function seedVipUsers(UserFactory $factory)
    {
        return $factory->count(3)->vip();
    }
 
    #[SeedTask(as: 'Seed users without authorization')]   
    public function bannedUsers(UserFactory $factory, $at = 'now')
    {
        return $factory->count(2)->banned($at);
    }
}
```

> [!TIP]
> 
> Yes, you can have a single seed task called `seed` and it will be called anyway. Great if you only have a single and simple seed task. Indeed, the updated Seeder stub comes with `seed()`.

If a method returns a `Factory` instance, an Eloquent Collection, or a Model, these will be automatically persisted in the database.

When executing the `db:seed` artisan command, the output will be something like this:

    php artisan db:seed
    
    INFO Seeding database.
    
    Database\Seeders\UserSeeder ...................................... RUNNING
    ↳ Seed normal users ................................................. DONE
    ↳ Seed vip users .................................................... DONE
    ↳ Seed users without authorization .................................. DONE
    Database\Seeders\UserSeeder .................................. 107 ms DONE
 
When the seeding fails, the seeding command will show the last seed task where it failed, making the seeding more informative, instead of seeing the Seeder name and figuring out _where_.

#### Calling with arguments

Currently, the `$this->call()` method accepts arguments, which are passed down to the `run()` method. When using the new seeder, the developer can set an array of arguments for each individual seed task by issuing their name as key and the arguments as an array.

```php
public function seedCommentTask()
{
    $this->call(CommentSeeder::class, [
        'bannedUsers' => ['at' => today()->subDay()]
    ]);
}
```

### Before, After, and onError.

A developer may need to set up some logic before and after a seeder runs with the `before()` and `after()` method, respectively. Maybe resetting a service status or configuration, or [skipping](#skipping-seed) the whole seeder. As with seed tasks, these are resolved by the Service Container. The `onError()` executes when a seed task throws an error, allowing the developer to do adjustments before throwing the exception, which van be great for reporting.

```php
/**
 * Execute logic before the seed tasks are executed 
 */
public function before()
{
    // Prepare some services...
}

/**
 * Execute logic after the seed tasks are executed.
 */
public function after()
{
    // Reset the services, remove artifacts...
}

public function onError($exception)
{
    // Remove some temporal files so we can try again...
}
```

I consider the above something more elegant than doing try-catch blocks everywhere.

### Skipping seed

There are two ways of skipping a seeder: completely or partially. Completely means skipping the seeder altogether, while partially means skipping only a given seed task.

Imagine we want to skip seeding the banned users if there is already one in existence. We only need to call `skip()` on the seed task, which will throw an exception that is safely caught by the seeder. The `skip()` method accepts a reason to skip, which is invaluable when seeding and figuring out why the seed task didn't complete or to avoid having more records that we need. 

```php
public function seedVipUsers()
{ 
    if (User::where('vip_at')->exists()) {
        $this->skip('There are already VIP users in the database');
    }
  
    // ...
}
```

When executing the `db:seed` artisan command, the output will be something like this, adding each seed task into the output:

    php artisan db:seed
    
    INFO Seeding database.
    
    Database\Seeders\UserSeeder ...................................... RUNNING
    ↳ Seed normal users ................................................. DONE
    ↳ Seed vip users ................................................. SKIPPED
    🛈 There are already VIP users in the database ...........................
    ↳ Seed banned users ................................................. DONE
    Database\Seeders\UserSeeder ................................... 95 ms DONE

To skip a seeder completely, the developer should call `skip()` inside the `before()` method.

```php
public function before()
{ 
    if (User::query()->exists()) {
        $this->skip('There are already users seeded in the database');
    }
  
    // ...
}
```

When executing the `db:seed` artisan command, the output will be something like this:

    php artisan db:seed
    
    INFO Seeding database.
    
    Database\Seeders\UserSeeder ...................................... RUNNING
    Database\Seeders\UserSeeder ...................................... SKIPPED
    🛈 There are already users seeded in the database ........................

### Transactions

The seeder **will wrap each seed task using a Database Transaction**. This not only makes seeding on SQLite out-of-the-box (file-based) more performant, but also to safely skip seeding without leaving orphaned or incomplete records. The latter will come in handy for [_resuming_ seeding](#stop--continue). 

The developer can disable transactions using the `useTransactions()` method of the seeder. If disabled, a warning will be shown since transactions are imperative for _safely_ continuing a previous failed seeding.  

```php
public function useTransactions()
{
    return false:
}
```

    php artisan db:seed
    
    INFO Seeding database.

    WARN Transactions are disabled. Errors may yield incomplete records.
    
    Database\Seeders\UserSeeder ...................................... RUNNING
    ↳ Seed normal users ................................................. DONE
    ↳ Seed vip users ................................................. SKIPPED
    🛈 There are already VIP users in the database ...........................
    ↳ Seed banned users ................................................. DONE
    Database\Seeders\UserSeeder ................................... 95 ms DONE

### Stop & Continue

One of my biggest problems when creating the seeders is that sometimes the seeding fails after a big seed. This means the developer needs to run the whole seeding operation again, especially of seeders depend on a previous one. This is why I implemented "Seed resuming", which can be enabled through the `--continue` option.

```shell
php artisan db:seed --continue
```

When the command executes, the list of seeders and seed tasks that ran is saved into a file (except when it completes). The file is named based on the seeder that ran, so these would have different lists saved:

```shell
php artisan db:seed --continue

php artisan db:seed --class=UserSeeder --continue
```

    storage/framework/database/seed.Database_Seeders_DatabaseSeeder.json
    
    storage/framework/database/seed.Database_Seeders_UserSeeder.json

The file is a JSON file like this, with the name of the class used to trigger the seeding and the list of called seeders and seed tasks.

```json
{
  "Database\\Seeders\\DatabaseSeeder": {
    "seedNormalUsers":  true,
    "seedVipUsers":  true,
    "seedBannedUsers":  true
  }
}
```

When the command receives the `--continue` option, it will check if there is a list, and load it into the Seeder. When the seeder calls the seeder's seed tasks, it will skip them as `CONTINUE` if these appear on the list. Once the whole seed completes successfully, the file is deleted.

    php artisan db:seed --continue
    
    INFO Seeding database.
    
    Database\Seeders\UserSeeder ...................................... RUNNING
    ↳ Seed normal users ............................................. CONTINUE
    ↳ Seed vip users ................................................ CONTINUE
    ↳ Seed banned users ................................................. DONE
    Database\Seeders\UserSeeder ................................... 95 ms DONE

What's imperative for the `--continue` to have transactions enabled. If a seed task fails, not wrapping the call with a transaction may create orphaned records.

> [!IMPORTANT]
> 
> Using the `--continue` option doesn't do anything on traditional seeders, or if the `illuminate/filesystem` package is not installed.

There is one issue for continuing an incomplete seeding operation: If the seed task was _skipped_, it counts as ran successfully and won't be invoked the next run.

## Retrocompatibility

I'm pretty confident this seeder is retro-compatible with the usual `run()`. Old projects do not need to change anything, new projects can get the updated stub with a single `seed()` method and be ready to work.