### PR TITLE
fix trim null arg deprecation

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -628,6 +628,10 @@ class LogManager implements LoggerInterface
             $driver ??= 'null';
         }
 
+        if ($driver === null) {
+            return null;
+        }
+
         return trim($driver);
     }
 


### PR DESCRIPTION
Avoid passing `null` as `$string` arg, because it causes a deprecation warning in php 8.6.4.