### PR TITLE
[13.x] feat: Add a callback to be called on transaction failure

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -79,7 +79,7 @@ trait ManagesTransactions
      * @param  \Throwable  $e
      * @param  int  $currentAttempt
      * @param  int  $maxAttempts
-     * @param Closure|null $onFailure
+     * @param  Closure|null  $onFailure
      * @return void
      *
      * @throws \Throwable

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -16,11 +16,12 @@ trait ManagesTransactions
      *
      * @param  (\Closure(static): TReturn)  $callback
      * @param  int  $attempts
+     * @param  Closure|null  $onFailure
      * @return TReturn
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1)
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailure = null)
     {
         for ($currentAttempt = 1; $currentAttempt <= $attempts; $currentAttempt++) {
             $this->beginTransaction();
@@ -37,7 +38,7 @@ trait ManagesTransactions
             // exception back out, and let the developer handle an uncaught exception.
             catch (Throwable $e) {
                 $this->handleTransactionException(
-                    $e, $currentAttempt, $attempts
+                    $e, $currentAttempt, $attempts, $onFailure
                 );
 
                 continue;
@@ -78,11 +79,12 @@ trait ManagesTransactions
      * @param  \Throwable  $e
      * @param  int  $currentAttempt
      * @param  int  $maxAttempts
+     * @param Closure|null $onFailure
      * @return void
      *
      * @throws \Throwable
      */
-    protected function handleTransactionException(Throwable $e, $currentAttempt, $maxAttempts)
+    protected function handleTransactionException(Throwable $e, $currentAttempt, $maxAttempts, ?Closure $onFailure)
     {
         // On a deadlock, MySQL rolls back the entire transaction so we can't just
         // retry the query. We have to throw this exception all the way out and
@@ -106,6 +108,10 @@ trait ManagesTransactions
         if ($this->causedByConcurrencyError($e) &&
             $currentAttempt < $maxAttempts) {
             return;
+        }
+
+        if ($onFailure !== null) {
+            $onFailure($e);
         }
 
         throw $e;

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -131,11 +131,12 @@ interface ConnectionInterface
      *
      * @param  \Closure  $callback
      * @param  int  $attempts
+     * @param  Closure|null  $onFailure
      * @return mixed
      *
      * @throws \Throwable
      */
-    public function transaction(Closure $callback, $attempts = 1);
+    public function transaction(Closure $callback, $attempts = 1, ?Closure $onFailure = null);
 
     /**
      * Start a new database transaction.

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -105,6 +105,42 @@ class DatabaseTransactionsTest extends DatabaseTestCase
         $this->assertTrue($secondObject->ran);
         $this->assertFalse($thirdObject->ran);
     }
+
+    public function testOnErrorCallbackIsCalled()
+    {
+        $executed = false;
+        try {
+            DB::transaction(function () {
+                throw new \Exception;
+            }, 1, function () use (&$executed) {
+                $executed = true;
+            });
+        } catch (\Throwable) {
+            // Ignore the exception
+        }
+
+        $this->assertTrue($executed);
+    }
+
+    public function testOnErrorCallbackIsCalledWithDeadlockRetry()
+    {
+        $executed = false;
+        $attempts = 0;
+
+        try {
+            DB::transaction(function () use (&$attempts) {
+                $attempts += 1;
+                throw new \Exception('has been chosen as the deadlock victim');
+            }, 3, function () use (&$executed) {
+                $executed = true;
+            });
+        } catch (\Throwable) {
+            // Ignore the exception
+        }
+
+        $this->assertSame(3, $attempts);
+        $this->assertTrue($executed);
+    }
 }
 
 class TestObjectForTransactions


### PR DESCRIPTION
This PR adds a new argument to `DB::transaction()` that allows you to pass in a callback to be executed when the transaction fails:

```php
DB::transaction(function () {
 // do DB stuff
}, onFailureCallback: function () {
    Notification::send($admin, new SomethingImportantBroke());
});
```

Original PR that reverted due to breaking changes: https://github.com/laravel/framework/pull/55338

Reintroducing it for the next release since breaking changes are acceptable.