### PR TITLE
[12.x] Fillable BelongsTo relation on Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 trait GuardsAttributes
 {
     /**
@@ -31,6 +33,20 @@ trait GuardsAttributes
      * @var array<string>
      */
     protected static $guardableColumns = [];
+
+    /**
+     * Indicates if filling an attribute named as a Belongs-To relation should be fillable.
+     *
+     * @var bool
+     */
+    public static $fillBelongsToRelations = false;
+
+    /**
+     * The cache for fillable Belongs To Relations methods.
+     *
+     * @var array<class-string<static>,bool>
+     */
+    protected static $fillableBelongsToRelationsCache = [];
 
     /**
      * Get the fillable attributes for the model.
@@ -256,5 +272,20 @@ trait GuardsAttributes
         }
 
         return $attributes;
+    }
+
+    /**
+     * Check if the relation is fillable.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isBelongsToFillable($key)
+    {
+        return static::$fillBelongsToRelations
+            && (
+            static::$fillableBelongsToRelationsCache[static::class][$key]
+                ??= $this->isRelation($key) && $this->{$key}() instanceof BelongsTo
+            );
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1053,6 +1053,22 @@ trait HasRelationships
     }
 
     /**
+     * Fills a Belongs To relation like it was an attribute value.
+     *
+     * @param  string  $key
+     * @param  \Illuminate\Database\Eloquent\Model $value
+     * @return $this
+     */
+    protected function fillBelongsToRelation($key, $value)
+    {
+        if (!$value->exists) {
+            $value->save();
+        }
+
+        return $this->{$key}()->associate($value);
+    }
+
+    /**
      * Get all the loaded relations for the instance.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -584,7 +584,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             // which means only those attributes may be set through mass assignment to
             // the model, and all others will just get ignored for security reasons.
             if ($this->isFillable($key)) {
-                $this->setAttribute($key, $value);
+                if ($value instanceof Model && $this->isBelongsToFillable($key)) {
+                    $this->fillBelongsToRelation($key, $value);
+                } else {
+                    $this->setAttribute($key, $value);
+                }
             } elseif ($totallyGuarded || static::preventsSilentlyDiscardingAttributes()) {
                 if (isset(static::$discardedAttributeViolationCallback)) {
                     call_user_func(static::$discardedAttributeViolationCallback, $this, [$key]);


### PR DESCRIPTION
## What?

This PR allows the developer to fill a `BelongsTo` relationship through the `fill()` method, instantly creating the related model if necessary. It only needs a Model instance¹, and setting `$fillBelongsToRelations` static property to `true` on the model class.

```php
use Illuminate\Database\Eloquent\Model;

class Car extends Model
{
    protected $fillable = ['name', 'driver', 'features'];
    
    public function driver()
    {
        return $this->belongsTo(Driver::class);
    }
    
    public function features()
    {
        return $this->belongsToMany(Feature::class);
    }
}

$driver = Driver::find(1);

// Before
$car = Car::make([
    'name' => 'Lamborghini Aventador'
])

$car->driver()->associate($driver);

$car->save();

// After
Car::$fillBelongsToRelations = true;

$car = Car::create([
    'name' => 'Lamborghini Aventador',
    'driver' => $driver,
])
```

## How?

When the attribute is filled, it will check if the key is _fillable_ as part of the Model fillable attributes. If it is, and the relation's name matches, it will _associate_ the model into the relation. If the model doesn't exists in the database, it will save it before associating it.

¹: The value **must** be a Model instance. This way it can be associated with `MorphTo` relations.

If the value is not a Model, then it will be understood it's a normal attribute and fill it like always.

This is opt-in, meaning, it has to be explicitly enabled by the developer (at least on this version), but with the hope that developers who require to create related records can do it in less lines and less complexity.