### PR TITLE
[12.x] Introducing `authorizeAfterValidation`

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -18,7 +18,9 @@ trait ValidatesWhenResolvedTrait
     {
         $this->prepareForValidation();
 
-        if (! $this->passesAuthorization()) {
+        $authorizeAfterValidation = $this->authorizeAfterValidation();
+
+        if (! $authorizeAfterValidation && ! $this->passesAuthorization()) {
             $this->failedAuthorization();
         }
 
@@ -30,6 +32,10 @@ trait ValidatesWhenResolvedTrait
 
         if ($instance->fails()) {
             $this->failedValidation($instance);
+        }
+
+        if ($authorizeAfterValidation && ! $this->passesAuthorization()) {
+            $this->failedAuthorization();
         }
 
         $this->passedValidation();
@@ -104,5 +110,15 @@ trait ValidatesWhenResolvedTrait
     protected function failedAuthorization()
     {
         throw new UnauthorizedException;
+    }
+
+    /**
+     * Determine if the request should verify the authorization only after validation.
+     *
+     * @return bool
+     */
+    protected function authorizeAfterValidation()
+    {
+        return false;
     }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -110,6 +110,16 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestForbiddenWithResponseStub::class)->validateResolved();
     }
 
+    public function testValidateThrowsNoAuthorizationExceptionIfValidationFails()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('error');
+
+        $request = $this->createRequest([], FoundationTestFormRequestAuthorizeAfterValidation::class);
+
+        $request->validateResolved();
+    }
+
     public function testValidateDoesntThrowExceptionFromResponseAllowed()
     {
         $this->createRequest([], FoundationTestFormRequestPassesWithResponseStub::class)->validateResolved();
@@ -434,6 +444,24 @@ class FoundationTestFormRequestHooks extends FormRequest
     public function passedValidation()
     {
         $this->replace(['name' => 'Adam']);
+    }
+}
+
+class FoundationTestFormRequestAuthorizeAfterValidation extends FormRequest
+{
+    public function authorize()
+    {
+        return Response::deny('foo');
+    }
+
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    protected function authorizeAfterValidation()
+    {
+        return true;
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Following good practices in the Laravel ecosystem, it is common to concentrate validation logic in FormRequest classes, which is highly recommended.

As we know, FormRequest provides the `authorize` method that allows you to authorize the request before executing the validation rules. In this method, you can return boolean values, use hard-coded rules directly, or even perform checks based on the authenticated user coming from the database, as the _spatie/laravel-permission_ package proposes.

The issue is that `authorize` runs before validation. **This means that even if the validation fails afterward, it’s likely that a database hit was executed unnecessarily.**

With this in mind, this PR proposes the addition of a new method:

```php
/**
 * Determine if the request should verify the authorization only after validation.
 *
 * @return bool
 */
protected function authorizeAfterValidation()
{
    return false;
}
```

This method allows us to invert the default order, making validation occur before authorization. **This way, we ensure that authorization — and possible database hits — are performed only if validation is successful.**

### Example

```php
class UpdatePostRequest extends FormRequest
{
    public function authorize()
    {
        // Example database hit...
        return Auth::user()
            ->where('rules', Roles::Editor)
            ->exists();
    }

    public function rules(): array
    {
        return [
            'title' => [
                'required',
                'min:20',
                'max:100',
                'regex:/^[a-zA-Z0-9\s]+$/',
            ],

            // ...
        ];
    }

    protected function authorizeAfterValidation(): bool
    {
        return true; // instructing the framework to authorize only after validating
    }
}
```

If the above validation fails due to `title` not matching the rules, **we will not get any database hits.**
