### PR TITLE
Database migrations: create enum column using the class name resolution operator

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1098,11 +1098,15 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|string  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if(is_string($allowed) && enum_exists($allowed)) {
+            $allowed = array_column($allowed::cases(), 'name');
+        }
+        
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 


### PR DESCRIPTION
To add an enum column, you had to manually extract the enum names:

```php
Schema::table('tasks', function (Blueprint $table) {
    $table->enum('status', array_column(TaskStatusEnum::cases(), 'name'));
});
```

With this change, you can now pass the enum class directly:

```php
Schema::table('tasks', function (Blueprint $table) {
    $table->enum('status', TaskStatusEnum::class);
});
```