### PR TITLE
Route list exit code

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -87,23 +87,26 @@ class RouteListCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         if (! $this->output->isVeryVerbose()) {
             $this->router->flushMiddlewareGroups();
         }
 
         if (! $this->router->getRoutes()->count()) {
-            return $this->components->error("Your application doesn't have any routes.");
+            $this->components->error("Your application doesn't have any routes.");
+            return static::FAILURE;
         }
 
         if (empty($routes = $this->getRoutes())) {
-            return $this->components->error("Your application doesn't have any routes matching the given criteria.");
+            $this->components->error("Your application doesn't have any routes matching the given criteria.");
+            return static::FAILURE;
         }
 
         $this->displayRoutes($routes);
+        return static::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -97,15 +97,18 @@ class RouteListCommand extends Command
 
         if (! $this->router->getRoutes()->count()) {
             $this->components->error("Your application doesn't have any routes.");
+
             return static::FAILURE;
         }
 
         if (empty($routes = $this->getRoutes())) {
             $this->components->error("Your application doesn't have any routes matching the given criteria.");
+
             return static::FAILURE;
         }
 
         $this->displayRoutes($routes);
+
         return static::SUCCESS;
     }
 


### PR DESCRIPTION
With this functionality you can check if a particular route exists en rely on the command's exit code instead of parsing the output.

For example, you could check if the Laravel 11 `/up` route is present to enable a liveness probe during deploy. Now, you need to parse the command output and check yourself if it failed or not. With this change you could simply validate the command's exit code.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
