### PR TITLE
[13.x] RFC: Lazy Services - New #[Lazy] Attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-ctype": "*",
         "ext-filter": "*",
         "ext-hash": "*",

--- a/src/Illuminate/Container/Attributes/Lazy.php
+++ b/src/Illuminate/Container/Attributes/Lazy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute]
+class Lazy
+{
+    //
+}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container;
 use ArrayAccess;
 use Closure;
 use Exception;
+use Illuminate\Container\Attributes\Lazy;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
@@ -1058,8 +1059,16 @@ class Container implements ArrayAccess, ContainerContract
 
         array_pop($this->buildStack);
 
+        if (!empty($reflector->getAttributes(Lazy::class))) {
+            $instance = $reflector->newLazyProxy(function () use ($concrete, $instances) {
+                return new $concrete(...$instances);
+            });
+        } else {
+            $instance = $reflector->newInstanceArgs($instances);
+        }
+
         $this->fireAfterResolvingAttributeCallbacks(
-            $reflector->getAttributes(), $instance = $reflector->newInstanceArgs($instances)
+            $reflector->getAttributes(), $instance
         );
 
         return $instance;

--- a/tests/Container/ContainerLazyTest.php
+++ b/tests/Container/ContainerLazyTest.php
@@ -90,6 +90,19 @@ class LazyWithAttributeStub
     }
 }
 
+class LazyWithTestRenameAttributeStub
+{
+    public function __construct()
+    {
+        throw new \RuntimeException('Lazy call');
+    }
+
+    public function work()
+    {
+        return 'work';
+    }
+}
+
 #[Lazy]
 class LazyWithAttributeLogicStub
 {
@@ -118,7 +131,7 @@ class LazyWithoutAttributeStub
 
 class LazyDependencyWithAttributeStub
 {
-    public function __construct(LazyWithAttributeStub $stub)
+    public function __construct(#[Lazy] LazyWithTestRenameAttributeStub $stub)
     {
         throw new \RuntimeException('Parent call');
     }

--- a/tests/Container/ContainerLazyTest.php
+++ b/tests/Container/ContainerLazyTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use Illuminate\Container\Attributes\Lazy;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+class ContainerLazyTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Container::setInstance();
+    }
+
+    public function testConcreteDoesNotThrowsExceptionWithAttribute()
+    {
+        $container = new Container;
+        $lazy = $container->make(LazyWithAttributeStub::class);
+
+        // No RuntimeException has occurred
+        // LazyWithAttributeStub behaves like a Lazy Object, but this is not obvious from its type
+        $this->assertInstanceOf(LazyWithAttributeStub::class, $lazy);
+    }
+
+    public function testConcreteThrowsExceptionWithoutAttribute()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Lazy call');
+
+        $container = new Container;
+        $container->make(LazyWithoutAttributeStub::class);
+    }
+
+    public function testConcreteDoesNotThrowsExceptionWithNoLogicConstructor()
+    {
+        $container = new Container;
+        $lazy = $container->make(LazyWithAttributeStub::class);
+
+        $this->assertInstanceOf(LazyWithAttributeStub::class, $lazy);
+
+        $this->assertSame('work', $lazy->work());
+    }
+
+    public function testConcreteDoesThrowsExceptionWithConstructorWithLogic()
+    {
+        $container = new Container;
+        $lazy = $container->make(LazyWithAttributeLogicStub::class);
+
+        // No RuntimeException has occurred so far
+        $this->assertInstanceOf(LazyWithAttributeLogicStub::class, $lazy);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Lazy call');
+
+        // Only the call to number() causes a RuntimeException
+        $lazy->number();
+    }
+
+    public function testConcreteThrowsExceptionButNotLazyDependency()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Parent call');
+
+        $container = new Container;
+        $container->make(LazyDependencyWithAttributeStub::class);
+    }
+
+    public function testConcreteNotLazyDependencyThrowsException()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Lazy call');
+
+        $container = new Container;
+        $container->make(LazyDependencyWithoutAttributeStub::class);
+    }
+}
+
+#[Lazy]
+class LazyWithAttributeStub
+{
+    public function __construct()
+    {
+        throw new \RuntimeException('Lazy call');
+    }
+
+    public function work()
+    {
+        return 'work';
+    }
+}
+
+#[Lazy]
+class LazyWithAttributeLogicStub
+{
+    public $number;
+
+    public function __construct()
+    {
+        $this->number = 10;
+
+        throw new \RuntimeException('Lazy call');
+    }
+
+    public function number()
+    {
+        $this->number += 10;
+    }
+}
+
+class LazyWithoutAttributeStub
+{
+    public function __construct()
+    {
+        throw new \RuntimeException('Lazy call');
+    }
+}
+
+class LazyDependencyWithAttributeStub
+{
+    public function __construct(LazyWithAttributeStub $stub)
+    {
+        throw new \RuntimeException('Parent call');
+    }
+}
+
+class LazyDependencyWithoutAttributeStub
+{
+    public function __construct(LazyWithoutAttributeStub $stub)
+    {
+        throw new \RuntimeException('Parent call');
+    }
+}


