### PR TITLE
Add Str:: prefixWith, suffixWith, and wrapWith helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -959,7 +959,7 @@ class Str
 
     /**
      * Repeat a string a given number of times, padding it on both sides.
-     * 
+     *
      * @param  string  $value
      * @param  int  $times
      * @param  string  $pad
@@ -972,7 +972,7 @@ class Str
 
     /**
      * Repeat a string a given number of times, padding it on the left side.
-     * 
+     *
      * @param  string  $value
      * @param  int  $times
      * @param  string  $pad
@@ -985,7 +985,7 @@ class Str
 
     /**
      * Repeat a string a given number of times, padding it on the right side.
-     * 
+     *
      * @param  string  $value
      * @param  int  $times
      * @param  string  $pad

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -991,7 +991,7 @@ class Str
      * @param  int  $times
      * @return string
      */
-    public static function suffixWith($value, $pad, $times)
+    public static function suffixWith($value, $pad, $times = 1)
     {
         return static::padRight($value, strlen($value) + $times, str_repeat($pad, $times));
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -958,40 +958,40 @@ class Str
     }
 
     /**
-     * Repeat a string a given number of times, padding it on both sides.
+     * Repeat a string a given number of times, concatenate it on both sides.
      *
      * @param  string  $value
-     * @param  int  $times
      * @param  string  $pad
+     * @param  int  $times
      * @return string
      */
-    public static function padRepeatBoth($value, $times, $pad = ' ')
+    public static function wrapWith($value, $pad, $times = 1)
     {
         return static::padBoth($value, strlen($value) + $times * 2, str_repeat($pad, $times));
     }
 
     /**
-     * Repeat a string a given number of times, padding it on the left side.
+     * Repeat a string a given number of times, concatenate it on the left side.
      *
      * @param  string  $value
-     * @param  int  $times
      * @param  string  $pad
+     * @param  int  $times
      * @return string
      */
-    public static function padRepeatLeft($value, $times, $pad = ' ')
+    public static function prefixWith($value, $pad, $times = 1)
     {
         return static::padLeft($value, strlen($value) + $times, str_repeat($pad, $times));
     }
 
     /**
-     * Repeat a string a given number of times, padding it on the right side.
+     * Repeat a string a given number of times, concatenate it on the right side.
      *
      * @param  string  $value
-     * @param  int  $times
      * @param  string  $pad
+     * @param  int  $times
      * @return string
      */
