### PR TITLE
[12.x] Add Dispatchable Trait to Auth Events for Modern Event Dispatching Support

### DIFF
--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Authenticated
 {

--- a/src/Illuminate/Auth/Events/Authenticated.php
+++ b/src/Illuminate/Auth/Events/Authenticated.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Authenticated
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class CurrentDeviceLogout
 {

--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class CurrentDeviceLogout
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Login
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Login
 {

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Logout
 {

--- a/src/Illuminate/Auth/Events/Logout.php
+++ b/src/Illuminate/Auth/Events/Logout.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Logout
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class OtherDeviceLogout
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/OtherDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/OtherDeviceLogout.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class OtherDeviceLogout
 {

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class PasswordReset
 {

--- a/src/Illuminate/Auth/Events/PasswordReset.php
+++ b/src/Illuminate/Auth/Events/PasswordReset.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class PasswordReset
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class PasswordResetLinkSent
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
+++ b/src/Illuminate/Auth/Events/PasswordResetLinkSent.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class PasswordResetLinkSent
 {

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Registered
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/Registered.php
+++ b/src/Illuminate/Auth/Events/Registered.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Registered
 {

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Validated
 {

--- a/src/Illuminate/Auth/Events/Validated.php
+++ b/src/Illuminate/Auth/Events/Validated.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Validated
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class Verified
 {

--- a/src/Illuminate/Auth/Events/Verified.php
+++ b/src/Illuminate/Auth/Events/Verified.php
@@ -3,10 +3,11 @@
 namespace Illuminate\Auth\Events;
 
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
 
 class Verified
 {
-    use SerializesModels;
+    use Dispatchable, SerializesModels;
 
     /**
      * Create a new event instance.


### PR DESCRIPTION
This PR adds the `Illuminate\Foundation\Events\Dispatchable` trait to multiple event classes within the `Illuminate\Auth\Events` namespace, enabling modern static and conditional dispatching methods.

Motivation:

Laravel supports a fluent and expressive event system where events can be dispatched statically using the `Dispatchable` trait. This trait enables:

```php
Event::dispatch(...)
Event::dispatchIf(...)
Event::dispatchUnless(...)
Event::broadcast(...)
```

Previously, these auth events required:

```php
event(new Verified($user));
```

Now, the following is supported:

```php
Verified::dispatch($user);
Verified::dispatchIf($user->createdByAdmin(), $user);
```

This change aligns auth events with the conventions followed across other Laravel core events and improves developer experience.

No breaking changes. Traditional event dispatching via `event(new ...)` still works as expected.