### PR TITLE
 [12.x] Provide target to contextual attribute

### DIFF
--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -63,6 +63,19 @@ class ContextualAttributeBindingTest extends TestCase
         $this->assertInstanceOf(ContainerTestImplB::class, $classB->property);
     }
 
+    public function testTargetIsProvidedWhenResolvingDependencyFromAttributeBinding()
+    {
+        $container = new Container;
+
+        $container->whenHasAttribute(ContainerTestAttributeThatReceivesTarget::class, function (ContainerTestAttributeThatReceivesTarget $attribute, Container $container, $target) {
+            return $target;
+        });
+
+        $class = $container->make(ContainerTestHasAttributeThatReceivesTarget::class);
+
+        $this->assertEquals(ContainerTestHasAttributeThatReceivesTarget::class, $class->property);
+    }
+
     public function testScalarDependencyCanBeResolvedFromAttributeBinding()
     {
         $container = new Container;
@@ -310,6 +323,15 @@ class ContainerTestAttributeThatResolvesContractImpl implements ContextualAttrib
     }
 }
 
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class ContainerTestAttributeThatReceivesTarget implements ContextualAttribute
+{
+    public function resolve(self $attribute, Container $container, $target): string
+    {
+        return $target;
+    }
+}
+
 interface ContainerTestContract
 {
 }
@@ -336,6 +358,15 @@ final class ContainerTestHasAttributeThatResolvesToImplB
     public function __construct(
         #[ContainerTestAttributeThatResolvesContractImpl('B')]
         public readonly ContainerTestContract $property
+    ) {
+    }
+}
+
+final class ContainerTestHasAttributeThatReceivesTarget
+{
+    public function __construct(
+        #[ContainerTestAttributeThatReceivesTarget]
+        public string $property
     ) {
     }
 }


### PR DESCRIPTION
Given a server:

```php
class Production
{
    protected array $features;

    public function __construct(array $features)
    {
        $this->features = $features;
    }
}
```

And a repository that holds registrations mapping a server to a set of features:

```php
class Registrar
{
    protected array $registrations = [
        Staging::class => [
            Nginx::class,
            Php::class,
        ],
        Production::class => [
            Caddy::class,
            Php::class,
        ],
    ];

    public function for(string $server): array
    {
        return $this->registrations[$server]
    }
}
```



It would be extremely useful to resolve only the features registered specifically to that server through a Contextual Attribute, instead of resolving the `Registrar` and performing an operation on it:

```php
class Production
{
    protected array $features;

    public function __construct(#[RegisteredFor] array $features)
    {
        $this->features = $features;
    }
}
```

However, Contextual Attribute resolution does not currently provide visibility into the class the dependency is being resolved for.

This PR passes the target into `ContextualAttribute@resolve()` allowing for:

```php
#[Attribute(Attribute::TARGET_PARAMETER)]
class RegisteredFor implements ContextualAttribute
{
    public static function resolve(self $attribute, Container $container, $target): array
    {
        return resolve(Registrar::class)->for($target);
    }
}
```

Note: Initially I had hoped that the class could be passed into the attribute -- requiring no change to the framework.
```php
class Production
{
    protected array $features;

    public function __construct(#[RegisteredFor(static::class)] array $features)
    {
        $this->features = $features;
    }
}
```

However, `static::class` cannot be used for compile-time class name resolution. `self::class` does work however, if the `__constructor` is inherited the string the `Attribute` receives is the parent's FQCN.
