### PR TITLE
[12.x] Add `flip()` method to `Illuminate\Support\Fluent`

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -125,7 +125,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
-     * Flip the items in the instance.
+     * Flip the attributes in the instance.
      *
      * @return static
      */

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -125,6 +125,16 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Flip the items in the instance.
+     *
+     * @return static
+     */
+    public function flip()
+    {
+        return new static(array_flip($this->attributes));
+    }
+
+    /**
      * Get all of the attributes from the fluent instance.
      *
      * @param  array|mixed|null  $keys

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -146,6 +146,28 @@ class SupportFluentTest extends TestCase
         $this->assertEquals(['forge', 'vapour', 'spark'], $fluent->scope('authors.taylor.products')->toArray());
     }
 
+    public function testFlip()
+    {
+        $fluent = new Fluent(['name' => 'taylor', 'framework' => 'laravel']);
+        $flipped = $fluent->flip();
+
+        $this->assertEquals(['taylor' => 'name', 'laravel' => 'framework'], $flipped->toArray());
+        $this->assertInstanceOf(Fluent::class, $flipped);
+
+        // Test with numeric keys
+        $fluent = new Fluent(['a', 'b', 'c']);
+        $flipped = $fluent->flip();
+
+        $this->assertEquals(['a' => 0, 'b' => 1, 'c' => 2], $flipped->toArray());
+
+        // Test that original fluent is unchanged
+        $original = new Fluent(['foo' => 'bar']);
+        $flipped = $original->flip();
+
+        $this->assertEquals(['foo' => 'bar'], $original->toArray());
+        $this->assertEquals(['bar' => 'foo'], $flipped->toArray());
+    }
+
     public function testToCollection()
     {
         $fluent = new Fluent(['forge', 'vapour', 'spark']);


### PR DESCRIPTION
### Description

This PR adds a `flip()` method to the `Illuminate\Support\Fluent` class that creates a new instance with keys exchanged with their corresponding values, similar to the existing `flip()` method available on Collections.

### Usage

```php
Fluent::make([
    'name' => 'Taylor', 
    'framework' => 'Laravel',
])->flip();

// Result: [
//    'Taylor' => 'name', 
//    'Laravel' => 'framework',
// ]

Fluent::make([
    'apple',
    'banana',
    'cherry'
])->flip();

// Result: [
//    'apple' => 0,
//    'banana' => 1,
//    'cherry' => 2,
// ]
```