### PR TITLE
Improvement handle falsy values in collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -341,43 +341,19 @@ trait EnumeratesValues
      * @param  TValueDefault|(\Closure(): TValueDefault)  $default
      * @return TValue|TValueDefault
      */
-    public function value($key, $default = null)
+    public function value($key, $default = null, $preserveFalsy = false)
     {
-        if ($value = $this->firstWhere($key)) {
+        if ($preserveFalsy === true) {
+            $value = $this->first();
+        } else {
+            $value = $this->firstWhere($key);
+        }
+
+        if ($value) {
             return data_get($value, $key, $default);
         }
 
         return value($default);
-    }
-
-    /**
-     * Get the value of a given key from the first item in the collection,
-     * even if the value is a falsy one like 0, false, or an empty string.
-     *
-     * This method avoids treating falsy values as null or non-existent.
-     *
-     * @param  string|int  $key     The key to retrieve from the first matching item.
-     * @param  mixed|null  $default Default value if key not found.
-     * @return mixed
-     */
-    public function valuePreservingFalsy($key, $default = null)
-    {
-        $item = $this->first();
-
-        if ($item === null) {
-            return value($default);
-        }
-
-        if (is_array($item) && array_key_exists($key, $item)) {
-            return $item[$key];
-        }
-
-        if (is_object($item) && property_exists($item, $key)) {
-            return $item->{$key};
-        }
-
-        // Fallback to dot notation
-        return data_get($item, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -341,15 +341,28 @@ trait EnumeratesValues
      * @param  TValueDefault|(\Closure(): TValueDefault)  $default
      * @return TValue|TValueDefault
      */
-    public function value($key, $default = null, $preserveFalsy = false)
+    public function value($key, $default = null)
     {
-        if ($preserveFalsy === true) {
-            $value = $this->first();
-        } else {
-            $value = $this->firstWhere($key);
+        if ($value = $this->firstWhere($key)) {
+            return data_get($value, $key, $default);
         }
 
-        if ($value) {
+        return value($default);
+    }
+
+    /**
+     * Get the value of a given key from the first item in the collection,
+     * even if the value is a falsy one like 0, false, or an empty string.
+     *
+     * This method avoids treating falsy values as null or non-existent.
+     *
+     * @param  string|int  $key     The key to retrieve from the first matching item.
+     * @param  mixed|null  $default Default value if key not found.
+     * @return mixed
+     */
+    public function valuePreservingFalsy($key, $default = null)
+    {
+        if ($value = $this->first()) {
             return data_get($value, $key, $default);
         }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -351,6 +351,36 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the value of a given key from the first item in the collection,
+     * even if the value is a falsy one like 0, false, or an empty string.
+     *
+     * This method avoids treating falsy values as null or non-existent.
+     *
+     * @param  string|int  $key     The key to retrieve from the first matching item.
+     * @param  mixed|null  $default Default value if key not found.
+     * @return mixed
+     */
+    public function valuePreservingFalsy($key, $default = null)
+    {
+        $item = $this->first();
+
+        if ($item === null) {
+            return value($default);
+        }
+
+        if (is_array($item) && array_key_exists($key, $item)) {
+            return $item[$key];
+        }
+
+        if (is_object($item) && property_exists($item, $key)) {
+            return $item->{$key};
+        }
+
+        // Fallback to dot notation
+        return data_get($item, $key, $default);
+    }
+
+    /**
      * Ensure that every item in the collection is of the expected type.
      *
      * @template TEnsureOfType

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -339,30 +339,14 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  TValueDefault|(\Closure(): TValueDefault)  $default
+     * @param  bool  $allowFalsy
      * @return TValue|TValueDefault
      */
-    public function value($key, $default = null)
+    public function value($key, $default = null, $allowFalsy = false)
     {
-        if ($value = $this->firstWhere($key)) {
-            return data_get($value, $key, $default);
-        }
+        $value = $allowFalsy ? $this->first() : $this->firstWhere($key);
 
-        return value($default);
-    }
-
-    /**
-     * Get the value of a given key from the first item in the collection,
-     * even if the value is a falsy one like 0, false, or an empty string.
-     *
-     * This method avoids treating falsy values as null or non-existent.
-     *
-     * @param  string|int  $key     The key to retrieve from the first matching item.
-     * @param  mixed|null  $default Default value if key not found.
-     * @return mixed
-     */
-    public function valuePreservingFalsy($key, $default = null)
-    {
-        if ($value = $this->first()) {
+        if ($value) {
             return data_get($value, $key, $default);
         }
 

--- a/tests/Support/ValuePreservingFalsyTest.php
+++ b/tests/Support/ValuePreservingFalsyTest.php
@@ -14,7 +14,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame(0, $collection->valuePreservingFalsy('balance'));
+        $this->assertSame(0, $collection->value('balance', allowFalsy: true));
     }
 
     // Test when the value is 0.0 (float)
@@ -25,7 +25,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200.5],
         ]);
 
-        $this->assertSame(0.0, $collection->valuePreservingFalsy('balance'));
+        $this->assertSame(0.0, $collection->value('balance', allowFalsy: true));
     }
 
     // Test when the value is false (boolean)
@@ -36,7 +36,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'Tim', 'vegetarian' => false],
         ]);
 
