### PR TITLE
Feature: add support straight join in mysql

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -777,6 +777,49 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a straight_join to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
+     * @param  \Closure|string  $first
+     * @param  string|null  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
+     * @return $this
+     */
+    public function straightJoin($table, $first, $operator = null, $second = null)
+    {
+        return $this->join($table, $first, $operator, $second, 'straight_join');
+    }
+
+    /**
+     * Add a "straight_join where" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $first
+     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $second
+     * @return $this
+     */
+    public function straightJoinWhere($table, $first, $operator, $second)
+    {
+        return $this->joinWhere($table, $first, $operator, $second, 'straight_join');
+    }
+
+    /**
+     * Add a subquery straight_join to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
+     * @param  string  $as
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $first
+     * @param  string|null  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
+     * @return $this
+     */
+    public function straightJoinSub($query, $as, $first, $operator = null, $second = null)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, 'straight_join');
+    }
+
+    /**
      * Get a new join clause.
      *
      * @param  string  $type

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -777,7 +777,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a straight_join to the query.
+     * Add a straight join to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  \Closure|string  $first
@@ -791,7 +791,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "straight_join where" clause to the query.
+     * Add a "straight join where" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $first
@@ -805,7 +805,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a subquery straight_join to the query.
+     * Add a subquery straight join to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
      * @param  string  $as

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -199,7 +199,7 @@ class Grammar extends BaseGrammar
                 return $this->compileJoinLateral($join, $tableAndNestedJoins);
             }
 
-            $joinWord = ($join->type === 'straight_join' && $this->supportStraightJoin()) ? '' : ' join';
+            $joinWord = ($join->type === 'straight_join' && $this->supportsStraightJoins()) ? '' : ' join';
 
             return trim("{$join->type}{$joinWord} {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
@@ -220,9 +220,11 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Determine if the grammar supports straight joins.
+     *
      * @return bool
      */
-    protected function supportStraightJoin(): bool
+    protected function supportsStraightJoins()
     {
         throw new RuntimeException('This database engine does not support straight joins.');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -199,7 +199,9 @@ class Grammar extends BaseGrammar
                 return $this->compileJoinLateral($join, $tableAndNestedJoins);
             }
 
-            return trim("{$join->type} join {$tableAndNestedJoins} {$this->compileWheres($join)}");
+            $joinWord = ($join->type === 'straight_join' && $this->supportStraightJoin()) ? '' : 'join';
+
+            return trim("{$join->type} {$joinWord} {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
     }
 
@@ -215,6 +217,14 @@ class Grammar extends BaseGrammar
     public function compileJoinLateral(JoinLateralClause $join, string $expression): string
     {
         throw new RuntimeException('This database engine does not support lateral joins.');
+    }
+
+    /**
+     * @return bool
+     */
+    protected function supportStraightJoin(): bool
+    {
+        throw new RuntimeException('This database engine does not support straight joins.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -199,9 +199,9 @@ class Grammar extends BaseGrammar
                 return $this->compileJoinLateral($join, $tableAndNestedJoins);
             }
 
-            $joinWord = ($join->type === 'straight_join' && $this->supportStraightJoin()) ? '' : 'join';
+            $joinWord = ($join->type === 'straight_join' && $this->supportStraightJoin()) ? '' : ' join';
 
-            return trim("{$join->type} {$joinWord} {$tableAndNestedJoins} {$this->compileWheres($join)}");
+            return trim("{$join->type}{$joinWord} {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
     }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -376,6 +376,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * @return bool
+     */
+    protected function supportStraightJoin(): bool
+    {
+        return true;
+    }
+
+    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -376,14 +376,6 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * @return bool
-     */
-    protected function supportStraightJoin(): bool
-    {
-        return true;
-    }
-
-    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join
@@ -393,6 +385,14 @@ class MySqlGrammar extends Grammar
     public function compileJoinLateral(JoinLateralClause $join, string $expression): string
     {
         return trim("{$join->type} join lateral {$expression} on true");
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function supportsStraightJoins()
+    {
+        return true;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3323,6 +3323,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->straightJoin('contacts', 'users.id', 'contacts.id');
+        $builder->toSql();
     }
 
     public function testStraightJoinSub()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3321,7 +3321,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testStraightJoinNoSupport()
     {
         $this->expectException(RuntimeException::class);
-        $builder = $this->getMySqlBuilder();
+        $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->select('*')->from('users')->straightJoin('contacts', 'users.id', 'contacts.id');
     }
@@ -3331,7 +3331,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->from('users')->straightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
-        $this->assertSame('select * from `users` straight_join (select * from `contacts`) as `sub` on `users`.`id` = `sub`.`id`', $builder->toSql());
+        $this->assertSame('select * from `users` straight_join (select * from "contacts") as `sub` on `users`.`id` = `sub`.`id`', $builder->toSql());
 
         $this->expectException(InvalidArgumentException::class);
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3304,17 +3304,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->select('*')->from('users')->straightJoin('contacts', 'users.id', 'contacts.id');
-        $this->assertSame('select * from "users" straight_join "contacts" on "users"."id" = "contacts"."id"', $builder->toSql());
+        $this->assertSame('select * from `users` straight_join `contacts` on `users`.`id` = `contacts`.`id`', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->select('*')->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->straightJoin('photos', 'users.id', '=', 'photos.id');
-        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" straight_join "photos" on "users"."id" = "photos"."id"', $builder->toSql());
+        $this->assertSame('select * from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` straight_join `photos` on `users`.`id` = `photos`.`id`', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->select('*')->from('users')->straightJoinWhere('photos', 'users.id', '=', 'bar')->joinWhere('photos', 'users.id', '=', 'foo');
-        $this->assertSame('select * from "users" straight_join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', $builder->toSql());
+        $this->assertSame('select * from `users` straight_join `photos` on `users`.`id` = ? inner join `photos` on `users`.`id` = ?', $builder->toSql());
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
 
@@ -3331,7 +3331,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->from('users')->straightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
-        $this->assertSame('select * from "users" straight_join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from `users` straight_join (select * from `contacts`) as `sub` on `users`.`id` = `sub`.`id`', $builder->toSql());
 
         $this->expectException(InvalidArgumentException::class);
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3322,7 +3322,6 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('getDatabaseName');
         $builder->select('*')->from('users')->straightJoin('contacts', 'users.id', 'contacts.id');
     }
 


### PR DESCRIPTION
**Enhancing `STRAIGHT_JOIN` Support in MySQL for Laravel**  

This PR adds compatibility for `STRAIGHT_JOIN` in MySQL within the Laravel framework, allowing developers to optimize queries where the order of tables in the `JOIN` execution is crucial for performance.  

**References:**  
- [Official MySQL Documentation on `JOIN`](https://dev.mysql.com/doc/refman/8.4/en/join.html)  
- [MariaDB `JOIN` Syntax](https://mariadb.com/kb/en/join-syntax/)  

