### PR TITLE
[13.x] `Cache::touch()` & `Store::touch()` for TTL Extension

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -93,7 +93,7 @@ class ApcStore extends TaggableStore
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -93,6 +93,24 @@ class ApcStore extends TaggableStore
     }
 
     /**
+     * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        $value = $this->apc->get($key = $this->getPrefix().$key);
+
+        if (is_null($value)) {
+            return false;
+        }
+
+        return $this->apc->put($key, $value, $seconds);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -101,20 +119,6 @@ class ApcStore extends TaggableStore
     public function forget($key)
     {
         return $this->apc->delete($this->prefix.$key);
-    }
-
-    /**
-     * Set the expiration time of a cached item.
-     */
-    public function touch(string $key, int $ttl): bool
-    {
-        $value = $this->apc->get($key = $this->getPrefix().$key);
-
-        if (is_null($value)) {
-            return false;
-        }
-
-        return $this->apc->put($key, $value, $ttl);
     }
 
     /**

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -104,6 +104,20 @@ class ApcStore extends TaggableStore
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        $value = $this->apc->get($key = $this->getPrefix().$key);
+
+        if (is_null($value)) {
+            return false;
+        }
+
+        return $this->apc->put($key, $value, $ttl);
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return bool

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -132,7 +132,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -133,8 +133,12 @@ class ArrayStore extends TaggableStore implements LockProvider
 
     /**
      * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
      */
-    public function touch(string $key, int $ttl): bool
+    public function touch($key, $seconds)
     {
         $item = Arr::get($this->storage, $key = $this->getPrefix().$key, null);
 
@@ -142,7 +146,7 @@ class ArrayStore extends TaggableStore implements LockProvider
             return false;
         }
 
-        $item['expiresAt'] = $this->calculateExpiration($ttl);
+        $item['expiresAt'] = $this->calculateExpiration($seconds);
 
         $this->storage = array_merge($this->storage, [$key => $item]);
 

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 
@@ -128,6 +129,24 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function forever($key, $value)
     {
         return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        $item = Arr::get($this->storage, $key = $this->getPrefix().$key, null);
+
+        if (is_null($item)) {
+            return false;
+        }
+
+        $item['expiresAt'] = $this->calculateExpiration($ttl);
+
+        $this->storage = array_merge($this->storage, [$key => $item]);
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -351,7 +351,7 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -351,6 +351,21 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        return (bool) $this->table()
+            ->where('key', '=', $this->getPrefix().$key)
+            ->where('expiration', '>', $now = $this->getTime())
+            ->update(['expiration' => $now + $seconds]);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -409,17 +424,6 @@ class DatabaseStore implements LockProvider, Store
             ->delete();
 
         return true;
-    }
-
-    /**
-     * Set the expiration time of a cached item.
-     */
-    public function touch(string $key, int $ttl): bool
-    {
-        return (bool) $this->table()
-            ->where('key', '=', $this->getPrefix().$key)
-            ->where('expiration', '>', $now = $this->getTime())
-            ->update(['expiration' => $now + $ttl]);
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -412,6 +412,17 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        return (bool) $this->table()
+            ->where('key', '=', $this->getPrefix().$key)
+            ->where('expiration', '>', $now = $this->getTime())
+            ->update(['expiration' => $now + $ttl]);
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return bool

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -429,7 +429,7 @@ class DynamoDbStore implements LockProvider, Store
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -239,6 +239,24 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        $payload = $this->getPayload($this->getPrefix().$key);
+
+        if (is_null($payload['data'])) {
+            return false;
+        }
+
+        return $this->put($key, $payload['data'], $seconds);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -255,20 +273,6 @@ class FileStore implements Store, LockProvider
         }
 
         return false;
-    }
-
-    /**
-     * Set the expiration time of a cached item.
-     */
-    public function touch(string $key, int $ttl): bool
-    {
-        $payload = $this->getPayload($this->getPrefix().$key);
-
-        if (is_null($payload['data'])) {
-            return false;
-        }
-
-        return $this->put($key, $payload['data'], $ttl);
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -239,7 +239,7 @@ class FileStore implements Store, LockProvider
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -258,6 +258,20 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        $payload = $this->getPayload($this->getPrefix().$key);
+
+        if (is_null($payload['data'])) {
+            return false;
+        }
+
+        return $this->put($key, $payload['data'], $ttl);
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return bool
@@ -298,7 +312,7 @@ class FileStore implements Store, LockProvider
             }
 
             $expire = substr($contents, 0, 10);
