### PR TITLE
Add BelongsToMany::pivot() and HasMany::toMany()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -176,6 +176,16 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Convert the relationship to a "has many" relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<TPivotModel>
+     */
+    public function pivot()
+    {
+        return new HasMany($this->getQuery(), $this->parent, $this->foreignPivotKey, $this->relatedPivotKey);
+    }
+
+    /**
      * Attempt to resolve the intermediate table name from the given string.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Support\Str;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -231,7 +231,7 @@ class EloquentHasManyTestUser2 extends Model
 
     public function articles(): BelongsToMany
     {
-        return $this->authorship()->toMany(EloquentHasManyTestArticle::class/*, localKey: 'author_id'*/);
+        return $this->authorship()->toMany(EloquentHasManyTestArticle::class);
     }
 }
 

--- a/tests/Integration/Database/EloquentHasManyTest.php
+++ b/tests/Integration/Database/EloquentHasManyTest.php
@@ -204,26 +204,6 @@ class EloquentHasManyTestUser2 extends Model
         return 'eloquent_has_many_test_user_id';
     }
 
-    public function logins(): HasMany
-    {
-        return $this->hasMany(EloquentHasManyTestLogin::class);
-    }
-
-    public function latestLogin(): HasOne
-    {
-        return $this->logins()->one()->latestOfMany('login_time');
-    }
-
-    public function oldestLogin(): HasOne
-    {
-        return $this->logins()->one()->oldestOfMany('login_time');
-    }
-
-    public function posts(): HasMany
-    {
-        return $this->hasMany(EloquentHasManyTestPost::class);
-    }
-
     public function authorship(): HasMany
     {
         return $this->hasMany(EloquentHasManyTestArticleAuthor::class);


### PR DESCRIPTION
# Current situation
When you have many to many relations (let's say `users - article_authors - articles`),
* you may sometimes need only the articles &rarr; `$user->articles`, there you go
* you may sometimes need both &rarr; `$user->article->pivot`, almost as easy
* but if you only need the pivot, you currently need to redefine the whole relation:
```php
class User extends Model
{
    protected $guarded = [];
    public $timestamps = false;

    public function articles(): BelongsToMany
    {
        return $this->belongsToMany(Article::class, Author::class)->using(Author::class);
    }

    public function authorship(): HasMany
    {
        return $this->hasMany(Author::class);
    }
}
```

# Solution
Similar to `$model->hasMany()->one()` and similar, I therefore propose `$this->belongsToMany()->pivot()` and `$this->hasMany()->toMany()`:
```php
class User extends Model
{
    protected $guarded = [];
    public $timestamps = false;

    public function articles(): BelongsToMany
    {
        return $this->belongsToMany(Article::class, Author::class)->using(Author::class);
    }

    public function authorship(): HasMany
    {
        return $this->articles()->pivot();
    }
}

// or the inverse
class User extends Model
{
    protected $guarded = [];
    public $timestamps = false;

    public function authorship(): HasMany
    {
        return $this->hasMany(Author::class);
    }

    public function articles(): BelongsToMany
    {
        return $this->authorship()->toMany(Article::class);
    }
}
```

# Related works/prior art
* #46443/ 38f022d since [v10.4.0](https://github.com/laravel/framework/releases/tag/v10.4.0)
* #45894/ d3a4cd2 since [v9.51.0](https://github.com/laravel/framework/releases/tag/v9.51.0)
