### PR TITLE
revert: #55939

### DIFF
--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -30,7 +30,7 @@ class NamespacedItemResolver
         // namespace, and is just a regular configuration item. Namespaces are a
         // tool for organizing configuration items for things such as modules.
         if (! str_contains($key, '::')) {
-            $segments = explode('.', (string) $key);
+            $segments = explode('.', $key);
 
             $parsed = $this->parseBasicSegments($segments);
         } else {
@@ -74,12 +74,12 @@ class NamespacedItemResolver
      */
     protected function parseNamespacedSegments($key)
     {
-        [$namespace, $item] = explode('::', (string) $key);
+        [$namespace, $item] = explode('::', $key);
 
         // First we'll just explode the first segment to get the namespace and group
         // since the item should be in the remaining segments. Once we have these
         // two pieces of data we can proceed with parsing out the item's value.
-        $itemSegments = explode('.', (string) $item);
+        $itemSegments = explode('.', $item);
 
         $groupAndItem = array_slice(
             $this->parseBasicSegments($itemSegments), 1


### PR DESCRIPTION
revert: https://github.com/laravel/framework/pull/55939

The first cast is never reached, because `! str_contains($key, '::')` would throw on `$key = null` . 
The other both casts would prevent PHP 8.4 from throwing on a real error (and are also never reached when called from within the class). 
`$key` should never be `null` here; it can only result in an undesired outcome.

The author of the PR didn't explain what their issue is. The merged PR is, however, the wrong fix.

cc: @Khuthaily