### PR TITLE
[12.x] Check if file exists before trying to delete it

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -305,7 +305,7 @@ class Filesystem
 
         foreach ($paths as $path) {
             try {
-                if (@unlink($path)) {
+                if (is_file($path) && @unlink($path)) {
                     clearstatcache(false, $path);
                 } else {
                     $success = false;


### PR DESCRIPTION
When having the error_reporting set to showing warnings, this avoids the warning "No such file or directory" if the file doesn't exist.

For example:
```shell
$ php artisan config:clear
unlink(/home/jellyfrog/code/librenms/bootstrap/cache/config.php): No such file or directory in /home/jellyfrog/code/librenms/vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php on line 308

   INFO  Configuration cache cleared successfully.
```

NOTE: This is not a 100% correct fix, in Linux you should check if you have write+execute permissions on the parent-folder, but since there is a try/catch-block and the @-suppression already, I believe it's a good enough middle ground. Let me know if you want the more correct fix instead.