### PR TITLE
[12.x] Add encrypt and decrypt Str helper methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1347,6 +1347,28 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Encrypt the string
+     *
+     * @param  bool  $serialize
+     * @return static
+     */
+    public function encrypt(bool $serialize = true)
+    {
+        return new static(encrypt($this->value, $serialize));
+    }
+
+    /**
+     * Decrypt the string
+     *
+     * @param  bool  $serialize
+     * @return static
+     */
+    public function decrypt(bool $serialize = true)
+    {
+        return new static(decrypt($this->value, $serialize));
+    }
+
+    /**
      * Dump the string.
      *
      * @param  mixed  ...$args

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1347,7 +1347,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Encrypt the string
+     * Encrypt the string.
      *
      * @param  bool  $serialize
      * @return static
@@ -1358,7 +1358,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Decrypt the string
+     * Decrypt the string.
      *
      * @param  bool  $serialize
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1352,7 +1352,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  bool  $serialize
      * @return static
      */
-    public function encrypt(bool $serialize = true)
+    public function encrypt(bool $serialize = false)
     {
         return new static(encrypt($this->value, $serialize));
     }
@@ -1363,7 +1363,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  bool  $serialize
      * @return static
      */
-    public function decrypt(bool $serialize = true)
+    public function decrypt(bool $serialize = false)
     {
         return new static(decrypt($this->value, $serialize));
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1441,10 +1441,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame(hash('sha256', 'foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
     }
 
-    public function testEncryptAndDecrypt(){
-        Container::setInstance( $this->container = new Container );
+    public function testEncryptAndDecrypt()
+    {
+        Container::setInstance($this->container = new Container);
 
-        $this->container->bind('encrypter', fn() => new Encrypter(str_repeat('b', 16)));
+        $this->container->bind('encrypter', fn () => new Encrypter(str_repeat('b', 16)));
 
         $encrypted = encrypt('foo');
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class SupportStringableTest extends TestCase
 {
+    protected Container $container;
+
     /**
      * @param  string  $string
      * @return \Illuminate\Support\Stringable

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Container\Container;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
@@ -1437,5 +1439,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame(hash('xxh3', 'foo'), (string) $this->stringable('foo')->hash('xxh3'));
         $this->assertSame(hash('xxh3', 'foobar'), (string) $this->stringable('foobar')->hash('xxh3'));
         $this->assertSame(hash('sha256', 'foobarbaz'), (string) $this->stringable('foobarbaz')->hash('sha256'));
+    }
+
+    public function testEncryptAndDecrypt(){
+        Container::setInstance( $this->container = new Container );
+
+        $this->container->bind('encrypter', fn() => new Encrypter(str_repeat('b', 16)));
+
+        $encrypted = encrypt('foo');
+
+        $this->assertNotSame('foo', $encrypted);
+        $this->assertSame('foo', decrypt($encrypted));
     }
 }


### PR DESCRIPTION
Inspired from https://github.com/laravel/framework/pull/55767, this PR introduces encrypt() and decrypt() methods to the Illuminate\Support\Stringable class, enabling seamless encryption/decryption within fluent string chains.

### Why?
Current approach requires breaking the fluent chain:
```
$encryptedToken = str('secret-api-token')
    ->pipe(fn(Stringable $str) => encrypt($str->value()))
    ->prepend('encrypted:')
    ->append(':end');
```

The new methods enable simpler method chaining and provide a more readable alternative:
```
$encryptedToken = str('secret-api-token')
    ->encrypt()
    ->prepend('encrypted:')
    ->append(':end');
```