### PR TITLE
[12.x] Add filterByRegex Method to Collection 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1922,4 +1922,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Filter the collection by matching values against a regular expression.
+     *
+     * @param  string  $regex
+     * @param  string|int|null  $key
+     * @return static
+     */
+    public function filterByRegex($regex, $key = null)
+    {
+        return $this->filter(fn ($item) => preg_match($regex, data_get($item, $key)) === 1);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5683,6 +5683,47 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    public function testFilterByRegex()
+    {
+        $data = new Collection(['php', 'laravel', 'python', 'pascal']);
+        $result = $data->filterByRegex('/^p/');
+        $this->assertSame(['php', 'python', 'pascal'], array_values($result->toArray()));
+
+        $data = new Collection([
+            ['email' => 'foo@gmail.com'],
+            ['email' => 'bar@yahoo.com'],
+            ['email' => 'baz@gmail.com'],
+        ]);
+        $result = $data->filterByRegex('/@gmail\.com$/', 'email');
+        $this->assertSame([
+            ['email' => 'foo@gmail.com'],
+            ['email' => 'baz@gmail.com'],
+        ], array_values($result->toArray()));
+
+        $data = new Collection([
+            ['user' => ['profile' => ['bio' => 'I love PHP']]],
+            ['user' => ['profile' => ['bio' => 'I prefer JS']]],
+            ['user' => ['profile' => ['bio' => 'PHP developer']]],
+        ]);
+        $result = $data->filterByRegex('/PHP/', 'user.profile.bio');
+        $this->assertSame([
+            ['user' => ['profile' => ['bio' => 'I love PHP']]],
+            ['user' => ['profile' => ['bio' => 'PHP developer']]],
+        ], array_values($result->toArray()));
+
+        $data = new Collection([
+            ['email' => 'admin@example.com', 'role' => 'admin', 'status' => 'active'],
+            ['email' => 'user@example.com', 'role' => 'user', 'status' => 'inactive'],
+            ['email' => 'manager@example.com', 'role' => 'manager', 'status' => 'active'],
+        ]);
+        $result = $data->filterByRegex('/^ad/', 'role')->filterByRegex('/^active$/', 'status');
+
+        $this->assertSame([
+            ['email' => 'admin@example.com', 'role' => 'admin', 'status' => 'active'],
+        ], array_values($result->toArray()));
+    }
+
+
     /**
      * Provides each collection class, respectively.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5723,7 +5723,6 @@ class SupportCollectionTest extends TestCase
         ], array_values($result->toArray()));
     }
 
-
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
This PR adds a new method `filterByRegex` to the `Collection` class. The method enables filtering collections using regular expressions, making complex regex-based filtering operations easier.✨
This feature was previously discussed in https://github.com/laravel/framework/discussions/55147. 🔍

Currently, filtering a collection by regex requires doing this:

```php
$collection->filter(function ($item) {
    return preg_match('/PHP/', $item['user']['profile']['bio']);
});
```

After this change, it becomes much more concise:

```php
$collection->filterByRegex('/PHP/', 'user.profile.bio');
```
This changes enables more flexibility by allowing the combination of multiple `filterByRegex` calls or using it alongside other methods for complex queries.🔄
It also makes using regex in collections easier and more readable.📝
Test coverage has been added for this change to ensure proper functionality. ✅