### PR TITLE
[12.x] Add whenJson/whenNotJson methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1201,7 +1201,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  callable|null  $default
      * @return static
      */
-    public function whenIsJson($callback, $default = null)
+    public function whenJson($callback, $default = null)
     {
         return $this->when($this->isJson(), $callback, $default);
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1195,6 +1195,30 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Execute the given callback if the string is a valid JSON string.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsJson($callback, $default = null)
+    {
+        return $this->when($this->isJson(), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string is not a valid JSON string.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenNotJson($callback, $default = null)
+    {
+        return $this->when(! $this->isJson(), $callback, $default);
+    }
+
+    /**
      * Execute the given callback if the string is a valid UUID.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -367,7 +367,7 @@ class SupportStringableTest extends TestCase
 
     public function testWhenNotJson()
     {
-        $this->assertSame('[1,2,3]', (string) $this->stringable()->whenNotJson(function ($stringable) {
+        $this->assertSame('[1,2,3]', (string) $this->stringable('[1,2,3]')->whenNotJson(function ($stringable) {
             return $stringable.' JSON';
         }));
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -350,6 +350,32 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenJson()
+    {
+        $this->assertSame('JSON: 1', (string) $this->stringable('1')->whenJson(function ($stringable) {
+            return $stringable->prepend('JSON: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not JSON: ');
+        }));
+
+        $this->assertSame('Not JSON: 1,', (string) $this->stringable('1,')->whenJson(function ($stringable) {
+            return $stringable->prepend('JSON: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not JSON: ');
+        }));
+    }
+
+    public function testWhenNotJson()
+    {
+        $this->assertSame('[1,2,3]', (string) $this->stringable()->whenNotJson(function ($stringable) {
+            return $stringable.' JSON';
+        }));
+
+        $this->assertSame('Not JSON', (string) $this->stringable('Not')->whenNotJson(function ($stringable) {
+            return $stringable.' JSON';
+        }));
+    }
+
     public function testWhenIsUuid()
     {
         $this->assertSame('Uuid: 2cdc7039-65a6-4ac7-8e5d-d554a98e7b15', (string) $this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->whenIsUuid(function ($stringable) {


### PR DESCRIPTION
I find the when/not when methods very readable and needed something similar for JSON strings. Hence a PR to support it!

**Before:**
```php
$stringable = str();

if ($stringable->isJson()) {
    // do something...
} else {
    // do something else
}
```
**After**
```php
str()->whenJson(function () {
    // do something...
}, function () {
    // do something else
})
```