### PR TITLE
[12.x] Add HasValidation Trait

### DIFF
--- a/src/Illuminate/Validation/HasValidation.php
+++ b/src/Illuminate/Validation/HasValidation.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use BackedEnum;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use UnitEnum;
+
+trait HasValidation
+{
+    private array $objectData;
+
+    private \Illuminate\Contracts\Validation\Validator|Validator $validator;
+
+    /**
+     * @throws ValidationException
+     */
+    public function validate(): void
+    {
+        if ($this->rules() === []) {
+            return;
+        }
+
+        $this->objectData = $this->buildDataForValidation();
+        if (! $this->validationPasses()) {
+            $this->failedValidation();
+        }
+    }
+
+    /**
+     * Defines the validation rules for the class.
+     */
+    protected function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * Defines the custom messages for validator errors.
+     */
+    protected function messages(): array
+    {
+        return [];
+    }
+
+    /**
+     * Defines the custom attributes for validator errors.
+     */
+    protected function attributes(): array
+    {
+        return [];
+    }
+
+    protected function after(Validator $validator): void
+    {
+        // Do nothing
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    protected function failedValidation(): void
+    {
+        throw new ValidationException($this->validator);
+    }
+
+    private function buildDataForValidation(): array
+    {
+        $mappedData = [];
+        $propertiesToValidated = array_keys($this->rules());
+        foreach ($propertiesToValidated as $property) {
+            if (
+                property_exists($this, $property)
+                || ($this instanceof Model && $this->hasAttribute($property))
+            ) {
+                $mappedData[$property] = $this->isArrayable($this->{$property})
+                    ? $this->formatArrayableValue($this->{$property})
+                    : $this->{$property};
+            }
+        }
+
+        return $mappedData;
+    }
+
+    private function validationPasses(): bool
+    {
+        $this->validator = \Illuminate\Support\Facades\Validator::make(
+            $this->objectData,
+            $this->rules(),
+            $this->messages(),
+            $this->attributes()
+        );
+
+        $this->validator->after(fn (Validator $validator) => $this->after($validator));
+
+        return $this->validator->passes();
+    }
+
+    private function isArrayable(mixed $value): bool
+    {
+        return is_array($value) ||
+            $value instanceof Arrayable ||
+            $value instanceof Collection ||
+            $value instanceof Model ||
+            (is_object($value) && ! ($value instanceof UploadedFile));
+    }
+
+    private function formatArrayableValue(mixed $value): array|int|string
+    {
+        return match (true) {
+            is_array($value) => $value,
+            $value instanceof BackedEnum => $value->value,
+            $value instanceof UnitEnum => $value->name,
+            $value instanceof Carbon || $value instanceof CarbonImmutable => $value->toISOString(true),
+            $value instanceof Collection => $this->transformCollectionToArray($value),
+            $value instanceof Arrayable => $value->toArray(),
+            is_object($value) => (array) $value,
+            default => [],
+        };
+    }
+
+    private function transformCollectionToArray(Collection $collection): array
+    {
+        return $collection->map(fn ($item) => $this->isArrayable($item)
+            ? $this->formatArrayableValue($item)
+            : $item
+        )->toArray();
+    }
+}

--- a/tests/Validation/HasValidationTest.php
+++ b/tests/Validation/HasValidationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\HasValidation;
+use Illuminate\Validation\ValidationException;
+use Orchestra\Testbench\TestCase;
+
+
+class HasValidationTest extends TestCase
+{
+    public function testHasValidationPassesIfNoRulesProvided()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $object = new DummyObject();
+        $object->validate();
+    }
+
+    public function testHasValidationPassesForDefinedRules()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $object = new DummyUser();
+        $object->email = 'test@laravel.com';
+        $object->name = 'Taylor';
+        $object->validate();
+    }
+
+    public function testHasValidationThrowsExceptionForDefinedRules()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The name field must be at least 3 characters.');
+
+        $object = new DummyUser();
+        $object->email = 'test@laravel.com';
+        $object->name = 'a';
+        $object->validate();
+    }
+
+    public function testHasValidationPassesForModelDefinedRules()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $object = new DummyUserModel();
+        $object->email = 'test@laravel.com';
+        $object->name = 'Taylor';
+        $object->validate();
+    }
+
+    public function testHasValidationThrowsExceptionForModelDefinedRules()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The name field must be at least 3 characters.');
+
+        $object = new DummyUserModel();
+        $object->email = 'test@laravel.com';
+        $object->name = 'a';
+        $object->validate();
+    }
+
+    public function testHasValidationPassesForDefinedArrayRules()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $object = new DummyReviewList();
+        $object->author = 'Taylor';
+        $object->reviews = collect([5,4]);
+        $object->validate();
+    }
+
+    public function testHasValidationThrowsExceptionForDefinedArrayRules()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The reviews.0 field must be an integer.');
+
+        $object = new DummyReviewList();
+        $object->author = 'Taylor';
+        $object->reviews = collect(['a','b']);
+        $object->validate();
+    }
+
+    public function testHasValidationUsesCustomMessage()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The brand is required for creating a new car.');
+
+        $object = new DummyCar();
+        $object->validate();
+    }
+}
+
+class DummyObject
+{
+    use HasValidation;
+
+    public string $name;
+}
+
+class DummyUser
+{
+    use HasValidation;
+
+    public string $email;
+
+    public string $name;
+
+    protected function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'name' => ['required', 'string', 'min:3'],
+        ];
+    }
+}
+
+class DummyUserModel extends Model
+{
+    use HasValidation;
+
+    protected $fillable = ['email', 'name'];
+
+    protected function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'name' => ['required', 'string', 'min:3'],
+        ];
+    }
+}
+
+class DummyReviewList
+{
+    use HasValidation;
+
+    public string $author;
+
+    public Collection $reviews;
+
+    protected function rules(): array
+    {
+        return [
+            'author' => ['required', 'string', 'min:3'],
+            'reviews' => ['required', 'array'],
+            'reviews.*' => ['required', 'int'],
+        ];
+    }
+}
+
+class DummyCar
+{
+    use HasValidation;
+
+    public ?string $brand = null;
+
+    protected function rules(): array
+    {
+        return [
+            'brand' => ['required', 'string'],
+        ];
+    }
+
+    protected function messages(): array
+    {
+        return [
+            'brand.required' => 'The brand is required for creating a new car.',
+        ];
+    }
+}

