### PR TITLE
Add `Str::split` Method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2083,4 +2083,17 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Split a string by a given separator.
+     *
+     * @param  string  $separator
+     * @param  string  $string
+     * @param  int  $limit
+     * @return array
+     */
+    public static function split(string $separator, string $string, int $limit = PHP_INT_MAX)
+    {
+        return explode($separator, $string, $limit);
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1823,7 +1823,6 @@ class SupportStrTest extends TestCase
         $this->assertSame(explode(',', ''), Str::split(',', ''));
         $this->assertSame(explode(',', 'no-separator'), Str::split(',', 'no-separator'));
     }
-
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1814,6 +1814,16 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testSplit()
+    {
+        $this->assertSame(explode(',', 'foo,bar'), Str::split(',', 'foo,bar'));
+        $this->assertSame(explode('-', 'one-two-three'), Str::split('-', 'one-two-three'));
+        $this->assertSame(explode(',', 'first,second,third', 2), Str::split(',', 'first,second,third', 2));
+        $this->assertSame(explode(',', ''), Str::split(',', ''));
+        $this->assertSame(explode(',', 'no-separator'), Str::split(',', 'no-separator'));
+    }
+
 }
 
 class StringableObjectStub


### PR DESCRIPTION
### Summary

This PR adds a new `Str::split` method to the `Illuminate\Support\Str` class. It wraps PHP’s native `explode()` function and provides an expressive, Laravel-style interface for splitting strings.

### Why This Is Needed

Many developers working in Laravel also work with other languages like JavaScript, Python, or Ruby, where the method to divide a string is commonly named `split`. In PHP, however, the equivalent function is `explode`, which can feel inconsistent or unintuitive when switching between languages.

Adding `Str::split` helps:

* **Bridge that mental gap** for multi-language developers
* **Align string API naming** with familiar terminology from JavaScript (`'foo,bar'.split(',')`), Python (`'foo,bar'.split(',')`), etc.
* Improve code readability and expressiveness within Laravel projects

### Features

* Splits a string using a specified separator
* Supports an optional `$limit` parameter, just like `explode()`
* Returns an array of string segments

### Example Usage

```php
Str::split('-', 'laravel-framework');
// ['laravel', 'framework']

Str::split(',', 'one,two,three,four', 3);
// ['one', 'two', 'three,four']
```

### Tests

* Thorough unit tests added to `SupportStrTest`
* Matches behavior of native `explode()` for reliability


### Documentation

The documentation for the new method has been added to the relevant section of the Laravel documentation in PR [#10428](https://github.com/laravel/docs/pull/10428), following the existing format and style for consistency.

