### PR TITLE
feat: Add --viewless option to make:component

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -44,7 +44,7 @@ class ComponentMakeCommand extends GeneratorCommand
     public function handle()
     {
         if ($this->option('view')) {
-            if($this->option('viewless')) {
+            if ($this->option('viewless')) {
                 $this->components->error('The --viewless option cannot be used with the --view option.');
 
                 return false;

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -44,6 +44,11 @@ class ComponentMakeCommand extends GeneratorCommand
     public function handle()
     {
         if ($this->option('view')) {
+
+            if($this->option('viewless')) {
+                $this->components->error('The --viewless option cannot be used with the --view option.');
+                return false;
+            }
             return $this->writeView();
         }
 
@@ -51,7 +56,7 @@ class ComponentMakeCommand extends GeneratorCommand
             return false;
         }
 
-        if (! $this->option('inline')) {
+        if (! $this->option('inline') && ! $this->option('viewless')) {
             $this->writeView();
         }
     }
@@ -99,6 +104,14 @@ class ComponentMakeCommand extends GeneratorCommand
             return str_replace(
                 ['DummyView', '{{ view }}'],
                 "<<<'blade'\n<div>\n    <!-- ".Inspiring::quotes()->random()." -->\n</div>\nblade",
+                parent::buildClass($name)
+            );
+        }
+
+        if ($this->option('viewless')) {
+            return str_replace(
+                ['DummyView', '{{ view }}'],
+        " ''; /*\n    This component is viewless. Implement the render method to return content directly.\n    Example: return '<div>My custom content</div>';\n    If you don't, it will render an empty string.\n    */", //
                 parent::buildClass($name)
             );
         }
@@ -179,6 +192,7 @@ class ComponentMakeCommand extends GeneratorCommand
         return [
             ['inline', null, InputOption::VALUE_NONE, 'Create a component that renders an inline view'],
             ['view', null, InputOption::VALUE_NONE, 'Create an anonymous component with only a view'],
+            ['viewless', null, InputOption::VALUE_NONE, 'Create a component class without a corresponding view file'],
             ['path', null, InputOption::VALUE_REQUIRED, 'The location where the component view should be created'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
         ];

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -44,9 +44,7 @@ class ComponentMakeCommand extends GeneratorCommand
     public function handle()
     {
         if ($this->option('view')) {
-
             if($this->option('viewless')) {
-
                 $this->components->error('The --viewless option cannot be used with the --view option.');
 
                 return false;

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -46,9 +46,12 @@ class ComponentMakeCommand extends GeneratorCommand
         if ($this->option('view')) {
 
             if($this->option('viewless')) {
+
                 $this->components->error('The --viewless option cannot be used with the --view option.');
+
                 return false;
             }
+
             return $this->writeView();
         }
 
@@ -111,7 +114,7 @@ class ComponentMakeCommand extends GeneratorCommand
         if ($this->option('viewless')) {
             return str_replace(
                 ['DummyView', '{{ view }}'],
-        " ''; /*\n    This component is viewless. Implement the render method to return content directly.\n    Example: return '<div>My custom content</div>';\n    If you don't, it will render an empty string.\n    */", //
+                " ''; /*\n    This component is viewless. Implement the render method to return content directly.\n    Example: return '<div>My custom content</div>';\n    If you don't, it will render an empty string.\n    */", //
                 parent::buildClass($name)
             );
         }

--- a/tests/Integration/Generators/ComponentMakeCommandTest.php
+++ b/tests/Integration/Generators/ComponentMakeCommandTest.php
@@ -104,6 +104,7 @@ class ComponentMakeCommandTest extends TestCase
         $this->assertFilenameExists('resources/views/custom/path/foo.blade.php');
         $this->assertFilenameNotExists('tests/Feature/View/Components/Nested/FooTest.php');
     }
+
     public function testItCanGenerateViewlessComponentFileWithoutView()
     {
         $this->artisan('make:component', [
@@ -122,6 +123,7 @@ class ComponentMakeCommandTest extends TestCase
 
         $this->assertFilenameNotExists('resources/views/components/my-viewless-component.blade.php');
     }
+
     public function testItCanGenerateViewlessInlineComponent()
     {
         $this->artisan('make:component', [


### PR DESCRIPTION
This pull request introduces a new --viewless option to the php artisan make:component Artisan command.

### Benefit to End Users & How it Makes Building Easier:

The --viewless option provides a more convenient way for developers to generate component classes that are not intended to have an associated Blade view file (either separate or inline).

Currently, if a developer wants a component class without a view (e.g., for a base component or a purely logical component), they might use --inline and then delete the boilerplate Blade code from the render() method, or generate a default component and delete the Blade file.

### This new option streamlines this process by:
1-Generating only the PHP component class.
2-Initializing the render() method to return an empty string with a guiding comment, providing a clean slate for developers who want to define rendering logic from scratch or for components that might not render any direct view themselves (relying on slots, etc.).

This makes it slightly quicker and more direct to create components intended for uses such as:

- Abstract base component classes.
- Logical components that primarily prepare data for slots.
- Components where the developer wants full control over the render() method's output without default HTML.

### Reasons it Does Not Break Any Existing Features:

- This change is purely additive. The new --viewless option does not alter the behavior of the make:component command when this option is not used.
- It does not affect existing options like --inline or --view unless used in a conflicting manner with --view (for which an error is now appropriately displayed).
- Existing component generation workflows remain unchanged.

### Testing:

- Manual testing has been performed across various scenarios.
- New PHPUnit tests have been added to Illuminate\Tests\Integration\Generators\ComponentMakeCommandTest to cover:
- Successful generation of a viewless component class without a view file.
- Correct content of the render() method in the generated viewless component.
- Proper interaction with the --inline option (behaves like --inline).
- Error handling when --viewless is used in conjunction with the --view option.
- All new and existing tests in the ComponentMakeCommandTest suite are passing.
