### PR TITLE
Add typehint to JsonResource::resolve() method

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -102,7 +102,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * @param  \Illuminate\Http\Request|null  $request
      * @return array
      */
-    public function resolve($request = null)
+    public function resolve($request = null): array
     {
         $data = $this->toArray(
             $request ?: Container::getInstance()->make('request')


### PR DESCRIPTION
This pull request adds a typehint to the resolve() method in the JsonResource class.

Benefits to end users:
- Improves static analysis and IDE support for developers extending or using JsonResource.
- Increases code safety by guaranteeing that this method always returns an array.

Backward compatibility:
- This change does not break any existing features or applications, as the return type is already an array in practice and in doc block.

Why this makes building web applications easier:
- Developers will benefit from better type safety and autocompletion when working with custom resources.
- This small improvement helps maintain code quality and consistency across the framework.