### PR TITLE
[12.x] Address Model@relationLoaded when relation is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1090,6 +1090,10 @@ trait HasRelationships
                 ? $relatedModels
                 : array_filter([$relatedModels]);
 
+            if (count($relatedModels) === 0) {
+                return false;
+            }
+
             foreach ($relatedModels as $related) {
                 if (! $related->relationLoaded($nestedRelation)) {
                     return false;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1088,7 +1088,7 @@ trait HasRelationships
         if ($nestedRelation !== null) {
             $relatedModels = is_iterable($relatedModels = $this->$relation)
                 ? $relatedModels
-                : [$relatedModels];
+                : array_filter([$relatedModels]);
 
             foreach ($relatedModels as $related) {
                 if (! $related->relationLoaded($nestedRelation)) {

--- a/tests/Integration/Database/EloquentModelRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelRelationLoadedTest.php
@@ -135,6 +135,21 @@ class EloquentModelRelationLoadedTest extends DatabaseTestCase
         $this->assertTrue($model->relationLoaded('two.one'));
         $this->assertTrue($model->two->one->is($one));
     }
+
+    public function testWhenRelationIsNull()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $three = $two->threes()->create();
+
+        $model = Three::query()
+            ->with('one.twos')
+            ->find($three->id);
+
+        $this->assertTrue($model->relationLoaded('one'));
+        $this->assertNull($model->one);
+        $this->assertFalse($model->relationLoaded('one.twos'));
+    }
 }
 
 class One extends Model


### PR DESCRIPTION
This is a fix after PR #55519

As noted by @nicekiwi on this comment:

https://github.com/laravel/framework/pull/55519#discussion_r2057105737

When a relation returns `null`, for example `$user->address`, the `$relatedModel` array introduced on PR #55519, becomes `[null]`.

That can lead to the following `foreach` to be executed, and fail as: `Error: Call to a member function relationLoaded() on null`

This PR:

- Addresses this case by adding an `array_filter()` call to ensure no `null`s are present
- Adds another test case covering these changes