### PR TITLE
[12.x] Add locale-aware number parsing methods to Number class

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -49,6 +49,47 @@ class Number
     }
 
     /**
+     * Parse the given string according to the specified format type.
+     *
+     * @param  string  $string
+     * @param  int|null  $type
+     * @param  string|null  $locale
+     * @return int|float|false
+     */
+    public static function parse(string $string, ?int $type = NumberFormatter::TYPE_DOUBLE, ?string $locale = null): int|float
+    {
+        static::ensureIntlExtensionIsInstalled();
+
+        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
+
+        return $formatter->parse($string, $type);
+    }
+
+    /**
+     * Parse a string into an integer according to the specified locale.
+     *
+     * @param  string  $string
+     * @param  string|null  $locale
+     * @return int|false
+     */
+    public static function parseInt(string $string, ?string $locale = null): int
+    {
+        return self::parse($string, NumberFormatter::TYPE_INT32, $locale);
+    }
+
+    /**
+     * Parse a string into a float according to the specified locale.
+     *
+     * @param  string  $string  The string to parse
+     * @param  string|null  $locale  The locale to use
+     * @return float|false
+     */
+    public static function parseFloat(string $string, ?string $locale = null ): float
+    {
+        return self::parse($string, NumberFormatter::TYPE_DOUBLE, $locale);
+    }
+
+    /**
      * Spell out the given number in the given locale.
      *
      * @param  int|float  $number

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -355,4 +355,39 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
     }
+
+    #[RequiresPhpExtension('intl')]
+    public function testParse()
+    {
+        $this->assertSame(1234.0, Number::parse('1,234'));
+        $this->assertSame(1234.5, Number::parse('1,234.5'));
+        $this->assertSame(1234.56, Number::parse('1,234.56'));
+        $this->assertSame(-1234.56, Number::parse('-1,234.56'));
+        
+        $this->assertSame(1234.56, Number::parse('1.234,56', locale: 'de'));
+        $this->assertSame(1234.56, Number::parse('1 234,56', locale: 'fr'));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testParseInt()
+    {
+        $this->assertSame(1234, Number::parseInt('1,234'));
+        $this->assertSame(1234, Number::parseInt('1,234.5'));
+        $this->assertSame(-1234, Number::parseInt('-1,234.56'));
+        
+        $this->assertSame(1234, Number::parseInt('1.234', locale: 'de'));
+        $this->assertSame(1234, Number::parseInt('1 234', locale: 'fr'));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testParseFloat()
+    {
+        $this->assertSame(1234.0, Number::parseFloat('1,234'));
+        $this->assertSame(1234.5, Number::parseFloat('1,234.5'));
+        $this->assertSame(1234.56, Number::parseFloat('1,234.56'));
+        $this->assertSame(-1234.56, Number::parseFloat('-1,234.56'));
+        
+        $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
+        $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
+    }
 }


### PR DESCRIPTION
# Add locale-aware number parsing methods

This PR adds three new methods to the Number class to complement the existing number formatting capabilities:
- `Number::parse(string $string, ?int $type = NumberFormatter::TYPE_DOUBLE, ?string $locale = null)`: Parses a localized number string into its numeric value
- `Number::parseInt(string $string, ?string $locale = null)`: Specifically parses a string into an integer with locale support
- `Number::parseFloat(string $string, ?string $locale = null)`: Specifically parses a string into a float with locale support

## Usage

Currently, I need to create something like 

`App\Helpers\NumberFormatter::parse($request->input('amount'))` 

or using directly 

`(new NumberFormatter(config('app.locale'), NumberFormatter::DECIMAL))
    ->parse($request->input('number'));` 

to parse string generated by `Number::format()`.

For eg:

```
$number = 12345.67;
$string = Number::format($number, locale: 'en'); //12,345.67
$string = Number::format($number, locale: 'de'); //12.345,67
$string = Number::format($number, locale: 'fr'); //12 345,67

$float = App\Helpers\NumberFormatter::parse($request->input($string));
```

Why should the key to start a car engine be different from the key to turn the engine off ?

Why not this ?

```
$number = 12345.67;
$string = Number::format($number, locale: 'en'); //12,345.67
$string = Number::format($number, locale: 'de'); //12.345,67
$string = Number::format($number, locale: 'fr'); //12 345,67

$float = Number::parse($request->input($string));
```