### PR TITLE
[12.x]: Fix hardcoded 'id' key in EmailVerificationRequest::authorize

### DIFF
--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -15,7 +15,7 @@ class EmailVerificationRequest extends FormRequest
      */
     public function authorize()
     {
-        if (! hash_equals((string) $this->user()->getKey(), (string) $this->route('id'))) {
+        if (! hash_equals((string) $this->user()->getKey(), (string) $this->route($this->user()->getKeyName()))) {
             return false;
         }
 


### PR DESCRIPTION
### Summary

This PR updates the `authorize` method in the `EmailVerificationRequest` class to improve support for applications using custom primary keys on the `User` model.

### Changes

- Replaces the hardcoded `'id'` key with `$this->user()->getKeyName()` when retrieving the route parameter for comparison.

### Rationale

Laravel supports custom primary key names on Eloquent models. However, the existing implementation assumes the user's key is always `'id'`, which can lead to issues in applications that override the default. This change ensures that the email verification logic correctly respects the dynamic key name defined by the user model.

### Impact

- Maintains backward compatibility.
- Ensures the email verification process works as expected with custom user model primary keys.
- No changes to other logic or behavior.