-        } catch (Exception) {
+        } catch (Exception $e) {
             return $this->emptyPayload();
         }
 
@@ -314,6 +328,7 @@ class FileStore implements Store, LockProvider
         try {
             $data = unserialize(substr($contents, 10));
         } catch (Exception) {
+
             $this->forget($key);
 
             return $this->emptyPayload();

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -312,7 +312,7 @@ class FileStore implements Store, LockProvider
             }
 
             $expire = substr($contents, 0, 10);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $this->emptyPayload();
         }
 
@@ -328,7 +328,6 @@ class FileStore implements Store, LockProvider
         try {
             $data = unserialize(substr($contents, 10));
         } catch (Exception) {
-
             $this->forget($key);
 
             return $this->emptyPayload();

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -203,7 +203,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -204,10 +204,14 @@ class MemcachedStore extends TaggableStore implements LockProvider
 
     /**
      * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
      */
-    public function touch(string $key, int $ttl): bool
+    public function touch($key, $seconds)
     {
-        return $this->memcached->touch($this->getPrefix().$key, $this->calculateExpiration($ttl));
+        return $this->memcached->touch($this->getPrefix().$key, $this->calculateExpiration($seconds));
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -203,6 +203,14 @@ class MemcachedStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        return $this->memcached->touch($this->getPrefix().$key, $this->calculateExpiration($ttl));
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -196,7 +196,7 @@ class MemoizedStore implements LockProvider, Store
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -196,6 +196,20 @@ class MemoizedStore implements LockProvider, Store
     }
 
     /**
+     * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        unset($this->cache[$this->prefix($key)]);
+
+        return $this->repository->touch($key, $seconds);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -206,16 +220,6 @@ class MemoizedStore implements LockProvider, Store
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->forget($key);
-    }
-
-    /**
-     * Set the expiration time of a cached item.
-     */
-    public function touch(string $key, int $ttl): bool
-    {
-        unset($this->cache[$this->prefix($key)]);
-        
-        return $this->repository->touch($key, $ttl);
     }
 
     /**

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -209,6 +209,16 @@ class MemoizedStore implements LockProvider, Store
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        unset($this->cache[$this->prefix($key)]);
+        
+        return $this->repository->touch($key, $ttl);
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return bool

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -96,7 +96,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Set the expiration time of a cached item.
      */
-    public function touch(string $key, int $ttl): bool
+    public function touch($key, $seconds)
     {
         return false;
     }

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -94,7 +94,7 @@ class NullStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -95,6 +95,10 @@ class NullStore extends TaggableStore implements LockProvider
 
     /**
      * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
      */
     public function touch($key, $seconds)
     {

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -94,6 +94,14 @@ class NullStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        return false;
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -250,10 +250,14 @@ class RedisStore extends TaggableStore implements LockProvider
 
     /**
      * Set the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
      */
-    public function touch(string $key, int $ttl): bool
+    public function touch($key, $seconds)
     {
-        return (bool) $this->connection()->expire($this->getPrefix().$key, (int) max(1, $ttl));
+        return (bool) $this->connection()->expire($this->getPrefix().$key, (int) max(1, $seconds));
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -249,7 +249,7 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Set the expiration time of a cached item.
+     * Adjust the expiration time of a cached item.
      *
      * @param  string  $key
      * @param  int  $seconds

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -249,6 +249,14 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Set the expiration time of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool
+    {
+        return (bool) $this->connection()->expire($this->getPrefix().$key, (int) max(1, $ttl));
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -458,7 +466,6 @@ class RedisStore extends TaggableStore implements LockProvider
      * Determine if the given value should be stored as plain value.
      *
      * @param  mixed  $value
-     * @return bool
      */
     protected function shouldBeStoredWithoutSerialization($value): bool
     {

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -466,6 +466,7 @@ class RedisStore extends TaggableStore implements LockProvider
      * Determine if the given value should be stored as plain value.
      *
      * @param  mixed  $value
+     * @return bool
      */
     protected function shouldBeStoredWithoutSerialization($value): bool
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -526,7 +526,7 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Set the expiration of a cached item; null TTL will retain indefinitely.
+     * Set the expiration of a cached item; null TTL will retain the item forever.
      *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -527,8 +527,12 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * Set the expiration of a cached item; null TTL will retain indefinitely.
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return bool
      */
-    public function touch(string $key, \DateTimeInterface|\DateInterval|int|null $ttl = null): bool
+    public function touch($key, $ttl = null)
     {
         $value = $this->get($key);
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -106,7 +106,6 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  array|string  $key
      * @param  mixed  $default
-     * @return mixed
      */
     public function get($key, $default = null): mixed
     {
@@ -251,8 +250,6 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
     public function set($key, $value, $ttl = null): bool
     {
@@ -262,7 +259,6 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
-     * @param  array  $values
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
@@ -296,7 +292,6 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store multiple items in the cache indefinitely.
      *
-     * @param  array  $values
      * @return bool
      */
     protected function putManyForever(array $values)
@@ -526,6 +521,22 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Set the expiration of a cached item; null TTL will retain indefinitely.
+     */
+    public function touch(string $key, \DateTimeInterface|\DateInterval|int|null $ttl = null): bool
+    {
+        $value = $this->get($key);
+        
+        if (is_null($value)) {
+            return false;
+        }
+
+        return is_null($ttl)
+            ? $this->forever($key, $value)
+            : $this->store->touch($this->itemKey($key), $this->getSeconds($ttl));
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -546,8 +557,6 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
     public function delete($key): bool
     {
@@ -556,8 +565,6 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
     public function deleteMultiple($keys): bool
     {
@@ -574,8 +581,6 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
     public function clear(): bool
     {
@@ -737,7 +742,6 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Set the event dispatcher instance.
      *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
     public function setEventDispatcher(Dispatcher $events)
@@ -749,7 +753,6 @@ class Repository implements ArrayAccess, CacheContract
      * Determine if a cached value exists.
      *
      * @param  string  $key
-     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -760,7 +763,6 @@ class Repository implements ArrayAccess, CacheContract
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @return mixed
      */
     public function offsetGet($key): mixed
     {
@@ -772,7 +774,6 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
      */
     public function offsetSet($key, $value): void
     {
@@ -783,7 +784,6 @@ class Repository implements ArrayAccess, CacheContract
      * Remove an item from the cache.
      *
      * @param  string  $key
-     * @return void
      */
     public function offsetUnset($key): void
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -106,6 +106,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  array|string  $key
      * @param  mixed  $default
+     * @return mixed
      */
     public function get($key, $default = null): mixed
     {
@@ -250,6 +251,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function set($key, $value, $ttl = null): bool
     {
@@ -259,6 +262,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
+     * @param  array  $values
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
@@ -292,6 +296,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store multiple items in the cache indefinitely.
      *
+     * @param  array  $values
      * @return bool
      */
     protected function putManyForever(array $values)
@@ -526,7 +531,7 @@ class Repository implements ArrayAccess, CacheContract
     public function touch(string $key, \DateTimeInterface|\DateInterval|int|null $ttl = null): bool
     {
         $value = $this->get($key);
-        
+
         if (is_null($value)) {
             return false;
         }
@@ -557,6 +562,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function delete($key): bool
     {
@@ -565,6 +572,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function deleteMultiple($keys): bool
     {
@@ -581,6 +590,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function clear(): bool
     {
@@ -742,6 +753,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Set the event dispatcher instance.
      *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void
      */
     public function setEventDispatcher(Dispatcher $events)
@@ -753,6 +765,7 @@ class Repository implements ArrayAccess, CacheContract
      * Determine if a cached value exists.
      *
      * @param  string  $key
+     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -763,6 +776,7 @@ class Repository implements ArrayAccess, CacheContract
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
+     * @return mixed
      */
     public function offsetGet($key): mixed
     {
@@ -774,6 +788,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @return void
      */
     public function offsetSet($key, $value): void
     {
@@ -784,6 +799,7 @@ class Repository implements ArrayAccess, CacheContract
      * Remove an item from the cache.
      *
      * @param  string  $key
+     * @return void
      */
     public function offsetUnset($key): void
     {

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -91,11 +91,6 @@ interface Repository extends CacheInterface
     public function sear($key, Closure $callback);
 
     /**
-     * Set the expiration of a cached item; null TTL will retain indefinitely.
-     */
-    public function touch(string $key, DateTimeInterface|DateInterval|int|null $ttl = null): bool;
-
-    /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
      * @template TCacheValue
@@ -105,6 +100,15 @@ interface Repository extends CacheInterface
      * @return TCacheValue
      */
     public function rememberForever($key, Closure $callback);
+
+    /**
+     * Set the expiration of a cached item; null TTL will retain indefinitely.
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return bool
+     */
+    public function touch($key, $ttl = null);
 
     /**
      * Remove an item from the cache.

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -102,7 +102,7 @@ interface Repository extends CacheInterface
     public function rememberForever($key, Closure $callback);
 
     /**
-     * Set the expiration of a cached item; null TTL will retain indefinitely.
+     * Set the expiration of a cached item; null TTL will retain the item forever.
      *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Contracts\Cache;
 
 use Closure;
+use DateInterval;
+use DateTimeInterface;
 use Psr\SimpleCache\CacheInterface;
 
 interface Repository extends CacheInterface
@@ -87,6 +89,11 @@ interface Repository extends CacheInterface
      * @return TCacheValue
      */
     public function sear($key, Closure $callback);
+
+    /**
+     * Set the expiration of a cached item; null TTL will retain indefinitely.
+     */
+    public function touch(string $key, DateTimeInterface|DateInterval|int|null $ttl = null): bool;
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -69,6 +69,15 @@ interface Store
     public function forever($key, $value);
 
     /**
+     * Set the expiration of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds);
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key
@@ -82,11 +91,6 @@ interface Store
      * @return bool
      */
     public function flush();
-
-    /**
-     * Set the expiration of a cached item.
-     */
-    public function touch(string $key, int $ttl): bool;
 
     /**
      * Get the cache key prefix.

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -84,6 +84,11 @@ interface Store
     public function flush();
 
     /**
+     * Set the expiration of a cached item.
+     */
+    public function touch(string $key, int $ttl): bool;
+
+    /**
      * Get the cache key prefix.
      *
      * @return string

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -36,6 +36,7 @@ namespace Illuminate\Support\Facades;
  * @method static mixed flexible(string $key, array $ttl, callable $callback, array|null $lock = null)
  * @method static bool forget(string $key)
  * @method static bool delete(string $key)
+ * @method static bool touch(string $key, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool deleteMultiple(iterable $keys)
  * @method static bool clear()
  * @method static \Illuminate\Cache\TaggedCache tags(array|mixed $names)

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ApcStore;
 use Illuminate\Cache\ApcWrapper;
-use Illuminate\Support\Carbon;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -146,6 +146,4 @@ class CacheApcStoreTest extends TestCase
         $result = $store->flush();
         $this->assertTrue($result);
     }
-
-
 }

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ApcStore;
 use Illuminate\Cache\ApcWrapper;
+use Illuminate\Support\Carbon;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -124,6 +125,19 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testTouchMethodProperlyCallsAPC(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get', 'put'])->getMock();
+
+        $apc->expects($this->once())->method('get')->with($this->equalTo($key))->willReturn('bar');
+        $apc->expects($this->once())->method('put')->with($this->equalTo($key), $this->equalTo('bar'), $this->equalTo($ttl))->willReturn(true);
+
+        $this->assertTrue((new ApcStore($apc))->touch($key, $ttl));
+    }
+
     public function testFlushesCached()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['flush'])->getMock();
@@ -132,4 +146,6 @@ class CacheApcStoreTest extends TestCase
         $result = $store->flush();
         $this->assertTrue($result);
     }
+
+
 }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -69,6 +69,23 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testTouchExtendsTtl(): void
+    {
+        $key = 'key';
+        $value = 'value';
+
+        $store = new ArrayStore;
+
+        Carbon::setTestNow($now = Carbon::now());
+
+        $store->put($key, $value, 30);
+        $store->touch($key, 60);
+
+        Carbon::setTestNow($now->addSeconds(45));
+
+        $this->assertSame($value, $store->get($key));
+    }
+
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\DatabaseStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -222,6 +223,50 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(2)]);
         $this->assertEquals(2, $store->decrement('bar'));
+    }
+
+    public function testTouchExtendsTtl()
+    {
+        $ttl = 60;
+
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $table = m::mock(stdClass::class);
+
+        $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
+        $store->expects($this->once())->method('getTime')->willReturn(0);
+        $table->shouldReceive('where')->twice()->andReturn($table);
+        $table->shouldReceive('update')->once()->with(['expiration' => $ttl])->andReturn(1);
+
+        $this->assertTrue($store->touch('foo', $ttl));
+    }
+    public function testTouchExtendsTtlOnPostgres(): void
+    {
+        $ttl = 60;
+
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
+        $table = m::mock(stdClass::class);
+
+        $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
+        $store->expects($this->once())->method('getTime')->willReturn(0);
+        $table->shouldReceive('where')->twice()->andReturn($table);
+        $table->shouldReceive('update')->once()->with(['expiration' => $ttl])->andReturn(1);
+
+        $this->assertTrue($store->touch('foo', $ttl));
+    }
+
+    public function testTouchExtendsTtlOnSqlite()
+    {
+        $ttl = 60;
+
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getSqliteMocks())->getMock();
+        $table = m::mock(stdClass::class);
+
+        $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
+        $store->expects($this->once())->method('getTime')->willReturn(0);
+        $table->shouldReceive('where')->twice()->andReturn($table);
+        $table->shouldReceive('update')->once()->with(['expiration' => $ttl])->andReturn(1);
+
+        $this->assertTrue($store->touch('foo', $ttl));
     }
 
     protected function getStore()

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -7,7 +7,6 @@ use Illuminate\Cache\DatabaseStore;
 use Illuminate\Database\Connection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
-use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;

--- a/tests/Cache/CacheDynamoDbStoreTest.php
+++ b/tests/Cache/CacheDynamoDbStoreTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Aws\AwsClient;
+use Aws\DynamoDb\DynamoDbClient;
+use Illuminate\Cache\DynamoDbStore;
+use PHPUnit\Framework\TestCase;
+
+class CacheDynamoDbStoreTest extends TestCase
+{
+    public function testTouchMethodCorrectlyCallsDynamoDb(): void
+    {
+        $table = 'table';
+        $key = 'key';
+        $ttl = 60;
+
+        $this->assertTrue((new DynamoDbStore($dynamo = new TestDynamo, $table))->touch($key, $ttl));
+
+        $this->assertTrue(
+            isset($dynamo->args['UpdateExpression'], $dynamo->args['TableName'], $dynamo->args['Key']['key']['S'])
+                && $dynamo->args['TableName'] === $table
+                && $dynamo->args['Key']['key']['S'] === $key
+                && str_contains($dynamo->args['UpdateExpression'], 'SET')
+       );
+
+        $this->assertTrue(
+            $ttl === $dynamo->args['ExpressionAttributeValues'][':expiry']['N']
+            - $dynamo->args['ExpressionAttributeValues'][':now']['N']
+        );
+    }
+}
+
+class TestDynamo extends DynamoDbClient
+{
+    public array $args;
+
+    public function __construct() {}
+
+    public function updateItem(array $args): bool
+    {
+        $this->args = $args;
+
+        return true;
+    }
+}

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -111,6 +111,39 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testTouchExtendsTtl(): void
+    {
+        $files = $this->mockFilesystem();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration', 'get', 'getPayload'])->setConstructorArgs([$files, __DIR__])->getMock();
+
+        $now = Carbon::now();
+
+        $key = 'foo';
+        $content = 'Hello World';
+        $ttl = 60;
+        $hash = sha1($key);
+        $path = __DIR__.'/'.substr($hash, 0, 2).'/'.substr($hash, 2, 2).'/'.$hash;
+
+        $store->expects($this->once())
+            ->method('expiration')
+            ->with($this->equalTo($ttl))
+            ->willReturn($now->clone()->addSeconds($ttl)->getTimestamp());
+        $store->expects($this->once())
+            ->method('getPayload')
+            ->with($key)
+            ->willReturn(['data' => $content, 'expiration' => $now->clone()->addSeconds($ttl)->getTimestamp()]);
+        $files->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->equalTo($path),
+                $this->equalTo(($now->clone()->addSeconds($ttl)->getTimestamp()).serialize($content)),
+                $this->equalTo(true)
+            )
+            ->willReturn(1);
+
+        $this->assertTrue($store->touch($key, $ttl));
+    }
+
     public function testStoreItemProperlySetsPermissions()
     {
         $files = m::mock(Filesystem::class);

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -67,6 +67,20 @@ class CacheMemcachedStoreTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testTouchMethodProperlyCallsMemcache(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+
+        $now = Carbon::now();
+
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['touch'])->getMock();
+
+        $memcache->expects($this->once())->method('touch')->with($this->equalTo($key), $this->equalTo($now->addSeconds($ttl)->getTimestamp()))->willReturn(true);
+
+        $this->assertTrue((new MemcachedStore($memcache))->touch($key, $ttl));
+    }
+
     public function testIncrementMethodProperlyCallsMemcache()
     {
         $memcached = m::mock(Memcached::class);

--- a/tests/Cache/CacheMemoizedStoreTest.php
+++ b/tests/Cache/CacheMemoizedStoreTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\MemcachedStore;
+use Illuminate\Cache\MemoizedStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Support\Carbon;
+use Memcached;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CacheMemoizedStoreTest extends TestCase
+{
+    public function testTouchExtendsTtl(): void
+    {
+        $store = new MemoizedStore('test', new Repository(new ArrayStore));
+
+        Carbon::setTestNow($now = Carbon::now());
+
+        $store->put('foo', 'bar', 30);
+        $store->touch('foo', 60);
+
+        Carbon::setTestNow($now->addSeconds(45));
+
+        $this->assertSame('bar', $store->get('foo'));
+    }
+}

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -33,4 +33,9 @@ class CacheNullStoreTest extends TestCase
         $this->assertFalse($store->increment('foo'));
         $this->assertFalse($store->decrement('foo'));
     }
+
+    public function testTouchReturnsFalse(): void
+    {
+        $this->assertFalse((new NullStore)->touch('foo', 30));
+    }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -136,14 +136,10 @@ class CacheRedisStoreTest extends TestCase
 
     public function testForgetMethodProperlyCallsRedis()
     {
-        $key = 'key';
-
         $redis = $this->getRedis();
-
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('del')->once()->with("prefix:$key");
-
-        $redis->forget($key);
+        $redis->getRedis()->shouldReceive('del')->once()->with('prefix:foo');
+        $redis->forget('foo');
     }
 
     public function testFlushesCached()

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -121,12 +121,29 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testTouchMethodProperlyCallsRedis(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+
+        $redis = $this->getRedis();
+
+        $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
+        $redis->getRedis()->shouldReceive('expire')->once()->with("prefix:$key", $ttl)->andReturn(true);
+
+        $this->assertTrue($redis->touch($key, $ttl));
+    }
+
     public function testForgetMethodProperlyCallsRedis()
     {
+        $key = 'key';
+
         $redis = $this->getRedis();
+
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('del')->once()->with('prefix:foo');
-        $redis->forget('foo');
+        $redis->getRedis()->shouldReceive('del')->once()->with("prefix:$key");
+
+        $redis->forget($key);
     }
 
     public function testFlushesCached()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -433,6 +433,52 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($nonTaggableRepo->supportsTags());
     }
 
+    public function testTouchWithNullTTLRemembersItemForever(): void
+    {
+        $key = 'key';
+        $ttl = null;
+        
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
+        $repo->getStore()->shouldReceive('forever')->once()->with($key, 'bar')->andReturn(true);
+        $this->assertTrue($repo->touch($key, $ttl));
+    }
+
+    public function testTouchWithSecondsTtlCorrectlyProxiesToStore(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+        
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
+        $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
+        $this->assertTrue($repo->touch($key, $ttl));
+    }
+
+    public function testTouchWithDatetimeTtlCorrectlyProxiesToStore(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+
+        Carbon::setTestNow($now = Carbon::now());
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
+        $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
+        $this->assertTrue($repo->touch($key, $now->addSeconds($ttl)));
+    }
+
+    public function testTouchWithDateIntervalTtlCorrectlyProxiesToStore(): void
+    {
+        $key = 'key';
+        $ttl = 60;
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->with($key)->andReturn('bar');
+        $repo->getStore()->shouldReceive('touch')->once()->with($key, $ttl)->andReturn(true);
+        $this->assertTrue($repo->touch($key, DateInterval::createFromDateString("$ttl seconds")));
+    }
+
     protected function getRepository()
     {
         $dispatcher = new Dispatcher(m::mock(Container::class));

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -461,7 +461,7 @@ class MemoizedStoreTest extends TestCase
                 return Cache::forget(...func_get_args());
             }
 
-            public function touch(string $key, int $ttl): bool
+            public function touch($key, $seconds)
             {
                 return Cache::touch(...func_get_args());
             }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -461,6 +461,11 @@ class MemoizedStoreTest extends TestCase
                 return Cache::forget(...func_get_args());
             }
 
+            public function touch(string $key, int $ttl): bool
+            {
+                return Cache::touch(...func_get_args());
+            }
+
             public function flush()
             {
                 return Cache::flush(...func_get_args());


### PR DESCRIPTION
This pull request introduces the `Cache::touch()` method,  addressing a fundamental challenge that developers encounter frequently: **extending cache TTL without the overhead of retrieving and re-storing data**.

**Basic Usage:**

```
// with seconds

Cache::touch('user_session:123', 3600); // extend by 1 hour

// with datetime

Cache::touch('analytics_data', now()->addHours(6));

// with carbon

Cache::touch('report_cache', Carbon::now()->addMinutes(30));
```

**Simplifies Common Patterns:**

```
// conditional re-caching

if (Cache::has($key)) {
    Cache::put($key, Cache::get($key), $newTtl);
}


// remember with forced refresh

Cache::forget($key);
Cache::remember($key, $ttl, $callback);


// manual ttl tracking

if ($value = Cache::get($key) && $this->shouldExtendCache($key)) {
    Cache::put($key, $value, $ttl);
}

// these all become:

Cache::touch($key, $ttl)
```

`Cache:touch()` & `$store->touch()` return `true` on success and `false` when the item is not found in the cache.

`Cache:touch()` accepts an `int`, `DateTimeInterface`, or `DateInterval` for extending the TTL; `null` will extend the TTL indefinitely; `$store->touch()` requires an `int` (conversion is handled in the `Repository`.

**This pull request includes the following:**

- Notation on `Cache` Facade
- Updated `Repository` and `Store` Contracts
- Implementations for all Drivers - `ApcStore`, `ArrayStore`,  `DatabaseStore`, `DynamoDbStore`, `FileStore`, `MemcachedStore`, `MemoizedStore` , `NullStore`, and `RedisStore`
- Complete Tests

---

## Primary Use Cases

**1. Activity-Based Cache Extension**

```
// user is actively browsing - extend their session cache

// instead of

$sessionData = Cache::get("user_session:{$user->id}");
if ($sessionData && $user->isActive()) {
    Cache::put("user_session:{$user->id}", $sessionData, 3600);
}

// now you can simply do this

if ($user->isActive()) {
    Cache::touch("user_session:{$user->id}", 3600); // Extend by 1 hour
}
```

**2. Cache Warming Maintenance**

```
// keep expensive computation results fresh during maintenance windows

foreach (['big_report', 'big_metrics', 'big_data'] as $key) {
    Cache::touch($key, now()->addHours(6)); // extend thru window
}
```

**3. Progressive Cache Strategies**

```
// extend cache for popular content

if ($post->isPopular()) {
    Cache::touch("post_content:{$post->id}", 86400); // keep popular posts cached longer
}
```


## Real-World Scenarios

**E-commerce Product Caching**

```
// extend cache for products being actively viewed/purchased

public function extendPopularProductCache(int $productId): void
{
    if (Redis::get("product_views:{$productId}:last_hour") > 50) {
        Cache::touch("product_details:{$productId}", 7200);
        Cache::touch("product_inventory:{$productId}", 1800);
    }
}
```

**API Response Caching**

```
// extend cache for frequently requested api endpoints

public function handleApiRequest(string $endpoint): bool
{
    $key = "api_response:" . md5($endpoint);

    if ($this->isFrequentlyRequested($endpoint)) {
        Cache::touch($key, 7200);
    }

    return Cache::remember($key, 1800, fn() => $this->fetchApiData($endpoint));
}
```


## Performance Benefits

**Network/Storage Efficiency**

* **Redis**: Avoids `GET` + `SET` operations, uses single `EXPIRE` command
* **Database**: Avoids `SELECT` + `UPDATE`, uses single `UPDATE` on timestamp
* **Memcached**: Uses `TOUCH` command instead of `GET` + `SET`

**Memory Efficiency**

```
// current approach - potentially large data transfer

$largeDataset = Cache::get('analytics_data'); // 10MB transfer
Cache::put('analytics_data', $largeDataset, 3600); // 10MB transfer


// with touch() - minimal overhead

Cache::touch('analytics_data', 3600); // just updates expiration
```


---

- **Solves Real Pain**: Every Laravel developer has written the inefficient get/put pattern
- **Clean API**: `Cache::touch($key, $seconds)` is immediately understandable
- **Performance Win**: Significant efficiency gains with minimal code change
- **Driver Agnostic**: Works across all cache backends
- **Framework Precedent**: Similar to filesystem `touch()` command developers know

---

💁🏼‍♂️ The author is available for hire -- inquire at yitzwillroth@gmail.com.
