### PR TITLE
[12.x] Introducing Collection `hasAll` Method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -615,6 +615,27 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if all keys exist in the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $keys
+     * @return bool
+     */
+    public function hasAll($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        if (empty($keys)) {
+            throw new InvalidArgumentException('Keys must be provided.');
+        }
+
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return empty(array_diff($keys, array_keys($this->all())));
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  (callable(TValue, TKey): mixed)|string|null  $value

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -738,6 +738,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @return bool
      */
     public function containsOneItem(?callable $callback = null): bool
     {
@@ -902,6 +903,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Multiply the items in the collection by the multiplier.
      *
+     * @param  int  $multiplier
      * @return static
      */
     public function multiply(int $multiplier)
@@ -1452,7 +1454,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $placeholder = new stdClass;
+        $placeholder = new stdClass();
 
         $item = $this->first($filter, $placeholder);
 
@@ -1572,6 +1574,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection using multiple comparisons.
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>  $comparisons
+     * @param  int  $options
      * @return static
      */
     protected function sortByMany(array $comparisons = [], int $options = SORT_REGULAR)
@@ -1857,6 +1860,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Count the number of items in the collection.
+     *
+     * @return int
      */
     public function count(): int
     {
@@ -1901,6 +1906,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if an item exists at an offset.
      *
      * @param  TKey  $key
+     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -1923,6 +1929,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  TKey|null  $key
      * @param  TValue  $value
+     * @return void
      */
     public function offsetSet($key, $value): void
     {
@@ -1937,6 +1944,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Unset the item at a given offset.
      *
      * @param  TKey  $key
+     * @return void
      */
     public function offsetUnset($key): void
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -619,6 +619,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  TKey|array<array-key, TKey>  $keys
      * @return bool
+     *
+     * @throws \InvalidArgumentException
      */
     public function hasAll($keys)
     {
@@ -736,7 +738,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @return bool
      */
     public function containsOneItem(?callable $callback = null): bool
     {
@@ -901,7 +902,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Multiply the items in the collection by the multiplier.
      *
-     * @param  int  $multiplier
      * @return static
      */
     public function multiply(int $multiplier)
@@ -1452,7 +1452,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $placeholder = new stdClass();
+        $placeholder = new stdClass;
 
         $item = $this->first($filter, $placeholder);
 
@@ -1572,7 +1572,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection using multiple comparisons.
      *
      * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>  $comparisons
-     * @param  int  $options
      * @return static
      */
     protected function sortByMany(array $comparisons = [], int $options = SORT_REGULAR)
@@ -1858,8 +1857,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Count the number of items in the collection.
-     *
-     * @return int
      */
     public function count(): int
     {
@@ -1904,7 +1901,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Determine if an item exists at an offset.
      *
      * @param  TKey  $key
-     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -1927,7 +1923,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  TKey|null  $key
      * @param  TValue  $value
-     * @return void
      */
     public function offsetSet($key, $value): void
     {
@@ -1942,7 +1937,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Unset the item at a given offset.
      *
      * @param  TKey  $key
-     * @return void
      */
     public function offsetUnset($key): void
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -632,6 +632,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  TKey|array<array-key, TKey>  $keys
      * @return bool
+     *
+     * @throws \InvalidArgumentException
      */
     public function hasAll($keys)
     {
@@ -895,7 +897,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Multiply the items in the collection by the multiplier.
      *
-     * @param  int  $multiplier
      * @return static
      */
     public function multiply(int $multiplier)
@@ -1634,7 +1635,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Take items in the collection until a given point in time.
      *
-     * @param  \DateTimeInterface  $timeout
      * @return static<TKey, TValue>
      */
     public function takeUntilTimeout(DateTimeInterface $timeout)
@@ -1837,8 +1837,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * Count the number of items in the collection.
-     *
-     * @return int
      */
     public function count(): int
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -897,6 +897,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Multiply the items in the collection by the multiplier.
      *
+     * @param  int  $multiplier
      * @return static
      */
     public function multiply(int $multiplier)
@@ -1635,6 +1636,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Take items in the collection until a given point in time.
      *
+     * @param  \DateTimeInterface  $timeout
      * @return static<TKey, TValue>
      */
     public function takeUntilTimeout(DateTimeInterface $timeout)
@@ -1837,6 +1839,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * Count the number of items in the collection.
+     *
+     * @return int
      */
     public function count(): int
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -628,6 +628,27 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if all keys exist in the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $keys
+     * @return bool
+     */
+    public function hasAll($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        if (empty($keys)) {
+            throw new InvalidArgumentException('Keys must be provided.');
+        }
+
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        return empty(array_diff($keys, array_keys($this->all())));
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  (callable(TValue, TKey): mixed)|string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2358,6 +2358,25 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testHasAll($collection)
+    {
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+
+        $this->assertTrue($data->hasAll('id'));
+        $this->assertTrue($data->hasAll('id', 'first', 'second'));
+        $this->assertFalse($data->hasAll('id', 'first', 'second', 'third'));
+        $this->assertTrue($data->hasAll(['id', 'first']));
+        $this->assertTrue($data->hasAll(['first', 'second']));
+        $this->assertFalse($data->hasAll(['third', 'fourth']));
+        $this->assertFalse($data->hasAll('third', 'fourth'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Keys must be provided.');
+
+        $data->hasAll([]);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Previous attempt: https://github.com/laravel/framework/pull/26543

---

This PR adds the `hasAll` method to collections. Although this method has already been attempted in the past, I believe that today, we live in a new moment where it can be useful in our daily lives. 

To exemplify the real benefit of this method, a few days ago I had to do the same, but manually:

```php
// ...

if (empty(array_diff([
    'file_content',
    'file_extension',
], array_keys($data))) === false) {
    return $next($data);
}
```

Although we could achieve this goal through Macros, having it as part of the framework would facilitate our use cases:

```php
collect(['file_content' => 'iVBORw0KGgoAA...', 'file_extension' => 'jpg'])
    ->hasAll('file_content', 'file_extension'); // true
```