### PR TITLE
[12.x] Support `useCurrent` on date and year column types

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -922,8 +922,6 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * Note: "useCurrent requires MariaDB or MySQL 8.0.13+."
-     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
@@ -1030,8 +1028,6 @@ class MySqlGrammar extends Grammar
 
     /**
      * Create the column definition for a year type.
-     *
-     * Note: "useCurrent requires MariaDB or MySQL 8.0.13+."
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -922,11 +922,23 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
+     * Note: "useCurrent requires MariaDB or MySQL 8.0.13+."
+     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDate(Fluent $column)
     {
+        $isMaria = $this->connection->isMaria();
+        $version = $this->connection->getServerVersion();
+
+        if ($isMaria ||
+            (! $isMaria && version_compare($version, '8.0.13', '>='))) {
+            if ($column->useCurrent) {
+                $column->default(new Expression('(CURDATE())'));
+            }
+        }
+
         return 'date';
     }
 
@@ -1019,11 +1031,23 @@ class MySqlGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
+     * Note: "useCurrent requires MariaDB or MySQL 8.0.13+."
+     *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeYear(Fluent $column)
     {
+        $isMaria = $this->connection->isMaria();
+        $version = $this->connection->getServerVersion();
+
+        if ($isMaria ||
+            (! $isMaria && version_compare($version, '8.0.13', '>='))) {
+            if ($column->useCurrent) {
+                $column->default(new Expression('(YEAR(CURDATE()))'));
+            }
+        }
+
         return 'year';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -922,6 +922,10 @@ class PostgresGrammar extends Grammar
      */
     protected function typeDate(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression('CURRENT_DATE'));
+        }
+
         return 'date';
     }
 
@@ -1007,6 +1011,10 @@ class PostgresGrammar extends Grammar
      */
     protected function typeYear(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression('EXTRACT(YEAR FROM CURRENT_DATE)'));
+        }
+
         return $this->typeInteger($column);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -907,6 +907,10 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeDate(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression('CURRENT_DATE'));
+        }
+
         return 'date';
     }
 
@@ -992,6 +996,10 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeYear(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression("(CAST(strftime('%Y', 'now') AS INTEGER))"));
+        }
+
         return $this->typeInteger($column);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -769,6 +769,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDate(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression('CAST(GETDATE() AS DATE)'));
+        }
+
         return 'date';
     }
 
@@ -856,6 +860,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeYear(Fluent $column)
     {
+        if ($column->useCurrent) {
+            $column->default(new Expression('CAST(YEAR(GETDATE()) AS INTEGER)'));
+        }
+
         return $this->typeInteger($column);
     }
 

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -873,7 +873,11 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(true);
+        $conn->shouldReceive('getServerVersion')->andReturn('10.3.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->date('foo');
         $statements = $blueprint->toSql();
 
@@ -881,13 +885,45 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
     }
 
+    public function testAddingDateWithDefaultCurrent()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(true);
+        $conn->shouldReceive('getServerVersion')->andReturn('10.3.0');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->date('foo')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` date not null default (CURDATE())', $statements[0]);
+    }
+
     public function testAddingYear()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(true);
+        $conn->shouldReceive('getServerVersion')->andReturn('10.3.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrent()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(true);
+        $conn->shouldReceive('getServerVersion')->andReturn('10.3.0');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `birth_year` year not null default (YEAR(CURDATE()))', $statements[0]);
     }
 
     public function testAddingDateTime()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -872,8 +872,40 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingDate()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('8.0.13');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->date('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
+    }
+
+    public function testAddingDateWithDefaultCurrent()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('8.0.13');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->date('foo')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` date not null default (CURDATE())', $statements[0]);
+    }
+
+    public function testAddingDateWithDefaultCurrentOn57()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('5.7');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->date('foo')->useCurrent();
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
@@ -882,9 +914,41 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingYear()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('8.0.13');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql();
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrent()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('8.0.13');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `birth_year` year not null default (YEAR(CURDATE()))', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrentOn57()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('isMaria')->andReturn(false);
+        $conn->shouldReceive('getServerVersion')->andReturn('5.7');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -714,6 +714,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->date('foo')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" date not null default CURRENT_DATE', $statements[0]);
+    }
+
     public function testAddingYear()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -721,6 +731,15 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "birth_year" integer not null default EXTRACT(YEAR FROM CURRENT_DATE)', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -640,6 +640,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->date('foo')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" date not null default CURRENT_DATE', $statements[0]);
+    }
+
     public function testAddingYear()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -647,6 +657,15 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "birth_year" integer not null default (CAST(strftime(\'%Y\', \'now\') AS INTEGER))', $statements[0]);
     }
 
     public function testAddingDateTime()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -102,6 +102,31 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertSame('prefix_geo_coordinates_spatialindex', $commands[0]->index);
     }
 
