### PR TITLE
feat(bus): allow adding multiple jobs to chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -221,9 +221,11 @@ trait Queueable
      */
     public function prependToChain($job)
     {
-        $jobs = ChainedBatch::prepareNestedBatches(new Collection([$job]));
+        $jobs = ChainedBatch::prepareNestedBatches(Collection::wrap($job));
 
-        $this->chained = Arr::prepend($this->chained, $this->serializeJob($jobs->first()));
+        foreach ($jobs->reverse() as $job) {
+            $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
+        }
 
         return $this;
     }
@@ -236,9 +238,11 @@ trait Queueable
      */
     public function appendToChain($job)
     {
-        $jobs = ChainedBatch::prepareNestedBatches(new Collection([$job]));
+        $jobs = ChainedBatch::prepareNestedBatches(Collection::wrap($job));
 
-        $this->chained = array_merge($this->chained, [$this->serializeJob($jobs->first())]);
+        foreach ($jobs as $job) {
+            $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
+        }
 
         return $this;
     }


### PR DESCRIPTION
Allow inserting multiple jobs to the same dispatched chain by passing a list of
jobs to `prependToChain()` and `appendToChain()`.

`prependToChain()` reverses the collection before inserting the jobs one
by one to ensure that the first job is processed before the second one.

Backwards compatibility should be given, due to the current implementation
wrapping the job in an array and therefore, enforcing a single job instance.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
