### PR TITLE
[13.x] fix bug: enhance handling of empty values in grouping

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -516,9 +516,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if (! is_array($groupKeys)) {
-                $groupKeys = [$groupKeys];
-            }
+            $groupKeys = match (true) {
+                ! is_array($groupKeys) => [$groupKeys],
+                is_array($groupKeys) && empty($groupKeys) => [null],
+                default => $groupKeys,
+            };  
 
             foreach ($groupKeys as $groupKey) {
                 $groupKey = match (true) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -520,7 +520,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 ! is_array($groupKeys) => [$groupKeys],
                 is_array($groupKeys) && empty($groupKeys) => [null],
                 default => $groupKeys,
-            };  
+            };
 
             foreach ($groupKeys as $groupKey) {
                 $groupKey = match (true) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3458,6 +3458,32 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testGroupWithEmptyValue($collection)
+    {
+        $data = new $collection([
+            10 => [],
+            20 => ['user' => 2, 'roles' => []],
+            30 => ['user' => 3, 'roles' => [null]],
+            40 => ['user' => 4, 'roles' => ['Role_2']],
+        ]);
+
+        $result = $data->groupBy('roles', true);
+
+        $expected_result = [
+            '' => [
+                10 => [],
+                20 => ['user' => 2, 'roles' => []],
+                30 => ['user' => 3, 'roles' => [null]],
+            ],
+            'Role_2' => [
+                40 => ['user' => 4, 'roles' => ['Role_2']],
+            ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testKeyByAttribute($collection)
     {
         $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);


### PR DESCRIPTION
# Description

This PR fixes a bug within `groupBy` in collections. I understand it can be considered as a breaking change in 12.x, so maybe worth to consider to fix this issue in 13.x

# How to reproduce
Prepare an array with some values, for demoing reasons, it's easier to spot the bug with `preserveKeys: true` enabled.

```php
collect([
  10 => [],
  20 => ['user' => 2, 'roles' => []], // missing
  30 => ['user' => 3, 'roles' => [null]],
  40 => ['user' => 4, 'roles' => ['Role_2']]
])->groupBy('roles', preserveKeys: true)
  ->dump();
```

The output after grouping missing key `20`, because of roles is an empty array, while key `30` is an array with a single value of `null`.

# Solution

Inside `groupBy` function, treat any empty array returned as a grouping key to `null` before processing. This ensures that items with an empty array are grouped under the “null” bucket rather than being skipped.