### PR TITLE
[12.x] Fix SSL Certificate and Connection Errors Leaking as Guzzle Exceptions

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -936,7 +936,6 @@ class PendingRequest
                     }
                 });
             } catch (TransferException $e) {
-
                 if ($e instanceof ConnectException) {
                     $exception = new ConnectionException($e->getMessage(), 0, $e);
                     $request = new Request($e->getRequest());

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -960,60 +960,6 @@ class PendingRequest
     }
 
     /**
-     * Handle the given connection exception.
-     *
-     * @param  \GuzzleHttp\Exception\ConnectException  $e
-     * @return void
-     */
-    protected function marshalConnectionException(ConnectException $e)
-    {
-        $exception = new ConnectionException($e->getMessage(), 0, $e);
-
-        $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
-        );
-
-        $this->dispatchConnectionFailedEvent($request, $exception);
-
-        throw $exception;
-    }
-
-    /**
-     * Handle the given request exception.
-     *
-     * @param  \GuzzleHttp\Exception\RequestException  $e
-     * @return void
-     */
-    protected function marshalRequestExceptionWithoutResponse(RequestException $e)
-    {
-        $exception = new ConnectionException($e->getMessage(), 0, $e);
-
-        $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
-        );
-
-        $this->dispatchConnectionFailedEvent($request, $exception);
-
-        throw $exception;
-    }
-
-    /**
-     * Handle the given request exception.
-     *
-     * @param  \GuzzleHttp\Exception\RequestException  $e
-     * @return void
-     */
-    protected function marshalRequestExceptionWithResponse(RequestException $e)
-    {
-        $this->factory?->recordRequestResponsePair(
-            new Request($e->getRequest()),
-            $response = $this->populateResponse($this->newResponse($e->getResponse()))
-        );
-
-        throw $response->toException();
-    }
-
-    /**
      * Substitute the URL parameters in the given URL.
      *
      * @param  string  $url
@@ -1574,6 +1520,60 @@ class PendingRequest
         if ($dispatcher = $this->factory?->getDispatcher()) {
             $dispatcher->dispatch(new ConnectionFailed($request, $exception));
         }
+    }
+
+    /**
+     * Handle the given connection exception.
+     *
+     * @param  \GuzzleHttp\Exception\ConnectException  $e
+     * @return void
+     */
+    protected function marshalConnectionException(ConnectException $e)
+    {
+        $exception = new ConnectionException($e->getMessage(), 0, $e);
+
+        $this->factory?->recordRequestResponsePair(
+            $request = new Request($e->getRequest()), null
+        );
+
+        $this->dispatchConnectionFailedEvent($request, $exception);
+
+        throw $exception;
+    }
+
+    /**
+     * Handle the given request exception.
+     *
+     * @param  \GuzzleHttp\Exception\RequestException  $e
+     * @return void
+     */
+    protected function marshalRequestExceptionWithoutResponse(RequestException $e)
+    {
+        $exception = new ConnectionException($e->getMessage(), 0, $e);
+
+        $this->factory?->recordRequestResponsePair(
+            $request = new Request($e->getRequest()), null
+        );
+
+        $this->dispatchConnectionFailedEvent($request, $exception);
+
+        throw $exception;
+    }
+
+    /**
+     * Handle the given request exception.
+     *
+     * @param  \GuzzleHttp\Exception\RequestException  $e
+     * @return void
+     */
+    protected function marshalRequestExceptionWithResponse(RequestException $e)
+    {
+        $this->factory?->recordRequestResponsePair(
+            new Request($e->getRequest()),
+            $response = $this->populateResponse($this->newResponse($e->getResponse()))
+        );
+
+        throw $response->toException();
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -938,23 +938,34 @@ class PendingRequest
             } catch (TransferException $e) {
                 if ($e instanceof ConnectException) {
                     $exception = new ConnectionException($e->getMessage(), 0, $e);
-                    $request = new Request($e->getRequest());
-                    $this->factory?->recordRequestResponsePair($request, null);
+
+                    $this->factory?->recordRequestResponsePair(
+                        $request = new Request($e->getRequest()), null
+                    );
+
                     $this->dispatchConnectionFailedEvent($request, $exception);
+
                     throw $exception;
                 }
 
                 if ($e instanceof RequestException && ! $e->hasResponse()) {
                     $exception = new ConnectionException($e->getMessage(), 0, $e);
-                    $request = new Request($e->getRequest());
-                    $this->factory?->recordRequestResponsePair($request, null);
+
+                    $this->factory?->recordRequestResponsePair(
+                        $request = new Request($e->getRequest()), null
+                    );
+
                     $this->dispatchConnectionFailedEvent($request, $exception);
+
                     throw $exception;
                 }
 
                 if ($e instanceof RequestException && $e->hasResponse()) {
-                    $response = $this->populateResponse($this->newResponse($e->getResponse()));
-                    $this->factory?->recordRequestResponsePair(new Request($e->getRequest()), $response);
+                    $this->factory?->recordRequestResponsePair(
+                        new Request($e->getRequest()),
+                        $response = $this->populateResponse($this->newResponse($e->getResponse()))
+                    );
+
                     throw $response->toException();
                 }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\TransferStats;
@@ -2514,6 +2516,22 @@ class HttpClientTest extends TestCase
                 $request->url() === 'https://laravel.example' &&
                 $request->hasHeader('X-Test-Header', 'Test');
         });
