### PR TITLE
[12.x] Allow limiting number of assets to preload

### DIFF
--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -9,17 +9,30 @@ use Illuminate\Support\Facades\Vite;
 class AddLinkHeadersForPreloadedAssets
 {
     /**
+     * Configure the middleware.
+     *
+     * @param  int  $limit
+     * @return string
+     */
+    public static function using($limit)
+    {
+        return static::class.':'.$limit;
+    }
+
+    /**
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
+     * @param  int  $limit
      * @return \Illuminate\Http\Response
      */
-    public function handle($request, $next)
+    public function handle($request, $next, $limit = null)
     {
-        return tap($next($request), function ($response) {
+        return tap($next($request), function ($response) use ($limit) {
             if ($response instanceof Response && Vite::preloadedAssets() !== []) {
                 $response->header('Link', (new Collection(Vite::preloadedAssets()))
+                    ->when($limit, fn ($assets, $limit) => $assets->take($limit))
                     ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
                     ->join(', '), false);
             }

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
@@ -105,5 +106,48 @@ class VitePreloadingTest extends TestCase
             ],
             $response->headers->all('Link'),
         );
+    }
+
+    public function testItCanLimitNumberOfAssetsPreloaded()
+    {
+        $app = new Container;
+        $app->instance(Vite::class, new class extends Vite
+        {
+            protected $preloadedAssets = [
+                'https://laravel.com/first.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+                'https://laravel.com/second.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+                'https://laravel.com/third.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+                'https://laravel.com/fourth.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+            ];
+        });
+        Facade::setFacadeApplication($app);
+
+        $response = (new AddLinkHeadersForPreloadedAssets)->handle(new Request, fn () => new Response('ok'), 2);
+
+        $this->assertSame(
+            [
+                '<https://laravel.com/first.js>; rel="modulepreload"; foo="bar", <https://laravel.com/second.js>; rel="modulepreload"; foo="bar"',
+            ],
+            $response->headers->all('Link'),
+        );
+    }
+
+    public function test_it_can_configure_the_middleware()
+    {
+        $definition = AddLinkHeadersForPreloadedAssets::using(limit: 5);
+
+        $this->assertSame('Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets:5', $definition);
     }
 }


### PR DESCRIPTION
When preloading a _lot_ of assets, this header can become problematically long. It can cause issues by overflowing the web servers maximum header length or simply be so long that it would be better off not sending it and allowing the html preload tags to kick in.

That isn't to say preloading via this header isn't a good default; it is. This is only for those applications that have an extreme number of assets that are to be preloaded by Vite.

This PR ensures you can limit the number of assets to preload to give some control over the header length.

```diff
- AddLinkHeadersForPreloadedAssets::class,
+ AddLinkHeadersForPreloadedAssets::using(limit: 10),
```

If we merge this PR I will roll out a sensible default to our packages.