### PR TITLE
[12.x] fix: honor 'verify' option in Hash::check and throw exception for invalid algorithms

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -66,7 +66,7 @@ class AuthManager implements FactoryContract
     {
         $name = $name ?: $this->getDefaultDriver();
 
-        return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
+        return $this->guards[$name] ??= $this->resolve($name);
     }
 
     /**

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,13 +22,13 @@ class Argon2IdHasher extends ArgonHasher
             return false;
         }
 
-        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+        $verifyOption = isset($options['verify']) ? (bool) $options['verify'] : null;
 
-        if($verifyOption === false) {
+        if ($verifyOption === false) {
             return password_verify($value, $hashedValue);
         }
 
-        if($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
+        if ($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,6 +22,16 @@ class Argon2IdHasher extends ArgonHasher
             return false;
         }
 
+        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+
+        if($verifyOption === false) {
+            return password_verify($value, $hashedValue);
+        }
+
+        if($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
+            throw new RuntimeException('This password does not use the Bcrypt algorithm.');
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -99,6 +99,16 @@ class ArgonHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
+        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+
+        if($verifyOption === false) {
+            return parent::check($value, $hashedValue, $options);
+        }
+
+        if($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
+            throw new RuntimeException('This password does not use the Argon2i algorithm.');
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -99,13 +99,13 @@ class ArgonHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
-        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+        $verifyOption = isset($options['verify']) ? (bool) $options['verify'] : null;
 
-        if($verifyOption === false) {
+        if ($verifyOption === false) {
             return parent::check($value, $hashedValue, $options);
         }
 
-        if($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
+        if ($verifyOption === true && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }
 

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -84,6 +84,16 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
+        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+
+        if($verifyOption === false) {
+            return parent::check($value, $hashedValue, $options);
+        }
+
+        if($verifyOption === true && $this->isUsingCorrectAlgorithm($hashedValue)) {
+            throw new RuntimeException('This password does not use the Bcrypt algorithm.');
+        }
+
         if ($this->verifyAlgorithm && ! $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -84,13 +84,13 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             return false;
         }
 
-        $verifyOption = isset($options['verify']) ? (bool)$options['verify'] : null;
+        $verifyOption = isset($options['verify']) ? (bool) $options['verify'] : null;
 
-        if($verifyOption === false) {
+        if ($verifyOption === false) {
             return parent::check($value, $hashedValue, $options);
         }
 
-        if($verifyOption === true && $this->isUsingCorrectAlgorithm($hashedValue)) {
+        if ($verifyOption === true && $this->isUsingCorrectAlgorithm($hashedValue)) {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 


### PR DESCRIPTION
In the current version of Laravel, when calling `Hash::check`, passing a `verify` option with a value of `true` or `false` does not affect the behavior as expected.

This can lead to confusion: a developer might expect that setting `verify` to `true` would throw an exception if the hash does not use the correct algorithm. However, the method simply returns a boolean result without any error, regardless of the `verify` value.

This update fixes that issue by properly honoring the `verify` option. Now, when `verify` is explicitly set to `true`, the method will throw an exception if the algorithm is incorrect — aligning the behavior with the developer’s intent.