### PR TITLE
[12.x] Batch Job Failure Callbacks Support

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -242,11 +242,7 @@ class Batch implements Arrayable, JsonSerializable
         $counts = $this->decrementPendingJobs($jobId);
 
         if ($this->hasProgressCallbacks()) {
-            $batch = $this->fresh();
-
-            (new Collection($this->options['progress']))->each(function ($handler) use ($batch) {
-                $this->invokeHandlerCallback($handler, $batch);
-            });
+            $this->invokeCallbacks('progress');
         }
 
         if ($counts->pendingJobs === 0) {
@@ -254,19 +250,23 @@ class Batch implements Arrayable, JsonSerializable
         }
 
         if ($counts->pendingJobs === 0 && $this->hasThenCallbacks()) {
-            $batch = $this->fresh();
-
-            (new Collection($this->options['then']))->each(function ($handler) use ($batch) {
-                $this->invokeHandlerCallback($handler, $batch);
-            });
+            $this->invokeCallbacks('then');
         }
 
         if ($counts->allJobsHaveRanExactlyOnce() && $this->hasFinallyCallbacks()) {
-            $batch = $this->fresh();
+            $this->invokeCallbacks('finally');
+        }
+    }
 
-            (new Collection($this->options['finally']))->each(function ($handler) use ($batch) {
-                $this->invokeHandlerCallback($handler, $batch);
-            });
+    /**
+     * Invoke the callbacks of the given type.
+     */
+    protected function invokeCallbacks(string $type, ?Throwable $e = null): void
+    {
+        $batch = $this->fresh();
+
+        foreach ($this->options[$type] ?? [] as $handler) {
+            $this->invokeHandlerCallback($handler, $batch, $e);
         }
     }
 
@@ -346,28 +346,22 @@ class Batch implements Arrayable, JsonSerializable
             $this->cancel();
         }
 
-        if ($this->hasProgressCallbacks() && $this->allowsFailures()) {
-            $batch = $this->fresh();
+        if ($this->allowsFailures()) {
+            if ($this->hasProgressCallbacks()) {
+                $this->invokeCallbacks('progress', $e);
+            }
 
-            (new Collection($this->options['progress']))->each(function ($handler) use ($batch, $e) {
-                $this->invokeHandlerCallback($handler, $batch, $e);
-            });
+            if ($this->hasFailureCallbacks()) {
+                $this->invokeCallbacks('failure', $e);
+            }
         }
 
         if ($counts->failedJobs === 1 && $this->hasCatchCallbacks()) {
-            $batch = $this->fresh();
-
-            (new Collection($this->options['catch']))->each(function ($handler) use ($batch, $e) {
-                $this->invokeHandlerCallback($handler, $batch, $e);
-            });
+            $this->invokeCallbacks('catch', $e);
         }
 
         if ($counts->allJobsHaveRanExactlyOnce() && $this->hasFinallyCallbacks()) {
-            $batch = $this->fresh();
-
-            (new Collection($this->options['finally']))->each(function ($handler) use ($batch, $e) {
-                $this->invokeHandlerCallback($handler, $batch, $e);
-            });
+            $this->invokeCallbacks('finally');
         }
     }
 
