### PR TITLE
[12.x] Remove Markdown mail settings from core config to match laravel/laravel

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -115,23 +115,4 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Markdown Mail Settings
-    |--------------------------------------------------------------------------
-    |
-    | If you are using Markdown based email rendering, you may configure your
-    | theme and component paths here, allowing you to customize the design
-    | of the emails. Or, you may simply stick with the Laravel defaults!
-    |
-    */
-
-    'markdown' => [
-        'theme' => env('MAIL_MARKDOWN_THEME', 'default'),
-
-        'paths' => [
-            resource_path('views/vendor/mail'),
-        ],
-    ],
-
 ];


### PR DESCRIPTION
**Description:**

Following up on the recent change made by Taylor in https://github.com/laravel/laravel/pull/6594/commits/71ae79305477df6975ef1382aaffe6281f2ebbc9, where the markdown section was removed from `config/mail.php`, I noticed that this section still exists in the core’s mail config.

To maintain consistency between the framework’s published config and the one in the application skeleton, I suggest removing the markdown mail settings from the core as well, unless there's a specific reason to retain it only in the core.