### PR TITLE
[12.x] Add flexible support to memoized cache store

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -163,6 +163,39 @@ class MemoizedStore implements Store, LockProvider
     }
 
     /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        if (! $this->repository->getStore() instanceof LockProvider) {
+            throw new BadMethodCallException('This cache store does not support locks.');
+        }
+
+        return $this->repository->getStore()->lock(...func_get_args());
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        if (! $this->repository instanceof LockProvider) {
+            throw new BadMethodCallException('This cache store does not support locks.');
+        }
+
+        return $this->repository->resoreLock(...func_get_args());
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -195,39 +228,6 @@ class MemoizedStore implements Store, LockProvider
     public function getPrefix()
     {
         return $this->repository->getPrefix();
-    }
-
-    /**
-     * Get a lock instance.
-     *
-     * @param  string  $name
-     * @param  int  $seconds
-     * @param  string|null  $owner
-     * @return \Illuminate\Contracts\Cache\Lock
-     */
-    public function lock($name, $seconds = 0, $owner = null)
-    {
-        if (! $this->repository->getStore() instanceof LockProvider) {
-            throw new BadMethodCallException('This cache store does not support locks.');
-        }
-
-        return $this->repository->getStore()->lock(...func_get_args());
-    }
-
-    /**
-     * Restore a lock instance using the owner identifier.
-     *
-     * @param  string  $name
-     * @param  string  $owner
-     * @return \Illuminate\Contracts\Cache\Lock
-     */
-    public function restoreLock($name, $owner)
-    {
-        if (! $this->repository instanceof LockProvider) {
-            throw new BadMethodCallException('This cache store does not support locks.');
-        }
-
-        return $this->repository->resoreLock(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -6,7 +6,7 @@ use BadMethodCallException;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 
-class MemoizedStore implements Store, LockProvider
+class MemoizedStore implements LockProvider, Store
 {
     /**
      * The memoized cache values.

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Cache;
 
+use BadMethodCallException;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 
-class MemoizedStore implements Store
+class MemoizedStore implements Store, LockProvider
 {
     /**
      * The memoized cache values.
@@ -193,6 +195,39 @@ class MemoizedStore implements Store
     public function getPrefix()
     {
         return $this->repository->getPrefix();
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        if (! $this->repository->getStore() instanceof LockProvider) {
+            throw new BadMethodCallException('This cache store does not support locks.');
+        }
+
+        return $this->repository->getStore()->lock(...func_get_args());
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        if (! $this->repository instanceof LockProvider) {
+            throw new BadMethodCallException('This cache store does not support locks.');
+        }
+
+        return $this->repository->resoreLock(...func_get_args());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/55700

Using flexible with cache memo silently fails. This ensures it works as expected.

We could make changes in the `flexible` method if we don't want to add the lock / restoreLock methods to the memoized cache driver, but I think it is fine and potentially even useful if you want to pass around a memoized store.