### PR TITLE
[12.x] Fix division by zero when `$perPage` is `0` in `LengthAwarePaginator`

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -58,7 +58,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = (int) $perPage;
-        $this->lastPage = max((int) ceil($total / $perPage), 1);
+        $this->lastPage = $this->perPage > 0 ? max((int) ceil($total / $perPage), 1) : 1;
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : new Collection($items);


### PR DESCRIPTION
### Description

This pull request prevents a potential division by zero error in the `LengthAwarePaginator` constructor when `$perPage` is set to `0`. Instead of attempting to divide by zero, the code now defaults the last page to `1` in such cases.

No breaking changes, fallback behavior is consistent with framework philosophy.

### References
N/A – this was a direct edge case improvement.