### PR TITLE
[12.x] perf: support iterables for event discovery paths

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -92,12 +92,12 @@ class ApplicationBuilder
     /**
      * Register the core event service provider for the application.
      *
-     * @param  array|bool  $discover
+     * @param  iterable<int, string>|bool  $discover
      * @return $this
      */
-    public function withEvents(array|bool $discover = [])
+    public function withEvents(iterable|bool $discover = true)
     {
-        if (is_array($discover) && count($discover) > 0) {
+        if (is_iterable($discover)) {
             AppEventServiceProvider::setEventDiscoveryPaths($discover);
         }
 

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Events;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
@@ -16,19 +17,23 @@ class DiscoverEvents
     /**
      * The callback to be used to guess class names.
      *
-     * @var callable(SplFileInfo, string): string|null
+     * @var (callable(SplFileInfo, string): class-string)|null
      */
     public static $guessClassNamesUsingCallback;
 
     /**
      * Get all of the events and listeners by searching the given listener directory.
      *
-     * @param  string  $listenerPath
+     * @param  array<int, string>|string  $listenerPath
      * @param  string  $basePath
      * @return array
      */
     public static function within($listenerPath, $basePath)
     {
+        if (Arr::wrap($listenerPath) === []) {
+            return [];
+        }
+
         $listeners = new Collection(static::getListenerEvents(
             Finder::create()->files()->in($listenerPath), $basePath
         ));
@@ -51,7 +56,7 @@ class DiscoverEvents
     /**
      * Get all of the listeners and their corresponding events.
      *
-     * @param  iterable  $listeners
+     * @param  iterable<string, SplFileInfo>  $listeners
      * @param  string  $basePath
      * @return array
      */
@@ -91,7 +96,7 @@ class DiscoverEvents
      *
      * @param  \SplFileInfo  $file
      * @param  string  $basePath
-     * @return string
+     * @return class-string
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
@@ -111,7 +116,7 @@ class DiscoverEvents
     /**
      * Specify a callback to be used to guess class names.
      *
-     * @param  callable(SplFileInfo, string): string  $callback
+     * @param  callable(SplFileInfo, string): class-string  $callback
      * @return void
      */
     public static function guessClassNamesUsing(callable $callback)

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -6,8 +6,8 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Events\DiscoverEvents;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -43,7 +43,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The configured event discovery paths.
      *
-     * @var array|null
+     * @var iterable<int, string>|null
      */
     protected static $eventDiscoveryPaths;
 
@@ -145,25 +145,23 @@ class EventServiceProvider extends ServiceProvider
      */
     public function discoverEvents()
     {
-        return (new Collection($this->discoverEventsWithin()))
+        return (new LazyCollection($this->discoverEventsWithin()))
             ->flatMap(function ($directory) {
                 return glob($directory, GLOB_ONLYDIR);
             })
             ->reject(function ($directory) {
                 return ! is_dir($directory);
             })
-            ->reduce(function ($discovered, $directory) {
-                return array_merge_recursive(
-                    $discovered,
-                    DiscoverEvents::within($directory, $this->eventDiscoveryBasePath())
-                );
-            }, []);
+            ->pipe(fn ($directories) => DiscoverEvents::within(
+                $directories->all(),
+                $this->eventDiscoveryBasePath(),
+            ));
     }
 
     /**
      * Get the listener directories that should be used to discover events.
      *
-     * @return array
+     * @return iterable<int, string>
      */
     protected function discoverEventsWithin()
     {
@@ -175,23 +173,24 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Add the given event discovery paths to the application's event discovery paths.
      *
-     * @param  string|array  $paths
+     * @param  string|iterable<int, string>  $paths
      * @return void
      */
-    public static function addEventDiscoveryPaths(array|string $paths)
+    public static function addEventDiscoveryPaths(iterable|string $paths)
     {
-        static::$eventDiscoveryPaths = array_values(array_unique(
-            array_merge(static::$eventDiscoveryPaths, Arr::wrap($paths))
-        ));
+        static::$eventDiscoveryPaths = (new LazyCollection(static::$eventDiscoveryPaths))
+            ->merge(is_string($paths) ? [$paths] : $paths)
+            ->unique()
+            ->values();
     }
 
     /**
      * Set the globally configured event discovery paths.
      *
-     * @param  array  $paths
+     * @param  iterable<int, string>  $paths
      * @return void
      */
-    public static function setEventDiscoveryPaths(array $paths)
+    public static function setEventDiscoveryPaths(iterable $paths)
     {
         static::$eventDiscoveryPaths = $paths;
     }

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -57,6 +57,33 @@ class DiscoverEventsTest extends TestCase
         ], $events);
     }
 
+    public function testMultipleDirectoriesCanBeDiscovered(): void
+    {
+        $events = DiscoverEvents::within([
+            __DIR__.'/Fixtures/EventDiscovery/Listeners',
+            __DIR__.'/Fixtures/EventDiscovery/UnionListeners',
+        ], getcwd());
+
+        $this->assertEquals([
+            EventOne::class => [
+                Listener::class.'@handle',
+                Listener::class.'@handleEventOne',
+                UnionListener::class.'@handle',
+            ],
+            EventTwo::class => [
+                Listener::class.'@handleEventTwo',
+                UnionListener::class.'@handle',
+            ],
+        ], $events);
+    }
+
+    public function testNoExceptionForEmptyDirectories(): void
+    {
+        $events = DiscoverEvents::within([], getcwd());
+
+        $this->assertEquals([], $events);
+    }
+
     public function testEventsCanBeDiscoveredUsingCustomClassNameGuessing()
     {
         DiscoverEvents::guessClassNamesUsing(function (SplFileInfo $file, $basePath) {


### PR DESCRIPTION
Hello!

This adds support for passing iterables to discover events. It also improves the performance of the event discovery by allowing multiple directories to be passed to `DiscoverEvents::within()`.

### Motivation

We have many modules and want to discover all listeners in a `Listeners` directory, to do that we have the following:
```php
// bootstrap/app.php
return Application::configure(basePath: dirname(__DIR__))
    ->withEvents(array_keys(iterator_to_array(
        Finder::create()
            ->directories()
            ->in([base_path('modules')])
            ->path('Listeners'),
    )))
    // ...
```

However, the problem is that the file system is walked **on every request** (adding ~30ms to the boot time) and **this argument isn't even used when the events are cached**---in short this is a wasted operation in production.

This PR will allow for something like the following (which does not walk the file system if the events are cached):

```php
// bootstrap/app.php
return Application::configure(basePath: dirname(__DIR__))
    ->withEvents(new LazyCollection(
        fn () => Finder::create()
            ->directories()
            ->in([base_path('modules')])
            ->path('Listeners')
    )->keys())
    // ...
```

Thanks!