### PR TITLE
[12.x] Introduce `Str::ucwords`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1811,6 +1811,19 @@ class Str
     }
 
     /**
+     * Make each word's first character uppercase in a string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function ucwords($string)
+    {
+        return (new Collection(explode($string, ' ')))
+            ->map(fn ($word) => static::ucfirst($word))
+            ->join(' ');
+    }
+
+    /**
      * Split a string into pieces by uppercase characters.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1818,7 +1818,7 @@ class Str
      */
     public static function ucwords($string)
     {
-        return (new Collection(explode($string, ' ')))
+        return (new Collection(explode(' ', $string)))
             ->map(fn ($word) => static::ucfirst($word))
             ->join(' ');
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1071,6 +1071,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Make each word's first character uppercase in a string.
+     *
+     * @return static
+     */
+    public function ucwords()
+    {
+        return new static(Str::ucwords($this->value));
+    }
+
+    /**
      * Split a string by uppercase characters.
      *
      * @return \Illuminate\Support\Collection<int, string>

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1220,7 +1220,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel', Str::ucwords('laravel'));
         $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
         $this->assertSame('Мама', Str::ucwords('мама'));
-        $this->assertSame('Мама Мыла Маму', Str::ucwords('мама мыла раму'));
+        $this->assertSame('Мама Мыла Pаму', Str::ucwords('мама мыла раму'));
     }
 
     public function testUcsplit()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1220,7 +1220,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel', Str::ucwords('laravel'));
         $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
         $this->assertSame('Мама', Str::ucwords('мама'));
-        $this->assertSame('Мама Мыла Pаму', Str::ucwords('мама мыла раму'));
+        $this->assertSame('Мама Мыла Раму', Str::ucwords('мама мыла раму'));
     }
 
     public function testUcsplit()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1215,6 +1215,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Laravel', Str::ucwords('laravel'));
+        $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
+        $this->assertSame('Мама', Str::ucwords('мама'));
+        $this->assertSame('Мама Мыла Маму', Str::ucwords('мама мыла раму'));
+    }
+
     public function testUcsplit()
     {
         $this->assertSame(['Laravel_p_h_p_framework'], Str::ucsplit('Laravel_p_h_p_framework'));


### PR DESCRIPTION
This PR introduces a new string helper function `ucwords` which makes each word's first character uppercase in a string.

```php
Str::ucwords('laravel framework');

// "Laravel Framework"
```