### PR TITLE
[12.x] feat: Add Command Handler Resolution via PHP 8 Attributes

### DIFF
--- a/src/Illuminate/Bus/Attributes/HandledBy.php
+++ b/src/Illuminate/Bus/Attributes/HandledBy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Bus\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class HandledBy
+{
+    /**
+     * Create a new HandledBy instance.
+     *
+     * @param  string  $handler
+     */
+    public function __construct(public string $handler)
+    {
+    }
+}

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -224,7 +224,7 @@ class Dispatcher implements QueueingDispatcher
             return false;
         }
 
-        if (!$attributes) {
+        if (! $attributes) {
             return false;
         }
 

--- a/tests/Bus/BusHandlerResolutionTest.php
+++ b/tests/Bus/BusHandlerResolutionTest.php
@@ -13,18 +13,18 @@ class BusHandlerResolutionTest extends TestCase
     {
         $resolution = (new Dispatcher(new Container()))
             ->getCommandHandler(new CommandForAttributeHandler());
-        
+
         $this->assertInstanceOf(AttributeHandler::class, $resolution);
     }
 
     public function test_command_handler_correctly_resolved_via_map()
     {
         $resolution = tap(
-            new Dispatcher(new Container()), 
-            function($dispatcher) {
+            new Dispatcher(new Container()),
+            function ($dispatcher) {
                 $dispatcher->map([CommandForMapHandler::class => MapHandler::class]);
-        })->getCommandHandler(new CommandForMapHandler());
-        
+            })->getCommandHandler(new CommandForMapHandler());
+
         $this->assertInstanceOf(MapHandler::class, $resolution);
     }
 
@@ -32,18 +32,18 @@ class BusHandlerResolutionTest extends TestCase
     {
         $resolution = (new Dispatcher(new Container()))
             ->getCommandHandler(new CommandForMapHandler());
-        
+
         $this->assertFalse($resolution);
     }
-    
+
     public function test_mapped_handler_takes_precedence_over_attribute_handler()
     {
         $resolution = tap(
-            new Dispatcher(new Container()), 
-            function($dispatcher) {
+            new Dispatcher(new Container()),
+            function ($dispatcher) {
                 $dispatcher->map([CommandForAttributeHandler::class => MapHandler::class]);
-        })->getCommandHandler(new CommandForAttributeHandler());
-                        
+            })->getCommandHandler(new CommandForAttributeHandler());
+
         $this->assertInstanceOf(MapHandler::class, $resolution);
         $this->assertNotInstanceOf(AttributeHandler::class, $resolution);
     }
@@ -52,22 +52,30 @@ class BusHandlerResolutionTest extends TestCase
     {
         $resolution = (new Dispatcher(new Container()))
             ->getCommandHandler(new \stdClass());
-    
+
         $this->assertFalse($resolution);
     }
 }
 
 #[HandledBy(AttributeHandler::class)]
-class CommandForAttributeHandler {}
+class CommandForAttributeHandler
+{
+}
 
-class CommandForMapHandler {}
+class CommandForMapHandler
+{
+}
 
 class AttributeHandler
 {
-    public function handle($command) {}
+    public function handle($command)
+    {
+    }
 }
 
 class MapHandler
 {
-    public function handle($command){}
+    public function handle($command)
+    {
+    }
 }

--- a/tests/Bus/BusHandlerResolutionTest.php
+++ b/tests/Bus/BusHandlerResolutionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Bus;
+
+use Illuminate\Bus\Attributes\HandledBy;
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+class BusHandlerResolutionTest extends TestCase
+{
+    public function test_command_handler_correctly_resolved_via_attribute()
+    {
+        $resolution = (new Dispatcher(new Container()))
+            ->getCommandHandler(new CommandForAttributeHandler());
+        
+        $this->assertInstanceOf(AttributeHandler::class, $resolution);
+    }
+
+    public function test_command_handler_correctly_resolved_via_map()
+    {
+        $resolution = tap(
+            new Dispatcher(new Container()), 
+            function($dispatcher) {
+                $dispatcher->map([CommandForMapHandler::class => MapHandler::class]);
+        })->getCommandHandler(new CommandForMapHandler());
+        
+        $this->assertInstanceOf(MapHandler::class, $resolution);
+    }
+
+    public function test_handler_resolution_returns_false_when_no_attribute_or_mapping()
+    {
+        $resolution = (new Dispatcher(new Container()))
+            ->getCommandHandler(new CommandForMapHandler());
+        
+        $this->assertFalse($resolution);
+    }
+    
+    public function test_mapped_handler_takes_precedence_over_attribute_handler()
+    {
+        $resolution = tap(
+            new Dispatcher(new Container()), 
+            function($dispatcher) {
+                $dispatcher->map([CommandForAttributeHandler::class => MapHandler::class]);
+        })->getCommandHandler(new CommandForAttributeHandler());
+                        
+        $this->assertInstanceOf(MapHandler::class, $resolution);
+        $this->assertNotInstanceOf(AttributeHandler::class, $resolution);
+    }
+
+    public function test_attribute_resolution_handles_reflection_exceptions_gracefully()
+    {
+        $resolution = (new Dispatcher(new Container()))
+            ->getCommandHandler(new \stdClass());
+    
+        $this->assertFalse($resolution);
+    }
+}
+
+#[HandledBy(AttributeHandler::class)]
+class CommandForAttributeHandler {}
+
+class CommandForMapHandler {}
+
+class AttributeHandler
+{
+    public function handle($command) {}
+}
+
+class MapHandler
+{
+    public function handle($command){}
+}


### PR DESCRIPTION
This PR introduces the ability to resolve command handlers using PHP 8 attributes, providing an alternative to the boilerplate of mapping handlers in service providers making the handler relationship more explicit, akin to the `#[ObservedBy(Observer::class)]` attribute for Model and Observer relationships.

**Problem**

Currently, Command Handlers must be registered in Service Providers:

```php
// In a ServiceProvider
Bus::map([
    UpdateUserCommand::class => UpdateUserHandler::class,
    DeleteUserCommand::class => DeleteUserHandler::class,
]);
```

This requires boilerplate code and separates the Command from its Handler definition, making the relationship less explicit.

**Solution**

With this pull request, Commands can now declare their Handlers directly using the `#[HandledBy(Handler::class)]` attribute, similar to how the existing `#[ObservedBy(Observer::class)]` attribute works for Models and Observers:

```php
use Illuminate\Bus\Attributes\HandledBy;

#[HandledBy(UpdateUserHandler::class)]
class UpdateUserCommand
{
    public function __construct(
        public int $userId,
        public array $data
    ) {}
}
```

**Implementation Details**

✅ Backward Compatible: Existing Service Provider mappings continue to work unchanged
✅ Precedence: Service Provider mappings take precedence over Attributes
✅ Performance: Attribute resolution only occurs when no explicit mapping exists
✅ Consistent Pattern: Follows the same approach as `#[ObservedBy]` for Model Observers

**Changes**

✅ Added `Illuminate\Bus\Attributes\HandledBy` Attribute class
✅ Enhanced `Dispatcher::getCommandHandler()` to support Attribute resolution
✅ Maintains all existing functionality and contracts

**Discussion**

🤔 For performance reasons, Service Provider mappings take precedence over Attributes. Perhaps, however, "closest to the code" should be the determining factor and Attributes should override Service Provider mappings?

