### PR TITLE
Add DateRangeDoesNotOverlap validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -163,6 +163,7 @@ return [
     'url' => 'The :attribute field must be a valid URL.',
     'ulid' => 'The :attribute field must be a valid ULID.',
     'uuid' => 'The :attribute field must be a valid UUID.',
+    'date_range_overlap' => 'The selected date range overlaps with an existing record.',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Illuminate/Validation/DateRangeValidationServiceProvider.php
+++ b/src/Illuminate/Validation/DateRangeValidationServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\Rules\DateRangeDoesNotOverlap;
+
+class DateRangeValidationServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Register the validation extension
+        $this->app->afterResolving('validator', function ($validator, $app) {
+            $this->registerDateRangeValidator($validator);
+        });
+    }
+
+    /**
+     * Register the date range validation rule.
+     *
+     * @param  \Illuminate\Validation\Factory  $validator
+     * @return void
+     */
+    protected function registerDateRangeValidator($validator)
+    {
+        $validator->extend('date_range_does_not_overlap', function ($attribute, $value, $parameters, $validator) {
+            $table = $parameters[0] ?? null;
+            $startColumn = $parameters[1] ?? 'start_date';
+            $endColumn = $parameters[2] ?? 'end_date';
+            $excludeId = $parameters[3] ?? null;
+            $idColumn = $parameters[4] ?? 'id';
+
+            if (! $table) {
+                return false;
+            }
+
+            $rule = new DateRangeDoesNotOverlap($table, $startColumn, $endColumn, $excludeId, $idColumn);
+
+            $fails = false;
+            $rule->validate($attribute, $value, function () use (&$fails) {
+                $fails = true;
+            });
+
+            return ! $fails;
+        });
+    }
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -22,6 +22,7 @@ use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\Rules\DateRangeDoesNotOverlap;
 
 class Rule
 {
@@ -258,6 +259,26 @@ class Rule
     public static function anyOf($rules)
     {
         return new AnyOf($rules);
+    }
+
+    /**
+     * Create a new "date range does not overlap" rule instance.
+     *
+     * @param  string  $table
+     * @param  string  $startColumn
+     * @param  string  $endColumn
+     * @param  mixed  $excludeId
+     * @param  string  $idColumn
+     * @return \Illuminate\Validation\Rules\DateRangeDoesNotOverlap
+     */
+    public static function dateRangeDoesNotOverlap(
+        string $table,
+        string $startColumn = 'start_date',
+        string $endColumn = 'end_date',
+        $excludeId = null,
+        string $idColumn = 'id'
+    ) {
+        return new DateRangeDoesNotOverlap($table, $startColumn, $endColumn, $excludeId, $idColumn);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/DateRangeDoesNotOverlap.php
+++ b/src/Illuminate/Validation/Rules/DateRangeDoesNotOverlap.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\DB;
+
+class DateRangeDoesNotOverlap implements ValidationRule
+{
+    /**
+     * The table to check for overlaps.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The column name for the start date.
+     *
+     * @var string
+     */
+    protected $startColumn;
+
+    /**
+     * The column name for the end date.
+     *
+     * @var string
+     */
+    protected $endColumn;
+
+    /**
+     * The ID to exclude from validation (for updates).
+     *
+     * @var mixed
+     */
+    protected $excludeId;
+
+    /**
+     * The ID column name.
+     *
+     * @var string
+     */
+    protected $idColumn;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  string  $table
+     * @param  string  $startColumn
+     * @param  string  $endColumn
+     * @param  mixed  $excludeId
+     * @param  string  $idColumn
+     * @return void
+     */
+    public function __construct(
+        string $table,
+        string $startColumn = 'start_date',
+        string $endColumn = 'end_date',
+        $excludeId = null,
+        string $idColumn = 'id'
+    ) {
+        $this->table = $table;
+        $this->startColumn = $startColumn;
+        $this->endColumn = $endColumn;
+        $this->excludeId = $excludeId;
+        $this->idColumn = $idColumn;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure  $fail
+     * @return void
+     */
+    public function validate($attribute, $value, $fail): void
+    {
+        $request = request();
+        $isStartDate = str_contains($attribute, 'start');
+
+        if ($isStartDate) {
+            $startDate = $value;
+            $endDate = $request->input($this->getEndFieldName($attribute));
+        } else {
+            $endDate = $value;
+            $startDate = $request->input($this->getStartFieldName($attribute));
+        }
+
+        // If we don't have both dates, we can't validate overlaps
+        if (! $startDate || ! $endDate) {
+            return;
+        }
+
+        $query = DB::table($this->table)
+            ->where(function ($query) use ($startDate, $endDate) {
+                // Case 1: Start date falls within an existing range
+                $query->where(function ($q) use ($startDate) {
+                    $q->where($this->startColumn, '<=', $startDate)
+                      ->where($this->endColumn, '>=', $startDate);
+                })
+                // Case 2: End date falls within an existing range
+                ->orWhere(function ($q) use ($endDate) {
+                    $q->where($this->startColumn, '<=', $endDate)
+                      ->where($this->endColumn, '>=', $endDate);
+                })
+                // Case 3: New range encompasses an existing range
+                ->orWhere(function ($q) use ($startDate, $endDate) {
+                    $q->where($this->startColumn, '>=', $startDate)
+                      ->where($this->endColumn, '<=', $endDate);
+                });
+            });
+
+        // Exclude the current record if we're updating
+        if ($this->excludeId !== null) {
+            $query->where($this->idColumn, '!=', $this->excludeId);
+        }
+
+        if ($query->exists()) {
+            $fail('validation.date_range_overlap')->translate();
+        }
+    }
+
+    /**
+     * Get the corresponding end date field name from a start date field.
+     *
+     * @param  string  $startFieldName
+     * @return string
+     */
+    protected function getEndFieldName($startFieldName)
+    {
+        return str_replace('start', 'end', $startFieldName);
+    }
+
+    /**
+     * Get the corresponding start date field name from an end date field.
+     *
+     * @param  string  $endFieldName
+     * @return string
+     */
+    protected function getStartFieldName($endFieldName)
+    {
+        return str_replace('end', 'start', $endFieldName);
+    }
+
+    /**
+     * Exclude a specific ID from the validation.
+     *
+     * @param  mixed  $id
+     * @return $this
+     */
+    public function exclude($id)
+    {
+        $this->excludeId = $id;
+
+        return $this;
+    }
+}

--- a/tests/Validation/DateRangeDoesNotOverlapTest.php
+++ b/tests/Validation/DateRangeDoesNotOverlapTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Mockery as m;
+
+class DateRangeDoesNotOverlapTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testItPassesWhenNoOverlapsExist()
+    {
+        $request = $this->mockRequest([
+            'start_date' => '2025-06-01',
+            'end_date' => '2025-06-05',
+        ]);
+
+        $dbMock = m::mock('alias:Illuminate\Support\Facades\DB');
+        $queryBuilder = m::mock();
+        $dbMock->shouldReceive('table')->once()->with('reservations')->andReturn($queryBuilder);
+
+        $queryBuilder->shouldReceive('where')->once()->andReturnSelf();
+        $queryBuilder->shouldReceive('exists')->once()->andReturn(false);
+
+        $rule = new DateRangeDoesNotOverlap('reservations');
+        $this->validateRule($rule, 'start_date', '2025-06-01');
+    }
+
+    public function testItFailsWhenOverlapsExist()
+    {
+        $request = $this->mockRequest([
+            'start_date' => '2025-06-01',
+            'end_date' => '2025-06-05',
+        ]);
+
+        $dbMock = m::mock('alias:Illuminate\Support\Facades\DB');
+        $queryBuilder = m::mock();
+        $dbMock->shouldReceive('table')->once()->with('reservations')->andReturn($queryBuilder);
+
+        $queryBuilder->shouldReceive('where')->once()->andReturnSelf();
+        $queryBuilder->shouldReceive('exists')->once()->andReturn(true);
+
+        $rule = new DateRangeDoesNotOverlap('reservations');
+
+        $failed = false;
+        $failCallback = function () use (&$failed) {
+            $failed = true;
+            return m::mock('Illuminate\Contracts\Validation\ValidationRule\Failed')
+                ->shouldReceive('translate')
+                ->once()
+                ->getMock();
+        };
+
+        $rule->validate('start_date', '2025-06-01', $failCallback);
+        $this->assertTrue($failed);
+    }
+
+    public function testItExcludesCurrentRecordForUpdates()
+    {
+        $request = $this->mockRequest([
+            'start_date' => '2025-06-01',
+            'end_date' => '2025-06-05',
+        ]);
+
+        $dbMock = m::mock('alias:Illuminate\Support\Facades\DB');
+        $queryBuilder = m::mock();
+        $subQueryBuilder = m::mock();
+
+        $dbMock->shouldReceive('table')->once()->with('reservations')->andReturn($queryBuilder);
+        $queryBuilder->shouldReceive('where')->once()->andReturnSelf();
+        $queryBuilder->shouldReceive('where')->once()->with('id', '!=', 5)->andReturnSelf();
+        $queryBuilder->shouldReceive('exists')->once()->andReturn(false);
+
+        $rule = new DateRangeDoesNotOverlap('reservations', 'start_date', 'end_date', 5);
+        $this->validateRule($rule, 'start_date', '2025-06-01');
+    }
+
+    public function testFluentApiForExclusion()
+    {
+        $rule = new DateRangeDoesNotOverlap('reservations');
+        $rule->exclude(5);
+
+        $this->assertSame(5, $this->getProtectedProperty($rule, 'excludeId'));
+    }
+
+    protected function mockRequest(array $data)
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('all')->andReturn($data);
+
+        foreach ($data as $key => $value) {
+            $request->shouldReceive('input')->with($key)->andReturn($value);
+        }
+
+        app()->instance('request', $request);
+
+        return $request;
+    }
+
+    protected function validateRule($rule, $attribute, $value)
+    {
+        $rule->validate($attribute, $value, function () {
+            return m::mock('Illuminate\Contracts\Validation\Failed')
+                ->shouldReceive('translate')
+                ->getMock();
+        });
+    }
+
+    protected function getProtectedProperty($object, $property)
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+
+        return $reflectionProperty->getValue($object);
+    }
+}

