### PR TITLE
[12.x] Remove unnecessary formatNotifiables method call

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -84,6 +84,7 @@ class NotificationSender
 
         if ($notification instanceof ShouldQueue) {
             $this->queueNotification($notifiables, $notification);
+
             return;
         }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -83,7 +83,8 @@ class NotificationSender
         $notifiables = $this->formatNotifiables($notifiables);
 
         if ($notification instanceof ShouldQueue) {
-            return $this->queueNotification($notifiables, $notification);
+            $this->queueNotification($notifiables, $notification);
+            return;
         }
 
         $this->sendNow($notifiables, $notification);
@@ -203,8 +204,6 @@ class NotificationSender
      */
     protected function queueNotification($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {


### PR DESCRIPTION
This PR includes the following changes:

- Removes the unnecessary `formatNotifiables` method call in the `queueNotification` method.
The method is already called within the `send` method, making the call in `queueNotification` redundant.

- Avoids returning from  `queueNotification`  void method.