### PR TITLE
[12.x] Introduce `Arr::missing()` helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -528,6 +528,46 @@ class Arr
     }
 
     /**
+     * Check if an item or items are missing in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function missing($array, $keys)
+    {
+        return ! static::has($array, $keys);
+    }
+
+    /**
+     * Determine if any of the keys are missing in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function missingAny($array, $keys)
+    {
+        if (is_null($keys)) {
+            return false;
+        }
+
+        $keys = (array) $keys;
+
+        if (! $array || $keys === []) {
+            return false;
+        }
+
+        foreach ($keys as $key) {
+            if (static::missing($array, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get an integer item from an array using "dot" notation.
      */
     public static function integer(ArrayAccess|array $array, string|int|null $key, ?int $default = null): int


### PR DESCRIPTION
This PR introduces two new methods, `missing()` and `missingAny()`, to the Arr helper class to complement the existing `has()` and `hasAny()` methods. These methods provide a convenient way to check for keys missing in an array using dot notation.

### Key changes in this PR:
- `missing($array, $keys)`:
Checks if all specified keys are missing in the array (inverted result of `has()`).

- `missingAny($array, $keys)`:
Checks if any of the specified keys are missing from the array.

### Behavior:
- `missing()` simply returns the inverse boolean of has() to preserve single responsibility and avoid code duplication.

- `missingAny()` iterates over keys and returns true immediately if any key is missing.