### PR TITLE
[12.x] Add Support for Selective Relationship Autoloading in withRelationshipAutoloading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -769,7 +769,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Enable relationship autoloading for all models in this collection.
      *
-     * @param array|string|null $relations Optional array or string defining which relations to autoload with optional column selection
+     * @param array|string|null  $relations
      * @return $this
      */
     public function withRelationshipAutoloading($relations = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -769,7 +769,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Enable relationship autoloading for all models in this collection.
      *
-     * @param array|string|null  $relations
+     * @param  array|string|null  $relations
      * @return $this
      */
     public function withRelationshipAutoloading($relations = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -801,7 +801,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         foreach ($this as $model) {
             if (! $model->hasRelationAutoloadCallback()) {
-                $model->autoloadRelationsUsing($callback);
+                $model->autoloadRelationsUsing($callback, $this);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1129,11 +1129,12 @@ trait HasRelationships
     /**
      * Enable relationship autoloading for this model.
      *
+     * @param  array|string|null  $relations
      * @return $this
      */
-    public function withRelationshipAutoloading()
+    public function withRelationshipAutoloading($relations = null)
     {
-        $this->newCollection([$this])->withRelationshipAutoloading();
+        $this->newCollection([$this])->withRelationshipAutoloading($relations);
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -293,6 +293,11 @@ class Post extends Model
 {
     public $timestamps = false;
 
+    protected $fillable = [
+        'title',
+        'content',
+    ];
+
     public function comments()
     {
         return $this->morphMany(Comment::class, 'commentable');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for selective column loading in `withRelationshipAutoloading`, similar to how `with('client:id,name')` works.

Please refer to [withRelationshipAutoloading](https://github.com/laravel/framework/pull/53655)

With this enhancement, you can now specify which columns to load for a relationship, improving query performance by only retrieving the necessary data.

For example:

```php
$orders->withRelationshipAutoloading(['client:id,name']);
```

> [!NOTE]
>
> Backward compatibility is preserved:
> When no columns are specified for a relationship, all columns continue to load by default. Other relationships continue autoloading as expected without needing to be explicitly defined.
