### PR TITLE
[12.x] Remove unused $guarded parameter from testChannelNameNormalization method

### DIFF
--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UsePusherChannelsNamesTest extends TestCase
 {
     #[DataProvider('channelsProvider')]
-    public function testChannelNameNormalization($requestChannelName, $normalizedName, $guarded)
+    public function testChannelNameNormalization($requestChannelName, $normalizedName, $_)
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 


### PR DESCRIPTION
Description
---
The `$guarded` parameter in the `testChannelNameNormalization` method is unused. I think this parameter was included in #55961 to match the structure of the shared `channelsProvider()` data provider, but the normalization test only requires the `$requestChannelName` and `$normalizedName` parameters.

The `$guarded` parameter is only needed in the `testIsGuardedChannel` method, so I think it can be safely removed by ignoring the unused parameter with an underscore.