### PR TITLE
[12.x] Support Multi-Column LIKE Queries via whereAnyLike and orWhereAnyLike in Eloquent

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1193,6 +1193,73 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where like clause to the query from array of columns
+     *
+     * @param array $columns
+     * @param $value
+     * @param $caseSensitive
+     * @param $boolean
+     * @param $not
+     * @return $this|Builder
+     */
+    public function whereLikeAny(array $columns, $value = null, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->whereNested(function ($query) use ($boolean, $not, $caseSensitive, $columns, $value) {
+            foreach ($columns as $column) {
+                $query->whereLike($column, $value, $caseSensitive, 'or');
+            }
+        }, $boolean);
+    }
+
+    /**
+     * Add a where like clause to the query from array of columns
+     *
+     * @param array $columns
+     * @param $value
+     * @param $caseSensitive
+     * @param $boolean
+     * @param $not
+     * @return $this|Builder
+     */
+    public function whereAnyLike(array $columns, $value = null, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        return $this->whereLikeAny($columns, $value, $caseSensitive, $boolean, $not);
+    }
+
+
+    /**
+     * Add a where like clause to the query from array of columns
+     *
+     * @param array $columns
+     * @param $value
+     * @param $caseSensitive
+     * @param $boolean
+     * @param $not
+     * @return $this|Builder
+     */
+    public function orWhereLikeAny(array $columns, $value = null, $caseSensitive = false, $boolean = 'or', $not = false)
+    {
+        return $this->whereLikeAny($columns, $value, $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add a where like clause to the query from array of columns.
+     *
+     * @alias orWhereLikeAny
+     * @param array $columns
+     * @param $value
+     * @param $caseSensitive
+     * @param $boolean
+     * @param $not
+     * @return $this|Builder
+     */
+    public function orWhereAnyLike(array $columns, $value = null, $caseSensitive = false, $boolean = 'or', $not = false)
+    {
+        return $this->orWhereLikeAny($columns, $value, $caseSensitive, $boolean, $not);
+    }
+
+
+    /**
      * Add a "where in" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column


### PR DESCRIPTION
###  Summary

This PR introduces four new methods to the Eloquent Query Builder for applying `LIKE` conditions across multiple columns in a single call:

1. `whereAnyLike` (alias: 3. `whereLikeAny`)
2. `orWhereAnyLike` (alias: 4. `orWhereLikeAny`)

---

###  Context

Currently, Laravel supports `whereLike` and `orWhereLike` for filtering using the `LIKE` operator (case-sensitive or case-insensitive), as well as `whereAny` and `orWhereAny` for filtering across multiple columns. However, there is no built-in method to apply a `LIKE` filter to multiple columns in a single, expressive call.

These new methods bridge that gap, allowing developers to apply `LIKE` filters to multiple columns efficiently, improving readability and reducing repetitive code.

---

###  Example Usage

```php
Customer::query()
    ->where('email', 'dd')
    ->whereLike('phone', '%017%')
    ->whereAnyLike(['name', 'id'], '%clif%')
    ->toRawSql();
```

**Generates SQL:**

```sql
select * from "customers"
where "email" = 'dd'
and "phone"::text ilike '%017%'
and ("name"::text ilike '%clif%' or "id"::text ilike '%clif%')
```

---

```php
Customer::query()
    ->where('email', 'dd')
    ->whereLike('phone', '%017%')
    ->orWhereAnyLike(['name', 'id'], '%clif%')
    ->toRawSql();
```

**Generates SQL:**

```sql
select * from "customers"
where "email" = 'dd'
and "phone"::text ilike '%017%'
or ("name"::text ilike '%clif%' or "id"::text ilike '%clif%')
```

---

### 📦 Benefits

* Simplifies applying `LIKE` filters across multiple columns.
* Improves code clarity and reduces redundancy in query logic.
* Especially useful in building advanced search filters for dashboards, admin panels, or APIs.

---