### PR TITLE
[12.x] Typed getters for Arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -49,7 +49,7 @@ class Arr
 
         if (! is_array($value)) {
             throw new InvalidArgumentException(
-                sprintf('Array value for key [%s] must be an array, %s given.', $key, gettype($value))
+                sprintf('Array value for key [%s] must be an array, %s found.', $key, gettype($value))
             );
         }
 
@@ -65,7 +65,7 @@ class Arr
 
         if (! is_bool($value)) {
             throw new InvalidArgumentException(
-                sprintf('Array value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+                sprintf('Array value for key [%s] must be a boolean, %s found.', $key, gettype($value))
             );
         }
 
@@ -327,7 +327,7 @@ class Arr
 
         if (! is_float($value)) {
             throw new InvalidArgumentException(
-                sprintf('Array value for key [%s] must be a float, %s given.', $key, gettype($value))
+                sprintf('Array value for key [%s] must be a float, %s found.', $key, gettype($value))
             );
         }
 
@@ -490,7 +490,7 @@ class Arr
 
         if (! is_integer($value)) {
             throw new InvalidArgumentException(
-                sprintf('Array value for key [%s] must be an integer, %s given.', $key, gettype($value))
+                sprintf('Array value for key [%s] must be an integer, %s found.', $key, gettype($value))
             );
         }
 
@@ -979,7 +979,7 @@ class Arr
 
         if (! is_string($value)) {
             throw new InvalidArgumentException(
-                sprintf('Array value for key [%s] must be a string, %s given.', $key, gettype($value))
+                sprintf('Array value for key [%s] must be a string, %s found.', $key, gettype($value))
             );
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -41,6 +41,38 @@ class Arr
     }
 
     /**
+     * Get an array item from an array using "dot" notation.
+     */
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): ?array
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Array value for key [%s] must be an array, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get a boolean item from an array using "dot" notation.
+     */
+    public static function boolean(ArrayAccess|array $array, string|int|null $key, ?bool $default = null): ?bool
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_bool($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Array value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Collapse an array of arrays into a single array.
      *
      * @param  iterable  $array
@@ -287,6 +319,22 @@ class Arr
     }
 
     /**
+     * Get a float item from an array using "dot" notation.
+     */
+    public static function float(ArrayAccess|array $array, string|int|null $key, ?float $default = null): ?float
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_float($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Array value for key [%s] must be a float, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array
@@ -431,6 +479,22 @@ class Arr
         }
 
         return false;
