### PR TITLE
[12.x] Add Enum support for assertJsonPath in AssertableJsonString.php

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -237,10 +237,8 @@ class AssertableJsonString implements ArrayAccess, Countable
     {
         if ($expect instanceof Closure) {
             PHPUnit::assertTrue($expect($this->json($path)));
-        } elseif ($expect instanceof \BackedEnum) {
-            PHPUnit::assertSame($expect->value, $this->json($path));
         } else {
-            PHPUnit::assertSame($expect, $this->json($path));
+            PHPUnit::assertSame(enum_value($expect), $this->json($path));
         }
 
         return $this;

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -237,6 +237,8 @@ class AssertableJsonString implements ArrayAccess, Countable
     {
         if ($expect instanceof Closure) {
             PHPUnit::assertTrue($expect($this->json($path)));
+        } elseif ($expect instanceof \BackedEnum){
+            PHPUnit::assertSame($expect->value, $this->json($path));
         } else {
             PHPUnit::assertSame($expect, $this->json($path));
         }

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Str;
 use Illuminate\Testing\Assert as PHPUnit;
 use JsonSerializable;
 
+use function Illuminate\Support\enum_value;
+
 class AssertableJsonString implements ArrayAccess, Countable
 {
     /**

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -237,7 +237,7 @@ class AssertableJsonString implements ArrayAccess, Countable
     {
         if ($expect instanceof Closure) {
             PHPUnit::assertTrue($expect($this->json($path)));
-        } elseif ($expect instanceof \BackedEnum){
+        } elseif ($expect instanceof \BackedEnum) {
             PHPUnit::assertSame($expect->value, $this->json($path));
         } else {
             PHPUnit::assertSame($expect, $this->json($path));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1437,6 +1437,27 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('data.foo', fn ($value) => $value === null);
     }
 
+    public function testAssertJsonPathWithEnum()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => ['status' => 'booked'],
+        ]));
+
+        $response->assertJsonPath('data.status', TestStatus::Booked);
+    }
+
+    public function testAssertJsonPathWithEnumCanFail()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => ['status' => 'failed'],
+        ]));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that two strings are identical.');
+
+        $response->assertJsonPath('data.status', TestStatus::Booked);
+    }
+
     public function testAssertJsonPathCanonicalizing()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
@@ -2953,4 +2974,9 @@ class TestModel extends Model
 class AnotherTestModel extends Model
 {
     protected $guarded = [];
+}
+
+enum TestStatus: string
+{
+    case Booked = 'booked';
 }


### PR DESCRIPTION

Hi,
To improve code readability and prevent typos, I added Enum support for assertJsonPath in this PR.

```php
// Before
$this->postJson('book')
     ->assertJsonPath('data.status', BookingStatus::Booked->value);
```


```php
// After
$this->postJson('book')
     ->assertJsonPath('data.status', BookingStatus::Booked);
```