### PR TITLE
[12.x] Introduce Arr::from()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -41,8 +41,7 @@ class Arr
             || $value instanceof Arrayable
             || $value instanceof Traversable
             || $value instanceof Jsonable
-            || $value instanceof JsonSerializable
-            || $value instanceof UnitEnum;
+            || $value instanceof JsonSerializable;
     }
 
     /**
@@ -406,7 +405,7 @@ class Arr
      * @template TKey of array-key = array-key
      * @template TValue = mixed
      *
-     * @param  array<TKey, TValue>|Enumerable<TKey, TValue>|Arrayable<TKey, TValue>|WeakMap<object, TValue>|Traversable<TKey, TValue>|Jsonable|JsonSerializable|UnitEnum  $items
+     * @param  array<TKey, TValue>|Enumerable<TKey, TValue>|Arrayable<TKey, TValue>|WeakMap<object, TValue>|Traversable<TKey, TValue>|Jsonable|JsonSerializable|object  $items
      * @return ($items is WeakMap ? list<TValue> : array<TKey, TValue>)
      *
      * @throws \InvalidArgumentException
@@ -421,7 +420,7 @@ class Arr
             $items instanceof Traversable => iterator_to_array($items),
             $items instanceof Jsonable => json_decode($items->toJson(), true),
             $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
-            $items instanceof UnitEnum => [$items],
+            is_object($items) && ! $items instanceof UnitEnum => (array) $items,
             default => throw new InvalidArgumentException('Items cannot be represented by a scalar value.'),
         };
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -30,6 +30,22 @@ class Arr
     }
 
     /**
+     * Determine whether the given value is arrayable.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function arrayable($value)
+    {
+        return is_array($value)
+            || $value instanceof Arrayable
+            || $value instanceof Traversable
+            || $value instanceof Jsonable
+            || $value instanceof JsonSerializable
+            || $value instanceof UnitEnum;
+    }
+
+    /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
 use JsonSerializable;
 use Random\Randomizer;
 use Traversable;
-use UnitEnum;
 use WeakMap;
 
 class Arr
@@ -420,7 +419,7 @@ class Arr
             $items instanceof Traversable => iterator_to_array($items),
             $items instanceof Jsonable => json_decode($items->toJson(), true),
             $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
-            is_object($items) && ! $items instanceof UnitEnum => (array) $items,
+            is_object($items) => (array) $items,
             default => throw new InvalidArgumentException('Items cannot be represented by a scalar value.'),
         };
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -392,6 +392,8 @@ class Arr
      *
      * @param  array<TKey, TValue>|Enumerable<TKey, TValue>|Arrayable<TKey, TValue>|WeakMap<object, TValue>|Traversable<TKey, TValue>|Jsonable|JsonSerializable|UnitEnum  $items
      * @return ($items is WeakMap ? list<TValue> : array<TKey, TValue>)
+     *
+     * @throws \InvalidArgumentException
      */
     public static function from($items)
     {
@@ -404,7 +406,7 @@ class Arr
             $items instanceof Jsonable => json_decode($items->toJson(), true),
             $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
             $items instanceof UnitEnum => [$items],
-            default => (array) $items,
+            default => throw new InvalidArgumentException('Items cannot be represented by a scalar value.'),
         };
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1059,7 +1059,7 @@ trait EnumeratesValues
         try {
             return Arr::from($items);
         } catch (InvalidArgumentException) {
-            return (array) $items;
+            return Arr::wrap($items);
         }
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
+use InvalidArgumentException;
 use JsonSerializable;
 use UnexpectedValueException;
 
