### PR TITLE
[12.x] Fix SQL Errors When Mixing Column Types in `whereAny`/`whereAll`/`whereNone`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2275,13 +2275,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'and');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addNestedWhereColumns($columns, $operator, $value, 'and', $boolean);
     }
 
     /**
@@ -2312,13 +2306,7 @@ class Builder implements BuilderContract
             $value, $operator, func_num_args() === 2
         );
 
-        $this->whereNested(function ($query) use ($columns, $operator, $value) {
-            foreach ($columns as $column) {
-                $query->where($column, $operator, $value, 'or');
-            }
-        }, $boolean);
-
-        return $this;
+        return $this->addNestedWhereColumns($columns, $operator, $value, 'or', $boolean);
     }
 
     /**
@@ -2359,6 +2347,27 @@ class Builder implements BuilderContract
     public function orWhereNone($columns, $operator = null, $value = null)
     {
         return $this->whereNone($columns, $operator, $value, 'or');
+    }
+
+    /**
+     * Add an "and/or where" clause to the query for multiple columns with "and/or" conditions between them.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression[]|\Closure[]|string[]  $columns
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $innerBoolean
+     * @param  string  $outerBoolean
+     * @return $this
+     */
+    protected function addNestedWhereColumns($columns, $operator, $value, $innerBoolean, $outerBoolean)
+    {
+        return $this->whereNested(function ($query) use ($columns, $operator, $value, $innerBoolean) {
+            foreach ($columns as $column) {
+                $column instanceof Closure
+                    ? $query->where($column, boolean: $innerBoolean)
+                    : $query->where($column, $operator, $value, $innerBoolean);
+            }
+        }, $outerBoolean);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1490,6 +1490,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where (("last_name" like ?) and ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAll([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where ("first_name" = ? and "last_name" = ? and ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testOrWhereAll()
@@ -1516,6 +1525,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or (("last_name" like ?) and ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAll([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("first_name" = ? and "last_name" = ? and ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['%Taylor%', 'Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testWhereAny()
@@ -1537,6 +1555,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereAny([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where ("first_name" = ? or "last_name" = ? or ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testOrWhereAny()
@@ -1563,6 +1590,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereAny([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where "first_name" like ? or ("first_name" = ? or "last_name" = ? or ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['%Taylor%', 'Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testWhereNone()
@@ -1589,6 +1625,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where not (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNone([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where not ("first_name" = ? or "last_name" = ? or ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testOrWhereNone()
@@ -1615,6 +1660,15 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
         $this->assertSame('select * from "users" where "first_name" like ? or not (("last_name" like ?) or ("email" like ?))', $builder->toSql());
         $this->assertEquals(['%Taylor%', '%Otwell%', '%Otwell%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('first_name', 'like', '%Taylor%')->orWhereNone([
+            'first_name',
+            new Raw('"last_name"'),
+            fn (Builder $query) => $query->where('email', 'like', '%Otwell%'),
+        ], 'Taylor');
+        $this->assertSame('select * from "users" where "first_name" like ? or not ("first_name" = ? or "last_name" = ? or ("email" like ?))', $builder->toSql());
+        $this->assertEquals(['%Taylor%', 'Taylor', 'Taylor', '%Otwell%'], $builder->getBindings());
     }
 
     public function testUnions()


### PR DESCRIPTION
This PR addresses SQL errors that occur when using whereAny, whereAll, or whereNone with a combination of column types (strings, expressions, and closures). While these methods support each type individually, combining them currently leads to malformed SQL.

Current Limitation:
Currently, using a combination of strings, expressions, and closures within these methods can lead to SQL errors. For example:

```PHP
User::query()
    ->whereAny([
        'first_name',
        DB::raw('last_name'),
        fn (Builder $q) => $q->where('email', 'like', '%Otwell%'),
    ], 'Taylor');
```
This results in malformed SQL:
> ⚠️❗Illuminate\Database\QueryException: SQLSTATE[42601]: Syntax error: 7 ERROR:  SELECT * with no tables specified is not valid

```SQL
select * from "users" where (
  "first_name" = 'Taylor' or 
  "last_name" = 'Taylor' or 
  (select * where "email" like '%Otwell%') = 'Taylor'
)
```

This will now generate the correct SQL:
```SQL
select * from "users" where (
  "first_name" = 'Taylor' or 
  "last_name" = 'Taylor' or 
  ("email" like '%Otwell%')
)
```

**What's been done:**

- Introduced a new internal method addNestedWhereColumns to handle mixed column types uniformly.
- Refactored whereAny and whereAll methods to utilize addNestedWhereColumns, reducing code duplication.
- Added comprehensive tests covering scenarios with strings, expressions, closures, and their combinations.

**Benefits:**

- Developers can now use a mix of column types within whereAny, whereAll, and whereNone without encountering SQL errors.
- Improved code maintainability and readability by consolidating logic into a single method.
- No breaking changes; existing functionality remains unaffected.

This enhancement ensures that developers can use mixed column types within these methods without encountering SQL errors.