### PR TITLE
Add Missing Exception throws Tags to Eloquent Builder 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1920,6 +1920,8 @@ class Builder implements BuilderContract
      *
      * @param  \Closure(): TModelValue  $scope
      * @return TModelValue
+     *
+     * @throws \Throwable
      */
     public function withSavepointIfNeeded(Closure $scope): mixed
     {
@@ -2249,6 +2251,8 @@ class Builder implements BuilderContract
      * @param  string  $mixin
      * @param  bool  $replace
      * @return void
+     *
+     * @throws \ReflectionException
      */
     protected static function registerMixin($mixin, $replace)
     {


### PR DESCRIPTION
In the Builder class, the `withSavepointIfNeeded` method can throw exceptions but was missing the `@throws` tag.
Also, the `registerMixin` method may throw a `ReflectionException`, so I added the missing `@throws` tag to its PHPDoc as well.

Since these methods are commonly used especially `withSavepointIfNeeded`, which is often called directly in user code adding these tags helps more aware of possible exceptions during development, and allows IDEs to provide better support.
