### PR TITLE
[12.x] feat: add extending env to configure step

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -229,20 +229,37 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Begin configuring a new Laravel application instance.
      *
      * @param  string|null  $basePath
+     * @param  array  $environments
      * @return \Illuminate\Foundation\Configuration\ApplicationBuilder
      */
-    public static function configure(?string $basePath = null)
+    public static function configure(?string $basePath = null, array $environments = [])
     {
         $basePath = match (true) {
             is_string($basePath) => $basePath,
             default => static::inferBasePath(),
         };
 
+        static::extendEnvironment($environments);
+
         return (new Configuration\ApplicationBuilder(new static($basePath)))
             ->withKernels()
             ->withEvents()
             ->withCommands()
             ->withProviders();
+    }
+
+    /**
+     * Extend environment with custom adapters
+     *
+     * @param  array  $environments
+     * @return void
+     */
+    protected static function extendEnvironment(array $environments)
+    {
+        foreach ($environments as $name => $callback)
+        {
+            Env::extend($callback, is_string($name) ? $name : null);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -249,15 +249,14 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
-     * Extend environment with custom adapters
+     * Extend environment with custom adapters.
      *
      * @param  array  $environments
      * @return void
      */
     protected static function extendEnvironment(array $environments)
     {
-        foreach ($environments as $name => $callback)
-        {
+        foreach ($environments as $name => $callback) {
             Env::extend($callback, is_string($name) ? $name : null);
         }
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Dotenv\Repository\Adapter\ArrayAdapter;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application;
@@ -269,6 +270,28 @@ class FoundationApplicationTest extends TestCase
         };
         $app->afterLoadingEnvironment($closure);
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables'));
+    }
+
+    public function testExtendingEnvironmentWithCustomAdapter()
+    {
+        $adapter = ArrayAdapter::create()->get();
+
+        $adapter->write('FOO', 'BAR');
+
+        $app = Application::configure(
+            environments: [
+                fn () => $adapter,
+            ]
+        )->create();
+        $closure = function () {
+            //
+        };
+        $app->afterLoadingEnvironment($closure);
+        $app->useConfigPath(__DIR__.'/fixtures/config');
+        $app->bootstrapWith([\Illuminate\Foundation\Bootstrap\LoadConfiguration::class]);
+
+        $this->assertSame('BAR', $app->make('config')->get('app.bar'));
+        $this->assertNotSame('foo', $app->make('config')->get('app.bar'));
     }
 
     public function testBeforeBootstrappingAddsClosure()

--- a/tests/Foundation/fixtures/config/app.php
+++ b/tests/Foundation/fixtures/config/app.php
@@ -2,4 +2,5 @@
 
 return [
     'foo' => 'bar',
+    'bar' => env('FOO', 'foo'),
 ];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
# Summary

This PR extends the work that was implemented in #54756. 

## Problem

The original PR added functionality for extending the Env with custom adapters. In the current state one needs to add a new line in `bootstrap/app.php` right before the application builder. While this works, it takes a way a bit of the feel of slickness and fluidity of configuring your Laravel application.

## Proposed Solution

My initial thought was to add a new static method that could be called before `configure`. I quickly came to the conclusion that this is a lot of unnecessary work. I opted instead for adding a new parameter to the method, since extending the environment still falls under the umbrella of "configuration" of the application.

This PR introduces a new parameter to `Application::configure` where you can pass an array of callbacks - with keys for names - which will seamlessly add new env adapters to your environment.

### Example

```php
Application::configure(
    environments: [
        fn () => ArrayAdapter::create()->get(),
    ]
)->create();
```
```php
Application::configure(
    environments: [
        'array_adapter' => fn () => ArrayAdapter::create()->get(),
    ]
)->create();
```