### PR TITLE
[12.x] feat(seed): Add multiple seeder support with enhanced validation

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -99,6 +99,20 @@ class SeedCommand extends Command
                 $class = 'DatabaseSeeder';
             }
 
+            if (! class_exists($class)) {
+                $this->components->error("Seeder class [{$class}] does not exist.");
+                continue;
+            }
+            if (! is_subclass_of($class, 'Illuminate\Database\Seeder')) {
+                $this->components->error("Seeder class [{$class}] must extend Illuminate\\Database\\Seeder.");
+                continue;
+            }
+            if (! method_exists($class, 'run')) {
+                $this->components->error("Seeder class [{$class}] must define a run method.");
+                continue;
+            }
+            $this->components->info("Seeding: {$class}");
+
             $response[] = $this->laravel->make($class)
                 ->setContainer($this->laravel)
                 ->setCommand($this);


### PR DESCRIPTION
## Description

This PR significantly enhances the `db:seed` command with two major improvements:
1. **Multiple Seeder Support**: Ability to run multiple seeders in a single command
2. **Validation Layer**: Comprehensive pre-execution checks for seeder integrity

## Changes

### 1. Multiple Seeder Implementation

**Core Changes:**
- Modified argument/option handling from singular `class` to plural `classes`
- Updated method signatures and help texts to reflect new capability
- Implemented array processing for multiple classes:
  ```php
  $classes = $this->input->getArgument('classes') ?? $this->input->getOption('classes');
  foreach (explode(',', $classes) as $class) {
      $class = trim($class);
      // Namespace handling and validation
  }