### PR TITLE
[12.x] Add withExtra() to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -43,6 +43,15 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $additional = [];
 
     /**
+     * The extra data that should be added directly to the top-level resource array.
+     *
+     * Added during response construction by the developer for runtime data or resource extensions.
+     *
+     * @var array
+     */
+    public $extra = [];
+
+    /**
      * The "data" wrapper that should be applied.
      *
      * @var string|null
@@ -114,7 +123,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             $data = $data->jsonSerialize();
         }
 
-        return $this->filter((array) $data);
+        return $this->filter((array) $data + $this->extra);
     }
 
     /**
@@ -173,6 +182,19 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function additional(array $data)
     {
         $this->additional = $data;
+
+        return $this;
+    }
+
+    /**
+     * Add extra data to the top-level resource response.
+     *
+     * @param  array  $extra
+     * @return $this
+     */
+    public function withExtra(array $extra): static
+    {
+        $this->extra = array_merge($this->extra, $extra);
 
         return $this;
     }


### PR DESCRIPTION
## ✨ Summary

I propose adding a `withExtra()` method to Laravel’s `Illuminate\Http\Resources\Json\JsonResource` class. This method would allow developers to **append additional top-level data** to a resource response in a clean, expressive, and reusable way — without overriding the existing `with()` method or manually modifying the array in `toArray()`.

---

## 💡 Motivation

While Laravel already supports attaching data via the [`with()`](https://laravel.com/docs/12.x/eloquent-resources#top-level-meta-data) method, its behavior is limited:

*   It **only applies** when the resource is the **outermost resource**.
*   It **places data inside a `meta` key**, which is ideal for metadata, but not for enriching the resource directly.

There are many cases where developers want to **add more fields to the top level** of a resource’s JSON structure. This could include:

*   Runtime-calculated properties
*   Related but non-relationship-based data
*   Data based on authentication context
*   Feature flags, tokens, etc.

---

## 📦 Example Use Case

Let’s say we're returning a `UserResource`. By default, it includes basic data. In some responses, we want to include **permissions** and a **JWT token** at the top level.

### ✅ Controller

```php
public function show(Request $request, User $user): JsonResponse
{
    return UserResource::make($user)
        ->withExtra([
            'permissions' => $user->getPermissions(),
            'token' => $request->user()?->createToken('access')->plainTextToken,
        ])
        ->toResponse($request);
}
```

### ✅ Resource

```php
class UserResource extends JsonResource
{
    public function toArray($request): array
    {
        return [
            'id'    => $this->id,
            'name'  => $this->name,
            'email' => $this->email,
        ];
    }
}
```

### 📤 Expected JSON Output

```json
{
  "id": 1,
  "name": "Jane Doe",
  "email": "jane@example.com",
  "permissions": ["read", "write"],
  "token": "abc123..."
}
```

---

## 🤔 Why Not Use `with()`?

The existing `with()` method works well for metadata — but it’s not suitable for inline data injection:

| Feature | `with()` | `withExtra()` (Proposed) |
|---|---|---|
| Shown on nested resources? | ❌ No | ✅ Yes |
| Appears at top-level JSON? | ❌ Inside `meta` only | ✅ Merged with main payload |
| Ideal for payload fields? | ❌ Not really | ✅ Yes |
| Target use case | Metadata | Resource enrichment |

---

## 🛠 Implementation Summary

To implement this behavior, the following minimal additions are proposed to `JsonResource`:

### 1. Add an `$extra` property

```php
protected array $extra = [];
```

---

### 2. Add the `withExtra()` method

```php
public function withExtra(array $extra): static
{
    $this->extra = array_merge($this->extra, $extra);

    return $this;
}
```

---

### 3. Update the `resolve()` method

```php
public function resolve($request = null)
{
    $data = $this->toArray(
        $request = $request ?: Container::getInstance()->make('request')
    );

    if ($data instanceof Arrayable) {
        $data = $data->toArray();
    } elseif ($data instanceof JsonSerializable) {
        $data = $data->jsonSerialize();
    }

    return $this->filter((array) $data + $this->extra);
}
```

---

## ✅ Benefits

*   ✅ Cleaner developer experience
*   ✅ Less boilerplate
*   ✅ Works consistently even when nested
*   ✅ No breaking changes — fully opt-in
