### PR TITLE
[12.x] Update schema dump to use new MySQL SSL disable flag

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -119,7 +119,7 @@ class MySqlSchemaState extends SchemaState
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
 
-            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_CLIENT_VERSION);
+            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
             $value .= version_compare($version, '8.0.40', '<')
                 ? ' --ssl=off'

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
+use PDO;
 use Symfony\Component\Process\Process;
 
 class MySqlSchemaState extends SchemaState
@@ -117,7 +118,12 @@ class MySqlSchemaState extends SchemaState
 
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-            $value .= ' --ssl=off';
+
+            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+            $value .= version_compare($version, '8.0.40', '<')
+                ? ' --ssl=off'
+                : ' --ssl-mode=DISABLED';
         }
 
         return $value;

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -117,9 +117,9 @@ class MySqlSchemaState extends SchemaState
 
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-            $version = $this->connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
-            $value .= version_compare($version, '8.0.40', '<')
+            // Connecting to the MySQL server via the MariaDB client requires different SSL options.
+            $value .= str_contains($this->makeProcess('mysql --version')->mustRun()->getOutput(), '-MariaDB')
                 ? ' --ssl=off'
                 : ' --ssl-mode=DISABLED';
         }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -117,7 +117,6 @@ class MySqlSchemaState extends SchemaState
 
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-
             // Connecting to the MySQL server via the MariaDB client requires different SSL options.
             $value .= str_contains($this->makeProcess('mysql --version')->mustRun()->getOutput(), '-MariaDB')
                 ? ' --ssl=off'

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -119,7 +119,7 @@ class MySqlSchemaState extends SchemaState
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
 
-            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_CLIENT_VERSION);
 
             $value .= version_compare($version, '8.0.40', '<')
                 ? ' --ssl=off'

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Schema;
 use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
-use PDO;
 use Symfony\Component\Process\Process;
 
 class MySqlSchemaState extends SchemaState
@@ -118,7 +117,7 @@ class MySqlSchemaState extends SchemaState
 
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-            $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+            $version = $this->connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
             $value .= version_compare($version, '8.0.40', '<')
                 ? ' --ssl=off'

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -118,7 +118,6 @@ class MySqlSchemaState extends SchemaState
 
         if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
             $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-
             $version = $this->connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
             $value .= version_compare($version, '8.0.40', '<')

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
+use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -16,8 +17,12 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     #[DataProvider('provider')]
     public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
     {
+        $pdo = $this->createMock(PDO::class);
+        $pdo->method('getAttribute')->with(PDO::ATTR_CLIENT_VERSION)->willReturn('8.0.40');
+
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
+        $connection->method('getPdo')->willReturn($pdo);
 
         $schemaState = new MySqlSchemaState($connection);
 
@@ -65,13 +70,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
                 ],
             ],
         ];
 
         yield 'no_ssl' => [
-            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl=off', [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-mode=DISABLED', [
                 'LARAVEL_LOAD_SOCKET' => '',
                 'LARAVEL_LOAD_HOST' => '',
                 'LARAVEL_LOAD_PORT' => '',
@@ -83,7 +88,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
-use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -17,8 +16,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     #[DataProvider('provider')]
     public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
     {
-        $pdo = $this->createMock(PDO::class);
-        $pdo->method('getAttribute')->with(PDO::ATTR_SERVER_VERSION)->willReturn('8.0.40');
+        $pdo = $this->createMock(\PDO::class);
+        $pdo->method('getAttribute')->with(\PDO::ATTR_SERVER_VERSION)->willReturn('8.0.40');
 
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
@@ -70,7 +69,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
                 ],
             ],
         ];
@@ -88,7 +87,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -18,7 +18,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
     {
         $pdo = $this->createMock(PDO::class);
-        $pdo->method('getAttribute')->with(PDO::ATTR_CLIENT_VERSION)->willReturn('8.0.40');
+        $pdo->method('getAttribute')->with(PDO::ATTR_SERVER_VERSION)->willReturn('8.0.40');
 
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -16,14 +16,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
     #[DataProvider('provider')]
     public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
     {
-        $pdo = $this->createMock(\PDO::class);
-        $pdo->method('getAttribute')->with(\PDO::ATTR_SERVER_VERSION)->willReturn('8.0.40');
-
         $connection = $this->createMock(MySqlConnection::class);
         $connection->method('getConfig')->willReturn($dbConfig);
-        $connection->method('getPdo')->willReturn($pdo);
 
-        $schemaState = new MySqlSchemaState($connection);
+        $schemaState = new MySqlSchemaState(
+            connection: $connection,
+            processFactory: fn () => $this->createMock(Process::class),
+        );
 
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');


### PR DESCRIPTION
https://github.com/laravel/framework/pull/55683 allowed SSL to be disabled when Laravel imports schema SQL. However, the `--ssl=off` flag was deprecated in 8.0.26 and removed in MySQL 8.0.40: `Error: [ERROR] unknown variable 'ssl=off'.`

This PR checks the MySQL version and uses the newer `--ssl-mode=DISABLED` for newer versions.

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-26.html#mysqld-8-0-26-deprecation-removal
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html#mysqld-8-4-0-deprecation-removal
https://dev.mysql.com/doc/refman/8.4/en/connection-options.html#option_general_ssl-mode

An alternative to this might be a generic `LARAVEL_LOAD_(MYSQL|MARIADB|POSTGRES|SQLITE)_OPTS=` env var that allows any custom options/flags to be added to the load command.