### PR TITLE
[12.x] Queue event listeners with enum values

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use ReflectionClass;
+use function Illuminate\Support\enum_value;
 
 class Dispatcher implements DispatcherContract
 {
@@ -631,8 +632,8 @@ class Dispatcher implements DispatcherContract
             : $listener->delay ?? null;
 
         is_null($delay)
-            ? $connection->pushOn($queue, $job)
-            : $connection->laterOn($queue, $delay, $job);
+            ? $connection->pushOn(enum_value($queue), $job)
+            : $connection->laterOn(enum_value($queue), $delay, $job);
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use ReflectionClass;
+
 use function Illuminate\Support\enum_value;
 
 class Dispatcher implements DispatcherContract

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -9,7 +9,6 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
-use Illuminate\Tests\Integration\Console\Events\ExampleQueueListener;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
+use Illuminate\Tests\Integration\Console\Events\ExampleQueueListener;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -199,6 +200,23 @@ class QueuedEventsTest extends TestCase
                 && $job->middleware[0]->b === 'bar';
         });
     }
+
+    public function testDispatchesOnQueueDefinedWithEnum()
+    {
+        $d = new Dispatcher;
+        $queue = m::mock(Queue::class);
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherViaQueueSupportsEnum::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushedOn('enumerated-queue', CallQueuedListener::class);
+    }
 }
 
 class TestDispatcherQueuedHandler implements ShouldQueue
@@ -365,5 +383,18 @@ class TestDispatcherGetDelayDynamically implements ShouldQueue
         }
 
         return 20;
+    }
+}
+
+enum TestQueueType: string
+{
+    case EnumeratedQueue = 'enumerated-queue';
+}
+
+class TestDispatcherViaQueueSupportsEnum implements ShouldQueue
+{
+    public function viaQueue()
+    {
+        return TestQueueType::EnumeratedQueue;
     }
 }


### PR DESCRIPTION
When the `viaQueue` method on a queued event listener returns an enum, it will fail with the error message:

```
Object of class App\Enums\QueueType could not be converted to string
```

With this PR the dispatcher will now convert an enum value to a string before dispatching the queued event listener to the queue.