### PR TITLE
[12.x] Improve circular relation check in Automatic Relation Loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -761,7 +761,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         foreach ($this as $model) {
             if (! $model->hasRelationAutoloadCallback()) {
-                $model->autoloadRelationsUsing($callback);
+                $model->autoloadRelationsUsing($callback, $this);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -125,7 +125,7 @@ trait HasRelationships
      */
     public function autoloadRelationsUsing(Closure $callback, $context = null)
     {
-        // prevent circular relation autoloading
+        // Prevent circular relation autoloading...
         if ($context && $this->relationAutoloadContext === $context) {
             return $this;
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -182,9 +182,15 @@ trait HasRelationships
 
         $callback = fn (array $tuples) => $this->invokeRelationAutoloadCallbackFor($key, $tuples);
 
+        if (! is_array($context)) {
+            $context = $context ? [$context] : [];
+        }
+
+        $context[] = $this;
+
         foreach ($models as $model) {
             // Check if relation autoload contexts are different to avoid circular relation autoload...
-            if ((is_null($context) || $context !== $model) && is_object($model) && method_exists($model, 'autoloadRelationsUsing')) {
+            if (array_search($model, $context, true) !== false) {
                 $model->autoloadRelationsUsing($callback, $context);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1120,7 +1120,7 @@ trait HasRelationships
     {
         $this->relations[$relation] = $value;
 
-        $this->propagateRelationAutoloadCallbackToRelation($relation, $value, $this);
+        $this->propagateRelationAutoloadCallbackToRelation($relation, $value);
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -61,6 +61,8 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $this->assertCount(2, DB::getQueryLog());
         $this->assertCount(3, $likes);
         $this->assertTrue($posts[0]->comments[0]->relationLoaded('likes'));
+
+        DB::disableQueryLog();
     }
 
     public function testRelationAutoloadForSingleModel()
@@ -81,9 +83,12 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
             $likes = array_merge($likes, $comment->likes->all());
         }
 
+
         $this->assertCount(2, DB::getQueryLog());
         $this->assertCount(2, $likes);
         $this->assertTrue($post->comments[0]->relationLoaded('likes'));
+
+        DB::disableQueryLog();
     }
 
     public function testRelationAutoloadWithSerialization()
@@ -106,9 +111,29 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
             $likes = array_merge($likes, $comment->likes->all());
         }
 
+
         $this->assertCount(2, DB::getQueryLog());
 
         Model::automaticallyEagerLoadRelationships(false);
+
+        DB::disableQueryLog();
+    }
+
+    public function testRelationAutoloadWithCircularRelations()
+    {
+        $post = Post::create();
+        $comment1 = $post->comments()->create(['parent_id' => null]);
+        $comment2 = $post->comments()->create(['parent_id' => $comment1->id]);
+
+        DB::enableQueryLog();
+
+        $post->withRelationshipAutoloading();
+        $comment = $post->comments->first();
+        $comment->setRelation('post', $post);
+
+        $this->assertCount(1, DB::getQueryLog());
+
+        DB::disableQueryLog();
     }
 
     public function testRelationAutoloadWithChaperoneRelations()
@@ -129,6 +154,8 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $this->assertCount(2, DB::getQueryLog());
 
         Model::automaticallyEagerLoadRelationships(false);
+
+        DB::disableQueryLog();
     }
 
     public function testRelationAutoloadVariousNestedMorphRelations()
@@ -183,6 +210,8 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $this->assertCount(2, $videos);
         $this->assertTrue($videoLike->relationLoaded('likeable'));
         $this->assertTrue($videoLike->likeable->relationLoaded('commentable'));
+
+        DB::disableQueryLog();
     }
 }
 

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -83,7 +83,6 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
             $likes = array_merge($likes, $comment->likes->all());
         }
 
-
         $this->assertCount(2, DB::getQueryLog());
         $this->assertCount(2, $likes);
         $this->assertTrue($post->comments[0]->relationLoaded('likes'));
@@ -110,7 +109,6 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         foreach ($post->comments as $comment) {
             $likes = array_merge($likes, $comment->likes->all());
         }
-
 
         $this->assertCount(2, DB::getQueryLog());
 

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -122,6 +122,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $post = Post::create();
         $comment1 = $post->comments()->create(['parent_id' => null]);
         $comment2 = $post->comments()->create(['parent_id' => $comment1->id]);
+        $post->likes()->create();
 
         DB::enableQueryLog();
 
@@ -129,7 +130,9 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         $comment = $post->comments->first();
         $comment->setRelation('post', $post);
 
-        $this->assertCount(1, DB::getQueryLog());
+        $this->assertCount(1, $post->likes);
+
+        $this->assertCount(2, DB::getQueryLog());
 
         DB::disableQueryLog();
     }


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/55526

In some cases, an infinite loop could occur — for example, when using Chaperone together with Automatic Relation Loading.

We can reproduce infinite loop:
```php
Model::automaticallyEagerLoadRelationships();

$user = User::first();
$post = $user->posts->first();

// make a circular relation
$post->setRelation('user', $user);

// trigger autoload for another relation
dump($user->comments);
```
Now we have a reference to the shared context, and we can check if it’s the same to prevent an infinite loop.