### PR TITLE
[12.x] Fix `ResponseFactory` should also accept `null` callback

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -186,14 +186,14 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new streamed response instance.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  int  $status
      * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function stream($callback, $status = 200, array $headers = [])
     {
-        if ((new ReflectionFunction($callback))->isGenerator()) {
+        if (! is_null($callback) && (new ReflectionFunction($callback))->isGenerator()) {
             return new StreamedResponse(function () use ($callback) {
                 foreach ($callback() as $chunk) {
                     echo $chunk;


### PR DESCRIPTION
`Symfony\Component\HttpFoundation\StreamedResponse` supports `callable|null` but we currently expect `$callback` to just be `Closure`.

Fixes #55831

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
