### PR TITLE
[12.x] - Add `Str::ordinal()` helper method to return ordinal suffixes for numbers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2087,4 +2087,22 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Get the ordinal suffix for a given number.
+     *
+     * @param  int  $number
+     * @return string
+     */
+    public static function ordinal(int $number)
+    {
+        if (!in_array(($number % 100), [11, 12, 13])) {
+            switch ($number % 10) {
+                case 1: return $number . "st";
+                case 2: return $number . "nd";
+                case 3: return $number . "rd";
+            }
+        }
+        return $number . "th";
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2096,13 +2096,17 @@ class Str
      */
     public static function ordinal(int $number)
     {
-        if (!in_array(($number % 100), [11, 12, 13])) {
+        if (! in_array($number % 100, [11, 12, 13])) {
             switch ($number % 10) {
-                case 1: return $number . "st";
-                case 2: return $number . "nd";
-                case 3: return $number . "rd";
+                case 1:
+                    return $number . 'st';
+                case 2:
+                    return $number . 'nd';
+                case 3:
+                    return $number . 'rd';
             }
         }
-        return $number . "th";
+
+        return $number . 'th';
     }
 }


### PR DESCRIPTION
This PR adds a new `Str::ordinal()` helper method to return the ordinal representation of a number (e.g., `1st`, `2nd`, `3rd`, etc.).

### Example

```php
Str::ordinal(1);   // "1st"
Str::ordinal(2);   // "2nd"
Str::ordinal(3);   // "3rd"
Str::ordinal(11);  // "11th"
Str::ordinal(21);  // "21st"
