### PR TITLE
[12.x] Refactor Notification Stubs: Decouple Queueable Trait into Queued-Specific Stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -100,6 +100,12 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('queued')) {
+            return $this->option('markdown')
+                ? $this->resolveStubPath('/stubs/markdown-notification.queued.stub')
+                : $this->resolveStubPath('/stubs/notification.queued.stub');
+        }
+
         return $this->option('markdown')
             ? $this->resolveStubPath('/stubs/markdown-notification.stub')
             : $this->resolveStubPath('/stubs/notification.stub');
@@ -166,6 +172,7 @@ class NotificationMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists'],
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
+            ['queued', null, InputOption::VALUE_NONE, 'Indicates the notification should be queued'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.queued.stub
@@ -2,11 +2,15 @@
 
 namespace {{ namespace }};
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class {{ class }} extends Notification
+class {{ class }} extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Create a new notification instance.
      */
@@ -30,10 +34,7 @@ class {{ class }} extends Notification
      */
     public function toMail(object $notifiable): MailMessage
     {
-        return (new MailMessage)
-            ->line('The introduction to the notification.')
-            ->action('Notification Action', url('/'))
-            ->line('Thank you for using our application!');
+        return (new MailMessage)->markdown('{{ view }}');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -2,15 +2,11 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 class {{ class }} extends Notification
 {
-    use Queueable;
-
     /**
      * Create a new notification instance.
      */

--- a/src/Illuminate/Foundation/Console/stubs/notification.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.queued.stub
@@ -2,11 +2,15 @@
 
 namespace {{ namespace }};
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class {{ class }} extends Notification
+class {{ class }} extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Create a new notification instance.
      */


### PR DESCRIPTION
This PR proposes a refactor in how notification classes are scaffolded using the `make:notification` Artisan command.

Currently, the default notification stubs (`notification.stub` and `markdown-notification.stub`) include the `Illuminate\Bus\Queueable` trait by default.
However, the `Illuminate\Bus\Queueable` trait is only actually needed if the notification implements `ShouldQueue` interface, because otherwise Laravel sends notifications immediately using the `sendNow` method, which doesn’t use the queue-related properties like `connection` or `queue` from the `Illuminate\Bus\Queueable` trait.

Here's a reference in https://github.com/laravel/framework/blob/12.x/src/Illuminate/Notifications/NotificationSender.php:

```php
    /**
     * Send the given notification to the given notifiable entities.
     *
     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
     * @param  mixed  $notification
     * @return void
     */
    public function send($notifiables, $notification)
    {
        $notifiables = $this->formatNotifiables($notifiables);

        if ($notification instanceof ShouldQueue) {
            return $this->queueNotification($notifiables, $notification);
        }

        $this->sendNow($notifiables, $notification);
    }
```

What This PR Changes:

- Removes the `queueable` trait and `ShouldQueue` interface from the default stubs
- Introduces two new stubs with the `queueable` trait and `ShouldQueue` interface
- Updates the `make:notification` Artisan command to use `--queued` flag