--- a/tests/Validation/ValidationDateRangeDoesNotOverlapTest.php
+++ b/tests/Validation/ValidationDateRangeDoesNotOverlapTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Illuminate\Validation\Rules;
+namespace Illuminate\Tests\Validation;
 
-use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\DateRangeDoesNotOverlap;
+use Orchestra\Testbench\TestCase;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Translation\ArrayLoader;
-use Illuminate\Translation\Translator;
 use Mockery as m;
 
-class DateRangeDoesNotOverlapTest extends TestCase
+class ValidationDateRangeDoesNotOverlapTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
         m::close();
     }
 
@@ -53,10 +53,7 @@ class DateRangeDoesNotOverlapTest extends TestCase
         $failed = false;
         $failCallback = function () use (&$failed) {
             $failed = true;
-            return m::mock('Illuminate\Contracts\Validation\ValidationRule\Failed')
-                ->shouldReceive('translate')
-                ->once()
-                ->getMock();
+            return m::mock()->shouldReceive('translate')->once()->getMock();
         };
 
         $rule->validate('start_date', '2025-06-01', $failCallback);
@@ -108,9 +105,7 @@ class DateRangeDoesNotOverlapTest extends TestCase
     protected function validateRule($rule, $attribute, $value)
     {
         $rule->validate($attribute, $value, function () {
-            return m::mock('Illuminate\Contracts\Validation\Failed')
-                ->shouldReceive('translate')
-                ->getMock();
+            return m::mock()->shouldReceive('translate')->getMock();
         });
     }
 


