### PR TITLE
[12.x] Ensure related models is iterable on `HasRelationships@relationLoaded()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1086,7 +1086,11 @@ trait HasRelationships
         }
 
         if ($nestedRelation !== null) {
-            foreach ($this->$relation as $related) {
+            $relatedModels = is_iterable($relatedModels = $this->$relation)
+                ? $relatedModels
+                : [$relatedModels];
+
+            foreach ($relatedModels as $related) {
                 if (! $related->relationLoaded($nestedRelation)) {
                     return false;
                 }

--- a/tests/Integration/Database/EloquentModelRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelRelationLoadedTest.php
@@ -119,6 +119,22 @@ class EloquentModelRelationLoadedTest extends DatabaseTestCase
         $this->assertTrue($model->relationLoaded('twos.threes'));
         $this->assertTrue($model->relationLoaded('twos.threes.one'));
     }
+
+    public function testWhenParentRelationIsASingleInstance()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $three = $two->threes()->create();
+
+        $model = Three::query()
+            ->with('two.one')
+            ->find($three->id);
+
+        $this->assertTrue($model->relationLoaded('two'));
+        $this->assertTrue($model->two->is($two));
+        $this->assertTrue($model->relationLoaded('two.one'));
+        $this->assertTrue($model->two->one->is($one));
+    }
 }
 
 class One extends Model


### PR DESCRIPTION
Closes #55518

PR #55471 introduced changes to the `HasRelationships@relationLoaded()` to improve performance.

It introduced an oversight when loading nesting relations assuming all relations would return am iterable (e.g. `Collection`). That is the case for some relations, such as `HasMany`.

But not the case for relations such as `BelongsTo`, `HasOne`, `MorphOne`, which return a single model.

So when iterating one of these relations, the `foreach` works iterating through the `Model` instance public properties such as `incrementing`, `exists`, ...

This PR:

- Ensure the relation is iterable before iterating the affected `foreach`
- Add a test case
