### PR TITLE
[12.x] Add tests for `EntityNotFoundException`

### DIFF
--- a/tests/Queue/EntityNotFoundExceptionTest.php
+++ b/tests/Queue/EntityNotFoundExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Contracts\Queue\EntityNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class EntityNotFoundExceptionTest extends TestCase
+{
+    public function test_it_creates_the_proper_exception_message()
+    {
+        $type = 'App\\Models\\User';
+        $id = 123;
+
+        $exception = new EntityNotFoundException($type, $id);
+
+        $this->assertSame(
+            "Queueable entity [{$type}] not found for ID [{$id}].",
+            $exception->getMessage()
+        );
+    }
+
+    public function test_it_converts_non_string_ids_to_strings()
+    {
+        $type = 'App\\Models\\Post';
+        $id = 456.789;
+
+        $exception = new EntityNotFoundException($type, $id);
+
+        $this->assertSame(
+            "Queueable entity [{$type}] not found for ID [456.789].",
+            $exception->getMessage()
+        );
+    }
+
+    public function test_it_extends_invalid_argument_exception()
+    {
+        $exception = new EntityNotFoundException('App\\Model', 1);
+
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive tests for the `EntityNotFoundException` class in the Queue component. These tests ensure that:

1. The exception message is created properly with the correct format
2. Non-string IDs are properly converted to strings in the exception message
3. The exception correctly extends the base `InvalidArgumentException` class

The added test coverage helps ensure the reliability of the exception handling in the Queue component.