### PR TITLE
[12.x] Set job instance on "failed" command instance

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -274,6 +274,7 @@ class CallQueuedHandler
      * @param  array  $data
      * @param  \Throwable|null  $e
      * @param  string  $uuid
+     * @param  \Illuminate\Contracts\Queue\Job|null  $job
      * @return void
      */
     public function failed(array $data, $e, string $uuid, ?Job $job = null)

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -276,9 +276,13 @@ class CallQueuedHandler
      * @param  string  $uuid
      * @return void
      */
-    public function failed(array $data, $e, string $uuid)
+    public function failed(array $data, $e, string $uuid, ?Job $job = null)
     {
         $command = $this->getCommand($data);
+
+        if (! is_null($job)) {
+            $command = $this->setJobInstanceIfNecessary($job, $command);
+        }
 
         if (! $command instanceof ShouldBeUniqueUntilProcessing) {
             $this->ensureUniqueJobLockIsReleased($command);

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -251,7 +251,7 @@ abstract class Job
         [$class, $method] = JobName::parse($payload['job']);
 
         if (method_exists($this->instance = $this->resolve($class), 'failed')) {
-            $this->instance->failed($payload['data'], $e, $payload['uuid'] ?? '');
+            $this->instance->failed($payload['data'], $e, $payload['uuid'] ?? '', $this);
         }
     }
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
+use Illuminate\Queue\Jobs\Job;
 use Mockery as m;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\PheanstalkManagerInterface;
@@ -39,7 +40,7 @@ class QueueBeanstalkdJobTest extends TestCase
         $job->getPheanstalkJob()->shouldReceive('getData')->andReturn(json_encode(['job' => 'foo', 'uuid' => 'test-uuid', 'data' => ['data']]));
         $job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock(BeanstalkdJobTestFailedTest::class));
         $job->getPheanstalk()->shouldReceive('delete')->once()->with($job->getPheanstalkJob())->andReturnSelf();
-        $handler->shouldReceive('failed')->once()->with(['data'], m::type(Exception::class), 'test-uuid');
+        $handler->shouldReceive('failed')->once()->with(['data'], m::type(Exception::class), 'test-uuid', m::type(Job::class));
         $job->getContainer()->shouldReceive('make')->once()->with(Dispatcher::class)->andReturn($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(JobFailed::class))->andReturnNull();
 


### PR DESCRIPTION
This sets the job instance on the command instance created when attempting to call the `failed` method on a job class. It is fully backwards compatible.

I have a job that does some logging to a channel that is only for the job itself. In order to group the messages together, I include the job instance ID in the log context. If something goes wrong, I wanted to log an error by adding a `failed` method to the job class. However, I could not reference the job instance from within the `failed` method even though I was using the `InteractsWithQueue` trait.