### PR TITLE
[12.x] Opt-In `Mailable::requiresExplicitSubject()` option

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -190,6 +190,13 @@ class Mailable implements MailableContract, Renderable
     public static $viewDataCallback;
 
     /**
+     * Defines whether the mailable requires an explicit subject.
+     *
+     * @var bool
+     */
+    public static $requiresExplicitSubject = false;
+
+    /**
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Factory|\Illuminate\Contracts\Mail\Mailer  $mailer
@@ -462,6 +469,7 @@ class Mailable implements MailableContract, Renderable
         if ($this->subject) {
             $message->subject($this->subject);
         } else {
+            throw_if(static::$requiresExplicitSubject, new MissingSubjectException($this));
             $message->subject(Str::title(Str::snake(class_basename($this), ' ')));
         }
 
@@ -1810,6 +1818,16 @@ class Mailable implements MailableContract, Renderable
     public static function buildViewDataUsing(callable $callback)
     {
         static::$viewDataCallback = $callback;
+    }
+
+    /**
+     * Indicate that the subject for all mailables must be explicitly set.
+     *
+     * @return void
+     */
+    public static function requiresExplicitSubject(bool $requiresExplicitSubject = true)
+    {
+        static::$requiresExplicitSubject = $requiresExplicitSubject;
     }
 
     /**

--- a/src/Illuminate/Mail/MissingSubjectException.php
+++ b/src/Illuminate/Mail/MissingSubjectException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Mail;
+
+use Exception;
+
+class MissingSubjectException extends Exception
+{
+    /**
+     * Create a new missing attribute exception instance.
+     *
+     * @param  Mailable  $mailable
+     * @return void
+     */
+    public function __construct(Mailable $mailable)
+    {
+        parent::__construct(sprintf(
+            'The mailable class [%s] is missing a defined subject.',
+            $mailable::class
+        ));
+    }
+}


### PR DESCRIPTION
### Summary

Currently, when a `Mailable` is sent without an explicitly defined subject, the default behavior is to use the class name as the subject. This often results in unintended subjects like `"Reset Password Mail"` or `"Reminder Notification"`, which are typically not suitable for end users.

This PR introduces a static method `Mailable::requiresExplicitSubject()`. When enabled, it ensures that any `Mailable` without a defined subject will throw a `MissingSubjectException`, preventing the email from being sent with an unintended subject line.

### Motivation

- Prevent accidental use of class names as email subjects.
- Encourage developers to set meaningful and intentional subjects for all mailables.
- Improve the quality and clarity of outgoing email communication.

### Usage

```php
Mailable::requiresExplicitSubject();
```