### PR TITLE
[12.x] Improve @use directive to support function and const modifiers

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -4,8 +4,8 @@ namespace Illuminate\View\Compilers\Concerns;
 
 trait CompilesUseStatements
 {
-    private const string FUNCTION_MODIFIER_WITH_TRAILING_SPACE = 'function ';
-    private const string CONST_MODIFIER_WITH_TRAILING_SPACE = 'const ';
+    private const FUNCTION_MODIFIER_WITH_TRAILING_SPACE = 'function ';
+    private const CONST_MODIFIER_WITH_TRAILING_SPACE = 'const ';
 
     /**
      * Compile the use statements into valid PHP.

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -4,9 +4,6 @@ namespace Illuminate\View\Compilers\Concerns;
 
 trait CompilesUseStatements
 {
-    private const FUNCTION_MODIFIER_WITH_TRAILING_SPACE = 'function ';
-    private const CONST_MODIFIER_WITH_TRAILING_SPACE = 'const ';
-
     /**
      * Compile the use statements into valid PHP.
      *
@@ -17,24 +14,25 @@ trait CompilesUseStatements
     {
         $expression = trim(preg_replace('/[()]/', '', $expression), " '\"");
 
-        // isolate alias
+        // Isolate alias...
         if (str_contains($expression, '{')) {
             $pathWithOptionalModifier = $expression;
             $aliasWithLeadingSpace = '';
         } else {
             $segments = explode(',', $expression);
             $pathWithOptionalModifier = trim($segments[0], " '\"");
+
             $aliasWithLeadingSpace = isset($segments[1])
                 ? ' as '.trim($segments[1], " '\"")
                 : '';
         }
 
-        // split modifier and path
-        if (str_starts_with($pathWithOptionalModifier, self::FUNCTION_MODIFIER_WITH_TRAILING_SPACE)) {
-            $modifierWithTrailingSpace = self::FUNCTION_MODIFIER_WITH_TRAILING_SPACE;
+        // Split modifier and path...
+        if (str_starts_with($pathWithOptionalModifier, 'function ')) {
+            $modifierWithTrailingSpace = 'function ';
             $path = explode(' ', $pathWithOptionalModifier, 2)[1] ?? $pathWithOptionalModifier;
-        } elseif (str_starts_with($pathWithOptionalModifier, self::CONST_MODIFIER_WITH_TRAILING_SPACE)) {
-            $modifierWithTrailingSpace = self::CONST_MODIFIER_WITH_TRAILING_SPACE;
+        } elseif (str_starts_with($pathWithOptionalModifier, 'const ')) {
+            $modifierWithTrailingSpace = 'const ';
             $path = explode(' ', $pathWithOptionalModifier, 2)[1] ?? $pathWithOptionalModifier;
         } else {
             $modifierWithTrailingSpace = '';

--- a/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesUseStatements.php
@@ -25,7 +25,7 @@ trait CompilesUseStatements
             $segments = explode(',', $expression);
             $pathWithOptionalModifier = trim($segments[0], " '\"");
             $aliasWithLeadingSpace = isset($segments[1])
-                ? ' as ' . trim($segments[1], " '\"")
+                ? ' as '.trim($segments[1], " '\"")
                 : '';
         }
 

--- a/tests/View/Blade/BladeUseTest.php
+++ b/tests/View/Blade/BladeUseTest.php
@@ -69,4 +69,70 @@ class BladeUseTest extends AbstractBladeTestCase
         $string = "Foo @use(\SomeNamespace\{Foo, Bar}) bar";
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testUseStatementsWithModifiersAreCompiled()
+    {
+        $expected = 'Foo <?php use function \SomeNamespace\SomeFunction as Foo; ?> bar';
+
+        $string = "Foo @use('function SomeNamespace\SomeFunction', 'Foo') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(function SomeNamespace\SomeFunction, Foo) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithModifiersWithoutAliasAreCompiled()
+    {
+        $expected = 'Foo <?php use const \SomeNamespace\SOME_CONST; ?> bar';
+
+        $string = "Foo @use('const SomeNamespace\SOME_CONST') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(const SomeNamespace\SOME_CONST) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithModifiersAndBackslashAtBeginningAreCompiled()
+    {
+        $expected = 'Foo <?php use function \SomeNamespace\SomeFunction; ?> bar';
+
+        $string = "Foo @use('function \SomeNamespace\SomeFunction') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(function \SomeNamespace\SomeFunction) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithModifiersBackslashAtBeginningAndAliasedAreCompiled()
+    {
+        $expected = 'Foo <?php use const \SomeNamespace\SOME_CONST as Foo; ?> bar';
+
+        $string = "Foo @use('const \SomeNamespace\SOME_CONST', 'Foo') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(const \SomeNamespace\SOME_CONST, Foo) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseStatementsWithModifiersWithBracesAreCompiledCorrectly()
+    {
+        $expected = 'Foo <?php use function \SomeNamespace\{Foo, Bar}; ?> bar';
+
+        $string = "Foo @use('function SomeNamespace\{Foo, Bar}') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(function SomeNamespace\{Foo, Bar}) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUseFunctionStatementWithBracesAndBackslashAreCompiledCorrectly()
+    {
+        $expected = 'Foo <?php use const \SomeNamespace\{FOO, BAR}; ?> bar';
+
+        $string = "Foo @use('const \SomeNamespace\{FOO, BAR}') bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = 'Foo @use(const \SomeNamespace\{FOO, BAR}) bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
## What's New? 🎉
The `@use` directive in Laravel just got a major upgrade!
Before, it only supported two parameters: a path and an alias.
Now you can also specify function 🧩 or const 🔥 imports directly within Blade templates!

#### ✅ Example
`@use(function App\Helpers)`
`@use(const App\Constants\MY_LITTLE_CONST, MY_LITTLE_ALIAS)`

#### ✅ Grouped imports still work beautifully
`@use(function App\Helpers\{foo, bar})`
`@use(const App\Constants\{FOO, BAR})`

#### ✅ Paths still work with or without leading slashes
`@use(function \App\Helpers)`

## Why is this awesome? 🧠💡

- **More readable 📝:** No need for messy `<?php` tags inside Blade views!
- **Fewer lines 🧹:** `@use` keeps your templates clean and tidy compared to multiple PHP use imports.
- **More idiomatic 🎨:** Feels natural and consistent with Blade syntax, avoiding context switching between PHP and Blade.
- **Blade power-up ⚡:** Leverage PHP constants and functions elegantly without breaking out of your Blade flow.
- **Future-friendly 🛡️:** Makes Blade templates more maintainable and expressive!

## TL;DR 🏎️
`@use` isn't just for classes anymore - now it's for functions and constants too!
Write cleaner, sharper Blade views without sacrificing PHP power! 🧙‍♂️✨

