### PR TITLE
Broadcasting Utilities

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -14,6 +14,7 @@ use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Broadcasting\Factory as FactoryContract;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Broadcasting\ShouldRescue;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Foundation\CachesRoutes;
@@ -178,7 +179,12 @@ class BroadcastManager implements FactoryContract
             (is_object($event) &&
              method_exists($event, 'shouldBroadcastNow') &&
              $event->shouldBroadcastNow())) {
-            return $this->app->make(BusDispatcherContract::class)->dispatchNow(new BroadcastEvent(clone $event));
+            $dispatchNow = fn () => $this->app->make(BusDispatcherContract::class)
+                ->dispatchNow(new BroadcastEvent(clone $event));
+
+            return $event instanceof ShouldRescue
+                ? $this->rescue($dispatchNow)
+                : $dispatchNow();
         }
 
         $queue = null;
@@ -201,9 +207,13 @@ class BroadcastManager implements FactoryContract
             }
         }
 
-        $this->app->make('queue')
+        $push = fn () => $this->app->make('queue')
             ->connection($event->connection ?? null)
             ->pushOn($queue, $broadcastEvent);
+
+        $event instanceof ShouldRescue
+            ? $this->rescue($push)
+            : $push();
     }
 
     /**
@@ -473,6 +483,21 @@ class BroadcastManager implements FactoryContract
         $this->customCreators[$driver] = $callback;
 
         return $this;
+    }
+
+    /**
+     * Execute the given callback using "rescue" if possible.
+     *
+     * @param  \Closure  $callback
+     * @return mixed
+     */
+    protected function rescue(Closure $callback)
+    {
+        if (function_exists('rescue')) {
+            return rescue($callback);
+        }
+
+        return $callback();
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -179,12 +179,12 @@ class BroadcastManager implements FactoryContract
             (is_object($event) &&
              method_exists($event, 'shouldBroadcastNow') &&
              $event->shouldBroadcastNow())) {
-            $dispatchNow = fn () => $this->app->make(BusDispatcherContract::class)
+            $dispatch = fn () => $this->app->make(BusDispatcherContract::class)
                 ->dispatchNow(new BroadcastEvent(clone $event));
 
             return $event instanceof ShouldRescue
-                ? $this->rescue($dispatchNow)
-                : $dispatchNow();
+                ? $this->rescue($dispatch)
+                : $dispatch();
         }
 
         $queue = null;

