### PR TITLE
[12.x] Typed getters for Env helper

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use Closure;
 use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Repository\RepositoryBuilder;
+use InvalidArgumentException;
 use PhpOption\Option;
 use RuntimeException;
 
@@ -112,6 +113,124 @@ class Env
     public static function getOrFail($key)
     {
         return self::getOption($key)->getOrThrow(new RuntimeException("Environment variable [$key] has no value."));
+    }
+
+    /**
+     * Get the specified string environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(string|null))|string|null  $default
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function string(string $key, $default = null): string
+    {
+        $value = Env::get($key, $default);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be a string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(int|null))|int|null  $default
+     * @return int
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function integer(string $key, $default = null): int
+    {
+        $value = Env::get($key, $default);
+
+        if (filter_var($value, FILTER_VALIDATE_INT) === false) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be an integer, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified float environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(float|null))|float|null  $default
+     * @return float
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function float(string $key, $default = null): float
+    {
+        $value = Env::get($key, $default);
+
+        if (filter_var($value, FILTER_VALIDATE_FLOAT) === false) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be a float, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified boolean environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(bool|null))|bool|null  $default
+     * @return bool
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function boolean(string $key, $default = null): bool
+    {
+        $value = Env::get($key, $default);
+
+        if (! is_bool($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be a boolean, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified array environment value.
+     *
+     * @param  string  $key
+     * @param  (Closure():(array|null))|array|null  $default
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function array(string $key, $default = null): array
+    {
+        $value = Env::get($key, $default);
+
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_string($value)) {
+            return array_map('trim', explode(',', $value));
+        }
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Environment value for key [%s] must be an array or comma-separated string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -192,15 +192,11 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if ($value === null) {
-            return [];
-        }
-
-        if (is_string($value)) {
-            return array_map('trim', explode(',', $value));
-        }
-
-        return check_type($value, 'array', $key, 'Environment');
+        return match (true) {
+            $value === null => [],
+            is_string($value) => array_map('trim', explode(',', $value)),
+            default => check_type($value, 'array', $key, 'Environment'),
+        };
     }
 
     /**

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -128,9 +128,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        check_type($value, 'string', $key, 'Environment');
-
-        return $value;
+        return check_type($value, 'string', $key, 'Environment');
     }
 
     /**
@@ -146,9 +144,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        check_type($value, 'int', $key, 'Environment');
-
-        return $value;
+        return check_type($value, 'int', $key, 'Environment');
     }
 
     /**
@@ -164,9 +160,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        check_type($value, 'float', $key, 'Environment');
-
-        return $value;
+        return check_type($value, 'float', $key, 'Environment');
     }
 
     /**
@@ -182,9 +176,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        check_type($value, 'bool', $key, 'Environment');
-
-        return $value;
+        return check_type($value, 'bool', $key, 'Environment');
     }
 
     /**
@@ -200,7 +192,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if (is_null($value)) {
+        if ($value === null) {
             return [];
         }
 
@@ -208,9 +200,7 @@ class Env
             return array_map('trim', explode(',', $value));
         }
 
-        check_type($value, 'array', $key, 'Environment');
-
-        return $value;
+        return check_type($value, 'array', $key, 'Environment');
     }
 
     /**

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -128,11 +128,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if (! is_string($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Environment value for key [%s] must be a string, %s given.', $key, gettype($value))
-            );
-        }
+        check_type($value, 'string', $key, 'Environment');
 
         return $value;
     }
@@ -150,11 +146,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if (filter_var($value, FILTER_VALIDATE_INT) === false) {
-            throw new InvalidArgumentException(
-                sprintf('Environment value for key [%s] must be an integer, %s given.', $key, gettype($value))
-            );
-        }
+        check_type($value, 'int', $key, 'Environment');
 
         return $value;
     }
@@ -172,11 +164,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if (filter_var($value, FILTER_VALIDATE_FLOAT) === false) {
-            throw new InvalidArgumentException(
-                sprintf('Environment value for key [%s] must be a float, %s given.', $key, gettype($value))
-            );
-        }
+        check_type($value, 'float', $key, 'Environment');
 
         return $value;
     }
@@ -194,11 +182,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if (! is_bool($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Environment value for key [%s] must be a boolean, %s given.', $key, gettype($value))
-            );
-        }
+        check_type($value, 'bool', $key, 'Environment');
 
         return $value;
     }
@@ -216,7 +200,7 @@ class Env
     {
         $value = Env::get($key, $default);
 
-        if ($value === null) {
+        if (is_null($value)) {
             return [];
         }
 
@@ -224,11 +208,7 @@ class Env
             return array_map('trim', explode(',', $value));
         }
 
-        if (! is_array($value)) {
-            throw new InvalidArgumentException(
-                sprintf('Environment value for key [%s] must be an array or comma-separated string, %s given.', $key, gettype($value))
-            );
-        }
+        check_type($value, 'array', $key, 'Environment');
 
         return $value;
     }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
+use InvalidArgumentException;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 if (! function_exists('Illuminate\Support\defer')) {
@@ -49,5 +50,43 @@ if (! function_exists('Illuminate\Support\artisan_binary')) {
     function artisan_binary()
     {
         return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
+    }
+}
+
+if (! function_exists('Illuminate\Support\check_type')) {
+    /**
+     * Validate that a given value matches the expected type.
+     *
+     * @param  mixed  $value
+     * @param  'string'|'int'|'integer'|'long'|'bool'|'boolean'|'float'|'double'|'real'|'array'  $type
+     * @param  string  $key
+     * @param  string  $group
+     * @return mixed
+     *
+     * @throws InvalidArgumentException If the value does not match the expected type.
+     */
+    function check_type(mixed $value, string $type, string $key, string $group = 'variable'): mixed
+    {
+        $isValid = match ($type) {
+            'string' => is_string($value),
+            'int', 'integer', 'long' => filter_var($value, FILTER_VALIDATE_INT) !== false,
+            'bool', 'boolean' => is_bool($value),
+            'float', 'double', 'real' => filter_var($value, FILTER_VALIDATE_FLOAT) !== false,
+            'array' => is_array($value),
+            default => throw new InvalidArgumentException('Type "'.$type.'" is not supported. Use one of: string, int, integer, long, bool, boolean, float, double, real, array')
+        };
+
+        throw_unless(
+            $isValid,
+            InvalidArgumentException::class,
+            sprintf('%s value for key [%s] must be a %s, %s given.',
+                $group,
+                $key,
+                $type,
+                is_object($value) ? get_class($value) : gettype($value)
+            ),
+        );
+
+        return $value;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1230,7 +1230,7 @@ class SupportHelpersTest extends TestCase
         $_SERVER['not_integer_key'] = 'foo';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Environment value for key \[not_integer_key\] must be an integer#');
+        $this->expectExceptionMessageMatches('#^Environment value for key \[not_integer_key\] must be a (int|integer|long), (.*) given.#');
 
         Env::integer('not_integer_key');
     }
@@ -1245,7 +1245,7 @@ class SupportHelpersTest extends TestCase
         $_SERVER['not_float_key'] = 'foo';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Environment value for key \[not_float_key\] must be a float#');
+        $this->expectExceptionMessageMatches('#^Environment value for key \[not_float_key\] must be a (float|double|real), (.*) given.#');
 
         Env::float('not_float_key');
     }
@@ -1262,7 +1262,7 @@ class SupportHelpersTest extends TestCase
         $_SERVER['not_bool_key'] = 'yes';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#Environment value for key \[not_bool_key\] must be a boolean#');
+        $this->expectExceptionMessageMatches('#^Environment value for key \[not_bool_key\] must be a (bool|boolean), (.*) given.#');
 
         Env::boolean('not_bool_key');
     }


### PR DESCRIPTION
### Added methods

- `Env::string(string $key, $default = null): string`
- `Env::integer(string $key, $default = null): int`
- `Env::float(string $key, $default = null): float`
- `Env::boolean(string $key, $default = null): bool`
- `Env::array(string $key, $default = null): array`

As exist on the `Config` facede and `Arr` helper.