### PR TITLE
[12.x] Add generics to `Model::unguarded()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -140,8 +140,10 @@ trait GuardsAttributes
     /**
      * Run the given callable while being unguarded.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TReturn
+     *
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function unguarded(callable $callback)
     {


### PR DESCRIPTION
This PR allows tools like PHPStorm and PHPStan to understand that the return value of the callback is returned by `Model::unguarded()`