### PR TITLE
[12.x] Implement releaseAfter method in RateLimited middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -26,6 +26,13 @@ class RateLimited
     protected $limiterName;
 
     /**
+     * The number of seconds before a job should be available again if the limit is exceeded.
+     *
+     * @var \DateTimeInterface|int|null
+     */
+    public $releaseAfter;
+
+    /**
      * Indicates if the job should be released if the limit is exceeded.
      *
      * @var bool
@@ -89,7 +96,7 @@ class RateLimited
         foreach ($limits as $limit) {
             if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
                 return $this->shouldRelease
-                    ? $job->release($this->getTimeUntilNextRetry($limit->key))
+                    ? $job->release($this->releaseAfter ?: $this->getTimeUntilNextRetry($limit->key))
                     : false;
             }
 
@@ -97,6 +104,19 @@ class RateLimited
         }
 
         return $next($job);
+    }
+
+    /**
+     * Set the delay (in seconds) to release the job back to the queue.
+     *
+     * @param  \DateTimeInterface|int  $releaseAfter
+     * @return $this
+     */
+    public function releaseAfter($releaseAfter)
+    {
+        $this->releaseAfter = $releaseAfter;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -50,7 +50,7 @@ class RateLimitedWithRedis extends RateLimited
         foreach ($limits as $limit) {
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
                 return $this->shouldRelease
-                    ? $job->release($this->getTimeUntilNextRetry($limit->key))
+                    ? $job->release($this->releaseAfter ?: $this->getTimeUntilNextRetry($limit->key))
                     : false;
             }
         }


### PR DESCRIPTION
By default jobs with the RateLimited or RateLimitedWithRedis middleware are released with a delay equal to when the rate limiter is available again +3 (?) seconds. This is great for 99% of cases but occassionaly it can be useful to specify the delay manually. This PR implements that functionality leaning heavily on the implemetation used in the WithoutOverlapping middleware.

See: https://laravel.com/docs/12.x/queues#preventing-job-overlaps