### PR TITLE
[12.x] Adds resolver for specific Model route binding fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2243,9 +2243,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if ($callback = static::$fieldResolvers[static::class][$field] ?? null) {
             $result = $callback($value, $field, $query);
 
-            return $result instanceof Builder || $result instanceof QueryBuilder
-                ? $result
-                : $query->where($field, $result);
+            return match (true) {
+                $result instanceof Builder,
+                $result instanceof QueryBuilder => $result,
+                $result === null => $query,
+                default => $query->where($field, $result),
+            };
         }
 
         return $query->where($field, $value);


### PR DESCRIPTION
## What?

This PR allows the developer to transform incoming route binding fields values, instead of overriding the Route Binding methods. The main problematic that it solves modifying the field value or query. 

The developer can use `resolveField()` on the target model to register a callback that will be executed for the specific implicit binding field. The callback receives the value, field name, and query builder. The developer may return a new field value, or completely hijack the query for better control.

In the following example, the `Car` model doesn't have an `ulid` column. Instead of creating that column in the database, we can _resolve_ the `ulid` field and transform the query to find the record by its UUID:

```php
use Illuminate\Database\Eloquent\Model;
use Symfony\Component\Uid\Ulid;

class Car extends Model 
{
    public static function booted()
    {
        static::resolveField('ulid', function ($value, $field, $query) {
            return $query->where('id', Ulid::fromString($value)->toRfc4122())
        })
    }
}
```

When the callback doesn't return an Eloquent Query or Base Query, it will use the returned value as part of the `where` key:

```php
Car::resolveField('id', function ($value) {
    return Str::of($value)->snake()->lower()->toString();
});
```

Also, because the field resolver is a _callable_, the user can register invokable class instances as resolver if needed, especially if their logic is too much for a single function.

```php
Car::resolveField('uuid', new UuidResolver())
```

Finally, the resolver can be deleted by setting `null`.

```php
Car::resolveField('uuid', null);
```