### PR TITLE
[12.x] Allow naming queued closures

### DIFF
--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -37,6 +37,13 @@ class CallQueuedClosure implements ShouldQueue
     public $deleteWhenMissingModels = true;
 
     /**
+     * Custom name for the job.
+     *
+     * @var string|null
+     */
+    public $name = null;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Laravel\SerializableClosure\SerializableClosure  $closure
@@ -103,8 +110,26 @@ class CallQueuedClosure implements ShouldQueue
      */
     public function displayName()
     {
+        $prefix = '';
         $reflection = new ReflectionFunction($this->closure->getClosure());
 
-        return 'Closure ('.basename($reflection->getFileName()).':'.$reflection->getStartLine().')';
+        if (! is_null($this->name)) {
+            $prefix = "{$this->name} - ";
+        }
+
+        return $prefix.'Closure ('.basename($reflection->getFileName()).':'.$reflection->getStartLine().')';
+    }
+
+    /**
+     * Set a custom name for the job.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -23,6 +23,13 @@ class CallQueuedClosure implements ShouldQueue
     public $closure;
 
     /**
+     * The name assigned to the job.
+     *
+     * @var string|null
+     */
+    public $name = null;
+
+    /**
      * The callbacks that should be executed on failure.
      *
      * @var array
@@ -35,13 +42,6 @@ class CallQueuedClosure implements ShouldQueue
      * @var bool
      */
     public $deleteWhenMissingModels = true;
-
-    /**
-     * Custom name for the job.
-     *
-     * @var string|null
-     */
-    public $name = null;
 
     /**
      * Create a new job instance.
@@ -110,18 +110,15 @@ class CallQueuedClosure implements ShouldQueue
      */
     public function displayName()
     {
-        $prefix = '';
         $reflection = new ReflectionFunction($this->closure->getClosure());
 
-        if (! is_null($this->name)) {
-            $prefix = "{$this->name} - ";
-        }
+        $prefix = is_null($this->name) ? '' : "{$this->name} - ";
 
         return $prefix.'Closure ('.basename($reflection->getFileName()).':'.$reflection->getStartLine().')';
     }
 
     /**
-     * Set a custom name for the job.
+     * Assign a name to the job.
      *
      * @param  string  $name
      * @return $this

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -166,6 +166,24 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertNull($events[3]->queue);
     }
 
+    public function testQueuedClosureCanBeNamed()
+    {
+        Config::set('queue.default', 'database');
+        $events = [];
+        $this->app['events']->listen(function (JobQueued $e) use (&$events) {
+            $events[] = $e;
+        });
+
+        dispatch(function () {
+            //
+        })->name('custom name');
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(JobQueued::class, $events[0]);
+        $this->assertSame('custom name', $events[0]->job->name);
+        $this->assertStringContainsString('custom name', $events[0]->job->displayName());
+    }
+
     public function testCanDisableDispatchingAfterResponse()
     {
         Job::dispatchAfterResponse('test');


### PR DESCRIPTION
This allows a queued closure to be given a name in order to be more easily identified. The name is prefixed to the display name so that it still denotes that it is a closure and where it is located.