### PR TITLE
[12.x] Replace alias `is_integer()` with `is_int()` to comply with Laravel Pint

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -558,7 +558,7 @@ class Arr
     {
         $value = Arr::get($array, $key, $default);
 
-        if (! is_integer($value)) {
+        if (! is_int($value)) {
             throw new InvalidArgumentException(
                 sprintf('Array value for key [%s] must be an integer, %s found.', $key, gettype($value))
             );


### PR DESCRIPTION
Updated the `Arr::integer()` method to use `is_int()` instead of its alias `is_integer()`.

This change improves code consistency and aligns with Laravel Pint's no_alias_functions rule.