### PR TITLE
[12.x] Introducing `toUri` to the `Stringable` Class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1431,6 +1431,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Get the underlying string value as a Uri instance.
+     *
+     * @return \Illuminate\Support\Uri
+     */
+    public function toUri()
+    {
+        return Uri::of($this->value);
+    }
+
+    /**
      * Convert the object to a string when JSON encoded.
      *
      * @return string

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
@@ -1395,6 +1396,17 @@ class SupportStringableTest extends TestCase
         $this->expectException(\Carbon\Exceptions\InvalidFormatException::class);
 
         $this->stringable('not a date')->toDate();
+    }
+
+    public function testToUri()
+    {
+        $sentence = 'Laravel is a PHP framework. You can access the docs in: {https://laravel.com/docs}';
+
+        $uri = $this->stringable($sentence)->between('{', '}')->toUri();
+
+        $this->assertInstanceOf(Uri::class, $uri);
+        $this->assertSame('https://laravel.com/docs', (string) $uri);
+        $this->assertSame('https://laravel.com/docs', $uri->toHtml());
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

With the recent addition of the `Illuminate\Support\Uri` class, we can interact with `Uri` to manipulate or retrieve specific items from the Uri. However, we often have URLs inside of text sentences that can be extracted using the Stringable class.

Here is a real-world example:

```
Go to {https://euhosting.com/support} for support.
```

We can get the URL using `Stringable`, like this:

```php
$url = str($sentence)->between('{', '}')->value(); // https://euhosting.com/support
```

However, there are cases where we are interacting with, for example, authenticated users (clients), where we can add extra parameters to the URL to direct the user to a page where the `client` can be identified by URL parameters, or better yet, define for example a query parameter, such as: `priority=emergency` due to some special condition of the client.

With this PR, we can achieve this result by combining Stringable and Uri by the `toUri` method:

```php
$sentence = 'Go to {https://euhosting.com/support} for support.';

$uri = str($sentence)->between('{', '}')->toUri(); // or Str::of($sentence)->between('{', '}')->toUri();

if (auth()->user()->isVip()) {
    $uri = $uri->withQuery(['customer' => auth()->user()->publicId()])
        ->withQuery(['priority' => 'emergency']);
}

return $uri->value();
```

In the above example, the return of `value()` will be:

- `https://euhosting.com/support` or `https://euhosting.com/support?customer=cus_17DC&priority=emergency`

According to the authenticated user's `isVip` status.