### PR TITLE
[11.x] Make Blueprint Resolver Statically

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -30,9 +30,9 @@ class Builder
     /**
      * The Blueprint resolver callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
-    protected $resolver;
+    protected static $resolver = null;
 
     /**
      * The default string length for migrations.
@@ -577,8 +577,8 @@ class Builder
                     ? $this->connection->getConfig('prefix')
                     : '';
 
-        if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $table, $callback, $prefix);
+        if (static::$resolver !== null) {
+            return call_user_func(static::$resolver, $table, $callback, $prefix);
         }
 
         return Container::getInstance()->make(Blueprint::class, compact('table', 'callback', 'prefix'));
@@ -610,11 +610,11 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  \Closure  $resolver
+     * @param null|\Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint $resolver
      * @return void
      */
-    public function blueprintResolver(Closure $resolver)
+    public function blueprintResolver(?Closure $resolver)
     {
-        $this->resolver = $resolver;
+        static::$resolver = $resolver;
     }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -610,7 +610,7 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param null|\Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint $resolver
+     * @param  null|\Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint  $resolver
      * @return void
      */
     public function blueprintResolver(?Closure $resolver)

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -40,7 +40,7 @@ namespace Illuminate\Support\Facades;
  * @method static mixed withoutForeignKeyConstraints(\Closure $callback)
  * @method static \Illuminate\Database\Connection getConnection()
  * @method static \Illuminate\Database\Schema\Builder setConnection(\Illuminate\Database\Connection $connection)
- * @method static void blueprintResolver(null|\Closure $resolver)
+ * @method static void blueprintResolver(\Closure $resolver)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -40,7 +40,7 @@ namespace Illuminate\Support\Facades;
  * @method static mixed withoutForeignKeyConstraints(\Closure $callback)
  * @method static \Illuminate\Database\Connection getConnection()
  * @method static \Illuminate\Database\Schema\Builder setConnection(\Illuminate\Database\Connection $connection)
- * @method static void blueprintResolver(\Closure $resolver)
+ * @method static void blueprintResolver(null|\Closure $resolver)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)


### PR DESCRIPTION
## Problem
The facade `\Illuminate\Support\Facades\Schema` calls `db.schema`, which is not a singleton. As a result, calling `Schema::blueprintResolver` has no effect.

## Solution
Adding the `static` modifier will make the property accessible across all instances. Furthermore, allowing `blueprintResolver` to accept `null` values will provide the ability to revert to the default builder if the custom builder was intended for single-use only.