### PR TITLE
[12.x] Add removeGlobalScope and removeGlobalScopes methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -62,6 +62,32 @@ trait HasGlobalScopes
     }
 
     /**
+     * Remove a registered global scope.
+     *
+     * Warning: This method permanently removes the global scope from the model class.
+     * If you need to temporarily remove a global scope for a specific query,
+     * use the withoutGlobalScope() method on the query builder instead.
+     *
+     * @param  \Illuminate\Database\Eloquent\Scope|(\Closure(\Illuminate\Database\Eloquent\Builder<static>): mixed)|string  $scope
+     * @return array Returns the original global scopes array before removal
+     */
+    public static function removeGlobalScope($scope)
+    {
+        $originals = static::getAllGlobalScopes();
+        $next = $originals;
+        if (is_string($scope)) {
+            unset($next[static::class][$scope]);
+        } elseif ($scope instanceof Closure) {
+            unset($next[static::class][spl_object_hash($scope)]);
+        } elseif ($scope instanceof Scope) {
+            unset($next[static::class][get_class($scope)]);
+        }
+        static::setAllGlobalScopes($next);
+
+        return $originals;
+    }
+
+    /**
      * Register multiple global scopes on the model.
      *
      * @param  array  $scopes
@@ -74,6 +100,27 @@ trait HasGlobalScopes
                 static::addGlobalScope($key, $scope);
             } else {
                 static::addGlobalScope($scope);
+            }
+        }
+    }
+
+    /**
+     * Remove multiple registered global scopes.
+     *
+     * Warning: This method permanently removes the global scopes from the model class.
+     * If you need to temporarily remove global scopes for a specific query,
+     * use the withoutGlobalScopes() method on the query builder instead.
+     *
+     * @param  array  $scopes
+     * @return void
+     */
+    public static function removeGlobalScopes(array $scopes)
+    {
+        foreach ($scopes as $key => $scope) {
+            if (is_string($key)) {
+                static::removeGlobalScope($key);
+            } else {
+                static::removeGlobalScope($scope);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds `removeGlobalScope()` method to permanently remove a single global scope from a model
- Adds `removeGlobalScopes()` method to permanently remove multiple global scopes from a model
- Both methods return the original global scopes array before removal, allowing for potential rollback

## Motivation
Currently, Laravel provides methods to add global scopes (`addGlobalScope()` and `addGlobalScopes()`) but no corresponding methods to remove them permanently. While `withoutGlobalScope()` exists for temporarily removing scopes within a query, there are use cases where developers need to permanently remove global scopes from a model class at runtime.

## Usage
```php
// Remove a single global scope
Model::removeGlobalScope('scope_name');
Model::removeGlobalScope($scopeInstance);
Model::removeGlobalScope(ScopeClass::class);

// Remove multiple global scopes
Model::removeGlobalScopes(['scope1', 'scope2', ScopeClass::class]);

// Rollback if needed
$original = Model::removeGlobalScope('scope_name');
Model::setAllGlobalScopes($original);
```

## Note
These methods permanently remove global scopes from the model class. For temporary removal within a specific query, developers should continue using `withoutGlobalScope()` and `withoutGlobalScopes()` on the query builder.
I wrote the message in the PHPDoc.

## Test plan
- [x] Added comprehensive tests for removing global scopes by string key
- [x] Added tests for removing global scopes by closure
- [x] Added tests for removing global scopes by class instance
- [x] Added tests for removing global scopes by class name
- [x] Added tests for batch removal of multiple scopes
- [x] Added tests to ensure non-existent scope removal doesn't throw exceptions
- [x] All existing tests pass