### PR TITLE
[12.x] Add `whereHasAny`, `orWhereHasAny`, `whereHasAll`, and `orWhereHasAll` Methods to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -292,7 +292,7 @@ trait QueriesRelationships
         $callback = function (Builder $query) use ($tuples, $operator, $value, $innerBoolean) {
             foreach ($tuples as $relation => $columns) {
                 $this->hasNestedColumns(
-                    $query, $relation, $columns, $operator, $value, $innerBoolean, 'and'
+                    $query, $relation, $columns, $operator, $value, $innerBoolean, $innerBoolean
                 );
             }
         };

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -227,7 +227,7 @@ trait QueriesRelationships
     /**
      * Add a "whereHas" condition with OR between columns inside relationships.
      *
-     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]> $tuples [relation => [columns]]
+     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]>  $tuples  [relation => [columns]]
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -240,7 +240,7 @@ trait QueriesRelationships
     /**
      * Add an "orWhereHas" condition with OR between columns inside relationships.
      *
-     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]> $tuples [relation => [columns]]
+     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]>  $tuples  [relation => [columns]]
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -254,7 +254,7 @@ trait QueriesRelationships
      * Internal method to build "has" conditions for relationships,
      * combining multiple columns with given boolean logic.
      *
-     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]> $tuples [relation => [columns]]
+     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]>  $tuples  [relation => [columns]]
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $innerBoolean
@@ -271,8 +271,8 @@ trait QueriesRelationships
     /**
      * Add nested where conditions for relationship queries.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
-     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]> $tuples [relation => [columns]]
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  array<string,\Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]>  $tuples  [relation => [columns]]
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $innerBoolean

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -914,7 +914,7 @@ class Builder implements BuilderContract
      * @param  string  $outerBoolean
      * @return $this
      */
