### PR TITLE
[12.x] Add `hash` string helper

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1336,6 +1336,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Return the hash of the string using the given algorithm.
+     *
+     * @param  string  $algo
+     * @return static
+     */
+    public function hash(string $algo)
+    {
+        return new static(hash($algo, $this->value));
+    }
+
+    /**
      * Dump the string.
      *
      * @param  mixed  ...$args

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1336,14 +1336,14 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Return the hash of the string using the given algorithm.
+     * Hash the string using the given algorithm.
      *
-     * @param  string  $algo
+     * @param  string  $algorithm
      * @return static
      */
-    public function hash(string $algo)
+    public function hash(string $algorithm)
     {
-        return new static(hash($algo, $this->value));
+        return new static(hash($algorithm, $this->value));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1419,4 +1419,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobar', (string) $this->stringable(base64_encode('foobar'))->fromBase64(true));
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
+
+    public function testHash()
+    {
+        $this->assertSame(hash('xxh3','foo'), (string) $this->stringable('foo')->hash('xxh3'));
+        $this->assertSame(hash('xxh3','foobar'), (string) $this->stringable('foobar')->hash('xxh3'));
+        $this->assertSame(hash('sha256','foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
+    }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1422,8 +1422,8 @@ class SupportStringableTest extends TestCase
 
     public function testHash()
     {
-        $this->assertSame(hash('xxh3','foo'), (string) $this->stringable('foo')->hash('xxh3'));
-        $this->assertSame(hash('xxh3','foobar'), (string) $this->stringable('foobar')->hash('xxh3'));
-        $this->assertSame(hash('sha256','foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
+        $this->assertSame(hash('xxh3', 'foo'), (string) $this->stringable('foo')->hash('xxh3'));
+        $this->assertSame(hash('xxh3', 'foobar'), (string) $this->stringable('foobar')->hash('xxh3'));
+        $this->assertSame(hash('sha256', 'foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
     }
 }


### PR DESCRIPTION
This PR adds a new `hash` method to the `Illuminate\Support\Stringable` class to simplify fluent string hashing and improve DX.

### Why?

Currently, hashing with algorithms like `xxh3` (which doesn't have a dedicated hash function) within a fluent chain can be verbose using `pipe()`:

```php
$appId = str('secret-unique-key')
    ->pipe(fn(Stringable $str) => hash('xxh3', (string) $str))
    ->limit(10)
    ->prepend('app-');
```

This new `hash()` method provides a more direct and readable alternative:

```php
$appId = str('secret-unique-key')
    ->hash('xxh3')
    ->limit(10)
    ->prepend('app-');
```