### PR TITLE
[12.x] Only pass model IDs to Eloquent `whereAttachedTo` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -803,7 +803,7 @@ trait QueriesRelationships
         $this->has(
             $relationshipName,
             boolean: $boolean,
-            callback: fn (Builder $query) => $query->whereKey($relatedCollection),
+            callback: fn (Builder $query) => $query->whereKey($relatedCollection->pluck($related->getKeyName())),
         );
 
         return $this;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1282,6 +1282,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $related = new EloquentBuilderTestModelFarRelatedStub;
         $related->id = 49;
+        $related->name = 'test';
 
         $builder = EloquentBuilderTestModelParentStub::whereAttachedTo($related, 'roles');
 
@@ -1292,9 +1293,11 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model1 = new EloquentBuilderTestModelParentStub;
         $model1->id = 3;
+        $model1->name = 'test3';
 
         $model2 = new EloquentBuilderTestModelParentStub;
         $model2->id = 4;
+        $model2->name = 'test4';
 
         $builder = EloquentBuilderTestModelFarRelatedStub::whereAttachedTo(new Collection([$model1, $model2]), 'roles');
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -173,6 +173,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
             $this->schema($connection)->create('achievements', function ($table) {
                 $table->increments('id');
+                $table->integer('status')->nullable();
             });
 
             $this->schema($connection)->create('eloquent_test_achievement_eloquent_test_user', function ($table) {
@@ -1497,7 +1498,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user1 = EloquentTestUser::create(['email' => 'user1@gmail.com']);
         $user2 = EloquentTestUser::create(['email' => 'user2@gmail.com']);
         $user3 = EloquentTestUser::create(['email' => 'user3@gmail.com']);
-        $achievement1 = EloquentTestAchievement::create();
+        $achievement1 = EloquentTestAchievement::create(['status' => 3]);
         $achievement2 = EloquentTestAchievement::create();
         $achievement3 = EloquentTestAchievement::create();
 
@@ -2988,6 +2989,7 @@ class EloquentTestAchievement extends Eloquent
     public $timestamps = false;
 
     protected $table = 'achievements';
+    protected $guarded = [];
 
     public function eloquentTestUsers()
     {


### PR DESCRIPTION
Fixes #55665 

I raised an issue for this beforehand to showcase the problem. This PR adds tests that fail without the provided fix.

Before:
<img width="1624" alt="before" src="https://github.com/user-attachments/assets/4282742f-6127-4fa4-bdd1-62597f8ed9e6" />

After:
<img width="1625" alt="after" src="https://github.com/user-attachments/assets/ec0a5da2-54ae-4670-93b6-cb1a8ce7b772" />
