### PR TITLE
Clear cast caches when discarding changes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2155,6 +2155,9 @@ trait HasAttributes
     {
         [$this->attributes, $this->changes, $this->previous] = [$this->original, [], []];
 
+        $this->classCastCache = [];
+        $this->attributeCastCache = [];
+
         return $this;
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3286,7 +3286,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelWithPrimitiveCasts();
 
         $model->address_line_one = '123 Main Street';
-        $model->address_line_two = 'Anytown';
 
         $this->assertEquals('123 Main Street', $model->address->lineOne);
         $this->assertEquals('123 MAIN STREET', $model->address_in_caps);


### PR DESCRIPTION
Let me know if I've misunderstood expected behaviour here, but it looks like there's a bug where cached casts aren't reset when calling `discardChanges()` so accessing those attributes after a discard will return incorrect values.

The test reproduces the issue and hopefully does a decent job of explaining what I mean.