### PR TITLE
[12.x] Preserve "previous" model state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -62,18 +62,18 @@ trait HasAttributes
     protected $original = [];
 
     /**
-     * The previous model attributes after synchronizing original state.
-     *
-     * @var array
-     */
-    protected $previous = [];
-
-    /**
      * The changed model attributes.
      *
      * @var array
      */
     protected $changes = [];
+
+    /**
+     * The previous state of changed model attributes.
+     *
+     * @var array
+     */
+    protected $previous = [];
 
     /**
      * The attributes that should be cast.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2210,7 +2210,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the attributes that were previously original when the model was last saved.
+     * Get the attributes that were previously original before the model was last saved.
      *
      * @return array
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -62,6 +62,13 @@ trait HasAttributes
     protected $original = [];
 
     /**
+     * The previous model attributes after synchronizing original state.
+     *
+     * @var array
+     */
+    protected $previous = [];
+
+    /**
      * The changed model attributes.
      *
      * @var array
@@ -2081,6 +2088,10 @@ trait HasAttributes
      */
     public function syncChanges()
     {
+        if ($this->isDirty()) {
+            $this->previous = $this->getRawOriginal();
+        }
+
         $this->changes = $this->getDirty();
 
         return $this;
@@ -2117,7 +2128,7 @@ trait HasAttributes
      */
     public function discardChanges()
     {
-        [$this->attributes, $this->changes] = [$this->original, []];
+        [$this->attributes, $this->changes, $this->previous] = [$this->original, [], []];
 
         return $this;
     }
@@ -2199,6 +2210,16 @@ trait HasAttributes
     public function getChanges()
     {
         return $this->changes;
+    }
+
+    /**
+     * Get the attributes that were previously original when the model was last saved.
+     *
+     * @return array
+     */
+    public function getPrevious()
+    {
+        return $this->previous;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -69,7 +69,7 @@ trait HasAttributes
     protected $changes = [];
 
     /**
-     * The previous state of changed model attributes.
+     * The previous state of the changed model attributes.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2088,11 +2088,8 @@ trait HasAttributes
      */
     public function syncChanges()
     {
-        if ($this->isDirty()) {
-            $this->previous = $this->getRawOriginal();
-        }
-
         $this->changes = $this->getDirty();
+        $this->previous = array_intersect_key($this->getRawOriginal(), $this->changes);
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -60,6 +60,8 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         Post::find($post->id)->update(['title' => 'patrick']);
 
+        $post->refresh();
+
         $this->assertEmpty($post->getDirty());
         $this->assertEmpty($post->getPrevious());
     }

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -54,6 +54,16 @@ class EloquentModelRefreshTest extends DatabaseTestCase
         $this->assertSame('patrick', $post->getOriginal('title'));
     }
 
+    public function testItDoesNotSyncPreviousOnRefresh()
+    {
+        $post = Post::create(['title' => 'pat']);
+
+        Post::find($post->id)->update(['title' => 'patrick']);
+
+        $this->assertEmpty($post->getDirty());
+        $this->assertEmpty($post->getPrevious());
+    }
+
     public function testAsPivot()
     {
         Schema::create('post_posts', function (Blueprint $table) {

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Testing\Assert;
 
 class EloquentModelTest extends DatabaseTestCase
 {
@@ -42,8 +41,8 @@ class EloquentModelTest extends DatabaseTestCase
 
     public function testAttributeChanges()
     {
-        $user = TestModel2::create($originalAttributes = [
-            'name' => Str::random(), 'title' => Str::random(),
+        $user = TestModel2::create([
+            'name' => $originalName = Str::random(), 'title' => Str::random(),
         ]);
 
         $this->assertEmpty($user->getDirty());
@@ -64,7 +63,7 @@ class EloquentModelTest extends DatabaseTestCase
 
         $this->assertEmpty($user->getDirty());
         $this->assertEquals(['name' => $overrideName], $user->getChanges());
-        Assert::assertArraySubset($originalAttributes, $user->getPrevious());
+        $this->assertEquals(['name' => $originalName], $user->getPrevious());
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Illuminate\Testing\Assert;
 
 class EloquentUpdateTest extends DatabaseTestCase
 {
@@ -149,7 +148,8 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $this->assertSame('Dr.', $model->title);
         $this->assertSame('Dr.', $model->getOriginal('title'));
-        Assert::assertArraySubset(['name' => $model->name, 'title' => 'Ms.'], $model->getPrevious());
+        $this->assertSame(['title' => 'Dr.'], $model->getChanges());
+        $this->assertSame(['title' => 'Ms.'], $model->getPrevious());
     }
 
     public function testSaveSyncsPrevious()
@@ -164,7 +164,8 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $this->assertSame('Dr.', $model->title);
         $this->assertSame('Dr.', $model->getOriginal('title'));
-        Assert::assertArraySubset(['name' => $model->name, 'title' => 'Ms.'], $model->getPrevious());
+        $this->assertSame(['title' => 'Dr.'], $model->getChanges());
+        $this->assertSame(['title' => 'Ms.'], $model->getPrevious());
     }
 
     public function testIncrementSyncsPrevious()
@@ -176,7 +177,8 @@ class EloquentUpdateTest extends DatabaseTestCase
         $model->increment('counter');
 
         $this->assertEquals(1, $model->counter);
-        Assert::assertArraySubset(['counter' => 0], $model->getPrevious());
+        $this->assertSame(['counter' => 1], $model->getChanges());
+        $this->assertSame(['counter' => 0], $model->getPrevious());
     }
 }
 


### PR DESCRIPTION
Based on #53901 but instead of mimicking `$original`, `$previous` instead follows `$changes`.


