### PR TITLE
[12.x] fix: Factory::state and ::prependState generics

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -518,7 +518,7 @@ abstract class Factory
     /**
      * Add a new state transformation to the model definition.
      *
-     * @param  (callable(array<string, mixed>, TModel|null): array<string, mixed>)|array<string, mixed>  $state
+     * @param  (callable(array<string, mixed>, Model|null): array<string, mixed>)|array<string, mixed>  $state
      * @return static
      */
     public function state($state)
@@ -533,7 +533,7 @@ abstract class Factory
     /**
      * Prepend a new state transformation to the model definition.
      *
-     * @param  (callable(array<string, mixed>, TModel|null): array<string, mixed>)|array<string, mixed>  $state
+     * @param  (callable(array<string, mixed>, Model|null): array<string, mixed>)|array<string, mixed>  $state
      * @return static
      */
     public function prependState($state)

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -16,6 +16,18 @@ class UserFactory extends Factory
     }
 }
 
+/** @extends Illuminate\Database\Eloquent\Factories\Factory<Post> */
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
 assertType('UserFactory', $factory = UserFactory::new());
 assertType('UserFactory', UserFactory::new(['string' => 'string']));
 assertType('UserFactory', UserFactory::new(function ($attributes) {
@@ -105,7 +117,7 @@ assertType('UserFactory', $factory->state(function ($attributes) {
 }));
 assertType('UserFactory', $factory->state(function ($attributes, $model) {
     assertType('array<string, mixed>', $attributes);
-    assertType('User|null', $model);
+    assertType('Illuminate\Database\Eloquent\Model|null', $model);
 
     return ['string' => 'string'];
 }));
@@ -164,3 +176,19 @@ Factory::guessFactoryNamesUsing(function (string $modelName) {
         default => throw new LogicException('Unknown factory'),
     };
 });
+
+UserFactory::new()->has(
+    PostFactory::new()
+        ->state(function ($attributes, $user) {
+            assertType('array<string, mixed>', $attributes);
+            assertType('Illuminate\Database\Eloquent\Model|null', $user);
+
+            return ['user_id' => $user?->getKey()];
+        })
+        ->prependState(function ($attributes, $user) {
+            assertType('array<string, mixed>', $attributes);
+            assertType('Illuminate\Database\Eloquent\Model|null', $user);
+
+            return ['user_id' => $user?->getKey()];
+        }),
+);


### PR DESCRIPTION
Hello!

The model passed to the closure is not the generic type `TModel`, but rather the parent model (if any). Because we can't easily determine the type of the parent model, we just use the base Model.

Closes https://github.com/larastan/larastan/discussions/2115

Thanks!