### PR TITLE
Fix typo in `class Blueprint`: `datetime` => `dateTime`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .styleci.yml export-ignore
-CHANGELOG-* export-ignore
+CHANGELOG.md export-ignore
 CODE_OF_CONDUCT.md export-ignore
 CONTRIBUTING.md export-ignore
 docker-compose.yml export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release Notes for 11.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v11.44.7...11.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v11.45.0...11.x)
+
+## [v11.45.0](https://github.com/laravel/framework/compare/v11.44.7...v11.45.0) - 2025-05-20
+
+* [11.x] Test Improvements by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/55549
+* [11.x] Install Passport 13.x by [@hafezdivandari](https://github.com/hafezdivandari) in https://github.com/laravel/framework/pull/55621
+* [11.x] Bump minimum league/commonmark by [@andrextor](https://github.com/andrextor) in https://github.com/laravel/framework/pull/55660
+* Backporting Timebox fixes to 11.x by [@valorin](https://github.com/valorin) in https://github.com/laravel/framework/pull/55705
+* Test SQLServer 2017 on Ubuntu 22.04 by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/55716
+* [11.x] Fix Symfony 7.3 deprecations by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/55711
+* [11.x] Backport `TestResponse::assertRedirectBack` by [@GrahamCampbell](https://github.com/GrahamCampbell) in https://github.com/laravel/framework/pull/55780
 
 ## [v11.44.7](https://github.com/laravel/framework/compare/v11.44.6...v11.44.7) - 2025-04-25
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1274,16 +1274,16 @@ class Blueprint
     }
 
     /**
-     * Add creation and update datetime columns to the table.
+     * Add creation and update dateTime columns to the table.
      *
      * @param  int|null  $precision
      * @return void
      */
-    public function datetimes($precision = 0)
+    public function dateTimes($precision = 0)
     {
-        $this->datetime('created_at', $precision)->nullable();
+        $this->dateTime('created_at', $precision)->nullable();
 
-        $this->datetime('updated_at', $precision)->nullable();
+        $this->dateTime('updated_at', $precision)->nullable();
     }
 
     /**
@@ -1319,7 +1319,7 @@ class Blueprint
      */
     public function softDeletesDatetime($column = 'deleted_at', $precision = 0)
     {
-        return $this->datetime($column, $precision)->nullable();
+        return $this->dateTime($column, $precision)->nullable();
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '11.44.7';
+    const VERSION = '11.45.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -72,12 +72,19 @@ class ResendTransport extends AbstractTransport
         if ($email->getAttachments()) {
             foreach ($email->getAttachments() as $attachment) {
                 $attachmentHeaders = $attachment->getPreparedHeaders();
+                $contentType = $attachmentHeaders->get('Content-Type')->getBody();
 
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
+                if ($contentType == 'text/calendar') {
+                    $content = $attachment->getBody();
+                } else {
+                    $content = str_replace("\r\n", '', $attachment->bodyToString());
+                }
+
                 $item = [
-                    'content_type' => $attachmentHeaders->get('Content-Type')->getBody(),
-                    'content' => str_replace("\r\n", '', $attachment->bodyToString()),
+                    'content_type' => $contentType,
+                    'content' => $content,
                     'filename' => $filename,
                 ];
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -215,6 +215,23 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting back to the previous location.
+     *
+     * @return $this
+     */
+    public function assertRedirectBack()
+    {
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $this->assertLocation(app('url')->previous());
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given route.
      *
      * @param  \BackedEnum|string  $name

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2631,6 +2631,27 @@ class TestResponseTest extends TestCase
         $response->assertRedirect();
     }
 
+    public function testAssertRedirectBack()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->setPreviousUrl('https://url.com');
+
+        app('url')->setSessionResolver(fn () => app('session.store'));
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response('', 302))->withHeaders(['Location' => 'https://url.com'])
+        );
+
+        $response->assertRedirectBack();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $store->setPreviousUrl('https://url.net');
+
+        $response->assertRedirectBack();
+    }
+
     public function testGetDecryptedCookie()
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
It still works, because of php case sensitive rules, but it's better correct.

You might want to also change `datetimes` to dateTimes` to be consistent?