+    }
+
+    public function testSslCertificateErrorsConvertedToConnectionException()
+    {
+        $this->factory->fake(function () {
+            $request = new GuzzleRequest('HEAD', 'https://ssl-error.laravel.example');
+            throw new GuzzleRequestException(
+                'cURL error 60: SSL certificate problem: unable to get local issuer certificate',
+                $request
+            );
+        });
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('cURL error 60: SSL certificate problem: unable to get local issuer certificate');
+
+        $this->factory->head('https://ssl-error.laravel.example');
     }
 
     public function testRequestExceptionIsNotThrownIfThePendingRequestIsSetToThrowOnFailureButTheResponseIsSuccessful()


### PR DESCRIPTION
## Problem

When SSL certificate errors or other connection-level failures occur during HTTP requests, Guzzle's `RequestException` instances leak through to the application instead of being converted to Laravel's `ConnectionException`.

This breaks the expected exception hierarchy and forces developers to catch Guzzle-specific exceptions.

### Example (Before Fix)

```php
try {
    Http::get('https://example.com');
} catch (\GuzzleHttp\Exception\RequestException $e) {
    // Unexpected - should be a Laravel ConnectionException
}
```

### Expected

```php
Illuminate\Http\Client\ConnectionException
```

### Actual

```php
GuzzleHttp\Exception\RequestException
```

Issue : https://github.com/laravel/framework/issues/55733
---

## Root Cause

The exception handling in `PendingRequest::send()` did not properly handle `RequestException` instances that occur without a response, such as:

- SSL handshake failures
- DNS resolution errors
- Timeouts

---

## Solution

Comprehensive exception handling logic was added to properly categorize and convert Guzzle exceptions:

- `ConnectException` → `ConnectionException` (connection-level failures)
- `RequestException` **without** response → `ConnectionException` (SSL, DNS, timeout failures)
- `RequestException` **with** response → Laravel response exceptions (HTTP-level errors)
- Other `TransferException` → Re-thrown as-is

---

## Changes Made

**File:** `src/Illuminate/Http/Client/PendingRequest.php`

- Added complete `TransferException` handling in the `send()` method.

---

## Test Coverage

Added tests covering:

- ✅ SSL certificate errors (cURL error 60)

---

## Backward Compatibility

- ✅ **No breaking changes**
- Affects only exception types for **connection-level failures**
- Converts Guzzle exceptions to Laravel-specific `ConnectionException`

---

## Fixes

- ❌ SSL certificate problems → ✅ Now throw `ConnectionException`
- ❌ DNS resolution errors → ✅ Now throw `ConnectionException`
- ❌ Connection timeouts → ✅ Now throw `ConnectionException`
- ✅ Existing behavior for successful and HTTP-level error responses is preserved

---

## Developer Benefit

This ensures developers can rely on Laravel's exception hierarchy:

```php
try {
    Http::get(...);
} catch (\Illuminate\Http\Client\ConnectionException $e) {
    // Proper handling of all connection-level errors
}
```

No need to catch Guzzle exceptions directly anymore.
