### PR TITLE
Install Broadcasting Command Fix for Livewire Starter Kit

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -106,18 +106,28 @@ class BroadcastingInstallCommand extends Command
 
             // Only add the bootstrap import for the standard JS implementation...
             if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
-                $bootstrapScript = file_get_contents(
-                    $bootstrapScriptPath
-                );
+                $bootstrapScript = file_get_contents($bootstrapScriptPath);
 
                 if (! str_contains($bootstrapScript, './echo')) {
                     file_put_contents(
                         $bootstrapScriptPath,
-                        trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
+                        trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL
+                    );
+                }
+            }
+            // Fallback: if no bootstrap.js, try app.js
+            elseif (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
+                $appScript = file_get_contents($appScriptPath);
+
+                if (! str_contains($appScript, './echo')) {
+                    file_put_contents(
+                        $appScriptPath,
+                        trim($appScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL
                     );
                 }
             }
         }
+
 
         $this->installReverb();
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -106,12 +106,14 @@ class BroadcastingInstallCommand extends Command
 
             // Only add the bootstrap import for the standard JS implementation...
             if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
-                $bootstrapScript = file_get_contents($bootstrapScriptPath);
+                $bootstrapScript = file_get_contents(
+                    $bootstrapScriptPath,
+                );
 
                 if (! str_contains($bootstrapScript, './echo')) {
                     file_put_contents(
                         $bootstrapScriptPath,
-                        trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL
+                        trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
                     );
                 }
             }
@@ -127,7 +129,6 @@ class BroadcastingInstallCommand extends Command
                 }
             }
         }
-
 
         $this->installReverb();
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -116,9 +116,8 @@ class BroadcastingInstallCommand extends Command
                         trim($bootstrapScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
                     );
                 }
-            }
-            // Fallback: if no bootstrap.js, try app.js
-            elseif (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
+            } elseif (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
+                // If no bootstrap.js, try app.js...
                 $appScript = file_get_contents(
                     $appScriptPath
                 );

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -107,7 +107,7 @@ class BroadcastingInstallCommand extends Command
             // Only add the bootstrap import for the standard JS implementation...
             if (file_exists($bootstrapScriptPath = $this->laravel->resourcePath('js/bootstrap.js'))) {
                 $bootstrapScript = file_get_contents(
-                    $bootstrapScriptPath,
+                    $bootstrapScriptPath
                 );
 
                 if (! str_contains($bootstrapScript, './echo')) {
@@ -119,12 +119,14 @@ class BroadcastingInstallCommand extends Command
             }
             // Fallback: if no bootstrap.js, try app.js
             elseif (file_exists($appScriptPath = $this->laravel->resourcePath('js/app.js'))) {
-                $appScript = file_get_contents($appScriptPath);
+                $appScript = file_get_contents(
+                    $appScriptPath
+                );
 
                 if (! str_contains($appScript, './echo')) {
                     file_put_contents(
                         $appScriptPath,
-                        trim($appScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL
+                        trim($appScript.PHP_EOL.file_get_contents(__DIR__.'/stubs/echo-bootstrap-js.stub')).PHP_EOL,
                     );
                 }
             }


### PR DESCRIPTION
When playing around with the new useEcho hook for the starter kits, I realized that the Broadcasting Install command no longer worked seamlessly for the Livewire starter kit. I assume this is because there is no more `bootstrap.js` for this starter kit and no longer needed for most Livewire applications.

That being said, I admittedly spent more time than I should have figuring out I did not have Echo proper instantiated after installing the Broadcasting command, so this PR is set up to add a check and add the `echo` file import for `app.js` if and only if `bootstrap.js` is not found. 

This means the `install:broadcasting` command is the only thing needed to run for any starter kit.
