### PR TITLE
[12.x] Allow rendering paginated data where cursor parameters are not in the response

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -33,6 +33,13 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     protected $hasMore;
 
     /**
+     * The function that transforms before rendering.
+     *
+     * @var \Closure(TValue): mixed
+     */
+    protected $transformer;
+
+    /**
      * Create a new paginator instance.
      *
      * @param  Collection<TKey, TValue>|Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
@@ -143,6 +150,29 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     }
 
     /**
+     * Set how data is transformed before rendering to JSON.
+     *
+     * @param  \Closure(TValue): mixed  $tranformer
+     * @return $this
+     */
+    public function setTransformer($tranformer)
+    {
+        $this->transformer = $tranformer;
+
+        return $this;
+    }
+
+    /**
+     * Prepare data for rendering.
+     *
+     * @return array
+     */
+    protected function transformedData()
+    {
+        return $this->transformer ? $this->items->map($this->transformer)->toArray() : $this->items->toArray();
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array
@@ -150,7 +180,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     public function toArray()
     {
         return [
-            'data' => $this->items->toArray(),
+            'data' => $this->transformedData(),
             'path' => $this->path(),
             'per_page' => $this->perPage(),
             'next_cursor' => $this->nextCursor()?->encode(),


### PR DESCRIPTION
If you attempt to render a CursorPaginator, but do not have the keys/aliases as properties on the underlying data, a warning is raised. On our production environments, this returns a 500.

Take for instance something like this:

```php
User::query()
    ->orderBy('created_at', 'asc')
    ->cursorPaginate(10)
    ->through(function(User $user) {
        return [
            'uuid' => $user->uuid,
            'name' => $user->name,
        ];
    })
    ->toArray();
```

I do not want to expose the integer ID nor the created at timestamps in my response, but this will produce a warning. The reason the warning is raised is because `through` transforms the items, but `AbstractCursorPagination::getParametersForItem()` looks to find the cursor parameters as properties on the modified data.

With this PR's changes, I can now do this:

```php
User::query()
    ->orderBy('created_at', 'asc')
    ->cursorPaginate(10)
    ->setTransformer(function(User $user) {
        return [
            'uuid' => $user->uuid,
            'name' => $user->name,
        ];
})->toArray();
```

**This is particularly meaningful if I want to transform my data into `Responsable` DTOs (with something Laravel Data).** While Laravel-Data does offer a paginated data collection class, it's not necessarily as easy to work with as the one that comes with the framework.
 If I have a Responsable object like this:

```php
class UserResponse extends Data
{
    public function __construct(
        public string $uuid,
        public string $name
    ) { }

    public static function fromModel(User $user): self
    {
        return new self($user->uuid, $user->name);
    }
}
```

Then cursor pagination will fail because there's no `id` field in the UserResponse.

## Other possibilites
Change the `through` method so it does not immediately act on the collection, but instead only does it at `toArray()` time. This would potentially be a breaking change for users that relied on this behavior.

Additionally, the signature of `through` could be changed to:

```php
public function through(callable $callback, bool $onlyBeforeRender = false)
```

Though this is a breaking change for anyone who has extended `CursorPaginator`. We could take the pseudo-argument approach where we check for a second argument being passed in, but not change the signature.

---
We could also create the cursor if one isn't set when the paginator is constructed. That could be done inside of setItems or directly after it. I am starting to think that this is cleaner.