### PR TITLE
Add schedule:display-cache artisan command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleDisplayCacheCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleDisplayCacheCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schedule:display-cache')]
+class ScheduleDisplayCacheCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:display-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Display the cached mutex files created by scheduler';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function handle(Schedule $schedule)
+    {
+        $existingMutex = false;
+
+        foreach ($schedule->events($this->laravel) as $event) {
+            if ($event->mutex->exists($event)) {
+                $this->components->info(sprintf('Existing mutex for [%s]', $event->command));
+
+                $existingMutex = true;
+            }
+        }
+
+        if (! $existingMutex) {
+            $this->components->info('No mutex files were found.');
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Cache\Console\PruneStaleTagsCommand;
 use Illuminate\Concurrency\Console\InvokeSerializedClosureCommand;
 use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
+use Illuminate\Console\Scheduling\ScheduleDisplayCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleInterruptCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
@@ -164,6 +165,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleList' => ScheduleListCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
         'ScheduleClearCache' => ScheduleClearCacheCommand::class,
+        'ScheduleDisplayCache' => ScheduleDisplayCacheCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'ScheduleInterrupt' => ScheduleInterruptCommand::class,


### PR DESCRIPTION
When our app instances are restarted/killed during an app deployment, if any scheduler task was running, the scheduler mutex gets locked until it expires. We need a way to check if there is any mutex locked in order to clear them manually.

This PR adds a `php artisan schedule:display-cache` command, the equivalent of `php artisan schedule:clear-cache` command but just to display existing mutex