-        $this->assertFalse($collection->where('name', 'Tim')->valuePreservingFalsy('vegetarian'));
+        $this->assertFalse($collection->where('name', 'Tim')->value('vegetarian', allowFalsy: true));
     }
 
     // Test when the value is an empty string
@@ -47,7 +47,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('', $collection->valuePreservingFalsy('status'));
+        $this->assertSame('', $collection->value('status', allowFalsy: true));
     }
 
     // Test when the value is null
@@ -58,7 +58,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'age' => 30],
         ]);
 
-        $this->assertNull($collection->valuePreservingFalsy('age'));
+        $this->assertNull($collection->value('age', allowFalsy: true));
     }
 
     // Test when the value is an empty array
@@ -69,7 +69,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'tags' => ['admin']],
         ]);
 
-        $this->assertSame([], $collection->valuePreservingFalsy('tags'));
+        $this->assertSame([], $collection->value('tags', allowFalsy: true));
     }
 
     // Test when the value is '0' (string zero)
@@ -80,7 +80,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => '100'],
         ]);
 
-        $this->assertSame('0', $collection->valuePreservingFalsy('balance'));
+        $this->assertSame('0', $collection->value('balance', allowFalsy: true));
     }
 
     // Test when a missing key is provided
@@ -91,7 +91,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame('default_value', $collection->valuePreservingFalsy('missing_key', 'default_value'));
+        $this->assertSame('default_value', $collection->value('missing_key', 'default_value', allowFalsy: true));
     }
 
     // Test when a falsy value in a subsequent item is returned (e.g. first item is falsy, second is not)
@@ -102,7 +102,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame(0, $collection->valuePreservingFalsy('status'));
+        $this->assertSame(0, $collection->value('status', allowFalsy: true));
     }
 
     // Test when a falsy value in a subsequent item is returned (string '0' case)
@@ -113,6 +113,6 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('0', $collection->valuePreservingFalsy('status'));
+        $this->assertSame('0', $collection->value('status', allowFalsy: true));
     }
 }

--- a/tests/Support/ValuePreservingFalsyTest.php
+++ b/tests/Support/ValuePreservingFalsyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\TestCase;
+
+class ValuePreservingFalsyTest extends TestCase
+{
+    // Test when the value is 0 (integer)
+    public function test_zero_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'balance' => 0],
+            ['name' => 'John', 'balance' => 200],
+        ]);
+
+        $this->assertSame(0, $collection->valuePreservingFalsy('balance'));
+    }
+
+    // Test when the value is 0.0 (float)
+    public function test_float_zero_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'balance' => 0.0],
+            ['name' => 'John', 'balance' => 200.5],
+        ]);
+
+        $this->assertSame(0.0, $collection->valuePreservingFalsy('balance'));
+    }
+
+    // Test when the value is false (boolean)
+    public function test_false_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'John', 'vegetarian' => true],
+            ['name' => 'Tim', 'vegetarian' => false],
+        ]);
+
+        $this->assertFalse($collection->where('name', 'Tim')->valuePreservingFalsy('vegetarian'));
+    }
+
+    // Test when the value is an empty string
+    public function test_empty_string_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'status' => ''],
+            ['name' => 'John', 'status' => 'active'],
+        ]);
+
+        $this->assertSame('', $collection->valuePreservingFalsy('status'));
+    }
+
+    // Test when the value is null
+    public function test_null_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'age' => null],
+            ['name' => 'John', 'age' => 30],
+        ]);
+
+        $this->assertNull($collection->valuePreservingFalsy('age'));
+    }
+
+    // Test when the value is an empty array
+    public function test_empty_array_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'tags' => []],
+            ['name' => 'John', 'tags' => ['admin']],
+        ]);
+
+        $this->assertSame([], $collection->valuePreservingFalsy('tags'));
+    }
+
+    // Test when the value is '0' (string zero)
+    public function test_string_zero_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'balance' => '0'],
+            ['name' => 'John', 'balance' => '100'],
+        ]);
+
+        $this->assertSame('0', $collection->valuePreservingFalsy('balance'));
+    }
+
+    // Test when a missing key is provided
+    public function test_missing_key_returns_default()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'balance' => 0],
+            ['name' => 'John', 'balance' => 200],
+        ]);
+
+        $this->assertSame('default_value', $collection->valuePreservingFalsy('missing_key', 'default_value'));
+    }
+
+    // Test when a falsy value in a subsequent item is returned (e.g. first item is falsy, second is not)
+    public function test_first_falsy_value_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'status' => 0],
+            ['name' => 'John', 'status' => 'active'],
+        ]);
+
+        $this->assertSame(0, $collection->valuePreservingFalsy('status'));
+    }
+
+    // Test when a falsy value in a subsequent item is returned (string '0' case)
+    public function test_first_item_with_string_zero_is_preserved()
+    {
+        $collection = collect([
+            ['name' => 'Tim', 'status' => '0'],
+            ['name' => 'John', 'status' => 'active'],
+        ]);
+
+        $this->assertSame('0', $collection->valuePreservingFalsy('status'));
+    }
+}

