### PR TITLE
[12.x] Allow for specifying a future date for soft deletion

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -22,7 +22,11 @@ class SoftDeletingScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereNull($model->getQualifiedDeletedAtColumn());
+        $builder->where(function (Builder $query) use ($model) {
+            $query
+                ->whereNull($model->getQualifiedDeletedAtColumn())
+                ->orWhere($model->getQualifiedDeletedAtColumn(), '>', now());
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1072,13 +1072,14 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRealNestedWhereWithScopes()
     {
+        Carbon::setTestNow($now = now());
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) {
             $query->where('baz', '>', 9000);
         });
-        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
-        $this->assertEquals(['bar', 9000], $query->getBindings());
+        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and ("table"."deleted_at" is null or "table"."deleted_at" > ?)', $query->toSql());
+        $this->assertEquals(['bar', 9000, $now], $query->getBindings());
     }
 
     public function testRealNestedWhereWithScopesMacro()
@@ -1094,13 +1095,14 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testRealNestedWhereWithMultipleScopesAndOneDeadScope()
     {
+        Carbon::setTestNow($now = now());
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->empty()->where('foo', '=', 'bar')->empty()->where(function ($query) {
             $query->empty()->where('baz', '>', 9000);
         });
-        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
-        $this->assertEquals(['bar', 9000], $query->getBindings());
+        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and ("table"."deleted_at" is null or "table"."deleted_at" > ?)', $query->toSql());
+        $this->assertEquals(['bar', 9000, $now], $query->getBindings());
     }
 
     public function testSimpleWhereNot()
@@ -2287,7 +2289,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, '');
         $query = $model->newQuery()->withoutGlobalScopes()->whereIn('foo', $model->newQuery()->select('id'));
-        $expected = 'select * from "table" where "foo" in (select "id" from "table" where "table"."deleted_at" is null)';
+        $expected = 'select * from "table" where "foo" in (select "id" from "table" where ("table"."deleted_at" is null or "table"."deleted_at" > ?))';
         $this->assertEquals($expected, $query->toSql());
     }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -591,7 +591,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
 
         $this->assertSame(
-            'select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null and "posts"."deleted_at" is null',
+            'select * from "posts" where "posts"."user_id" = ? and "posts"."user_id" is not null and ("posts"."deleted_at" is null or "posts"."deleted_at" > ?)',
             $abigail->posts()->toSql()
         );
     }
@@ -684,7 +684,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     public function testSoftDeleteIsAppliedToNewQuery()
     {
         $query = (new SoftDeletesTestUser)->newQuery();
-        $this->assertSame('select * from "users" where "users"."deleted_at" is null', $query->toSql());
+        $this->assertSame('select * from "users" where ("users"."deleted_at" is null or "users"."deleted_at" > ?)', $query->toSql());
     }
 
     public function testSecondLevelRelationshipCanBeSoftDeleted()


### PR DESCRIPTION
This PR updates the `SoftDeletingScope` to allow for setting a future `deleted_at`.

Currently, if you set `deleted_at` on your model manually to a timestamp that is in the future, the `SoftDeletingScope` deems this as deleted, even though we haven't reached the `deleted_at` timestamp yet. This is because the current behaviour simply checks whether the column is `null` or has a value set.

With this PR, you will now be able to set a future `deleted_at` timestamp and only have the model to be considered soft-deleted once that timestamp has been reached.
