### PR TITLE
[12.x] style: remove unnecessary curly braces in string interpolations

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -82,7 +82,7 @@ class AuthManager implements FactoryContract
         $config = $this->getConfig($name);
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("Auth guard [{$name}] is not defined.");
+            throw new InvalidArgumentException("Auth guard [$name] is not defined.");
         }
 
         if (isset($this->customCreators[$config['driver']])) {
@@ -96,7 +96,7 @@ class AuthManager implements FactoryContract
         }
 
         throw new InvalidArgumentException(
-            "Auth driver [{$config['driver']}] for guard [{$name}] is not defined."
+            "Auth driver [{$config['driver']}] for guard [$name] is not defined."
         );
     }
 
@@ -184,7 +184,7 @@ class AuthManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["auth.guards.{$name}"];
+        return $this->app['config']["auth.guards.$name"];
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -219,7 +219,7 @@ class LogManager implements LoggerInterface
         $config ??= $this->configurationFor($name);
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("Log [{$name}] is not defined.");
+            throw new InvalidArgumentException("Log [$name] is not defined.");
         }
 
         if (isset($this->customCreators[$config['driver']])) {
@@ -558,7 +558,7 @@ class LogManager implements LoggerInterface
      */
     protected function configurationFor($name)
     {
-        return $this->app['config']["logging.channels.{$name}"];
+        return $this->app['config']["logging.channels.$name"];
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -113,7 +113,7 @@ class MailManager implements FactoryContract
         $config = $this->getConfig($name);
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
+            throw new InvalidArgumentException("Mailer [$name] is not defined.");
         }
 
         // Once we have created the mailer instance we will set a container instance
@@ -174,7 +174,7 @@ class MailManager implements FactoryContract
 
         if (trim($transport ?? '') === '' ||
             ! method_exists($this, $method = 'create'.ucfirst(Str::camel($transport)).'Transport')) {
-            throw new InvalidArgumentException("Unsupported mail transport [{$transport}].");
+            throw new InvalidArgumentException("Unsupported mail transport [$transport].");
         }
 
         return $this->{$method}($config);


### PR DESCRIPTION
This PR removes redundant curly braces in string interpolations where they were not required, improving code readability and compliance with PSR-12 coding standards.