--- a/tests/Validation/HasValidationTest.php
+++ b/tests/Validation/HasValidationTest.php
@@ -67,7 +67,7 @@ class HasValidationTest extends TestCase
 
         $object = new DummyReviewList();
         $object->author = 'Taylor';
-        $object->reviews = collect([5,4]);
+        $object->reviews = collect([5, 4]);
         $object->validate();
     }
 
@@ -78,7 +78,7 @@ class HasValidationTest extends TestCase
 
         $object = new DummyReviewList();
         $object->author = 'Taylor';
-        $object->reviews = collect(['a','b']);
+        $object->reviews = collect(['a', 'b']);
         $object->validate();
     }
 

--- a/tests/Validation/HasValidationTest.php
+++ b/tests/Validation/HasValidationTest.php
@@ -8,7 +8,6 @@ use Illuminate\Validation\HasValidation;
 use Illuminate\Validation\ValidationException;
 use Orchestra\Testbench\TestCase;
 
-
 class HasValidationTest extends TestCase
 {
     public function testHasValidationPassesIfNoRulesProvided()


### PR DESCRIPTION
## Changes

This PR adds a new trait: `HasValidation`. This was heavily inspired (and most of its implementation is based also) in my Validated DTO package. The trait is an abstraction around the `Validator` facade, making it easier to create any types of classes with a built-in validation system.

## Why to have this Trait

The `Validator` facade already helps a lot on creating validations for any classes we want, this is just a small improvement on DX that will abstract the "boilerplate" code.

With this, any classes (even Models) can define their validations by simply using the Trait and defining a `rules` method. But it also gives control for setting custom messages with the `messages` method, setting custom attributes with the `attributes` method and it also supports the `after` validation of the `Validator`.

## Example

```php
class DummyUser
{
    use HasValidation;

    public string $email;

    public string $name;

    protected function rules(): array
    {
        return [
            'email' => ['required', 'email'],
            'name' => ['required', 'string', 'min:3'],
        ];
    }
}

$user = new DummyUser();
$user->email = 'test@laravel.com';
$user->name = 'a';
$user->validate(); // Throw ValidationException

$user->name = 'Taylor';
$user->validate(); // No exception is thrown
```

More examples can be found in the Test file in this PR.