### PR TITLE
[12.x] `ScheduledTaskFailed` not dispatched on scheduled forground task fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "laravel-framework",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "laravel-framework",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -97,10 +97,6 @@ class ScheduleRunCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @return void
      */
     public function handle(Schedule $schedule, Dispatcher $dispatcher, Cache $cache, ExceptionHandler $handler)
@@ -197,11 +193,11 @@ class ScheduleRunCommand extends Command
                     round(microtime(true) - $start, 2)
                 ));
 
+                $this->eventsRan = true;
+
                 if ($event->exitCode != 0 && ! $event->runInBackground) {
                     throw new Exception("Scheduled command [{$event->command}] failed with exit code [{$event->exitCode}].");
                 }
-
-                $this->eventsRan = true;
             } catch (Throwable $e) {
                 $this->dispatcher->dispatch(new ScheduledTaskFailed($event, $e));
 

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -97,6 +97,10 @@ class ScheduleRunCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $handler
      * @return void
      */
     public function handle(Schedule $schedule, Dispatcher $dispatcher, Cache $cache, ExceptionHandler $handler)

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Exception;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\Events\ScheduledTaskFailed;
@@ -195,6 +196,10 @@ class ScheduleRunCommand extends Command
                     $event,
                     round(microtime(true) - $start, 2)
                 ));
