### PR TITLE
Feature/new feature Make Repository Interface Command

### DIFF
--- a/src/Illuminate/Foundation/Console/MakeRepositoryCommand.php
+++ b/src/Illuminate/Foundation/Console/MakeRepositoryCommand.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Pluralizer;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'make:repository')]
+class MakeRepositoryCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:repository {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Making Repository and Interface';
+
+    /**
+     * Filesystem instance
+     *
+     * @var Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        /**
+         * For Interface
+         */
+        $path = $this->getSourceFilePath();
+
+        $this->makeDirectory(dirname($path));
+
+        $contents = $this->getSourceFile();
+
+        if (! $this->files->exists($path)) {
+            $this->files->put($path, $contents);
+            $this->info("File : {$path} created");
+        } else {
+            $this->warn("File : {$path} Already Exist");
+        }
+
+        /**
+         * For Repository
+         */
+        $pathrepo = $this->getSourceFilePathRepo();
+
+        $this->makeDirectory(dirname($pathrepo));
+
+        $contentsrepo = $this->getSourceFileRepo();
+
+        if (! $this->files->exists($pathrepo)) {
+            $this->files->put($pathrepo, $contentsrepo);
+            $this->info("File : {$pathrepo} created");
+        } else {
+            $this->info("File : {$pathrepo} already exits");
+        }
+    }
+
+    public function getSourceFile()
+    {
+        return $this->getStubContents($this->getStubPath(), $this->getStubVariables());
+    }
+
+    public function getSourceFileRepo()
+    {
+        return $this->getStubContents($this->getStubPathRepo(), $this->getStubVariablesRepo());
+    }
+
+    public function getStubVariables()
+    {
+        return [
+            'NAMESPACE' => 'App\\Repositories\\Interface',
+            'CLASS_NAME' => $this->getSingularClassName($this->argument('name')),
+        ];
+    }
+
+    public function getStubVariablesRepo()
+    {
+        return [
+            'NAMESPACE' => 'App\\Repositories\\Repository',
+            'CLASS_NAME' => $this->getSingularClassName($this->argument('name')),
+        ];
+    }
+
+    public function getSingularClassName($name)
+    {
+        return ucwords(Pluralizer::singular($name));
+    }
+
+    public function getStubContents($stub, $stubVariables = [])
+    {
+        $contents = file_get_contents($stub);
+
+        foreach ($stubVariables as $search => $replace) {
+            $contents = str_replace('$' . $search . '$', $replace, $contents);
+        }
+
+        return $contents;
+    }
+
+    public function getSourceFilePath()
+    {
+        return app_path('Repositories/Interface/' . $this->argument('name') . 'RepositoryInterface.php');
+    }
+
+    public function getSourceFilePathRepo()
+    {
+        return app_path('Repositories/Repository/' . $this->argument('name') . 'Repository.php');
+    }
+
+    public function getStubPath()
+    {
+        return __DIR__ . '/stubs/repository-interface.stub';
+    }
+
+    public function getStubPathRepo()
+    {
+        return __DIR__ . '/stubs/repository.stub';
+    }
+
+    protected function makeDirectory($path): string
+    {
+        if (! $this->files->isDirectory($path)) {
+            $this->files->makeDirectory($path, 0755, true, true);
+        }
+
+        return $path;
+    }
+
+    public function getSignature(): string
+    {
+        return $this->signature;
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/repository-interface.stub
+++ b/src/Illuminate/Foundation/Console/stubs/repository-interface.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace $NAMESPACE$;
+
+interface $CLASS_NAME$RepositoryInterface
+{
+    
+}

--- a/src/Illuminate/Foundation/Console/stubs/repository.stub
+++ b/src/Illuminate/Foundation/Console/stubs/repository.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace $NAMESPACE$;
+
+use App\Repositories\Interface\$CLASS_NAME$RepositoryInterface;
+
+class $CLASS_NAME$Repository implements $CLASS_NAME$RepositoryInterface
+{
+    
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -61,6 +61,7 @@ use Illuminate\Foundation\Console\KeyGenerateCommand;
 use Illuminate\Foundation\Console\LangPublishCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
 use Illuminate\Foundation\Console\MailMakeCommand;
+use Illuminate\Foundation\Console\MakeRepositoryCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
 use Illuminate\Foundation\Console\ObserverMakeCommand;
@@ -217,6 +218,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'RequestMake' => RequestMakeCommand::class,
         'ResourceMake' => ResourceMakeCommand::class,
         'RuleMake' => RuleMakeCommand::class,
+        'RepositoryMake' => MakeRepositoryCommand::class,
         'ScopeMake' => ScopeMakeCommand::class,
         'SeederMake' => SeederMakeCommand::class,
         'SessionTable' => SessionTableCommand::class,
@@ -839,6 +841,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(RouteClearCommand::class, function ($app) {
             return new RouteClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMakeRepositoryCommand()
+    {
+        $this->app->singleton(MakeRepositoryCommand::class, function ($app) {
+            return new MakeRepositoryCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Generators/MakeRepositoryCommandTest.php
+++ b/tests/Integration/Generators/MakeRepositoryCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use Tests\TestCase;
+use Illuminate\Foundation\Console\MakeRepositoryCommand;
+use Illuminate\Support\Facades\Artisan;
+
+class MakeRepositoryCommandTest extends TestCase
+{
+    protected $filesystem;
+    protected $interfacePath;
+    protected $repositoryPath;
+    protected $testName = 'TestRepo';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->interfacePath = app_path('Repositories/Interface/' . $this->testName . 'RepositoryInterface.php');
+        $this->repositoryPath = app_path('Repositories/Repository/' . $this->testName . 'Repository.php');
+
+        // Clean up before each test
+        if ($this->filesystem->exists($this->interfacePath)) {
+            $this->filesystem->delete($this->interfacePath);
+        }
+        if ($this->filesystem->exists($this->repositoryPath)) {
+            $this->filesystem->delete($this->repositoryPath);
+        }
+    }
+
+    // ... rest of the test class ...
+    public function test_command_is_registered()
+    {
+        // Option 1: Check via Artisan (requires service provider to be registered)
+        $this->assertArrayHasKey(
+            'make:repository',
+            Artisan::all(),
+            'Command should be registered'
+        );
+    }
+
+    public function test_command_signature()
+    {
+        $command = new MakeRepositoryCommand(new Filesystem());
+        $this->assertEquals('make:repository {name}', $command->getSignature());
+    }
+
+    public function test_command_properties()
+    {
+        $command = new MakeRepositoryCommand(new Filesystem());
+
+        $reflection = new \ReflectionClass($command);
+        $property = $reflection->getProperty('signature');
+        $property->setAccessible(true);
+
+        $this->assertEquals('make:repository {name}', $property->getValue($command));
+    }
+
+    public function test_command_execution()
+    {
+        // Get the actual path the command will use
+        $expectedInterfacePath = app_path('Repositories/Interface/TestRepositoryInterface.php');
+        $expectedRepoPath = app_path('Repositories/Repository/TestRepository.php');
+
+        // Clean up if files exist from previous tests
+        if (file_exists($expectedInterfacePath)) {
+            unlink($expectedInterfacePath);
+        }
+        if (file_exists($expectedRepoPath)) {
+            unlink($expectedRepoPath);
+        }
+
+        $this->artisan('make:repository', ['name' => 'Test'])
+            ->expectsOutput("File : {$expectedInterfacePath} created")
+            ->expectsOutput("File : {$expectedRepoPath} created")
+            ->assertExitCode(0);
+
+        // Verify files were actually created
+        $this->assertFileExists($expectedInterfacePath);
+        $this->assertFileExists($expectedRepoPath);
+    }
+}


### PR DESCRIPTION
Title : Make Repository Functionality for developers

Description : So when dependency injections wants to use for developers and they want to separate the business logic. They can use this approach to generate the Repository and Interface file dynamic. With binding this repository class and interface in providers they can use this for separate the business logic.

Testing : 
I have also added the MakeRepositoryCommandTest.php file & at for tests well and working fine no issues in that
MakeRepositoryCommandTest.php

composer test

Attaching the screenshot of test.

<img width="820" alt="image" src="https://github.com/user-attachments/assets/ec90c5ff-d5dc-485f-9d7c-0d8e474dd538" />
