### PR TITLE
Enhance updateOrInsert to Support Insert-Only Fields via $onlyInsert Parameter

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3857,7 +3857,7 @@ class Builder implements BuilderContract
      *
      * @return bool
      */
-    public function updateOrInsert(array $attributes, array|callable $values = [])
+    public function updateOrInsert(array $attributes, array|callable $values = [],array $onlyInsert = [])
     {
         $exists = $this->where($attributes)->exists();
 
@@ -3866,7 +3866,7 @@ class Builder implements BuilderContract
         }
 
         if (! $exists) {
-            return $this->insert(array_merge($attributes, $values));
+            return $this->insert(array_merge($attributes, $values, $onlyInsert));
         }
 
         if (empty($values)) {


### PR DESCRIPTION
I understand the importance of thorough explanations and proper testing for proposed changes. I've updated the pull request with the necessary details and would like to provide an overview here as well.

### Summary of the Change
I’ve added a third parameter **$onlyInsert** to the **updateOrInsert** method in Laravel’s query builder:

`public function updateOrInsert(array $attributes, array|callable $values = [], array $onlyInsert = [])`

### Purpose
The $onlyInsert parameter allows developers to specify additional fields that should only be included during the insert operation when the record does not already exist. These fields will be ignored in the update scenario.

### Use case:
Sometimes, we need to include fields like created_by, created_at, or other initialization values that are relevant only during insertion. This enhancement enables a cleaner, more expressive way to handle such cases without having to write custom insert logic outside of updateOrInsert.

```
if (! $exists) {
    return $this->insert(array_merge($attributes, $values, $onlyInsert));
}
```
    **If the record does not exist, all three arrays **($attributes, $values, $onlyInsert)** are merged and inserted.
    If the record exists, only **$values** are used to update the record, and **$onlyInsert** is ignored.**

### Benefits to End Users

Adds clarity and control to the **updateOrInsert** flow.
Reduces boilerplate logic for common insertion scenarios.
Maintains backward compatibility with the existing method signature by placing the new parameter at the end with a default value.
Improves the developer experience by allowing cleaner code and avoiding duplicated insert checks.

