### PR TITLE
[12.x] Prevent `preventsLazyLoading` exception when using `automaticallyEagerLoadRelationships`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -562,7 +562,7 @@ trait HasAttributes
             return $this->relations[$key];
         }
 
-        if ($this->preventsLazyLoading) {
+        if ($this->preventsLazyLoading && ! self::isAutomaticallyEagerLoadingRelationships()) {
             $this->handleLazyLoadingViolation($key);
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While `automaticallyEagerLoadRelationships` is still advertised as "Beta", it is available for use - I have personally used it in production and have seen good behavior from it, and for this reason it no longer makes sense to throw the `preventsLazyLoad` exception when `automaticallyEagerLoadingRelationships` is enabled.
