### PR TITLE
[12.x] Remove the only @return tag left on a constructor

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -567,7 +567,6 @@ class DatabaseConnectionTestMockPDOException extends PDOException
      *
      * @param  string|null  $message
      * @param  string|null  $code
-     * @return void
      */
     public function __construct($message = null, $code = null)
     {


### PR DESCRIPTION
Continuation of https://github.com/laravel/framework/pull/55076, https://github.com/laravel/framework/pull/55136 and https://github.com/laravel/framework/pull/55858