### PR TITLE
[12.x] style: Use null coalescing assignment (??=) for cleaner code

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -66,7 +66,7 @@ class AuthManager implements FactoryContract
     {
         $name = $name ?: $this->getDefaultDriver();
 
-        return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
+        return $this->guards[$name] ??= $this->resolve($name);
     }
 
     /**


### PR DESCRIPTION
This PR includes a small but meaningful syntax improvement. The original code was:

```
return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
```

This checks whether `$this->guards[$name]` exists, and if not, assigns it a resolved value.

It has been replaced with the more concise and modern null coalescing assignment operator (`??=`) available since PHP 7.4:

```
return $this->guards[$name] ??= $this->resolve($name);
```

This change improves code readability and leverages modern PHP syntax without altering functionality.