### PR TITLE
[12.x] Add `assertRedirectToAction` method to test redirection to controller actions

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -267,27 +267,6 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert whether the response is redirecting to a given controller action.
-     *
-     * @param  string|array  $name
-     * @param  array  $parameters
-     * @return $this
-     */
-    public function assertRedirectToAction($name, $parameters = [])
-    {
-        $uri = action($name, $parameters);
-
-        PHPUnit::withResponse($this)->assertTrue(
-            $this->isRedirect(),
-            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
-        );
-
-        $this->assertLocation($uri);
-
-        return $this;
-    }
-
-    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  \BackedEnum|string|null  $name
@@ -322,6 +301,27 @@ class TestResponse implements ArrayAccess
                 app('url')->to($uri), $expectedUri
             );
         }
+
+        return $this;
+    }
+
+    /**
+     * Assert whether the response is redirecting to a given controller action.
+     *
+     * @param  string|array  $name
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function assertRedirectToAction($name, $parameters = [])
+    {
+        $uri = action($name, $parameters);
+
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $this->assertLocation($uri);
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -267,6 +267,27 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting to a given controller action.
+     *
+     * @param  string|array  $name
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function assertRedirectToAction($name, $parameters = [])
+    {
+        $uri = action($name, $parameters);
+
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $this->assertLocation($uri);
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  \BackedEnum|string|null  $name

--- a/tests/Testing/AssertRedirectToActionTest.php
+++ b/tests/Testing/AssertRedirectToActionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
+use Orchestra\Testbench\TestCase;
+
+class AssertRedirectToActionTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Contracts\Routing\Registrar
+     */
+    private $router;
+
+    /**
+     * @var \Illuminate\Routing\UrlGenerator
+     */
+    public $urlGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = $this->app->make(Registrar::class);
+
+        $this->router->get('controller/index', [TestActionController::class, 'index']);
+        $this->router->get('controller/show/{id}', [TestActionController::class, 'show']);
+
+        $this->router->get('redirect-to-index', function () {
+            return new RedirectResponse($this->urlGenerator->action([TestActionController::class, 'index']));
+        });
+
+        $this->router->get('redirect-to-show', function () {
+            return new RedirectResponse($this->urlGenerator->action([TestActionController::class, 'show'], ['id' => 123]));
+        });
+
+        $this->urlGenerator = $this->app->make(UrlGenerator::class);
+    }
+
+    public function testAssertRedirectToActionWithoutParameters()
+    {
+        $this->get('redirect-to-index')
+            ->assertRedirectToAction([TestActionController::class, 'index']);
+    }
+
+    public function testAssertRedirectToActionWithParameters()
+    {
+        $this->get('redirect-to-show')
+            ->assertRedirectToAction([TestActionController::class, 'show'], ['id' => 123]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Facade::setFacadeApplication(null);
+    }
+}
+
+class TestActionController extends Controller
+{
+    public function index()
+    {
+        return 'ok';
+    }
+
+    public function show($id)
+    {
+        return "id: $id";
+    }
+}


### PR DESCRIPTION
This PR introduces a new `assertRedirectToAction` assertion to the HTTP test response, allowing developers to assert that a response redirects to a specific controller action.
Currently, Laravel offers `assertRedirect`, `assertRedirectToRoute`, and `assertRedirectToSignedRoute`, but lacks an assertion specifically for controller actions. Developers often use controller actions in their redirection logic via `redirect()->action(...)`, and this new assertion makes testing such redirects more expressive and consistent with Laravel's existing testing API.