### PR DESCRIPTION
### In short
A new attribute #[Lazy] has been introduced, which defers the initialization of a class until it is actually used.

### Example
Let’s assume we have a service that creates a connection to Redis.
```php
namespace App\Services;

use Illuminate\Container\Attributes\Lazy;
use Illuminate\Contracts\Redis\Factory;
use Predis\Client;

class RedisService
{
    private Client $client;

    public function __construct(private Factory $redisFactory)
    {
        $this->client = $this->redisFactory->connection()->client();

        var_dump('Redis client loaded');

        // ...
    }
    
    // ...
}
```
The above service is used in a controller:

```php
namespace App\Http\Controllers;

use App\Services\RedisService;
use Illuminate\Http\JsonResponse;

class ProductController extends Controller
{
    public function __construct(
        private RedisService $redisService
    ) {
    }

    public function index(): JsonResponse
    {
        $products = Product::query()->take(10)->get();

        return response()->json(['products' => $products]);
    }

    public function show(int $productId): JsonResponse
    {
        $product = $this->redisService->getProduct($productId);

        if (null === $product) {
            $product = Product::query()->find($productId);
        }

        // …

        return response()->json(['product' => $product]);
    }
}
```
In short. I have a service that handles the Redis connection. I have a controller that handles two endpoints. The first returns a list of products (Redis is not used). The second returns a product object – Redis is used as a cache.

In the current form, there is no Lazy Services support. Traditionally, I make a request to the product listing endpoint:

![image](https://github.com/user-attachments/assets/f5e408ae-75d3-4b58-be61-b92962493c16)

You can see that even though Redis is not used in the product listing endpoint, Redis is still initialized.

Now let’s add the previously mentioned “#[Lazy]” attribute to the service.
```php
namespace App\Services;

use Illuminate\Container\Attributes\Lazy;
use Illuminate\Contracts\Redis\Factory;
use Predis\Client;

#[Lazy]
class RedisService
{
    private Client $client;

    public function __construct(private Factory $redisFactory)
    {
        $this->client = $this->redisFactory->connection()->client();

        var_dump('Redis client loaded');

        // ...
    }
    
    // ...
}
```
As you can see above. I added the special “#[Lazy]” attribute, which marks the class as Lazy, meaning it will be a Lazy Object in the container until the class is used.

Let’s see what happens now:

![image](https://github.com/user-attachments/assets/5e8db52b-9480-4999-8809-486d98619514)

Send a request to the products endpoint skips loading Redis, why? Because it’s in the container as a Lazy Object. Only using Redis – in this case, fetching a single product – will trigger Redis to load.

### Discussion and usage
In 2018 there was a proposal to implement Lazy Service in Laravel. On that occasion, a discussion arose:
- https://github.com/laravel/ideas/issues/1436

As mentioned in the linked discussion above, Lazy Services are already implemented in:
- https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Lazy.html
- https://symfony.com/doc/current/service_container/lazy_services.html

First, a lot has changed since 2018, and second, it was just a proposal. In the meantime, Lazy Objects have been natively supported by PHP since version 8.4.

I decided to create a working POC and possibly start a discussion.

### Challenges and future development opportunities
- Proxies are not easily noticeable to the developer; it's unclear whether it's a regular object or a lazy one – this can only be inferred from behavior or a var_dump,
- Due to the structure of the class and its dependencies in the container, I haven’t been able to add support for attributes on parameters at this moment:
```php
class ProductController
{
    public function __construct(
        #[Lazy] public RedisService $redisService
    ) {
    }
}

class RedisService
{
    public function __construct()
    {
        throw new \RuntimeException('Lazy call');
    }
}
```

Here’s the Proof of Concept, and I’d appreciate your feedback. Feel free to join the discussion about this feature and whether there is a place for it in Laravel.