### PR TITLE
[12.x] Use native named parameter instead of unused variable

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -332,7 +332,7 @@ class Container implements ArrayAccess, ContainerContract
             }
 
             return $container->resolve(
-                $concrete, $parameters, $raiseEvents = false
+                $concrete, $parameters, raiseEvents: false
             );
         };
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/25d09454-3527-4e9d-81c4-2912033f125b)
