### PR TITLE
[12.x] Add a command option for making batchable jobs

### DIFF
--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -40,6 +40,10 @@ class JobMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('batched')) {
+            return $this->resolveStubPath('/stubs/job.batched.queued.stub');
+        }
+
         return $this->option('sync')
             ? $this->resolveStubPath('/stubs/job.stub')
             : $this->resolveStubPath('/stubs/job.queued.stub');
@@ -79,6 +83,7 @@ class JobMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job already exists'],
             ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous'],
+            ['batched', null, InputOption::VALUE_NONE, 'Indicates that job should be batchable'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -82,8 +82,8 @@ class JobMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job already exists'],
-            ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous'],
-            ['batched', null, InputOption::VALUE_NONE, 'Indicates that job should be batchable'],
+            ['sync', null, InputOption::VALUE_NONE, 'Indicates that the job should be synchronous'],
+            ['batched', null, InputOption::VALUE_NONE, 'Indicates that the job should be batchable'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/job.batched.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.batched.queued.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class {{ class }} implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if ($this->batch()->cancelled()) {
+            // The batch has been cancelled...
+
+            return;
+        }
+
+        //
+    }
+}


### PR DESCRIPTION
This PR adds `--batched` option to `make:job` command to make [batchable jobs](https://laravel.com/docs/12.x/queues#defining-batchable-jobs):

```shell
php artisan make:job ProcessPodcast --batched
```