@@ -400,6 +394,16 @@ class Batch implements Arrayable, JsonSerializable
     public function hasFinallyCallbacks()
     {
         return isset($this->options['finally']) && ! empty($this->options['finally']);
+    }
+
+    /**
+     * Determine if the batch has "failure" callbacks.
+     *
+     * @return bool
+     */
+    public function hasFailureCallbacks()
+    {
+        return isset($this->options['failure']) && ! empty($this->options['failure']);
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -259,6 +259,17 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Decrement the pending jobs for the batch.
+     *
+     * @param  string  $jobId
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     */
+    public function decrementPendingJobs(string $jobId)
+    {
+        return $this->repository->decrementPendingJobs($this->id, $jobId);
+    }
+
+    /**
      * Invoke the callbacks of the given type.
      */
     protected function invokeCallbacks(string $type, ?Throwable $e = null): void
@@ -268,17 +279,6 @@ class Batch implements Arrayable, JsonSerializable
         foreach ($this->options[$type] ?? [] as $handler) {
             $this->invokeHandlerCallback($handler, $batch, $e);
         }
-    }
-
-    /**
-     * Decrement the pending jobs for the batch.
-     *
-     * @param  string  $jobId
-     * @return \Illuminate\Bus\UpdatedBatchJobCounts
-     */
-    public function decrementPendingJobs(string $jobId)
-    {
-        return $this->repository->decrementPendingJobs($this->id, $jobId);
     }
 
     /**
@@ -387,6 +387,14 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
+     * Determine if the batch has "failure" callbacks.
+     */
+    public function hasFailureCallbacks(): bool
+    {
+        return isset($this->options['failure']) && ! empty($this->options['failure']);
+    }
+
+    /**
      * Determine if the batch has "finally" callbacks.
      *
      * @return bool
@@ -394,14 +402,6 @@ class Batch implements Arrayable, JsonSerializable
     public function hasFinallyCallbacks()
     {
         return isset($this->options['finally']) && ! empty($this->options['finally']);
-    }
-
-    /**
-     * Determine if the batch has "failure" callbacks.
-     */
-    public function hasFailureCallbacks(): bool
-    {
-        return isset($this->options['failure']) && ! empty($this->options['failure']);
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -398,10 +398,8 @@ class Batch implements Arrayable, JsonSerializable
 
     /**
      * Determine if the batch has "failure" callbacks.
-     *
-     * @return bool
      */
-    public function hasFailureCallbacks()
+    public function hasFailureCallbacks(): bool
     {
         return isset($this->options['failure']) && ! empty($this->options['failure']);
     }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -119,9 +119,7 @@ class PendingBatch
      */
     public function before($callback)
     {
-        $this->options['before'][] = $callback instanceof Closure
-            ? new SerializableClosure($callback)
-            : $callback;
+        $this->registerCallback('before', $callback);
 
         return $this;
     }
@@ -144,9 +142,7 @@ class PendingBatch
      */
     public function progress($callback)
     {
-        $this->options['progress'][] = $callback instanceof Closure
-            ? new SerializableClosure($callback)
-            : $callback;
+        $this->registerCallback('progress', $callback);
 
         return $this;
     }
@@ -169,9 +165,7 @@ class PendingBatch
      */
     public function then($callback)
     {
-        $this->options['then'][] = $callback instanceof Closure
-            ? new SerializableClosure($callback)
-            : $callback;
+        $this->registerCallback('then', $callback);
 
         return $this;
     }
@@ -194,9 +188,7 @@ class PendingBatch
      */
     public function catch($callback)
     {
-        $this->options['catch'][] = $callback instanceof Closure
-            ? new SerializableClosure($callback)
-            : $callback;
+        $this->registerCallback('catch', $callback);
 
         return $this;
     }
@@ -219,9 +211,7 @@ class PendingBatch
      */
     public function finally($callback)
     {
-        $this->options['finally'][] = $callback instanceof Closure
-            ? new SerializableClosure($callback)
-            : $callback;
+        $this->registerCallback('finally', $callback);
 
         return $this;
     }
@@ -237,14 +227,31 @@ class PendingBatch
     }
 
     /**
-     * Indicate that the batch should not be cancelled when a job within the batch fails.
+     * Indicate that the batch should not be canceled when a job within the batch fails;
+     * optionally add callbacks to be executed upon each job failure.
      *
-     * @param  bool  $allowFailures
-     * @return $this
+     * When passed a boolean true, enables failure tolerance without callbacks.
+     * When passed a boolean false, disables failure tolerance.
+     * When passed callable(s), registers failure callbacks and enables failure tolerance.
+     * Invalid callables are silently ignored during registration.
+     *
+     * @template TParam of Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
+     *
+     * @param bool|TParam|array<array-key, TParam> $param
      */
