### PR TITLE
[12.x] Add enum support to notification locale method

### DIFF
--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -4,6 +4,8 @@ namespace Illuminate\Notifications;
 
 use Illuminate\Queue\SerializesModels;
 
+use function Illuminate\Support\enum_value;
+
 class Notification
 {
     use SerializesModels;
@@ -35,12 +37,12 @@ class Notification
     /**
      * Set the locale to send this notification in.
      *
-     * @param  string  $locale
+     * @param  \UnitEnum|string  $locale
      * @return $this
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
+        $this->locale = enum_value($locale);
 
         return $this;
     }


### PR DESCRIPTION
This PR enhances the `locale()` method by allowing it to accept enum values in addition to strings.

Usage example:

```php

//Before
$user->notify((new InvoicePaid($invoice))->locale(LOCALE::EN->value));

//After
$user->notify((new InvoicePaid($invoice))->locale(LOCALE::EN));
```