### PR TITLE
[12.x] Update `assertSessionMissing()` signature to match `assertSessionHas()`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1640,19 +1640,26 @@ class TestResponse implements ArrayAccess
      * Assert that the session does not have a given key.
      *
      * @param  string|array  $key
+     * @param  mixed  $value
      * @return $this
      */
-    public function assertSessionMissing($key)
+    public function assertSessionMissing($key, $value = null)
     {
         if (is_array($key)) {
             foreach ($key as $value) {
                 $this->assertSessionMissing($value);
             }
-        } else {
+        }
+
+        if (is_null($value)) {
             PHPUnit::withResponse($this)->assertFalse(
                 $this->session()->has($key),
                 "Session has unexpected key [{$key}]."
             );
+        } elseif ($value instanceof Closure) {
+            PHPUnit::withResponse($this)->assertTrue($value($this->session()->get($key)));
+        } else {
+            PHPUnit::withResponse($this)->assertEquals($value, $this->session()->get($key));
         }
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2807,6 +2807,18 @@ class TestResponseTest extends TestCase
         $response->assertSessionMissing('foo');
     }
 
+    public function testAssertSessionMissingValue()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('foo', 'goodvalue');
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertSessionMissing('foo', 'badvalue');
+    }
+
     public function testAssertSessionHasInput()
     {
         app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));


### PR DESCRIPTION
## Problem

Until now, it has been impossible to check the session to confirm that a specific value is *not* set.

For example: let's say I have a session key called `guest_id` which contains a value that must rotate to a new randomly generated string on every page view.  Prior to this patch, there was no easy way to validate that the value had actually changed.  You could assert that the key was the same or that the value was missing, but you could not check that it had rotated to some new unknown value.

**NOTE:** This is *not* a breaking change

## Proposed solution

I mostly replicated the logic from `assertSessionHas()` above to allow a user to provide a specific value that must not be set in a specific key.  Also like `assertSessionHas()`, it preserves the original logic where if no value is provided, it just checks that the key is missing altogether.