-    public function allowFailures($allowFailures = true)
+    public function allowFailures(bool|Closure|callable|array $param = true): self
     {
-        $this->options['allowFailures'] = $allowFailures;
+        if (! is_bool($param)) {
+            $param = Arr::wrap($param);
+
+            foreach ($param as $callback) {
+                if (is_callable($callback)) {
+                    $this->registerCallback('failure', $callback);
+                }
+            }
+        }
+
+        $this->options['allowFailures'] = ! ($param === false);
 
         return $this;
     }
@@ -257,6 +264,26 @@ class PendingBatch
     public function allowsFailures()
     {
         return Arr::get($this->options, 'allowFailures', false) === true;
+    }
+
+    /**
+     * Get the "failure" callbacks that have been registered with the pending batch.
+     *
+     * @return array<array-key, Closure|callable>
+     */
+    public function failureCallbacks(): array
+    {
+        return $this->options['failure'] ?? [];
+    }
+
+    /**
+     * Register a callback with proper serialization.
+     */
+    private function registerCallback(string $type, Closure|callable $callback): void
+    {
+        $this->options[$type][] = $callback instanceof Closure
+            ? new SerializableClosure($callback)
+            : $callback;
     }
 
     /**
@@ -335,7 +362,7 @@ class PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return Batch
      *
      * @throws \Throwable
      */
