### PR TITLE
[12.x] Allow setting the `RequestException` truncation limit per request

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1533,7 +1533,7 @@ class PendingRequest
     }
 
     /**
-     * When a RequestException is thrown, truncate it to this length.
+     * Indicate that request exceptions should be truncated to the given length.
      *
      * @param  int<1, max>  $length
      * @return $this
@@ -1546,7 +1546,7 @@ class PendingRequest
     }
 
     /**
-     * Do not truncate a RequestException if thrown.
+     * Indicate that request exceptions should not be truncated.
      *
      * @return $this
      */

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -910,12 +910,7 @@ class PendingRequest
         try {
             if ($this->truncateAt !== null) {
                 $originalTruncateAt = LaravelRequestException::$truncateAt;
-                if ($this->truncateAt === false) {
-                    LaravelRequestException::dontTruncate();
-                }
-                else {
-                    LaravelRequestException::truncateAt($this->truncateAt);
-                }
+                $this->truncateAt === false ? LaravelRequestException::dontTruncate() : LaravelRequestException::truncateAt($this->truncateAt);
             }
             return retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
                 try {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -215,9 +215,11 @@ class PendingRequest
     ];
 
     /**
+     * The length to which request exceptions should be truncated to.
+     *
      * @var int<1, max>|false|null
      */
-    protected $truncateAt = null;
+    protected $truncateExceptionsAt = null;
 
     /**
      * Create a new HTTP Client instance.
@@ -1430,10 +1432,13 @@ class PendingRequest
     protected function newResponse($response)
     {
         return tap(new Response($response), function (Response $laravelResponse) {
-            if ($this->truncateAt === null) {
+            if ($this->truncateExceptionsAt === null) {
                 return;
             }
-            $this->truncateAt === false ? $laravelResponse->dontTruncate() : $laravelResponse->truncateAt($this->truncateAt);
+
+            $this->truncateExceptionsAt === false
+                ? $laravelResponse->dontTruncateExceptions()
+                : $laravelResponse->truncateExceptionsAt($this->truncateExceptionsAt);
         });
     }
 
@@ -1528,6 +1533,31 @@ class PendingRequest
     }
 
     /**
+     * When a RequestException is thrown, truncate it to this length.
+     *
+     * @param  int<1, max>  $length
+     * @return $this
+     */
+    public function truncateExceptionsAt(int $length)
+    {
+        $this->truncateExceptionsAt = $length;
+
+        return $this;
+    }
+
+    /**
+     * Do not truncate a RequestException if thrown.
+     *
+     * @return $this
+     */
+    public function dontTruncateExceptions()
+    {
+        $this->truncateExceptionsAt = false;
+
+        return $this;
+    }
+
+    /**
      * Set the client instance.
      *
      * @param  \GuzzleHttp\Client  $client
@@ -1561,30 +1591,5 @@ class PendingRequest
     public function getOptions()
     {
         return $this->options;
-    }
-
-    /**
-     * When a RequestException is thrown, truncate to this length.
-     *
-     * @param  int<1, max>  $length
-     * @return $this
-     */
-    public function truncateAt(int $length)
-    {
-        $this->truncateAt = $length;
-
-        return $this;
-    }
-
-    /**
-     * Do not truncate a RequestException if thrown.
-     *
-     * @return $this
-     */
-    public function dontTruncate()
-    {
-        $this->truncateAt = false;
-
-        return $this;
     }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -27,7 +27,6 @@ use OutOfBoundsException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\VarDumper\VarDumper;
-use Illuminate\Http\Client\RequestException as LaravelRequestException;
 
 class PendingRequest
 {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -215,7 +215,7 @@ class PendingRequest
     ];
 
     /**
-     * The length to which request exceptions should be truncated to.
+     * The length at which request exceptions will be truncated.
      *
      * @var int<1, max>|false|null
      */

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -48,9 +48,11 @@ class Response implements ArrayAccess, Stringable
     public $transferStats;
 
     /**
+     * The length to which request exceptions should be truncated to.
+     *
      * @var int<1, max>|false|null
      */
-    protected $truncateAt = null;
+    protected $truncateExceptionsAt = null;
 
     /**
      * Create a new response instance.
@@ -295,31 +297,6 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * When a RequestException is thrown, truncate to this length.
-     *
-     * @param  int<1, max>  $length
-     * @return $this
-     */
-    public function truncateAt(int $length)
-    {
-        $this->truncateAt = $length;
-
-        return $this;
-    }
-
-    /**
-     * Do not truncate a RequestException if thrown.
-     *
-     * @return $this
-     */
-    public function dontTruncate()
-    {
-        $this->truncateAt = false;
-
-        return $this;
-    }
-
-    /**
      * Create an exception if a server or client error occurred.
      *
      * @return \Illuminate\Http\Client\RequestException|null
@@ -328,9 +305,12 @@ class Response implements ArrayAccess, Stringable
     {
         if ($this->failed()) {
             $originalTruncateAt = RequestException::$truncateAt;
+
             try {
-                if ($this->truncateAt !== null) {
-                    $this->truncateAt === false ? RequestException::dontTruncate() : RequestException::truncateAt($this->truncateAt);
+                if ($this->truncateExceptionsAt !== null) {
+                    $this->truncateExceptionsAt === false
+                        ? RequestException::dontTruncate()
+                        : RequestException::truncateAt($this->truncateExceptionsAt);
                 }
 
                 return new RequestException($this);
@@ -432,6 +412,31 @@ class Response implements ArrayAccess, Stringable
     public function throwIfServerError()
     {
         return $this->serverError() ? $this->throw() : $this;
+    }
+
+    /**
+     * When a RequestException is thrown, truncate it to this length.
+     *
+     * @param  int<1, max>  $length
+     * @return $this
+     */
+    public function truncateExceptionsAt(int $length)
+    {
+        $this->truncateExceptionsAt = $length;
+
+        return $this;
+    }
+
+    /**
+     * Do not truncate a RequestException if thrown.
+     *
+     * @return $this
+     */
+    public function dontTruncateExceptions()
+    {
+        $this->truncateExceptionsAt = false;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -48,7 +48,7 @@ class Response implements ArrayAccess, Stringable
     public $transferStats;
 
     /**
-     * The length to which request exceptions should be truncated to.
+     * The length at which request exceptions will be truncated.
      *
      * @var int<1, max>|false|null
      */

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -415,7 +415,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * When a RequestException is thrown, truncate it to this length.
+     * Indicate that request exceptions should be truncated to the given length.
      *
      * @param  int<1, max>  $length
      * @return $this
@@ -428,7 +428,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Do not truncate a RequestException if thrown.
+     * Indicate that request exceptions should not be truncated.
      *
      * @return $this
      */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1314,7 +1314,7 @@ class HttpClientTest extends TestCase
 
         $exception = null;
         try {
-            $this->factory->throw()->truncateAt(3)->get('http://foo.com/json');
+            $this->factory->throw()->truncateExceptionsAt(3)->get('http://foo.com/json');
         } catch (RequestException $e) {
             $exception = $e;
         }
@@ -1333,8 +1333,9 @@ class HttpClientTest extends TestCase
         ]);
 
         $exception = null;
