### PR TITLE
Correct return type in PhpDoc for command fail method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -263,7 +263,7 @@ class Command extends SymfonyCommand
      * Fail the command manually.
      *
      * @param  \Throwable|string|null  $exception
-     * @return void
+     * @return never
      *
      * @throws \Illuminate\Console\ManuallyFailedException|\Throwable
      */


### PR DESCRIPTION
PhpStan ignore command fail method.

See [larastan issue](https://github.com/larastan/larastan/issues/2289#issuecomment-2891959988).

![image](https://github.com/user-attachments/assets/1f29211b-10e4-4241-a457-351e7a93472e)
