### PR TITLE
[12.x] Adds `AsInstance::of()` castable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedInstance.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedInstance.php
@@ -22,12 +22,13 @@ class AsEncryptedInstance implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            protected string $class;
-
-            public function __construct(array $arguments)
+            public function __construct(protected array $arguments)
             {
-                $this->class = $arguments[0]
-                    ?? throw new InvalidArgumentException('A class name must be provided to cast as an instance.');
+                $this->arguments = array_pad(array_values($this->arguments), 2, '');
+
+                if (!$this->arguments[0]) {
+                    throw new InvalidArgumentException('A class name must be provided to cast as an instance.');
+                }
             }
 
             public function get($model, $key, $value, $attributes)
@@ -42,11 +43,11 @@ class AsEncryptedInstance implements Castable
                     return null;
                 }
 
-                if (method_exists($this->class, 'fromArray')) {
-                    return $this->class::fromArray($data);
+                if ($this->arguments[1]) {
+                    return $this->arguments[0]::{$this->arguments[1]}($data);
                 }
 
-                return new $this->class($data);
+                return new $this->arguments[0]($data);
             }
 
             public function set($model, $key, $value, $attributes)
@@ -58,7 +59,7 @@ class AsEncryptedInstance implements Castable
                                 $value instanceof Jsonable => $value->toJson(),
                                 $value instanceof Arrayable => Json::encode($value->toArray()),
                                 default => throw new ValueError(sprintf(
-                                    'The %s class should implement Jsonable or Arrayable contract.', $this->class
+                                    'The %s class should implement Jsonable or Arrayable contract.', $this->arguments[0]
                                 ))
                             }
                         )

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedInstance.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedInstance.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Facades\Crypt;
+use InvalidArgumentException;
+use ValueError;
+
+class AsEncryptedInstance implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            protected string $class;
+
+            public function __construct(array $arguments)
+            {
+                $this->class = $arguments[0]
+                    ?? throw new InvalidArgumentException('A class name must be provided to cast as an instance.');
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                $data = Json::decode(Crypt::decryptString($attributes[$key]));
+
+                if (! is_array($data)) {
+                    return null;
+                }
+
+                if (method_exists($this->class, 'fromArray')) {
+                    return $this->class::fromArray($data);
+                }
+
+                return new $this->class($data);
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (! is_null($value)) {
+                    return [
+                        $key => Crypt::encryptString(
+                            match(true) {
+                                $value instanceof Jsonable => $value->toJson(),
+                                $value instanceof Arrayable => Json::encode($value->toArray()),
+                                default => throw new ValueError(sprintf(
+                                    'The %s class should implement Jsonable or Arrayable contract.', $this->class
+                                ))
+                            }
+                        )
+                    ];
+                }
+
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Specify the class to make an instance from.
+     *
+     * @param  class-string  $class
+     * @return string
+     */
+    public static function of($class)
+    {
+        return static::class . ':' . $class;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsInstance.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsInstance.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use InvalidArgumentException;
+use ValueError;
+
+class AsInstance implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            protected string $class;
+
+            public function __construct(array $arguments)
+            {
+                $this->class = $arguments[0]
+                    ?? throw new InvalidArgumentException('A class name must be provided to cast as an instance.');
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                $data = Json::decode($attributes[$key]);
+
+                if (! is_array($data)) {
+                    return null;
+                }
+
+                if (method_exists($this->class, 'fromArray')) {
+                    return $this->class::fromArray($data);
+                }
+
+                return new $this->class($data);
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key])) {
+                    return;
+                }
+
+                return [
+                    $key => match(true) {
+                        $value instanceof Jsonable => $value->toJson(),
+                        $value instanceof Arrayable => Json::encode($value->toArray()),
+                        default => throw new ValueError(sprintf(
+                            'The %s class should implement Jsonable or Arrayable contract.', $this->class)
+                        )
+                    }
+                ];
+            }
+        };
+    }
+
+    /**
+     * Specify the class to make an instance from.
+     *
+     * @param  class-string  $class
+     * @return string
+     */
+    public static function of($class)
+    {
+        return static::class . ':' . $class;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsInstance.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsInstance.php
@@ -50,19 +50,19 @@ class AsInstance implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                if (! isset($attributes[$key])) {
-                    return;
+                if (! is_null($value)) {
+                    return [
+                        $key => match(true) {
+                            $value instanceof Jsonable => $value->toJson(),
+                            $value instanceof Arrayable => Json::encode($value->toArray()),
+                            default => throw new ValueError(sprintf(
+                                    'The %s class should implement Jsonable or Arrayable contract.', $this->class)
+                            )
+                        }
+                    ];
                 }
 
-                return [
-                    $key => match(true) {
-                        $value instanceof Jsonable => $value->toJson(),
-                        $value instanceof Arrayable => Json::encode($value->toArray()),
-                        default => throw new ValueError(sprintf(
-                            'The %s class should implement Jsonable or Arrayable contract.', $this->class)
-                        )
-                    }
-                ];
+                return null;
             }
         };
     }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -78,7 +78,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
                 'age' => 34,
                 'meta' => ['title' => 'Developer'],
             ],
-            $model->array_object->toArray(),
+            $model->array_object->toArray()
         );
 
         $this->assertEquals(
@@ -87,7 +87,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
                 'age' => 34,
                 'meta' => ['title' => 'Developer'],
             ],
-            $model->array_object_json->toArray(),
+            $model->array_object_json->toArray()
         );
     }
 
@@ -147,7 +147,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
                 'name' => 'Taylor',
                 'meta' => ['title' => 'Developer'],
             ],
-            $model->array_object->toArray(),
+            $model->array_object->toArray()
         );
 
         $this->assertEquals(
@@ -155,7 +155,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
                 'name' => 'Taylor',
                 'meta' => ['title' => 'Developer'],
             ],
-            $model->array_object_json->toArray(),
+            $model->array_object_json->toArray()
         );
     }
 
@@ -240,11 +240,11 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $this->assertSame('2', $model->instance->bar);
     }
 
-    public function test_as_instance_of_class_with_from_array(): void
+    public function test_as_instance_of_class_with_callable(): void
     {
         $model = new TestEloquentModelWithCustomCasts();
         $model->mergeCasts([
-            'instance' => AsInstance::of(InstanceAttributeWithFromArray::class),
+            'instance' => AsInstance::of([InstanceAttributeWithFromArray::class, 'fromArray']),
         ]);
 
         $model->setRawAttributes([


### PR DESCRIPTION
# What?

Adds a new especial cast to instance custom objects from-and-to the model attribute. This is another way to simply the model casting instead of using mutators/accessors.

```php
use App\ValueObjects\Points;
use Illuminate\Database\Eloquent\Casts\AsInstance;
use Illuminate\Database\Eloquent\Casts\Attribute;
use Illuminate\Database\Eloquent\Model;

// Before
class Article extends Model
{
    public function points(): Attribute
    {
        return Attribute::make(
            get: fn($value) => is_null($value) ? null : Points::fromArray(json_decode($value)),
            set: fn(Points $value) => $value->toJson()
        );
    }
}

// After
class Article extends Model
{
    protected function casts()
    {
        return [
            'points' => AsInstance::of([Points::class, 'fromArray'])
        ];
    }
}
```

This simplifies most of the JSON handling since it's done at `AsInstance` level automatically. It supports casting a value from the decoded array from the database as part of the constructor and also using a static method from the class (or any class) to create one.

Also included, `AsEncryptedInstance` that does the same but encrypts/decrypts the value.