### PR TITLE
[12.x] check not empty before concat url

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -724,7 +724,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function url($path)
     {
-        if (isset($this->config['prefix']) && ! empty($this->config['prefix'])) {
+        if (isset($this->config['prefix'])) {
             $path = $this->concatPathToUrl($this->config['prefix'], $path);
         }
 
@@ -846,6 +846,14 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function concatPathToUrl($url, $path)
     {
+        if (empty($url)) {
+            return trim($path, '/');
+        }
+
+        if (empty($path)) {
+            return trim($url, '/');
+        }
+
         return rtrim($url, '/').'/'.ltrim($path, '/');
     }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -724,7 +724,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function url($path)
     {
-        if (isset($this->config['prefix'])) {
+        if (isset($this->config['prefix']) && ! empty($this->config['prefix'])) {
             $path = $this->concatPathToUrl($this->config['prefix'], $path);
         }
 


### PR DESCRIPTION
When using packages that adds a default prefix in filesystem config (example [steffjenl/laravel-azure-blob-storage](https://github.com/steffjenl/laravel-azure-blob-storage)).

The FilesystemAdapter adds a "/" before the path as it only checks if prefix is set not also if its not empty, this may result in a url with double slashes "//".

this pull checks if prefix is not empty before combining it with path