--- a/tests/Support/ValuePreservingFalsyTest.php
+++ b/tests/Support/ValuePreservingFalsyTest.php
@@ -14,7 +14,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame(0, $collection->value('balance', preserveFalsy: true));
+        $this->assertSame(0, $collection->valuePreservingFalsy('balance'));
     }
 
     // Test when the value is 0.0 (float)
@@ -25,7 +25,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200.5],
         ]);
 
-        $this->assertSame(0.0, $collection->value('balance', preserveFalsy: true));
+        $this->assertSame(0.0, $collection->valuePreservingFalsy('balance'));
     }
 
     // Test when the value is false (boolean)
@@ -36,7 +36,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'Tim', 'vegetarian' => false],
         ]);
 
-        $this->assertFalse($collection->where('name', 'Tim')->value('vegetarian', preserveFalsy: true));
+        $this->assertFalse($collection->where('name', 'Tim')->valuePreservingFalsy('vegetarian'));
     }
 
     // Test when the value is an empty string
@@ -47,7 +47,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('', $collection->value('status', preserveFalsy: true));
+        $this->assertSame('', $collection->valuePreservingFalsy('status'));
     }
 
     // Test when the value is null
@@ -58,7 +58,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'age' => 30],
         ]);
 
-        $this->assertNull($collection->value('age', preserveFalsy: true));
+        $this->assertNull($collection->valuePreservingFalsy('age'));
     }
 
     // Test when the value is an empty array
@@ -69,7 +69,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'tags' => ['admin']],
         ]);
 
-        $this->assertSame([], $collection->value('tags', preserveFalsy: true));
+        $this->assertSame([], $collection->valuePreservingFalsy('tags'));
     }
 
     // Test when the value is '0' (string zero)
@@ -80,7 +80,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => '100'],
         ]);
 
-        $this->assertSame('0', $collection->value('balance', preserveFalsy: true));
+        $this->assertSame('0', $collection->valuePreservingFalsy('balance'));
     }
 
     // Test when a missing key is provided
@@ -91,7 +91,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame('default_value', $collection->value('missing_key', 'default_value', preserveFalsy: true));
+        $this->assertSame('default_value', $collection->valuePreservingFalsy('missing_key', 'default_value'));
     }
 
     // Test when a falsy value in a subsequent item is returned (e.g. first item is falsy, second is not)
@@ -102,7 +102,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame(0, $collection->value('status', preserveFalsy: true));
+        $this->assertSame(0, $collection->valuePreservingFalsy('status'));
     }
 
     // Test when a falsy value in a subsequent item is returned (string '0' case)
@@ -113,6 +113,6 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('0', $collection->value('status', preserveFalsy: true));
+        $this->assertSame('0', $collection->valuePreservingFalsy('status'));
     }
 }

