### PR TITLE
Remove `@internal` Annotation from `$components` Property in `InteractsWithIO`

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -19,8 +19,6 @@ trait InteractsWithIO
      * The console components factory.
      *
      * @var \Illuminate\Console\View\Components\Factory
-     *
-     * @internal This property is not meant to be used or overwritten outside the framework.
      */
     protected $components;
 


### PR DESCRIPTION
**Summary:**

This PR removes the `@internal` annotation from the `$components` property in the `InteractsWithIO`. The change was made to allow more flexibility for users extending the console components factory.

**Reasoning:**

The `@internal` annotation suggested that this property was not meant to be accessed or overwritten outside the framework. However, after evaluating the use case and feedback from the community, it seems that exposing this property could be beneficial for custom console component handling, making it a more flexible option for developers.

**Impact:**

- Developers who need to extend or modify the console components factory can now safely interact with the `$components` property.
- No breaking changes are expected, as this is a documentation change to the visibility of the property.
 