### PR TITLE
[12.x] Update PHPDoc for whereRaw to allow Expression as $sql

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1101,7 +1101,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw where clause to the query.
      *
-     * @param  string  $sql
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $sql
      * @param  mixed  $bindings
      * @param  string  $boolean
      * @return $this


### PR DESCRIPTION
This PR updates the PHPDoc of the whereRaw method to reflect that the $sql parameter supports both string and Illuminate\Database\Query\Expression instances.