### PR TITLE
[12.x] perf: Optimize BladeCompiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -233,6 +233,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function getOpenAndClosingPhpTokens($contents)
     {
         $tokens = [];
+
         foreach (token_get_all($contents) as $token) {
             if ($token[0] === T_OPEN_TAG || $token[0] === T_OPEN_TAG_WITH_ECHO || $token[0] === T_CLOSE_TAG) {
                 $tokens[] = $token[0];

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -232,11 +232,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function getOpenAndClosingPhpTokens($contents)
     {
-        return (new Collection(token_get_all($contents)))
-            ->pluck(0)
-            ->filter(function ($token) {
-                return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
-            });
+        $tokens = [];
+        foreach (token_get_all($contents) as $token) {
+            if ($token[0] === T_OPEN_TAG || $token[0] === T_OPEN_TAG_WITH_ECHO || $token[0] === T_CLOSE_TAG) {
+                $tokens[] = $token[0];
+            }
+        }
+        return new Collection($tokens);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -238,6 +238,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $tokens[] = $token[0];
             }
         }
+
         return new Collection($tokens);
     }
 


### PR DESCRIPTION
This PR reduces the execution time for `getOpenAndClosingPhpTokens()` by up to 5-8x and the `compile()` by up to 3x, based on my testing. 

As the improvements are for the BladeCompiler, these benefit the most situations when the Blade Components are not cached (local and misconfigured production environments).


I used the Livewire starter kit on PHP 8.3 and my mac with M3 Max to test my changes. 

page | v1 | v2 | v3 | this version (v4)
-- | -- | -- | -- | --
complex page (92 calls) | **43.06 ms** | 16.73 ms | 13.98 ms | **8.65 ms**
billing page (51 calls) | **18.74 ms** | 7.22 ms | 6.22 ms | **4.18 ms**
dashboard (94 calls) | **35.42 ms** | 13.69 ms | 11.60 ms | **7.57 ms**
profile page (56 calls) | **23.21 ms** | 8.97 ms | 7.64 ms | **5.05 ms**


I went through a few iterations which I will add here:
v1: Original
```php
        return (new Collection(token_get_all($contents)))
            ->pluck(0)
            ->filter(function ($token) {
                return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
            });
```
v2: Most obvious optimization, doing the pluck after the filter
```php 
        return (new Collection(token_get_all($contents)))
            ->filter(function ($token) {
                return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
            })
            ->pluck(0);
```
v3: Switching to `foreach()`, instead of using collection
```php
        $tokens = [];
        foreach (token_get_all($contents) as $token) {
            if (in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG])) {
                $tokens[] = $token[0];
            }
        }
        return new Collection($tokens);
```
v4: **Final optimization**: Switch from in_array, to multiple if conditions
```php
        $tokens = [];
        foreach (token_get_all($contents) as $token) {
            if ($token[0] === T_OPEN_TAG || $token[0] === T_OPEN_TAG_WITH_ECHO || $token[0] === T_CLOSE_TAG) {
                $tokens[] = $token[0];
            }
        }
        return new Collection($tokens);
```