+    }
+
+    /**
+     * Get an integer item from an array using "dot" notation.
+     */
+    public static function integer(ArrayAccess|array $array, string|int|null $key, ?int $default = null): ?int
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_integer($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Array value for key [%s] must be an integer, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
     }
 
     /**
@@ -904,6 +968,22 @@ class Arr
     public static function sortRecursiveDesc($array, $options = SORT_REGULAR)
     {
         return static::sortRecursive($array, $options, true);
+    }
+
+    /**
+     * Get a string item from an array using "dot" notation.
+     */
+    public static function string(ArrayAccess|array $array, string|int|null $key, ?string $default = null): ?string
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Array value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -43,7 +43,7 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): ?array
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): array
     {
         $value = Arr::get($array, $key, $default);
 
@@ -59,7 +59,7 @@ class Arr
     /**
      * Get a boolean item from an array using "dot" notation.
      */
-    public static function boolean(ArrayAccess|array $array, string|int|null $key, ?bool $default = null): ?bool
+    public static function boolean(ArrayAccess|array $array, string|int|null $key, ?bool $default = null): bool
     {
         $value = Arr::get($array, $key, $default);
 
@@ -321,7 +321,7 @@ class Arr
     /**
      * Get a float item from an array using "dot" notation.
      */
-    public static function float(ArrayAccess|array $array, string|int|null $key, ?float $default = null): ?float
+    public static function float(ArrayAccess|array $array, string|int|null $key, ?float $default = null): float
     {
         $value = Arr::get($array, $key, $default);
 
@@ -484,7 +484,7 @@ class Arr
     /**
      * Get an integer item from an array using "dot" notation.
      */
-    public static function integer(ArrayAccess|array $array, string|int|null $key, ?int $default = null): ?int
+    public static function integer(ArrayAccess|array $array, string|int|null $key, ?int $default = null): int
     {
         $value = Arr::get($array, $key, $default);
 
@@ -973,7 +973,7 @@ class Arr
     /**
      * Get a string item from an array using "dot" notation.
      */
-    public static function string(ArrayAccess|array $array, string|int|null $key, ?string $default = null): ?string
+    public static function string(ArrayAccess|array $array, string|int|null $key, ?string $default = null): string
     {
         $value = Arr::get($array, $key, $default);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -518,7 +518,7 @@ class SupportArrTest extends TestCase
 
     public function testItGetsAString()
     {
-        $test_array = ['string' => 'foo bar','integer' => 1234];
+        $test_array = ['string' => 'foo bar', 'integer' => 1234];
 
         // Test string values are returned as strings
         $this->assertSame(

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -532,7 +532,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a string
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[integer\] must be a string, (.*) given.#');
+        $this->expectExceptionMessageMatches('#^Array value for key \[integer\] must be a string, (.*) found.#');
         Arr::string($test_array, 'integer');
     }
 
@@ -552,7 +552,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not an integer
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an integer, (.*) given.#');
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an integer, (.*) found.#');
         Arr::integer($test_array, 'string');
     }
 
@@ -572,7 +572,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a float
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a float, (.*) given.#');
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a float, (.*) found.#');
         Arr::float($test_array, 'string');
     }
 
@@ -592,7 +592,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not a boolean
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a boolean, (.*) given.#');
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a boolean, (.*) found.#');
         Arr::boolean($test_array, 'string');
     }
 
@@ -612,7 +612,7 @@ class SupportArrTest extends TestCase
 
         // Test that an exception is raised if the value is not an array
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an array, (.*) given.#');
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an array, (.*) found.#');
         Arr::array($test_array, 'string');
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -599,7 +599,7 @@ class SupportArrTest extends TestCase
     public function testItGetsAnArray()
     {
         $test_array = ['string' => 'foo bar', 'array' => ['foo', 'bar']];
-        
+
         // Test array values are returned as arrays
         $this->assertSame(
             ['foo', 'bar'], Arr::array($test_array, 'array')

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -516,6 +516,106 @@ class SupportArrTest extends TestCase
         $this->assertSame('bar', Arr::get(['' => ['' => 'bar']], '.'));
     }
 
+    public function testItGetsAString()
+    {
+        $test_array = ['string' => 'foo bar','integer' => 1234];
+
+        // Test string values are returned as strings
+        $this->assertSame(
+            'foo bar', Arr::string($test_array, 'string')
+        );
+
+        // Test that default string values are returned for missing keys
+        $this->assertSame(
+            'default', Arr::string($test_array, 'missing_key', 'default')
+        );
+
+        // Test that an exception is raised if the value is not a string
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Array value for key \[integer\] must be a string, (.*) given.#');
+        Arr::string($test_array, 'integer');
+    }
+
+    public function testItGetsAnInteger()
+    {
+        $test_array = ['string' => 'foo bar', 'integer' => 1234];
+
+        // Test integer values are returned as integers
+        $this->assertSame(
+            1234, Arr::integer($test_array, 'integer')
+        );
+
+        // Test that default integer values are returned for missing keys
+        $this->assertSame(
+            999, Arr::integer($test_array, 'missing_key', 999)
+        );
+
+        // Test that an exception is raised if the value is not an integer
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an integer, (.*) given.#');
+        Arr::integer($test_array, 'string');
+    }
+
+    public function testItGetsAFloat()
+    {
+        $test_array = ['string' => 'foo bar', 'float' => 12.34];
+
+        // Test float values are returned as floats
+        $this->assertSame(
+            12.34, Arr::float($test_array, 'float')
+        );
+
+        // Test that default float values are returned for missing keys
+        $this->assertSame(
+            56.78, Arr::float($test_array, 'missing_key', 56.78)
+        );
+
+        // Test that an exception is raised if the value is not a float
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a float, (.*) given.#');
+        Arr::float($test_array, 'string');
+    }
+
+    public function testItGetsABoolean()
+    {
+        $test_array = ['string' => 'foo bar',  'boolean' => true];
+
+        // Test boolean values are returned as booleans
+        $this->assertSame(
+            true, Arr::boolean($test_array, 'boolean')
+        );
+
+        // Test that default boolean values are returned for missing keys
+        $this->assertSame(
+            true, Arr::boolean($test_array, 'missing_key', true)
+        );
+
+        // Test that an exception is raised if the value is not a boolean
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be a boolean, (.*) given.#');
+        Arr::boolean($test_array, 'string');
+    }
+
+    public function testItGetsAnArray()
+    {
+        $test_array = ['string' => 'foo bar', 'array' => ['foo', 'bar']];
+        
+        // Test array values are returned as arrays
+        $this->assertSame(
+            ['foo', 'bar'], Arr::array($test_array, 'array')
+        );
+
+        // Test that default array values are returned for missing keys
+        $this->assertSame(
+            [1, 'two'], Arr::array($test_array, 'missing_key', [1, 'two'])
+        );
+
+        // Test that an exception is raised if the value is not an array
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Array value for key \[string\] must be an array, (.*) given.#');
+        Arr::array($test_array, 'string');
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
Adds typed getter helpers (`Arr::string()`, `Arr::integer()`, `Arr::float()`, `Arr::boolean()`, `Arr::array()`) as also exist on the `Config` facade, in an effort to make static analysis easier when using the `Arr::get()` helper (including tests).

Documentation PR: https://github.com/laravel/docs/pull/10354