### PR TITLE
Add JSON serialization consistency for empty arrays to objects

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -59,7 +59,7 @@ use function Illuminate\Support\enum_value;
  */
 trait EnumeratesValues
 {
-    use Conditionable;
+    use Conditionable, EnforcesJsonObjectSerialization;
 
     /**
      * Indicates that the object's string representation should be escaped when __toString is invoked.
@@ -959,11 +959,11 @@ trait EnumeratesValues
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array<TKey, mixed>
+     * @return array<TKey, mixed>|object
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): array|object
     {
-        return array_map(function ($value) {
+        $items = array_map(function ($value) {
             if ($value instanceof JsonSerializable) {
                 return $value->jsonSerialize();
             } elseif ($value instanceof Jsonable) {
@@ -974,6 +974,8 @@ trait EnumeratesValues
 
             return $value;
         }, $this->all());
+
+        return $this->enforceJsonObjectSerialization($items);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
+use Illuminate\Support\Traits\EnforcesJsonObjectSerialization;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
@@ -41,7 +42,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
         Concerns\TransformsToResource,
-        ForwardsCalls;
+        ForwardsCalls,
+        EnforcesJsonObjectSerialization;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
 
@@ -1760,7 +1762,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function jsonSerialize(): mixed
     {
-        return $this->toArray();
+        $data = $this->toArray();
+
+        return $this->enforceJsonObjectSerialization($data);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -12,12 +12,13 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
+use Illuminate\Support\Traits\EnforcesJsonObjectSerialization;
 use JsonException;
 use JsonSerializable;
 
 class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
 {
-    use ConditionallyLoadsAttributes, DelegatesToResource;
+    use ConditionallyLoadsAttributes, DelegatesToResource, EnforcesJsonObjectSerialization;
 
     /**
      * The resource instance.
@@ -247,10 +248,12 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Prepare the resource for JSON serialization.
      *
-     * @return array
+     * @return array|object
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): array|object
     {
-        return $this->resolve(Container::getInstance()->make('request'));
+        $data = $this->resolve(Container::getInstance()->make('request'));
+
+        return $this->enforceJsonObjectSerialization($data);
     }
 }

--- a/src/Illuminate/Support/Traits/EnforcesJsonObjectSerialization.php
+++ b/src/Illuminate/Support/Traits/EnforcesJsonObjectSerialization.php
@@ -70,4 +70,3 @@ trait EnforcesJsonObjectSerialization
         return $this;
     }
 }
-

--- a/src/Illuminate/Support/Traits/EnforcesJsonObjectSerialization.php
+++ b/src/Illuminate/Support/Traits/EnforcesJsonObjectSerialization.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait EnforcesJsonObjectSerialization
+{
+    /**
+     * The attributes that should always be serialized as JSON objects.
+     *
+     * @var list<string>
+     */
+    protected array $serializeAsObjects = [];
+
+    /**
+     * Determines if empty arrays should be cast to objects when serialized to JSON.
+     */
+    protected bool $serializeEmptyAsObject = false;
+
+    /**
+     * Convert empty arrays to objects during JSON serialization based on configuration.
+     *
+     * This method handles two use cases:
+     * 1. Converting an entire empty array/collection to an object (useful for collections)
+     * 2. Converting specific attributes to objects regardless of their content (useful for models)
+     */
+    protected function enforceJsonObjectSerialization(array $data): array|object
+    {
+        // Fast path for collection case - entire dataset as object when empty
+        if (empty($data) && $this->serializeEmptyAsObject) {
+            return (object) [];
+        }
+
+        // Fast path for attribute case - if no attributes configured or data is empty
+        if (empty($data) || empty($this->serializeAsObjects)) {
+            return $data;
+        }
+
+        // Handle specific attributes
+        foreach ($this->serializeAsObjects as $attribute) {
+            // Only transform arrays, preserve null values
+            if (isset($data[$attribute]) && is_array($data[$attribute]) && empty($data[$attribute])) {
+                $data[$attribute] = (object) [];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Configure collection to be serialized as an object when empty.
+     */
+    public function serializeEmptyAsObject(bool $value = true): static
+    {
+        $this->serializeEmptyAsObject = $value;
+
+        return $this;
+    }
+
+    /**
+     * Configure specific attributes to be serialized as objects.
+     *
+     * @param  list<string>|string  $attributes
+     */
+    public function serializeAttributesAsObjects(array|string $attributes): static
+    {
+        $this->serializeAsObjects = is_array($attributes)
+            ? $attributes
+            : func_get_args();
+
+        return $this;
+    }
+}
+

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3285,6 +3285,40 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
     }
 
+    public function testJsonSerialization()
+    {
+        // Create a custom model stub
+        $model = new class extends Model {};
+
+        // Set test data - use a property without a mutator
+        $model->name = 'foo';
+        $model->empty_array = [];
+
+        // First check normal serialization
+        $json = $model->toJson();
+        $decoded = json_decode($json);
+        $this->assertIsArray($decoded->empty_array);
+
+        // Apply our trait functionality
+        $model->serializeAttributesAsObjects(['empty_array']);
+
+        // Re-serialize and verify transformation
+        $json = $model->toJson();
+        $decoded = json_decode($json);
+        $this->assertIsObject($decoded->empty_array);
+
+        // Test empty model serialization
+        $emptyModel = new class extends Model {};
+
+        // Default behavior should be empty array
+        $emptyJson = $emptyModel->toJson();
+        $this->assertSame('[]', $emptyJson);
+
+        // Configure for empty object
+        $emptyModel->serializeEmptyAsObject();
+        $this->assertSame('{}', $emptyModel->toJson());
+    }
+
     public function testFillableWithMutators()
     {
         $model = new EloquentModelWithMutators;

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MissingValue;
 use Mockery as m;
@@ -45,5 +46,66 @@ class JsonResourceTest extends TestCase
         $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
 
         $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
+    }
+
+    public function testJsonResourceEmptyAttributesSerializeAsObjects()
+    {
+        // Create a request mock
+        $request = new Request();
+        app()->instance('request', $request);
+
+        // Create a test model with empty array attributes
+        $model = new class extends Model {
+            protected $attributes = [
+                'settings' => [],
+                'options' => [],
+                'meta' => [],
+            ];
+        };
+
+        // Create a resource and specify which attribute should be serialized as an object
+        $resource = new class($model) extends JsonResource {
+            public function toArray($request)
+            {
+                return [
+                    'settings' => $this->settings,
+                    'options' => $this->options,
+                    'meta' => $this->meta,
+                ];
+            }
+        };
+
+        // Configure only 'settings' to be serialized as an object
+        $resource->serializeAttributesAsObjects(['settings']);
+
+        // Convert to JSON and decode for assertions
+        $json = $resource->toJson();
+        $decoded = json_decode($json);
+
+        // Assert that 'settings' is an object but other empty arrays remain as arrays
+        $this->assertIsObject($decoded->settings);
+        $this->assertIsArray($decoded->options);
+        $this->assertIsArray($decoded->meta);
+    }
+
+    public function testJsonResourceEmptyResultSerializesAsObject()
+    {
+        // Create a request mock
+        $request = new Request();
+        app()->instance('request', $request);
+
+        // Create an empty resource
+        $resource = new class([]) extends JsonResource {
+            public function toArray($request)
+            {
+                return [];
+            }
+        };
+
+        // Configure the resource to serialize empty results as objects
+        $resource->serializeEmptyAsObject();
+
+        // The result should be {} instead of []
+        $this->assertSame('{}', $resource->toJson());
     }
 }

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -55,7 +55,8 @@ class JsonResourceTest extends TestCase
         app()->instance('request', $request);
 
         // Create a test model with empty array attributes
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
             protected $attributes = [
                 'settings' => [],
                 'options' => [],
@@ -64,7 +65,8 @@ class JsonResourceTest extends TestCase
         };
 
         // Create a resource and specify which attribute should be serialized as an object
-        $resource = new class($model) extends JsonResource {
+        $resource = new class($model) extends JsonResource
+        {
             public function toArray($request)
             {
                 return [
@@ -95,7 +97,8 @@ class JsonResourceTest extends TestCase
         app()->instance('request', $request);
 
         // Create an empty resource
-        $resource = new class([]) extends JsonResource {
+        $resource = new class([]) extends JsonResource
+        {
             public function toArray($request)
             {
                 return [];

--- a/tests/Support/EnforcesJsonObjectSerializationTest.php
+++ b/tests/Support/EnforcesJsonObjectSerializationTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Traits\EnforcesJsonObjectSerialization;
+use PHPUnit\Framework\TestCase;
 
 class EnforcesJsonObjectSerializationTest extends TestCase
 {

--- a/tests/Support/EnforcesJsonObjectSerializationTest.php
+++ b/tests/Support/EnforcesJsonObjectSerializationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Traits\EnforcesJsonObjectSerialization;
+
+class EnforcesJsonObjectSerializationTest extends TestCase
+{
+    public function testEmptyArrayIsSerializedAsObject()
+    {
+        $collection = new TestCollection([]);
+        $collection->serializeEmptyAsObject();
+
+        $json = json_encode($collection);
+
+        $this->assertSame('{}', $json);
+    }
+
+    public function testNonEmptyArrayIsSerializedAsArray()
+    {
+        $collection = new TestCollection(['item1', 'item2']);
+        $collection->serializeEmptyAsObject();
+
+        $json = json_encode($collection);
+
+        $this->assertSame('["item1","item2"]', $json);
+    }
+
+    public function testEmptyAttributeIsSerializedAsObject()
+    {
+        $model = new TestModel([
+            'name' => 'Test',
+            'meta' => [],
+            'settings' => [],
+        ]);
+        $model->serializeAttributesAsObjects(['meta']);
+
+        $json = json_encode($model);
+        $decoded = json_decode($json, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('Test', $decoded['name']);
+        $this->assertIsObject(json_decode($json)->meta);
+        $this->assertIsArray(json_decode($json)->settings);
+    }
+
+    public function testMultipleAttributesAreSerializedAsObjects()
+    {
+        $model = new TestModel([
+            'name' => 'Test',
+            'meta' => [],
+            'settings' => [],
+            'options' => [],
+        ]);
+        $model->serializeAttributesAsObjects(['meta', 'options']);
+
+        $json = json_encode($model);
+        $decoded = json_decode($json);
+
+        $this->assertIsObject($decoded->meta);
+        $this->assertIsObject($decoded->options);
+        $this->assertIsArray($decoded->settings);
+    }
+
+    public function testNullAttributeRemainsNull()
+    {
+        $model = new TestModel([
+            'name' => 'Test',
+            'meta' => null,
+        ]);
+        $model->serializeAttributesAsObjects(['meta']);
+
+        $json = json_encode($model);
+        $decoded = json_decode($json);
+
+        $this->assertNull($decoded->meta);
+    }
+
+    public function testAcceptsStringArgumentForSingleAttribute()
+    {
+        $model = new TestModel([
+            'name' => 'Test',
+            'meta' => [],
+        ]);
+        $model->serializeAttributesAsObjects('meta');
+
+        $json = json_encode($model);
+        $decoded = json_decode($json);
+
+        $this->assertIsObject($decoded->meta);
+    }
+
+    public function testDefaultBehaviorDoesNotModifySerialization()
+    {
+        $collection = new TestCollection([]);
+        $json = json_encode($collection);
+
+        $this->assertSame('[]', $json);
+
+        $model = new TestModel([
+            'meta' => [],
+        ]);
+        $json = json_encode($model);
+        $decoded = json_decode($json);
+
+        $this->assertIsArray($decoded->meta);
+    }
+}
+
+// Test helper classes
+
+class TestCollection implements \JsonSerializable
+{
+    use EnforcesJsonObjectSerialization;
+
+    protected array $items;
+
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->enforceJsonObjectSerialization($this->items);
+    }
+}
+
+class TestModel implements \JsonSerializable
+{
+    use EnforcesJsonObjectSerialization;
+
+    protected array $attributes;
+
+    public function __construct(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->enforceJsonObjectSerialization($this->attributes);
+    }
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -664,6 +664,29 @@ class SupportCollectionTest extends TestCase
         $this->assertJsonStringEqualsJsonString(json_encode(['foo']), (string) $c);
     }
 
+    public function testEmptyCollectionSerializedAsObject()
+    {
+        $collection = new Collection([]);
+
+        // Default behavior should serialize empty collection as array
+        $this->assertSame('[]', $collection->toJson());
+
+        // Configure to serialize as an object
+        $collection->serializeEmptyAsObject();
+
+        // Now it should serialize as an object
+        $this->assertSame('{}', $collection->toJson());
+
+        // Test that method is fluent
+        $this->assertSame(
+            $collection,
+            $collection->serializeEmptyAsObject(false)
+        );
+
+        // Test that it returns to default behavior when disabled
+        $this->assertSame('[]', $collection->toJson());
+    }
+
     public function testOffsetAccess()
     {
         $c = new Collection(['name' => 'taylor']);


### PR DESCRIPTION
This PR adds the ability to control how empty arrays are serialized to JSON in Laravel's core classes. The problem is that JSON serialization of empty arrays (`[]`) and associative arrays (`{"key":"value"}`) creates inconsistency:

* Empty arrays serialize as JSON arrays: `[]`
* Associative arrays serialize as JSON objects: `{"key":"value"}`

This causes issues with frontend clients and type systems where an attribute might change its type depending on whether it's empty or not.

## Example 1: Model attributes
```php
$user = new User;
$user->customFields = [];
return $user; // customFields serializes as [] (array)

// Later when populated
$user->customFields = ['foo' => 'bar'];
return $user; // customFields serializes as {"foo":"bar"} (object)
```

With this PR:
```php
$user = new User;
$user->customFields = [];
$user->serializeAttributesAsObjects(['customFields']);
return $user; // customFields now serializes as {} (object)
```

## Example 2: Empty collection
```php
// Before: empty collection serializes as [] (array)
return collect([])->toJson(); // "[]"

// After: can be serialized as {} (object)
return collect([])->serializeEmptyAsObject()->toJson(); // "{}"
```

## Why this matters
1) **Frontend Type Consistency**: Prevents type errors in TypeScript or other typed frameworks
2) **Client Expectations**: APIs should return consistent data structures
3) **GraphQL/OpenAPI Compatibility**: Schema definitions often expect consistent types
This is implemented with minimal overhead using a trait that's applied to Model, Collection, and JsonResource to provide consistent behavior across the framework.

-----

Note: No documentation has been added yet, as I'd like to confirm the approach meets the project's expectations before adding it to the docs.