### PR TITLE
[12.x] Allow retrieving all reported exceptions from `ExceptionHandlerFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -58,16 +58,6 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
-     * Get the exceptions that have been reported.
-     *
-     * @return list<\Throwable>
-     */
-    public function reported()
-    {
-        return $this->reported;
-    }
-
-    /**
      * Assert if an exception of the given type has been reported.
      *
      * @param  (\Closure(\Throwable): bool)|class-string<\Throwable>  $exception
@@ -256,6 +246,16 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
         }
 
         return $this;
+    }
+
+    /**
+     * Get the exceptions that have been reported.
+     *
+     * @return list<\Throwable>
+     */
+    public function reported()
+    {
+        return $this->reported;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -58,6 +58,16 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
     }
 
     /**
+     * Get the exceptions that have been reported.
+     *
+     * @return list<\Throwable>
+     */
+    public function reported()
+    {
+        return $this->reported;
+    }
+
+    /**
      * Assert if an exception of the given type has been reported.
      *
      * @param  (\Closure(\Throwable): bool)|class-string<\Throwable>  $exception

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -23,13 +23,17 @@ class ExceptionsFacadeTest extends TestCase
     {
         Exceptions::fake();
 
-        Exceptions::report(new RuntimeException('test 1'));
+        Exceptions::report($thrownException = new RuntimeException('test 1'));
         report(new RuntimeException('test 2'));
 
         Exceptions::assertReported(RuntimeException::class);
         Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 1');
         Exceptions::assertReported(fn (RuntimeException $e) => $e->getMessage() === 'test 2');
         Exceptions::assertReportedCount(2);
+
+        $reported = Exceptions::reported();
+        $this->assertCount(1, $reported);
+        $this->assertSame($thrownException, $reported[0]);
     }
 
     public function testFakeAssertReportedCount()

--- a/tests/Integration/Support/ExceptionsFacadeTest.php
+++ b/tests/Integration/Support/ExceptionsFacadeTest.php
@@ -32,7 +32,7 @@ class ExceptionsFacadeTest extends TestCase
         Exceptions::assertReportedCount(2);
 
         $reported = Exceptions::reported();
-        $this->assertCount(1, $reported);
+        $this->assertCount(2, $reported);
         $this->assertSame($thrownException, $reported[0]);
     }
 


### PR DESCRIPTION
I have a use-case where I am writing tests that leverage a data provider. The data provider gives invalid data, an exception class, and the message we are expecting. In different conditions, different exceptions are reported. I want to confirm that they are indeed reported

```php
public static function missingAttributesDataProvider(): array
{
    return [
        'no id' => [
            ['name' => 'Totwell', 'product' => 'Taylor Otwell branded tater tots'],
            UnexpectedValueException::class,
            'No id present'
        ]
    ];
}

#[Test]
#[DataProvider('missingAttributesDataProvider')]
public function missingAttribute_throwsException(array $attributes, string $expectedExceptionClass, string $message): void
{
    Exceptions::fake();

    // Do something with those $attributes

    // Then
    Exceptions::assertReported(fn ($e) => $e instanceof $expectedExceptionClass && $e->getMessage() === $message);
}
```

But this blows up, because there's no typehint provided to the Closure.

With this change, I can change my test to:

```php
$reported = Exceptions::reported();
$this->assertCount(1, $reported);
$this->assertInstanceOf($expectedExceptionClass, $reported[0]);
$this->assertSame($message, $reported[0]->getMessage());
```