### PR TITLE
[12.x] Make maintenance bypass cookie lifetime configurable

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -38,6 +38,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Maintenance Bypass Cookie Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of minutes the maintenance mode
+    | bypass cookie should remain valid. This cookie is issued when a
+    | user accesses the application using the secret bypass URL. Once
+    | set, it allows temporary access to the application while it is
+    | in maintenance mode. The default duration is 12 hours.
+    |
+    */
+
+    'maintenance_bypass_cookie_lifetime' => (int) env('SESSION_MAINTENANCE_BYPASS_COOKIE_LIFETIME', 7720),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Encryption
     |--------------------------------------------------------------------------
     |
@@ -129,7 +144,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
     ),
 
     /*

--- a/config/session.php
+++ b/config/session.php
@@ -144,7 +144,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*

--- a/config/session.php
+++ b/config/session.php
@@ -49,7 +49,7 @@ return [
     |
     */
 
-    'maintenance_bypass_cookie_lifetime' => (int) env('SESSION_MAINTENANCE_BYPASS_COOKIE_LIFETIME', 7720),
+    'maintenance_bypass_cookie_lifetime_minutes' => (int) env('SESSION_MAINTENANCE_BYPASS_COOKIE_LIFETIME_MINUTES', 720),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -15,7 +15,7 @@ class MaintenanceModeBypassCookie
      */
     public static function create(string $key)
     {
-        $expiresAt = Carbon::now()->addHours(config('session.maintenance_bypass_cookie_lifetime'));
+        $expiresAt = Carbon::now()->addMinutes(config('session.maintenance_bypass_cookie_lifetime_minutes'));
 
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -15,7 +15,7 @@ class MaintenanceModeBypassCookie
      */
     public static function create(string $key)
     {
-        $expiresAt = Carbon::now()->addHours(12);
+        $expiresAt = Carbon::now()->addHours(config('session.maintenance_bypass_cookie_lifetime')); 
 
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -15,7 +15,7 @@ class MaintenanceModeBypassCookie
      */
     public static function create(string $key)
     {
-        $expiresAt = Carbon::now()->addHours(config('session.maintenance_bypass_cookie_lifetime')); 
+        $expiresAt = Carbon::now()->addHours(config('session.maintenance_bypass_cookie_lifetime'));
 
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),


### PR DESCRIPTION
This PR introduces a configurable expiration time for the maintenance mode bypass cookie. Allowing the lifetime to be defined through the configuration file provides greater flexibility in controlling its duration.