### PR TITLE
[12.x]: New Commands to Encrypt Generic Files

### DIFF
--- a/src/Illuminate/Foundation/Console/FileDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/FileDecryptCommand.php
@@ -28,7 +28,6 @@ class FileDecryptCommand extends Command
                     {--filename= : Filename of the decrypted file}
                     {--force : Overwrite the existing file}';
 
-
     /**
      * The console command description.
      *
@@ -67,7 +66,7 @@ class FileDecryptCommand extends Command
         $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
         if (! $filename && $this->input->isInteractive()) {
-            $filename = text('What is the filename to encrypt?');
+            $filename = text('What is the filename to decrypt?');
         }
 
         if (! $filename) {
@@ -86,11 +85,11 @@ class FileDecryptCommand extends Command
 
         $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
-        $mainFile = Str::finish($this->option('path') ?: $this->laravel->basePath(), DIRECTORY_SEPARATOR).$filename;
+        $encryptedFile = Str::finish($this->option('path') ?: $this->laravel->basePath(), DIRECTORY_SEPARATOR).$filename;
 
-        $encryptedFile = $mainFile.'.encrypted';
+        $mainFile = Str::remove('.encrypted', $encryptedFile);
 
-        if (Str::endsWith($mainFile, '.encrypted')) {
+        if (!Str::endsWith($encryptedFile, '.encrypted')) {
             $this->fail('Invalid filename.');
         }
 

--- a/src/Illuminate/Foundation/Console/FileDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/FileDecryptCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\text;
+
+#[AsCommand(name: 'file:decrypt')]
+class FileDecryptCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'file:decrypt
+                    {--key= : The encryption key}
+                    {--cipher= : The encryption cipher}
+                    {--path= : Path to write the decrypted file}
+                    {--filename= : Filename of the decrypted file}
+                    {--force : Overwrite the existing file}';
+
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Decrypt an file';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $filename = $this->option('filename');
+
+        $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
+
+        if (! $filename && $this->input->isInteractive()) {
+            $filename = text('What is the filename to encrypt?');
+        }
+
+        if (! $filename) {
+            $this->fail('A filename is required.');
+        }
+
+        if (! $key && $this->input->isInteractive()) {
+            $key = password('What is the decryption key?');
+        }
+
+        if (! $key) {
+            $this->fail('A decryption key is required.');
+        }
+
+        $key = $this->parseKey($key);
+
+        $cipher = $this->option('cipher') ?: 'AES-256-CBC';
+
+        $mainFile = Str::finish($this->option('path') ?: $this->laravel->basePath(), DIRECTORY_SEPARATOR).$filename;
+
+        $encryptedFile = $mainFile.'.encrypted';
+
+        if (Str::endsWith($mainFile, '.encrypted')) {
+            $this->fail('Invalid filename.');
+        }
+
+        if (! $this->files->exists($encryptedFile)) {
+            $this->fail('Encrypted file not found.');
+        }
+
+        if ($this->files->exists($mainFile) && ! $this->option('force')) {
+            $this->fail('File already exists.');
+        }
+
+        try {
+            $encrypter = new Encrypter($key, $cipher);
+
+            $this->files->put(
+                $mainFile,
+                $encrypter->decrypt($this->files->get($encryptedFile))
+            );
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->components->info('File successfully decrypted.');
+
+        $this->components->twoColumnDetail('Decrypted file', $mainFile);
+
+        $this->newLine();
+    }
+
+    /**
+     * Parse the encryption key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function parseKey(string $key)
+    {
+        if (Str::startsWith($key, $prefix = 'base64:')) {
+            $key = base64_decode(Str::after($key, $prefix));
+        }
+
+        return $key;
+    }
+}

--- a/src/Illuminate/Foundation/Console/FileDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/FileDecryptCommand.php
@@ -89,7 +89,7 @@ class FileDecryptCommand extends Command
 
         $mainFile = Str::remove('.encrypted', $encryptedFile);
 
-        if (!Str::endsWith($encryptedFile, '.encrypted')) {
+        if (! Str::endsWith($encryptedFile, '.encrypted')) {
             $this->fail('Invalid filename.');
         }
 

--- a/src/Illuminate/Foundation/Console/FileEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/FileEncryptCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+#[AsCommand(name: 'file:encrypt')]
+class FileEncryptCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'file:encrypt
+                    {--key= : The encryption key}
+                    {--cipher= : The encryption cipher}
+                    {--path= : Path to write the encrypted file}
+                    {--filename= : Filename of the encrypted file}
+                    {--prune : Delete the original file}
+                    {--force : Overwrite the existing encrypted file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Encrypt an file';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $key = $this->option('key');
+
+        $filename = $this->option('filename');
+
+        $cipher = $this->option('cipher') ?: 'AES-256-CBC';
+
+        if (! $filename && $this->input->isInteractive()) {
+            $filename = text('What is the filename to encrypt?');
+        }
+
+        if (! $filename) {
+            $this->fail('A filename is required.');
+        }
+
+        if (! $key && $this->input->isInteractive()) {
+            $ask = select(
+                label: 'What encryption key would you like to use?',
+                options: [
+                    'generate' => 'Generate a random encryption key',
+                    'ask' => 'Provide an encryption key',
+                ],
+                default: 'generate'
+            );
+
+            if ($ask == 'ask') {
+                $key = password('What is the encryption key?');
+            }
+        }
+
+        $keyPassed = $key !== null;
+
+        $mainFile = Str::finish($this->option('path') ?: $this->laravel->basePath(), DIRECTORY_SEPARATOR).$filename;
+
+        $encryptedFile = $mainFile.'.encrypted';
+
+        if (! $keyPassed) {
+            $key = Encrypter::generateKey($cipher);
+        }
+
+        if (! $this->files->exists($mainFile)) {
+            $this->fail('File not found.');
+        }
+
+        if ($this->files->exists($encryptedFile) && ! $this->option('force')) {
+            $this->fail('Encrypted file already exists.');
+        }
+
+        try {
+            $encrypter = new Encrypter($this->parseKey($key), $cipher);
+
+            $this->files->put(
+                $encryptedFile,
+                $encrypter->encrypt($this->files->get($mainFile))
+            );
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        if ($this->option('prune')) {
+            $this->files->delete($mainFile);
+        }
+
+        $this->components->info('File successfully encrypted.');
+
+        $this->components->twoColumnDetail('Key', $keyPassed ? $key : 'base64:'.base64_encode($key));
+        $this->components->twoColumnDetail('Cipher', $cipher);
+        $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
+
+        $this->newLine();
+    }
+
+    /**
+     * Parse the encryption key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function parseKey(string $key)
+    {
+        if (Str::startsWith($key, $prefix = 'base64:')) {
+            $key = base64_decode(Str::after($key, $prefix));
+        }
+
+        return $key;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -54,6 +54,8 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FileDecryptCommand;
+use Illuminate\Foundation\Console\FileEncryptCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\JobMiddlewareMakeCommand;
@@ -137,6 +139,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
+        'FileDecrypt' => FileDecryptCommand::class,
+        'FileEncrypt' => FileEncryptCommand::class,
         'InvokeSerializedClosure' => InvokeSerializedClosureCommand::class,
         'KeyGenerate' => KeyGenerateCommand::class,
         'Optimize' => OptimizeCommand::class,

--- a/tests/Integration/Console/FileDecryptCommandTest.php
+++ b/tests/Integration/Console/FileDecryptCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class FileDecryptCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = m::spy(Filesystem::class);
+        $this->filesystem->shouldReceive('put')
+            ->andReturn(true);
+        File::swap($this->filesystem);
+    }
+}

--- a/tests/Integration/Console/FileDecryptCommandTest.php
+++ b/tests/Integration/Console/FileDecryptCommandTest.php
@@ -92,7 +92,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter($key = Encrypter::generateKey('AES-256-CBC'), 'AES-256-CBC'))
-                    ->encrypt('APP_NAME=Laravel')
+                    ->encrypt('//registry.npmjs.org/:_authToken=123_ABC')
             );
 
         $this->artisan('file:decrypt', ['--force' => true, '--key' => 'base64:'.base64_encode($key)])
@@ -101,7 +101,7 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.npmrc'), 'APP_NAME=Laravel');
+            ->with(base_path('.npmrc'), '//registry.npmjs.org/:_authToken=123_ABC');
     }
 
     public function testItGeneratesTheFileWithUserProvidedKey()
@@ -116,7 +116,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter('abcdefghijklmnop', 'aes-128-gcm'))
-                    ->encrypt('APP_NAME="Laravel Two"')
+                    ->encrypt('//registry.npmjs.org/:_authToken=ABC_123')
             );
 
         $this->artisan('file:decrypt', ['--cipher' => 'aes-128-gcm', '--key' => 'abcdefghijklmnop'])
@@ -125,7 +125,7 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.npmrc'), 'APP_NAME="Laravel Two"');
+            ->with(base_path('.npmrc'), '//registry.npmjs.org/:_authToken=ABC_123');
     }
 
     public function testItGeneratesTheFileWithKeyFromEnvironment()
@@ -142,7 +142,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter('ponmlkjihgfedcbaponmlkjihgfedcba', 'AES-256-CBC'))
-                    ->encrypt('APP_NAME="Laravel Three"')
+                    ->encrypt('//registry.npmjs.org/:_authToken=1A_2B_3C')
             );
 
         $this->artisan('file:decrypt')
@@ -151,7 +151,7 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.npmrc'), 'APP_NAME="Laravel Three"');
+            ->with(base_path('.npmrc'), '//registry.npmjs.org/:_authToken=1A_2B_3C');
 
         unset($_SERVER['LARAVEL_ENV_ENCRYPTION_KEY']);
     }
@@ -168,7 +168,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter('abcdefghijklmnop', 'aes-128-gcm'))
-                    ->encrypt('APP_NAME="Laravel Two"')
+                    ->encrypt('//registry.npmjs.org/:_authToken=ABC_123')
             );
 
         $this->artisan('file:decrypt', ['--force' => true, '--key' => 'abcdefghijklmnop', '--cipher' => 'aes-128-gcm'])
@@ -177,27 +177,15 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.npmrc'), 'APP_NAME="Laravel Two"');
+            ->with(base_path('.npmrc'), '//registry.npmjs.org/:_authToken=ABC_123');
     }
 
     public function testItDecryptsMultiLineFileCorrectly()
     {
         $contents = <<<'Text'
-        APP_NAME=Laravel
-        APP_ENV=local
-        APP_DEBUG=true
-        APP_URL=http://localhost
-
-        LOG_CHANNEL=stack
-        LOG_DEPRECATIONS_CHANNEL=null
-        LOG_LEVEL=debug
-
-        DB_CONNECTION=mysql
-        DB_HOST=127.0.0.1
-        DB_PORT=3306
-        DB_DATABASE=laravel
-        DB_USERNAME=root
-        DB_PASSWORD=
+        //registry.npmjs.org/:_authToken=ABC_123
+        //registry.npmjs.org/:_authToken=123_ABC
+        //registry.npmjs.org/:_authToken=1A_2B_3C
         Text;
 
         $this->filesystem->shouldReceive('exists')
@@ -234,7 +222,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter('abcdefghijklmnopabcdefghijklmnop', 'AES-256-CBC'))
-                    ->encrypt('APP_NAME="Laravel Two"')
+                    ->encrypt('//registry.npmjs.org/:_authToken=123_ABC')
             );
 
         $this->artisan('file:decrypt', ['--key' => 'abcdefghijklmnopabcdefghijklmnop', '--path' => '/tmp'])
@@ -243,7 +231,7 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with('/tmp'.DIRECTORY_SEPARATOR.'.npmrc.production', 'APP_NAME="Laravel Two"');
+            ->with('/tmp'.DIRECTORY_SEPARATOR.'.npmrc.production', '//registry.npmjs.org/:_authToken=123_ABC');
     }
 
     public function testItCannotOverwriteEncryptedFiles()
@@ -271,7 +259,7 @@ class FileDecryptCommandTest extends TestCase
             ->once()
             ->andReturn(
                 (new Encrypter($key = 'abcdefghijklmnop', 'aes-128-gcm'))
-                    ->encrypt('APP_NAME="Laravel Two"')
+                    ->encrypt('//registry.npmjs.org/:_authToken=B2_C3_A1')
             );
 
         $this->artisan('file:decrypt', ['--cipher' => 'aes-128-gcm'])
@@ -281,6 +269,6 @@ class FileDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.npmrc'), 'APP_NAME="Laravel Two"');
+            ->with(base_path('.npmrc'), '//registry.npmjs.org/:_authToken=B2_C3_A1');
     }
 }

--- a/tests/Integration/Console/FileEncryptCommandTest.php
+++ b/tests/Integration/Console/FileEncryptCommandTest.php
@@ -20,7 +20,7 @@ class FileEncryptCommandTest extends TestCase
         $this->filesystem->shouldReceive('get')
             ->andReturn(true)
             ->shouldReceive('put')
-            ->andReturn('APP_NAME=Laravel');
+            ->andReturn('//registry.npmjs.org/:_authToken=NPM_TOKEN');
         File::swap($this->filesystem);
     }
 

--- a/tests/Integration/Console/FileEncryptCommandTest.php
+++ b/tests/Integration/Console/FileEncryptCommandTest.php
@@ -23,4 +23,180 @@ class FileEncryptCommandTest extends TestCase
             ->andReturn('APP_NAME=Laravel');
         File::swap($this->filesystem);
     }
+
+    public function testItFailsWhenFilenameIsNotProvided()
+    {
+        $this->artisan('file:encrypt')
+            ->expectsQuestion('What is the filename to encrypt?', '')
+            ->expectsOutputToContain('A filename is required.')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWithInvalidCipherFails()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt', ['--cipher' => 'invalid'])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('Unsupported cipher')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsUsingCipherWithInvalidKey()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt', ['--key' => 'invalid', '--cipher' => 'aes-128-cbc'])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsOutputToContain('incorrect key length')
+            ->assertExitCode(1);
+    }
+
+    public function testItGeneratesTheCorrectFile()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt')
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.npmrc.encrypted'), m::any());
+    }
+
+    public function testItFailsWhenFileCannotBeFound()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(false);
+
+        $this->artisan('file:encrypt')
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('File not found.')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWhenEncryptionFileExists()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(true);
+
+        $this->artisan('file:encrypt')
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('Encrypted file already exists.')
+            ->assertExitCode(1);
+    }
+
+    public function testItGeneratesTheEncryptionFileWhenForcing()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true);
+
+        $this->artisan('file:encrypt', ['--force' => true])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.npmrc.encrypted'), m::any());
+    }
+
+    public function testItEncryptsWithGivenKeyAndDisplaysIt()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt', ['--key' => $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsOutputToContain('File successfully encrypted')
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->expectsOutputToContain($key)
+            ->assertExitCode(0);
+    }
+
+    public function testItEncryptsWithGivenGeneratedBase64KeyAndDisplaysIt()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $key = Encrypter::generateKey('AES-256-CBC');
+
+        $this->artisan('file:encrypt', ['--key' => 'base64:'.base64_encode($key)])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsOutputToContain('File successfully encrypted')
+            ->expectsOutputToContain('base64:'.base64_encode($key))
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->assertExitCode(0);
+    }
+
+    public function testItCanRemoveTheOriginalFile()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt', ['--prune' => true])
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'generate')
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.npmrc.encrypted'), m::any());
+
+        $this->filesystem->shouldHaveReceived('delete')
+            ->with(base_path('.npmrc'));
+    }
+
+    public function testItEncryptsWithInteractivelyGivenKeyAndDisplaysIt()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('file:encrypt')
+            ->expectsQuestion('What is the filename to encrypt?', '.npmrc')
+            ->expectsQuestion('What encryption key would you like to use?', 'ask')
+            ->expectsQuestion('What is the encryption key?', $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP')
+            ->expectsOutputToContain('File successfully encrypted')
+            ->expectsOutputToContain('.npmrc.encrypted')
+            ->expectsOutputToContain($key)
+            ->assertExitCode(0);
+    }
 }

--- a/tests/Integration/Console/FileEncryptCommandTest.php
+++ b/tests/Integration/Console/FileEncryptCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class FileEncryptCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = m::spy(Filesystem::class);
+        $this->filesystem->shouldReceive('get')
+            ->andReturn(true)
+            ->shouldReceive('put')
+            ->andReturn('APP_NAME=Laravel');
+        File::swap($this->filesystem);
+    }
+}


### PR DESCRIPTION
**📌 Rationale and Importance of This Feature**

Laravel currently provides native support for encrypting and decrypting .env files, allowing developers and DevOps teams to safely version these files, keeping them encrypted within public or private repositories, and decrypting them only during the build or deployment process.

This approach enhances security and simplifies automation by preventing the accidental exposure of sensitive data.

The purpose of this PR is to expand this functionality to support any type of file, such as .npmrc, .pypirc, .dockerconfig, JSON configuration files, YAML secrets, and other files that sometimes also need to be securely versioned or shared.

Key benefits of this improvement:

- 🔐 Unified security workflow: Allows any sensitive file to be securely versioned alongside the codebase, encrypted with the same key used by Laravel.

- 🛠️ CI/CD pipeline integration: Enables full automation of deployment processes, where configuration files or credentials can be safely decrypted in the target environment without prior exposure.

- 📦 Centralized standard: Removes the need for external tools or custom scripts to encrypt additional files, keeping a consistent and native workflow within the Laravel ecosystem.

- 📜 Safe version control: Allows important configuration files to be versioned in the repository without risk, making it easier to manage history and collaborate within teams.

This extension is particularly valuable in scenarios where Laravel applications interact with external services or tools that require configuration files containing tokens, credentials, or other private information.

**I know I've already opened this PR other times, but it's really a feature that I really need.**