### PR TITLE
[12.x] feat(cache): Add rememberWhen method to conditionally store cached values

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -475,6 +475,36 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Get an item from the cache, or execute the given Closure and store the result only if it passes validation.
+     *
+     * @template TCacheValue
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @param  \Closure(TCacheValue): bool  $validator
+     * @return TCacheValue
+     */
+    public function rememberWhen($key, $ttl, Closure $callback, Closure $validator)
+    {
+        $value = $this->get($key);
+
+        // If the item exists in the cache we will just return this immediately
+        if (! is_null($value)) {
+            return $value;
+        }
+
+        $value = $callback();
+
+        // Only store the result in cache if it passes the validator
+        if ($validator($value)) {
+            $this->put($key, $value, value($ttl, $value));
+        }
+
+        return $value;
+    }
+
+    /**
      * Retrieve an item from the cache by key, refreshing it in the background if it is stale.
      *
      * @template TCacheValue

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -255,6 +255,36 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->add('foo', 'bar'));
     }
 
+    public function testRememberWhenMethodStoresWhenValidatorPasses()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+
+        $result = $repo->rememberWhen('foo', 10, function () {
+            return 'bar';
+        }, function ($value) {
+            return $value === 'bar';
+        });
+
+        $this->assertEquals('bar', $result);
+    }
+
+    public function testRememberWhenMethodDoesNotStoreWhenValidatorFails()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->never();
+
+        $result = $repo->rememberWhen('foo', 10, function () {
+            return 'bar';
+        }, function ($value) {
+            return $value === 'not-bar';
+        });
+
+        $this->assertEquals('bar', $result);
+    }
+
     public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately()
     {
         $repo = $this->getRepository();


### PR DESCRIPTION
# Add `rememberWhen` method to Cache repository

## Description

This PR adds a new `rememberWhen` method to the Cache repository that extends Laravel's caching capabilities by adding conditional validation before storing values in the cache.

The current `remember` method always caches the callback result, regardless of its content. This can lead to caching empty arrays, error responses, or other undesirable values. The new `rememberWhen` method allows developers to validate the callback's output before committing it to cache.

## Use Case

Often when caching API responses or expensive database queries, we want to cache results only if they meet certain criteria (not empty, contain required fields, etc.). For example:

```php
// Before: Requires manual checking or separate method
$data = Cache::remember('api-data', 3600, function () {
    $response = Http::get('api.example.com/data')->json();
    return $response; // Always cached, even if empty or error response
});

// After: Built-in validation
$data = Cache::rememberWhen('api-data', 3600, function () {
    return Http::get('api.example.com/data')->json();
}, function ($value) {
    return !empty($value) && isset($value['success']) && $value['success'] === true;
});
```

## Implementation Details

The implementation follows Laravel's coding style and pattern of other remember-type methods. The method accepts four parameters:
- `$key`: The cache key
- `$ttl`: Time-to-live for the cached item
- `$callback`: The closure that generates the value
- `$validator`: A closure that receives the callback result and returns a boolean indicating whether to cache it

## Testing

Added two test cases:
1. Verifies that values are stored when the validator passes
2. Verifies that values are NOT stored when the validator fails

All tests pass with the current implementation.

## Breaking Changes

None. This adds a new method without modifying existing behavior.