### PR TITLE
[12.x] Default `$contents` as empty string for `Filesystem::put()`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -199,7 +199,7 @@ class Filesystem
      * @param  bool  $lock
      * @return int|bool
      */
-    public function put($path, $contents, $lock = false)
+    public function put($path, $contents = '', $lock = false)
     {
         return file_put_contents($path, $contents, $lock ? LOCK_EX : 0);
     }


### PR DESCRIPTION
Non-breaking change, since currently the second parameter must be provided.

When testing file operations, we often don't care about the content, so `put()` empty strings.

Making that explicit, by not providing content, would also be consistent with the behaviour of `assertExists()` where content is optional.

```diff
-$fs->put('file.foo', '');
-$fs->put('file.bar', '');
+$fs->put('file.foo');
+$fs->put('file.bar');
$fs->assertExists('file.foo');
$fs->assertExists('file.bar');
```