### PR TITLE
[13.x] Do not allow new model instances to be created during boot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -145,6 +145,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $dispatcher;
 
     /**
+     * The models that are currently being booted.
+     *
+     * @var array
+     */
+    protected static $booting = [];
+
+    /**
      * The array of booted models.
      *
      * @var array
@@ -157,11 +164,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @var array
      */
     protected static $bootedCallbacks = [];
-
-    /**
-     * Models currently being booted.
-     */
-    protected static array $booting = [];
 
     /**
      * The array of trait initializers that will be called on each new instance.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -293,7 +293,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         if (! isset(static::$booted[static::class])) {
             if (isset(static::$booting[static::class])) {
-                throw new Exception('"'.__METHOD__.'" cannot be called on the "'.static::class.'" class while it is already being booted.');
+                throw new LogicException('The ['.__METHOD__.'] method may not be called on model ['.static::class.'] while it is being booted.');
             }
 
             static::$booting[static::class] = true;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -286,12 +286,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected function bootIfNotBooted()
     {
         if (! isset(static::$booted[static::class])) {
-            static::$booted[static::class] = true;
 
             $this->fireModelEvent('booting', false);
 
             static::booting();
             static::boot();
+
+            static::$booted[static::class] = true;
+
             static::booted();
 
             static::$bootedCallbacks[static::class] ??= [];

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -158,6 +158,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $bootedCallbacks = [];
 
     /**
+     * Models currently being booted.
+     */
+    protected static array $booting = [];
+
+    /**
      * The array of trait initializers that will be called on each new instance.
      *
      * @var array
@@ -287,12 +292,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         if (! isset(static::$booted[static::class])) {
 
+            static::$booting[static::class] = true;
+
             $this->fireModelEvent('booting', false);
 
             static::booting();
             static::boot();
 
             static::$booted[static::class] = true;
+            unset(static::$booting[static::class]);
 
             static::booted();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
 use Closure;
+use Exception;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -291,6 +292,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected function bootIfNotBooted()
     {
         if (! isset(static::$booted[static::class])) {
+            if (isset(static::$booting[static::class])) {
+                throw new Exception('"'.__METHOD__.'" cannot be called on the "'.static::class.'" class while it is already being booted.');
+            }
 
             static::$booting[static::class] = true;
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3333,7 +3333,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testNestedModelBootingIsDisallowed()
     {
-        $this->expectExceptionMessageMatches('/".+" cannot be called on the ".+" class while it is already being booted\./');
+        $this->expectExceptionMessageMatches('/The \[(.+)] method may not be called on model \[(.+)\] while it is being booted\./');
 
         $model = new class extends Model
         {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3330,6 +3330,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelWithUseFactoryAttribute::class, $factory->modelName());
         $this->assertEquals('test name', $instance->name); // Small smoke test to ensure the factory is working
     }
+
+    public function testNestedModelBootingIsDisallowed()
+    {
+        $this->expectExceptionMessageMatches('/".+" cannot be called on the ".+" class while it is already being booted\./');
+
+        $model = new class extends Model
+        {
+            protected static function boot()
+            {
+                parent::boot();
+
+                $tableName = (new static())->getTable();
+            }
+        };
+    }
 }
 
 class EloquentTestObserverStub


### PR DESCRIPTION
This PR does three things:
1. Changes `booted` to only be set after a model class has finished booting, as its name implies.
2. Adds a new `booting` flag that is set to `true` when booting first begins and is removed when booting has finished.
3. Throws an exception if `bootIfNotBooted` is called while currently booting, since this implies nested booting.

These changes allow issues with nested booting to be caught immediately and would have helped track down this [very tricky bug](https://github.com/laravel/framework/pull/55286) much sooner.

Right now, if you create a new instance of a model while booting, whether that is in the `boot` method for a model itself or the `boot*` method in a trait, the instance is created, but in an inconsistent state. This happens because the second call to `bootIfNotBooted` skips the boot process because `booted` is marked as `true` when starting to boot. This thankfully avoids a recursive stack overflow, however, it also means that the model class has not been completely booted yet and causing the inconsistent state. Anything done with the returned model instance then has the potential to work improperly, as was seen in #55286.

This is a breaking change since existing code may be creating new model instances while booting, which would then trigger an exception where it did not before.