### PR TITLE
Allow Listeners to dynamically specify deleteWhenMissingModels

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -51,6 +51,13 @@ class BroadcastEvent implements ShouldQueue
     public $maxExceptions;
 
     /**
+     * Indicate if the job should be deleted when models are missing.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels;
+
+    /**
      * Create a new job handler instance.
      *
      * @param  mixed  $event
@@ -63,6 +70,7 @@ class BroadcastEvent implements ShouldQueue
         $this->backoff = property_exists($event, 'backoff') ? $event->backoff : null;
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
         $this->maxExceptions = property_exists($event, 'maxExceptions') ? $event->maxExceptions : null;
+        $this->deleteWhenMissingModels = property_exists($event, 'deleteWhenMissingModels') ? $event->deleteWhenMissingModels : null;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -51,7 +51,7 @@ class BroadcastEvent implements ShouldQueue
     public $maxExceptions;
 
     /**
-     * Indicate if the job should be deleted when models are missing.
+     * Indicates if the job should be deleted when models are missing.
      *
      * @var bool
      */

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -83,6 +83,13 @@ class CallQueuedListener implements ShouldQueue
     public $shouldBeEncrypted = false;
 
     /**
+     * Indicate if the job should be deleted when models are missing.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels;
+
+    /**
      * Create a new job instance.
      *
      * @param  class-string  $class

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -83,7 +83,7 @@ class CallQueuedListener implements ShouldQueue
     public $shouldBeEncrypted = false;
 
     /**
-     * Indicate if the job should be deleted when models are missing.
+     * Indicates if the job should be deleted when models are missing.
      *
      * @var bool
      */

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -677,6 +677,7 @@ class Dispatcher implements DispatcherContract
             $job->timeout = $listener->timeout ?? null;
             $job->failOnTimeout = $listener->failOnTimeout ?? false;
             $job->tries = $listener->tries ?? null;
+            $job->deleteWhenMissingModels = $listener->deleteWhenMissingModels ?? false;
 
             $job->through(array_merge(
                 method_exists($listener, 'middleware') ? $listener->middleware(...$data) : [],


### PR DESCRIPTION
When dispatching events to queue, models may be deleted before the job is processed.  Allowing listeners to dynamically specify `deleteWhenMissingModels` aims to handle this use case with builtin job property.