### PR TITLE
Add support for #[PaginatedBy(...)] attribute to customize paginator classes per model

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -541,18 +541,15 @@ trait BuildsQueries
     /**
      * Create a new length-aware paginator instance.
      *
-     * @template TLengthPaginator of \Illuminate\Pagination\LengthAwarePaginator
-     *
      * @param  \Illuminate\Support\Collection  $items
      * @param  int  $total
      * @param  int  $perPage
      * @param  int  $currentPage
      * @param  array  $options
-     * @return TLengthPaginator
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {
-        /** @var class-string<TLengthPaginator> $paginatorClass */
         $paginatorClass = $this->getPaginatorClassForModel(LengthAwarePaginator::class);
 
         return Container::getInstance()->makeWith($paginatorClass, compact(
@@ -563,17 +560,14 @@ trait BuildsQueries
     /**
      * Create a new simple paginator instance.
      *
-     * @template TSimplePaginator of \Illuminate\Pagination\Paginator
-     *
      * @param  \Illuminate\Support\Collection  $items
      * @param  int  $perPage
      * @param  int  $currentPage
      * @param  array  $options
-     * @return TSimplePaginator
+     * @return \Illuminate\Pagination\Paginator
      */
     protected function simplePaginator($items, $perPage, $currentPage, $options)
     {
-        /** @var class-string<TSimplePaginator> $paginatorClass */
         $paginatorClass = $this->getPaginatorClassForModel(Paginator::class);
 
         return Container::getInstance()->makeWith($paginatorClass, compact(
@@ -584,17 +578,14 @@ trait BuildsQueries
     /**
      * Create a new cursor paginator instance.
      *
-     * @template TCursorPaginator of \Illuminate\Pagination\CursorPaginator
-     *
      * @param  \Illuminate\Support\Collection  $items
      * @param  int  $perPage
      * @param  \Illuminate\Pagination\Cursor  $cursor
      * @param  array  $options
-     * @return TCursorPaginator
+     * @return \Illuminate\Pagination\CursorPaginator
      */
     protected function cursorPaginator($items, $perPage, $cursor, $options)
     {
-        /** @var class-string<TCursorPaginator> $paginatorClass */
         $paginatorClass = $this->getPaginatorClassForModel(CursorPaginator::class);
 
         return Container::getInstance()->makeWith($paginatorClass, compact(
@@ -605,10 +596,10 @@ trait BuildsQueries
     /**
      * Get paginator class from #[PaginatedBy] attribute or fallback.
      *
-     * @template T of \Illuminate\Pagination\AbstractPaginator
+     * @template TPaginator of \Illuminate\Pagination\AbstractPaginator
      *
-     * @param  class-string<T>  $default
-     * @return class-string<T>
+     * @param  class-string<TPaginator>  $default
+     * @return class-string<TPaginator>
      */
     protected function getPaginatorClassForModel(string $default): string
     {
@@ -632,11 +623,11 @@ trait BuildsQueries
     }
 
     /**
-     * @template T of \Illuminate\Pagination\AbstractPaginator
+     * @template TPaginator of \Illuminate\Pagination\AbstractPaginator
      *
-     * @param  class-string<T>|null  $custom
-     * @param  class-string<T>  $expectedBase
-     * @return class-string<T>
+     * @param  class-string<TPaginator>|null  $custom
+     * @param  class-string<TPaginator>  $expectedBase
+     * @return class-string<TPaginator>
      */
     protected function validatePaginatorClass(?string $custom, string $expectedBase): string
     {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Attributes\PaginatedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
@@ -546,7 +547,7 @@ trait BuildsQueries
      * @param  int  $perPage
      * @param  int  $currentPage
      * @param  array  $options
-     * @return \Illuminate\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginator
      */
     protected function paginator($items, $total, $perPage, $currentPage, $options)
     {
@@ -564,7 +565,7 @@ trait BuildsQueries
      * @param  int  $perPage
      * @param  int  $currentPage
      * @param  array  $options
-     * @return \Illuminate\Pagination\Paginator
+     * @return Paginator
      */
     protected function simplePaginator($items, $perPage, $currentPage, $options)
     {
@@ -582,7 +583,7 @@ trait BuildsQueries
      * @param  int  $perPage
      * @param  \Illuminate\Pagination\Cursor  $cursor
      * @param  array  $options
-     * @return \Illuminate\Pagination\CursorPaginator
+     * @return CursorPaginator
      */
     protected function cursorPaginator($items, $perPage, $cursor, $options)
     {
@@ -594,7 +595,7 @@ trait BuildsQueries
     }
 
     /**
-     * Get paginator class from #[PaginatedBy] attribute or fallback.
+     * Get paginator class from `#[PaginatedBy]` attribute or fallback.
      *
      * @template TPaginator of \Illuminate\Pagination\AbstractPaginator
      *
@@ -609,19 +610,19 @@ trait BuildsQueries
 
         $modelClass = get_class($this->getModel());
         $reflectionClass = new ReflectionClass($modelClass);
-        $attributes = $reflectionClass->getAttributes(\Illuminate\Database\Eloquent\Attributes\PaginatedBy::class);
+        $attributes = $reflectionClass->getAttributes(PaginatedBy::class);
 
-        if (empty($attributes)) {
+        if ($attributes === []) {
             return $default;
         }
 
-        /** @var \Illuminate\Database\Eloquent\Attributes\PaginatedBy $instance */
+        /** @var PaginatedBy $instance */
         $instance = $attributes[0]->newInstance();
 
         return match ($default) {
-            \Illuminate\Pagination\LengthAwarePaginator::class => $this->validatePaginatorClass($instance->lengthAware, $default),
-            \Illuminate\Pagination\Paginator::class => $this->validatePaginatorClass($instance->simple, $default),
-            \Illuminate\Pagination\CursorPaginator::class => $this->validatePaginatorClass($instance->cursor, $default),
+            LengthAwarePaginator::class => $this->validatePaginatorClass($instance->lengthAware, $default),
+            Paginator::class => $this->validatePaginatorClass($instance->simple, $default),
+            CursorPaginator::class => $this->validatePaginatorClass($instance->cursor, $default),
             default => $default,
         };
     }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -107,7 +107,7 @@ trait BuildsQueries
      * @param  int  $count
      * @return bool
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function each(callable $callback, $count = 1000)
     {
@@ -158,7 +158,7 @@ trait BuildsQueries
      * @param  bool  $descending
      * @return bool
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
     {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -603,6 +603,10 @@ trait BuildsQueries
      */
     protected function getPaginatorClassForModel(string $default): string
     {
+        if (! method_exists($this, 'getModel')) {
+            return $default;
+        }
+
         $modelClass = get_class($this->getModel());
         $reflectionClass = new ReflectionClass($modelClass);
         $attributes = $reflectionClass->getAttributes(\Illuminate\Database\Eloquent\Attributes\PaginatedBy::class);

--- a/src/Illuminate/Database/Eloquent/Attributes/PaginatedBy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/PaginatedBy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class PaginatedBy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<\Illuminate\Pagination\LengthAwarePaginator>|null  $lengthAware
+     * @param  class-string<\Illuminate\Pagination\Paginator>|null  $simple
+     * @param  class-string<\Illuminate\Pagination\CursorPaginator>|null  $cursor
+     */
+    public function __construct(
+        public ?string $lengthAware = null,
+        public ?string $simple = null,
+        public ?string $cursor = null,
+    ) {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1073,12 +1073,14 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query.
      *
+     * @template TLengthPaginator of \Illuminate\Pagination\LengthAwarePaginator
+     *
      * @param  int|null|\Closure  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
      * @param  \Closure|int|null  $total
-     * @return \Illuminate\Pagination\LengthAwarePaginator
+     * @return TLengthPaginator
      *
      * @throws \InvalidArgumentException
      */
@@ -1103,11 +1105,13 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a simple paginator.
      *
+     * @template TSimplePaginator of \Illuminate\Contracts\Pagination\Paginator
+     *
      * @param  int|null  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return TSimplePaginator
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
@@ -1129,11 +1133,13 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a cursor paginator.
      *
+     * @template TCursorPaginator of \Illuminate\Contracts\Pagination\CursorPaginator
+     *
      * @param  int|null  $perPage
      * @param  array|string  $columns
      * @param  string  $cursorName
      * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
-     * @return \Illuminate\Contracts\Pagination\CursorPaginator
+     * @return TCursorPaginator
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1073,14 +1073,12 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query.
      *
-     * @template TLengthPaginator of \Illuminate\Pagination\LengthAwarePaginator
-     *
      * @param  int|null|\Closure  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
      * @param  \Closure|int|null  $total
-     * @return TLengthPaginator
+     * @return \Illuminate\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */
@@ -1105,13 +1103,11 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a simple paginator.
      *
-     * @template TSimplePaginator of \Illuminate\Contracts\Pagination\Paginator
-     *
      * @param  int|null  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return TSimplePaginator
+     * @return \Illuminate\Contracts\Pagination\Paginator
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
@@ -1133,13 +1129,11 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a cursor paginator.
      *
-     * @template TCursorPaginator of \Illuminate\Contracts\Pagination\CursorPaginator
-     *
      * @param  int|null  $perPage
      * @param  array|string  $columns
      * @param  string  $cursorName
      * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
-     * @return TCursorPaginator
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {


### PR DESCRIPTION
### Summary

This PR introduces support for customizing paginator classes per Eloquent model using a new PHP attribute:
```php
#[PaginatedBy(
    lengthAware: \App\Pagination\CustomLengthPaginator::class,
    simple: \App\Pagination\CustomSimplePaginator::class,
    cursor: \App\Pagination\CustomCursorPaginator::class,
)]
final class User extends Model {}
```
When applied, Eloquent’s paginate(), simplePaginate() and cursorPaginate() methods will now automatically use the defined paginator classes instead of the default Laravel implementations.

### Example

```php
#[PaginatedBy(lengthAware: \App\Pagination\ApiPaginator::class)]
final class Product extends Model {}

Product::query()->paginate(10); // returns instance of ApiPaginator
```