### PR TITLE
[12.x] Types: InteractsWithPivotTable::sync

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -66,7 +66,7 @@ trait InteractsWithPivotTable
     /**
      * Sync the intermediate tables with a list of IDs without detaching.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array|int|string  $ids
      * @return array{attached: array, detached: array, updated: array}
      */
     public function syncWithoutDetaching($ids)
@@ -77,7 +77,7 @@ trait InteractsWithPivotTable
     /**
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array|int|string  $ids
      * @param  bool  $detaching
      * @return array{attached: array, detached: array, updated: array}
      */
@@ -130,7 +130,7 @@ trait InteractsWithPivotTable
     /**
      * Sync the intermediate tables with a list of IDs or collection of models with the given pivot values.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array|int|string  $ids
      * @param  array  $values
      * @param  bool  $detaching
      * @return array{attached: array, detached: array, updated: array}


### PR DESCRIPTION
`InteractsWithPivotTable::sync` currently works when passing a single ID to it:

```php
$category->food()->sync($item->id);

// works due to:
protected function parseIds($value)
{
    if ($value instanceof Model) {
        // ...
    }

    if ($value instanceof EloquentCollection) {
        // ...
    }

    if ($value instanceof BaseCollection || is_array($value)) {
        // ...
    }

    return (array) $value;
}
```

However, static analysis doesn't know about this, due to:
```php
  /**
   * Sync the intermediate tables with a list of IDs or collection of models.
   *
   * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
   * @param  bool  $detaching
   * @return array{attached: array, detached: array, updated: array}
   */
  public function sync($ids, $detaching = true)
```

My usecase only uses `int $ids` but I thought it best to add `string` whilst I was on (for uuids).

I also applied this change to methods that call the `sync` method.