### PR TITLE
 Revert "Use value() helper in 'when' method to simplify code" #55465

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -20,7 +20,7 @@ trait Conditionable
      */
     public function when($value = null, ?callable $callback = null, ?callable $default = null)
     {
-        $value = value($value, $this);
+        $value = $value instanceof Closure ? $value($this) : $value;
 
         if (func_num_args() === 0) {
             return new HigherOrderWhenProxy($this);


### PR DESCRIPTION
In a [previous PR](https://github.com/laravel/framework/pull/55465), I replaced the logic inside the when method with a call to the value() helper for better readability and to avoid duplicating logic.
However, since Conditionable is intended to be used as a standalone package, relying on the value() helper — which comes from illuminate/collections — is incorrect.
This PR reverts that change to ensure Conditionable remains fully self-contained.

