### PR TITLE
Prevent opening multiple Redis pipelines simultaneously when using PhpRedis (non-cluster)

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -131,7 +131,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
             }
         };
 
-        if ($connection instanceof PhpRedisClusterConnection) {
+        if ($connection instanceof PhpRedisClusterConnection || $connection instanceof PhpRedisConnection) {
             $connection->transaction($bulk);
         } elseif ($connection instanceof PredisClusterConnection) {
             $connection->pipeline($bulk);


### PR DESCRIPTION
I'm sure a lot of people who are using PhpRedis as queue driver have seen this error:

```
Redis::pipeline(): Can't activate pipeline in multi mode!
```

I'm fairly sure the problem occurs when pushing a combination of chains/batches to a queue, as the current behavior in the RedisQueue class opens both a pipeline and a transaction. PhpRedis does not allow nesting `pipeline()` and `transaction()`.

A simple workaround is to use Predis and not worry about transactions, but considering the performance of PhpRedis, I'd prefer to have this behavior fixed.

This problem has been mentioned before:

- https://github.com/laravel/framework/issues/36978
- [This thread on Laracasts](https://laracasts.com/discuss/channels/laravel/redispipeline-cant-activate-pipeline-in-multi-mode)