### PR TITLE
[12.x] Allow more pagination options in resource collections

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -255,9 +255,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Include pagination headers in the response
+     * Include pagination headers in the response.
      *
-     * @param bool $value
+     * @param  bool  $value
      * @return void
      */
     public static function withPaginationHeaders($value = true)
@@ -266,7 +266,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Disable pagination headers in the response
+     * Disable pagination headers in the response.
      *
      * @return void
      */

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,6 +50,20 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static $wrap = 'data';
 
     /**
+     * Should pagination 'links' and 'meta' should be included in the response body.
+     *
+     * @var bool
+     */
+    public static $withPagination = true;
+
+    /**
+     * Should pagination 'links' and 'meta' should be included in the response header.
+     *
+     * @var bool
+     */
+    public static $withPaginationHeaders = false;
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  $resource
@@ -218,6 +232,47 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static function withoutWrapping()
     {
         static::$wrap = null;
+    }
+
+    /**
+     * Enable pagination within the resource array.
+     *
+     * @return void
+     */
+    public static function paginate($value)
+    {
+        static::$withPagination = $value;
+    }
+
+    /**
+     * Disable pagination within the resource array.
+     *
+     * @return void
+     */
+    public static function withoutPagination()
+    {
+        static::$withPagination = false;
+    }
+
+    /**
+     * Include pagination headers in the response
+     *
+     * @param bool $value
+     * @return void
+     */
+    public static function withPaginationHeaders($value = true)
+    {
+        static::$withPaginationHeaders = $value;
+    }
+
+    /**
+     * Disable pagination headers in the response
+     *
+     * @return void
+     */
+    public static function withoutPaginationHeaders()
+    {
+        static::$withPaginationHeaders = false;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Resources\Json;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 class PaginatedResourceResponse extends ResourceResponse
 {

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -14,17 +14,19 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     public function toResponse($request)
     {
+        $paginationInformation = $this->paginationInformation($request);
+
         return tap(response()->json(
             $this->wrap(
                 $this->resource->resolve($request),
                 array_merge_recursive(
-                    $this->paginationInformation($request),
+                    $this->paginationEnabled() ? $paginationInformation: [],
                     $this->resource->with($request),
                     $this->resource->additional
                 )
             ),
             $this->calculateStatus(),
-            [],
+            $this->paginationHeadersEnabled() ? $this->responseHeaders($paginationInformation) : [],
             $this->resource->jsonOptions()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->map(function ($item) {
@@ -88,6 +90,29 @@ class PaginatedResourceResponse extends ResourceResponse
             'last_page_url',
             'prev_page_url',
             'next_page_url',
+        ]);
+    }
+
+    /**
+     * Get the response headers for the given pagination information.
+     *
+     * @param  array  $pagination
+     * @return array
+     */
+    protected function responseHeaders($pagination)
+    {
+        return array_filter([
+            'X-Pagination-Current-Page' => $pagination['meta']['current_page'] ?? null,
+            'X-Pagination-From' => $pagination['meta']['from'] ?? null,
+            'X-Pagination-Last-Page' => $pagination['meta']['last_page'] ?? null,
+            'X-Pagination-Path' => $pagination['meta']['path'] ?? null,
+            'X-Pagination-Per-Page' => $pagination['meta']['per_page'] ?? null,
+            'X-Pagination-To' => $pagination['meta']['to'] ?? null,
+            'X-Pagination-Total' => $pagination['meta']['total'] ?? null,
+            'X-Pagination-Links-First' => $pagination['links']['first'] ?? null,
+            'X-Pagination-Links-Last' => $pagination['links']['last'] ?? null,
+            'X-Pagination-Links-Prev' => $pagination['links']['prev'] ?? null,
+            'X-Pagination-Links-Next' => $pagination['links']['next'] ?? null,
         ]);
     }
 }

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -20,7 +20,7 @@ class PaginatedResourceResponse extends ResourceResponse
             $this->wrap(
                 $this->resource->resolve($request),
                 array_merge_recursive(
-                    $this->paginationEnabled() ? $paginationInformation: [],
+                    $this->paginationEnabled() ? $paginationInformation : [],
                     $this->resource->with($request),
                     $this->resource->additional
                 )

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -109,6 +109,26 @@ class ResourceResponse implements Responsable
     }
 
     /**
+     * Get whether the resource has enabled pagination headers.
+     *
+     * @return bool
+     */
+    protected function paginationEnabled()
+    {
+        return get_class($this->resource)::$withPagination;
+    }
+
+    /**
+     * Get whether the resource has enabled pagination headers.
+     *
+     * @return bool
+     */
+    protected function paginationHeadersEnabled()
+    {
+        return get_class($this->resource)::$withPaginationHeaders;
+    }
+
+    /**
      * Calculate the appropriate status code for the response.
      *
      * @return int

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithHeaderPagination.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithHeaderPagination.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithHeaderPagination extends ResourceCollection
+{
+    public static $withPagination = false;
+    public static $withPaginationHeaders = true;
+
+    public static $wrap = null;
+
+    public $collects = PostResource::class;
+}

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
@@ -24,4 +24,14 @@ class PostCollectionResourceWithPaginationInformation extends ResourceCollection
             'total_page' => $paginated['last_page'],
         ];
     }
+
+    public function responseHeaders($request, $pagination, $default)
+    {
+        return array_filter([
+            'X-Pagination-Current-Page' => $pagination['current_page'] ?? null,
+            'X-Pagination-Per-Page' => $pagination['per_page'] ?? null,
+            'X-Pagination-Total' => $pagination['total'] ?? null,
+            'X-Pagination-Total-Page' => $pagination['total_page'] ?? null,
+        ]);
+    }
 }

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutPagination.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutPagination.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithoutPagination extends ResourceCollection
+{
+    public static $withPagination = false;
+
+    public $collects = PostResource::class;
+}

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrap.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrap.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithoutWrap extends ResourceCollection
+{
+    public static $withPagination = false;
+
+    public static $wrap = null;
+
+    public $collects = PostResource::class;
+}

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrapAndExtraData.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrapAndExtraData.php
@@ -12,7 +12,8 @@ class PostCollectionResourceWithoutWrapAndExtraData extends ResourceCollection
 
     public $collects = PostResource::class;
 
-    public function with($request) {
+    public function with($request)
+    {
         return [
             'extra_data' => 'extra_value',
         ];

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrapAndExtraData.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithoutWrapAndExtraData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithoutWrapAndExtraData extends ResourceCollection
+{
+    public static $withPagination = false;
+
+    public static $wrap = null;
+
+    public $collects = PostResource::class;
+
+    public function with($request) {
+        return [
+            'extra_data' => 'extra_value',
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -242,7 +242,7 @@ class ResourceTest extends TestCase
         $response->assertHeader('X-Pagination-Links-Last', '/?page=10');
         $response->assertHeader('X-Pagination-Links-Next', '/?page=2');
     }
-    
+
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -242,8 +242,7 @@ class ResourceTest extends TestCase
         $response->assertHeader('X-Pagination-Links-Last', '/?page=10');
         $response->assertHeader('X-Pagination-Links-Next', '/?page=2');
     }
-
-
+    
     public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {


### PR DESCRIPTION
This PR allows more control over the pagination and wrapping in resource collection responses. Note that it leaves default response behaviour unchanged so there are no breaking changes.

This seems to be a pain point that I have run into a few times in the past few years. Others have also had the issue (#37472, #26021).

When using `JsonResource::withoutWrapping()`, any collection responses are still automatically (and perhaps unexpectedly) wrapped to allow pagination within the response:

Single resource:

```php
JsonResource::withoutWrapping();

public function view(MyModel $model): JsonResource
{
    return new MyModelResource($model);
}
```

```js
{
   "id": 123
}
```

Resource collection, wrappers are now back and can't easily be removed without a custom `toResponse()` method:

```php
JsonResource::withoutWrapping();

public function viewAll(): JsonResource
{
    return MyModelResource::collection(MyModel::paginate());
}
```

```js
{
  "data": [
    {
       "id": 123
    }
  ],
  "meta": {...},
  "links": {...}
}
```

This is a little annoying and somewhat unintuitive.

This PR adds some extra static methods and properties to define extra pagination options within collection responses.

## Usage

```php

// As existing, disable wrapping where possible
JsonResource::withoutWrapping();

// Include pagination HTTP headers in the response
JsonResource::withPaginationHeaders();

// Disable pagination in the collection response body, allowing data to be unwrapped
JsonResource::withoutPagination();
```

## Examples

<details>
<summary>1. Include pagination in headers as well as response</summary>

```php
JsonResource::withPaginationHeaders();

public function viewAll(): JsonResource
{
    return MyModelResource::collection(MyModel::paginate());
}
```

```http
HTTP/1.1 200 OK
Server: nginx/1.27.3
Content-Type: application/json
Transfer-Encoding: chunked
Connection: close
X-Powered-By: PHP/8.3.15
SPX-Debug-Profiling-Triggered: 0
X-Pagination-Current-Page: 1
X-Pagination-From: 1
X-Pagination-Last-Page: 1
X-Pagination-Path: https://localhost/api/my-models
X-Pagination-Per-Page: 15
X-Pagination-To: 1
X-Pagination-Total: 1
X-Pagination-Links-First: https://localhost/api/my-models?page=1
X-Pagination-Links-Last: https://localhost/api/my-models?page=1
Cache-Control: no-cache, private
Date: Thu, 22 May 2025 13:56:28 GMT
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 59
Access-Control-Allow-Origin: *

{
  "data": [
    {
       "id": 123
    }
  ],
  "meta": {...},
  "links": {...}
}
```
</details>

<details>
<summary>2. Move pagination to headers only</summary>

```php
JsonResource::withPaginationHeaders();
JsonResource::withoutPagination();

public function viewAll(): JsonResource
{
    return MyModelResource::collection(MyModel::paginate());
}
```

```http
HTTP/1.1 200 OK
Server: nginx/1.27.3
Content-Type: application/json
Transfer-Encoding: chunked
Connection: close
X-Powered-By: PHP/8.3.15
SPX-Debug-Profiling-Triggered: 0
X-Pagination-Current-Page: 1
X-Pagination-From: 1
X-Pagination-Last-Page: 1
X-Pagination-Path: https://localhost/api/my-models
X-Pagination-Per-Page: 15
X-Pagination-To: 1
X-Pagination-Total: 1
X-Pagination-Links-First: https://localhost/api/my-models?page=1
X-Pagination-Links-Last: https://localhost/api/my-models?page=1
Cache-Control: no-cache, private
Date: Thu, 22 May 2025 13:56:28 GMT
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 59
Access-Control-Allow-Origin: *

{
  "data": [
    {
       "id": 123
    },
    {
       "id": 456
    }
  ]
}
```
</details>

<details>
<summary>3. Move pagination to headers only and remove wrapping</summary>

```php
JsonResource::withPaginationHeaders();
JsonResource::withoutPagination();
JsonResource::withoutWrapping();

public function viewAll(): JsonResource
{
    return MyModelResource::collection(MyModel::paginate());
}
```

```http
HTTP/1.1 200 OK
Server: nginx/1.27.3
Content-Type: application/json
Transfer-Encoding: chunked
Connection: close
X-Powered-By: PHP/8.3.15
SPX-Debug-Profiling-Triggered: 0
X-Pagination-Current-Page: 1
X-Pagination-From: 1
X-Pagination-Last-Page: 1
X-Pagination-Path: https://localhost/api/my-models
X-Pagination-Per-Page: 15
X-Pagination-To: 1
X-Pagination-Total: 1
X-Pagination-Links-First: https://localhost/api/my-models?page=1
X-Pagination-Links-Last: https://localhost/api/my-models?page=1
Cache-Control: no-cache, private
Date: Thu, 22 May 2025 13:56:28 GMT
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 59
Access-Control-Allow-Origin: *

[
    {
       "id": 123
    },
    {
       "id": 456
    }
]
```
</details>

## Note

When including extra data within a resource (`MyResource::with()`), wrapping is still re-introduced, as I could not see a clean way of handling this use case without wrapping.