### PR TITLE
[12.x] Add a default option when retrieving an enum from data

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -312,15 +312,16 @@ trait InteractsWithData
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
+     * @param  TEnum|null  $default
      * @return TEnum|null
      */
-    public function enum($key, $enumClass)
+    public function enum($key, $enumClass, $default = null)
     {
         if ($this->isNotFilled($key) || ! $this->isBackedEnum($enumClass)) {
-            return null;
+            return $default;
         }
 
-        return $enumClass::tryFrom($this->data($key));
+        return $enumClass::tryFrom($this->data($key)) ?: $default;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -318,10 +318,10 @@ trait InteractsWithData
     public function enum($key, $enumClass, $default = null)
     {
         if ($this->isNotFilled($key) || ! $this->isBackedEnum($enumClass)) {
-            return $default;
+            return value($default);
         }
 
-        return $enumClass::tryFrom($this->data($key)) ?: $default;
+        return $enumClass::tryFrom($this->data($key)) ?: value($default);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -804,6 +804,9 @@ class HttpRequestTest extends TestCase
 
         $this->assertNull($request->enum('doesnt_exist', TestEnumBacked::class));
 
+        $this->assertEquals(TestEnumBacked::test, $request->enum('invalid_enum_value', TestEnumBacked::class, TestEnumBacked::test));
+        $this->assertEquals(TestEnumBacked::test, $request->enum('missing_key', TestEnumBacked::class, TestEnumBacked::test));
+
         $this->assertEquals(TestEnumBacked::test, $request->enum('valid_enum_value', TestEnumBacked::class));
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnumBacked::class));


### PR DESCRIPTION
Enables you to provide a default value when retrieving an enum from data which is consistent with other getters in the `InteractsWithData` trait  An example use case is when you're handling GET params in a dashboard.

Old:
```php
$chartType = request()->enum('chart_type', ChartTypeEnum::class) ?: ChartTypeEnum::Bar;
```

New:
```php
$chartType = request()->enum('chart_type', ChartTypeEnum::class, ChartTypeEnum::Bar);
```