### PR TITLE
[12.x] Fix the `getCurrentlyAttachedPivots` wrong `morphClass` for morph to many relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -121,13 +121,14 @@ class MorphToMany extends BelongsToMany
     }
 
     /**
-     * Get the pivot models that are currently attached.
+     * Get the pivot models that are currently attached, filtered by related model keys.
      *
-     * @return \Illuminate\Support\Collection<int, TPivotModel>
+     * @param  mixed  $ids
+     * @return \Illuminate\Support\Collection
      */
-    protected function getCurrentlyAttachedPivots()
+    protected function getCurrentlyAttachedPivotsForIds($ids = null)
     {
-        return parent::getCurrentlyAttachedPivots()->map(function ($record) {
+        return parent::getCurrentlyAttachedPivotsForIds($ids)->map(function ($record) {
             return $record instanceof MorphPivot
                 ? $record->setMorphType($this->morphType)
                     ->setMorphClass($this->morphClass)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -124,7 +124,7 @@ class MorphToMany extends BelongsToMany
      * Get the pivot models that are currently attached, filtered by related model keys.
      *
      * @param  mixed  $ids
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, TPivotModel>
      */
     protected function getCurrentlyAttachedPivotsForIds($ids = null)
     {

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -179,6 +179,16 @@ class EloquentPivotEventsTest extends DatabaseTestCase
 
         $project->equipments()->save($equipment);
         $equipment->projects()->sync([]);
+
+        $this->assertEquals(
+            [PivotEventsTestProject::class, PivotEventsTestProject::class, PivotEventsTestProject::class, PivotEventsTestProject::class, PivotEventsTestProject::class, PivotEventsTestProject::class],
+            PivotEventsTestModelEquipment::$eventsMorphClasses
+        );
+
+        $this->assertEquals(
+            ['equipmentable_type', 'equipmentable_type', 'equipmentable_type', 'equipmentable_type', 'equipmentable_type', 'equipmentable_type'],
+            PivotEventsTestModelEquipment::$eventsMorphTypes
+        );
     }
 }
 
@@ -236,6 +246,55 @@ class PivotEventsTestProject extends Model
 class PivotEventsTestModelEquipment extends MorphPivot
 {
     public $table = 'equipmentables';
+
+    public static $eventsMorphClasses = [];
+
+    public static $eventsMorphTypes = [];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::created(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::updating(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::updated(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::saving(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::saved(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::deleting(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+
+        static::deleted(function ($model) {
+            static::$eventsMorphClasses[] = $model->morphClass;
+            static::$eventsMorphTypes[] = $model->morphType;
+        });
+    }
 
     public function equipment()
     {


### PR DESCRIPTION
Fixes #55698