### PR TITLE
[12.x] Fix scheduler errors by adding exitCode for tasks running in background

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -133,7 +133,7 @@ class Event
         $this->exitCode = $this->start($container);
 
         if (! $this->runInBackground) {
-            $this->finish($container);
+            $this->finish($container, $this->exitCode);
         }
     }
 
@@ -210,10 +210,13 @@ class Event
      * Mark the command process as finished and run callbacks/cleanup.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  int  $exitCode
      * @return void
      */
-    public function finish(Container $container)
+    public function finish(Container $container, $exitCode)
     {
+        $this->exitCode = (int) $exitCode;
+
         try {
             $this->callAfterCallbacks($container);
         } finally {

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -130,10 +130,10 @@ class Event
             return;
         }
 
-        $exitCode = $this->start($container);
+        $this->exitCode = $this->start($container);
 
         if (! $this->runInBackground) {
-            $this->finish($container, $exitCode);
+            $this->finish($container);
         }
     }
 
@@ -210,13 +210,10 @@ class Event
      * Mark the command process as finished and run callbacks/cleanup.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  int  $exitCode
      * @return void
      */
-    public function finish(Container $container, $exitCode)
+    public function finish(Container $container)
     {
-        $this->exitCode = (int) $exitCode;
-
         try {
             $this->callAfterCallbacks($container);
         } finally {


### PR DESCRIPTION
This PR sets exitCode for all scheduled tasks.

PR https://github.com/laravel/framework/pull/55572 added new exception if `exitCode != 0`. For some reason exitCode was not set for scheduled tasks that had runInBackground set to true.