### PR TITLE
[12.x] Add Context contextual attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Context.php
+++ b/src/Illuminate/Container/Attributes/Context.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Illuminate\Log\Context\Repository;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Context implements ContextualAttribute
+{
+    /**
+     * Create a new attribute instance.
+     */
+    public function __construct(public string $key, public mixed $default = null)
+    {
+    }
+
+    /**
+     * Resolve the configuration value.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container): mixed
+    {
+        return $container->make(Repository::class)->get($attribute->key, $attribute->default);
+    }
+}

--- a/src/Illuminate/Container/Attributes/Context.php
+++ b/src/Illuminate/Container/Attributes/Context.php
@@ -18,7 +18,7 @@ class Context implements ContextualAttribute
     }
 
     /**
-     * Resolve the configuration value.
+     * Resolve the context value.
      *
      * @param  self  $attribute
      * @param  \Illuminate\Contracts\Container\Container  $container

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -11,6 +11,7 @@ use Illuminate\Container\Attributes\Auth;
 use Illuminate\Container\Attributes\Authenticated;
 use Illuminate\Container\Attributes\Cache;
 use Illuminate\Container\Attributes\Config;
+use Illuminate\Container\Attributes\Context;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Container\Attributes\Database;
 use Illuminate\Container\Attributes\Log;
@@ -28,6 +29,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Http\Request;
+use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Log\LogManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -213,6 +215,20 @@ class ContextualAttributeBindingTest extends TestCase
         });
 
         $container->make(RouteParameterTest::class);
+    }
+
+    public function testContextAttribute(): void
+    {
+        $container = new Container;
+
+        $container->singleton(ContextRepository::class, function () {
+            $context = m::mock(ContextRepository::class);
+            $context->shouldReceive('get')->once()->with('foo', null)->andReturn('foo');
+
+            return $context;
+        });
+
+        $container->make(ContextTest::class);
     }
 
     public function testStorageAttribute()
@@ -421,6 +437,13 @@ final class CacheTest
 final class ConfigTest
 {
     public function __construct(#[Config('foo')] string $foo, #[Config('bar')] string $bar)
+    {
+    }
+}
+
+final class ContextTest
+{
+    public function __construct(#[Context('foo')] string $foo)
     {
     }
 }


### PR DESCRIPTION
Adds a new `Context` contextual attribute for resolving context values.

This idea was borne out of a pattern I use in database seeders, where I usually find myself wanting to re-use created models across seeder classes. For example, creating a `User` in one seeder class and then using that `User` instance as a related model in other seeder classes.

I was using [context](https://laravel.com/docs/12.x/context) to store these model references to avoid re-querying them in subsequent seeders. Instead of doing `Context::get` calls (where I have to manually check a value was returned and it’s of the type I’m expecting if a value was returned) I then decided to see if dependency injection worked in the `run` method of seeder classes (it does), which then led me to the idea of injecting context data as parameters so I could also get type-hinting. However, was surprised to find there wasn’t already a `Context` contextual attribute.

With this new `Context` contextual attribute, developers are now able to do something like:

```php
use App\Models\User;
use Illuminate\Database\Seeder;
use Illuminate\Support\Facades\Context;

class UserSeeder extends Seeder
{
    public function run(): void
    {
        $user = User::factory()->create();

        // Store context data for subsequent seeders...
        Context::add('user', $user);
    }
}
```
```php
use App\Models\Channel;
use App\Models\User;
use Illuminate\Container\Attributes\Context;
use Illuminate\Database\Seeder;

class ChannelSeeder extends Seeder
{
    public function run(
        // Retrieve context data with added type-hinting...
        #[Context('user')] User $user,
    ): void {
        $channel = Channel::factory()->create();

        $channel->users()->attach($user);
    }
}
```