### PR TITLE
Add config option to ignore view cache timestamps

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -33,4 +33,21 @@ return [
         realpath(storage_path('framework/views'))
     ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Ignore view cache timestamps
+    |--------------------------------------------------------------------------
+    |
+    | This option determines whether timestamps of cached views should be
+    | ignored. You should only enable this if you have pre-compiled all views
+    | with `artisan view:cache`. Whenever a view templates changes, you must
+    | run this command again to update the view cache.
+    |
+    */
+
+    'ignore_cache_timestamps' => env(
+        'VIEW_CACHE_IGNORE_TIMESTAMPS',
+        false
+    ),
+
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -33,21 +33,4 @@ return [
         realpath(storage_path('framework/views'))
     ),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Ignore view cache timestamps
-    |--------------------------------------------------------------------------
-    |
-    | This option determines whether timestamps of cached views should be
-    | ignored. You should only enable this if you have pre-compiled all views
-    | with `artisan view:cache`. Whenever a view templates changes, you must
-    | run this command again to update the view cache.
-    |
-    */
-
-    'ignore_cache_timestamps' => env(
-        'VIEW_CACHE_IGNORE_TIMESTAMPS',
-        false
-    ),
-
 ];

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -42,14 +42,14 @@ abstract class Compiler
      *
      * @var string
      */
-    protected $compiledExtension;
+    protected $compiledExtension = 'php';
 
     /**
-     * Determines if view cache timestamps should be ignored.
+     * Indicates if view cache timestamps should be checked.
      *
      * @var bool
      */
-    protected $ignoreCacheTimestamps;
+    protected $shouldCheckTimestamps;
 
     /**
      * Create a new compiler instance.
@@ -58,6 +58,7 @@ abstract class Compiler
      * @param  string  $cachePath
      * @param  string  $basePath
      * @param  bool  $shouldCache
+     * @param  bool  $shouldCheckTimestamps
      * @param  string  $compiledExtension
      *
      * @throws \InvalidArgumentException
@@ -68,7 +69,7 @@ abstract class Compiler
         $basePath = '',
         $shouldCache = true,
         $compiledExtension = 'php',
-        $ignoreCacheTimestamps = false,
+        $shouldCheckTimestamps = true,
     ) {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
@@ -79,7 +80,7 @@ abstract class Compiler
         $this->basePath = $basePath;
         $this->shouldCache = $shouldCache;
         $this->compiledExtension = $compiledExtension;
-        $this->ignoreCacheTimestamps = $ignoreCacheTimestamps;
+        $this->shouldCheckTimestamps = $shouldCheckTimestamps;
     }
 
     /**
@@ -103,10 +104,6 @@ abstract class Compiler
      */
     public function isExpired($path)
     {
-        if ($this->ignoreCacheTimestamps) {
-            return false;
-        }
-
         if (! $this->shouldCache) {
             return true;
         }
@@ -118,6 +115,10 @@ abstract class Compiler
         // of the views is less than the modification times of the compiled views.
         if (! $this->files->exists($compiled)) {
             return true;
+        }
+
+        if (! $this->shouldCheckTimestamps) {
+            return false;
         }
 
         try {

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -42,7 +42,14 @@ abstract class Compiler
      *
      * @var string
      */
-    protected $compiledExtension = 'php';
+    protected $compiledExtension;
+
+    /**
+     * Determines if view cache timestamps should be ignored.
+     *
+     * @var bool
+     */
+    protected $ignoreCacheTimestamps;
 
     /**
      * Create a new compiler instance.
@@ -61,6 +68,7 @@ abstract class Compiler
         $basePath = '',
         $shouldCache = true,
         $compiledExtension = 'php',
+        $ignoreCacheTimestamps = false,
     ) {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
@@ -71,6 +79,7 @@ abstract class Compiler
         $this->basePath = $basePath;
         $this->shouldCache = $shouldCache;
         $this->compiledExtension = $compiledExtension;
+        $this->ignoreCacheTimestamps = $ignoreCacheTimestamps;
     }
 
     /**
@@ -94,6 +103,10 @@ abstract class Compiler
      */
     public function isExpired($path)
     {
+        if ($this->ignoreCacheTimestamps) {
+            return false;
+        }
+
         if (! $this->shouldCache) {
             return true;
         }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -100,6 +100,7 @@ class ViewServiceProvider extends ServiceProvider
                 $app['config']->get('view.relative_hash', false) ? $app->basePath() : '',
                 $app['config']->get('view.cache', true),
                 $app['config']->get('view.compiled_extension', 'php'),
+                $app['config']->get('view.ignore_cache_timestamps', false),
             ), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -100,7 +100,7 @@ class ViewServiceProvider extends ServiceProvider
                 $app['config']->get('view.relative_hash', false) ? $app->basePath() : '',
                 $app['config']->get('view.cache', true),
                 $app['config']->get('view.compiled_extension', 'php'),
-                $app['config']->get('view.ignore_cache_timestamps', false),
+                $app['config']->get('view.check_cache_timestamps', true),
             ), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -57,7 +57,8 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testIsExpiredReturnsFalseWhenIgnoreCacheTimestampsIsTrue()
     {
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__, ignoreCacheTimestamps: true);
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, shouldCheckTimestamps: false);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.hash('xxh128', 'v2foo').'.php')->andReturn(true);
         $this->assertFalse($compiler->isExpired('foo'));
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -51,7 +51,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testIsExpiredReturnsTrueWhenUseCacheIsFalse()
     {
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, $basePath = '', $useCache = false);
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, shouldCache: false);
         $this->assertTrue($compiler->isExpired('foo'));
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -55,6 +55,12 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
+    public function testIsExpiredReturnsFalseWhenIgnoreCacheTimestampsIsTrue()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, ignoreCacheTimestamps: true);
+        $this->assertFalse($compiler->isExpired('foo'));
+    }
+
     public function testCompilePathIsProperlyCreated()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
When running in a read-only filesystem container with views pre-cached at build time, Laravel checks if the cached view's timestamp is older than the source's to decide when to recompile. This is fine as long as we do not make OCI image builds reproducible.
If we do however, the timestamps match (because timestamps of all files are set to 01.01.1970), so Laravel recompiles the view, tries to write to a read-only filesystem and the container crashes.

This patch introduces a new config option `view.ignore_cache_timestamps` which does exactly what the name suggests.

This renders #55450 and #55517 obsolete, at least for the scenario described above.