### PR TITLE
[12.x] Add ServiceProvider method `loadCommandsFrom()`

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
 use Illuminate\View\Compilers\BladeCompiler;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @property array<string, string> $bindings All of the container bindings that should be registered.
@@ -180,6 +181,31 @@ abstract class ServiceProvider
                 require $path, $config->get($key, [])
             ));
         }
+    }
+
+    /**
+     * Register all of the commands in the given directory.
+     *
+     * @param  string  $path
+     * @param  string  $namespace
+     * @return void
+     */
+    protected function loadCommandsFrom($path, $namespace)
+    {
+        if (! $this->app->runningInConsole()) {
+            return;
+        }
+
+        $commands = [];
+        foreach (Finder::create()->in($path)->files() as $file) {
+            $commands[] = $namespace.str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                Str::after($file->getRealPath(), realpath($path))
+            );
+        }
+
+        $this->commands($commands);
     }
 
     /**


### PR DESCRIPTION
Usage:

```php
public function boot(): void
{
    $this->loadCommandsFrom(__DIR__.'/Commands', __NAMESPACE__.'\Commands');
}
```

This change introduces a new dependency (symfony/finder) which is not
listed in the `./src/Illuminate/Support/composer.json` but is listed in
`./composer.json`.

I assume, that that is okay, because the same is the case for the
"illuminate/view" dependency introduced by the BladeCompiler usage.

Other somewhat related resources:

- <https://github.com/laravel/framework/issues/46656>
- <https://laracasts.com/index.php/discuss/channels/laravel/how-to-register-artisan-commands-outside-default-folder>