### PR TITLE
[12.x] Remove unused namespaces from stub files

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -2,11 +2,8 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -2,9 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
-
 class {{ class }}
 {
     /**

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -3,7 +3,6 @@
 namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -3,7 +3,6 @@
 namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -3,7 +3,6 @@
 namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 


### PR DESCRIPTION
In this PR, unused namespaces have been removed from these files:

- event.stub
- listener.stub
- mail.stub
- notification.stub
- markdown-notification.stub

These changes improve code readability and optimize the project by eliminating unnecessary code.
