### PR TITLE
[12.x] Allow withoutMiddleware() function to Disable All Middlewares Defined in middleware() When No Argument is Passed

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1161,11 +1161,19 @@ class Route
     /**
      * Specify middleware that should be removed from the given route.
      *
-     * @param  array|string  $middleware
+     * @param  array|string|null  $middleware
      * @return $this
      */
-    public function withoutMiddleware($middleware)
+    public function withoutMiddleware($middleware = null)
     {
+        if (is_null($middleware) || $middleware === []) {
+            $middleware = array_values(
+                array_diff(
+                    $this->action['middleware'],
+                    ['web']
+                 )
+            );
+        }
         $this->action['excluded_middleware'] = array_merge(
             (array) ($this->action['excluded_middleware'] ?? []), Arr::wrap($middleware)
         );

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -99,7 +99,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
- * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
+ * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string|null $middleware)
  * @method static \Illuminate\Routing\RouteRegistrar withoutScopedBindings()
  *
  * @see \Illuminate\Routing\Router

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -138,6 +138,17 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 
+    public function testWithoutMiddlewareWithNullArgument() 
+    {
+        $this->router->middleware(['one', 'two', 'three'])->get('users', function () {
+            return 'all-users';
+        })->withoutMiddleware();
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+
+        $this->assertEquals(['one', 'two', 'three'], $this->getRoute()->excludedMiddleware());
+    }
+
     public function testGetRouteWithTrashed()
     {
         $route = $this->router->get('users', [RouteRegistrarControllerStub::class, 'index'])->withTrashed();


### PR DESCRIPTION
### Summary

This PR enhances the `withoutMiddleware()` method by allowing it to accept a `null` value. When `null` is passed (or no argument is provided), it will now disable all route middlewares that were defined using the `middleware()`.

---

### Example 1: Before the Change (Manual Middleware Removal)

```php
Route::get('/some-route', function () {
    return "This route has middleware!";
})->middleware(['auth', 'verified', 'logRequest']);
```
If you wanted to disable all middleware for this route, you'd previously have to list them individually:
```php
Route::get('/some-route', function () {
    return "No middleware applied!";
})->middleware(['auth', 'verified', 'logRequest'])
  ->withoutMiddleware(['auth', 'verified', 'logRequest']);
```

###  Example 2: After the Change (Using withoutMiddleware() with No Argument)
Now, you can simply call withoutMiddleware() with no arguments to disable all middleware applied through the middleware() function:
```php
Route::get('/some-route', function () {
    return "No middleware applied!";
})->middleware(['auth', 'verified', 'logRequest'])
  ->withoutMiddleware(); // withoutMiddleware([]); will also work
```
This makes the code cleaner and eliminates the need to manually list all middleware, which is especially useful when dealing with multiple middleware assignment.

#### If a you still wants to disable specific middleware, the original usage continues to work exactly the same:
```php
Route::get('/some-route', function () {
    return "No middleware applied!";
})->middleware(['auth', 'verified', 'logRequest'])
  ->withoutMiddleware(['auth', 'verified']);
```


### Impact
✅ No breaking changes introduced.

✅ Backward-compatible: previous usages with string and array arguments remain valid.

✅ Cleaner, more intuitive API for disabling middleware during tests or on route