### PR TITLE
[12.x] Fix `TestResponse::assertSessionMissing()` when given an array of keys

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1670,6 +1670,8 @@ class TestResponse implements ArrayAccess
             foreach ($key as $value) {
                 $this->assertSessionMissing($value);
             }
+
+            return $this;
         }
 
         if (is_null($value)) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -27,6 +27,7 @@ use Illuminate\Testing\TestResponse;
 use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -2807,7 +2808,10 @@ class TestResponseTest extends TestCase
         $response->assertSessionMissing('foo');
     }
 
-    public function testAssertSessionMissingValue()
+    #[TestWith(['foo', 'badvalue'])]
+    #[TestWith(['foo', null])]
+    #[TestWith([['foo'], null])]
+    public function testAssertSessionMissingValue(array|string $key, mixed $value)
     {
         $this->expectException(AssertionFailedError::class);
 
@@ -2816,7 +2820,7 @@ class TestResponseTest extends TestCase
         $store->put('foo', 'goodvalue');
 
         $response = TestResponse::fromBaseResponse(new Response());
-        $response->assertSessionMissing('foo', 'badvalue');
+        $response->assertSessionMissing($key, $value);
     }
 
     public function testAssertSessionHasInput()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2808,9 +2808,9 @@ class TestResponseTest extends TestCase
         $response->assertSessionMissing('foo');
     }
 
-    #[TestWith(['foo', 'badvalue'])]
+    #[aTestWith(['foo', 'badvalue'])]
     #[TestWith(['foo', null])]
-    #[TestWith([['foo'], null])]
+    #[aTestWith([['foo', 'bar'], null])]
     public function testAssertSessionMissingValue(array|string $key, mixed $value)
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2808,9 +2808,9 @@ class TestResponseTest extends TestCase
         $response->assertSessionMissing('foo');
     }
 
-    #[aTestWith(['foo', 'badvalue'])]
+    #[TestWith(['foo', 'badvalue'])]
     #[TestWith(['foo', null])]
-    #[aTestWith([['foo', 'bar'], null])]
+    #[TestWith([['foo', 'bar'], null])]
     public function testAssertSessionMissingValue(array|string $key, mixed $value)
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
PR #55763 removes `else` from the `is_array($key)` condition, which causes a regression bug in the existing applications.

![CleanShot 2025-05-21 at 11 50 14](https://github.com/user-attachments/assets/e8973432-0573-4760-a224-1b58d00615c0)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
