### PR TITLE
Fix deprecation warning in PHP 8.3 by ensuring string type in explode()

### DIFF
--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -30,7 +30,7 @@ class NamespacedItemResolver
         // namespace, and is just a regular configuration item. Namespaces are a
         // tool for organizing configuration items for things such as modules.
         if (! str_contains($key, '::')) {
-            $segments = explode('.', $key);
+            $segments = explode('.', (string) $key);
 
             $parsed = $this->parseBasicSegments($segments);
         } else {
@@ -74,12 +74,12 @@ class NamespacedItemResolver
      */
     protected function parseNamespacedSegments($key)
     {
-        [$namespace, $item] = explode('::', $key);
+        [$namespace, $item] = explode('::', (string) $key);
 
         // First we'll just explode the first segment to get the namespace and group
         // since the item should be in the remaining segments. Once we have these
         // two pieces of data we can proceed with parsing out the item's value.
-        $itemSegments = explode('.', $item);
+        $itemSegments = explode('.', (string) $item);
 
         $groupAndItem = array_slice(
             $this->parseBasicSegments($itemSegments), 1


### PR DESCRIPTION
PHP 8.3 introduces a deprecation warning when `null` is passed to the second parameter of `explode()`. This change ensures type safety by casting potential `null` values to `string`s before calling `explode()`.

This fix ensures compatibility with PHP 8.3 and maintains backward compatibility with previous versions.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
