### PR TITLE
[12.x] Add Ability to Validate Array of Enum Values in Enum Rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -68,6 +68,37 @@ class Enum implements Rule, ValidatorAwareRule
             return false;
         }
 
+        if (is_array($value)) {
+            return $this->isValidEnums($value);
+        }
+
+        return $this->isValidEnum($value);
+    }
+
+    /**
+     * Determine if the given values is a valid.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    protected function isValidEnums($values)
+    {
+        return collect($values)
+            ->every($this->isValidEnum(...));
+    }
+
+    /**
+     * Determine if the given value is a valid.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isValidEnum($value)
+    {
+        if ($value instanceof $this->type) {
+            return $this->isDesirable($value);
+        }
+
         try {
             $value = $this->type::tryFrom($value);
 

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -265,6 +265,37 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
     }
 
+    public function testValidationFailsForDifferentCaseEnumArray()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => ['DONE', 'PENDING'],
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
+    public function testValidationForDifferentCaseEnumArray()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => ['pending', 'done'],
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     public static function conditionalCasesDataProvider(): array
     {
         return [
@@ -283,7 +314,8 @@ class ValidationEnumRuleTest extends TestCase
 
         $container->bind('translator', function () {
             return new Translator(
-                new ArrayLoader, 'en'
+                new ArrayLoader,
+                'en'
             );
         });
 


### PR DESCRIPTION
This pull request introduces support for validating an array of enum values using the `Illuminate\Validation\Rules\Enum` rule. Previously, the rule only handled single values. With this enhancement, arrays of values can now be validated to ensure that all entries are valid enum cases.

---

## Enum

```php
enum Status: string {
    case Active = 'active';
    case Inactive = 'inactive';
}
```

## Before

```php
// Would pass:
Validator::make(
    ['status' => 'active'],
    ['status' => [new Enum(Status::class)]]
)->passes(); // ✅

// Would fail (unexpectedly — no array support):
Validator::make(
    ['status' => ['active', 'inactive']],
    ['status' => [new Enum(Status::class)]]
)->passes(); // ❌
```

---

## After

```php
// Single value still passes:
Validator::make(
    ['status' => 'active'],
    ['status' => [new Enum(Status::class)]]
)->passes(); // ✅

// Now also supports an array of values:
Validator::make(
    ['statuses' => ['active', 'inactive']],
    ['statuses' => [new Enum(Status::class)]]
)->passes(); // ✅

Validator::make(
    ['statuses' => ['active', 'invalid']],
    ['statuses' => [new Enum(Status::class)]]
)->passes(); // ❌
```
