### PR TITLE
[12.x] Update "Number::fileSize" to use correct prefix and add prefix param

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -166,7 +166,10 @@ class Number
     public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, bool $useBinaryPrefix = false)
     {
         $base = $useBinaryPrefix ? 1024 : 1000;
-        $units = $useBinaryPrefix ? ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'RiB', 'QiB'] : ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
+
+        $units = $useBinaryPrefix
+            ? ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'RiB', 'QiB']
+            : ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
 
         for ($i = 0; ($bytes / $base) > 0.9 && ($i < count($units) - 1); $i++) {
             $bytes /= $base;

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -160,7 +160,7 @@ class Number
      * @param  int|float  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
-     * @param  bool $useBinaryPrefix
+     * @param  bool  $useBinaryPrefix
      * @return string
      */
     public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, bool $useBinaryPrefix = false)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -160,14 +160,16 @@ class Number
      * @param  int|float  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
+     * @param  bool $useBinaryPrefix
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null, bool $useBinaryPrefix = false)
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $base = $useBinaryPrefix ? 1024 : 1000;
+        $units = $useBinaryPrefix ? ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'RiB', 'QiB'] : ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
 
-        for ($i = 0; ($bytes / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
-            $bytes /= 1024;
+        for ($i = 0; ($bytes / $base) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bytes /= $base;
         }
 
         return sprintf('%s %s', static::format($bytes, $precision, $maxPrecision), $units[$i]);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -199,13 +199,13 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1.234 KiB', Number::fileSize(1264.12345, maxPrecision: 3, useBinaryPrefix: true));
         $this->assertSame('1.234 KiB', Number::fileSize(1264, 3, useBinaryPrefix: true));
         $this->assertSame('5 GiB', Number::fileSize(1024 * 1024 * 1024 * 5, useBinaryPrefix: true));
-        $this->assertSame('10 TiB', Number::fileSize((1024 ** 4) * 10), useBinaryPrefix: true);
-        $this->assertSame('10 PiB', Number::fileSize((1024 ** 5) * 10), useBinaryPrefix: true);
-        $this->assertSame('1 ZiB', Number::fileSize(1024 ** 7), useBinaryPrefix: true);
-        $this->assertSame('1 YiB', Number::fileSize(1024 ** 8), useBinaryPrefix: true);
-        $this->assertSame('1 RiB', Number::fileSize(1024 ** 9), useBinaryPrefix: true);
-        $this->assertSame('1 QiB', Number::fileSize(1024 ** 10), useBinaryPrefix: true);
-        $this->assertSame('1,024 QiB', Number::fileSize(1024 ** 11), useBinaryPrefix: true);
+        $this->assertSame('10 TiB', Number::fileSize((1024 ** 4) * 10, useBinaryPrefix: true));
+        $this->assertSame('10 PiB', Number::fileSize((1024 ** 5) * 10, useBinaryPrefix: true));
+        $this->assertSame('1 ZiB', Number::fileSize(1024 ** 7, useBinaryPrefix: true));
+        $this->assertSame('1 YiB', Number::fileSize(1024 ** 8, useBinaryPrefix: true));
+        $this->assertSame('1 RiB', Number::fileSize(1024 ** 9, useBinaryPrefix: true));
+        $this->assertSame('1 QiB', Number::fileSize(1024 ** 10, useBinaryPrefix: true));
+        $this->assertSame('1,024 QiB', Number::fileSize(1024 ** 11, useBinaryPrefix: true));
     }
 
     public function testClamp()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -174,18 +174,38 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0 B', Number::fileSize(0));
         $this->assertSame('0.00 B', Number::fileSize(0, precision: 2));
         $this->assertSame('1 B', Number::fileSize(1));
-        $this->assertSame('1 KB', Number::fileSize(1024));
-        $this->assertSame('2 KB', Number::fileSize(2048));
-        $this->assertSame('2.00 KB', Number::fileSize(2048, precision: 2));
-        $this->assertSame('1.23 KB', Number::fileSize(1264, precision: 2));
-        $this->assertSame('1.234 KB', Number::fileSize(1264.12345, maxPrecision: 3));
-        $this->assertSame('1.234 KB', Number::fileSize(1264, 3));
-        $this->assertSame('5 GB', Number::fileSize(1024 * 1024 * 1024 * 5));
-        $this->assertSame('10 TB', Number::fileSize((1024 ** 4) * 10));
-        $this->assertSame('10 PB', Number::fileSize((1024 ** 5) * 10));
-        $this->assertSame('1 ZB', Number::fileSize(1024 ** 7));
-        $this->assertSame('1 YB', Number::fileSize(1024 ** 8));
-        $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
+        $this->assertSame('1 KB', Number::fileSize(1000));
+        $this->assertSame('2 KB', Number::fileSize(2000));
+        $this->assertSame('2.00 KB', Number::fileSize(2000, precision: 2));
+        $this->assertSame('1.23 KB', Number::fileSize(1234, precision: 2));
+        $this->assertSame('1.234 KB', Number::fileSize(1234, maxPrecision: 3));
+        $this->assertSame('1.234 KB', Number::fileSize(1234, 3));
+        $this->assertSame('5 GB', Number::fileSize(1000 * 1000 * 1000 * 5));
+        $this->assertSame('10 TB', Number::fileSize((1000 ** 4) * 10));
+        $this->assertSame('10 PB', Number::fileSize((1000 ** 5) * 10));
+        $this->assertSame('1 ZB', Number::fileSize(1000 ** 7));
+        $this->assertSame('1 YB', Number::fileSize(1000 ** 8));
+        $this->assertSame('1 RB', Number::fileSize(1000 ** 9));
+        $this->assertSame('1 QB', Number::fileSize(1000 ** 10));
+        $this->assertSame('1,000 QB', Number::fileSize(1000 ** 11));
+
+        $this->assertSame('0 B', Number::fileSize(0, useBinaryPrefix: true));
+        $this->assertSame('0.00 B', Number::fileSize(0, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1 B', Number::fileSize(1, useBinaryPrefix: true));
+        $this->assertSame('1 KiB', Number::fileSize(1024, useBinaryPrefix: true));
+        $this->assertSame('2 KiB', Number::fileSize(2048, useBinaryPrefix: true));
+        $this->assertSame('2.00 KiB', Number::fileSize(2048, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1.23 KiB', Number::fileSize(1264, precision: 2, useBinaryPrefix: true));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264.12345, maxPrecision: 3, useBinaryPrefix: true));
+        $this->assertSame('1.234 KiB', Number::fileSize(1264, 3, useBinaryPrefix: true));
+        $this->assertSame('5 GiB', Number::fileSize(1024 * 1024 * 1024 * 5, useBinaryPrefix: true));
+        $this->assertSame('10 TiB', Number::fileSize((1024 ** 4) * 10), useBinaryPrefix: true);
+        $this->assertSame('10 PiB', Number::fileSize((1024 ** 5) * 10), useBinaryPrefix: true);
+        $this->assertSame('1 ZiB', Number::fileSize(1024 ** 7), useBinaryPrefix: true);
+        $this->assertSame('1 YiB', Number::fileSize(1024 ** 8), useBinaryPrefix: true);
+        $this->assertSame('1 RiB', Number::fileSize(1024 ** 9), useBinaryPrefix: true);
+        $this->assertSame('1 QiB', Number::fileSize(1024 ** 10), useBinaryPrefix: true);
+        $this->assertSame('1,024 QiB', Number::fileSize(1024 ** 11), useBinaryPrefix: true);
     }
 
     public function testClamp()


### PR DESCRIPTION
Currently `Number::fileSize` uses 1024 as base to do the calculations but labels it wrong. With base 1024 a binary prefix should be used.
Normally people expect 1000 as base but for more technical applications base 1024 is needed. That's why there is now an optional parameter to use the binary prefix.

I also added `RB`/ `RiB` and `QB`/ `QiB` to the units array.