### PR TITLE
[12.x] Remove redundant string casts from config files

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -130,7 +130,7 @@ return [
 
     'previous_keys' => [
         ...array_filter(
-            explode(',', (string) env('APP_PREVIOUS_KEYS', ''))
+            explode(',', env('APP_PREVIOUS_KEYS', ''))
         ),
     ],
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -103,6 +103,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -148,7 +148,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel'), '_').'_database_'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
             'persistent' => env('REDIS_PERSISTENT', false),
         ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -54,7 +54,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', env('LOG_STACK', 'single')),
             'ignore_exceptions' => false,
         ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -46,7 +46,7 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 
         'ses' => [

--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug((string) env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
     ),
 
     /*


### PR DESCRIPTION
Description
---
This PR removes unnecessary string casts from calls to the `env()` helper in Laravel's configuration files.

The `env()` function already returns string values by default for the following, so explicit string casting is redundant.

```php
dump(gettype(env('APP_NAME', 'laravel')));  // "string"
dump(gettype(env('APP_URL', 'http://localhost')));  // "string"
dump(gettype(env('LOG_STACK', 'single')));  // "string"
dump(gettype(env('APP_PREVIOUS_KEYS', '')));  // "string"
```

These casts may also give the misleading impression that `env()` might return non-string values in cases where it does not, potentially confusing developers about the function's behavior. Removing these casts improves code clarity.

Reverts: https://github.com/laravel/framework/pull/55737