### PR TITLE
[12.x] Add `keyByListValues` array helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -633,6 +633,23 @@ class Arr
     }
 
     /**
+     * Key a non-associative/partially associative array by its items while replacing them with a specified default value.
+     *
+     * @template TKey of array-key
+     * @template TKeyableItem of array-key
+     * @template TItem
+     * @template TDefaultValue
+     *
+     * @param  array<TKey, (TKey is int ? TKeyableItem : TItem)>  $array
+     * @param  TDefaultValue  $value
+     * @return array<(TKey is int ? TKeyableItem : TKey), (TKey is int ? TDefaultValue : TItem)>
+     */
+    public static function keyByListValues($array, $value = null)
+    {
+        return static::mapWithKeys($array, fn ($item, $key) => is_int($key) ? [$item => $value] : [$key => $item]);
+    }
+
+    /**
      * Prepend the key names of an associative array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -638,15 +638,15 @@ class Arr
      * @template TKey of array-key
      * @template TKeyableItem of array-key
      * @template TItem
-     * @template TDefaultValue
+     * @template TDefault
      *
      * @param  array<TKey, (TKey is int ? TKeyableItem : TItem)>  $array
-     * @param  TDefaultValue  $value
-     * @return array<(TKey is int ? TKeyableItem : TKey), (TKey is int ? TDefaultValue : TItem)>
+     * @param  TDefault  $default
+     * @return array<(TKey is int ? TKeyableItem : TKey), (TKey is int ? TDefault : TItem)>
      */
-    public static function keyByListValues($array, $value = null)
+    public static function keyByListValues($array, $default = null)
     {
-        return static::mapWithKeys($array, fn ($item, $key) => is_int($key) ? [$item => $value] : [$key => $item]);
+        return static::mapWithKeys($array, fn ($item, $key) => is_int($key) ? [$item => $default] : [$key => $item]);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use TypeError;
 use WeakMap;
 
 include_once 'Common.php';
@@ -1648,6 +1649,16 @@ class SupportArrTest extends TestCase
             '345' => ['id' => '345', 'data' => 'def'],
             '498' => ['id' => '498', 'data' => 'hgi'],
         ], Arr::keyBy($array, 'id'));
+    }
+
+    public function testKeyByListValues()
+    {
+        $array = ['a' => 1, 'b' => [], 'c'];
+        $this->assertEquals(['a' => 1, 'b' => [], 'c' => 3], Arr::keyByListValues($array, 3));
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Cannot access offset of type array on array');
+        Arr::keyByListValues([[]]);
     }
 
     public function testPrependKeysWith()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1657,7 +1657,6 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['a' => 1, 'b' => [], 'c' => 3], Arr::keyByListValues($array, 3));
 
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('Cannot access offset of type array on array');
         Arr::keyByListValues([[]]);
     }
 


### PR DESCRIPTION
This PR adds new `keyByListValues` array helper function.
This function keys array *list* entries by its values while preserving its associative part, thus making array 100% associative.
Newly keyed entries' values are replaced with some default value (2nd argument).
The caller is responsible for *list* entries to be valid array keys.

*(I don't know if terminology is correct because AFAIK arrays can be either associative or non-associative, not both)*

Suggested use case is when some optional parameter(s) may be associated with array entry (likely class name or some identifier):
```php
$middleware = [
    EnsureUserHasRole::class => ['role' => 'editor'],
    SomeOtherMiddleware::class,
];

Arr::keyByListValues($middleware, []);

/*[
    EnsureUserHasRole::class => ['role' => 'editor'],
    SomeOtherMiddleware::class => [],
];*/
```
