### PR TITLE
[12.x] Add append keys with arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -511,6 +511,18 @@ class Arr
     }
 
     /**
+     * Append the key names of an associative array.
+     *
+     * @param  array  $array
+     * @param  string  $appendWith
+     * @return array
+     */
+    public static function appendKeysWith($array, $appendWith)
+    {
+        return static::mapWithKeys($array, fn ($item, $key) => [$key.$appendWith => $item]);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1499,6 +1499,27 @@ class SupportArrTest extends TestCase
         ], Arr::prependKeysWith($array, 'test.'));
     }
 
+    public function testAppendKeysWith()
+    {
+        $array = [
+            'id' => 1,
+            'name' => 'Lennart',
+            'skills' => ['php', 'mysql', 'laravel'],
+            'meta' => [
+                'prs' => 1,
+            ],
+        ];
+
+        $this->assertEquals([
+            'id_user' => 1,
+            'name_user' => 'Lennart',
+            'skills_user' => ['php', 'mysql', 'laravel'],
+            'meta_user' => [
+                'prs' => 1,
+            ],
+        ], Arr::appendKeysWith($array, appendWith: '_user'));
+    }
+
     public function testTake(): void
     {
         $array = [1, 2, 3, 4, 5, 6];


### PR DESCRIPTION
Non-breaking change that adds the missing `appendKeysWith` method to the `Arr` helper class.

This can be useful for mass-updating the keys of API response data or preparing validation rule arrays that are reused, but under different keys having suffixes.

The docs PR can be found here: https://github.com/laravel/docs/pull/10352