### PR TITLE
[12.x] Allowing `Context` Attribute to Interact with Hidden

### DIFF
--- a/src/Illuminate/Container/Attributes/Context.php
+++ b/src/Illuminate/Container/Attributes/Context.php
@@ -13,7 +13,7 @@ class Context implements ContextualAttribute
     /**
      * Create a new attribute instance.
      */
-    public function __construct(public string $key, public mixed $default = null)
+    public function __construct(public string $key, public mixed $default = null, public bool $hidden = false)
     {
     }
 
@@ -26,6 +26,11 @@ class Context implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container): mixed
     {
-        return $container->make(Repository::class)->get($attribute->key, $attribute->default);
+        $repository = $container->make(Repository::class);
+
+        return match ($attribute->hidden) {
+            true => $repository->getHidden($attribute->key, $attribute->default),
+            false => $repository->get($attribute->key, $attribute->default),
+        };
     }
 }

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -231,6 +231,21 @@ class ContextualAttributeBindingTest extends TestCase
         $container->make(ContextTest::class);
     }
 
+    public function testContextAttributeInteractingWithHidden(): void
+    {
+        $container = new Container;
+
+        $container->singleton(ContextRepository::class, function () {
+            $context = m::mock(ContextRepository::class);
+            $context->shouldReceive('getHidden')->once()->with('bar', null)->andReturn('bar');
+            $context->shouldNotReceive('get');
+
+            return $context;
+        });
+
+        $container->make(ContextHiddenTest::class);
+    }
+
     public function testStorageAttribute()
     {
         $container = new Container;
@@ -444,6 +459,13 @@ final class ConfigTest
 final class ContextTest
 {
     public function __construct(#[Context('foo')] string $foo)
+    {
+    }
+}
+
+final class ContextHiddenTest
+{
+    public function __construct(#[Context('bar', hidden: true)] string $foo)
     {
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In addition to https://github.com/laravel/framework/pull/55760

---

The PR https://github.com/laravel/framework/pull/55760 implements the _{very useful}_ `#[Context]` attribute to interact with  [Context](https://laravel.com/docs/12.x/context#main-content). However, the addition left out something extremely important when we're talking about Context: **the hidden items.** I would venture to say that hidden items are used more than common ones.

This PR implements the ability to retrieve hidden items by passing the parameter `hidden` as true. Thanks to modern PHP's named attributes, we can do something similar to what we find in the docs for things like _Livewire_:

```php
final class CreateUserAction
{
    public function __construct(#[Context('user', hidden: true)] User $user)
    {
        // ...
    }
}
```

I thought about creating a second _{HiddenContext}_ attribute, but IMHO it would be too much. A property like `hidden` serves us very well in this case. Thoughts?