### PR TITLE
[12.x] Validate that `outOf` is greater than 0 in `Lottery` helper

### DIFF
--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -45,7 +45,7 @@ class Lottery
      * Create a new Lottery instance.
      *
      * @param  int|float  $chances
-     * @param  int|null  $outOf
+     * @param  int<1, max>|null  $outOf
      */
     public function __construct($chances, $outOf = null)
     {
@@ -54,7 +54,7 @@ class Lottery
         }
 
         if ($outOf !== null && $outOf < 1) {
-            throw new RuntimeException('The opportunities to win must be greater or equals to 1.');
+            throw new RuntimeException('Lottery "out of" value must be greater than or equal to 1.');
         }
 
         $this->chances = $chances;

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -53,6 +53,10 @@ class Lottery
             throw new RuntimeException('Float must not be greater than 1.');
         }
 
+        if ($outOf !== null && $outOf < 1) {
+            throw new RuntimeException('The opportunities to win must be greater than 1.');
+        }
+
         $this->chances = $chances;
 
         $this->outOf = $outOf;

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -54,7 +54,7 @@ class Lottery
         }
 
         if ($outOf !== null && $outOf < 1) {
-            throw new RuntimeException('The opportunities to win must be greater than 1.');
+            throw new RuntimeException('The opportunities to win must be greater or equals to 1.');
         }
 
         $this->chances = $chances;

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -154,6 +154,14 @@ class LotteryTest extends TestCase
         new Lottery(1.1);
     }
 
+    public function testItThrowsForOutOfLessThanOne()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The opportunities to win must be greater than 1.');
+
+        new Lottery(1, 0);
+    }
+
     public function testItCanWinWithFloat()
     {
         $wins = false;

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -157,7 +157,7 @@ class LotteryTest extends TestCase
     public function testItThrowsForOutOfLessThanOne()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The opportunities to win must be greater than 1.');
+        $this->expectExceptionMessage('The opportunities to win must be greater or equals to 1.');
 
         new Lottery(1, 0);
     }

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -157,7 +157,6 @@ class LotteryTest extends TestCase
     public function testItThrowsForOutOfLessThanOne()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The opportunities to win must be greater or equals to 1.');
 
         new Lottery(1, 0);
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cea892d3-d471-44f3-ba61-4ac7eba21027)

When using the Lottery helper, I encountered a ```ValueError: random_int(): Argument #1 ($min) must be less than or equal to argument #2 ($max)``` when the `outOf` value is set to 0. After seeing this error, I had to trace into the library to understand the root cause.

This pull request adds validation to ensure the `outOf` value is greater than 0.
