### PR TITLE
[12.x] Fix typo in PHPDoc

### DIFF
--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -44,7 +44,7 @@ namespace Illuminate\Support\Facades;
  * @method static void setRequestLocale(string $locale)
  * @method static void setDefaultRequestLocale(string $locale)
  * @method static mixed user(string|null $guard = null)
- * @method static \Illuminate\Routing\Route|(object|string|null route(string|null $param = null, mixed $default = null)
+ * @method static \Illuminate\Routing\Route|object|string|null route(string|null $param = null, mixed $default = null)
  * @method static string fingerprint()
  * @method static \Illuminate\Http\Request setJson(\Symfony\Component\HttpFoundation\InputBag $json)
  * @method static \Closure getUserResolver()


### PR DESCRIPTION
Description
---
I think that the parenthesis after `\Illuminate\Routing\Route|` is unbalanced. In PHPDoc syntax, union types like `A|B|C` must be properly grouped without unbalanced parentheses.