### PR TITLE
[12.x] Add `Rule::contains`

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -261,6 +261,21 @@ class Rule
     }
 
     /**
+     * Get a contains rule builder instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @return \Illuminate\Validation\Rules\Contains
+     */
+    public static function contains($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        return new Rules\Contains(is_array($values) ? $values : func_get_args());
+    }
+
+    /**
      * Compile a set of rules for an attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rules/Contains.php
+++ b/src/Illuminate/Validation/Rules/Contains.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+
+use function Illuminate\Support\enum_value;
+
+class Contains implements Stringable
+{
+    /**
+     * The values that should be contained in the attribute.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new contains rule instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @return void
+     */
+    public function __construct($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->values = is_array($values) ? $values : func_get_args();
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $values = array_map(function ($value) {
+            $value = enum_value($value);
+
+            return '"'.str_replace('"', '""', $value).'"';
+        }, $this->values);
+
+        return 'contains:'.implode(',', $values);
+    }
+}

--- a/tests/Validation/ValidationRuleContainsTest.php
+++ b/tests/Validation/ValidationRuleContainsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+include_once 'Enums.php';
+
+class ValidationRuleContainsTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = Rule::contains('Taylor');
+        $this->assertSame('contains:"Taylor"', (string) $rule);
+
+        $rule = Rule::contains('Taylor', 'Abigail');
+        $this->assertSame('contains:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::contains(['Taylor', 'Abigail']);
+        $this->assertSame('contains:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::contains(collect(['Taylor', 'Abigail']));
+        $this->assertSame('contains:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::contains([ArrayKeys::key_1, ArrayKeys::key_2]);
+        $this->assertSame('contains:"key_1","key_2"', (string) $rule);
+
+        $rule = Rule::contains([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2]);
+        $this->assertSame('contains:"key_1","key_2"', (string) $rule);
+
+        $rule = Rule::contains(['Taylor', 'Taylor']);
+        $this->assertSame('contains:"Taylor","Taylor"', (string) $rule);
+
+        $rule = Rule::contains([1, 2, 3]);
+        $this->assertSame('contains:"1","2","3"', (string) $rule);
+
+        $rule = Rule::contains(['"foo"', '"bar"', '"baz"']);
+        $this->assertSame('contains:"""foo""","""bar""","""baz"""', (string) $rule);
+    }
+
+    public function testContainsValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        // Test fails when value is string
+        $v = new Validator($trans, ['roles' => 'admin'], ['roles' => Rule::contains('editor')]);
+        $this->assertTrue($v->fails());
+
+        // Test passes when array contains the value
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::contains('admin')]);
+        $this->assertTrue($v->passes());
+
+        // Test fails when array doesn't contain all the values
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::contains(['admin', 'editor'])]);
+        $this->assertTrue($v->fails());
+
+        // Test fails when array doesn't contain all the values (using multiple arguments)
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::contains('admin', 'editor')]);
+        $this->assertTrue($v->fails());
+
+        // Test passes when array contains all the values
+        $v = new Validator($trans, ['roles' => ['admin', 'user', 'editor']], ['roles' => Rule::contains(['admin', 'editor'])]);
+        $this->assertTrue($v->passes());
+
+        // Test passes when array contains all the values (using multiple arguments)
+        $v = new Validator($trans, ['roles' => ['admin', 'user', 'editor']], ['roles' => Rule::contains('admin', 'editor')]);
+        $this->assertTrue($v->passes());
+
+        // Test fails when array doesn't contain the value
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::contains('editor')]);
+        $this->assertTrue($v->fails());
+
+        // Test fails when array doesn't contain any of the values
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::contains(['editor', 'manager'])]);
+        $this->assertTrue($v->fails());
+
+        // Test with empty array
+        $v = new Validator($trans, ['roles' => []], ['roles' => Rule::contains('admin')]);
+        $this->assertTrue($v->fails());
+
+        // Test with nullable field
+        $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::contains('admin')]]);
+        $this->assertTrue($v->passes());
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a new `Contains` class and `contains` method to the `Illuminate\Validation\Rule` class.

It compiles into the existing [`contains`](https://laravel.com/docs/12.x/validation#rule-contains) validation rule string to check if an array contains all of the specified values.

### Purpose

Laravel currently includes `Rule::in(...)` and `Rule::array(...)` to assist in creating their respective validation rules that contain enums, constants, and arrayables (collections, etc.). Having a method for the `contains` rule assists in this as well.

### Usage

**Before**:

```php
Validator::make($request->all(), [
    'roles' => [
        'required',
        'array',
        'contains:'.implode(',', array_column([Role::Admin, Role::Editor], 'value')),
    ],
]);
```

**After**:

```php
Validator::make($request->all(), [
    'roles' => [
        'required',
        'array',
        Rule::contains([Role::Admin, Role::Editor]),
    ],
]);
```