### PR TITLE
[12.x] Dispatch NotificationFailed when sending fails

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -67,6 +67,7 @@ class NotificationSender
         $this->events = $events;
         $this->locale = $locale;
         $this->manager = $manager;
+
         $this->events->listen(NotificationFailed::class, fn () => $this->failedEventWasDispatched = true);
     }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -6,11 +6,13 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Localizable;
+use Throwable;
 
 class NotificationSender
 {
@@ -45,6 +47,13 @@ class NotificationSender
     protected $locale;
 
     /**
+     * Indicates whether a NotificationFailed event has been dispatched.
+     *
+     * @var bool
+     */
+    protected $failedEventWasDispatched = false;
+
+    /**
      * Create a new notification sender instance.
      *
      * @param  \Illuminate\Notifications\ChannelManager  $manager
@@ -58,6 +67,7 @@ class NotificationSender
         $this->events = $events;
         $this->locale = $locale;
         $this->manager = $manager;
+        $this->events->listen(NotificationFailed::class, fn () => $this->failedEventWasDispatched = true);
     }
 
     /**
@@ -144,7 +154,19 @@ class NotificationSender
             return;
         }
 
-        $response = $this->manager->driver($channel)->send($notifiable, $notification);
+        try {
+            $response = $this->manager->driver($channel)->send($notifiable, $notification);
+        } catch (Throwable $exception) {
+            if (! $this->failedEventWasDispatched) {
+                $this->events->dispatch(
+                    new NotificationFailed($notifiable, $notification, $channel, ['exception' => $exception])
+                );
+            }
+
+            $this->failedEventWasDispatched = false;
+
+            throw $exception;
+        }
 
         $this->events->dispatch(
             new NotificationSent($notifiable, $notification, $channel, $response)

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -2,17 +2,20 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\ChannelManager;
+use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -34,6 +37,7 @@ class NotificationChannelManagerTest extends TestCase
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
         $manager->shouldReceive('driver')->andReturn($driver = m::mock());
+        $events->shouldReceive('listen')->once();
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
         $driver->shouldReceive('send')->once();
         $events->shouldReceive('dispatch')->with(m::type(NotificationSent::class));
@@ -49,6 +53,7 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
         $events->shouldReceive('until')->once()->with(m::type(NotificationSending::class))->andReturn(false);
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
         $manager->shouldReceive('driver')->once()->andReturn($driver = m::mock());
@@ -66,6 +71,7 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
         $manager->shouldNotReceive('driver');
         $events->shouldNotReceive('dispatch');
@@ -81,12 +87,63 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
         $manager->shouldReceive('driver')->once()->andReturn($driver = m::mock());
         $driver->shouldReceive('send')->once();
         $events->shouldReceive('dispatch')->once()->with(m::type(NotificationSent::class));
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotCancelledNotification);
+    }
+
+    public function testNotificationNotSentWhenFailed()
+    {
+        $this->expectException(Exception::class);
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Dispatcher::class, $events = m::mock());
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $manager->shouldReceive('driver')->andReturn($driver = m::mock());
+        $driver->shouldReceive('send')->andThrow(new Exception());
+        $events->shouldReceive('listen')->once();
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with(m::type(NotificationFailed::class));
+        $events->shouldReceive('dispatch')->never()->with(m::type(NotificationSent::class));
+
+        $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
+    }
+
+    public function testNotificationFailedDispatchedOnlyOnceWhenFailed()
+    {
+        $this->expectException(Exception::class);
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Dispatcher::class, $events = m::mock(Dispatcher::class));
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $manager->shouldReceive('driver')->andReturn($driver = m::mock());
+        $driver->shouldReceive('send')->andReturnUsing(function ($notifiable, $notification) use ($events) {
+            $events->dispatch(new NotificationFailed($notifiable, $notification, 'test'));
+            throw new Exception();
+        });
+        $listeners = new Collection();
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('listen')->once()->andReturnUsing(function ($event, $callback) use ($listeners) {
+            $listeners->push($callback);
+        });
+        $events->shouldReceive('dispatch')->once()->with(m::type(NotificationFailed::class))->andReturnUsing(function ($event) use ($listeners) {
+            foreach ($listeners as $listener) {
+                $listener($event);
+            }
+        });
+        $events->shouldReceive('dispatch')->never()->with(m::type(NotificationSent::class));
+
+        $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
     }
 
     public function testNotificationCanBeQueued()
@@ -98,6 +155,7 @@ class NotificationChannelManagerTest extends TestCase
         $bus->shouldReceive('dispatch')->with(m::type(SendQueuedNotifications::class));
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestQueuedNotification);
     }

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -30,6 +30,7 @@ class NotificationSenderTest extends TestCase
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldReceive('dispatch');
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -43,6 +44,7 @@ class NotificationSenderTest extends TestCase
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldNotReceive('dispatch');
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -56,6 +58,7 @@ class NotificationSenderTest extends TestCase
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldNotReceive('dispatch');
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -72,6 +75,7 @@ class NotificationSenderTest extends TestCase
                 return $job->middleware[0] instanceof TestNotificationMiddleware;
             });
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -99,6 +103,7 @@ class NotificationSenderTest extends TestCase
                 return empty($job->middleware);
             });
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -122,6 +127,7 @@ class NotificationSenderTest extends TestCase
             });
 
         $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
 
         $sender = new NotificationSender($manager, $bus, $events);
 


### PR DESCRIPTION
Closes #55479

As noted on issue #55479, the `Illuminate\Notifications\Events\NotificationFailed` is never dispatched by the framework.

There is also a `TODO` comment on `laravel/nighwatch` about this:

https://github.com/laravel/nightwatch/blob/7cdfc295f71619fde964b45662237f71e3c7559b/src/Sensors/NotificationSensor.php#L68

As noted on this comment on issue #55479:

https://github.com/laravel/framework/issues/55479#issuecomment-2818433572

Some community provided channels are already dispatching the `Illuminate\Notifications\Events\NotificationFailed` on their own. 

A listener was added to prevent this event being double dispatched.

This PR:

- Adds a `try/catch` block to the `Illuminate\Notifications\NotificationSender@sendToNotifiable()` method, so the `NotificationFailed` event is dispatched if an exception is thrown when sending a notification
- Register a listener to the `NotificationFailed` event to prevent double dispatching this event to users
- Adds corresponding test cases