### PR TITLE
[12.x] Add `Arr::soleValue` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -842,6 +842,25 @@ class Arr
     }
 
     /**
+     * Get a single value from the first element matching the given callback or from the only element in the array.
+     *
+     * @template TKey
+     * @template TValue
+     * 
+     * @param  iterable<TKey, TValue>  $array
+     * @param  string|int|callable  $key
+     * @param  callable|null  $callback
+     * @return mixed
+     * 
+     * @throws \Illuminate\Support\ItemNotFoundException
+     * @throws \Illuminate\Support\MultipleItemsFoundException
+     */
+    public static function soleValue($array, $key, ?callable $callback = null)
+    {
+        return static::get(static::sole($array, $callback), $key);
+    }
+
+    /**
      * Sort the array using the given callback or "dot" notation.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -846,12 +846,12 @@ class Arr
      *
      * @template TKey
      * @template TValue
-     * 
+     *
      * @param  iterable<TKey, TValue>  $array
      * @param  string|int|callable  $key
      * @param  callable|null  $callback
      * @return mixed
-     * 
+     *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException
      */

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1098,6 +1098,41 @@ class SupportArrTest extends TestCase
         Arr::sole(['baz', 'foo', 'baz'], fn (string $value) => $value === 'baz');
     }
 
+    public function testSoleValueReturnsValueFromSingleElement()
+    {
+        $array = [
+            ['name' => 'foo', 'age' => 25],
+        ];
+
+        $this->assertSame('foo', Arr::soleValue($array, 'name'));
+        $this->assertSame(25, Arr::soleValue($array, 'age'));
+    }
+
+    public function testSoleValueReturnsValueFromCallbackFilteredElement()
+    {
+        $array = [
+            ['name' => 'foo', 'age' => 25],
+            ['name' => 'bar', 'age' => 30],
+        ];
+
+        $this->assertSame('foo', Arr::soleValue($array, 'name', fn (array $value) => $value['age'] === 25));
+        $this->assertSame(30, Arr::soleValue($array, 'age', fn (array $value) => $value['name'] === 'bar'));
+    }
+
+    public function testSoleValueThrowsExceptionIfNoItemsExist()
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        Arr::soleValue([], 'id');
+    }
+
+    public function testSoleValueThrowsExceptionIfMoreThanOneItemExists()
+    {
+        $this->expectExceptionObject(new MultipleItemsFoundException(2));
+
+        Arr::soleValue([['id' => 1], ['id' => 2]], 'id');
+    }
+
     public function testEmptyShuffle()
     {
         $this->assertEquals([], Arr::shuffle([]));


### PR DESCRIPTION
This PR adds a `soleValue` method to the `Arr` class. This method works similarly to `sole`, but instead of returning the entire item, it only returns a specific field or key from the sole item.

Since the `sole` method was recently added to the `Arr` class in version 12, and a similar `soleValue` method exists in Query Builder and Eloquent, adding this method to `Arr` creates greater consistency between Laravel's various APIs.

**Changes:**
- Add `soleValue` method to the `Arr` class
- Add comprehensive tests for the new functionality
