### PR TITLE
Add support for sending raw (non-encoded) attachments in Resend mail

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -72,12 +72,19 @@ class ResendTransport extends AbstractTransport
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
                 $attachmentHeaders = $attachment->getPreparedHeaders();
+                $contentType = $attachmentHeaders->get('Content-Type')->getBody();
 
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
+                if($contentType == 'text/calendar') {
+                    $content = $attachment->getBody();
+                } else {
+                    $content = str_replace("\r\n", '', $attachment->bodyToString());
+                }
+
                 $item = [
-                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
-                    'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                    'content_type' => $contentType,
+                    'content' => $content,
                     'filename' => $filename,
                 ];
 

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -76,7 +76,7 @@ class ResendTransport extends AbstractTransport
 
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
-                if($contentType == 'text/calendar') {
+                if ($contentType == 'text/calendar') {
                     $content = $attachment->getBody();
                 } else {
                     $content = str_replace("\r\n", '', $attachment->bodyToString());


### PR DESCRIPTION
(This is the same PR as https://github.com/laravel/framework/pull/55803, but then for V11.)

This PR adds support for sending raw (non-base64 encoded) attachments in the Resend mail driver, which is useful for cases like sending .ics (calendar) files. 

The Resend API currently does not properly handle base64-encoded .ics attachments. As a workaround, this PR allows certain attachments (e.g., with the text/calendar MIME type) to be sent as raw content without encoding.

## Changes
Introduces conditional logic in ResendTransport to skip encoding when the attachment has a media type of text/calendar

## Why this is needed
- Resend currently fails to decode base64 .ics attachments properly.
- Users sending calendar invites need the .ics file to be sent as plain text for compatibility with calendar clients.
