### PR TITLE
[12.x] feat: Add `current_page_url` to Paginator

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -153,6 +153,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     {
         return [
             'current_page' => $this->currentPage(),
+            'current_page_url' => $this->url($this->currentPage()),
             'data' => $this->items->toArray(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -21,6 +21,7 @@ class PaginatorTest extends TestCase
             'per_page' => 2,
             'current_page' => 2,
             'first_page_url' => '/?page=1',
+            'current_page_url' => '/?page=2',
             'next_page_url' => '/?page=3',
             'prev_page_url' => '/?page=1',
             'from' => 3,


### PR DESCRIPTION
Sometimes, it is useful to have the current page URL for the Paginator, for example, to customize how the pagination information is returned in the API resources collections:

```php
class ApiResourceCollection extends AnonymousResourceCollection
{
    public function paginationInformation(Request $request, array $paginated, array $default): array
    {
        return [
            'links' => [
                'self' => $paginated['current_page_url'],
                'next' => $paginated['next_page_url'] ?? null,
            ],
        ];
    }
}
```

It simply adds a property to the `toArray()` method, so it shouldn't break anything.
