### PR TITLE
skip appending page=1 in pagination URLs

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -185,19 +185,25 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
             $page = 1;
         }
 
+        // Only add the page parameter if it's greater than 1.
+        // This prevents unnecessary ?page=1 in the URL and improves SEO by avoiding duplicate content.
+        $parameters = $page > 1 ? [$this->pageName => $page] : [];
+
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
-
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
         }
 
+        // Build the query string and attach it to the path
+        $query = Arr::query($parameters);
+
         return $this->path()
-                        .(str_contains($this->path(), '?') ? '&' : '?')
-                        .Arr::query($parameters)
-                        .$this->buildFragment();
+            . ($query === ''
+                ? ''
+                : (str_contains($this->path(), '?') ? '&' : '?') . $query)
+            . $this->buildFragment();
     }
 
     /**


### PR DESCRIPTION
feat(pagination): omit ?page=1 and prevent dangling separators

Skip adding the `page` query parameter when the requested page equals 1, returning the canonical base path instead.

When no extra query parameters are present, the function now suppresses the `?` / `&` separator entirely. This prevents URLs such as `/users?` or `/users&` and avoids duplicate‑content issues for the first page.

Behaviour for pages >1 and for existing custom query strings is unchanged.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
