### PR TITLE
[12.x] Show skipped migrations in `migrate:status`

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -103,12 +103,12 @@ class StatusCommand extends BaseCommand
             ->map(function ($migration) use ($ran, $batches) {
                 $migrationName = $this->migrator->getMigrationName($migration);
 
-                $status = in_array($migrationName, $ran)
-                    ? '<fg=green;options=bold>Ran</>'
-                    : '<fg=yellow;options=bold>Pending</>';
-
                 if (in_array($migrationName, $ran)) {
-                    $status = '['.$batches[$migrationName].'] '.$status;
+                    $status = '['.$batches[$migrationName].'] '.'<fg=green;options=bold>Ran</>';
+                } else {
+                    $status = $this->migrator->resolvePath($migration)?->shouldRun() === false
+                        ? '<fg=yellow;options=bold>Pending</>'
+                        : '<fg=blue;options=bold>Skipped</>';
                 }
 
                 return [$migrationName, $status];

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -106,7 +106,7 @@ class StatusCommand extends BaseCommand
                 if (in_array($migrationName, $ran)) {
                     $status = '['.$batches[$migrationName].'] '.'<fg=green;options=bold>Ran</>';
                 } else {
-                    $status = $this->migrator->resolvePath($migration)?->shouldRun() === false
+                    $status = $this->migrator->resolvePath($migration)?->shouldRun() !== true
                         ? '<fg=yellow;options=bold>Pending</>'
                         : '<fg=blue;options=bold>Skipped</>';
                 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -536,7 +536,7 @@ class Migrator
      * @param  string  $path
      * @return object
      */
-    protected function resolvePath(string $path)
+    public function resolvePath(string $path)
     {
         $class = $this->getMigrationClass($this->getMigrationName($path));
 


### PR DESCRIPTION
This PR updates `migrate:status` to identify skipped status migrations (`shouldRun()` returns `false`), as a simpler version of a previous PR: https://github.com/laravel/framework/pull/55557 

This would be really useful in order to see which migrations would be skipped in a specific app environment.

<img width="1203" alt="Screenshot 2025-04-29 at 21 36 09" src="https://github.com/user-attachments/assets/2e3e781f-d20e-46c9-a355-2cf6c656372a" />

