### PR TITLE
[12.x] Added option to always defer for flexible cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -483,9 +483,10 @@ class Repository implements ArrayAccess, CacheContract
      * @param  array{ 0: \DateTimeInterface|\DateInterval|int, 1: \DateTimeInterface|\DateInterval|int }  $ttl
      * @param  (callable(): TCacheValue)  $callback
      * @param  array{ seconds?: int, owner?: string }|null  $lock
+     * @param  bool  $alwaysDefer
      * @return TCacheValue
      */
-    public function flexible($key, $ttl, $callback, $lock = null)
+    public function flexible($key, $ttl, $callback, $lock = null, $alwaysDefer = false)
     {
         [
             $key => $value,
@@ -520,7 +521,7 @@ class Repository implements ArrayAccess, CacheContract
             });
         };
 
-        defer($refresh, "illuminate:cache:flexible:{$key}");
+        defer($refresh, "illuminate:cache:flexible:{$key}", $alwaysDefer);
 
         return $value;
     }

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -238,6 +238,31 @@ class RepositoryTest extends TestCase
         $this->assertTrue($cache->missing('illuminate:cache:flexible:created:count'));
     }
 
+    public function testItCanAlwaysDefer()
+    {
+        $this->freezeTime();
+        $cache = Cache::driver('array');
+        $count = 0;
+
+        // Cache is empty. The value should be populated...
+        $cache->flexible('foo', [10, 20], function () use (&$count) {
+            return ++$count;
+        }, alwaysDefer: true);
+
+        // First call to flexible() should not defer
+        $this->assertCount(0, defer());
+
+        Carbon::setTestNow(now()->addSeconds(11));
+
+        // Second callback should defer with always now true
+        $cache->flexible('foo', [10, 20], function () use (&$count) {
+            return ++$count;
+        }, alwaysDefer: true);
+
+        $this->assertCount(1, defer());
+        $this->assertTrue(defer()->first()->always);
+    }
+
     public function testItRoundsDateTimeValuesToAccountForTimePassedDuringScriptExecution()
     {
         // do not freeze time as this test depends on time progressing duration execution.


### PR DESCRIPTION
### Problem

As a developer I would like to be able to refresh a stale flexible cache when the applications returns a non successful response code.

Right now in the `Cache::flexible` it is deferred without the `always` parameter:
```php
public function flexible($key, $ttl, $callback, $lock = null)
{
    ...

    defer($refresh, "illuminate:cache:flexible:{$key}");

    return $value;
}
```

### Proposal

An extra optional parameter `alwaysDefer` with a default value of false to make it a **non-breaking** change.
```php
public function flexible($key, $ttl, $callback, $lock = null, $alwaysDefer = false)
{
    ...

    defer($refresh, "illuminate:cache:flexible:{$key}", $alwaysDefer);

    return $value;
}
```

### Use cases

#### Using flexible cache in the `PreventRequestsDuringMaintenance` middleware

The app is heavily dependent on an external API and put the app in downtime when the external API is in maintenance or has downtime.

```php
class PreventRequestsDuringMaintenance extends Middleware
{
    public function handle($request, Closure $next)
    {
        $isDown = Cache::flexible($url, [120, 600], function () {
            $response = Http::get('https://api.external.com/healthcheck');

            return $response->json('status') !== 'ok';
        }, alwaysDefer: true);

        if ($isDown) {
            throw new HttpException(
                503,
                'Service Unavailable'
            );
        }

        return parent::handle($request, $next);
    }
}
```

#### Using flexible cache in validations

In addition to the example above you could rely on an external API for specific data validations

```php
class LocationsRule implements ValidationRule
{
    public function validate(string $attribute, mixed $value, Closure $fail): void
    {
        $locations = Cache::flexible($url, [120, 600], function () {
            $response = Http::get('https://api.external.com/available-locations');

            return $response->json('data');
        }, alwaysDefer: true);

        if (! in_array($value, $locations)) {
            $fail('The :attribute is not longer available.');
        }
    }
}
```