### PR TITLE
document `through()` method in interfaces to fix IDE warnings

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -6,6 +6,8 @@ namespace Illuminate\Contracts\Pagination;
  * @template TKey of array-key
  *
  * @template-covariant TValue
+ *
+ * @method $this through(callable(TValue): mixed $callback)
  */
 interface CursorPaginator
 {

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -6,6 +6,8 @@ namespace Illuminate\Contracts\Pagination;
  * @template TKey of array-key
  *
  * @template-covariant TValue
+ *
+ * @method $this through(callable(TValue): mixed $callback)
  */
 interface Paginator
 {


### PR DESCRIPTION
Related PR: #51638