### PR TITLE
[12.x] Dropping `take(2)` from `sole` Method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -186,7 +186,7 @@ abstract class Relation implements BuilderContract
      */
     public function sole($columns = ['*'])
     {
-        $result = $this->take(2)->get($columns);
+        $result = $this->get($columns);
 
         $count = $result->count();
 


### PR DESCRIPTION
The `sole` method is extremely useful, but it has a small problem. For situations where there are several similar cases:

![CleanShot 2025-04-22 at 15 16 10](https://github.com/user-attachments/assets/afd1fda3-be51-4c43-950b-7859f846398d)

The exception message `MultipleRecordsFoundException` mentions a wrong quantity, because we applied `take(2)` to the query performed.

```php
use App\Models\User;

$user = User::query()
        ->where('role', UserRoles::Admin)
        ->sole();
```

```
\Illuminate\Database\MultipleRecordsFoundException: 2 records were found.
```

This causes the expectation of the count to be different from the actual result of the query WITHOUT `take(2)`. That's why this PR proposes to remove `take(2)` from sole, so that `$count` has the total count of the multiple results, **keeping the original logic of `sole` but with the correct quantity in case of `MultipleRecordsFoundException` is thrown.**

### After This PR:

```
\Illuminate\Database\MultipleRecordsFoundException: 12 records were found.
```