### PR TITLE
[12.x] Prevent relation autoload context from being serialized

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2502,6 +2502,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->classCastCache = [];
         $this->attributeCastCache = [];
         $this->relationAutoloadCallback = null;
+        $this->relationAutoloadContext = null;
 
         return array_keys(get_object_vars($this));
     }


### PR DESCRIPTION
Excludes relationAutoloadContext from serialization since it will be automatically re-initialized when relation autoloading is activated after deserialization.

This helps keep the serialized model smaller and cleaner.