### PR TITLE
[12.x] Remove call to deprecated `getDefaultDescription` method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -101,9 +101,7 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        if (! isset($this->description)) {
-            $this->setDescription((string) static::getDefaultDescription());
-        } else {
+        if (isset($this->description)) {
             $this->setDescription((string) $this->description);
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The `getDefaultDescription` method on the (Symfony) `Command` class has been deprecated as of v7.3, see https://github.com/symfony/symfony/pull/59565. This call was introduced in #45117, apparently to serve as a fallback for when no description is set in the Laravel `Command` child class implementation. 

However, given that in the `Symfony` class this call is already part of the constructor in 7.2 (see https://github.com/symfony/symfony/blob/ac794a799f5eda52a67e099d6a2752574b86833f/src/Symfony/Component/Console/Command/Command.php#L100), the call here looks useless to me. (*edit*: it has been around since 5.3 even; see https://github.com/symfony/symfony/blob/a57252fb11b4cd856476aa4e4dd359404d3537fb/src/Symfony/Component/Console/Command/Command.php#L120).

To prevent this call from triggering deprecation messages (like the one forcefully suppressed in #55888), I therefore propose simply removing it altogether.

Use cases:
- commands where the user implementing does not provide a `description` property value
- commands where the user opts to use the `AsCommand` attribute from Symfony to provide command metadata