### PR TITLE
[12.x] Restore lazy loading check

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -562,7 +562,7 @@ trait HasAttributes
             return $this->relations[$key];
         }
 
-        if ($this->preventsLazyLoading && ! self::isAutomaticallyEagerLoadingRelationships()) {
+        if ($this->preventsLazyLoading) {
             $this->handleLazyLoadingViolation($key);
         }
 


### PR DESCRIPTION
This reverts https://github.com/laravel/framework/pull/55771

I (and some other people) don't see much point in that change. If `automaticallyEagerLoadingRelationships` is working correctly then the code will not reach this point. If it's wrong in some situations (packages or some complex cases) then we should see the exception but after that change we won't.

`automaticallyEagerLoadingRelationships` works with `preventLazyLoading` nicely so why do we need disable this check?