### PR TITLE
[12.x] Change priority in optimize:clear

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -59,9 +59,9 @@ class OptimizeClearCommand extends Command
     public function getOptimizeClearTasks()
     {
         return [
+            'config' => 'config:clear',
             'cache' => 'cache:clear',
             'compiled' => 'clear-compiled',
-            'config' => 'config:clear',
             'events' => 'event:clear',
             'routes' => 'route:clear',
             'views' => 'view:clear',


### PR DESCRIPTION
The problem occurs when you change the cache configs and since the configs are still cached, 
cache:clear throws an error.
So it's better to clear the config first.