### PR TITLE
Ensure fake job implements job contract

### DIFF
--- a/src/Illuminate/Queue/Jobs/FakeJob.php
+++ b/src/Illuminate/Queue/Jobs/FakeJob.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Queue\Jobs;
 
+use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Support\Str;
 
-class FakeJob extends Job
+class FakeJob extends Job implements JobContract
 {
     /**
      * The number of seconds the released job was delayed.


### PR DESCRIPTION
The fake job is used in places where an implementation of the job contract is expected.

This ensures that the fake job supports strict typing of the job contract when, for example, listening for events and passing the job instance around.

<img width="545" alt="Screenshot 2025-04-28 at 10 16 10" src="https://github.com/user-attachments/assets/a2ca7194-1c31-46f5-ac9f-b623bf41c758" />

