### PR TITLE
[12.x] Typehints for bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4171,7 +4171,7 @@ class Builder implements BuilderContract
      * Set the bindings on the query builder.
      *
      * @param  list<mixed>  $bindings
-     * @param  string  $type
+     * @param  "select"|"from"|"join"|"where"|"groupBy"|"having"|"order"|"union"|"unionOrder"  $type
      * @return $this
      *
      * @throws \InvalidArgumentException
@@ -4191,7 +4191,7 @@ class Builder implements BuilderContract
      * Add a binding to the query.
      *
      * @param  mixed  $value
-     * @param  string  $type
+     * @param  "select"|"from"|"join"|"where"|"groupBy"|"having"|"order"|"union"|"unionOrder"  $type
      * @return $this
      *
      * @throws \InvalidArgumentException


### PR DESCRIPTION
To aid in static analysis when setting bindings. This is especially important for someone who is building an insertUsing() call.

```php
FavoritePodcast::query()->insertUsing(
    ['id', 'created_at', 'user_id'],
    Podcast::query()
        ->where('category_id', 123)
        ->select(['id', DB::raw('? as created_at'), DB::raw('? as user_id')])
        ->addBindings(
            [now(), $user->id],
            'select' // this will now give me a static analysis warning if I input something bogus, and it's much easier to discover what the acceptable values are
        )
);
```