### PR TITLE
Re-use class method for Collection::map() callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -622,7 +622,7 @@ trait InteractsWithPivotTable
 
         if ($value instanceof BaseCollection || is_array($value)) {
             return (new BaseCollection($value))
-                ->map(fn ($item) => $item instanceof Model ? $item->{$this->relatedKey} : $item)
+                ->map($this->parseId(...))
                 ->all();
         }
 


### PR DESCRIPTION
https://github.com/laravel/framework/blob/fba3b98d1ff22f75ea4bd70f8200cfa0b6a3f43d/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L623-L627

&darr;

https://github.com/laravel/framework/blob/fba3b98d1ff22f75ea4bd70f8200cfa0b6a3f43d/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L632-L641