### PR TITLE
Improved PHPDoc Return Types for Eloquent's Original Attribute Methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1960,7 +1960,7 @@ trait HasAttributes
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed|array
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function getOriginal($key = null, $default = null)
     {
@@ -1974,7 +1974,7 @@ trait HasAttributes
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed|array
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
     protected function getOriginalWithoutRewindingModel($key = null, $default = null)
     {
@@ -1994,7 +1994,7 @@ trait HasAttributes
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return mixed|array
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function getRawOriginal($key = null, $default = null)
     {


### PR DESCRIPTION
This PR enhances the type information in PHPDoc blocks for three methods that retrieve original attributes:

- `getOriginal()`
- `getOriginalWithoutRewindingModel()`
- `getRawOriginal()`

## Changes
Replaced the generic `@return mixed|array` with a more precise conditional return type: `@return ($key is null ? array<string, mixed> : mixed)`

This better communicates that:

- When no key is provided, these methods return an array of all original attributes
- When a key is provided, they return a mixed value for that specific attribute

## Benefits

- Improved static analysis capabilities
- Better IDE type hinting and autocompletion
- More accurate documentation for developers

No functional changes were made to the implementation.