+
+                if ($event->exitCode != 0 && ! $event->runInBackground) {
+                    throw new Exception("Scheduled command [{$event->command}] failed with exit code [{$event->exitCode}].");
+                }
 
                 $this->eventsRan = true;
             } catch (Throwable $e) {

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -39,8 +39,7 @@ class ScheduleRunCommandTest extends TestCase
         // Create a schedule and add the command
         $schedule = $this->app->make(Schedule::class);
         $task = $schedule->exec('exit 1')
-            ->everyMinute()
-            ->withoutOverlapping();
+            ->everyMinute();
 
         // Make sure it will run regardless of schedule
         $task->when(function () {
@@ -104,8 +103,7 @@ class ScheduleRunCommandTest extends TestCase
         // Create a schedule and add the command
         $schedule = $this->app->make(Schedule::class);
         $task = $schedule->exec('exit 0')
-            ->everyMinute()
-            ->withoutOverlapping();
+            ->everyMinute();
 
         // Make sure it will run regardless of schedule
         $task->when(function () {
@@ -135,8 +133,7 @@ class ScheduleRunCommandTest extends TestCase
         // Create a schedule and add the command that just performs an action without explicit exit
         $schedule = $this->app->make(Schedule::class);
         $task = $schedule->exec('true')
-            ->everyMinute()
-            ->withoutOverlapping();
+            ->everyMinute();
 
         // Make sure it will run regardless of schedule
         $task->when(function () {

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleRunCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::now());
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_failing_command_in_foreground_triggers_event()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        // Create a schedule and add the command
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('exit 1')
+            ->everyMinute()
+            ->withoutOverlapping();
+
+        // Make sure it will run regardless of schedule
+        $task->when(function () {
+            return true;
+        });
+
+        // Execute the scheduler
+        $this->artisan('schedule:run');
+
+        // Verify the event sequence
+        Event::assertDispatched(ScheduledTaskStarting::class);
+        Event::assertDispatched(ScheduledTaskFinished::class);
+        Event::assertDispatched(ScheduledTaskFailed::class, function ($event) use ($task) {
+            return $event->task === $task &&
+                   $event->exception->getMessage() === 'Scheduled command [exit 1] failed with exit code [1].';
+        });
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_failing_command_in_background_does_not_trigger_event()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        // Create a schedule and add the command
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('exit 1')
+            ->everyMinute()
+            ->runInBackground();
+
+        // Make sure it will run regardless of schedule
+        $task->when(function () {
+            return true;
+        });
+
+        // Execute the scheduler
+        $this->artisan('schedule:run');
+
+        // Verify the event sequence
+        Event::assertDispatched(ScheduledTaskStarting::class);
+        Event::assertDispatched(ScheduledTaskFinished::class);
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_successful_command_does_not_trigger_event()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        // Create a schedule and add the command
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('exit 0')
+            ->everyMinute()
+            ->withoutOverlapping();
+
+        // Make sure it will run regardless of schedule
+        $task->when(function () {
+            return true;
+        });
+
+        // Execute the scheduler
+        $this->artisan('schedule:run');
+
+        // Verify the event sequence
+        Event::assertDispatched(ScheduledTaskStarting::class);
+        Event::assertDispatched(ScheduledTaskFinished::class);
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+}

--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -151,4 +151,66 @@ class ScheduleRunCommandTest extends TestCase
         Event::assertDispatched(ScheduledTaskFinished::class);
         Event::assertNotDispatched(ScheduledTaskFailed::class);
     }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_successful_command_in_background_does_not_trigger_event()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        // Create a schedule and add the command
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('exit 0')
+            ->everyMinute()
+            ->runInBackground();
+
+        // Make sure it will run regardless of schedule
+        $task->when(function () {
+            return true;
+        });
+
+        // Execute the scheduler
+        $this->artisan('schedule:run');
+
+        // Verify the event sequence
+        Event::assertDispatched(ScheduledTaskStarting::class);
+        Event::assertDispatched(ScheduledTaskFinished::class);
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_command_with_no_explicit_return_in_background_does_not_trigger_event()
+    {
+        Event::fake([
+            ScheduledTaskStarting::class,
+            ScheduledTaskFinished::class,
+            ScheduledTaskFailed::class,
+        ]);
+
+        // Create a schedule and add the command that just performs an action without explicit exit
+        $schedule = $this->app->make(Schedule::class);
+        $task = $schedule->exec('true')
+            ->everyMinute()
+            ->runInBackground();
+
+        // Make sure it will run regardless of schedule
+        $task->when(function () {
+            return true;
+        });
+
+        // Execute the scheduler
+        $this->artisan('schedule:run');
+
+        // Verify the event sequence
+        Event::assertDispatched(ScheduledTaskStarting::class);
+        Event::assertDispatched(ScheduledTaskFinished::class);
+        Event::assertNotDispatched(ScheduledTaskFailed::class);
+    }
 }


### PR DESCRIPTION
Fix: Consistent Failure Event Dispatching for Foreground and Background Scheduled Tasks

### Description

This PR resolves inconsistencies in Laravel's scheduler related to how task failures are handled and how the ScheduledTaskFailed event is dispatched.

### Problem

Two main issues were affecting scheduled task failure behavior:

1.  **Foreground task failures** (e.g., exceptions or non-zero exit codes) did not always result in `ScheduledTaskFailed` being dispatched properly.
    
2.  **Background tasks** using runInBackground() could cause unexpected exceptions when exit codes were not returned or were null, disrupting the scheduler.
    

This led to unreliable error monitoring and regressions after PR #55572, which had to be reverted due to these side effects.

### Solution

This PR ensures:

*   **Foreground task failures** now reliably dispatch the ScheduledTaskFailed event when a task throws an exception or exits with a non-zero status code.
    
*   **Background tasks** (runInBackground()) are excluded from failure exceptions when exit codes are not explicitly returned, preventing unintended scheduler crashes.
    
*   The scheduler behaves consistently across both execution modes while preserving Laravel's event-driven error handling model.
 
- before this fix : 

|  Scenario | `ScheduledTaskFinished`  | `ScheduledTaskFailed`  |  
| ------------- | ------------- | ------------- |
| Command runs and throws an exception within itself | ✅ Dispatched | ❌ Not dispatched  |
| Command runs and returns non-zero $exitCode | ✅ Dispatched | ❌ Not dispatched  |
|`$event->run($this->laravel); `itself throws | ❌ Not dispatched | ✅ Dispatched  |

- after the fix : 

|  Scenario | `ScheduledTaskFinished`  | `ScheduledTaskFailed`  |  
| ------------- | ------------- | ------------- |
| Command runs and throws an exception within itself | ✅ Dispatched | ✅ Dispatched  |
| Command runs and returns non-zero $exitCode | ✅ Dispatched | ✅ Dispatched  |
|`$event->run($this->laravel); `itself throws | ❌ Not dispatched | ✅ Dispatched  |

So to be clear, ScheduledTaskFinished should always be dispatched unless the exception happens before or outside the actual command execution (e.g. command not found, or failure to start).

### Impact

*   Ensures accurate and consistent dispatching of the ScheduledTaskFailed event.
    
*   Prevents exceptions from being thrown for background tasks with null or missing exit codes.
    
*   Maintains backward compatibility and avoids introducing regressions.
    

### Related Issues

*   Fixes #55614
    
*   Builds on discussion from reverted PR #55572