### PR TITLE
add ability to use notScope()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1482,6 +1482,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Determine if the given model has a negate scope.
+     *
+     * @param  string  $scope
+     * @return bool
+     */
+    public function hasNamedScopeIgnoringNot($scope)
+    {
+        return $this->model && $this->model->hasNamedScopeIgnoringNot($scope);
+    }
+
+    /**
      * Call the given local model scopes.
      *
      * @param  array|string  $scopes
@@ -2198,6 +2209,10 @@ class Builder implements BuilderContract
 
         if ($this->hasNamedScope($method)) {
             return $this->callNamedScope($method, $parameters);
+        }
+
+        if ($this->hasNamedScopeIgnoringNot($method)) {
+            return $this->whereNot(fn($query) => $query->callNamedScope(substr($method, 3), $parameters));
         }
 
         if (in_array(strtolower($method), $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1693,6 +1693,22 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Determine if the model has a Negate given scope.
+     *
+     * @param  string  $scope
+     * @return bool
+     */
+    public function hasNamedScopeIgnoringNot($scope)
+    {
+        if (str_starts_with(ucfirst($scope), 'Not')) {
+            return method_exists($this, 'scope' . ucfirst(substr($scope, 3))) ||
+                static::isScopeMethodWithAttribute(substr($scope, 3));
+        }
+
+        return false;
+    }
+
+    /**
      * Apply the given named scope if possible.
      *
      * @param  string  $scope

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1700,8 +1700,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function hasNamedScopeIgnoringNot($scope)
     {
-        if (str_starts_with(ucfirst($scope), 'Not')) {
-            return method_exists($this, 'scope' . ucfirst(substr($scope, 3))) ||
+        if (str_starts_with($scope, 'not')) {
+            return method_exists($this, 'scope'.ucfirst(substr($scope, 3))) ||
                 static::isScopeMethodWithAttribute(substr($scope, 3));
         }
 

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -30,9 +30,13 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $model = new EloquentLocalScopesTestModel;
 
         $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScopeIgnoringNot('notActive'));
+
         $this->assertTrue($model->hasNamedScope('type'));
+        $this->assertTrue($model->hasNamedScopeIgnoringNot('notType'));
 
         $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+        $this->assertFalse($model->hasNamedScopeIgnoringNot('notNonExistentLocalScope'));
     }
 
     public function testLocalScopeIsApplied()
@@ -41,6 +45,11 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $query = $model->newQuery()->active();
 
         $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([true], $query->getBindings());
+
+        $query = $model->newQuery()->notActive();
+
+        $this->assertSame('select * from "table" where not ("active" = ?)', $query->toSql());
         $this->assertEquals([true], $query->getBindings());
     }
 
@@ -51,6 +60,11 @@ class DatabaseEloquentLocalScopesTest extends TestCase
 
         $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
         $this->assertEquals(['foo'], $query->getBindings());
+
+        $query = $model->newQuery()->notType('foo');
+
+        $this->assertSame('select * from "table" where not ("type" = ?)', $query->toSql());
+        $this->assertEquals(['foo'], $query->getBindings());
     }
 
     public function testLocalScopesCanChained()
@@ -59,6 +73,11 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $query = $model->newQuery()->active()->type('foo');
 
         $this->assertSame('select * from "table" where "active" = ? and "type" = ?', $query->toSql());
+        $this->assertEquals([true, 'foo'], $query->getBindings());
+
+        $query = $model->newQuery()->notActive()->notType('foo');
+
+        $this->assertSame('select * from "table" where not ("active" = ?) and not ("type" = ?)', $query->toSql());
         $this->assertEquals([true, 'foo'], $query->getBindings());
     }
 

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -28,6 +28,27 @@ class EloquentModelScopeTest extends DatabaseTestCase
 
         $this->assertTrue($model->hasNamedScope('existsAsWell'));
     }
+
+    public function testModelHasNegateScope()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertTrue($model->hasNamedScopeIgnoringNot('notExists'));
+    }
+
+    public function testModelDoesNotHaveNegateScope()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertFalse($model->hasNamedScopeIgnoringNot('notDoesNotExist'));
+    }
+
+    public function testModelHasAttributedNegateScope()
+    {
+        $model = new TestScopeModel1;
+
+        $this->assertTrue($model->hasNamedScopeIgnoringNot('notExistsAsWell'));
+    }
 }
 
 class TestScopeModel1 extends Model


### PR DESCRIPTION
# Add Support for Negative Local Scopes in Laravel

## Description
This PR introduces a new feature that allows Laravel developers to use negative conditions with existing local scopes without creating additional scope methods. This enhancement improves code reusability and reduces boilerplate code.

## Before
Previously, to implement a negative condition for an existing scope, developers had to create a new scope method. For example:

```php
// Original scope
public function scopeActive($query)
{
    return $query->where('status', 'active');
}

// Had to create a new scope for negative condition
public function scopeNotActive($query)
{
    return $query->where('status', '!=', 'active');
}
```

## After
With this enhancement, you can now use the `Not` prefix with any existing scope to create its negative condition automatically. The builder will intelligently convert the condition to its negative form.

```php
// Original scope remains the same
public function scopeActive($query)
{
    return $query->where('status', 'active');
}

// Now you can use NotActive directly
$query->notActive(); // Automatically converts to: where not (status = 'active')
```

## Example Usage
```php
// Using positive condition
$query->active();

// Using negative condition
$query->notActive();

// Both work with existing scopes
$query->published();
$query->notPublished();
```

## Note:
if there is already created scope start with Not like NotActive()
the query builder will use the already created scope

```php

public function scopeActive($query)
{
    return $query->where('status', 'active');
}

public function scopeNotActive($query)
{
    return $query->where('status', 'not_active');
}

$query->notActive(); // will be converted to: where status = 'not_active'
```