### PR TITLE
[12.x] Add `in_array_keys` validation rule to check for presence of specified array keys

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -73,6 +73,7 @@ return [
     'image' => 'The :attribute field must be an image.',
     'in' => 'The selected :attribute is invalid.',
     'in_array' => 'The :attribute field must exist in :other.',
+    'in_array_keys' => 'The :attribute field must contain at least one of the following keys: :values.',
     'integer' => 'The :attribute field must be an integer.',
     'ip' => 'The :attribute field must be a valid IP address.',
     'ipv4' => 'The :attribute field must be a valid IPv4 address.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -326,6 +326,24 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the in_array_keys rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceInArrayKeys($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the required_array_keys rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1451,6 +1451,33 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an array has at least one of the given keys.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateInArrayKeys($attribute, $value, $parameters)
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        if (empty($parameters)) {
+            return false;
+        }
+
+        foreach ($parameters as $param) {
+            if (Arr::exists($value, $param)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Validate that an attribute is an integer.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationInArrayKeysTest.php
+++ b/tests/Validation/ValidationInArrayKeysTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationInArrayKeysTest extends TestCase
+{
+    public function testInArrayKeysValidation()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        // Test passes when array has at least one of the specified keys
+        $v = new Validator($trans, ['foo' => ['first_key' => 'bar', 'second_key' => 'baz']], ['foo' => 'in_array_keys:first_key,third_key']);
+        $this->assertTrue($v->passes());
+
+        // Test passes when array has multiple of the specified keys
+        $v = new Validator($trans, ['foo' => ['first_key' => 'bar', 'second_key' => 'baz']], ['foo' => 'in_array_keys:first_key,second_key']);
+        $this->assertTrue($v->passes());
+
+        // Test fails when array doesn't have any of the specified keys
+        $v = new Validator($trans, ['foo' => ['first_key' => 'bar', 'second_key' => 'baz']], ['foo' => 'in_array_keys:third_key,fourth_key']);
+        $this->assertTrue($v->fails());
+
+        // Test fails when value is not an array
+        $v = new Validator($trans, ['foo' => 'not-an-array'], ['foo' => 'in_array_keys:first_key']);
+        $this->assertTrue($v->fails());
+
+        // Test fails when no keys are specified
+        $v = new Validator($trans, ['foo' => ['first_key' => 'bar']], ['foo' => 'in_array_keys:']);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testInArrayKeysValidationWithNestedArrays()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        // Test passes with nested arrays
+        $v = new Validator($trans, [
+            'foo' => [
+                'first_key' => ['nested' => 'value'],
+                'second_key' => 'baz'
+            ]
+        ], ['foo' => 'in_array_keys:first_key,third_key']);
+        $this->assertTrue($v->passes());
+
+        // Test with dot notation for nested arrays
+        $v = new Validator($trans, [
+            'foo' => [
+                'first' => [
+                    'nested_key' => 'value'
+                ]
+            ]
+        ], ['foo.first' => 'in_array_keys:nested_key']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testInArrayKeysValidationErrorMessage()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.in_array_keys' => 'The :attribute field must contain at least one of the following keys: :values.',
+        ], 'en');
+
+        $v = new Validator($trans, ['foo' => ['wrong_key' => 'bar']], ['foo' => 'in_array_keys:first_key,second_key']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals(
+            'The foo field must contain at least one of the following keys: first_key, second_key.',
+            $v->messages()->first('foo')
+        );
+    }
+
+    protected function getIlluminateArrayTranslator()
+    {
+        return new Translator(new ArrayLoader, 'en');
+    }
+}

--- a/tests/Validation/ValidationInArrayKeysTest.php
+++ b/tests/Validation/ValidationInArrayKeysTest.php
@@ -52,7 +52,7 @@ class ValidationInArrayKeysTest extends TestCase
             'foo' => [
                 'first' => [
                     'nested_key' => 'value',
-                ]
+                ],
             ],
         ], ['foo.first' => 'in_array_keys:nested_key']);
         $this->assertTrue($v->passes());

--- a/tests/Validation/ValidationInArrayKeysTest.php
+++ b/tests/Validation/ValidationInArrayKeysTest.php
@@ -43,7 +43,7 @@ class ValidationInArrayKeysTest extends TestCase
             'foo' => [
                 'first_key' => ['nested' => 'value'],
                 'second_key' => 'baz',
-            ]
+            ],
         ], ['foo' => 'in_array_keys:first_key,third_key']);
         $this->assertTrue($v->passes());
 
@@ -53,7 +53,7 @@ class ValidationInArrayKeysTest extends TestCase
                 'first' => [
                     'nested_key' => 'value',
                 ]
-            ]
+            ],
         ], ['foo.first' => 'in_array_keys:nested_key']);
         $this->assertTrue($v->passes());
     }

--- a/tests/Validation/ValidationInArrayKeysTest.php
+++ b/tests/Validation/ValidationInArrayKeysTest.php
@@ -42,7 +42,7 @@ class ValidationInArrayKeysTest extends TestCase
         $v = new Validator($trans, [
             'foo' => [
                 'first_key' => ['nested' => 'value'],
-                'second_key' => 'baz'
+                'second_key' => 'baz',
             ]
         ], ['foo' => 'in_array_keys:first_key,third_key']);
         $this->assertTrue($v->passes());
@@ -51,7 +51,7 @@ class ValidationInArrayKeysTest extends TestCase
         $v = new Validator($trans, [
             'foo' => [
                 'first' => [
-                    'nested_key' => 'value'
+                    'nested_key' => 'value',
                 ]
             ]
         ], ['foo.first' => 'in_array_keys:nested_key']);


### PR DESCRIPTION
### Description

This PR introduces a new validation rule called `in_array_keys` that validates whether an array contains at least one of the specified keys. It is named to follow the convention of existing rules (`in_array` and `required_array_keys`).

### Purpose

While the `required_array_keys` rule exists which ensures all specified keys exist in an array, there is no built-in way to validate that an array has at least one of a given set of keys.

### Usage

```php
$validator = Validator::make($request->all(), [
    'config' => 'array|in_array_keys:api_key,access_token,oauth_token',
    'config.api_key' => 'nullable|string|min:32|max:64',
    'config.access_token' => 'nullable|string|min:40',
    'config.oauth_token' => 'nullable|string|starts_with:oauth_',
]);
```

Let me know if you'd like anything changed or adjusted! Thanks for your time 🙏 