-    protected function addWhereNestedOfColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
+    protected function addNestedWhereColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
     {
         return $this->whereNested(function ($query) use ($columns, $operator, $value, $innerBoolean) {
             foreach ($columns as $column) {
@@ -2294,7 +2294,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addWhereNestedOfColumns($columns, $operator, $value, 'and', $boolean);
+        return $this->addNestedWhereColumns($columns, $operator, $value, 'and', $boolean);
     }
 
     /**
@@ -2325,7 +2325,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addWhereNestedOfColumns($columns, $operator, $value, 'or', $boolean);
+        return $this->addNestedWhereColumns($columns, $operator, $value, 'or', $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -905,7 +905,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "and/or where" clause to the query for multiple columns with "and/or" conditions between them
+     * Add an "and/or where" clause to the query for multiple columns with "and/or" conditions between them.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
      * @param  mixed  $operator

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -914,7 +914,7 @@ class Builder implements BuilderContract
      * @param  string  $outerBoolean
      * @return $this
      */
-    protected function addWhereNestedGroup($columns, $operator, $value, $innerBoolean = 'and', $outerBoolean = 'and')
+    protected function addWhereNestedOfColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
     {
         return $this->whereNested(function ($query) use ($columns, $operator, $value, $innerBoolean) {
             foreach ($columns as $column) {
@@ -2294,7 +2294,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addWhereNestedGroup($columns, $operator, $value, 'and', $boolean);
+        return $this->addWhereNestedOfColumns($columns, $operator, $value, 'and', $boolean);
     }
 
     /**
@@ -2325,7 +2325,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addWhereNestedGroup($columns, $operator, $value, 'or', $boolean);
+        return $this->addWhereNestedOfColumns($columns, $operator, $value, 'or', $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -914,7 +914,7 @@ class Builder implements BuilderContract
      * @param  string  $outerBoolean
      * @return $this
      */
-    protected function addNestedWhereColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
+    public function addNestedWhereColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
     {
         return $this->whereNested(function ($query) use ($columns, $operator, $value, $innerBoolean) {
             foreach ($columns as $column) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -905,6 +905,25 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "and/or where" clause to the query for multiple columns with "and/or" conditions between them
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $innerBoolean
+     * @param  string  $outerBoolean
+     * @return $this
+     */
+    protected function addWhereNestedGroup($columns, $operator, $value, $innerBoolean = 'and', $outerBoolean = 'and')
+    {
+        return $this->whereNested(function ($query) use ($columns, $operator, $value, $innerBoolean) {
+            foreach ($columns as $column) {
+                $query->where($column, $operator, $value, $innerBoolean);
+            }
+        }, $outerBoolean);
+    }
+
+    /**
      * Add an array of where clauses to the query.
      *
      * @param  array  $column
@@ -2275,13 +2294,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'and');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addWhereNestedGroup($columns, $operator, $value, 'and', $boolean);
     }
 
     /**
@@ -2312,13 +2325,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'or');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addWhereNestedGroup($columns, $operator, $value, 'or', $boolean);
     }
 
     /**


### PR DESCRIPTION
Even though [PR #55303](https://github.com/laravel/framework/pull/55303) was rejected, I truly believe that Eloquent should offer native support for whereAny across relationships.

Working with complex nested relationships is a daily reality for many developers building real-world applications.
Currently, chaining multiple whereHas and orWhereHas conditions manually makes the code repetitive, harder to read, and more prone to mistakes.

Adding first-class support for whereHasAny, orWhereHasAny, whereHasAll, and orWhereHasAll would not only simplify our queries — it would empower developers to express their intentions more clearly, with better performance and less boilerplate.

I genuinely believe that Eloquent deserves this improvement.
It would make a real difference for many of us working with complex data structures every day.

This PR introduces four new methods to the Eloquent Builder:

- [x]  Add whereHasAny method
- [x]  Add orWhereHasAny method
- [x]  Add whereHasAll method
- [x]  Add orWhereHasAll method
- [x]  Add corresponding tests

These new methods allow for more expressive and concise querying when filtering models based on multiple nested relationships combined by "any" (OR) or "all" (AND) logic across specific columns.

## Motivation
Previously, to perform a search across multiple nested relationships, developers had to manually chain multiple whereHas and orWhereHas statements, leading to repetitive, verbose, and harder-to-maintain code.

This feature improves readability, developer experience, and maintainability, while keeping the flexibility and performance of Eloquent queries.

### Before:
```PHP
User::query()
   ->whereHas('orders.orderItems.product.category', function (Builder $query) use ($search) {
        $query->where('name', $search);
    })
    ->orWhereHas('orders.orderItems.product', function (Builder $query) use ($search) {
        $query->whereAny(['title', 'description'], $search);
    })
    ->orWhereHas('profile', function (Builder $query) use ($search) {
        $query->where('bio', $search);
    })
    ->orWhereHas('profile.address', function (Builder $query) use ($search) {
        $query->where('city', $search);
    })
    ->orWhereHas('orders.shippingAddress', function (Builder $query) use ($search) {
        $query->where('country', $search);
    });
```

### After (with new whereHasAny)
```PHP
User::query()->whereHasAny([
    'orders.orderItems.product.category' => [ 'name' ],
    'orders.orderItems.product' => [ 'title', 'description' ],
    'profile' => [ 'bio' ],
    'profile.address' => [
      'city', // string
      DB::raw("..."), // Expression
    ],
    'orders.shippingAddress' => fn($query) => $query..., // Closure
], $search);
```

### Comparison across different relationships
One powerful advantage of whereHasAll is that it allows you to compare the same value across different relationships.

This is extremely useful for real-world scenarios, such as when the same identifier (code, reference, etc.) needs to match across multiple related tables.

For example, suppose a User has both shipments and orders, and you want to find users where both a shipment and an order have the same code:

### Before
```PHP
User::query()
  ->whereHas('shipments', function ($query) use ($search) {
      $query->where('code', $search);
  })
  ->whereHas('orders', function ($query) use ($search) {
      $query->where('code', $search);
  });
```

### After (with new whereHasAll)
```PHP
User::query()->whereHasAll([
  'shipments' => [ 'code' ],
  'orders' => [ 'code' ],
], $search);
```


### Notes about columns
Internally, the `whereHasAny`, `orWhereHasAny`, `whereHasAll`, and `orWhereHasAll` methods instantiate their conditions using the existing `whereAny` and `whereAll` methods from the Builder class.
```PHP
$q->whereHasAny([
    'profile' => [
        'name',                    // simple column name
        'profiles.name',            // full table.column to avoid ambiguities
    ],
    // ...
]);
```
This approach offers maximum flexibility when filtering nested relationships, supporting direct column names, explicit table.column syntax for disambiguation, and full custom query logic via closures.


Please feel free to share your thoughts — I would love to hear your feedback!