### PR TITLE
Fix: php artisan db command if no password

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -157,15 +157,21 @@ class DbCommand extends Command
      */
     protected function getMysqlArguments(array $connection)
     {
+        $optionalArguments = [
+            'password' => '--password='.$connection['password'],
+            'unix_socket' => '--socket='.($connection['unix_socket'] ?? ''),
+            'charset' => '--default-character-set='.($connection['charset'] ?? ''),
+        ];
+
+        if (! $connection['password']) {
+            unset($optionalArguments['password']);
+        }
+
         return array_merge([
             '--host='.$connection['host'],
             '--port='.$connection['port'],
             '--user='.$connection['username'],
-        ], $this->getOptionalArguments([
-            'password' => '--password='.$connection['password'],
-            'unix_socket' => '--socket='.($connection['unix_socket'] ?? ''),
-            'charset' => '--default-character-set='.($connection['charset'] ?? ''),
-        ], $connection), [$connection['database']]);
+        ], $this->getOptionalArguments($optionalArguments, $connection), [$connection['database']]);
     }
 
     /**


### PR DESCRIPTION
If there is no password in the DB connection, it will not connect and will throw an error.

This pull request includes a small update to the `getMysqlArguments` method in `src/Illuminate/Database/Console/DbCommand.php`. The change ensures that the `--password` argument is only included if a password is provided, improving the handling of optional connection parameters.