--- a/tests/Support/ValuePreservingFalsyTest.php
+++ b/tests/Support/ValuePreservingFalsyTest.php
@@ -14,7 +14,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame(0, $collection->valuePreservingFalsy('balance'));
+        $this->assertSame(0, $collection->value('balance', preserveFalsy: true));
     }
 
     // Test when the value is 0.0 (float)
@@ -25,7 +25,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200.5],
         ]);
 
-        $this->assertSame(0.0, $collection->valuePreservingFalsy('balance'));
+        $this->assertSame(0.0, $collection->value('balance', preserveFalsy: true));
     }
 
     // Test when the value is false (boolean)
@@ -36,7 +36,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'Tim', 'vegetarian' => false],
         ]);
 
-        $this->assertFalse($collection->where('name', 'Tim')->valuePreservingFalsy('vegetarian'));
+        $this->assertFalse($collection->where('name', 'Tim')->value('vegetarian', preserveFalsy: true));
     }
 
     // Test when the value is an empty string
@@ -47,7 +47,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('', $collection->valuePreservingFalsy('status'));
+        $this->assertSame('', $collection->value('status', preserveFalsy: true));
     }
 
     // Test when the value is null
@@ -58,7 +58,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'age' => 30],
         ]);
 
-        $this->assertNull($collection->valuePreservingFalsy('age'));
+        $this->assertNull($collection->value('age', preserveFalsy: true));
     }
 
     // Test when the value is an empty array
@@ -69,7 +69,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'tags' => ['admin']],
         ]);
 
-        $this->assertSame([], $collection->valuePreservingFalsy('tags'));
+        $this->assertSame([], $collection->value('tags', preserveFalsy: true));
     }
 
     // Test when the value is '0' (string zero)
@@ -80,7 +80,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => '100'],
         ]);
 
-        $this->assertSame('0', $collection->valuePreservingFalsy('balance'));
+        $this->assertSame('0', $collection->value('balance', preserveFalsy: true));
     }
 
     // Test when a missing key is provided
@@ -91,7 +91,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'balance' => 200],
         ]);
 
-        $this->assertSame('default_value', $collection->valuePreservingFalsy('missing_key', 'default_value'));
+        $this->assertSame('default_value', $collection->value('missing_key', 'default_value', preserveFalsy: true));
     }
 
     // Test when a falsy value in a subsequent item is returned (e.g. first item is falsy, second is not)
@@ -102,7 +102,7 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame(0, $collection->valuePreservingFalsy('status'));
+        $this->assertSame(0, $collection->value('status', preserveFalsy: true));
     }
 
     // Test when a falsy value in a subsequent item is returned (string '0' case)
@@ -113,6 +113,6 @@ class ValuePreservingFalsyTest extends TestCase
             ['name' => 'John', 'status' => 'active'],
         ]);
 
-        $this->assertSame('0', $collection->valuePreservingFalsy('status'));
+        $this->assertSame('0', $collection->value('status', preserveFalsy: true));
     }
 }


### PR DESCRIPTION
# Purpose
 This PR introduces a new `$allowFalsy` flag to the existing `value()` method on Laravel Collections. This enhancement allows developers to safely retrieve values for a given key without discarding valid **falsy values** such as 0, false, '0', or empty arrays.

# Benefit to End Users
Currently, the `value()` method relies on `firstWhere()`, which only returns the first truthy match—unintentionally excluding legitimate falsy values. With this change, users can opt-in to preserve and correctly retrieve falsy values when needed, improving the accuracy and flexibility of value retrieval from collections.

# Backward Compatibility
This is a non-breaking change. The `$allowFalsy` flag is optional and defaults to false, preserving the current behavior. Developers can adopt the new behavior only when required.

# Example
```php
$collection = collect([
    ['name' => 'Tim', 'balance' => 0],
    ['name' => 'John', 'balance' => ['amount' => 0, 'active' => false]],
]);

$collection->value("balance", allowFalsy: true); // returns 0
$collection->where('name', "John")->value("balance.active", allowFalsy: true); // returns false
$collection->where('name', "John")->value("balance.amount", allowFalsy: true); // returns 0
$collection->where('name', "John123")->value("balance.amount", allowFalsy: true); // returns null
$collection->where('name', "John")->value("balance.unknown_column", allowFalsy: true); // returns null
```

# Test coverage for all major PHP falsy values:
-   0 (int)
-   0.0 (float)
-   '0' (string)
-   false
-   [] (empty array)
-   null
-   '' (empty string)

# Related Issue

Closes https://github.com/laravel/framework/issues/54910