### PR TITLE
Acknowledge "Data set #0 has more arguments" warning from PHPUnit 12.2

### DIFF
--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UsePusherChannelsNamesTest extends TestCase
 {
     #[DataProvider('channelsProvider')]
-    public function testChannelNameNormalization($requestChannelName, $normalizedName)
+    public function testChannelNameNormalization($requestChannelName, $normalizedName, $_)
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 


### PR DESCRIPTION
Running test suite of 12.x Laravel branch using PHPUnit 12.2.1 exit with an error code and produces this output:

```
1 test triggered 49 PHPUnit warnings:

1) Illuminate\Tests\Broadcasting\UsePusherChannelsNamesTest::testChannelNameNormalization
* Data set #0 has more arguments (3) than the test method accepts (2)

* Data set #1 has more arguments (3) than the test method accepts (2)

* ...

* Data set #48 has more arguments (3) than the test method accepts (2)

/tests/Broadcasting/UsePusherChannelsNamesTest.php:13
```

Acknowledging the presence of the third variable with `$_` makes it pass again.

If this is wished to pass with PHPUnit >= 12.2, I guess this might be a possible fix.

Another possibility is to wrap each case into a bag class:
```php
$tests[] = ['public-test', 'public-test', false];
```
To become:
```php
$tests[] = [new ChannelCase(requestChannelName: 'public-test', normalizedName: 'public-test', guarded: false)];
```

So the test would look like:
```php
#[DataProvider('channelsProvider')]
public function testChannelNameNormalization(ChannelCase $case)
{
    $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;

    $this->assertSame(
        $case->normalizedName,
        $broadcaster->normalizeChannelName($case->requestChannelName)
    );
}
```

If you prefer this solution, I can do the change in `UsePusherChannelsNamesTest`.