### PR TITLE
[13.x] Adds starting method to Monitor interface

### DIFF
--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -21,6 +21,14 @@ interface Monitor
     public function failing($callback);
 
     /**
+     * Register a callback to be executed when a daemon queue is starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback);
+
+    /**
      * Register a callback to be executed when a daemon queue is stopping.
      *
      * @param  mixed  $callback


### PR DESCRIPTION
A breaking change follow-up to https://github.com/laravel/framework/pull/55941, adds the `starting` method to the `Monitor` interface to match the existence of `stopping` in this interface and the `starting` method implemented in `src/Illuminate/Queue/QueueManager.php`.

This is failing CI as the changes merged in https://github.com/laravel/framework/pull/55941 are not yet merged back into `master`. If how this gets merged in needs to be changed I can wait on it.