### PR TITLE
[12.x] Add Expired Flag to cache:clear

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -9,7 +9,6 @@ use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use TypeError;
 
 #[AsCommand(name: 'cache:clear')]
 class ClearCommand extends Command
@@ -48,8 +47,8 @@ class ClearCommand extends Command
     /**
      * Create a new cache clear command instance.
      *
-     * @param \Illuminate\Cache\CacheManager $cache
-     * @param \Illuminate\Filesystem\Filesystem $files
+     * @param  \Illuminate\Cache\CacheManager  $cache
+     * @param  \Illuminate\Filesystem\Filesystem  $files
      */
     public function __construct(CacheManager $cache, Filesystem $files)
     {
@@ -70,7 +69,7 @@ class ClearCommand extends Command
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
 
-        if($this->option('expired')) {
+        if ($this->option('expired')) {
             $store = $this->cache()->getStore();
             if ($store instanceof DatabaseStore) {
                 $successful = $store->flushExpired();
@@ -86,7 +85,7 @@ class ClearCommand extends Command
 
         $this->flushFacades();
 
-        if (!$successful) {
+        if (! $successful) {
             return $this->components->error('Failed to clear cache. Make sure you have the appropriate permissions.');
         }
 
@@ -104,7 +103,7 @@ class ClearCommand extends Command
      */
     public function flushFacades()
     {
-        if (!$this->files->exists($storagePath = storage_path('framework/cache'))) {
+        if (! $this->files->exists($storagePath = storage_path('framework/cache'))) {
             return;
         }
 

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -69,18 +69,16 @@ class ClearCommand extends Command
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
 
+        $message = self::MSG_APP_SUCCESS;
+
         if ($this->option('expired')) {
             $store = $this->cache()->getStore();
-            if ($store instanceof DatabaseStore) {
-                $successful = $store->flushExpired();
-                $message = self::MSG_EXPIRED_SUCCESS;
-            } else {
-                $successful = $this->cache()->flush();
-                $message = self::MSG_APP_SUCCESS;
-            }
+
+            $successful = $store instanceof DatabaseStore
+                ? ($message = self::MSG_EXPIRED_SUCCESS) && $store->flushExpired()
+                : $this->cache()->flush();
         } else {
             $successful = $this->cache()->flush();
-            $message = self::MSG_APP_SUCCESS;
         }
 
         $this->flushFacades();

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -424,6 +424,20 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Remove all expired items from the cache.
+     *
+     * @return bool
+     */
+    public function flushExpired()
+    {
+        $this->table()
+            ->where('expiration', '<=', $this->getTime())
+            ->delete();
+
+        return true;
+    }
+
+    /**
      * Get a query builder for the cache table.
      *
      * @return \Illuminate\Database\Query\Builder


### PR DESCRIPTION
### Overview
This PR adds the `--expired` flag to the `cache:clear` artisan command. This is useful because expired cache items are not automatically deleted from the cache table once they have expired.

The main thought behind adding this flag is that `cache:clear --expired` would be run on a set schedule (i.e. daily) inside of `routes/console.php`.

### Usage
- Running `cache:clear --expired` will clean up any expired cache items for the `DatabaseStore` only.
- When the `--expired` flag is passed, only expired cache items will be removed from the cache table.
- This flag will not affect cache items that have not yet expired.
- If the `cache:clear --expired` is run on a non-`DatabaseStore` cache store, the command will run as if `--expired` was not passed in the first place.

Please let me know if you would like me to make any changes.

Note: An alternative option could be a dedicated command rather than changing behavior based on a flag. If desired, I can make those modifications in this PR.