### PR TITLE
Adding the template method to the Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2083,4 +2083,37 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Generate a random string according to the given template.
+     * Alphabetical [a-zA-Z] characters will be converted to a random letter individually
+     * Numerical [0-9] characters will be converted to a random number individually
+     * Other characters won't be modified.
+     *
+     *
+     * @param  string  $format
+     * @return string
+     */
+    public static function template(string $format)
+    {
+        $value = '';
+
+        $char = strlen($format);
+
+        for($i = 0; $i < $char; $i++) {
+            if(preg_match('/[a-zA-Z]/', $format[$i])) {
+                if (ctype_lower($format[$i])) {
+                    $value .= chr(random_int(97, 122));
+                } else {
+                    $value .= chr(random_int(65, 90));
+                }
+            } elseif(preg_match('/\d/', $format[$i])) {
+                $value .= random_int(0, 9);
+            } else {
+                $value .= $format[$i];
+            }
+        }
+
+        return $value;
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1814,6 +1814,19 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testGenerateTemplate(): void
+    {
+        foreach ([
+            ['XXXX-9999-X9X9-99XX', '/^[A-Z]{4}-[0-9]{4}-[A-Z][0-9][A-Z][0-9]-[0-9]{2}[A-Z]{2}$/'],
+            ['XXX-999-XX', '/^[A-Z]{3}-[0-9]{3}-[A-Z]{2}$/'],
+            ['ABC-123-de', '/^[A-Z]{3}-[0-9]{3}-[a-z]{2}$/'],
+        ] as $value) {
+            [$template, $pattern] = $value;
+            $this->assertMatchesRegularExpression($pattern, Str::template($template));
+        }
+
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
## Str::template() explanation

The Str::template function generates a string based on a specified template format. The template format can include placeholders for characters and numbers, which will be randomly generated according to the following rules:

- Uppercase Letters (A-Z): Represented by uppercase letters in the template (e.g., X).
- Lowercase Letters (a-z): Represented by lowercase letters in the template (e.g., x).
- Digits (0-9): Represented by digits in the template (e.g., 9).
- Other Characters: Any other characters in the template will be included in the output as-is.

### How It Works
The function iterates through each character in the template string and replaces it with a randomly generated character or digit based on the rules above.

```php
$result = Str::template('XXX-999-XXX');
// Possible Output: "ABC-123-DEF"

$result = Str::template('xXx-999-xXx');
// Possible Output: "aBc-123-dEf"

$result = Str::template('XXX@999#xxx');
// Possible Output: "ABC@123#def"
```

### Why ?

This function is useful for generating random strings that follow a specific pattern, such as generating random IDs, codes, or placeholders.