### PR TITLE
[12.x] Add param type for `assertJsonStructure` & `assertExactJsonStructure` methods

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -906,7 +906,7 @@ class TestResponse implements ArrayAccess
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertJsonStructure(?array $structure = null, $responseData = null)
+    public function assertJsonStructure(?array $structure = null, ?array $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData);
 
@@ -920,7 +920,7 @@ class TestResponse implements ArrayAccess
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertExactJsonStructure(?array $structure = null, $responseData = null)
+    public function assertExactJsonStructure(?array $structure = null, ?array $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData, true);
 


### PR DESCRIPTION
This pull request introduces parameter type hints for the `assertJsonStructure` and `assertExactJsonStructure` methods in Laravel’s testing framework. The `$structure` parameter exactly determines the type.

> This change is backward-compatible and non-breaking. It aligns with Laravel’s continuous improvement of type safety