### PR TITLE
[12.x] feat: Add WorkerStarting event when worker daemon starts

### DIFF
--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -21,6 +21,14 @@ interface Monitor
     public function failing($callback);
 
     /**
+     * Register a callback to be executed when a daemon queue is starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback);
+
+    /**
      * Register a callback to be executed when a daemon queue is stopping.
      *
      * @param  mixed  $callback

--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -21,14 +21,6 @@ interface Monitor
     public function failing($callback);
 
     /**
-     * Register a callback to be executed when a daemon queue is starting.
-     *
-     * @param  mixed  $callback
-     * @return void
-     */
-    public function starting($callback);
-
-    /**
      * Register a callback to be executed when a daemon queue is stopping.
      *
      * @param  mixed  $callback

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerStarting
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\WorkerOptions  $options
+     */
+    public function __construct(
+        public $connectionName,
+        public $queue,
+        public $workerOptions
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -99,6 +99,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Register an event listener for the daemon queue starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback)
+    {
+        $this->app['events']->listen(Events\WorkerStarting::class, $callback);
+    }
+
+    /**
      * Register an event listener for the daemon queue stopping.
      *
      * @param  mixed  $callback

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -627,7 +627,7 @@ class Worker
     }
 
     /**
-     * Raise the before job has been popped.
+     * Raise an event indicating the worker is starting.
      *
      * @param  string  $connectionName
      * @param  string  $queue
@@ -640,7 +640,7 @@ class Worker
     }
 
     /**
-     * Raise the before job has been popped.
+     * Raise an event indicating a job is being popped from the queue.
      *
      * @param  string  $connectionName
      * @return void
@@ -651,7 +651,7 @@ class Worker
     }
 
     /**
-     * Raise the after job has been popped.
+     * Raise an event indicating a job has been popped from the queue.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job|null  $job
@@ -665,7 +665,7 @@ class Worker
     }
 
     /**
-     * Raise the before queue job event.
+     * Raise an event indicating a job is being processed.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job
@@ -679,7 +679,7 @@ class Worker
     }
 
     /**
-     * Raise the after queue job event.
+     * Raise an event indicating a job has been processed.
      *
      * @param  string  $connectionName
      * @param  \Illuminate\Contracts\Queue\Job  $job

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -396,7 +396,7 @@ class QueueWorkerTest extends TestCase
             $secondJob = new WorkerFakeJob(),
         ]]);
 
-        $status = $worker->daemon('default', 'queue', $workerOptions);
+        $worker->daemon('default', 'queue', $workerOptions);
 
         $this->assertTrue($firstJob->fired);
         $this->assertTrue($secondJob->fired);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -390,6 +390,7 @@ class QueueWorkerTest extends TestCase
     public function testWorkerStartingIsDispatched()
     {
         $workerOptions = new WorkerOptions();
+        $workerOptions->stopWhenEmpty = true;
 
         $worker = $this->getWorker('default', ['queue' => [
             $firstJob = new WorkerFakeJob(),

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Events\JobPopped;
 use Illuminate\Queue\Events\JobPopping;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker;
@@ -384,6 +385,23 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($customJob->fired);
 
         Worker::popUsing('myworker', null);
+    }
+
+    public function testWorkerStartingIsDispatched()
+    {
+        $workerOptions = new WorkerOptions();
+
+        $worker = $this->getWorker('default', ['queue' => [
+            $firstJob = new WorkerFakeJob(),
+            $secondJob = new WorkerFakeJob(),
+        ]]);
+
+        $status = $worker->daemon('default', 'queue', $workerOptions);
+
+        $this->assertTrue($firstJob->fired);
+        $this->assertTrue($secondJob->fired);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(WorkerStarting::class))->once();
     }
 
     /**


### PR DESCRIPTION
Creates a new `WorkerStarting` event that fires just as a new worker daemon starts.

This provides an excellent hook point to perform actions just as a worker starts, instead of having to rely on handling things before processing individual jobs.
I have personally encountered the need to apply extra setup as a worker starts. Without this, I have needed to execute certain setup before each job starts with `JobProcessing`.

Although the core of the change is backward compatible, I added a `starting` method to `src/Illuminate/Queue/QueueManager.php` and the `src/Illuminate/Contracts/Queue/Monitor.php` interface. Which I can revert if it is determined that the changing of an interface is not wanted at this time.