--- a/src/Illuminate/Broadcasting/FakePendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/FakePendingBroadcast.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Broadcasting;
+
+class FakePendingBroadcast extends PendingBroadcast
+{
+    /**
+     * Create a new pending broadcast instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Broadcast the event using a specific broadcaster.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function via($connection = null)
+    {
+        return $this;
+    }
+
+    /**
+     * Broadcast the event to everyone except the current user.
+     *
+     * @return $this
+     */
+    public function toOthers()
+    {
+        return $this;
+    }
+
+    /**
+     * Handle the object's destruction.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Contracts/Broadcasting/ShouldRescue.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldRescue.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Broadcasting;
+
+interface ShouldRescue
+{
+    //
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Broadcasting\NoopPendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
@@ -224,6 +225,42 @@ if (! function_exists('broadcast')) {
     function broadcast($event = null)
     {
         return app(BroadcastFactory::class)->event($event);
+    }
+}
+
+if (! function_exists('broadcast_if')) {
+    /**
+     * Begin broadcasting an event if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed|null  $event
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    function broadcast_if($boolean, $event = null)
+    {
+        if ($boolean) {
+            return app(BroadcastFactory::class)->event($event);
+        } else {
+            return new FakePendingBroadcast;
+        }
+    }
+}
+
+if (! function_exists('broadcast_unless')) {
+    /**
+     * Begin broadcasting an event unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed|null  $event
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    function broadcast_unless($boolean, $event = null)
+    {
+        if (! $boolean) {
+            return app(BroadcastFactory::class)->event($event);
+        } else {
+            return new FakePendingBroadcast;
+        }
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Broadcasting\NoopPendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Broadcasting\NoopPendingBroadcast;
+use Illuminate\Broadcasting\FakePendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
@@ -33,7 +33,6 @@ if (! function_exists('abort')) {
      *
      * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
-     * @param  array  $headers
      * @return never
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -59,7 +58,6 @@ if (! function_exists('abort_if')) {
      * @param  bool  $boolean
      * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
-     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -80,7 +78,6 @@ if (! function_exists('abort_unless')) {
      * @param  bool  $boolean
      * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
-     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -116,7 +113,6 @@ if (! function_exists('app')) {
      * @template TClass of object
      *
      * @param  string|class-string<TClass>|null  $abstract
-     * @param  array  $parameters
      * @return ($abstract is class-string<TClass> ? TClass : ($abstract is null ? \Illuminate\Foundation\Application : mixed))
      */
     function app($abstract = null, array $parameters = [])
@@ -443,9 +439,6 @@ if (! function_exists('defer')) {
     /**
      * Defer execution of the given callback.
      *
-     * @param  callable|null  $callback
-     * @param  string|null  $name
-     * @param  bool  $always
      * @return \Illuminate\Support\Defer\DeferredCallback
      */
     function defer(?callable $callback = null, ?string $name = null, bool $always = false)
@@ -558,7 +551,6 @@ if (! function_exists('logger')) {
      * Log a debug message to the logs.
      *
      * @param  string|null  $message
-     * @param  array  $context
      * @return ($message is null ? \Illuminate\Log\LogManager : null)
      */
     function logger($message = null, array $context = [])
@@ -836,7 +828,6 @@ if (! function_exists('resolve')) {
      * @template TClass of object
      *
      * @param  string|class-string<TClass>  $name
-     * @param  array  $parameters
      * @return ($name is class-string<TClass> ? TClass : mixed)
      */
     function resolve($name, array $parameters = [])
@@ -864,7 +855,6 @@ if (! function_exists('response')) {
      *
      * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
-     * @param  array  $headers
      * @return ($content is null ? \Illuminate\Contracts\Routing\ResponseFactory : \Illuminate\Http\Response)
      */
     function response($content = null, $status = 200, array $headers = [])
@@ -1012,7 +1002,6 @@ if (! function_exists('trans_choice')) {
      *
      * @param  string  $key
      * @param  \Countable|int|float|array  $number
-     * @param  array  $replace
      * @param  string|null  $locale
      * @return string
      */
@@ -1078,10 +1067,6 @@ if (! function_exists('validator')) {
     /**
      * Create a new Validator instance.
      *
-     * @param  array|null  $data
-     * @param  array  $rules
-     * @param  array  $messages
-     * @param  array  $attributes
      * @return ($data is null ? \Illuminate\Contracts\Validation\Factory : \Illuminate\Contracts\Validation\Validator)
      */
     function validator(?array $data = null, array $rules = [], array $messages = [], array $attributes = [])

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Broadcasting\FakePendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Config\Repository;
@@ -294,5 +295,10 @@ class FoundationHelpersTest extends TestCase
         Container::setInstance($app);
 
         abort($code, $message, $headers);
+    }
+
+    public function testBroadcastIfReturnsFakeOnFalse()
+    {
+        $this->assertInstanceOf(FakePendingBroadcast::class, broadcast_if(false, 'foo'));
     }
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Broadcasting\ShouldRescue;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Bus;
@@ -39,6 +40,28 @@ class BroadcastManagerTest extends TestCase
 
         Bus::assertNotDispatched(BroadcastEvent::class);
         Queue::assertPushed(BroadcastEvent::class);
+    }
+
+    public function testEventsCanBeRescued()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventRescue);
+
+        Bus::assertNotDispatched(BroadcastEvent::class);
+        Queue::assertPushed(BroadcastEvent::class);
+    }
+
+    public function testNowEventsCanBeRescued()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventNowRescue);
+
+        Bus::assertDispatched(BroadcastEvent::class);
+        Queue::assertNotPushed(BroadcastEvent::class);
     }
 
     public function testUniqueEventsCanBeBroadcast()
@@ -113,6 +136,32 @@ class TestEventNow implements ShouldBroadcastNow
 }
 
 class TestEventUnique implements ShouldBroadcast, ShouldBeUnique
+{
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     */
+    public function broadcastOn()
+    {
+        //
+    }
+}
+
+class TestEventRescue implements ShouldBroadcast, ShouldRescue
+{
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     */
+    public function broadcastOn()
+    {
+        //
+    }
+}
+
+class TestEventNowRescue implements ShouldBroadcastNow, ShouldRescue
 {
     /**
      * Get the channels the event should broadcast on.


### PR DESCRIPTION
- Allow `ShouldRescue` on broadcast events to not throw exceptions if queue or broadcast system is down, while still reporting exceptions.
- Add `broadcast_if` and `broadcast_unless` and `FakePendingBroadcast`.