### PR TITLE
Add DB::sanitizeSqlLike method to sanitize % or _ from user input

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -139,6 +139,24 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * Sanitizes a +string+ so that it is safe to use within an SQL
+     * LIKE statement. This method uses +escape_character+ to escape all
+     * occurrences of itself, "_" and "%".
+     *
+     * @param  string  $string
+     * @param  string  $escapeChar
+     * @return string
+     */
+    public static function sanitizeSqlLike(string $string, string $escapeChar = '\\')
+    {
+        if (str_contains($string, $escapeChar) && $escapeChar !== '%' && $escapeChar !== '_') {
+            $string = str_replace($escapeChar, $escapeChar.$escapeChar, $string);
+        }
+
+        return preg_replace('/(?=[%_])/', $escapeChar, $string);
+    }
+
+    /**
      * Get a database connection instance from the given configuration.
      *
      * @param  string  $name

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -114,6 +114,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static void rollBack(int|null $toLevel = null)
  * @method static int transactionLevel()
  * @method static void afterCommit(callable $callback)
+ * @method static string sanitizeSqlLike(string $string, string $escapeChar = '\\')
  *
  * @see \Illuminate\Database\DatabaseManager
  */

--- a/tests/Database/DatabaseManagerTest.php
+++ b/tests/Database/DatabaseManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class DatabaseManagerTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        tap(new Manager)->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ])->bootEloquent();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::unsetConnectionResolver();
+    }
+    public function testSanitizeSqlLike()
+    {
+        $this->assertEquals('100\%', DB::sanitizeSqlLike('100%'));
+        $this->assertEquals('snake\_cased\_string', DB::sanitizeSqlLike('snake_cased_string'));
+        $this->assertEquals('great!!', DB::sanitizeSqlLike('great!', '!'));
+        $this->assertEquals('C:\\\\Programs\\\\MsPaint', DB::sanitizeSqlLike('C:\\Programs\\MsPaint'));
+        $this->assertEquals('normal string 42', DB::sanitizeSqlLike('normal string 42'));
+    }
+
+    public function testSanitizeSqlLikeWithCustomEscapeCharacter()
+    {
+        $this->assertEquals('100!%', DB::sanitizeSqlLike('100%', '!'));
+        $this->assertEquals('snake!_cased!_string', DB::sanitizeSqlLike('snake_cased_string', '!'));
+        $this->assertEquals('great!!', DB::sanitizeSqlLike('great!', '!'));
+        $this->assertEquals('C:\\Programs\\MsPaint', DB::sanitizeSqlLike('C:\\Programs\\MsPaint', '!'));
+        $this->assertEquals('normal string 42', DB::sanitizeSqlLike('normal string 42', '!'));
+    }
+
+    public function testSanitizeSqlLikeWithWildcardAsEscapeCharacter()
+    {
+        $this->assertEquals('1__000_%', DB::sanitizeSqlLike('1_000%', '_'));
+        $this->assertEquals('1%_000%%', DB::sanitizeSqlLike('1_000%', '%'));
+    }
+
+    public function testSanitizeSqlLikeExampleUseCase()
+    {
+        [$binding] = Post::query()->searchAsScope('20% _reduction_!')->getBindings();
+
+        $this->assertSame('20\% \_reduction\_!', $binding);
+    }
+}
+
+class Post extends Model
+{
+    public function scopeSearchAsScope($query, string $term)
+    {
+        $term = DB::sanitizeSqlLike($term);
+
+        return $query->where('title', 'LIKE', $term);
+    }
+}


### PR DESCRIPTION
## use case
sometimes we need to add the following query `LIKE $q%` to match any character at the right side only to keep the index used because `%$q%' won't use the index.

but if we add the following eloquent method `whereLike('name', "$q%")` the user may pass the query prefixed with % like this `%me%` which will make the query look for any characters from the both side and won't use the index

## solution
i know there is solution for it in Rails and i couldn't find something similar in laravel. they have a method to sanitize sql for like statement [here](https://api.rubyonrails.org/v8.0.2/classes/ActiveRecord/Sanitization/ClassMethods.html#method-i-sanitize_sql_like) and i believe we need to bring it here.

## testing
before
![image](https://github.com/user-attachments/assets/5fe7c2bf-120b-405f-add4-16a798ad6227)

after
![image](https://github.com/user-attachments/assets/c4d79ed1-1d35-40f5-b38f-3c4cf3911b79)
