### PR TITLE
[12.x] Ability to perform higher order static calls on collection items

### DIFF
--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -61,7 +61,9 @@ class HigherOrderCollectionProxy
     public function __call($method, $parameters)
     {
         return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
-            return $value->{$method}(...$parameters);
+            return is_string($value)
+                ? $value::{$method}(...$parameters)
+                : $value->{$method}(...$parameters);
         });
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5007,6 +5007,19 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testHigherOrderCollectionStaticCall($collection)
+    {
+        $class1 = TestSupportCollectionHigherOrderStaticClass1::class;
+        $class2 = TestSupportCollectionHigherOrderStaticClass2::class;
+
+        $classes = new $collection([$class1, $class2]);
+
+        $this->assertEquals(['TAYLOR', 't a y l o r'], $classes->map->transform('taylor')->toArray());
+        $this->assertEquals(TestSupportCollectionHigherOrderStaticClass1::class, $classes->first->matches('Taylor'));
+        $this->assertEquals(TestSupportCollectionHigherOrderStaticClass2::class, $classes->first->matches('Otwell'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testPartition($collection)
     {
         $data = new $collection(range(1, 10));
@@ -5714,6 +5727,32 @@ class TestSupportCollectionHigherOrderItem
     public function is($name)
     {
         return $this->name === $name;
+    }
+}
+
+class TestSupportCollectionHigherOrderStaticClass1
+{
+    public static function transform($name)
+    {
+        return strtoupper($name);
+    }
+
+    public static function matches($name)
+    {
+        return str_starts_with($name, 'T');
+    }
+}
+
+class TestSupportCollectionHigherOrderStaticClass2
+{
+    public static function transform($name)
+    {
+        return trim(chunk_split($name, 1, ' '));
+    }
+
+    public static function matches($name)
+    {
+        return str_starts_with($name, 'O');
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5015,8 +5015,8 @@ class SupportCollectionTest extends TestCase
         $classes = new $collection([$class1, $class2]);
 
         $this->assertEquals(['TAYLOR', 't a y l o r'], $classes->map->transform('taylor')->toArray());
-        $this->assertEquals(TestSupportCollectionHigherOrderStaticClass1::class, $classes->first->matches('Taylor'));
-        $this->assertEquals(TestSupportCollectionHigherOrderStaticClass2::class, $classes->first->matches('Otwell'));
+        $this->assertEquals($class1, $classes->first->matches('Taylor'));
+        $this->assertEquals($class2, $classes->first->matches('Otwell'));
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR adds ability to perform higher order static calls on collection items (class names).

Example usage scenario:
```php
interface Handler
{
    public static function satisfies($condition): bool;
}

class HandlerFactory
{
    protected Collection $handlers;

    /**
     * @param  list<class-string<Handler>>  $handlers
     */
    public function construct(array $handlers) // ❤️giveConfig
    {
        $this->handlers = collect($handlers);
    }

    public function make($condition): Handler
    {
        $handler = $this->handlers->first->satisfies($condition) ?? FallbackHandler::class;

        return new $handler;
    }
}
```
