### PR TITLE
Don't verify hash algorithm if verify option is set to false

### DIFF
--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,6 +22,10 @@ class Argon2IdHasher extends ArgonHasher
             return false;
         }
 
+        if (isset($options['verify'])) {
+            $this->verifyAlgorithm = $options['verify'];
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -99,6 +99,10 @@ class ArgonHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
+        if (isset($options['verify'])) {
+            $this->verifyAlgorithm = $options['verify'];
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -84,6 +84,10 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
+        if (isset($options['verify'])) {
+            $this->verifyAlgorithm = $options['verify'];
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -57,6 +57,9 @@ class HasherTest extends TestCase
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
         $this->assertGreaterThanOrEqual(12, password_get_info($value)['options']['cost']);
         $this->assertTrue($this->hashManager->isHashed($value));
+
+        $value = str_replace('$2y$', '$2a$', $hasher->make('password'));
+        $this->assertTrue($hasher->check('password', $value, ['verify' => false]));
     }
 
     public function testBcryptValueTooLong()


### PR DESCRIPTION
I reported a bug in #55759 where you can turn off verify of rounds/algorithm.
This seems to be bugged that it won't allow you to use older versions of bcrypt, but it'll allow you to use different amounts of rounds. This change allows both a different version and rounds count.