### PR TITLE
Only hit limiters if no limit was reached

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -153,7 +153,9 @@ class ThrottleRequests
             if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
-
+        }
+        // Only hit limiters if none failed
+        foreach ($limits as $limit) {
             $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 


### PR DESCRIPTION
When reading the [multiple rate limits](https://laravel.com/docs/12.x/routing#multiple-rate-limits) documentation the way I thought this would intuitively work is not the way it actually worked.

What I expected:
When I provide a  `Limit::perMinute(1)` and `Limit::perHour(10)` I expect to be able to make multiple requests in a minute and only one of them passes, hitting both limiters once. In effect I should be able to make a total of 1 non-limited request per minute and a total of 10 non-limited requests per hour.

What actually occurs:
Limits are hit dependent on the order of the array, and any smaller limit hit impedes on a higher limit. 429 responses within the first minute cause additional hits and count towards the hourly limit if the hourly limit is provided first in the array, and if provided second in the array the `X-RateLimit-Reset` header provides a false reading of when you will be able to use the endpoint again, showing the 1 minute rate first, and only ever showing the 1 hour rate once every minute of not hitting the minute limit.

If my expectations do not align with the Laravel team's or others I am happy for you to close this and I will just create an overriding class in my projects.