### PR TITLE
[12.x] Fix double query in model relation serialization

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -107,7 +107,7 @@ trait SerializesAndRestoresModelIdentifiers
     {
         return $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->firstOrFail()->load($value->relations ?? []);
+        )->useWritePdo()->firstOrFail()->loadMissing($value->relations ?? []);
     }
 
     /**

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -31,6 +31,8 @@ class ModelSerializationTest extends TestCase
     {
         parent::setUp();
 
+        Model::preventLazyLoading(false);
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -163,6 +163,28 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($unSerialized->order->getRelations(), $order->getRelations());
     }
 
+    public function testItReloadsRelationshipsOnlyOnce()
+    {
+        $order = tap(ModelSerializationTestCustomOrder::create(), function (ModelSerializationTestCustomOrder $order) {
+            $order->wasRecentlyCreated = false;
+        });
+
+        $product1 = Product::create();
+        $product2 = Product::create();
+
+        Line::create(['order_id' => $order->id, 'product_id' => $product1->id]);
+        Line::create(['order_id' => $order->id, 'product_id' => $product2->id]);
+
+        $order->load('line', 'lines', 'products');
+
+        $this->expectsDatabaseQueryCount(4);
+
+        $serialized = serialize(new ModelRelationSerializationTestClass($order));
+        $unSerialized = unserialize($serialized);
+
+        $this->assertEquals($unSerialized->order->getRelations(), $order->getRelations());
+    }
+
     public function testItReloadsNestedRelationships()
     {
         $order = tap(Order::create(), function (Order $order) {
@@ -432,6 +454,29 @@ class ModelSerializationTestCustomUser extends Model
     public function newCollection(array $models = [])
     {
         return new ModelSerializationTestCustomUserCollection($models);
+    }
+}
+
+class ModelSerializationTestCustomOrder extends Model
+{
+    public $table = 'orders';
+    public $guarded = [];
+    public $timestamps = false;
+    public $with = ['line', 'lines', 'products'];
+
+    public function line()
+    {
+        return $this->hasOne(Line::class, 'order_id');
+    }
+
+    public function lines()
+    {
+        return $this->hasMany(Line::class, 'order_id');
+    }
+
+    public function products()
+    {
+        return $this->belongsToMany(Product::class, 'lines', 'order_id');
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Why
When a model has an eager-loaded relation through `$with`, the unserialization process ends up loading the relation twice (first through `$with` and then again when loading the relations that were serialized). Issue #55546 highlights what this PR tries to fix.

I created a repo that reproduces this error: https://github.com/AndrewMast/laravel-testing/tree/issue-55546 (see [diff](https://github.com/AndrewMast/laravel-testing/compare/main...issue-55546)).

## What
The `restoreModel()` method in `SerializesAndRestoresModelIdentifiers.php` uses the `load` method to fetch all the serialized relations. However, this leads to the double query for relations already loaded (i.e. in `$with`). Changing `load` to `loadMissing` resolves this issue.