### PR TITLE
[11.x] Bump minimum league/commonmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
         "laravel/serializable-closure": "^1.3|^2.0",
-        "league/commonmark": "^2.6",
+        "league/commonmark": "^2.7",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",
         "league/uri": "^7.5.1",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^11.0",
         "illuminate/macroable": "^11.0",
         "illuminate/support": "^11.0",
-        "league/commonmark": "^2.6",
+        "league/commonmark": "^2.7",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/mailer": "^7.0.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.5"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -49,7 +49,7 @@
     "suggest": {
         "illuminate/filesystem": "Required to use the Composer class (^11.0).",
         "laravel/serializable-closure": "Required to use the once function (^1.3|^2.0).",
-        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.6).",
+        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
         "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
         "symfony/process": "Required to use the Composer class (^7.0).",


### PR DESCRIPTION
This PR bumps the minimum required version of league/commonmark to ^2.7 in order to patch a moderate-severity XSS vulnerability in the [Attributes extension](https://github.com/advisories/GHSA-3527-qv2q-pfvx).

The vulnerability affects versions <2.7.0 and allows malicious HTML attributes to be injected into rendered Markdown—even when secure configuration options like html_input: 'strip' and allow_unsafe_links: false are used. A specially crafted payload such as: