### PR TITLE
Add deleteWhen for throttle exceptions job middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -58,11 +58,11 @@ class ThrottlesExceptions
     protected $whenCallback;
 
     /**
-     * The callbacks that determine if the job should be deleted.
+     * The callbacks that determine if the job should be skipped / deleted.
      *
      * @var callable[]
      */
-    protected array $deleteWhenCallbacks = [];
+    protected array $skipWhenCallbacks = [];
 
     /**
      * The prefix of the rate limiter key.
@@ -118,7 +118,7 @@ class ThrottlesExceptions
                 report($throwable);
             }
 
-            if ($this->shouldDelete($throwable)) {
+            if ($this->shouldSkip($throwable)) {
                 return $job->delete();
             }
 
@@ -142,31 +142,31 @@ class ThrottlesExceptions
     }
 
     /**
-     * Add a callback that should determine if the job should be deleted.
+     * Add a callback that should determine if the job should be skipped / deleted.
      *
      * @param  callable|string  $callback
      * @return $this
      */
-    public function deleteWhen(callable|string $callback)
+    public function skipWhen(callable|string $callback)
     {
         if (is_string($callback)) {
-            $this->deleteWhenCallbacks[] = fn (Throwable $e) => $e instanceof $callback;
+            $this->skipWhenCallbacks[] = fn (Throwable $e) => $e instanceof $callback;
         } else {
-            $this->deleteWhenCallbacks[] = $callback;
+            $this->skipWhenCallbacks[] = $callback;
         }
 
         return $this;
     }
 
     /**
-     * Run the delete callbacks to see if the job should be deleted for the given exception.
+     * Run the skip / delete callbacks to see if the job should be deleted for the given exception.
      *
      * @param  Throwable  $throwable
      * @return bool
      */
-    protected function shouldDelete(Throwable $throwable): bool
+    protected function shouldSkip(Throwable $throwable): bool
     {
-        foreach ($this->deleteWhenCallbacks as $callback) {
+        foreach ($this->skipWhenCallbacks as $callback) {
             if (call_user_func($callback, $throwable)) {
                 return true;
             }

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -58,6 +58,13 @@ class ThrottlesExceptions
     protected $whenCallback;
 
     /**
+     * The callbacks that determine if the job should be deleted.
+     *
+     * @var callable[]
+     */
+    protected array $deleteWhenCallbacks = [];
+
+    /**
      * The prefix of the rate limiter key.
      *
      * @var string
@@ -111,6 +118,10 @@ class ThrottlesExceptions
                 report($throwable);
             }
 
+            if ($this->shouldDelete($throwable)) {
+                return $job->delete();
+            }
+
             $this->limiter->hit($jobKey, $this->decaySeconds);
 
             return $job->release($this->retryAfterMinutes * 60);
@@ -128,6 +139,40 @@ class ThrottlesExceptions
         $this->whenCallback = $callback;
 
         return $this;
+    }
+
+    /**
+     * Add a callback that should determine if the job should be deleted.
+     *
+     * @param  callable|string  $callback
+     * @return $this
+     */
+    public function deleteWhen(callable|string $callback)
+    {
+        if (is_string($callback)) {
+            $this->deleteWhenCallbacks[] = fn (Throwable $e) => $e instanceof $callback;
+        } else {
+            $this->deleteWhenCallbacks[] = $callback;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Run the delete callbacks to see if the job should be deleted for the given exception.
+     *
+     * @param  Throwable  $throwable
+     * @return bool
+     */
+    protected function shouldDelete(Throwable $throwable): bool
+    {
+        foreach ($this->deleteWhenCallbacks as $callback) {
+            if (call_user_func($callback, $throwable)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -58,6 +58,10 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
                 report($throwable);
             }
 
+            if ($this->shouldDelete($throwable)) {
+                return $job->delete();
+            }
+
             $this->limiter->acquire();
 
             return $job->release($this->retryAfterMinutes * 60);

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -58,7 +58,7 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
                 report($throwable);
             }
 
-            if ($this->shouldSkip($throwable)) {
+            if ($this->shouldDelete($throwable)) {
                 return $job->delete();
             }
 

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -58,7 +58,7 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
                 report($throwable);
             }
 
-            if ($this->shouldDelete($throwable)) {
+            if ($this->shouldSkip($throwable)) {
                 return $job->delete();
             }
 

--- a/tests/Integration/Queue/ThrottlesExceptions.php
+++ b/tests/Integration/Queue/ThrottlesExceptions.php
@@ -40,9 +40,9 @@ class ThrottlesExceptionsTest extends TestCase
         $this->assertJobWasReleasedWithDelay(CircuitBreakerTestJob::class);
     }
 
-    public function testJobIsDeleted()
+    public function testCircuitCanSkipJob()
     {
-        $this->assertJobWasDeleted(CircuitBreakerTestDeleteWhenJob::class);
+        $this->assertJobWasDeleted(CircuitBreakerSkipJob::class);
     }
 
     protected function assertJobWasReleasedImmediately($class)
@@ -340,7 +340,7 @@ class CircuitBreakerTestJob
     }
 }
 
-class CircuitBreakerTestDeleteWhenJob
+class CircuitBreakerSkipJob
 {
     use InteractsWithQueue, Queueable;
 
@@ -355,7 +355,7 @@ class CircuitBreakerTestDeleteWhenJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptions(2, 10 * 60))->deleteWhen(Exception::class)];
+        return [(new ThrottlesExceptions(2, 10 * 60))->skipWhen(Exception::class)];
     }
 }
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -97,6 +97,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('hasFailed')->once()->andReturn(false);
         $job->shouldReceive('delete')->once();
         $job->shouldReceive('isDeleted')->andReturn(true);
+        $job->shouldReceive('isReleased')->once()->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -97,7 +97,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('hasFailed')->once()->andReturn(false);
         $job->shouldReceive('delete')->once();
         $job->shouldReceive('isDeleted')->andReturn(true);
-        $job->shouldReceive('isReleased')->once()->andReturn(false);
+        $job->shouldReceive('isReleased')->twice()->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -42,7 +42,7 @@ class ThrottlesExceptionsTest extends TestCase
 
     public function testJobIsDeleted()
     {
-        $this->assertJobWasDeleted(CircuitBreakerTestJob::class);
+        $this->assertJobWasDeleted(CircuitBreakerTestDeleteWhenJob::class);
     }
 
     protected function assertJobWasReleasedImmediately($class)
@@ -336,6 +336,25 @@ class CircuitBreakerTestJob
     public function middleware()
     {
         return [(new ThrottlesExceptions(2, 10 * 60))->by('test')];
+    }
+}
+
+class CircuitBreakerTestDeleteWhenJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+
+        throw new Exception;
+    }
+
+    public function middleware()
+    {
+        return [(new ThrottlesExceptions(2, 10 * 60))->deleteWhen(Exception::class)];
     }
 }
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -355,7 +355,7 @@ class CircuitBreakerSkipJob
 
     public function middleware()
     {
-        return [(new ThrottlesExceptions(2, 10 * 60))->skipWhen(Exception::class)];
+        return [(new ThrottlesExceptions(2, 10 * 60))->deleteWhen(Exception::class)];
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## What
Adds `->deleteWhen(..)` to `ThrottlesExceptions` job middleware (and of course `ThrottlesExceptionsWithRedis`)

## Examples
```php
use Illuminate\Queue\Middleware\ThrottlesExceptions;
 
public function middleware(): array
{
    return [
        new ThrottlesExceptions(10, 5)
            ->deleteWhen(ExceptionThatIsOk::class),
    ];
}
```

```php
use Illuminate\Queue\Middleware\ThrottlesExceptions;
 
public function middleware(): array
{
    return [
        new ThrottlesExceptions(10, 5)
            ->deleteWhen(fn (\Throwable $throwable) => str($throwable)->contains('its all ok'))
            ->deleteWhen(fn (\Throwable $throwable) => $throwable instanceof \Illuminate\Database\QueryException
                && str($throwable->getMessage())->contains('a foreign key constraint fails')
            ),
    ];
}
```

## Details
When using `ThrottlesExceptions` job middleware, we can pass a callback for `->when(..)` the job should not be released back and instead throw an exception. But for most use cases, you will likely be retrying this job and therefore the job will be attempted again. The new `->deleteWhen(..)` functionality allows you to exit the circuit of either throw exception or release back onto the queue, and instead to just delete the job. In this way, the job will just be deleted when this exception occurs. (Of course, you can still choose to report the exception just like before.)