### PR TITLE
[12.x] Add `except` and `exceptHidden` methods to `Context` class

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -194,6 +194,28 @@ class Repository
     }
 
     /**
+     * Retrieve all values except those with the given keys.
+     *
+     * @param  array<int, string>  $keys
+     * @return array<string, mixed>
+     */
+    public function except($keys)
+    {
+        return array_diff_key($this->data, array_flip($keys));
+    }
+
+    /**
+     * Retrieve all hidden values except those with the given keys.
+     *
+     * @param  array<int, string>  $keys
+     * @return array<string, mixed>
+     */
+    public function exceptHidden($keys)
+    {
+        return array_diff_key($this->hidden, array_flip($keys));
+    }
+
+    /**
      * Add a context value.
      *
      * @param  string|array<string, mixed>  $key

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -364,6 +364,34 @@ class ContextTest extends TestCase
         ]));
     }
 
+    public function test_it_can_exclude_subset_of_context()
+    {
+        Context::add('parent.child.1', 5);
+        Context::add('parent.child.2', 6);
+        Context::add('another', 7);
+
+        $this->assertSame([
+            'another' => 7,
+        ], Context::except([
+            'parent.child.1',
+            'parent.child.2',
+        ]));
+    }
+
+    public function test_it_can_exclude_subset_of_hidden_context()
+    {
+        Context::addHidden('parent.child.1', 5);
+        Context::addHidden('parent.child.2', 6);
+        Context::addHidden('another', 7);
+
+        $this->assertSame([
+            'another' => 7,
+        ], Context::exceptHidden([
+            'parent.child.1',
+            'parent.child.2',
+        ]));
+    }
+
     public function test_it_adds_context_to_logging()
     {
         $path = storage_path('logs/laravel.log');


### PR DESCRIPTION
This PR adds two new methods to the `Context` class — `except` and `exceptHidden` — which allow for selective exclusion of keys when retrieving context or hidden context data.

``` php

Context::add('user_id', 42);
Context::add('request_id', 'req-abc123');
Context::add('ip_address', '192.168.0.1');
Context::add('sensitive_token', 'secret');

$logData = Context::except(['sensitive_token']);

// Result:
[
    'user_id' => 42,
    'request_id' => 'req-abc123',
    'ip_address' => '192.168.0.1',
]