### PR TITLE
[12.x] Use xxh128 when comparing views for changes

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -199,9 +199,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 return;
             }
 
-            $compiledHash = $this->files->hash($compiledPath, 'sha256');
+            $compiledHash = $this->files->hash($compiledPath, 'xxh128');
 
-            if ($compiledHash !== hash('sha256', $contents)) {
+            if ($compiledHash !== hash('xxh128', $contents)) {
                 $this->files->put($compiledPath, $contents);
             }
         }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -88,7 +88,7 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
         $files->shouldReceive('exists')->once()->with($compiledPath)->andReturn(true);
-        $files->shouldReceive('hash')->once()->with($compiledPath, 'sha256')->andReturn(hash('sha256', 'outdated content'));
+        $files->shouldReceive('hash')->once()->with($compiledPath, 'xxh128')->andReturn(hash('xxh128', 'outdated content'));
         $files->shouldReceive('put')->once()->with($compiledPath, 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
     }
@@ -101,7 +101,7 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(false);
         $files->shouldReceive('makeDirectory')->once()->with(__DIR__, 0777, true, true);
         $files->shouldReceive('exists')->once()->with($compiledPath)->andReturn(true);
-        $files->shouldReceive('hash')->once()->with($compiledPath, 'sha256')->andReturn(hash('sha256', 'Hello World<?php /**PATH foo ENDPATH**/ ?>'));
+        $files->shouldReceive('hash')->once()->with($compiledPath, 'xxh128')->andReturn(hash('xxh128', 'Hello World<?php /**PATH foo ENDPATH**/ ?>'));
         $compiler->compile('foo');
     }
 


### PR DESCRIPTION
In #55450, it was suggested to use xxh128 instead of sha256 for comparing changes. The change to use xxh128 was not made prior to the PR being merged. See [Taylor's comment](https://github.com/laravel/framework/pull/55450#issuecomment-2815397626) and the discussion for reference.
