### PR TITLE
Move Timebox for Authentication and add to password resets

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -112,4 +112,17 @@ return [
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Timebox Duration
+    |--------------------------------------------------------------------------
+    |
+    | The number of microseconds the Timebox will wait during authentication
+    | and password reset requests, to prevent response times from leaking
+    | existence of user accounts, to prevent user enumeration attempts.
+    |
+    */
+
+    'timebox_duration' => env('AUTH_TIMEBOX_DURATION', 200000),
+
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -112,17 +112,4 @@ return [
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Timebox Duration
-    |--------------------------------------------------------------------------
-    |
-    | The number of microseconds the Timebox will wait during authentication
-    | and password reset requests, to prevent response times from leaking
-    | existence of user accounts, to prevent user enumeration attempts.
-    |
-    */
-
-    'timebox_duration' => env('AUTH_TIMEBOX_DURATION', 200000),
-
 ];

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -126,6 +126,7 @@ class AuthManager implements FactoryContract
             $this->createUserProvider($config['provider'] ?? null),
             $this->app['session.store'],
             rehashOnLogin: $this->app['config']->get('hashing.rehash_on_login', true),
+            timeboxDuration: $this->app['config']->get('auth.timebox_duration', 200000),
         );
 
         // When using the remember me functionality of the authentication services we

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -140,6 +140,8 @@ class PasswordBroker implements PasswordBrokerContract
 
             $this->tokens->delete($user);
 
+            $timebox->returnEarly();
+
             return static::PASSWORD_RESET;
         }, $this->timeboxDuration);
     }

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -43,7 +43,7 @@ class PasswordBroker implements PasswordBrokerContract
     protected $timebox;
 
     /**
-     * The number of microseconds that the Timebox should wait for.
+     * The number of microseconds that the timebox should wait for.
      *
      * @var int
      */

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Timebox;
 use UnexpectedValueException;
 
 class PasswordBroker implements PasswordBrokerContract
@@ -35,17 +36,40 @@ class PasswordBroker implements PasswordBrokerContract
     protected $events;
 
     /**
+     * The timebox instance.
+     *
+     * @var \Illuminate\Support\Timebox
+     */
+    protected $timebox;
+
+    /**
+     * The number of microseconds that the Timebox should wait for.
+     *
+     * @var int
+     */
+    protected $timeboxDuration;
+
+    /**
      * Create a new password broker instance.
      *
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
+     * @param  \Illuminate\Support\Timebox|null  $timebox
+     * @param  int  $timeboxDuration
      */
