### PR TITLE
[12.x] Make Blueprint Resolver Statically

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 
+/**
+ * @template TResolver of \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint
+ */
 class Builder
 {
     use Macroable;
@@ -30,9 +33,9 @@ class Builder
     /**
      * The Blueprint resolver callback.
      *
-     * @var \Closure
+     * @var TResolver|null
      */
-    protected $resolver;
+    protected static $resolver = null;
 
     /**
      * The default string length for migrations.
@@ -629,8 +632,8 @@ class Builder
     {
         $connection = $this->connection;
 
-        if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $connection, $table, $callback);
+        if (static::$resolver !== null) {
+            return call_user_func(static::$resolver, $connection, $table, $callback);
         }
 
         return Container::getInstance()->make(Blueprint::class, compact('connection', 'table', 'callback'));
@@ -698,11 +701,11 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  \Closure  $resolver
+     * @param  TResolver|null  $resolver
      * @return void
      */
-    public function blueprintResolver(Closure $resolver)
+    public function blueprintResolver(?Closure $resolver)
     {
-        $this->resolver = $resolver;
+        static::$resolver = $resolver;
     }
 }


### PR DESCRIPTION
## Bug
The facade `\Illuminate\Support\Facades\Schema` calls `db.schema`, which is not a singleton. As a result, calling `Schema::blueprintResolver` has no effect.

## Solution
Adding the `static` modifier will make the property accessible across all instances. Furthermore, allowing `blueprintResolver` to accept `null` values will provide the ability to revert to the default builder if the custom builder was intended for single-use only.

## Compatibility
Since this functionality is currently not fully operational, fixing this bug does not pose any compatibility issues.