### PR TITLE
[12.x] Add a command option for making unique or encrypted jobs

### DIFF
--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -40,6 +40,14 @@ class JobMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('unique')) {
+            return $this->resolveStubPath('/stubs/job.unique.queued.stub');
+        }
+
+        if ($this->option('encrypted')) {
+            return $this->resolveStubPath('/stubs/job.encrypted.queued.stub');
+        }
+
         if ($this->option('batched')) {
             return $this->resolveStubPath('/stubs/job.batched.queued.stub');
         }
@@ -83,6 +91,8 @@ class JobMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the job already exists'],
             ['sync', null, InputOption::VALUE_NONE, 'Indicates that the job should be synchronous'],
+            ['unique', null, InputOption::VALUE_NONE, 'Indicates that the job should be unique'],
+            ['encrypted', null, InputOption::VALUE_NONE, 'Indicates that the job should be encrypted'],
             ['batched', null, InputOption::VALUE_NONE, 'Indicates that the job should be batchable'],
         ];
     }

--- a/src/Illuminate/Foundation/Console/stubs/job.encrypted.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.encrypted.queued.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Foundation\Queue\Queueable;
+
+class {{ class }} implements ShouldQueue, ShouldBeEncrypted
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/job.unique.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.unique.queued.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Foundation\Queue\Queueable;
+
+class {{ class }} implements ShouldQueue, ShouldBeUnique
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds a new command-line option to the `make:job` Artisan command to support creating unique and encrypted jobs.

This allows developers to quickly scaffold jobs that implement the necessary interfaces or use appropriate traits for handling uniqueness and encryption, improving DX and consistency.

What's Added:

- `--unique` option: Adds the `ShouldBeUnique` interface to the generated job class.
- `--encrypted` option: Adds the `ShouldBeEncrypted` interface to the generated job class.

Why?

In `src/Illuminate/Foundation/Console/JobMakeCommand.php`, we already have similar logic for the `--sync` option, which conditionally applies the `ShouldQueue` interface. This PR extends that idea to support more advanced job features out of the box.
