### PR TITLE
[12.x] Resolve issue with BelongsToManyRelationship factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -50,9 +50,13 @@ class BelongsToManyRelationship
      */
     public function createFor(Model $model)
     {
-        $relationship = $model->{$this->relationship}();
+        $factoryInstance = $this->factory instanceof Factory;
 
-        Collection::wrap($this->factory instanceof Factory ? $this->factory->prependState($relationship->getQuery()->pendingAttributes)->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
+        if($factoryInstance) {
+            $relationship = $model->{$this->relationship}();
+        }
+
+        Collection::wrap($factoryInstance ? $this->factory->prependState($relationship->getQuery()->pendingAttributes)->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
             $model->{$this->relationship}()->attach(
                 $attachable,
                 is_callable($this->pivot) ? call_user_func($this->pivot, $model) : $this->pivot

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -52,7 +52,7 @@ class BelongsToManyRelationship
     {
         $factoryInstance = $this->factory instanceof Factory;
 
-        if($factoryInstance) {
+        if ($factoryInstance) {
             $relationship = $model->{$this->relationship}();
         }
 


### PR DESCRIPTION
When updating to 12.11.0, I noticed a bunch of tests started to fail with : 

```
BadMethodCallException: Call to undefined method Illuminate\Database\Query\Builder::()
```

This looks to be have been introduced via https://github.com/laravel/framework/pull/55558

This is because : 
https://github.com/laravel/framework/blob/bcc92201ab6d786477fed578cc2e3ea4c4e1b093/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php#L53

If it's not an instance of Factory, this relationship can be an empty string-- thus causing this to fail as there's no function to call.  The `$relationship` var is only used if it's a factory instance anyway, so this makes sense- I hope!


Here's a failing test as a rough example:
```php
    #[DataProvider('providerExample')]
    public function test_belongs_to_many_relationship_empty_factory(int $relationshipTotal)
    {
        $relation = FactoryTestRoleFactory::times($relationshipTotal)->create();
        
        FactoryTestUserFactory::times(2)
            ->hasAttached($relation)
            ->create();

        $this->assertCount(2, FactoryTestUser::all());
    }

    public static function providerExample()
    {
        return [
            [0], // maybe I want to assert something if there's no relation
            [1],
            [2]
        ];
    }
```



Cheers 🫡 