-    public static function padRepeatRight($value, $times, $pad = ' ')
+    public static function suffixWith($value, $pad, $times)
     {
         return static::padRight($value, strlen($value) + $times, str_repeat($pad, $times));
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -958,6 +958,45 @@ class Str
     }
 
     /**
+     * Repeat a string a given number of times, padding it on both sides.
+     * 
+     * @param  string  $value
+     * @param  int  $times
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padRepeatBoth($value, $times, $pad = ' ')
+    {
+        return static::padBoth($value, strlen($value) + $times * 2, str_repeat($pad, $times));
+    }
+
+    /**
+     * Repeat a string a given number of times, padding it on the left side.
+     * 
+     * @param  string  $value
+     * @param  int  $times
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padRepeatLeft($value, $times, $pad = ' ')
+    {
+        return static::padLeft($value, strlen($value) + $times, str_repeat($pad, $times));
+    }
+
+    /**
+     * Repeat a string a given number of times, padding it on the right side.
+     * 
+     * @param  string  $value
+     * @param  int  $times
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padRepeatRight($value, $times, $pad = ' ')
+    {
+        return static::padRight($value, strlen($value) + $times, str_repeat($pad, $times));
+    }
+
+    /**
      * Parse a Class[@]method style callback into class and method.
      *
      * @param  string  $callback

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1268,7 +1268,7 @@ class SupportStrTest extends TestCase
     public function testWrapWith()
     {
         $this->assertSame('   Laravel   ', Str::wrapWith('Laravel', ' ', 3));
-        $this->assertSame('----Laravel----', Str::wrapWith('Laravel','-' , 4));
+        $this->assertSame('----Laravel----', Str::wrapWith('Laravel', '-', 4));
         $this->assertSame('❤❤Laravel❤❤', Str::wrapWith('Laravel', '❤', 2));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1265,6 +1265,27 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆❤☆❤☆❤', Str::padRight('❤MultiByte☆', 16, '❤☆'));
     }
 
+    public function testPadRepeatBoth()
+    {
+        $this->assertSame('   Laravel   ', Str::padRepeatBoth('Laravel', 3, ' '));
+        $this->assertSame('----Laravel----', Str::padRepeatBoth('Laravel', 4, '-'));
+        $this->assertSame('❤❤Laravel❤❤', Str::padRepeatBoth('Laravel', 2, '❤'));
+    }
+
+    public function testPadRepeatLeft()
+    {
+        $this->assertSame('   Laravel', Str::padRepeatLeft('Laravel', 3, ' '));
+        $this->assertSame('----Laravel', Str::padRepeatLeft('Laravel', 4, '-'));
+        $this->assertSame('❤❤Laravel', Str::padRepeatLeft('Laravel', 2, '❤'));
+    }
+
+    public function testPadRepeatRight()
+    {
+        $this->assertSame('Laravel   ', Str::padRepeatRight('Laravel', 3, ' '));
+        $this->assertSame('Laravel----', Str::padRepeatRight('Laravel', 4, '-'));
+        $this->assertSame('Laravel❤❤', Str::padRepeatRight('Laravel', 2, '❤'));
+    }
+
     public function testSwapKeywords(): void
     {
         $this->assertSame(

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1265,25 +1265,25 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆❤☆❤☆❤', Str::padRight('❤MultiByte☆', 16, '❤☆'));
     }
 
-    public function testPadRepeatBoth()
+    public function testWrapWith()
     {
-        $this->assertSame('   Laravel   ', Str::padRepeatBoth('Laravel', 3, ' '));
-        $this->assertSame('----Laravel----', Str::padRepeatBoth('Laravel', 4, '-'));
-        $this->assertSame('❤❤Laravel❤❤', Str::padRepeatBoth('Laravel', 2, '❤'));
+        $this->assertSame('   Laravel   ', Str::wrapWith('Laravel', ' ', 3));
+        $this->assertSame('----Laravel----', Str::wrapWith('Laravel','-' , 4));
+        $this->assertSame('❤❤Laravel❤❤', Str::wrapWith('Laravel', '❤', 2));
     }
 
-    public function testPadRepeatLeft()
+    public function testPrefixWith()
     {
-        $this->assertSame('   Laravel', Str::padRepeatLeft('Laravel', 3, ' '));
-        $this->assertSame('----Laravel', Str::padRepeatLeft('Laravel', 4, '-'));
-        $this->assertSame('❤❤Laravel', Str::padRepeatLeft('Laravel', 2, '❤'));
+        $this->assertSame('   Laravel', Str::prefixWith('Laravel', ' ', 3));
+        $this->assertSame('----Laravel', Str::prefixWith('Laravel', '-', 4));
+        $this->assertSame('❤❤Laravel', Str::prefixWith('Laravel', '❤', 2));
     }
 
-    public function testPadRepeatRight()
+    public function testSuffixWith()
     {
-        $this->assertSame('Laravel   ', Str::padRepeatRight('Laravel', 3, ' '));
-        $this->assertSame('Laravel----', Str::padRepeatRight('Laravel', 4, '-'));
-        $this->assertSame('Laravel❤❤', Str::padRepeatRight('Laravel', 2, '❤'));
+        $this->assertSame('Laravel   ', Str::suffixWith('Laravel', ' ', 3));
+        $this->assertSame('Laravel----', Str::suffixWith('Laravel', '-', 4));
+        $this->assertSame('Laravel❤❤', Str::suffixWith('Laravel', '❤', 2));
     }
 
     public function testSwapKeywords(): void


### PR DESCRIPTION
📄 PR Description
This PR introduces three new utility methods to the Illuminate\Support\Str class:

Str:: prefixWith($value, string $pad, $times)

Str:: suffixWith($value, string $pad, $times)

Str:: wrapWith($value, string $pad, $times)

These methods provide a more expressive and reusable way to pad strings by repeating a given character (or string) a specific number of times on the left, right, or both sides.