### PR TITLE
[12.x] feat: Make custom eloquent castings comparable for more granular isDirty check

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface ComparesCastableAttributes
+{
+    /**
+     * Compare two values for an attribute and check if they are equal.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value1
+     * @param  mixed  $value2
+     * @return bool
+     */
+    public function compare($model, string $key, $value1, $value2);
+}

--- a/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
@@ -2,16 +2,18 @@
 
 namespace Illuminate\Contracts\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Model;
+
 interface ComparesCastableAttributes
 {
     /**
-     * Compare two values for an attribute and check if they are equal.
+     * Determine if the given values are equal.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @param  mixed  $value1
-     * @param  mixed  $value2
+     * @param  mixed  $firstValue
+     * @param  mixed  $secondValue
      * @return bool
      */
-    public function compare($model, string $key, $value1, $value2);
+    public function compare(Model $model, string $key, mixed $firstValue, mixed $secondValue);
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -991,6 +991,21 @@ trait HasAttributes
     }
 
     /**
+     * Compare two values for the given attribute using the custom cast class.
+     *
+     * @param  string  $key
+     * @param  mixed  $original
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function compareClassCastableAttribute($key, $original, $value)
+    {
+        return $this->resolveCasterClass($key)->compare(
+            $this, $key, $original, $value
+        );
+    }
+
+    /**
      * Determine if the cast type is a custom date time cast.
      *
      * @param  string  $cast
@@ -1801,6 +1816,19 @@ trait HasAttributes
     }
 
     /**
+     * Determine if the key is comparable using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassComparable($key)
+    {
+        return ! $this->isEnumCastable($key) &&
+            $this->isClassCastable($key) &&
+            method_exists($this->resolveCasterClass($key), 'compare');
+    }
+
+    /**
      * Resolve the custom caster class for a given key.
      *
      * @param  string  $key
@@ -2265,6 +2293,8 @@ trait HasAttributes
             }
 
             return false;
+        } elseif ($this->isClassComparable($key)) {
+            return $this->compareClassCastableAttribute($key, $original, $attribute);
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -6,6 +6,7 @@ use Brick\Math\BigNumber;
 use GMP;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\ComparesCastableAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
@@ -53,6 +54,11 @@ class EloquentModelCustomCastingTest extends TestCase
             $table->increments('id');
             $table->decimal('amount', 4, 2);
         });
+
+        $this->schema()->create('documents', function (Blueprint $table) {
+            $table->increments('id');
+            $table->json('document');
+        });
     }
 
     /**
@@ -64,6 +70,7 @@ class EloquentModelCustomCastingTest extends TestCase
     {
         $this->schema()->drop('casting_table');
         $this->schema()->drop('members');
+        $this->schema()->drop('documents');
     }
 
     #[RequiresPhpExtension('gmp')]
@@ -174,6 +181,25 @@ class EloquentModelCustomCastingTest extends TestCase
 
         $model->increment('amount', new Euro('1'));
         $this->assertEquals('3.00', $model->amount->value);
+    }
+
+    public function test_model_with_custom_casts_compare_function()
+    {
+        // Set raw attribute, this is an example of how we would receive JSON string from the database.
+        // Note the spaces after the colon.
+        $model = new Document();
+        $model->setRawAttributes(['document' => '{"content": "content", "title": "hello world"}']);
+        $model->save();
+
+        // Inverse title and content this would result in a different JSON string when json_encode is used
+        $document = new \stdClass();
+        $document->title = 'hello world';
+        $document->content = 'content';
+        $model->document = $document;
+
+        $this->assertFalse($model->isDirty('document'));
+        $document->title = 'hello world 2';
+        $this->assertTrue($model->isDirty('document'));
     }
 
     /**
@@ -409,4 +435,31 @@ class Member extends Model
     protected $casts = [
         'amount' => Euro::class,
     ];
+}
+
+class Document extends Model
+{
+    public $timestamps = false;
+
+    protected $casts = [
+        'document' => StructuredDocumentCaster::class,
+    ];
+}
+
+class StructuredDocumentCaster implements CastsAttributes, ComparesCastableAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return json_decode($value);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return json_encode($value);
+    }
+
+    public function compare($model, $key, $value1, $value2)
+    {
+        return json_decode($value1) == json_decode($value2);
+    }
 }


### PR DESCRIPTION
This PR adds the ability to compare custom casted attributes to detect if a model attribute is dirty or not.

Some background: 
Currently when a JSON field is used in the database and a cast to  `object` or `collection` is used, the format `{"key": "value", "key2": "value"}` and `{"key":"value","key2":"value"}` will match and will not be flagged as dirty. 

The problem is that this isn't possible for custom casts (A good example would be [spatie/laravel-data](https://spatie.be/docs/laravel-data/v4/advanced-usage/eloquent-casting))

This PR doesn't solve the problem directly for JSON fields, but gives custom casts the possibility to give more granular control about how the values will be compared in the `originalIsEquivalent` method.

This is done by checking if the attribute is casted by a class and if that custom caster has the method `compare`

This also gives the ability to prevent dirty hits when the order of a JSON field is changed, There was a loose comparison but that was reverted in https://github.com/laravel/framework/pull/41337 