### PR TITLE
[12.x] Support nested relations on `relationLoaded` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -543,7 +543,7 @@ trait HasAttributes
         // If the key already exists in the relationships array, it just means the
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.
-        if ($this->relationLoaded($key)) {
+        if (array_key_exists($key, $this->relations)) {
             return $this->relations[$key];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1090,7 +1090,7 @@ trait HasRelationships
         $nestedRelation = $relations[1];
 
         // A relation may contain a single Model or collection of Models.
-        // So we prepare for both scenarios.
+        // So we prepare for both scenarios
         $relationValue = $this->getRelationValue($childRelation);
         $relationValues = is_iterable($relationValue) ? $relationValue : [$relationValue];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1090,7 +1090,7 @@ trait HasRelationships
         $nestedRelation = $relations[1];
 
         // A relation may contain a single Model or collection of Models.
-        // So we prepare for both scenarios
+        // So we prepare for both scenarios.
         $relationValue = $this->getRelationValue($childRelation);
         $relationValues = is_iterable($relationValue) ? $relationValue : [$relationValue];
 

--- a/tests/Integration/Database/EloquentModelRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelRelationLoadedTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelRelationLoadedTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelRelationLoadedTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('ones', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('twos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('threes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('two_id');
+            $table->integer('one_id')->nullable();
+        });
+    }
+
+    public function testWhenRelationIsInvalid()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+        $one->load('twos');
+
+        $this->assertFalse($one->relationLoaded(''));
+        $this->assertFalse($one->relationLoaded('.'));
+        $this->assertFalse($one->relationLoaded('null'));
+        $this->assertFalse($one->relationLoaded('invalid'));
+    }
+
+    public function testWhenNestedRelationIsInvalid()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+        $one->load('twos.threes');
+
+        $this->assertFalse($one->relationLoaded('twos.'));
+        $this->assertFalse($one->relationLoaded('twos.null'));
+        $this->assertFalse($one->relationLoaded('twos.invalid'));
+    }
+
+    public function testWhenRelationNotLoaded()
+    {
+        $one = One::query()->create();
+
+        $this->assertFalse($one->relationLoaded('twos'));
+    }
+
+    public function testWhenRelationLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+        $one->load(['twos']);
+
+        $this->assertTrue($one->relationLoaded('twos'));
+    }
+
+    public function testWhenChildRelationIsNotLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+        $one->load('twos');
+
+        $this->assertTrue($one->relationLoaded('twos'));
+        $this->assertFalse($one->relationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+        $one->load('twos.threes');
+
+        $this->assertTrue($one->relationLoaded('twos'));
+        $this->assertTrue($one->relationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRecursiveRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create(['one_id' => $one->id]);
+        $one->load('twos.threes.one');
+
+        $this->assertTrue($one->relationLoaded('twos'));
+        $this->assertTrue($one->relationLoaded('twos.threes'));
+        $this->assertTrue($one->relationLoaded('twos.threes.one'));
+    }
+
+    public function testWhenParentRelationIsASingleInstance()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $three = $two->threes()->create();
+        $three->load('two.one');
+
+        $this->assertTrue($three->relationLoaded('two'));
+        $this->assertTrue($three->relationLoaded('two.one'));
+    }
+
+    public function testWhenSetRelationsWithValidData()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $one->setRelations([
+            'twos' => $one->twos()->with('threes')->get(),
+        ]);
+
+        $this->assertTrue($one->relationLoaded('twos'));
+        $this->assertTrue($one->relationLoaded('twos.threes'));
+        $this->assertNull($one->getAttribute('twos.threes'));
+    }
+
+    public function testWhenGetNestedAttribute()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+        $one->load('twos.threes');
+
+        $this->assertNull($one->getAttribute('twos.threes'));
+    }
+
+    /**
+     * This is a regression test to ensure previous functionality remains intact.
+     */
+    public function testWhenSetRelationsWithCustomData()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $three = $two->threes()->create();
+        $three->load('two.one');
+
+        $this->assertTrue($three->relationLoaded('two'));
+        $this->assertTrue($three->relationLoaded('two.one'));
+
+        $three->setRelations(['a' => ['x', 'y', 'z']]);
+
+        $this->assertFalse($three->relationLoaded('two'));
+        $this->assertFalse($three->relationLoaded('two.one'));
+        $this->assertNull($three->getAttribute('a.z'));
+        $this->assertTrue($three->relationLoaded('a'));
+        $this->assertIsArray($three->getRelationValue('a'));
+    }
+
+    public function testWhenSetRelationsWithDotsInRelationNames()
+    {
+        $one = One::query()->create();
+
+        $one->setRelations(['foo.bar' => ['x', 'y', 'z']]);
+
+        $this->assertNotNull($one->getRelationValue('foo.bar'));
+    }
+
+    public function testGetRelationValue()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+        $one->load('twos.threes');
+
+        $this->assertNotNull($one->getAttribute('twos'));
+        $this->assertNull($one->getRelationValue('twos.threes'));
+    }
+}
+
+class One extends Model
+{
+    public $table = 'ones';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos(): HasMany
+    {
+        return $this->hasMany(Two::class, 'one_id');
+    }
+}
+
+class Two extends Model
+{
+    public $table = 'twos';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function threes(): HasMany
+    {
+        return $this->hasMany(Three::class, 'two_id');
+    }
+}
+
+class Three extends Model
+{
+    public $table = 'threes';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function two(): BelongsTo
+    {
+        return $this->belongsTo(Two::class, 'two_id');
+    }
+}


### PR DESCRIPTION
# Added support to check nested relations when using `relationLoaded()` method of Eloquent Model

> This is the 2nd attempt of previously reverted https://github.com/laravel/framework/pull/55471

## Why?

Current `relationLoaded()` method only checks single level relation of the Model. Now users can check nested relations.

```
$user->load('posts.comments');

// Previously
$user->relationLoaded('posts'); // true
$user->relationLoaded('posts.comments'); // false

// Now
$user->relationLoaded('posts'); // true
$user->relationLoaded('posts.comments'); // true
```

## Benefits

End users can check whether the nested relation loaded once and load the desired relation.

## About break existing features...

Checked and updated all usage inside the framework and added regressions tests to ensure previous functionality.

Usage of the method outside framework will not break because the feature preserves single level relation check as previously worked.

This is the 2nd attempt of previously reverted https://github.com/laravel/framework/pull/55471

Has added test cases to verify the issues identified previously by @rodrigopedra @danharrin @tabuna.

## Related

https://github.com/laravel/framework/pull/55471
https://github.com/laravel/framework/issues/55518
https://github.com/laravel/framework/pull/55519
https://github.com/laravel/framework/issues/55535
https://github.com/laravel/framework/commit/dc5b445c0a9aa794f3b6d04b3bf10ed5b00c7814