### PR TITLE
[12.x] test PhpEngine error handling

### DIFF
--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use Error;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Engines\PhpEngine;
 use PHPUnit\Framework\TestCase;

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -14,4 +14,13 @@ class ViewPhpEngineTest extends TestCase
         $this->assertSame('Hello World
 ', $engine->get(__DIR__.'/fixtures/basic.php'));
     }
+
+    public function testErrorInViewThrowsException()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to undefined function undefinedFunction()');
+
+        $engine = new PhpEngine(new Filesystem);
+        $engine->get(__DIR__.'/fixtures/error.php');
+    }
 }

--- a/tests/View/fixtures/error.php
+++ b/tests/View/fixtures/error.php
@@ -1,0 +1,4 @@
+<?php
+
+// Intentionally cause an error by calling undefined function
+undefinedFunction(); 

--- a/tests/View/fixtures/error.php
+++ b/tests/View/fixtures/error.php
@@ -1,4 +1,3 @@
 <?php
 
-// Intentionally cause an error by calling undefined function
-undefinedFunction(); 
+undefinedFunction();


### PR DESCRIPTION
This PR adds a test for error handling in the `PhpEngine `class, which was previously untested.

### Changes Made
- Added `testErrorInViewThrowsException()` test method to verify error propagation
- Created `error.php` fixture file to simulate PHP runtime errors
- Tests that undefined function errors are properly caught and thrown

### Related
- Improves test coverage for `Illuminate\View\Engines\PhpEngine`
- Specifically tests the error handling path in `handleViewException()`