### PR TITLE
[12.x] Add option to disable MySQL ssl when restoring or squashing migrations

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -115,9 +115,8 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
-        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT])
-            && $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false
-        ) {
+        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) && 
+            $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
             $value .= ' --ssl=off';
         }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -115,6 +115,12 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
+        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT])
+            && $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false
+        ) {
+            $value .= ' --ssl=off';
+        }
+
         return $value;
     }
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -70,6 +70,24 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             ],
         ];
 
+        yield 'no_ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl=off', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                ],
+            ],
+        ];
+
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
                 'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',


### PR DESCRIPTION
Newer versions of the MySQL client are enforcing a more strict SSL certificate check and resulting in the following error when squashing migrations or running `migrate:fresh`

```
ERROR 2026 (HY000): TLS/SSL error: self-signed certificate in certificate chain
```

Currently, to bypass this error we need to edit the MySQL config file. To make things easier, this PR adds a new option to disable SSL when executing the commands to dump/restore MySQL database.