-    public function __construct(#[\SensitiveParameter] TokenRepositoryInterface $tokens, UserProvider $users, ?Dispatcher $dispatcher = null)
-    {
+    public function __construct(
+        #[\SensitiveParameter] TokenRepositoryInterface $tokens,
+        UserProvider $users,
+        ?Dispatcher $dispatcher = null,
+        ?Timebox $timebox = null,
+        int $timeboxDuration = 200000,
+    ) {
         $this->users = $users;
         $this->tokens = $tokens;
         $this->events = $dispatcher;
+        $this->timebox = $timebox ?: new Timebox;
+        $this->timeboxDuration = $timeboxDuration;
     }
 
     /**
@@ -57,33 +81,35 @@ class PasswordBroker implements PasswordBrokerContract
      */
     public function sendResetLink(#[\SensitiveParameter] array $credentials, ?Closure $callback = null)
     {
-        // First we will check to see if we found a user at the given credentials and
-        // if we did not we will redirect back to this current URI with a piece of
-        // "flash" data in the session to indicate to the developers the errors.
-        $user = $this->getUser($credentials);
+        return $this->timebox->call(function () use ($credentials, $callback) {
+            // First we will check to see if we found a user at the given credentials and
+            // if we did not we will redirect back to this current URI with a piece of
+            // "flash" data in the session to indicate to the developers the errors.
+            $user = $this->getUser($credentials);
 
-        if (is_null($user)) {
-            return static::INVALID_USER;
-        }
+            if (is_null($user)) {
+                return static::INVALID_USER;
+            }
 
-        if ($this->tokens->recentlyCreatedToken($user)) {
-            return static::RESET_THROTTLED;
-        }
+            if ($this->tokens->recentlyCreatedToken($user)) {
+                return static::RESET_THROTTLED;
+            }
 
-        $token = $this->tokens->create($user);
+            $token = $this->tokens->create($user);
 
-        if ($callback) {
-            return $callback($user, $token) ?? static::RESET_LINK_SENT;
-        }
+            if ($callback) {
+                return $callback($user, $token) ?? static::RESET_LINK_SENT;
+            }
 
-        // Once we have the reset token, we are ready to send the message out to this
-        // user with a link to reset their password. We will then redirect back to
-        // the current URI having nothing set in the session to indicate errors.
-        $user->sendPasswordResetNotification($token);
+            // Once we have the reset token, we are ready to send the message out to this
+            // user with a link to reset their password. We will then redirect back to
+            // the current URI having nothing set in the session to indicate errors.
+            $user->sendPasswordResetNotification($token);
 
-        $this->events?->dispatch(new PasswordResetLinkSent($user));
+            $this->events?->dispatch(new PasswordResetLinkSent($user));
 
-        return static::RESET_LINK_SENT;
+            return static::RESET_LINK_SENT;
+        }, $this->timeboxDuration);
     }
 
     /**
@@ -95,25 +121,27 @@ class PasswordBroker implements PasswordBrokerContract
      */
     public function reset(#[\SensitiveParameter] array $credentials, Closure $callback)
     {
-        $user = $this->validateReset($credentials);
+        return $this->timebox->call(function ($timebox) use ($credentials, $callback) {
+            $user = $this->validateReset($credentials);
 
-        // If the responses from the validate method is not a user instance, we will
-        // assume that it is a redirect and simply return it from this method and
-        // the user is properly redirected having an error message on the post.
-        if (! $user instanceof CanResetPasswordContract) {
-            return $user;
-        }
+            // If the responses from the validate method is not a user instance, we will
+            // assume that it is a redirect and simply return it from this method and
+            // the user is properly redirected having an error message on the post.
+            if (! $user instanceof CanResetPasswordContract) {
+                return $user;
+            }
 
-        $password = $credentials['password'];
+            $password = $credentials['password'];
 
-        // Once the reset has been validated, we'll call the given callback with the
-        // new password. This gives the user an opportunity to store the password
-        // in their persistent storage. Then we'll delete the token and return.
-        $callback($user, $password);
+            // Once the reset has been validated, we'll call the given callback with the
+            // new password. This gives the user an opportunity to store the password
+            // in their persistent storage. Then we'll delete the token and return.
+            $callback($user, $password);
 
-        $this->tokens->delete($user);
+            $this->tokens->delete($user);
 
-        return static::PASSWORD_RESET;
+            return static::PASSWORD_RESET;
+        }, $this->timeboxDuration);
     }
 
     /**
@@ -198,5 +226,15 @@ class PasswordBroker implements PasswordBrokerContract
     public function getRepository()
     {
         return $this->tokens;
+    }
+
+    /**
+     * Get the timebox instance used by the guard.
+     *
+     * @return \Illuminate\Support\Timebox
+     */
+    public function getTimebox()
+    {
+        return $this->timebox;
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -70,6 +70,7 @@ class PasswordBrokerManager implements FactoryContract
             $this->createTokenRepository($config),
             $this->app['auth']->createUserProvider($config['provider'] ?? null),
             $this->app['events'] ?? null,
+            timeboxDuration: $this->app['config']->get('auth.timebox_duration', 200000),
         );
     }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -101,7 +101,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @var int
      */
-    protected $timeboxDuration = 200000;
+    protected $timeboxDuration;
 
     /**
      * Indicates if passwords should be rehashed on login if needed.
@@ -133,6 +133,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Symfony\Component\HttpFoundation\Request|null  $request
      * @param  \Illuminate\Support\Timebox|null  $timebox
      * @param  bool  $rehashOnLogin
+     * @param  int  $timeboxDuration
      */
     public function __construct(
         $name,
@@ -141,6 +142,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         ?Request $request = null,
         ?Timebox $timebox = null,
         bool $rehashOnLogin = true,
+        int $timeboxDuration = 200000,
     ) {
         $this->name = $name;
         $this->session = $session;
@@ -148,6 +150,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->provider = $provider;
         $this->timebox = $timebox ?: new Timebox;
         $this->rehashOnLogin = $rehashOnLogin;
+        $this->timeboxDuration = $timeboxDuration;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -97,6 +97,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $timebox;
 
     /**
+     * The number of microseconds that the Timebox should wait for.
+     *
+     * @var int
+     */
+    protected $timeboxDuration = 200000;
+
+    /**
      * Indicates if passwords should be rehashed on login if needed.
      *
      * @var bool
@@ -290,9 +297,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function validate(array $credentials = [])
     {
-        $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
+        return $this->timebox->call(function ($timebox) use ($credentials) {
+            $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
 
-        return $this->hasValidCredentials($user, $credentials);
+            $validated = $this->hasValidCredentials($user, $credentials);
+
+            if ($validated) {
+                $timebox->returnEarly();
+            }
+
+            return $validated;
+        }, $this->timeboxDuration);
     }
 
     /**
@@ -390,27 +405,31 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function attempt(array $credentials = [], $remember = false)
     {
-        $this->fireAttemptEvent($credentials, $remember);
+        return $this->timebox->call(function ($timebox) use ($credentials, $remember) {
+            $this->fireAttemptEvent($credentials, $remember);
 
-        $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
+            $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
 
-        // If an implementation of UserInterface was returned, we'll ask the provider
-        // to validate the user against the given credentials, and if they are in
-        // fact valid we'll log the users into the application and return true.
-        if ($this->hasValidCredentials($user, $credentials)) {
-            $this->rehashPasswordIfRequired($user, $credentials);
+            // If an implementation of UserInterface was returned, we'll ask the provider
+            // to validate the user against the given credentials, and if they are in
+            // fact valid we'll log the users into the application and return true.
+            if ($this->hasValidCredentials($user, $credentials)) {
+                $this->rehashPasswordIfRequired($user, $credentials);
 
-            $this->login($user, $remember);
+                $this->login($user, $remember);
 
-            return true;
-        }
+                $timebox->returnEarly();
 
-        // If the authentication attempt fails we will fire an event so that the user
-        // may be notified of any suspicious attempts to access their account from
-        // an unrecognized user. A developer may listen to this event as needed.
-        $this->fireFailedEvent($user, $credentials);
+                return true;
+            }
 
-        return false;
+            // If the authentication attempt fails we will fire an event so that the user
+            // may be notified of any suspicious attempts to access their account from
+            // an unrecognized user. A developer may listen to this event as needed.
+            $this->fireFailedEvent($user, $credentials);
+
+            return false;
+        }, $this->timeboxDuration);
     }
 
     /**
@@ -423,24 +442,28 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function attemptWhen(array $credentials = [], $callbacks = null, $remember = false)
     {
-        $this->fireAttemptEvent($credentials, $remember);
+        return $this->timebox->call(function ($timebox) use ($credentials, $callbacks, $remember) {
+            $this->fireAttemptEvent($credentials, $remember);
 
-        $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
+            $this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
 
-        // This method does the exact same thing as attempt, but also executes callbacks after
-        // the user is retrieved and validated. If one of the callbacks returns falsy we do
-        // not login the user. Instead, we will fail the specific authentication attempt.
-        if ($this->hasValidCredentials($user, $credentials) && $this->shouldLogin($callbacks, $user)) {
-            $this->rehashPasswordIfRequired($user, $credentials);
+            // This method does the exact same thing as attempt, but also executes callbacks after
+            // the user is retrieved and validated. If one of the callbacks returns falsy we do
+            // not login the user. Instead, we will fail the specific authentication attempt.
+            if ($this->hasValidCredentials($user, $credentials) && $this->shouldLogin($callbacks, $user)) {
+                $this->rehashPasswordIfRequired($user, $credentials);
 
-            $this->login($user, $remember);
+                $this->login($user, $remember);
 
-            return true;
-        }
+                $timebox->returnEarly();
 
-        $this->fireFailedEvent($user, $credentials);
+                return true;
+            }
 
-        return false;
+            $this->fireFailedEvent($user, $credentials);
+
+            return false;
+        }, $this->timeboxDuration);
     }
 
     /**
@@ -452,17 +475,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function hasValidCredentials($user, $credentials)
     {
-        return $this->timebox->call(function ($timebox) use ($user, $credentials) {
-            $validated = ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
+        $validated = ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
 
-            if ($validated) {
-                $timebox->returnEarly();
+        if ($validated) {
+            $this->fireValidatedEvent($user);
+        }
 
-                $this->fireValidatedEvent($user);
-            }
-
-            return $validated;
-        }, 200 * 1000);
+        return $validated;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -97,7 +97,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $timebox;
 
     /**
-     * The number of microseconds that the Timebox should wait for.
+     * The number of microseconds that the timebox should wait for.
      *
      * @var int
      */


### PR DESCRIPTION
This PR fixes two related issues, and should be back-ported to all versions where security fixes are applied.

### 1. Authentication flow Timebox in wrong spot

The Timebox class was introduced in https://github.com/laravel/framework/pull/44069 inside the `SessionGuard::hasValidCredentials()` method as a way to mask timing differences within the authentication flow that can lead to user enumeration attacks. However it was implemented in the wrong spot - it is applied **after** the database is queried for a user record. As such, the response time for a request where the user record doesn't exist will be slightly shorter than that where the user does exist - making it measurable and vulnerable to an enumeration attack.

To fix the issue, and maintain backwards compatibility, I've moved the Timebox from `SessionGuard::hasValidCredentials()` to the three methods which call `hasValidCredentials`: `validate`, `attempt`, and `attemptWhen`. This allows the Timebox to encapsulate the database queries, masking user existence and making user enumeration significantly more difficult.

I also added the `auth.timebox_duration` configuration option, as in my tests the default 200,000 microsecond wait time wasn't sufficient for a slow server to mask the timing differences. By making this configurable, devs can easily tweak it to optimise for their infrastructure.

_I tried getting meaningful but simple benchmarks but the timing differences were too subtle. The differences are easy to observe in isolation - such as the difference in query time, but tying them together to benchmark the whole request was difficult. I can provide more details as needed._

### 2. Adding Timebox to the Password Reset

The Timebox was also missing from password reset requests, which would allow an attacker to easily enumerate user accounts based on that response time too. I added the Timebox to `PasswordBroker::sendResetLink()`, and `PasswordBroker::reset()`, both of which could be used to enumerate user accounts.

**Notes**

- Preventing timing attacks is virtually impossible, as there will always been some variations between different requests, however detecting these variations can be extremely difficult, so if enumeration is a concern then adding the Timebox can make a difference and slow down an attacker. 
- The default Starter Kits leak user existence in other ways, regardless of these changes. This fix is for the devs who have implemented their own authentication system on top of the framework and expect the Timebox to prevent enumeration.
