### PR TITLE
[12.x] Extends `AsCollection` to map through a closure

### DIFF
--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -215,6 +215,37 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $this->assertInstanceOf(FluentWithCallback::class, $model->collection->first());
         $this->assertSame('bar', $model->collection->first()->foo);
     }
+
+    public function test_as_collection_with_map_using_closure()
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::of(fn ($data) => new Fluent($data)),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(Fluent::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
+
+    public function test_as_custom_collection_with_map_using_closure()
+    {
+        $model = new TestEloquentModelWithCustomCasts();
+        $model->mergeCasts([
+            'collection' => AsCollection::using(CustomCollection::class, fn ($data) => new Fluent($data)),
+        ]);
+
+        $model->setRawAttributes([
+            'collection' => json_encode([['foo' => 'bar']]),
+        ]);
+
+        $this->assertInstanceOf(CustomCollection::class, $model->collection);
+        $this->assertInstanceOf(Fluent::class, $model->collection->first());
+        $this->assertSame('bar', $model->collection->first()->foo);
+    }
 }
 
 class TestEloquentModelWithCustomCasts extends Model


### PR DESCRIPTION
### Feature
The aim of this code is to be able to provide a closure to the `$map` parameter of the `AsCollection::of()` and `AsCollection::using()` methods, in order to be able to fully customize the creation of each item inside the collection.
```php
public function casts(): array
{
    return [
        'collection' => AsCollection::of(function ($item) {
            // Custom logic here
        },
    ];
}
```
As casts needs to be serializable, I used the `SerializableClosure` in case a closure is used for the $map parameter.

I also extends this feature to the `AsEncryptedCollection` class:
```php
public function casts(): array
{
    return [
        'collection' => AsEncryptedCollection::of(function ($item) {
            // Custom logic here
        },
    ];
}
```

### Context
I want to use this new `$map` parameter (from the recent PR #55383) to generate a collection of data objects created with spatie/laravel-data, that are very well-suited for Eloquent casting. This is what I tried:
```php
public function casts(): array
{
    return [
        'collection' => AsCollection::of([DataObject::class, 'from']),
    ];
}
```

To instantiate the data objects with the `from()` method, the `Collection::map()` method is used, which calls `array_map([DataObject::class, 'from'], $array, $keys)` internally. However, as the `$keys` are passed, the `from()` method thinks that these are properties of the `DataObject`, which is not.

With a closure, I would be able to do that to makes spatie/laravel-data objects works:
```php
public function casts(): array
{
    return [
        'collection' => AsCollection::of(fn ($item) => DataObject::from($item)),
    ];
}
```