### PR TITLE
Enhance error handling in PendingRequest to convert TooManyRedirectsE…

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1613,7 +1613,13 @@ class PendingRequest
             $response = $this->populateResponse($this->newResponse($e->getResponse()))
         );
 
-        throw $response->toException();
+        $exception = $response->toException();
+
+        if ($exception === null) {
+            $exception = new ConnectionException($e->getMessage(), 0, $e);
+        }
+
+        throw $exception;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1613,13 +1613,7 @@ class PendingRequest
             $response = $this->populateResponse($this->newResponse($e->getResponse()))
         );
 
-        $exception = $response->toException();
-
-        if ($exception === null) {
-            $exception = new ConnectionException($e->getMessage(), 0, $e);
-        }
-
-        throw $exception;
+        throw $response->toException() ?? new ConnectionException($e->getMessage(), 0, $e);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2615,7 +2615,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake(function () {
             $request = new GuzzleRequest('GET', 'https://redirect.laravel.example');
             $response = new Psr7Response(301, ['Location' => 'https://redirect2.laravel.example']);
-            
+
             throw new TooManyRedirectsException(
                 'Maximum number of redirects (5) exceeded',
                 $request,


### PR DESCRIPTION
## Fix  https://github.com/laravel/framework/issues/55989 TooManyRedirectsException handling in HTTP client

### Problem

Since Laravel v12.18.0, when an HTTP request exceeds the maximum number of redirects, a `TooManyRedirectsException` from Guzzle causes a PHP `Error` to be thrown with the message "Can only throw objects" instead of the expected `ConnectionException`.

This breaks existing applications that rely on catching `ConnectionException` for redirect limit handling, particularly for health checks and similar use cases.

**Before this fix:**
```php
Http::fake([
    '1.example.com' => Http::response(null, 301, ['Location' => 'https://2.example.com']),
    '2.example.com' => Http::response(null, 301, ['Location' => 'https://3.example.com']),
    '3.example.com' => Http::response('', 200),
]);

// This throws: Error: "Can only throw objects"
Http::createPendingRequest()
    ->maxRedirects(1)
    ->get('https://1.example.com');
```

**After this fix:**
```php
// This correctly throws: Illuminate\Http\Client\ConnectionException
Http::createPendingRequest()
    ->maxRedirects(1)
    ->get('https://1.example.com');
```

### Root Cause

The issue occurs in `PendingRequest::marshalRequestExceptionWithResponse()` method:

1. When `TooManyRedirectsException` is thrown by Guzzle, it includes the last redirect response (typically 301/302 status)
2. The method calls `$response->toException()` which only returns a `RequestException` for 4xx/5xx errors
3. For 3xx redirect responses, `toException()` returns `null` because `failed()` returns `false`
4. The method then tries to `throw null`, causing the PHP Error

### Solution

Modified `marshalRequestExceptionWithResponse()` to handle the case where `toException()` returns `null`:

```php
protected function marshalRequestExceptionWithResponse(RequestException $e)
{
    $this->factory?->recordRequestResponsePair(
        new Request($e->getRequest()),
        $response = $this->populateResponse($this->newResponse($e->getResponse()))
    );

    $exception = $response->toException();

    if ($exception === null) {
        // For cases like TooManyRedirectsException where the response isn't an error status code
        $exception = new ConnectionException($e->getMessage(), 0, $e);
    }

    throw $exception;
}
```

This ensures that:
- `TooManyRedirectsException` and similar exceptions are properly wrapped as `ConnectionException`
- The original Guzzle exception and message are preserved
- Normal 4xx/5xx error handling remains unchanged

### Tests Added

- **`testTooManyRedirectsExceptionConvertedToConnectionException`**: Tests direct Guzzle exception handling
- **`testTooManyRedirectsWithFakedRedirectChain`**: Tests the scenario from the original issue using faked responses

### Impact

- ✅ **Bug Fix**: Resolves "Can only throw objects" error
- ✅ **Backward Compatible**: Existing code will work as expected
- ✅ **Type Safety**: Proper exception hierarchy maintained

---

**Related to:** Laravel v12.18.0 Guzzle exception handling refactoring  