### PR TITLE
[12.x] Improve Cache Tests

### DIFF
--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Exception;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Sleep;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
@@ -43,10 +44,11 @@ class FileCacheLockTest extends TestCase
 
     public function testConcurrentLocksAreReleasedSafely()
     {
+        Sleep::fake(syncWithCarbon: true);
 
         $firstLock = Cache::lock('foo', 1);
         $this->assertTrue($firstLock->get());
-        sleep(2);
+        Sleep::for(2)->seconds();
 
         $secondLock = Cache::lock('foo', 10);
         $this->assertTrue($secondLock->get());


### PR DESCRIPTION
Hey,

inspired from today' s stream by @jasonmccreary (about atomic locks and the struggle to test the exception)
i've added a missing test which also can be used as an example on how to test lock/block for other users.

* Each test had `Cache::lock('foo')->forceRelease();` as first line => moved to `setUp`
* found a slow test using `sleep(2)` to test the lock is release afterwards => used `Sleep` facade which is use in `Cache`
* added a missing test for the exception when `block` runs into a timeout

let me know if i should split this up into more PRs.

cheers
adrian