### PR TITLE
[12.x] Replacing sha1 with hash in email verification link

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -85,7 +85,7 @@ class VerifyEmail extends Notification
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
                 'id' => $notifiable->getKey(),
-                'hash' => sha1($notifiable->getEmailForVerification()),
+                'hash' => hash('sha256', $notifiable->getEmailForVerification()),
             ]
         );
     }

--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -19,7 +19,7 @@ class EmailVerificationRequest extends FormRequest
             return false;
         }
 
-        if (! hash_equals(sha1($this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
+        if (! hash_equals(hash('sha256', $this->user()->getEmailForVerification()), (string) $this->route('hash'))) {
             return false;
         }
 


### PR DESCRIPTION
According to one of PestPHP default architecture standards, it is not recommended to use sha1/md5.

PestPHP Pattern: `arch()->preset()->security();`

So I replaced the `sha1` used in the email verification link so that it uses the `hash` function with the sha256 algorithm, maintaining the same level of security.