### PR TITLE
[12.x] Support PHP 8.4 property hooks as virtual Eloquent attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -671,7 +671,7 @@ trait HasAttributes
                     $returnType->getName() === Attribute::class;
     }
 
-    protected function hasPropertyHook(string $key): bool
+    protected function hasPropertyHook(string $key, ?string $propertyHookType = null): bool
     {
         if (version_compare(phpversion(), '8.4.0', '<')) {
             return false;
@@ -682,6 +682,10 @@ trait HasAttributes
         } catch (\ReflectionException) {
             // Property doesn't exist.
             return false;
+        }
+
+        if ($propertyHookType) {
+            return $property->hasHook(\PropertyHookType::from($propertyHookType));
         }
 
         return $property->getHooks() !== [];
@@ -1058,6 +1062,9 @@ trait HasAttributes
             return $this->setMutatedAttributeValue($key, $value);
         } elseif ($this->hasAttributeSetMutator($key)) {
             return $this->setAttributeMarkedMutatedAttributeValue($key, $value);
+        } elseif ($this->hasPropertyHook($key, 'set')) {
+            $this->{$key} = $value;
+            return;
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2304,6 +2304,8 @@ trait HasAttributes
             return $this->mutateAttribute($key, $value);
         } elseif ($this->hasAttributeGetMutator($key)) {
             return $this->mutateAttributeMarkedAttribute($key, $value);
+        } elseif ($this->hasPropertyHook($key)) {
+            return $this->{$key};
         }
 
         // If the attribute exists within the cast array, we will convert it to

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -460,6 +460,7 @@ trait HasAttributes
             array_key_exists($key, $this->casts) ||
             $this->hasGetMutator($key) ||
             $this->hasAttributeMutator($key) ||
+            $this->hasPropertyHook($key) ||
             $this->isClassCastable($key);
     }
 
@@ -668,6 +669,22 @@ trait HasAttributes
         return static::$attributeMutatorCache[get_class($this)][$key] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
+    }
+
+    protected function hasPropertyHook(string $key): bool
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            return false;
+        }
+
+        try {
+            $property = (new ReflectionClass($this))->getProperty($key);
+        } catch (\ReflectionException) {
+            // Property doesn't exist.
+            return false;
+        }
+
+        return $property->getHooks() !== [];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1869,6 +1869,7 @@ trait HasAttributes
     {
         $this->mergeAttributesFromClassCasts();
         $this->mergeAttributesFromAttributeCasts();
+        $this->mergeAttributesFromPropertyHooks();
     }
 
     /**
@@ -1914,6 +1915,27 @@ trait HasAttributes
                     $key, $callback($value, $this->attributes)
                 )
             );
+        }
+    }
+
+    /**
+     * Merge the property hooked attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromPropertyHooks()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            return;
+        }
+
+        foreach ((new ReflectionClass($this))->getProperties() as $property) {
+            if (! $property->hasHook(\PropertyHookType::Get)) {
+                continue;
+            }
+
+            $name = $property->getName();
+            $this->attributes[$name] = $this->{$name};
         }
     }
 

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseConcernsHasAttributesTest extends TestCase
@@ -60,6 +61,24 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         unset($instance->cacheableProperty);
 
         $this->assertFalse($instance->cachedAttributeIsset('cacheableProperty'));
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testCanCastAttributeWithGetPropertyHook()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->first_name = 'John';
+        $class->last_name = 'Doe';
+        $this->assertSame('John Doe', $class->full_name);
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testCanCastAttributeWithSetPropertyHook()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->full_name = 'John Doe';
+        $this->assertEquals('John', $class->first_name);
+        $this->assertEquals('Doe', $class->last_name);
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -52,6 +52,7 @@ use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
@@ -591,6 +592,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(isset($model['table']));
         $this->assertEquals(null, $model['table']);
         $this->assertFalse(isset($model['with']));
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testArrayAccessReturnsValueFromPropertyHook()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->first_name = 'John';
+        $class->last_name = 'Doe';
+
+        $this->assertTrue(isset($class['full_name']));
+        $this->assertSame('John Doe', $class['full_name']);
     }
 
     public function testOnly()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1600,6 +1600,30 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('bar', $model->age);
     }
 
+    #[RequiresPhp('>= 8.4.0')]
+    public function testPropertyHookedAttributeIsFillable()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->fill([
+            'full_name' => 'John Doe',
+        ]);
+
+        $this->assertSame('John', $class->first_name);
+        $this->assertSame('Doe', $class->last_name);
+    }
+
+    #[RequiresPhp('>= 8.4.0')]
+    public function testPropertyHookedAttributeIsFillableViaConstructor()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class = new $class([
+            'full_name' => 'John Doe',
+        ]);
+
+        $this->assertSame('John', $class->first_name);
+        $this->assertSame('Doe', $class->last_name);
+    }
+
     public function testQualifyColumn()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -618,6 +618,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('John Doe', $class['full_name']);
     }
 
+    #[RequiresPhp('>= 8.4.0')]
+    public function testPropertyHookedAttributeCanBeSetViaArrayAccess()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class['full_name'] = 'John Doe';
+
+        $this->assertSame('John', $class->first_name);
+        $this->assertSame('Doe', $class->last_name);
+    }
+
     public function testOnly()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -580,6 +580,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($hash, $model->password_hash);
     }
 
+    #[RequiresPhp('>= 8.4.0')]
+    public function testPropertyHookedAttributeIsInTheAttributesArray()
+    {
+        $class = require __DIR__.'/stubs/EloquentModelWithPropertyHook.php';
+        $class->first_name = 'John';
+        $class->last_name = 'Doe';
+
+        $attributes = $class->getAttributes();
+        $this->assertArrayHasKey('full_name', $attributes);
+        $this->assertSame('John Doe', $attributes['full_name']);
+        $this->assertSame('John Doe', $class->getAttribute('full_name'));
+    }
+
     public function testArrayAccessToAttributes()
     {
         $model = new EloquentModelStub(['attributes' => 1, 'connection' => 2, 'table' => 3]);

--- a/tests/Database/stubs/EloquentModelWithPropertyHook.php
+++ b/tests/Database/stubs/EloquentModelWithPropertyHook.php
@@ -4,6 +4,10 @@ use Illuminate\Database\Eloquent\Model;
 
 return new class extends Model
 {
+    protected $fillable = [
+        'full_name',
+    ];
+
     public $attributes = [
         'first_name' => null,
         'last_name' => null,

--- a/tests/Database/stubs/EloquentModelWithPropertyHook.php
+++ b/tests/Database/stubs/EloquentModelWithPropertyHook.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+return new class extends Model
+{
+    public $attributes = [
+        'first_name' => null,
+        'last_name' => null,
+    ];
+
+    public string $full_name {
+        get => "$this->first_name $this->last_name";
+        set (string $value) {
+            [$firstName, $lastName] = explode(' ', $value);
+            $this->attributes['first_name'] = $firstName;
+            $this->attributes['last_name'] = $lastName;
+        }
+    }
+};


### PR DESCRIPTION
This PR adds support for treating PHP 8.4+ property hooks as Model attributes, and continues the work started in https://github.com/laravel/framework/pull/55822.

Only applies on PHP >= 8.4 and doesn’t affect existing behavior or lower versions.