### PR TITLE
[12.x] Set class-string generics on `Enum` rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -16,7 +16,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * The type of the enum.
      *
-     * @var class-string
+     * @var class-string<\UnitEnum>
      */
     protected $type;
 
@@ -44,7 +44,7 @@ class Enum implements Rule, ValidatorAwareRule
     /**
      * Create a new rule instance.
      *
-     * @param  class-string  $type
+     * @param  class-string<\UnitEnum>  $type
      */
     public function __construct($type)
     {


### PR DESCRIPTION
Adds class-string generics to the `Enum` rule. Will aid in static analysis.

---

Dear Taylor,

Lord knows you don't want to see another typehint PR.

But me, and countless others, are slaves to PHPStan. It's not enough to have PHPStan as a part of the development process and let it guide me. No... it rules my life. Every commit I make is at the mercy of the PHPStan pipeline. If I don't keep PHPStan on level 7 satisfied, I fear my children will not eat. You can't fault a man for wanting to sustain his livelihood.

And sickest of all, perhaps, is that I'm the one who added PHPStan to our pipelines. But I digress.

I hope that you can sympathize with my plight and consider this humble PR. 🙏 

Kind regards,
Luke