@@ -1055,7 +1056,11 @@ trait EnumeratesValues
      */
     protected function getArrayableItems($items)
     {
-        return Arr::from($items);
+        try {
+            return Arr::from($items);
+        } catch (InvalidArgumentException) {
+            return (array) $items;
+        }
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -12,9 +12,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
-use InvalidArgumentException;
 use JsonSerializable;
 use UnexpectedValueException;
+use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
@@ -1056,11 +1056,9 @@ trait EnumeratesValues
      */
     protected function getArrayableItems($items)
     {
-        try {
-            return Arr::from($items);
-        } catch (InvalidArgumentException) {
-            return Arr::wrap($items);
-        }
+        return is_null($items) || is_scalar($items) || $items instanceof UnitEnum
+            ? Arr::wrap($items)
+            : Arr::from($items);
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -12,12 +12,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
-use InvalidArgumentException;
 use JsonSerializable;
-use Traversable;
 use UnexpectedValueException;
-use UnitEnum;
-use WeakMap;
 
 use function Illuminate\Support\enum_value;
 
@@ -1059,17 +1055,7 @@ trait EnumeratesValues
      */
     protected function getArrayableItems($items)
     {
-        return match (true) {
-            is_array($items) => $items,
-            $items instanceof WeakMap => throw new InvalidArgumentException('Collections can not be created using instances of WeakMap.'),
-            $items instanceof Enumerable => $items->all(),
-            $items instanceof Arrayable => $items->toArray(),
-            $items instanceof Traversable => iterator_to_array($items),
-            $items instanceof Jsonable => json_decode($items->toJson(), true),
-            $items instanceof JsonSerializable => (array) $items->jsonSerialize(),
-            $items instanceof UnitEnum => [$items],
-            default => (array) $items,
-        };
+        return Arr::from($items);
     }
 
     /**

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -77,9 +77,9 @@ if (! function_exists('data_get')) {
             $segment = match ($segment) {
                 '\*' => '*',
                 '\{first}' => '{first}',
-                '{first}' => array_key_first(is_array($target) ? $target : (new Collection($target))->all()),
+                '{first}' => array_key_first(Arr::from($target)),
                 '\{last}' => '{last}',
-                '{last}' => array_key_last(is_array($target) ? $target : (new Collection($target))->all()),
+                '{last}' => array_key_last(Arr::from($target)),
                 default => $segment,
             };
 

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncation.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 trait DatabaseTruncation
@@ -120,7 +121,7 @@ trait DatabaseTruncation
 
         $schema = $connection->getSchemaBuilder();
 
-        return static::$allTables[$name] = (new Collection($schema->getTables($schema->getCurrentSchemaListing())))->all();
+        return static::$allTables[$name] = Arr::from($schema->getTables($schema->getCurrentSchemaListing()));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -18,6 +18,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Symfony\Component\Uid\Ulid;
 use Throwable;
+use Traversable;
 use voku\helper\ASCII;
 
 class Str
@@ -1178,7 +1179,9 @@ class Str
      */
     public static function replaceArray($search, $replace, $subject)
     {
-        $replace = Arr::from($replace);
+        if ($replace instanceof Traversable) {
+            $replace = Arr::from($replace);
+        }
 
         $segments = explode($search, $subject);
 
@@ -1218,9 +1221,17 @@ class Str
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {
-        $search = Arr::from($search);
-        $replace = Arr::from($replace);
-        $subject = Arr::from($subject);
+        if ($search instanceof Traversable) {
+            $search = Arr::from($search);
+        }
+
+        if ($replace instanceof Traversable) {
+            $replace = Arr::from($replace);
+        }
+
+        if ($subject instanceof Traversable) {
+            $subject = Arr::from($subject);
+        }
 
         return $caseSensitive
             ? str_replace($search, $replace, $subject)
@@ -1351,7 +1362,9 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        $search = Arr::from($search);
+        if ($search instanceof Traversable) {
+            $search = Arr::from($search);
+        }
 
         return $caseSensitive
             ? str_replace($search, '', $subject)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -18,7 +18,6 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Symfony\Component\Uid\Ulid;
 use Throwable;
-use Traversable;
 use voku\helper\ASCII;
 
 class Str
@@ -1179,8 +1178,8 @@ class Str
      */
     public static function replaceArray($search, $replace, $subject)
     {
-        if ($replace instanceof Traversable) {
-            $replace = (new Collection($replace))->all();
+        if (Arr::arrayable($replace)) {
+            $replace = Arr::from($replace);
         }
 
         $segments = explode($search, $subject);
@@ -1221,16 +1220,16 @@ class Str
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {
-        if ($search instanceof Traversable) {
-            $search = (new Collection($search))->all();
+        if (Arr::arrayable($search)) {
+            $search = Arr::from($search);
         }
 
-        if ($replace instanceof Traversable) {
-            $replace = (new Collection($replace))->all();
+        if (Arr::arrayable($replace)) {
+            $replace = Arr::from($replace);
         }
 
-        if ($subject instanceof Traversable) {
-            $subject = (new Collection($subject))->all();
+        if (Arr::arrayable($subject)) {
+            $subject = Arr::from($subject);
         }
 
         return $caseSensitive
@@ -1362,8 +1361,8 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        if ($search instanceof Traversable) {
-            $search = (new Collection($search))->all();
+        if (Arr::arrayable($search)) {
+            $search = Arr::from($search);
         }
 
         return $caseSensitive

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1178,9 +1178,7 @@ class Str
      */
     public static function replaceArray($search, $replace, $subject)
     {
-        if (Arr::arrayable($replace)) {
-            $replace = Arr::from($replace);
-        }
+        $replace = Arr::from($replace);
 
         $segments = explode($search, $subject);
 
@@ -1220,17 +1218,9 @@ class Str
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {
-        if (Arr::arrayable($search)) {
-            $search = Arr::from($search);
-        }
-
-        if (Arr::arrayable($replace)) {
-            $replace = Arr::from($replace);
-        }
-
-        if (Arr::arrayable($subject)) {
-            $subject = Arr::from($subject);
-        }
+        $search = Arr::from($search);
+        $replace = Arr::from($replace);
+        $subject = Arr::from($subject);
 
         return $caseSensitive
             ? str_replace($search, $replace, $subject)
@@ -1361,9 +1351,7 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        if (Arr::arrayable($search)) {
-            $search = Arr::from($search);
-        }
+        $search = Arr::from($search);
 
         return $caseSensitive
             ? str_replace($search, '', $subject)

--- a/tests/Support/Common.php
+++ b/tests/Support/Common.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+class TestArrayableObject implements Arrayable
+{
+    public function toArray()
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonableObject implements Jsonable
+{
+    public function toJson($options = 0)
+    {
+        return '{"foo":"bar"}';
+    }
+}
+
+class TestJsonSerializeObject implements JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonSerializeWithScalarValueObject implements JsonSerializable
+{
+    public function jsonSerialize(): string
+    {
+        return 'foo';
+    }
+}
+
+class TestTraversableAndJsonSerializableObject implements IteratorAggregate, JsonSerializable
+{
+    public $items;
+
+    public function __construct($items)
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return json_decode(json_encode($this->items), true);
+    }
+}

--- a/tests/Support/Common.php
+++ b/tests/Support/Common.php
@@ -45,7 +45,7 @@ class TestTraversableAndJsonSerializableObject implements IteratorAggregate, Jso
 {
     public $items;
 
-    public function __construct($items)
+    public function __construct($items = [])
     {
         $this->items = $items;
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1503,6 +1503,10 @@ class SupportArrTest extends TestCase
         $items = new WeakMap;
         $items[$temp = new class {}] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
+        Arr::from(123);
     }
 
     public function testWrap()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -35,6 +35,25 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::accessible(static fn () => null));
     }
 
+    public function testArrayable(): void
+    {
+        $this->assertTrue(Arr::arrayable([]));
+        $this->assertTrue(Arr::arrayable(new TestArrayableObject));
+        $this->assertTrue(Arr::arrayable(new TestJsonableObject));
+        $this->assertTrue(Arr::arrayable(new TestJsonSerializeObject));
+        $this->assertTrue(Arr::arrayable(new TestTraversableAndJsonSerializableObject));
+
+        $this->assertFalse(Arr::arrayable(null));
+        $this->assertFalse(Arr::arrayable('abc'));
+        $this->assertFalse(Arr::arrayable(new stdClass));
+        $this->assertFalse(Arr::arrayable((object) ['a' => 1, 'b' => 2]));
+        $this->assertFalse(Arr::arrayable(123));
+        $this->assertFalse(Arr::arrayable(12.34));
+        $this->assertFalse(Arr::arrayable(true));
+        $this->assertFalse(Arr::arrayable(new \DateTime));
+        $this->assertFalse(Arr::arrayable(static fn () => null));
+    }
+
     public function testAdd()
     {
         $array = Arr::add(['name' => 'Desk'], 'price', 100);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1517,6 +1517,10 @@ class SupportArrTest extends TestCase
         $this->assertSame(['foo' => 'bar'], Arr::from(new TestJsonSerializeObject));
         $this->assertSame(['foo'], Arr::from(new TestJsonSerializeWithScalarValueObject));
 
+        $this->assertSame(['name' => 'A'], Arr::from(TestEnum::A));
+        $this->assertSame(['name' => 'A', 'value' => 1], Arr::from(TestBackedEnum::A));
+        $this->assertSame(['name' => 'A', 'value' => 'A'], Arr::from(TestStringBackedEnum::A));
+
         $subject = [new stdClass, new stdClass];
         $items = new TestTraversableAndJsonSerializableObject($subject);
         $this->assertSame($subject, Arr::from($items));
@@ -1528,10 +1532,6 @@ class SupportArrTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
         Arr::from(123);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
-        Arr::from(TestEnum::A);
     }
 
     public function testWrap()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -11,6 +11,9 @@ use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use WeakMap;
+
+include_once 'Common.php';
 
 class SupportArrTest extends TestCase
 {
@@ -1483,6 +1486,23 @@ class SupportArrTest extends TestCase
         $array = [2 => [1 => 'products', 3 => 'users']];
         Arr::forget($array, 2.3);
         $this->assertEquals([2 => [1 => 'products']], $array);
+    }
+
+    public function testFrom()
+    {
+        $this->assertSame(['foo' => 'bar'], Arr::from(['foo' => 'bar']));
+        $this->assertSame(['foo' => 'bar'], Arr::from(new TestArrayableObject));
+        $this->assertSame(['foo' => 'bar'], Arr::from(new TestJsonableObject));
+        $this->assertSame(['foo' => 'bar'], Arr::from(new TestJsonSerializeObject));
+        $this->assertSame(['foo'], Arr::from(new TestJsonSerializeWithScalarValueObject));
+
+        $subject = [new stdClass, new stdClass];
+        $items = new TestTraversableAndJsonSerializableObject($subject);
+        $this->assertSame($subject, Arr::from($items));
+
+        $items = new WeakMap;
+        $items[$temp = new class {}] = 'bar';
+        $this->assertSame(['bar'], Arr::from($items));
     }
 
     public function testWrap()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -14,6 +14,7 @@ use stdClass;
 use WeakMap;
 
 include_once 'Common.php';
+include_once 'Enums.php';
 
 class SupportArrTest extends TestCase
 {
@@ -1510,6 +1511,7 @@ class SupportArrTest extends TestCase
     public function testFrom()
     {
         $this->assertSame(['foo' => 'bar'], Arr::from(['foo' => 'bar']));
+        $this->assertSame(['foo' => 'bar'], Arr::from((object) ['foo' => 'bar']));
         $this->assertSame(['foo' => 'bar'], Arr::from(new TestArrayableObject));
         $this->assertSame(['foo' => 'bar'], Arr::from(new TestJsonableObject));
         $this->assertSame(['foo' => 'bar'], Arr::from(new TestJsonSerializeObject));
@@ -1526,6 +1528,10 @@ class SupportArrTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
         Arr::from(123);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Items cannot be represented by a scalar value.');
+        Arr::from(TestEnum::A);
     }
 
     public function testWrap()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -8,7 +8,6 @@ use ArrayObject;
 use CachingIterator;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
@@ -18,7 +17,6 @@ use Illuminate\Support\MultipleItemsFoundException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
-use IteratorAggregate;
 use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -26,10 +24,10 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
-use Traversable;
 use UnexpectedValueException;
 use WeakMap;
 
+include_once 'Common.php';
 include_once 'Enums.php';
 
 class SupportCollectionTest extends TestCase
@@ -2915,14 +2913,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testConstructMethodFromWeakMap($collection)
     {
-        $this->expectException('InvalidArgumentException');
-
         $map = new WeakMap();
         $object = new stdClass;
         $object->foo = 'bar';
         $map[$object] = 3;
-
         $data = new $collection($map);
+        $this->assertEquals([3], $data->all());
     }
 
     public function testSplice()
@@ -5787,63 +5783,11 @@ class TestArrayAccessImplementation implements ArrayAccess
     }
 }
 
-class TestArrayableObject implements Arrayable
-{
-    public function toArray()
-    {
-        return ['foo' => 'bar'];
-    }
-}
-
-class TestJsonableObject implements Jsonable
-{
-    public function toJson($options = 0)
-    {
-        return '{"foo":"bar"}';
-    }
-}
-
-class TestJsonSerializeObject implements JsonSerializable
-{
-    public function jsonSerialize(): array
-    {
-        return ['foo' => 'bar'];
-    }
-}
-
 class TestJsonSerializeToStringObject implements JsonSerializable
 {
     public function jsonSerialize(): string
     {
         return 'foobar';
-    }
-}
-
-class TestJsonSerializeWithScalarValueObject implements JsonSerializable
-{
-    public function jsonSerialize(): string
-    {
-        return 'foo';
-    }
-}
-
-class TestTraversableAndJsonSerializableObject implements IteratorAggregate, JsonSerializable
-{
-    public $items;
-
-    public function __construct($items)
-    {
-        $this->items = $items;
-    }
-
-    public function getIterator(): Traversable
-    {
-        return new ArrayIterator($this->items);
-    }
-
-    public function jsonSerialize(): array
-    {
-        return json_decode(json_encode($this->items), true);
     }
 }
 


### PR DESCRIPTION
This PR is a second attempt at extracting `getArrayableItems()` functionality into separate function ([first PR](49202)).

Key differences from previous PR are:
- `Arr::from()` won't wrap scalar values to follow single responsibility principle;
- Enums are handled as regular objects (wrapping logic kept in `getArrayableItems` - see #42839);
- `WeakMap` instances are now convertable into lists (keys cannot be preserved for obvious reasons);
- `Arr::arrayable()` helper function has been added to be used in pair with `Arr:from()` when needed.

As for `WeakMap` [concern](https://github.com/laravel/framework/issues/49202#issuecomment-1836867459):
I am convinced that [this issue](49089) valid for both collections and arrays - arrays cannot be created with objects as a keys.
We can handle this situation by throwing an exception (current behavior) or by omitting `WeakMap` keys during casting to array (this PR).
Let me know if you prefer to keep current behavior.