### PR TITLE
[12.x] add PHP Doc types to arrays for methods in Database\Grammar

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -31,8 +31,8 @@ abstract class Grammar
     /**
      * Wrap an array of values.
      *
-     * @param  array  $values
-     * @return array
+     * @param  array<\Illuminate\Contracts\Database\Query\Expression|string>  $values
+     * @return array<string>
      */
     public function wrapArray(array $values)
     {
@@ -136,7 +136,7 @@ abstract class Grammar
     /**
      * Wrap the given value segments.
      *
-     * @param  array  $segments
+     * @param  list<string>  $segments
      * @return string
      */
     protected function wrapSegments($segments)
@@ -190,7 +190,7 @@ abstract class Grammar
     /**
      * Convert an array of column names into a delimited string.
      *
-     * @param  array  $columns
+     * @param  array<\Illuminate\Contracts\Database\Query\Expression|string>  $columns
      * @return string
      */
     public function columnize(array $columns)
@@ -201,7 +201,7 @@ abstract class Grammar
     /**
      * Create query parameter place-holders for an array.
      *
-     * @param  array  $values
+     * @param  array<mixed>  $values
      * @return string
      */
     public function parameterize(array $values)
@@ -223,7 +223,7 @@ abstract class Grammar
     /**
      * Quote the given string literal.
      *
-     * @param  string|array  $value
+     * @param  string|array<string>  $value
      * @return string
      */
     public function quoteString($value)


### PR DESCRIPTION
This is another PR to add and improve the PhpDoc by adding generics to types.

This will result in better static type checking and better code completion when using IDEs.