### PR TITLE
[12.x] incorrect use of generics in Schema\Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 
-/**
- * @template TResolver of \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint
- */
 class Builder
 {
     use Macroable;
@@ -33,7 +30,7 @@ class Builder
     /**
      * The Blueprint resolver callback.
      *
-     * @var TResolver|null
+     * @var \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint|null
      */
     protected static $resolver = null;
 
@@ -701,7 +698,7 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  TResolver|null  $resolver
+     * @param  \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint|null  $resolver
      * @return void
      */
     public function blueprintResolver(?Closure $resolver)


### PR DESCRIPTION
https://github.com/laravel/framework/pull/55607 added generics to Schema\Builder class, but it's used incorrectly.

If you define a template for a class, the type should appear in the constructor which doesn't happen in this case.

The author probably thought `@template` was a type alias (like `@phpstan-type` or `@psalm-type`).

This PR removes the `@template` and just embeds type in the docs.
