### PR TITLE
[12.x] Passthru `getCountForPagination` on an Eloquent\Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -118,6 +118,7 @@ class Builder implements BuilderContract
         'explain',
         'getbindings',
         'getconnection',
+        'getcountforpagination',
         'getgrammar',
         'getrawbindings',
         'implode',


### PR DESCRIPTION
I tried running:

```php
$response->setTotal(User::query()->getCountForPagination());
```

Only to discover that getCountForPagination returns a builder instance 😩 