### PR TITLE
[12.x] Handle Null Check in Str::contains

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -388,12 +388,12 @@ class Str
      */
     public static function endsWith($haystack, $needles)
     {
-        if (! is_iterable($needles)) {
-            $needles = (array) $needles;
-        }
-
         if (is_null($haystack)) {
             return false;
+        }
+
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
         }
 
         foreach ($needles as $needle) {
@@ -1642,12 +1642,12 @@ class Str
      */
     public static function startsWith($haystack, $needles)
     {
-        if (! is_iterable($needles)) {
-            $needles = [$needles];
-        }
-
         if (is_null($haystack)) {
             return false;
+        }
+
+        if (! is_iterable($needles)) {
+            $needles = [$needles];
         }
 
         foreach ($needles as $needle) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -297,6 +297,10 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if (is_null($haystack)) {
+            return false;
+        }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
         }


### PR DESCRIPTION
This PR adds a null check to the $haystack parameter for Str::contains(). Null values for this parameter have been deprecated.
```php
> Str::contains(null, "a")

   DEPRECATED  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in vendor/laravel/framework/src/Illuminate/Support/Str.php on line 313.
```

Also micro-optimizes Str::startsWith and Str::endsWith by returning earlier if $haystack is null.