### PR TITLE
Add Arr::filterKeys() method to filter arrays by keys

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1194,6 +1194,7 @@ class Arr
                 $result[$key] = $value;
             }
         }
+
         return $result;
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1177,4 +1177,25 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Filter the array by its keys using the given callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function filterKeys(array $array, callable $callback)
+    {
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            if ($callback($key)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1194,8 +1194,6 @@ class Arr
                 $result[$key] = $value;
             }
         }
-
         return $result;
     }
-
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1773,4 +1773,22 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testFilterKeys()
+    {
+        $array = [
+            'name' => 'Taylor',
+            'age' => 40,
+            'email' => 'taylor@example.com',
+        ];
+
+        $filtered = Arr::filterKeys($array, function ($key) {
+            return in_array($key, ['name', 'email']);
+        });
+
+        $this->assertSame([
+            'name' => 'Taylor',
+            'email' => 'taylor@example.com',
+        ], $filtered);
+    }
 }


### PR DESCRIPTION
## Added `Arr::filterKeys()` method to filter array by keys

### Description
This PR introduces a new method `filterKeys` in the `Illuminate\Support\Arr` class.  
This method allows filtering an array by its keys using a callback function, returning a new array containing only the key-value pairs where the callback returns true for the key.

### Why is this useful?
Currently, Laravel provides methods like `mapWithKeys` and `filter`, but there is no convenient method to filter arrays based specifically on their keys.  
`filterKeys` fills this gap by providing a clean, expressive, and reusable way to filter arrays by keys.

### Example usage

```php
$array = [
    'name' => 'Taylor',
    'age' => 40,
    'email' => 'taylor@example.com',
];

$filtered = Arr::filterKeys($array, function ($key) {
    return in_array($key, ['name', 'email']);
});

// $filtered will be:
// ['name' => 'Taylor', 'email' => 'taylor@example.com']
