### PR TITLE
[12.x] Fix handling of default values for route parameters with a binding field

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -197,9 +197,14 @@ class RouteUrlGenerator
                 unset($parameters[$name]);
 
                 continue;
-            } elseif (! isset($this->defaultParameters[$name]) && ! isset($optionalParameters[$name])) {
-                // No named parameter or default value for a required parameter, try to match to positional parameter below...
-                array_push($requiredRouteParametersWithoutDefaultsOrNamedParameters, $name);
+            } else {
+                $bindingField = $route->bindingFieldFor($name);
+                $defaultParameterKey = $bindingField ? "$name:$bindingField" : $name;
+
+                if (! isset($this->defaultParameters[$defaultParameterKey]) && ! isset($optionalParameters[$name])) {
+                    // No named parameter or default value for a required parameter, try to match to positional parameter below...
+                    array_push($requiredRouteParametersWithoutDefaultsOrNamedParameters, $name);
+                }
             }
 
             $namedParameters[$name] = '';

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -1066,6 +1066,24 @@ class RoutingUrlGeneratorTest extends TestCase
             $url->route('tenantSlugPost', ['post' => $keyParam('concretePost')]),
         );
 
+        // Repeat the two assertions above without the 'tenant' default (without slug)
+        $url->defaults(['tenant' => null]);
+
+        // tenantSlugPost: Tenant (with default) omitted, post passed positionally, with the default value for 'tenant' (without slug) removed
+        $this->assertSame(
+            'https://www.foo.com/tenantSlugPost/defaultTenantSlug/concretePost',
+            $url->route('tenantSlugPost', [$keyParam('concretePost')]),
+        );
+
+        // tenantSlugPost: Tenant (with default) omitted, post passed using key, with the default value for 'tenant' (without slug) removed
+        $this->assertSame(
+            'https://www.foo.com/tenantSlugPost/defaultTenantSlug/concretePost',
+            $url->route('tenantSlugPost', ['post' => $keyParam('concretePost')]),
+        );
+
+        // Revert the default value for the tenant parameter back
+        $url->defaults(['tenant' => 'defaultTenant']);
+
         /**
          * One parameter with a default value, one without a default value.
          *


### PR DESCRIPTION
This fixes a case where you set a default value for a route parameter with a binding field (`tenant:slug`) but **not** for that same parameter without a binding field (`tenant`).

I overlooked this in my original PR, essentially a false positive due to the structure of the tests (all defaults were always set). Now I temporarily remove the default value while repeating some assertions. Can confirm the tests fail without the fix. And the fix just makes sure to check the *right* default (with the binding field in mind).