### PR TITLE
[12.x] Add data_map helper

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -622,6 +622,46 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
+    public function testDataMap()
+    {
+        $data = [
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['order' => 1],
+                        (object) [],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) [],
+                        (object) ['order' => 2],
+                    ],
+                ],
+            ],
+        ];
+
+        data_map($data, 'posts.*.comments.*.key', fn ($old, $key) => $key);
+        data_map($data, 'posts.*.comments.*.order', fn ($old) => isset($old) ? ++$old : null);
+
+        $this->assertEquals([
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['key' => 'posts.0.comments.0', 'order' => 2],
+                        (object) ['key' => 'posts.0.comments.1', 'order' => null],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['key' => 'posts.1.comments.0', 'order' => null],
+                        (object) ['key' => 'posts.1.comments.1', 'order' => 3],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+
     public function testDataRemove()
     {
         $data = ['foo' => 'bar', 'hello' => 'world'];


### PR DESCRIPTION
This PR adds a new helper to the Collection helper. In addition to the existing `data_set` which is limited to set static data, this PR adds the `data_map` helper that can be used to map a callable using dot notation. 

For example:
```php
$data = [
    'company' => [
        'name' => 'Acme Corporation',
        'employees' => [
            ['name' => 'John Doe', 'age' => 30],
            ['name' => 'Jane Smith', 'age' => 25],
        ]
    ]
];

data_map($data, 'company.employees.*.age', fn ($old) => ++$old);

// Result
$data = [
    'company' => [
        'name' => 'Acme Corporation',
        'employees' => [
            ['name' => 'John Doe', 'age' => 31],
            ['name' => 'Jane Smith', 'age' => 26],
        ]
    ]
];
```

The callable can accept 2 params:
- `$old` : previous value or null if not defined
- `$key` : the key to the mapped item (eg: `company.employees.0`)