### PR TITLE
Add support for third argument to updateOrInsert, used only during in…

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3857,7 +3857,7 @@ class Builder implements BuilderContract
      *
      * @return bool
      */
-    public function updateOrInsert(array $attributes, array|callable $values = [])
+    public function updateOrInsert(array $attributes, array|callable $values = [],array $onlyInsert = [])
     {
         $exists = $this->where($attributes)->exists();
 
@@ -3866,7 +3866,7 @@ class Builder implements BuilderContract
         }
 
         if (! $exists) {
-            return $this->insert(array_merge($attributes, $values));
+            return $this->insert(array_merge($attributes, $values, $onlyInsert));
         }
 
         if (empty($values)) {


### PR DESCRIPTION
This pull request introduces an enhancement to the updateOrInsert method. It now accepts an optional third argument—an array of values that will only be used when a new record is inserted. This change does not affect the update behavior or the existing two-argument usage.

Key changes:
Modified method signature to accept an optional third parameter.

When a record is not found and insertion is triggered, values from the third array are merged into the insert payload.

The third array is ignored if the record already exists (i.e., during update).

Use case / Motivation:
Previously, updateOrInsert only supported passing values that were shared between update and insert. In some cases, developers may want to include fields (like timestamps, default flags, or metadata) only during insert operations without affecting updates. This change enables more precise and flexible behavior.
