### PR TITLE
[12.x] Container `currentlyResolving` utility

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1295,6 +1295,16 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Get currently resolving.
+     *
+     * @return class-string|string|null
+     */
+    public function currentlyResolving()
+    {
+        return end($this->buildStack) ?: null;
+    }
+
+    /**
      * Register a new before resolving callback for all types.
      *
      * @param  \Closure|string  $abstract

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1295,16 +1295,6 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Get currently resolving.
-     *
-     * @return class-string|string|null
-     */
-    public function currentlyResolving()
-    {
-        return end($this->buildStack) ?: null;
-    }
-
-    /**
      * Register a new before resolving callback for all types.
      *
      * @param  \Closure|string  $abstract
@@ -1504,6 +1494,16 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($callbacks as $callback) {
             $callback($object, $this);
         }
+    }
+
+    /**
+     * Get the name of the binding the container is currently resolving.
+     *
+     * @return class-string|string|null
+     */
+    public function currentlyResolving()
+    {
+        return end($this->buildStack) ?: null;
     }
 
     /**

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -207,6 +207,13 @@ interface Container extends ContainerInterface
     public function resolved($abstract);
 
     /**
+     * Get currently resolving.
+     *
+     * @return class-string|string|null
+     */
+    public function currentlyResolving();
+
+    /**
      * Register a new before resolving callback.
      *
      * @param  \Closure|string  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -207,13 +207,6 @@ interface Container extends ContainerInterface
     public function resolved($abstract);
 
     /**
-     * Get currently resolving.
-     *
-     * @return class-string|string|null
-     */
-    public function currentlyResolving();
-
-    /**
      * Register a new before resolving callback.
      *
      * @param  \Closure|string  $abstract


### PR DESCRIPTION
Exposing what the container is currently resolving would be a useful feature.

For example, given a server:

```php
class Production
{
    protected array $features;

    public function __construct(array $features)
    {
        $this->features = $features;
    }
}
```

And a repository that holds registrations mapping a server to features:

```php
class Registrar
{
    protected array $registrations = [
        Staging::class => [
            Nginx::class,
            Php::class,
        ],
        Production::class => [
            Caddy::class,
            Php::class,
        ],
    ];

    public function for(string $server): array
    {
        return $this->registrations[$server]
    }
}
```

We could have a Contextual Attribute responsible for returning the features registered specifically to a server instead of having to perform an operation on our `Registrar`

```php
class Production
{
    protected array $features;

    public function __construct(#[RegisteredFor] array $features)
    {
        $this->features = $features;
    }
}
```

This PR provides access to what the container is currently resolving -- allowing:

```php
#[Attribute(Attribute::TARGET_PARAMETER)]
class RegisteredFor implements ContextualAttribute
{
    public static function resolve(self $attribute, Container $container): array
    {
        $resolving = $container->currentlyResolving(); // Production::class

        return resolve(Registrar::class)->for($resolving);
    }
}
```

Note: I was unsure the best way to test this since `Container::$buildStack` is not modified until `Container::build()` is called which is after the before callbacks. The resolving item is also popped off `Container::$buildStack` before the after callbacks.
