### PR TITLE
Support PHP 8.4 property hooks as virtual Eloquent attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -460,6 +460,7 @@ trait HasAttributes
             array_key_exists($key, $this->casts) ||
             $this->hasGetMutator($key) ||
             $this->hasAttributeMutator($key) ||
+            $this->hasPropertyHook($key) ||
             $this->isClassCastable($key);
     }
 
@@ -668,6 +669,22 @@ trait HasAttributes
         return static::$attributeMutatorCache[get_class($this)][$key] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
+    }
+
+    protected function hasPropertyHook(string $key): bool
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            return false;
+        }
+
+        try {
+            $property = (new ReflectionClass($this))->getProperty($key);
+        } catch (\ReflectionException) {
+            // Property doesn't exist.
+            return false;
+        }
+
+        return $property->getHooks() !== [];
     }
 
     /**

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseConcernsHasAttributesTest extends TestCase
@@ -60,6 +61,24 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         unset($instance->cacheableProperty);
 
         $this->assertFalse($instance->cachedAttributeIsset('cacheableProperty'));
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testCanCastAttributeWithGetPropertyHook()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->first_name = 'John';
+        $class->last_name = 'Doe';
+        $this->assertSame('John Doe', $class->full_name);
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testCanCastAttributeWithSetPropertyHook()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->full_name = 'John Doe';
+        $this->assertEquals('John', $class->first_name);
+        $this->assertEquals('Doe', $class->last_name);
     }
 }
 

--- a/tests/Database/stubs/EloquentModelWithPropertyHook.php
+++ b/tests/Database/stubs/EloquentModelWithPropertyHook.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+return new class extends Model
+{
+    public $attributes = [
+        'first_name' => null,
+        'last_name' => null,
+    ];
+
+    public string $full_name {
+        get => "$this->first_name $this->last_name";
+        set (string $value) {
+            [$firstName, $lastName] = explode(' ', $value);
+            $this->attributes['first_name'] = $firstName;
+            $this->attributes['last_name'] = $lastName;
+        }
+    }
+};


### PR DESCRIPTION
This PR adds support for treating PHP 8.4+ property hooks as attributes in hasAttribute(). This enables native getter/setter hooks to be recognized during attribute resolution, similar to mutators.

Only applies on PHP >= 8.4 and doesn’t affect existing behavior or lower versions.

I’m not a regular Laravel contributor, so please let me know if I’ve overlooked any edge cases or conventions.