### PR TITLE
[12.x] Allow Gate to find policy class from collection instances

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -691,14 +691,14 @@ class Gate implements GateContract
     protected function getPolicyClass($obj)
     {
         if ($obj instanceof Collection) {
-            $classes = $obj->map(fn ($obj) => get_class($obj))
+            $classes = $obj->map(fn ($value) => get_class($value))
                 ->unique();
 
             if ($classes->count() > 1) {
                 throw new InvalidArgumentException('Collection must not contain different object types');
             }
 
-            return $classes->first();
+            return $classes->first() ?? get_class($obj);
         }
 
         return get_class($obj);

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -658,7 +658,7 @@ class Gate implements GateContract
     public function getPolicyFor($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $class = $this->getPolicyClass($class);
         }
 
         if (! is_string($class)) {
@@ -680,6 +680,30 @@ class Gate implements GateContract
                 return $this->resolvePolicy($policy);
             }
         }
+
+        return false;
+    }
+
+    /**
+     * Get policy class from object
+     *
+     * @param object $obj
+     * @return string
+     */
+    protected function getPolicyClass($obj)
+    {
+        if ($obj instanceof Collection) {
+            $classes = $obj->map(fn ($obj) => get_class($obj))
+                ->unique();
+
+            if ($classes->count() > 1) {
+                throw new InvalidArgumentException('Collection must not contain different object types');
+            }
+
+            return $classes->first();
+        }
+
+        return get_class($obj);
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -683,9 +683,9 @@ class Gate implements GateContract
     }
 
     /**
-     * Get policy class from object
+     * Get policy class from object.
      *
-     * @param object $obj
+     * @param  object  $obj
      * @return string
      */
     protected function getPolicyClass($obj)

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -680,8 +680,6 @@ class Gate implements GateContract
                 return $this->resolvePolicy($policy);
             }
         }
-
-        return false;
     }
 
     /**

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1276,7 +1276,7 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertTrue(
             $gate->check([AbilitiesEnum::UPDATE_MULTIPLE],
-            new \Illuminate\Database\Eloquent\Collection([new AccessGateTestDummy(), new AccessGateTestDummy()]))
+                new \Illuminate\Database\Eloquent\Collection([new AccessGateTestDummy(), new AccessGateTestDummy()]))
         );
     }
 

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1288,6 +1288,15 @@ class AuthAccessGateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->assertFalse($gate->check([AbilitiesEnum::UPDATE_MULTIPLE], collect([new AccessGateTestDummy(), new stdClass()])));
     }
+
+    public function testPolicyCollectionsFailsIfEmpty()
+    {
+        $gate = $this->getBasicGate();
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertFalse($gate->check([AbilitiesEnum::UPDATE_MULTIPLE], collect([])));
+        $this->assertFalse($gate->check([AbilitiesEnum::UPDATE_MULTIPLE], new \Illuminate\Database\Eloquent\Collection([])));
+    }
 }
 
 class AccessGateTestClassForGuest

--- a/tests/Auth/Enums.php
+++ b/tests/Auth/Enums.php
@@ -6,4 +6,6 @@ enum AbilitiesEnum: string
 {
     case VIEW_DASHBOARD = 'view-dashboard';
     case UPDATE = 'update';
+
+    case UPDATE_MULTIPLE = 'update-multiple';
 }


### PR DESCRIPTION
This PR aims to allow users to pass a Collection instance (of the same object type) and allow Laravel to find the correct policy based on the first element of the array.

I believe this will benefit users because it allows users to develop better policies that cover a collection of data. This will put more of the authorization logic in one place instead of repeating in multiple places or a separate service class because the user wants to do a check on a collection.

The code in the PR checks if the object being passed is a collection, throws an error if there's different object types int the collection, returns the class of the first element if collection or else it'll just return the class of the passed in object.

Here's an example of what the PR would solve and what it'll look like in the real world:

### PostUpdateRequest.php

```php
//...
protected function passedValidation(): void
{
    $posts = Post::query()
        ->whereIn('id', $this->safe()->input('ids'))
        ->get();

    // This is the issue I had, that would be solved with the PR
    Gate::authorize('update-multiple', $posts);
}
```

 ### PostPolicy
```php
//...
public function updateMultiple(User $user, Collection $posts): bool
{
    return $posts->every(fn ($post) => $post->author_id === $user->id);
}
```