@@ -365,7 +392,7 @@ class PendingBatch
     /**
      * Dispatch the batch after the response is sent to the browser.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return Batch
      */
     public function dispatchAfterResponse()
     {
@@ -385,7 +412,7 @@ class PendingBatch
     /**
      * Dispatch an existing batch.
      *
-     * @param  \Illuminate\Bus\Batch  $batch
+     * @param Batch $batch
      * @return void
      *
      * @throws \Throwable
@@ -409,7 +436,7 @@ class PendingBatch
      * Dispatch the batch if the given truth test passes.
      *
      * @param  bool|\Closure  $boolean
-     * @return \Illuminate\Bus\Batch|null
+     * @return Batch|null
      */
     public function dispatchIf($boolean)
     {
@@ -420,7 +447,7 @@ class PendingBatch
      * Dispatch the batch unless the given truth test passes.
      *
      * @param  bool|\Closure  $boolean
-     * @return \Illuminate\Bus\Batch|null
+     * @return Batch|null
      */
     public function dispatchUnless($boolean)
     {
@@ -431,7 +458,7 @@ class PendingBatch
      * Store the batch using the given repository.
      *
      * @param  \Illuminate\Bus\BatchRepository  $repository
-     * @return \Illuminate\Bus\Batch
+     * @return Batch
      */
     protected function store($repository)
     {

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -237,7 +237,7 @@ class PendingBatch
      *
      * @template TParam of Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
      *
-     * @param bool|TParam|array<array-key, TParam> $param
+     * @param  bool|TParam|array<array-key, TParam>  $param
      */
     public function allowFailures(bool|Closure|callable|array $param = true): self
     {
@@ -362,7 +362,7 @@ class PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return Batch
+     * @return \Illuminate\Bus\Batch
      *
      * @throws \Throwable
      */
@@ -392,7 +392,7 @@ class PendingBatch
     /**
      * Dispatch the batch after the response is sent to the browser.
      *
-     * @return Batch
+     * @return \Illuminate\Bus\Batch
      */
     public function dispatchAfterResponse()
     {
@@ -412,7 +412,7 @@ class PendingBatch
     /**
      * Dispatch an existing batch.
      *
-     * @param Batch $batch
+     * @param  \Illuminate\Bus\Batch  $batch
      * @return void
      *
      * @throws \Throwable
@@ -436,7 +436,7 @@ class PendingBatch
      * Dispatch the batch if the given truth test passes.
      *
      * @param  bool|\Closure  $boolean
-     * @return Batch|null
+     * @return \Illuminate\Bus\Batch|null
      */
     public function dispatchIf($boolean)
     {
@@ -447,7 +447,7 @@ class PendingBatch
      * Dispatch the batch unless the given truth test passes.
      *
      * @param  bool|\Closure  $boolean
-     * @return Batch|null
+     * @return \Illuminate\Bus\Batch|null
      */
     public function dispatchUnless($boolean)
     {
@@ -458,7 +458,7 @@ class PendingBatch
      * Store the batch using the given repository.
      *
      * @param  \Illuminate\Bus\BatchRepository  $repository
-     * @return Batch
+     * @return \Illuminate\Bus\Batch
      */
     protected function store($repository)
     {

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -227,19 +227,16 @@ class PendingBatch
     }
 
     /**
-     * Indicate that the batch should not be canceled when a job within the batch fails;
-     * optionally add callbacks to be executed upon each job failure.
+     * Indicate that the batch should not be canceled when a job within the batch fails.
      *
-     * When passed a boolean true, enables failure tolerance without callbacks.
-     * When passed a boolean false, disables failure tolerance.
-     * When passed callable(s), registers failure callbacks and enables failure tolerance.
-     * Invalid callables are silently ignored during registration.
+     * Optionally, add callbacks to be executed upon each job failure.
      *
      * @template TParam of Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
      *
      * @param  bool|TParam|array<array-key, TParam>  $param
+     * @return $this
      */
-    public function allowFailures(bool|Closure|callable|array $param = true): self
+    public function allowFailures(Closure|callable|array|bool $param = true)
     {
         if (! is_bool($param)) {
             $param = Arr::wrap($param);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -10,6 +10,7 @@ use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Capsule\Manager as DB;
@@ -295,6 +296,63 @@ class BusBatchTest extends TestCase
         $this->assertEquals(1, $_SERVER['__catch.count']);
         $this->assertEquals(2, $_SERVER['__progress.count']);
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
+    }
+
+    public function test_failure_callbacks_execute_correctly(): void
+    {
+        $queue = m::mock(Factory::class);
+
+        $repository = new DatabaseBatchRepository(new BatchFactory($queue), DB::connection(), 'job_batches');
+
+        $pendingBatch = (new PendingBatch(new Container, collect()))
+            ->allowFailures([
+                static fn (Batch $batch, $e): true => $_SERVER['__failure1.invoked'] = true,
+                function (Batch $batch, $e) {
+                    $_SERVER['__failure2.invoked'] = true;
+                },
+                function (Batch $batch, $e) {
+                    $_SERVER['__failure3.batch'] = $batch;
+                    $_SERVER['__failure3.exception'] = $e;
+                    $_SERVER['__failure3.batch_id'] = $batch->id;
+                    $_SERVER['__failure3.batch_class'] = get_class($batch);
+                    $_SERVER['__failure3.exception_class'] = get_class($e);
+                    $_SERVER['__failure3.exception_message'] = $e->getMessage();
+                    $_SERVER['__failure3.param_count'] = func_num_args();
+                },
+            ])
+            ->onConnection('test-connection')
+            ->onQueue('test-queue');
+
+        $batch = $repository->store($pendingBatch);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once();
+
+        $batch = $batch->add([$job]);
+
+        $_SERVER['__failure1.invoked'] = false;
+        $_SERVER['__failure2.invoked'] = false;
+        $_SERVER['__failure3.batch'] = null;
+        $_SERVER['__failure3.exception'] = null;
+
+        $batch->recordFailedJob('test-id', new RuntimeException('Comprehensive callback test.'));
+
+        $this->assertTrue($_SERVER['__failure1.invoked']);
+        $this->assertTrue($_SERVER['__failure2.invoked']);
+        $this->assertInstanceOf(Batch::class, $_SERVER['__failure3.batch']);
+        $this->assertSame('Comprehensive callback test.', $_SERVER['__failure3.exception']->getMessage());
+        $this->assertSame($batch->id, $_SERVER['__failure3.batch_id']);
+        $this->assertSame(Batch::class, $_SERVER['__failure3.batch_class']);
+        $this->assertSame(RuntimeException::class, $_SERVER['__failure3.exception_class']);
+        $this->assertEquals(2, $_SERVER['__failure3.param_count']);
     }
 
     public function test_batch_can_be_cancelled()

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -10,7 +10,6 @@ use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Capsule\Manager as DB;

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -259,6 +259,144 @@ class BusPendingBatchTest extends TestCase
         );
         $this->expectNotToPerformAssertions();
     }
+
+    public function test_allow_failures_with_boolean_true_enables_failure_tolerance(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures(true);
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertEmpty($batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_with_boolean_false_disables_failure_tolerance(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures(false);
+
+        $this->assertSame($batch, $result);
+        $this->assertFalse($batch->options['allowFailures']);
+        $this->assertEmpty($batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_with_single_closure_registers_callback(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures(static fn (): true => true);
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertCount(1, $batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_with_single_callable_registers_callback(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures('strlen');
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertCount(1, $batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_with_array_of_callables_registers_multiple_callbacks(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures([
+            static fn (): true => true,
+            'strlen',
+            [$batch, 'failureCallbacks'],
+            strlen(...),
+        ]);
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertCount(4, $batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_registers_only_valid_callbacks(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures([
+            // 3 valid
+            static fn (): true => true,
+            'strlen',
+            [$batch, 'failureCallbacks'],
+            // 5 invalid
+            'invalid_function_name',
+            123,
+            null,
+            [],
+            new stdClass,
+        ]);
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertCount(3, $batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_with_empty_array_enables_tolerance_without_callbacks(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $result = $batch->allowFailures([]);
+
+        $this->assertSame($batch, $result);
+        $this->assertTrue($batch->options['allowFailures']);
+        $this->assertEmpty($batch->failureCallbacks());
+    }
+
+    public function test_allow_failures_is_chainable(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $this->assertSame($batch, $batch->allowFailures(true));
+        $this->assertSame($batch, $batch->allowFailures(false));
+        $this->assertSame($batch, $batch->allowFailures(static fn (): true => true));
+        $this->assertSame($batch, $batch->allowFailures('strlen'));
+        $this->assertSame($batch, $batch->allowFailures([static fn (): true => true, 'strlen']));
+        $this->assertSame($batch, $batch->allowFailures([]));
+    }
+
+    public function test_failure_callbacks_accessor_returns_registered_callbacks(): void
+    {
+        $batch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $this->assertEmpty($batch->failureCallbacks());
+
+        $batch->allowFailures(
+            static fn (): true => true
+        );
+
+        $this->assertCount(1, $batch->failureCallbacks());
+
+        $freshBatch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $freshBatch->allowFailures([
+            'strlen',
+            [$freshBatch, 'failureCallbacks'],
+        ]);
+
+        $this->assertCount(2, $freshBatch->failureCallbacks());
+
+        $anotherBatch = new PendingBatch(new Container, new Collection([new BatchableJob]));
+
+        $anotherBatch->allowFailures([
+            static fn (): false => false,
+            'trim',
+            123,
+            'invalid_function',
+        ]);
+
+        $this->assertCount(2, $anotherBatch->failureCallbacks());
+    }
 }
 
 class BatchableJob


### PR DESCRIPTION
### Functional Enhancement

The functional change is in `PendingBatch::allowFailures()`, which now accepts:

- A boolean value (original behavior)
- A callable/Closure
- An array of callables/Closures

This allows the registration of callbacks that will be executed when a job fails, providing more granular control over failure handling in batch processing. The `Batch` class has been updated with corresponding methods to handle these new failure callbacks.

```php
// New usage example:
$batch->allowFailures(function ($batch, $exception) {
    // Handle individual job failure
    Log::error("Job failed in batch {$batch->id}: {$exception->getMessage()}");
});
```

Of course, `$batch->allowFailures()` and `$batch->allowFailures($boolean)` still work as before.

### Additional Changes

- Refactored callback invocation into a centralized `invokeCallbacks` method in the Batch class

### Notes

- I debated going with `$batch->failure($callback)` instead of dual-purposing `$batch->allowFailures()`, but went with the latter since the former would require either a call to `allowFailures()` anyway, setting this option implicitly in the `failure()` implementation, or reworking the logic of `allowsFailures()` to also return true when failure callbacks are present. I'm open to reworking this in any of those directions.
- I envision a possible future `JobContext` object that would be passed to the callback providing more job specific detail, making this potentially more useful.

---

💁🏼‍♂️ The author is available for hire -- inquire at yitzwillroth@gmail.com.