### PR TITLE
[12.x] fix no arguments return type in request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -417,7 +417,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return \Symfony\Component\HttpFoundation\InputBag|mixed
+     * @return ($key is null ? \Symfony\Component\HttpFoundation\InputBag : mixed)
      */
     public function json($key = null, $default = null)
     {
@@ -633,7 +633,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string|null  $param
      * @param  mixed  $default
-     * @return \Illuminate\Routing\Route|object|string|null
+     * @return ($param is null ? \Illuminate\Routing\Route : object|string|null)
      */
     public function route($param = null, $default = null)
     {

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -18,6 +18,5 @@ assertType('TestEnum|null', $request->enum('key', TestEnum::class));
 assertType('Illuminate\Routing\Route', $request->route());
 assertType('object|string|null', $request->route('key'));
 
-
 assertType('Symfony\Component\HttpFoundation\InputBag', $request->json());
 assertType('mixed', $request->json('key'));

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -14,3 +14,10 @@ $request = Request::create('/', 'GET', [
 ]);
 
 assertType('TestEnum|null', $request->enum('key', TestEnum::class));
+
+assertType('Illuminate\Routing\Route', $request->route());
+assertType('object|string|null', $request->route('key'));
+
+
+assertType('Symfony\Component\HttpFoundation\InputBag', $request->json());
+assertType('mixed', $request->json('key'));


### PR DESCRIPTION
Yet another type fixing pr... sorry... 


This PR fixes the return type of `route` and `json` method in `Request` class when `null` no arguments are passed to them. 