### PR TITLE
🔨 Use "Enums" as default directory for new Enums

### DIFF
--- a/src/Illuminate/Foundation/Console/EnumMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EnumMakeCommand.php
@@ -72,7 +72,7 @@ class EnumMakeCommand extends GeneratorCommand
         return match (true) {
             is_dir(app_path('Enums')) => $rootNamespace.'\\Enums',
             is_dir(app_path('Enumerations')) => $rootNamespace.'\\Enumerations',
-            default => $rootNamespace,
+            default => $rootNamespace.'\\Enums',
         };
     }
 

--- a/tests/Integration/Generators/EnumMakeCommandTest.php
+++ b/tests/Integration/Generators/EnumMakeCommandTest.php
@@ -7,9 +7,9 @@ use Illuminate\Tests\Integration\Generators\TestCase;
 class EnumMakeCommandTest extends TestCase
 {
     protected $files = [
-        'app/IntEnum.php',
-        'app/StatusEnum.php',
-        'app/StringEnum.php',
+        'app/Enums/IntEnum.php',
+        'app/Enums/StatusEnum.php',
+        'app/Enums/StringEnum.php',
         'app/*/OrderStatusEnum.php',
     ];
 
@@ -19,9 +19,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App/Enums;',
             'enum StatusEnum',
-        ], 'app/StatusEnum.php');
+        ], 'app/Enums/StatusEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithString()
@@ -30,9 +30,9 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum StringEnum: string',
-        ], 'app/StringEnum.php');
+        ], 'app/Enums/StringEnum.php');
     }
 
     public function testItCanGenerateEnumFileWithInt()
@@ -41,7 +41,7 @@ class EnumMakeCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertFileContains([
-            'namespace App;',
+            'namespace App\Enums;',
             'enum IntEnum: int',
         ], 'app/IntEnum.php');
     }


### PR DESCRIPTION
This pull request improves the make:enum Artisan command by automatically placing new Enum classes inside an app/Enums directory. 

Currently, enums are generated directly in the app folder by default, which can lead to clutter as your project grows. 

Please let me know if you'd like me to help tailor it further.