### PR TITLE
[12.x] feat: create UsePolicy attribute

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -672,7 +672,7 @@ class Gate implements GateContract
 
         $policy = $this->getPolicyFromAttribute($class);
 
-        if ($policy !== null) {
+        if (! is_null($policy)) {
             return $this->resolvePolicy($policy);
         }
 
@@ -690,7 +690,7 @@ class Gate implements GateContract
     }
 
     /**
-     * Get the policy from the class attribute.
+     * Get the policy class from the class attribute.
      *
      * @param  class-string<*>  $class
      * @return class-string<*>|null
@@ -703,11 +703,9 @@ class Gate implements GateContract
 
         $attributes = (new ReflectionClass($class))->getAttributes(UsePolicy::class);
 
-        if ($attributes === []) {
-            return null;
-        }
-
-        return $attributes[0]->newInstance()->class;
+        return $attributes !== []
+            ? $attributes[0]->newInstance()->class
+            : null;
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -669,6 +670,12 @@ class Gate implements GateContract
             return $this->resolvePolicy($this->policies[$class]);
         }
 
+        $policy = $this->getPolicyFromAttribute($class);
+
+        if ($policy !== null) {
+            return $this->resolvePolicy($policy);
+        }
+
         foreach ($this->guessPolicyName($class) as $guessedPolicy) {
             if (class_exists($guessedPolicy)) {
                 return $this->resolvePolicy($guessedPolicy);
@@ -680,6 +687,27 @@ class Gate implements GateContract
                 return $this->resolvePolicy($policy);
             }
         }
+    }
+
+    /**
+     * Get the policy from the class attribute.
+     *
+     * @param  class-string<*>  $class
+     * @return class-string<*>|null
+     */
+    protected function getPolicyFromAttribute(string $class): ?string
+    {
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new ReflectionClass($class))->getAttributes(UsePolicy::class);
+
+        if ($attributes === []) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance()->class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Attributes/UsePolicy.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UsePolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UsePolicy
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<*>  $class
+     */
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Integration\Auth;
 
 use Illuminate\Auth\Access\Events\GateEvaluated;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
@@ -78,4 +80,20 @@ class GatePolicyResolutionTest extends TestCase
             Gate::getPolicyFor(AuthenticationTestUser::class)
         );
     }
+
+    public function testPolicyCanBeGivenByAttribute(): void
+    {
+        Gate::guessPolicyNamesUsing(fn () => [AuthenticationTestUserPolicy::class]);
+
+        $this->assertInstanceOf(PostPolicy::class, Gate::getPolicyFor(Post::class));
+    }
+}
+
+#[UsePolicy(PostPolicy::class)]
+class Post extends Model
+{
+}
+
+class PostPolicy
+{
 }


### PR DESCRIPTION
Hello!

This was bundled in #55765, but I'm splitting out into its own PR. Renamed from `PolicedBy` to `UsePolicy`.


```php
#[UsePolicy(PostPolicy::class)]
class Post extends Model
{
}
```

Thanks!