+    public function testDefaultCurrentDate()
+    {
+        $getSql = function ($grammar, $mysql57 = false) {
+            if ($grammar == 'MySql') {
+                $connection = $this->getConnection($grammar);
+                $mysql57 ? $connection->shouldReceive('getServerVersion')->andReturn('5.7') : $connection->shouldReceive('getServerVersion')->andReturn('8.0.13');
+                $connection->shouldReceive('isMaria')->andReturn(false);
+
+                return (new Blueprint($connection, 'users', function ($table) {
+                    $table->date('created')->useCurrent();
+                }))->toSql();
+            } else {
+                return $this->getBlueprint($grammar, 'users', function ($table) {
+                    $table->date('created')->useCurrent();
+                })->toSql();
+            }
+        };
+
+        $this->assertEquals(['alter table `users` add `created` date not null default (CURDATE())'], $getSql('MySql'));
+        $this->assertEquals(['alter table `users` add `created` date not null'], $getSql('MySql', mysql57: true));
+        $this->assertEquals(['alter table "users" add column "created" date not null default CURRENT_DATE'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" add column "created" date not null default CURRENT_DATE'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "users" add "created" date not null default CAST(GETDATE() AS DATE)'], $getSql('SqlServer'));
+    }
+
     public function testDefaultCurrentDateTime()
     {
         $getSql = function ($grammar) {
@@ -128,6 +153,31 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
         $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
+    }
+
+    public function testDefaultCurrentYear()
+    {
+        $getSql = function ($grammar, $mysql57 = false) {
+            if ($grammar == 'MySql') {
+                $connection = $this->getConnection($grammar);
+                $mysql57 ? $connection->shouldReceive('getServerVersion')->andReturn('5.7') : $connection->shouldReceive('getServerVersion')->andReturn('8.0.13');
+                $connection->shouldReceive('isMaria')->andReturn(false);
+
+                return (new Blueprint($connection, 'users', function ($table) {
+                    $table->year('birth_year')->useCurrent();
+                }))->toSql();
+            } else {
+                return $this->getBlueprint($grammar, 'users', function ($table) {
+                    $table->year('birth_year')->useCurrent();
+                })->toSql();
+            }
+        };
+
+        $this->assertEquals(['alter table `users` add `birth_year` year not null default (YEAR(CURDATE()))'], $getSql('MySql'));
+        $this->assertEquals(['alter table `users` add `birth_year` year not null'], $getSql('MySql', mysql57: true));
+        $this->assertEquals(['alter table "users" add column "birth_year" integer not null default EXTRACT(YEAR FROM CURRENT_DATE)'], $getSql('Postgres'));
+        $this->assertEquals(['alter table "users" add column "birth_year" integer not null default (CAST(strftime(\'%Y\', \'now\') AS INTEGER))'], $getSql('SQLite'));
+        $this->assertEquals(['alter table "users" add "birth_year" int not null default CAST(YEAR(GETDATE()) AS INTEGER)'], $getSql('SqlServer'));
     }
 
     public function testRemoveColumn()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -614,6 +614,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "foo" date not null', $statements[0]);
     }
 
+    public function testAddingDateWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->date('foo')->useCurrent();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" date not null default CAST(GETDATE() AS DATE)', $statements[0]);
+    }
+
     public function testAddingYear()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -621,6 +631,15 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "birth_year" int not null', $statements[0]);
+    }
+
+    public function testAddingYearWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->year('birth_year')->useCurrent();
+        $statements = $blueprint->toSql();
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "birth_year" int not null default CAST(YEAR(GETDATE()) AS INTEGER)', $statements[0]);
     }
 
     public function testAddingDateTime()


### PR DESCRIPTION
This PR adds support for the `useCurrent` column modifier on `DATE` and `YEAR` column types. This allows these columns to default to the current date/year, like the `TIMESTAMP` column type.

**Usage**

```php
$table->date('foo')->useCurrent();

$table->year('birth_year')->useCurrent();

```

This works across all supported versions of MariaDB, PostgreSQL, SQLite, and SQL Server, as well as MySQL 8.0.13+. 

For MySQL, it checks against the server version and is supported on 8.0.13 and later. This is due to older versions not supporting default expressions.

**Generated queries**

```sql
-- MariaDB

# date
alter table `users` add `foo` date not null default (CURDATE());
# year
alter table `users` add `birth_year` year not null default (YEAR(CURDATE()));
```
```sql
-- PostgreSQL

# date
alter table "users" add column "foo" date not null default CURRENT_DATE;
# year
alter table "users" add column "birth_year" integer not null default EXTRACT(YEAR FROM CURRENT_DATE);
```
```sql
-- SQLite

# date
alter table "users" add column "foo" date not null default CURRENT_DATE;
# year
alter table "users" add column "birth_year" integer not null default (CAST(strftime('%Y', 'now') AS INTEGER));
```
```sql
-- SQL Server

# date
alter table "users" add "foo" date not null default CAST(GETDATE() AS DATE);
# year
alter table "users" add "birth_year" int not null default CAST(YEAR(GETDATE()) AS INTEGER);
```
```sql
-- MySQL (8.0.13+)

# date
alter table `users` add `foo` date not null default (CURDATE());
# year 
alter table `users` add `birth_year` year not null default (YEAR(CURDATE()));
```
```sql
-- MySQL (5.7 - 8.0.12)
# (the useCurrent modifier is ignored)

# date
alter table `users` add `foo` date not null;
# year 
alter table `users` add `birth_year` year not null;
```
**Use Case**

This simplifies setting the default values to current date/year since the syntax varies greatly between the different database types and avoids having to use and know an expression.