### PR TITLE
[12.x] Pass flags to custom Json::$encoder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Json.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Json.php
@@ -23,7 +23,9 @@ class Json
      */
     public static function encode(mixed $value, int $flags = 0): mixed
     {
-        return isset(static::$encoder) ? (static::$encoder)($value) : json_encode($value, $flags);
+        return isset(static::$encoder)
+            ? (static::$encoder)($value, $flags)
+            : json_encode($value, $flags);
     }
 
     /**


### PR DESCRIPTION
While reading through closed PR #55537, I realized one could use a custom JSON encoder for Eloquent's built-in casters, by providing a custom callable implementation using:

```php
// assuming MyJsonEncoder is an invokable class,
// this method accepts any callable
Illuminate\Database\Eloquent\Casts\Json::encodeUsing(new MyJsonEncoder());
```

Then I remembered that, I recently migrated a project from Laravel 8, to Laravel 12, which uses a custom encoder, in a very similar fashion.

But as on Laravel 8, this class wasn't available (it was introduced on Laravel 10, by PR #46552), I ended up duplicating some of the built-in casters to make use of this encoder.

While reviewing the code to simplify it using this approach, I noticed my custom encoder accepts the `$flags` from the caster, which the built-in encoder does not.

This PR:

- Updates the `Illuminate\Database\Eloquent\Casts\Json::encode()` method to pass the `$flags` argument down to a user provided encoder.

Note: the symmetric `Json::decode()` static method, already passes the `$associative` argument down to a user provided decoder.
