### PR TITLE
[12.x] Introducing `Arr::hasAll`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -510,15 +510,13 @@ class Arr
             return false;
         }
 
-        $result = true;
-
         foreach ($keys as $key) {
             if (! static::has($array, $key)) {
-                $result = false;
+                return false;
             }
         }
 
-        return $result;
+        return true;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -496,6 +496,32 @@ class Arr
     }
 
     /**
+     * Determine if all keys exist in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function hasAll($array, $keys)
+    {
+        $keys = (array) $keys;
+
+        if (! $array || $keys === []) {
+            return false;
+        }
+
+        $result = true;
+
+        foreach ($keys as $key) {
+            if (! static::has($array, $key)) {
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Determine if any of the keys exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -702,6 +702,26 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has([], ['']));
     }
 
+    public function testHasAllMethod()
+    {
+        $array = ['name' => 'Taylor', 'age' => '', 'city' => null];
+        $this->assertTrue(Arr::hasAll($array, 'name'));
+        $this->assertTrue(Arr::hasAll($array, 'age'));
+        $this->assertTrue(Arr::hasAll($array, 'city'));
+        $this->assertTrue(Arr::hasAll($array, ['name', 'age', 'city']));
+
+        $array = ['user' => ['name' => 'Taylor']];
+        $this->assertTrue(Arr::hasAll($array, 'user.name'));
+        $this->assertFalse(Arr::hasAll($array, 'user.age'));
+
+        $array = ['name' => 'Taylor', 'age' => '', 'city' => null];
+        $this->assertFalse(Arr::hasAll($array, 'foo'));
+        $this->assertFalse(Arr::hasAll($array, 'bar'));
+        $this->assertFalse(Arr::hasAll($array, 'baz'));
+        $this->assertFalse(Arr::hasAll($array, 'bah'));
+        $this->assertFalse(Arr::hasAll($array, ['foo', 'bar', 'baz', 'bar']));
+    }
+
     public function testHasAnyMethod()
     {
         $array = ['name' => 'Taylor', 'age' => '', 'city' => null];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -707,8 +707,11 @@ class SupportArrTest extends TestCase
         $array = ['name' => 'Taylor', 'age' => '', 'city' => null];
         $this->assertTrue(Arr::hasAll($array, 'name'));
         $this->assertTrue(Arr::hasAll($array, 'age'));
+        $this->assertFalse(Arr::hasAll($array, ['age', 'car']));
         $this->assertTrue(Arr::hasAll($array, 'city'));
+        $this->assertFalse(Arr::hasAll($array, ['city', 'some']));
         $this->assertTrue(Arr::hasAll($array, ['name', 'age', 'city']));
+        $this->assertFalse(Arr::hasAll($array, ['name', 'age', 'city', 'country']));
 
         $array = ['user' => ['name' => 'Taylor']];
         $this->assertTrue(Arr::hasAll($array, 'user.name'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Continuation of https://github.com/laravel/framework/pull/55770, https://github.com/laravel/framework/pull/26543

---

Previously, I made a new attempt to introduce `hasAll` due to frequent needs, but for the wrong target, Collections. Following PR https://github.com/laravel/framework/pull/55770 I am now targeting the correct place, the _Arr_ helper.

### Example

```php
use Illuminate\Support\Arr;

$array = ['name' => 'Taylor', 'language' => 'php'];

Arr::hasAll($array, ['name']); // ✅
Arr::hasAll($array, ['name', 'language']); // ✅
Arr::hasAll($array, ['name', 'ide']); // ❌, $array does not have all these keys
```

Although there are _manual ways - PHP only_, to achieve the same result without relying on the _Arr_ helper, this brings benefits to framework users in favor of having a helper ready to use, without relying on framework macros or _PHP_ codes written when necessary.

Behind the scenes, [we ensure that we use the native `has`](https://github.com/laravel/framework/pull/55815/files#diff-3327c2ea79edc991c709e353854136a6569c610c5342f8bff02d633391bb9f21R515-R519), so that dot notation is fully supported in it.