### PR TITLE
[12.x] Use pendingAttributes of relationships when creating relationship models via model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -50,7 +50,9 @@ class BelongsToManyRelationship
      */
     public function createFor(Model $model)
     {
-        Collection::wrap($this->factory instanceof Factory ? $this->factory->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
+        $relationship = $model->{$this->relationship}();
+
+        Collection::wrap($this->factory instanceof Factory ? $this->factory->prependState($relationship->getQuery()->pendingAttributes)->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
             $model->{$this->relationship}()->attach(
                 $attachable,
                 is_callable($this->pivot) ? call_user_func($this->pivot, $model) : $this->pivot

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -531,6 +531,21 @@ abstract class Factory
     }
 
     /**
+     * Prepend a new state transformation to the model definition.
+     *
+     * @param  (callable(array<string, mixed>, TModel|null): array<string, mixed>)|array<string, mixed>  $state
+     * @return static
+     */
+    public function prependState($state)
+    {
+        return $this->newInstance([
+            'states' => $this->states->prepend(
+                is_callable($state) ? $state : fn () => $state,
+            ),
+        ]);
+    }
+
+    /**
      * Set a single model attribute.
      *
      * @param  string|int  $key

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -49,13 +49,15 @@ class Relationship
             $this->factory->state([
                 $relationship->getMorphType() => $relationship->getMorphClass(),
                 $relationship->getForeignKeyName() => $relationship->getParentKey(),
-            ])->create([], $parent);
+            ])->prependState($relationship->getQuery()->pendingAttributes)->create([], $parent);
         } elseif ($relationship instanceof HasOneOrMany) {
             $this->factory->state([
                 $relationship->getForeignKeyName() => $relationship->getParentKey(),
-            ])->create([], $parent);
+            ])->prependState($relationship->getQuery()->pendingAttributes)->create([], $parent);
         } elseif ($relationship instanceof BelongsToMany) {
-            $relationship->attach($this->factory->create([], $parent));
+            $relationship->attach(
+                $this->factory->prependState($relationship->getQuery()->pendingAttributes)->create([], $parent)
+            );
         }
     }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -850,6 +850,62 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertEquals(FactoryTestGuessModelFactory::new()->modelName(), FactoryTestGuessModel::class);
     }
 
+    public function test_factory_model_has_many_relationship_has_pending_attributes()
+    {
+        FactoryTestUser::factory()->has(new FactoryTestPostFactory(), 'postsWithFooBarBazAsTitle')->create();
+
+        $this->assertEquals('foo bar baz', FactoryTestPost::first()->title);
+    }
+
+    public function test_factory_model_has_many_relationship_has_pending_attributes_override()
+    {
+        FactoryTestUser::factory()->has((new FactoryTestPostFactory())->state(['title' => 'other title']), 'postsWithFooBarBazAsTitle')->create();
+
+        $this->assertEquals('other title', FactoryTestPost::first()->title);
+    }
+
+    public function test_factory_model_has_one_relationship_has_pending_attributes()
+    {
+        FactoryTestUser::factory()->has(new FactoryTestPostFactory(), 'postWithFooBarBazAsTitle')->create();
+
+        $this->assertEquals('foo bar baz', FactoryTestPost::first()->title);
+    }
+
+    public function test_factory_model_has_one_relationship_has_pending_attributes_override()
+    {
+        FactoryTestUser::factory()->has((new FactoryTestPostFactory())->state(['title' => 'other title']), 'postWithFooBarBazAsTitle')->create();
+
+        $this->assertEquals('other title', FactoryTestPost::first()->title);
+    }
+
+    public function test_factory_model_belongs_to_many_relationship_has_pending_attributes()
+    {
+        FactoryTestUser::factory()->has(new FactoryTestRoleFactory(), 'rolesWithFooBarBazAsName')->create();
+
+        $this->assertEquals('foo bar baz', FactoryTestRole::first()->name);
+    }
+
+    public function test_factory_model_belongs_to_many_relationship_has_pending_attributes_override()
+    {
+        FactoryTestUser::factory()->has((new FactoryTestRoleFactory())->state(['name' => 'other name']), 'rolesWithFooBarBazAsName')->create();
+
+        $this->assertEquals('other name', FactoryTestRole::first()->name);
+    }
+
+    public function test_factory_model_morph_many_relationship_has_pending_attributes()
+    {
+        (new FactoryTestPostFactory())->has(new FactoryTestCommentFactory(), 'commentsWithFooBarBazAsBody')->create();
+
+        $this->assertEquals('foo bar baz', FactoryTestComment::first()->body);
+    }
+
+    public function test_factory_model_morph_many_relationship_has_pending_attributes_override()
+    {
+        (new FactoryTestPostFactory())->has((new FactoryTestCommentFactory())->state(['body' => 'other body']), 'commentsWithFooBarBazAsBody')->create();
+
+        $this->assertEquals('other body', FactoryTestComment::first()->body);
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -895,9 +951,24 @@ class FactoryTestUser extends Eloquent
         return $this->hasMany(FactoryTestPost::class, 'user_id');
     }
 
+    public function postsWithFooBarBazAsTitle()
+    {
+        return $this->hasMany(FactoryTestPost::class, 'user_id')->withAttributes(['title' => 'foo bar baz']);
+    }
+
+    public function postWithFooBarBazAsTitle()
+    {
+        return $this->hasOne(FactoryTestPost::class, 'user_id')->withAttributes(['title' => 'foo bar baz']);
+    }
+
     public function roles()
     {
         return $this->belongsToMany(FactoryTestRole::class, 'role_user', 'user_id', 'role_id')->withPivot('admin');
+    }
+
+    public function rolesWithFooBarBazAsName()
+    {
+        return $this->belongsToMany(FactoryTestRole::class, 'role_user', 'user_id', 'role_id')->withPivot('admin')->withAttributes(['name' => 'foo bar baz']);
     }
 
     public function factoryTestRoles()
@@ -943,6 +1014,11 @@ class FactoryTestPost extends Eloquent
     public function comments()
     {
         return $this->morphMany(FactoryTestComment::class, 'commentable');
+    }
+
+    public function commentsWithFooBarBazAsBody()
+    {
+        return $this->morphMany(FactoryTestComment::class, 'commentable')->withAttributes(['body' => 'foo bar baz']);
     }
 }
 


### PR DESCRIPTION
When a relationship uses the `withAttributes()` method, then those attributes are currently not used when creating a relationship via a parent model factory
```php
class Page extends Model
{
    public function currentVersion(): HasOne
    {
        return $this->hasOne(PageVersion::class)->withAttributes(['is_current' => true]);
    }
}
```
```php
// The created page version will not have 'is_current' set to 'true'
$page = Page::factory()->hasCurrentVersion()->create();

// You currently have to explicitly set 'is_current' to true
$page = Page::factory()->hasCurrentVersion(['is_current' => true])->create();
```
This PR fixes that: the relationship's pending attributes will now be used by the model factories:
```php
// The created page version will now have 'is_current' set to 'true'
$page = Page::factory()->hasCurrentVersion()->create();

// You still can override the values of the relationship's default attributes
// I added this behavior for backward compatibility in case someone those that
$page = Page::factory()->hasCurrentVersion(['is_current' => false])->create();
```