### PR TITLE
[12.x] Support Virtual Properties When Serializing Models

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -36,6 +36,10 @@ trait SerializesModels
                 continue;
             }
 
+            if (method_exists($property, 'isVirtual') && $property->isVirtual()) {
+                continue;
+            }
+
             $value = $this->getPropertyValue($property);
 
             if ($property->hasDefaultValue() && $value === $property->getDefaultValue()) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When serializing models using the `SerializesModels` trait that contain PHP 8.4's new property hooks. The serializing fails with the following error: 

```php
namespace MyNamespace;

class MyClass
{
  use SerializesModels;

  public string $property {
    get {
      return 'Foo';
    }
  }
}
```

```
Property MyNamespace\MyClass::$property is read-only
```

These new property that do not actually contain any value, are `virtual` and can be safely ignored during serialization.

I'm not a 100% sure on how to test this code since it's only applicable to PHP 8.4.