### PR TITLE
[12.x] Add assertRedirectBackWithErrors to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -246,6 +246,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting back to the previous location and the session has the given errors.
+     *
+     * @param  string|array  $keys
+     * @param  mixed  $format
+     * @param  string  $errorBag
+     * @return $this
+     */
+    public function assertRedirectBackWithErrors($keys = [], $format = null, $errorBag = 'default')
+    {
+        $this->assertRedirectBack();
+        $this->assertSessionHasErrors($keys, $format, $errorBag);
+    }
+
+    /**
      * Assert whether the response is redirecting to a given route.
      *
      * @param  \BackedEnum|string  $name

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -259,7 +259,7 @@ class TestResponse implements ArrayAccess
 
         $this->assertSessionHasErrors($keys, $format, $errorBag);
 
-        return $this;
+        return $this; 
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -263,6 +263,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting back to the previous location with no errors in the session.
+     *
+     * @return $this
+     */
+    public function assertRedirectBackWithoutErrors()
+    {
+        $this->assertRedirectBack();
+
+        $this->assertSessionHasNoErrors();
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given route.
      *
      * @param  \BackedEnum|string  $name

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -259,7 +259,7 @@ class TestResponse implements ArrayAccess
 
         $this->assertSessionHasErrors($keys, $format, $errorBag);
 
-        return $this; 
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -256,7 +256,10 @@ class TestResponse implements ArrayAccess
     public function assertRedirectBackWithErrors($keys = [], $format = null, $errorBag = 'default')
     {
         $this->assertRedirectBack();
+
         $this->assertSessionHasErrors($keys, $format, $errorBag);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Description
---
This PR introduces a new `assertRedirectBackWithErrors()` method to streamline testing redirect-back responses that include validation errors.

Currently, developers need to write:

```php
$response->assertRedirectBack();
$response->assertSessionHasErrors([
    // ...
]);
```

With this addition, the test can be simplified to:

```php
$response->assertRedirectBackWithErrors([
    // ...
]);
```

Internally, this method simply calls `assertRedirectBack()` and `assertSessionHasErrors()`, so it's a convenience wrapper that improves test readability and reduces duplication.

About tests
---
I didn't include a separate test for this method since it delegates entirely to two existing, well-tested assertions.