### PR TITLE
fix(cache/redis): use connectionAwareSerialize in RedisStore::putMany()

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -140,7 +140,7 @@ class RedisStore extends TaggableStore implements LockProvider
         $serializedValues = [];
 
         foreach ($values as $key => $value) {
-            $serializedValues[$this->prefix.$key] = $this->serialize($value);
+            $serializedValues[$this->prefix.$key] = $this->connectionAwareSerialize($value, $connection);
         }
 
         $connection->multi();


### PR DESCRIPTION
Cache RedisStore::putMany() should not serialize values if the connection already uses serialization.  

This prevents a bug with the following setup:  
* Using Redis cache driver  
* Using phpredis client  
* Configuring phpredis to use serialization - eg `"serializer" => Redis::SERIALIZER_IGBINARY`  

When using `Cache::flexible()`, the value returned is correct only the first time. Subsequent calls return a PHP serialized value:  

```
> Cache::flexible('test:flex', [now()->addHours(12), now()->addHours(24)], fn () => ["test" => "ok"] )
= [
    "test" => "ok",
  ]

> Cache::flexible('test:flex', [now()->addHours(12), now()->addHours(24)], fn () => ["test" => "ok"])
= "a:1:{s:4:"test";s:2:"ok";}"
```

This is caused by `RedisStore::putMany()` method, which - contrarily to other methods in this class - doesn't use `RedisStore::connectionAwareSerialize`.  
In the meantime, `RedisStore::many()` method uses  `RedisStore::connectionAwareUnserialize()`, so it _doesn't_ unserialize the value that is returned.  

This PR fixes this inconsistent behavior by changing  `RedisStore::putMany()` so it uses `RedisStore::connectionAwareSerialize`.  

The result is what one should expect:  
```
> Cache::flexible('test:flex', [now()->addHours(12), now()->addHours(24)], fn () => ["test" => "ok"] )
= [
    "test" => "ok",
  ]

> Cache::flexible('test:flex', [now()->addHours(12), now()->addHours(24)], fn () => ["test" => "ok"] )
= [
    "test" => "ok",
  ]
```
