### PR TITLE
[12.x] Add `assertClientError` method to `TestResponse`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -132,6 +132,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response is a client error.
+     *
+     * @return $this
+     */
+    public function assertClientError()
+    {
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->isClientError(),
+            $this->statusMessageWithDetails('>=400, < 500', $this->getStatusCode())
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response is a server error.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1086,6 +1086,18 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertClientError()
+    {
+        $statusCode = 400;
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertClientError();
+    }
+
     public function testAssertServerError()
     {
         $statusCode = 500;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds the assertClientError to the TestResponse class.

It provides a convenient way to assert that the response status code is in the 4xx range, improving test readability when the specific client error code is not important.

This will allow to use:
```
$response->assertClientError();
```

instead of:
```
$this->assertTrue($response->isClientError());
```

This aligns with other expressive methods like assertServerError() and makes tests more readable and intention-revealing.
