### PR TITLE
[12.x] Add `pull` method to `Fluent` class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -66,6 +66,20 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Get the value of a given key and then forget it.
+     *
+     * @template TPullDefault
+     *
+     * @param  TKey  $key
+     * @param  TPullDefault|(\Closure(): TPullDefault)  $default
+     * @return TValue|TPullDefault
+     */
+    public function pull($key, $default = null)
+    {
+        return Arr::pull($this->attributes, $key, $default);
+    }
+
+    /**
      * Set an attribute on the fluent instance using "dot" notation.
      *
      * @param  TKey  $key

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -77,6 +77,28 @@ class SupportFluentTest extends TestCase
         $this->assertSame(['color' => 'silver'], $fluent->computer);
     }
 
+    public function testPull()
+    {
+        $fluent = new Fluent;
+
+        $fluent->set('name', 'Taylor');
+        $fluent->set('developer', true);
+        $fluent->set('posts', 25);
+        $fluent->set('computer.color', 'silver');
+
+        $name = $fluent->pull('name');
+        $this->assertSame('Taylor', $name);
+
+        $color = $fluent->pull('computer.color');
+        $this->assertSame('silver', $color);
+
+        $this->assertSame([
+            'developer' => true,
+            'posts' => 25,
+            'computer' => [],
+        ], $fluent->toArray());
+    }
+
     public function testArrayAccessToAttributes()
     {
         $fluent = new Fluent(['attributes' => '1']);


### PR DESCRIPTION
This PR introduces a `pull` method to the `Fluent` class, allowing retrieval and removal of values in one operation.
Since many core Laravel classes (like Arr, Collection, Cache and more) already implement a pull method, I believe adding similar functionality to Fluent improves API consistency and developer ergonomics.