### PR DESCRIPTION
# Add Date Range Does Not Overlap validation rule

## Introduction

This PR adds a new validation rule, `dateRangeDoesNotOverlap`, that helps validate that date ranges (e.g., reservations, appointments, bookings) don't overlap with existing records in the database. This is a common requirement for many applications, and currently requires developers to implement custom validation logic.

The rule handles the common issue where date range validation during record updates incorrectly identifies the record being updated as a conflict. By accepting an optional `excludeId` parameter, the rule can properly handle both creation and update operations.

## Usage examples

```php
// When creating a new record:
$request->validate([
    'start_date' => [
        'required', 
        'date',
        Rule::dateRangeDoesNotOverlap('reservations', 'start_date', 'end_date')
    ],
    'end_date' => ['required', 'date', 'after:start_date'],
]);

// When updating an existing record:
$request->validate([
    'start_date' => [
        'required', 
        'date',
        Rule::dateRangeDoesNotOverlap('reservations', 'start_date', 'end_date', $reservation->id)
        // Or using fluent API:
        // Rule::dateRangeDoesNotOverlap('reservations')->exclude($reservation->id)
    ],
    'end_date' => ['required', 'date', 'after:start_date'],
]);
```

## Implementation details

The rule checks for three types of overlaps:
1. The start date falls within an existing range
2. The end date falls within an existing range
3. The new range completely encompasses an existing range

The rule can be applied to either the start or end date field, and it will automatically find the corresponding field in the request data.

## Related Issues and PRs

This rule addresses common challenges faced by developers when implementing date range validation, especially during update operations.

## Checklist

- [x] Added new rule implementation
- [x] Added tests for the new rule
- [x] Extended the Rule facade with the new method
- [x] Added language entries for validation errors
- [x] Documentation is updated (in-line code documentation)
- [x] All tests pass

## Notes for Reviewers

This rule is designed to be simple and flexible. It allows for customization of table names, column names, and exclusion IDs to support various use cases.

The validation logic follows existing Laravel practices for validation rules, and the implementation is consistent with other Laravel validation rules.