+
         try {
-            $this->factory->throw()->dontTruncate()->get('http://foo.com/json');
+            $this->factory->throw()->dontTruncateExceptions()->get('http://foo.com/json');
         } catch (RequestException $e) {
             $exception = $e;
         }
@@ -1354,7 +1355,7 @@ class HttpClientTest extends TestCase
 
         $exception = null;
         try {
-            $this->factory->throw()->truncateAt(3)->get('http://foo.com/json');
+            $this->factory->throw()->truncateExceptionsAt(3)->get('http://foo.com/json');
         } catch (RequestException $e) {
             $exception = $e;
         }
@@ -1371,7 +1372,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $exception = $this->factory->async()->throw()->truncateAt(4)->get('http://foo.com/json')->wait();
+        $exception = $this->factory->async()->throw()->truncateExceptionsAt(4)->get('http://foo.com/json')->wait();
 
         $this->assertInstanceOf(RequestException::class, $exception);
         $this->assertEquals("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1364,6 +1364,20 @@ class HttpClientTest extends TestCase
         $this->assertFalse(RequestException::$truncateAt);
     }
 
+    public function testAsyncRequestExceptionsRespectRequestTruncation()
+    {
+        RequestException::dontTruncate();
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $exception = $this->factory->async()->throw()->truncateAt(4)->get('http://foo.com/json')->wait();
+
+        $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertEquals("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());
+        $this->assertFalse(RequestException::$truncateAt);
+    }
+
     public function testRequestExceptionEmptyBody()
     {
         $this->expectException(RequestException::class);


### PR DESCRIPTION
Building off of https://github.com/laravel/framework/pull/53734

I saw a comment in the [Prism repo](https://github.com/prism-php/prism/pull/357) mentioning that this would be handy. I think for a lot of client/library code, it would be nice to have this enabled on a per request basis for reporting.