### PR TITLE
Add Arr::swap method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -907,6 +907,28 @@ class Arr
     }
 
     /**
+     * Swap places of items in an array.
+     *
+     * @param  array  $array
+     * @param  string|int  $keyOne
+     * @param  string|int  $keyTwo
+     * @return void
+     */
+    public static function swap(&$array, $keyOne, $keyTwo)
+    {
+        if (! static::exists($array, $keyOne) || ! static::exists($array, $keyTwo)) {
+            throw new InvalidArgumentException('One or both keys do not exist in the array.');
+        }
+
+        // Short-circuit the method if both keys are the same.
+        if ($keyOne === $keyTwo) {
+            return;
+        }
+
+        [$array[$keyOne], $array[$keyTwo]] = [$array[$keyTwo], $array[$keyOne]];
+    }
+
+    /**
      * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1268,6 +1268,28 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expect, Arr::sortRecursiveDesc($array));
     }
 
+    public function testSwap()
+    {
+        $array = [
+            'foo' => 'is',
+            'bar' => 'Laravel',
+            'baz' => 'the',
+            17 => 'framework',
+            'qux' => 'PHP',
+            23 => 'best',
+        ];
+
+        Arr::swap($array, 'foo', 'bar');
+        Arr::swap($array, 23, 17);
+
+        $this->assertEquals($array['foo'], 'Laravel');
+        $this->assertEquals($array['bar'], 'is');
+        $this->assertEquals($array['baz'], 'the');
+        $this->assertEquals($array[17], 'best');
+        $this->assertEquals($array['qux'], 'PHP');
+        $this->assertEquals($array[23], 'framework');
+    }
+
     public function testToCssClasses()
     {
         $classes = Arr::toCssClasses([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Recently I had the need to swap places of items in an array (in some conditions an item should've been the first to come, but the item that was actually the first  one shouldn't have been removed from the collection).

Usage:

```
<?php

use Illuminate\Support\Arr;

$array = [
      'a' => 'world',
      'b'  => 'bar',
      'c' => 'hello',
];

Arr::swap($array, 'a', 'c');

// $array:
// [
//    'a' => 'hello',
//    'b' => 'bar',
//    'c' => 'world',
// ]

```



