### PR TITLE
Add a json() helper function as a shortcut for response()->json()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -529,6 +529,14 @@ if (! function_exists('with')) {
 
 
 if(!function_exists('json')){
+    /** 
+     *  A shortcut for response()->json()
+     * @param $data
+     * @param int $status
+     * @param array $headers
+     * @param int $options
+     * @return \Illuminate\Http\JsonResponse
+     */
     function json(
         $data = [],
         $status = 200,

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -526,3 +526,16 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+
+if(!function_exists('json')){
+    function json(
+        $data = [],
+        $status = 200,
+        array $headers = [],
+        $options = 0
+    ) {
+        return response()->json($data, $status, $headers, $options);
+    }
+}
+


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This helper provides a quick way to achieve the same result as response()->json() which is more longer and verbose. 

Usage : 
`return json()` 
