### PR TITLE
[12.x] feat: Add ability to override SendQueuedNotifications job class

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -249,7 +249,11 @@ class NotificationSender
                 }
 
                 $this->bus->dispatch(
-                    (new SendQueuedNotifications($notifiable, $notification, [$channel]))
+                    $this->manager->getContainer()->make(SendQueuedNotifications::class, [
+                        'notifiables' => $notifiable,
+                        'notification' => $notification,
+                        'channels' => [$channel],
+                    ])
                         ->onConnection($connection)
                         ->onQueue($queue)
                         ->delay(is_array($delay) ? ($delay[$channel] ?? null) : $delay)

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -40,5 +40,7 @@ class NotificationServiceProvider extends ServiceProvider
         $this->app->alias(
             ChannelManager::class, FactoryContract::class
         );
+
+        $this->app->bind(SendQueuedNotifications::class, SendQueuedNotifications::class);
     }
 }

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -40,7 +40,5 @@ class NotificationServiceProvider extends ServiceProvider
         $this->app->alias(
             ChannelManager::class, FactoryContract::class
         );
-
-        $this->app->bind(SendQueuedNotifications::class, SendQueuedNotifications::class);
     }
 }

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -27,6 +27,7 @@ class NotificationSenderTest extends TestCase
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldReceive('dispatch');
         $events = m::mock(EventDispatcher::class);
@@ -55,6 +56,7 @@ class NotificationSenderTest extends TestCase
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldNotReceive('dispatch');
         $events = m::mock(EventDispatcher::class);
@@ -76,6 +78,7 @@ class NotificationSenderTest extends TestCase
             });
         $events = m::mock(EventDispatcher::class);
         $events->shouldReceive('listen')->once();
+        $manager->shouldReceive('getContainer')->andReturn(app());
 
         $sender = new NotificationSender($manager, $bus, $events);
 
@@ -86,6 +89,7 @@ class NotificationSenderTest extends TestCase
     {
         $notifiable = m::mock(Notifiable::class);
         $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldReceive('dispatch')
             ->once()
@@ -114,6 +118,7 @@ class NotificationSenderTest extends TestCase
     {
         $notifiable = new AnonymousNotifiable;
         $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
         $bus = m::mock(BusDispatcher::class);
         $bus->shouldReceive('dispatch')
             ->once()


### PR DESCRIPTION
Adds the ability to bind a job to override SendQueuedNotifications in the container.

Often, folks may want to have a lot more control over the Notification sending queued job. Without this change, it is a large amount of effort and overrides to make changes to this job.