### PR TITLE
[12.x] Refactor formatParameters method

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -437,7 +437,7 @@ class RouteUrlGenerator
     /**
      * Fill in default values for any empty parameters.
      *
-     * @param  array  $namedParameters
+     * @param  array<string, mixed>  $namedParameters
      * @param  \Illuminate\Routing\Route  $route
      * @return array
      */
@@ -458,7 +458,7 @@ class RouteUrlGenerator
     /**
      * Format the final parameters collection.
      *
-     * @param  array  $parameters
+     * @param  array<string, mixed>  $parameters
      * @param  \Illuminate\Routing\Route  $route
      * @return array
      */


### PR DESCRIPTION
This PR extracts two internal responsibilities from the `formatParameters` method into their own dedicated methods:

- `fillDefaultValues` handles filling in default route parameter values.
- `formatFinalParameters` processes the final route parameters.

These changes improve the readability and maintainability of the method without altering its behavior.