### PR TITLE
Add dot notation access to Http\Client\Request::data()

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -156,17 +156,24 @@ class Request implements ArrayAccess
     /**
      * Get the request's data (form parameters or JSON).
      *
-     * @return array
+     * @param  string|null  $key
+     * @return ($key is null ? array : mixed)
      */
-    public function data()
+    public function data($key = null)
     {
         if ($this->isForm()) {
-            return $this->parameters();
+            $data = $this->parameters();
         } elseif ($this->isJson()) {
-            return $this->json();
+            $data = $this->json();
+        } else {
+            $data = $this->data ?? [];
         }
 
-        return $this->data ?? [];
+        if (is_null($key)) {
+            return $data;
+        }
+
+        return Arr::get($data, $key);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -422,6 +422,22 @@ class HttpClientTest extends TestCase
         $this->assertEquals(new Fluent([]), $response->fluent('missing_key'));
     }
 
+    public function testCanAccessDataOfRequestUsingDotNotation()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://foo.com/json', [
+            'parent' => ['name' => 'Taylor'],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->data() === ['parent' => ['name' => 'Taylor']] &&
+                $request->data('parent') === ['name' => 'Taylor'] &&
+                $request->data('parent.name') === 'Taylor' &&
+                $request->data('data.missing.key') === null;
+        });
+    }
+
     public function testSendRequestBodyAsJsonByDefault()
     {
         $body = '{"test":"phpunit"}';


### PR DESCRIPTION
Greetings!

This PR introduces a backwards-compatible enhancement to the `Illuminate\Http\Client\Request::data()` method by adding `$key` parameter. This allows access to specific parts of the request data using "dot" notation.

This behavior is consistent with conventions used across the framework for methods that interact with input, request or response data. It enables conventional access to request payloads (for example, when logging requests or writing HTTP client-based tests):

```php
// Before (old)
$title = Arr::get($request, 'message.title');
// or
$title = $request['message']['title'] ?? null;

// After (new)
$title = $request->data('message.title');
```

The `Request` class already supports similar access patterns for headers via the `header($key)` method. Since the word "data" can serve both as singular and plural I feel like this change also preserves naming consistency.