### PR TITLE
[12.x] Correct testEncryptAndDecrypt to properly test new methods

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1449,9 +1449,9 @@ class SupportStringableTest extends TestCase
 
         $this->container->bind('encrypter', fn () => new Encrypter(str_repeat('b', 16)));
 
-        $encrypted = encrypt('foo');
+        $encrypted = $this->stringable('foo')->encrypt();
 
-        $this->assertNotSame('foo', $encrypted);
-        $this->assertSame('foo', decrypt($encrypted));
+        $this->assertNotSame('foo', $encrypted->value());
+        $this->assertSame('foo', $encrypted->decrypt()->value());
     }
 }


### PR DESCRIPTION
The previous PR's tests https://github.com/laravel/framework/pull/55931#pullrequestreview-2914856164 weren't properly testing the new functionality. 
This fixes the test implementation to correctly test the new features.