### PR TITLE
[12.x] Fix `AnyOf` constructor parameter type

### DIFF
--- a/src/Illuminate/Validation/Rules/AnyOf.php
+++ b/src/Illuminate/Validation/Rules/AnyOf.php
@@ -27,7 +27,7 @@ class AnyOf implements Rule, ValidatorAwareRule
     /**
      * Sets the validation rules to match against.
      *
-     * @param  Illuminate\Contracts\Validation\ValidationRule[][]  $rules
+     * @param  array  $rules
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
The `AnyOf` rule was introduced in https://github.com/laravel/framework/pull/55191 and allows developers to specify multiple validation paths for a single field.

The doc block of the rule's constructor is currently invalid (its missing a starting backslash), but even if that were to be fixed the doc block would still be invalid. This is because the doc currently doesn't allow `Illuminate\Contracts\Validation\Rule` nor `string` rules. This PR fixes this by changing the argument type to `array` which matches `Rule::anyOf()`.