### PR TITLE
[12.x] Add template variables to scope

### DIFF
--- a/src/Illuminate/Database/Eloquent/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scope.php
@@ -7,8 +7,10 @@ interface Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
+     * @param  TModel  $model
      * @return void
      */
     public function apply(Builder $builder, Model $model);


### PR DESCRIPTION
I run phpstan with max level on [the example from the docs](https://laravel.com/docs/12.x/eloquent#writing-global-scopes):

```
<?php

namespace App\Models\Scopes;

use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\Scope;

class AncientScope implements Scope
{
    /**
     * Apply the scope to a given Eloquent query builder.
     */
    public function apply(Builder $builder, Model $model): void
    {
        $builder->where('created_at', '<', now()->subYears(2000));
    }
}
```

I get the error-message:

```
Method App\Models\Scopes\AncientScope::apply() has parameter $builder with generic class
Illuminate\Database\Eloquent\Builder but does not specify its types: TModel
🪪 missingType.generics
```

Therefore I specify the type like this:

```
<?php

namespace App\Models\Scopes;

use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\Scope;

class AncientScope implements Scope
{
    /**
     * Apply the scope to a given Eloquent query builder.
     *
     * @template TModel of Model
     *
     * @param Builder<TModel> $builder
     * @param TModel $model
     */
    public function apply(Builder $builder, Model $model): void
    {
        $builder->where('created_at', '<', now()->subYears(2000));
    }
}
```

But now I get a different message:

```
Parameter #1 $builder (Illuminate\Database\Eloquent\Builder<TModel of Illuminate\Database\Eloquent\Model>)
of method App\Models\Scopes\AncientScope::apply() should be contravariant with parameter $builder
(Illuminate\Database\Eloquent\Builder) of method Illuminate\Database\Eloquent\Scope::apply()
🪪 method.childParameterType
✏️ app/Models/Scopes/AncientScope.php
```

By setting the templates variable on the scope-interface I can even drop the docblocks on the Ancient-scope and phpstan is all green.