### PR TITLE
Add roman numeral conversion method and corresponding tests

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -427,4 +427,45 @@ class Number
             throw new RuntimeException('The "intl" PHP extension is required to use the ['.$method.'] method.');
         }
     }
+
+    /**
+     * Convert an integer into its Roman numeral representation.
+     *
+     * @param  int  $number  The number to convert (must be between 1 and 3999)
+     * @return string  The Roman numeral representation
+     * @throws \InvalidArgumentException  If the number is not between 1 and 3999
+     */
+    public static function roman(int $number): string
+    {
+        if ($number <= 0 || $number > 3999) {
+            throw new \InvalidArgumentException('Number must be between 1 and 3999.');
+        }
+
+        $map = [
+            'M'  => 1000,
+            'CM' => 900,
+            'D'  => 500,
+            'CD' => 400,
+            'C'  => 100,
+            'XC' => 90,
+            'L'  => 50,
+            'XL' => 40,
+            'X'  => 10,
+            'IX' => 9,
+            'V'  => 5,
+            'IV' => 4,
+            'I'  => 1,
+        ];
+
+        $result = '';
+
+        foreach ($map as $roman => $value) {
+            while ($number >= $value) {
+                $result .= $roman;
+                $number -= $value;
+            }
+        }
+
+        return $result;
+    }
 }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use NumberFormatter;
 use RuntimeException;
 
@@ -432,29 +433,30 @@ class Number
      * Convert an integer into its Roman numeral representation.
      *
      * @param  int  $number  The number to convert (must be between 1 and 3999)
-     * @return string  The Roman numeral representation
-     * @throws \InvalidArgumentException  If the number is not between 1 and 3999
+     * @return string The Roman numeral representation
+     *
+     * @throws InvalidArgumentException If the number is not between 1 and 3999
      */
     public static function roman(int $number): string
     {
         if ($number <= 0 || $number > 3999) {
-            throw new \InvalidArgumentException('Number must be between 1 and 3999.');
+            throw new InvalidArgumentException('Number must be between 1 and 3999.');
         }
 
         $map = [
-            'M'  => 1000,
+            'M' => 1000,
             'CM' => 900,
-            'D'  => 500,
+            'D' => 500,
             'CD' => 400,
-            'C'  => 100,
+            'C' => 100,
             'XC' => 90,
-            'L'  => 50,
+            'L' => 50,
             'XL' => 40,
-            'X'  => 10,
+            'X' => 10,
             'IX' => 9,
-            'V'  => 5,
+            'V' => 5,
             'IV' => 4,
-            'I'  => 1,
+            'I' => 1,
         ];
 
         $result = '';

--- a/tests/Support/NumberTest.php
+++ b/tests/Support/NumberTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Number;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class NumberTest extends TestCase
+{
+    public function testRoman()
+    {
+        $this->assertSame('I', Number::roman(1));
+        $this->assertSame('IV', Number::roman(4));
+        $this->assertSame('IX', Number::roman(9));
+        $this->assertSame('LVIII', Number::roman(58));
+        $this->assertSame('MCMXCIV', Number::roman(1994));
+        $this->assertSame('MMMCMXCIX', Number::roman(3999));
+    }
+
+    public function testRomanWithInvalidLowNumber()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Number must be between 1 and 3999.');
+        Number::roman(0);
+    }
+
+    public function testRomanWithInvalidHighNumber()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Number must be between 1 and 3999.');
+        Number::roman(4000);
+    }
+}


### PR DESCRIPTION
# Add Number::roman() method for Roman numeral conversion

This PR introduces a new `Number::roman()` method that converts integers into their Roman numeral representation. The implementation is straightforward and efficient, handling numbers from 1 to 3999 (the standard range for Roman numerals).

## Features

- Converts integers to Roman numerals (e.g., `Number::roman(1994)` returns "MCMXCIV")
- Validates input range (1-3999) with clear exception messages
- Follows Laravel's coding style and documentation standards
- Includes comprehensive test coverage

## Use Cases

- Displaying chapter numbers in books or documents
- Representing centuries or monarch names (e.g., "King Henry VIII")
- Styling ordered lists in applications

## Implementation

The method uses a map of Roman numeral symbols to their decimal values and builds the Roman numeral string by iteratively subtracting the largest possible values. This approach ensures correct representation of all valid Roman numerals.

## Examples

```php
use Illuminate\Support\Number;

echo Number::roman(1);    // Output: I
echo Number::roman(4);    // Output: IV
echo Number::roman(9);    // Output: IX
echo Number::roman(58);   // Output: LVIII
echo Number::roman(1994); // Output: MCMXCIV