### PR TITLE
Fix typo in `Blueprint`: `datetime` => `dateTime`

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1282,9 +1282,9 @@ class Blueprint
      */
     public function datetimes($precision = null)
     {
-        $this->datetime('created_at', $precision)->nullable();
+        $this->dateTime('created_at', $precision)->nullable();
 
-        $this->datetime('updated_at', $precision)->nullable();
+        $this->dateTime('updated_at', $precision)->nullable();
     }
 
     /**
@@ -1320,7 +1320,7 @@ class Blueprint
      */
     public function softDeletesDatetime($column = 'deleted_at', $precision = null)
     {
-        return $this->datetime($column, $precision)->nullable();
+        return $this->dateTime($column, $precision)->nullable();
     }
 
     /**


### PR DESCRIPTION
It still works, because of php case sensitive rules, but it's better correct.

You might want to also change `datetimes` to dateTimes` to be consistent?

