### PR TITLE
[12.x] collapseWithKeys - Prevent exception in base case

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -165,6 +165,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             $results[$key] = $values;
         }
 
+        if (!$results) {
+            return $this;
+        }
+
         return new static(array_replace(...$results));
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -165,7 +165,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             $results[$key] = $values;
         }
 
-        if (!$results) {
+        if (! $results) {
             return $this;
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -166,7 +166,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         if (! $results) {
-            return $this;
+            return new static;
         }
 
         return new static(array_replace(...$results));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1772,6 +1772,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([[1 => 'a'], [3 => 'c'], [2 => 'b'], 'drop']);
         $this->assertEquals([1 => 'a', 3 => 'c', 2 => 'b'], $data->collapseWithKeys()->all());
+
+        // Case with an already flat collection
+        $data = new $collection(['a', 'b', 'c']);
+        $this->assertEquals(['a', 'b', 'c'], $data->collapseWithKeys()->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1775,7 +1775,7 @@ class SupportCollectionTest extends TestCase
 
         // Case with an already flat collection
         $data = new $collection(['a', 'b', 'c']);
-        $this->assertEquals(['a', 'b', 'c'], $data->collapseWithKeys()->all());
+        $this->assertEquals([], $data->collapseWithKeys()->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
Currently the `collapseWithKeys` method of Collections will throw an exception if the collection is already flat (i.e. none of the top level elements are arrays or collections).

Before the changes in this PR:
```
Psy Shell v0.12.8 (PHP 8.3.21 — cli) by Justin Hileman
> collect(['a', 'b', 'c'])->collapseWithKeys();

   ArgumentCountError  array_replace() expects at least 1 argument, 0 given.

```

After the changes in this PR:
```
Psy Shell v0.12.8 (PHP 8.3.21 — cli) by Justin Hileman
> collect(['a', 'b', 'c'])->collapseWithKeys();
= Illuminate\Support\Collection {#12283
    all: [],
  }

```

This PR handles this case by returning an empty collection, similar to what `LazyCollection` does.

This PR should be considered for merging because it allows `collapseWithKeys` to operate over a larger scope of potential inputs sensibly without causing exceptions to be thrown. The user of `collapseWithKeys` should be able to use it on collections without having to check the structure of the collection first to prevent exceptions.

Happy to make any adjustments, no hard feelings if closure.