### PR TITLE
[12.x] Add support for callback evaluation in containsOneItem method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -712,12 +712,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Determine if the collection contains a single item.
+     * Determine if the collection contains exactly one item. If a callback is provided, it checks if exactly one item matches the condition.
      *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool
      */
-    public function containsOneItem()
+    public function containsOneItem(?callable $callback = null): bool
     {
+        if ($callback) {
+            return $this->filter($callback)->count() === 1;
+        }
+
         return $this->count() === 1;
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -712,7 +712,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Determine if the collection contains exactly one item. If a callback is provided, it checks if exactly one item matches the condition.
+     * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -838,6 +838,10 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse((new $collection([]))->containsOneItem());
         $this->assertTrue((new $collection([1]))->containsOneItem());
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
+
+        $this->assertFalse(collect([1, 2, 2])->containsOneItem(fn ($number) => $number === 2));
+        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) === 4));
+        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) > 4));
     }
 
     public function testIterable()


### PR DESCRIPTION
### Why this change?

This PR extends the `containsOneItem` method to accept an optional callback. This allows users to determine whether **exactly one item** in the collection satisfies a given condition.

### Example usage

```php
$collection = collect([1, 2, 3]);

$collection->containsOneItem(fn($item) => $item === 2); // true
$collection->containsOneItem(fn($item) => $item > 1);   // false (2 and 3 match)
```