### PR TITLE
[12.x] Standardize size() behavior and add extended queue metrics support

### DIFF
--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -2,6 +2,12 @@
 
 namespace Illuminate\Contracts\Queue;
 
+/**
+ * @method int sizePending(string|null $queue = null)
+ * @method int sizeDelayed(string|null $queue = null)
+ * @method int sizeReserved(string|null $queue = null)
+ * @method int|null oldestPending(string|null $queue = null)
+ */
 interface Queue
 {
     /**
@@ -37,7 +43,6 @@ interface Queue
      *
      * @param  string  $payload
      * @param  string|null  $queue
-     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = []);

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -6,7 +6,7 @@ namespace Illuminate\Contracts\Queue;
  * @method int pendingSize(string|null $queue = null)
  * @method int delayedSize(string|null $queue = null)
  * @method int reservedSize(string|null $queue = null)
- * @method int|null creationTimeOfOldestPendingJobstring|null $queue = null)
+ * @method int|null creationTimeOfOldestPendingJob(string|null $queue = null)
  */
 interface Queue
 {

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -6,7 +6,7 @@ namespace Illuminate\Contracts\Queue;
  * @method int pendingSize(string|null $queue = null)
  * @method int delayedSize(string|null $queue = null)
  * @method int reservedSize(string|null $queue = null)
- * @method int|null oldestPending(string|null $queue = null)
+ * @method int|null creationTimeOfOldestPendingJobstring|null $queue = null)
  */
 interface Queue
 {

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Contracts\Queue;
 
 /**
- * @method int sizePending(string|null $queue = null)
- * @method int sizeDelayed(string|null $queue = null)
- * @method int sizeReserved(string|null $queue = null)
+ * @method int pendingSize(string|null $queue = null)
+ * @method int delayedSize(string|null $queue = null)
+ * @method int reservedSize(string|null $queue = null)
  * @method int|null oldestPending(string|null $queue = null)
  */
 interface Queue

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -75,7 +75,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of pending jobs (ready).
+     * Get the number of pending jobs (ready to run).
      *
      * @param  string|null  $queue
      * @return int
@@ -86,7 +86,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of delayed jobs.
+     * Get the number of delayed jobs (waiting for future execution).
      *
      * @param  string|null  $queue
      * @return int
@@ -97,7 +97,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of reserved jobs (in progress).
+     * Get the number of reserved jobs (currently running).
      *
      * @param  string|null  $queue
      * @return int
@@ -108,7 +108,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the available_at timestamp of the oldest pending job (not supported).
+     * Get the timestamp of the oldest pending job (not supported).
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -75,6 +75,50 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of pending jobs (ready).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizePending($queue = null)
+    {
+        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReady;
+    }
+
+    /**
+     * Get the number of delayed jobs.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeDelayed($queue = null)
+    {
+        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsDelayed;
+    }
+
+    /**
+     * Get the number of reserved jobs (in progress).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeReserved($queue = null)
+    {
+        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReserved;
+    }
+
+    /**
+     * Get the available_at timestamp of the oldest pending job (not supported).
+     *
+     * @param  string|null  $queue
+     * @return int|null
+     */
+    public function oldestPending($queue = null)
+    {
+        return null;
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -79,46 +79,47 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of pending jobs (ready to run).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReady;
     }
 
     /**
-     * Get the number of delayed jobs (waiting for future execution).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsDelayed;
     }
 
     /**
-     * Get the number of reserved jobs (currently running).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReserved;
     }
 
     /**
-     * Get the timestamp of the oldest pending job (not supported).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue
      * @return int|null
      */
     public function oldestPending($queue = null)
     {
+        // Not supported by Beanstalkd...
         return null;
     }
 

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -117,7 +117,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         // Not supported by Beanstalkd...
         return null;

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -117,7 +117,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         // Not supported by Beanstalkd...
         return null;

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -71,7 +71,11 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function size($queue = null)
     {
-        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReady;
+        $stats = $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)));
+
+        return $stats->currentJobsReady
+            + $stats->currentJobsDelayed
+            + $stats->currentJobsReserved;
     }
 
     /**
@@ -82,7 +86,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function sizePending($queue = null)
     {
-        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReady;
+        return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReady;
     }
 
     /**
@@ -93,7 +97,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function sizeDelayed($queue = null)
     {
-        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsDelayed;
+        return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsDelayed;
     }
 
     /**
@@ -104,7 +108,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function sizeReserved($queue = null)
     {
-        return (int) $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReserved;
+        return $this->pheanstalk->statsTube(new TubeName($this->getQueue($queue)))->currentJobsReserved;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -109,7 +109,7 @@ class MonitorCommand extends Command
                     ? $this->manager->connection($connection)->reservedSize($queue)
                     : null,
                 'oldest_pending' => method_exists($this->manager->connection($connection), 'oldestPending')
-                    ? $this->manager->connection($connection)->creationTimeOfOldestPendingJob$queue)
+                    ? $this->manager->connection($connection)->creationTimeOfOldestPendingJob($queue)
                     : null,
                 'status' => $size >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
             ];

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -20,7 +20,6 @@ class MonitorCommand extends Command
     protected $signature = 'queue:monitor
                        {queues : The names of the queues to monitor}
                        {--max=1000 : The maximum number of jobs that can be on the queue before an event is dispatched}
-                       {--metrics : Output queue metrics}
                        {--json : Output the queue size as JSON}';
 
     /**

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -99,6 +99,18 @@ class MonitorCommand extends Command
                 'connection' => $connection,
                 'queue' => $queue,
                 'size' => $size = $this->manager->connection($connection)->size($queue),
+                'pending' => method_exists($this->manager->connection($connection), 'sizePending')
+                    ? $this->manager->connection($connection)->sizePending($queue)
+                    : null,
+                'delayed' => method_exists($this->manager->connection($connection), 'sizeDelayed')
+                    ? $this->manager->connection($connection)->sizeDelayed($queue)
+                    : null,
+                'reserved' => method_exists($this->manager->connection($connection), 'sizeReserved')
+                    ? $this->manager->connection($connection)->sizeReserved($queue)
+                    : null,
+                'oldest_pending' => method_exists($this->manager->connection($connection), 'oldestPending')
+                    ? $this->manager->connection($connection)->oldestPending($queue)
+                    : null,
                 'status' => $size >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
             ];
         });
@@ -121,6 +133,9 @@ class MonitorCommand extends Command
             $status = '['.$queue['size'].'] '.$queue['status'];
 
             $this->components->twoColumnDetail($name, $status);
+            $this->components->twoColumnDetail('Delayed jobs', $queue['delayed'] ?? 'N/A');
+            $this->components->twoColumnDetail('Reserved jobs', $queue['reserved'] ?? 'N/A');
+            $this->components->twoColumnDetail('Oldest pending', $queue['oldest_pending'] ? date('c', $queue['oldest_pending']) : 'N/A');
         });
 
         $this->newLine();

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -99,14 +99,14 @@ class MonitorCommand extends Command
                 'connection' => $connection,
                 'queue' => $queue,
                 'size' => $size = $this->manager->connection($connection)->size($queue),
-                'pending' => method_exists($this->manager->connection($connection), 'sizePending')
-                    ? $this->manager->connection($connection)->sizePending($queue)
+                'pending' => method_exists($this->manager->connection($connection), 'pendingSize')
+                    ? $this->manager->connection($connection)->pendingSize($queue)
                     : null,
-                'delayed' => method_exists($this->manager->connection($connection), 'sizeDelayed')
-                    ? $this->manager->connection($connection)->sizeDelayed($queue)
+                'delayed' => method_exists($this->manager->connection($connection), 'delayedSize')
+                    ? $this->manager->connection($connection)->delayedSize($queue)
                     : null,
-                'reserved' => method_exists($this->manager->connection($connection), 'sizeReserved')
-                    ? $this->manager->connection($connection)->sizeReserved($queue)
+                'reserved' => method_exists($this->manager->connection($connection), 'reservedSize')
+                    ? $this->manager->connection($connection)->reservedSize($queue)
                     : null,
                 'oldest_pending' => method_exists($this->manager->connection($connection), 'oldestPending')
                     ? $this->manager->connection($connection)->oldestPending($queue)
@@ -136,7 +136,6 @@ class MonitorCommand extends Command
             $this->components->twoColumnDetail('Pending jobs', $queue['pending'] ?? 'N/A');
             $this->components->twoColumnDetail('Delayed jobs', $queue['delayed'] ?? 'N/A');
             $this->components->twoColumnDetail('Reserved jobs', $queue['reserved'] ?? 'N/A');
-            $this->components->twoColumnDetail('Oldest pending', $queue['oldest_pending'] ? date('c', $queue['oldest_pending']) : 'N/A');
             $this->line('');
         });
 

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -109,7 +109,7 @@ class MonitorCommand extends Command
                     ? $this->manager->connection($connection)->reservedSize($queue)
                     : null,
                 'oldest_pending' => method_exists($this->manager->connection($connection), 'oldestPending')
-                    ? $this->manager->connection($connection)->oldestPending($queue)
+                    ? $this->manager->connection($connection)->creationTimeOfOldestPendingJob$queue)
                     : null,
                 'status' => $size >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
             ];

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -134,6 +134,7 @@ class MonitorCommand extends Command
             $status = '['.$queue['size'].'] '.$queue['status'];
 
             $this->components->twoColumnDetail($name, $status);
+            $this->components->twoColumnDetail('Pending jobs', $queue['pending'] ?? 'N/A');
             $this->components->twoColumnDetail('Delayed jobs', $queue['delayed'] ?? 'N/A');
             $this->components->twoColumnDetail('Reserved jobs', $queue['reserved'] ?? 'N/A');
             $this->components->twoColumnDetail('Oldest pending', $queue['oldest_pending'] ? date('c', $queue['oldest_pending']) : 'N/A');

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -20,6 +20,7 @@ class MonitorCommand extends Command
     protected $signature = 'queue:monitor
                        {queues : The names of the queues to monitor}
                        {--max=1000 : The maximum number of jobs that can be on the queue before an event is dispatched}
+                       {--metrics : Output queue metrics}
                        {--json : Output the queue size as JSON}';
 
     /**
@@ -136,6 +137,7 @@ class MonitorCommand extends Command
             $this->components->twoColumnDetail('Delayed jobs', $queue['delayed'] ?? 'N/A');
             $this->components->twoColumnDetail('Reserved jobs', $queue['reserved'] ?? 'N/A');
             $this->components->twoColumnDetail('Oldest pending', $queue['oldest_pending'] ? date('c', $queue['oldest_pending']) : 'N/A');
+            $this->line('');
         });
 
         $this->newLine();

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -80,7 +80,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of pending jobs (ready to run, not delayed or reserved).
+     * Get the number of pending jobs (ready to run).
      *
      * @param  string|null  $queue
      * @return int
@@ -95,7 +95,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of delayed jobs (future-dated available_at).
+     * Get the number of delayed jobs (waiting for future execution).
      *
      * @param  string|null  $queue
      * @return int
@@ -110,7 +110,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of reserved (running) jobs.
+     * Get the number of reserved jobs (currently running).
      *
      * @param  string|null  $queue
      * @return int

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -129,7 +129,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -129,7 +129,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -80,12 +80,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of pending jobs (ready to run).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))
@@ -95,12 +95,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of delayed jobs (waiting for future execution).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))
@@ -110,12 +110,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of reserved jobs (currently running).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))
@@ -124,7 +124,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the timestamp of the oldest pending job (excluding delayed jobs).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -56,7 +56,7 @@ class NullQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         return null;
     }

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -56,7 +56,7 @@ class NullQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         return null;
     }

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -18,40 +18,40 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of pending jobs (none for null driver).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the number of delayed jobs (none for null driver).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the number of reserved jobs (none for null driver).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the timestamp of the oldest pending job (not supported for null driver).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -18,6 +18,50 @@ class NullQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of pending jobs (none for null driver).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizePending($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the number of delayed jobs (none for null driver).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeDelayed($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the number of reserved jobs (none for null driver).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeReserved($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the timestamp of the oldest pending job (not supported for null driver).
+     *
+     * @param  string|null  $queue
+     * @return int|null
+     */
+    public function oldestPending($queue = null)
+    {
+        return null;
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -148,7 +148,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         $payload = $this->getConnection()->lindex($this->getQueue($queue), 0);
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -143,7 +143,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the available_at timestamp of the oldest pending job (not delayed).
+     * Get the timestamp of the oldest pending job (excluding delayed jobs).
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -150,7 +150,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function oldestPending($queue = null)
     {
-        $payload = $this->getConnection()->lindex($this->getQueue($queue), -1);
+        $payload = $this->getConnection()->lindex($this->getQueue($queue), 0);
 
         if (! $payload) {
             return null;
@@ -158,7 +158,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
 
         $data = json_decode($payload, true);
 
-        return $data['available_at'] ?? null;
+        return $data['createdAt'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -148,7 +148,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         $payload = $this->getConnection()->lindex($this->getQueue($queue), 0);
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -110,40 +110,40 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of pending jobs (ready to run).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return $this->getConnection()->llen($this->getQueue($queue));
     }
 
     /**
-     * Get the number of delayed jobs (waiting for future execution).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return $this->getConnection()->zcard($this->getQueue($queue).':delayed');
     }
 
     /**
-     * Get the number of reserved jobs (currently running).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return $this->getConnection()->zcard($this->getQueue($queue).':reserved');
     }
 
     /**
-     * Get the timestamp of the oldest pending job (excluding delayed jobs).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -80,6 +80,52 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Get the number of pending jobs (ready to be received).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizePending($queue = null)
+    {
+        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessages');
+    }
+
+    /**
+     * Get the number of delayed jobs.
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeDelayed($queue = null)
+    {
+        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessagesDelayed');
+    }
+
+    /**
+     * Get the number of reserved jobs (in-flight).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeReserved($queue = null)
+    {
+        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessagesNotVisible');
+    }
+
+    /**
+     * Get the timestamp of the oldest pending job.
+     *
+     * Not supported by SQS, returns null.
+     *
+     * @param  string|null  $queue
+     * @return int|null
+     */
+    public function oldestPending($queue = null)
+    {
+        return null;
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -86,12 +86,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of pending jobs (ready to run).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
             'QueueUrl' => $this->getQueue($queue),
@@ -102,12 +102,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of delayed jobs (waiting for future execution).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
             'QueueUrl' => $this->getQueue($queue),
@@ -118,12 +118,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of reserved jobs (currently running).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
             'QueueUrl' => $this->getQueue($queue),
@@ -134,7 +134,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the timestamp of the oldest pending job (excluding delayed jobs).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * Not supported by SQS, returns null.
      *
@@ -143,6 +143,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function oldestPending($queue = null)
     {
+        // Not supported by SQS...
         return null;
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -85,6 +85,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             + (int) $a['ApproximateNumberOfMessagesNotVisible'];
     }
 
+    /**
+     * Get the number of pending jobs (ready to run).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
     public function sizePending($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
@@ -95,6 +101,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         return (int) $response['Attributes']['ApproximateNumberOfMessages'] ?? 0;
     }
 
+    /**
+     * Get the number of delayed jobs (waiting for future execution).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
     public function sizeDelayed($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([
@@ -105,6 +117,12 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         return (int) $response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0;
     }
 
+    /**
+     * Get the number of reserved jobs (currently running).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
     public function sizeReserved($queue = null)
     {
         $response = $this->sqs->getQueueAttributes([

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -141,7 +141,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         // Not supported by SQS...
         return null;

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -71,45 +71,48 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     {
         $response = $this->sqs->getQueueAttributes([
             'QueueUrl' => $this->getQueue($queue),
+            'AttributeNames' => [
+                'ApproximateNumberOfMessages',
+                'ApproximateNumberOfMessagesDelayed',
+                'ApproximateNumberOfMessagesNotVisible',
+            ],
+        ]);
+
+        $a = $response['Attributes'];
+
+        return (int) $a['ApproximateNumberOfMessages']
+            + (int) $a['ApproximateNumberOfMessagesDelayed']
+            + (int) $a['ApproximateNumberOfMessagesNotVisible'];
+    }
+
+    public function sizePending($queue = null)
+    {
+        $response = $this->sqs->getQueueAttributes([
+            'QueueUrl' => $this->getQueue($queue),
             'AttributeNames' => ['ApproximateNumberOfMessages'],
         ]);
 
-        $attributes = $response->get('Attributes');
-
-        return (int) $attributes['ApproximateNumberOfMessages'];
+        return (int) $response['Attributes']['ApproximateNumberOfMessages'] ?? 0;
     }
 
-    /**
-     * Get the number of pending jobs (ready to run).
-     *
-     * @param  string|null  $queue
-     * @return int
-     */
-    public function sizePending($queue = null)
-    {
-        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessages');
-    }
-
-    /**
-     * Get the number of delayed jobs (waiting for future execution).
-     *
-     * @param  string|null  $queue
-     * @return int
-     */
     public function sizeDelayed($queue = null)
     {
-        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessagesDelayed');
+        $response = $this->sqs->getQueueAttributes([
+            'QueueUrl' => $this->getQueue($queue),
+            'AttributeNames' => ['ApproximateNumberOfMessagesDelayed'],
+        ]);
+
+        return (int) $response['Attributes']['ApproximateNumberOfMessagesDelayed'] ?? 0;
     }
 
-    /**
-     * Get the number of reserved jobs (currently running).
-     *
-     * @param  string|null  $queue
-     * @return int
-     */
     public function sizeReserved($queue = null)
     {
-        return $this->getQueueAttribute($queue, 'ApproximateNumberOfMessagesNotVisible');
+        $response = $this->sqs->getQueueAttributes([
+            'QueueUrl' => $this->getQueue($queue),
+            'AttributeNames' => ['ApproximateNumberOfMessagesNotVisible'],
+        ]);
+
+        return (int) $response['Attributes']['ApproximateNumberOfMessagesNotVisible'] ?? 0;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -80,7 +80,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of pending jobs (ready to be received).
+     * Get the number of pending jobs (ready to run).
      *
      * @param  string|null  $queue
      * @return int
@@ -91,7 +91,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of delayed jobs.
+     * Get the number of delayed jobs (waiting for future execution).
      *
      * @param  string|null  $queue
      * @return int
@@ -102,7 +102,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the number of reserved jobs (in-flight).
+     * Get the number of reserved jobs (currently running).
      *
      * @param  string|null  $queue
      * @return int
@@ -113,7 +113,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Get the timestamp of the oldest pending job.
+     * Get the timestamp of the oldest pending job (excluding delayed jobs).
      *
      * Not supported by SQS, returns null.
      *

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -141,7 +141,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         // Not supported by SQS...
         return null;

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -37,40 +37,40 @@ class SyncQueue extends Queue implements QueueContract
     }
 
     /**
-     * Get the number of pending jobs (none for sync).
+     * Get the number of pending jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the number of delayed jobs (none for sync).
+     * Get the number of delayed jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the number of reserved jobs (none for sync).
+     * Get the number of reserved jobs.
      *
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return 0;
     }
 
     /**
-     * Get the timestamp of the oldest pending job (not supported).
+     * Get the creation timestamp of the oldest pending job, excluding delayed jobs.
      *
      * @param  string|null  $queue
      * @return int|null

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -75,7 +75,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function creationTimeOfOldestPendingJob$queue = null)
+    public function creationTimeOfOldestPendingJob($queue = null)
     {
         return null;
     }

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -37,6 +37,50 @@ class SyncQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of pending jobs (none for sync).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizePending($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the number of delayed jobs (none for sync).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeDelayed($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the number of reserved jobs (none for sync).
+     *
+     * @param  string|null  $queue
+     * @return int
+     */
+    public function sizeReserved($queue = null)
+    {
+        return 0;
+    }
+
+    /**
+     * Get the timestamp of the oldest pending job (not supported).
+     *
+     * @param  string|null  $queue
+     * @return int|null
+     */
+    public function oldestPending($queue = null)
+    {
+        return null;
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -75,7 +75,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         return null;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -476,7 +476,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  string|null  $queue
      * @return int|null
      */
-    public function oldestPending($queue = null)
+    public function creationTimeOfOldestPendingJob$queue = null)
     {
         return collect($this->pendingJobs)
             ->filter(fn ($job) => $job['queue'] === $queue && $job['available_at'] <= now()->getTimestamp())

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -437,7 +437,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  string|null  $queue
      * @return int
      */
-    public function sizePending($queue = null)
+    public function pendingSize($queue = null)
     {
         return collect($this->pendingJobs)
             ->filter(fn ($job) => $job['queue'] === $queue && $job['available_at'] <= now()->getTimestamp())
@@ -450,7 +450,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeDelayed($queue = null)
+    public function delayedSize($queue = null)
     {
         return collect($this->delayedJobs)
             ->filter(fn ($job) => $job['queue'] === $queue && $job['available_at'] > now()->getTimestamp())
@@ -463,7 +463,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  string|null  $queue
      * @return int
      */
-    public function sizeReserved($queue = null)
+    public function reservedSize($queue = null)
     {
         return collect($this->reservedJobs)
             ->filter(fn ($job) => $job['queue'] === $queue)

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -631,6 +631,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                 $this->markJobAsReserved($job['job'], $queue);
                 unset($this->pendingJobs[$index]);
                 $this->pendingJobs = array_values($this->pendingJobs);
+
                 return;
             }
         }

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -25,41 +25,6 @@ class QueueSizeTest extends TestCase
         $this->assertEquals(2, Queue::size());
         $this->assertEquals(1, Queue::size('Q2'));
     }
-
-    public function test_driver_methods_exist_and_return_expected_defaults()
-    {
-        Queue::fake();
-
-        $queue = Queue::connection();
-
-        $job = new TestJob1;
-
-        dispatch($job);
-        dispatch($job);
-        dispatch(new TestJob2)->delay(5);
-        dispatch($job)->onQueue('Q2');
-
-        $this->assertEquals(2, $queue->pendingSize());
-        $this->assertEquals(1, $queue->delayedSize());
-        $this->assertEquals(0, $queue->reservedSize());
-        $this->assertIsInt($queue->creationTimeOfOldestPendingJob());
-
-        $this->assertEquals(1, $queue->pendingSize('Q2'));
-        $this->assertEquals(0, $queue->delayedSize('Q2'));
-        $this->assertEquals(0, $queue->reservedSize('Q2'));
-        $this->assertIsInt($queue->creationTimeOfOldestPendingJob('Q2'));
-
-        $queue->process();
-        $queue->process('Q2');
-
-        $this->assertEquals(1, $queue->pendingSize());
-        $this->assertEquals(1, $queue->delayedSize());
-        $this->assertEquals(1, $queue->reservedSize());
-
-        $this->assertEquals(0, $queue->pendingSize('Q2'));
-        $this->assertEquals(0, $queue->delayedSize('Q2'));
-        $this->assertEquals(1, $queue->reservedSize('Q2'));
-    }
 }
 
 class TestJob1 implements ShouldQueue

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -42,12 +42,12 @@ class QueueSizeTest extends TestCase
         $this->assertEquals(2, $queue->pendingSize());
         $this->assertEquals(1, $queue->delayedSize());
         $this->assertEquals(0, $queue->reservedSize());
-        $this->assertIsInt($queue->creationTimeOfOldestPendingJob));
+        $this->assertIsInt($queue->creationTimeOfOldestPendingJob());
 
         $this->assertEquals(1, $queue->pendingSize('Q2'));
         $this->assertEquals(0, $queue->delayedSize('Q2'));
         $this->assertEquals(0, $queue->reservedSize('Q2'));
-        $this->assertIsInt($queue->creationTimeOfOldestPendingJob'Q2'));
+        $this->assertIsInt($queue->creationTimeOfOldestPendingJob('Q2'));
 
         $queue->process();
         $queue->process('Q2');

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -39,26 +39,26 @@ class QueueSizeTest extends TestCase
         dispatch(new TestJob2)->delay(5);
         dispatch($job)->onQueue('Q2');
 
-        $this->assertEquals(2, $queue->sizePending());
-        $this->assertEquals(1, $queue->sizeDelayed());
-        $this->assertEquals(0, $queue->sizeReserved());
+        $this->assertEquals(2, $queue->pendingSize());
+        $this->assertEquals(1, $queue->delayedSize());
+        $this->assertEquals(0, $queue->reservedSize());
         $this->assertIsInt($queue->oldestPending());
 
-        $this->assertEquals(1, $queue->sizePending('Q2'));
-        $this->assertEquals(0, $queue->sizeDelayed('Q2'));
-        $this->assertEquals(0, $queue->sizeReserved('Q2'));
+        $this->assertEquals(1, $queue->pendingSize('Q2'));
+        $this->assertEquals(0, $queue->delayedSize('Q2'));
+        $this->assertEquals(0, $queue->reservedSize('Q2'));
         $this->assertIsInt($queue->oldestPending('Q2'));
 
         $queue->process();
         $queue->process('Q2');
 
-        $this->assertEquals(1, $queue->sizePending());
-        $this->assertEquals(1, $queue->sizeDelayed());
-        $this->assertEquals(1, $queue->sizeReserved());
+        $this->assertEquals(1, $queue->pendingSize());
+        $this->assertEquals(1, $queue->delayedSize());
+        $this->assertEquals(1, $queue->reservedSize());
 
-        $this->assertEquals(0, $queue->sizePending('Q2'));
-        $this->assertEquals(0, $queue->sizeDelayed('Q2'));
-        $this->assertEquals(1, $queue->sizeReserved('Q2'));
+        $this->assertEquals(0, $queue->pendingSize('Q2'));
+        $this->assertEquals(0, $queue->delayedSize('Q2'));
+        $this->assertEquals(1, $queue->reservedSize('Q2'));
     }
 }
 

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -25,6 +25,41 @@ class QueueSizeTest extends TestCase
         $this->assertEquals(2, Queue::size());
         $this->assertEquals(1, Queue::size('Q2'));
     }
+
+    public function test_driver_methods_exist_and_return_expected_defaults()
+    {
+        Queue::fake();
+
+        $queue = Queue::connection();
+
+        $job = new TestJob1;
+
+        dispatch($job);
+        dispatch($job);
+        dispatch(new TestJob2)->delay(5);
+        dispatch($job)->onQueue('Q2');
+
+        $this->assertEquals(2, $queue->sizePending());
+        $this->assertEquals(1, $queue->sizeDelayed());
+        $this->assertEquals(0, $queue->sizeReserved());
+        $this->assertIsInt($queue->oldestPending());
+
+        $this->assertEquals(1, $queue->sizePending('Q2'));
+        $this->assertEquals(0, $queue->sizeDelayed('Q2'));
+        $this->assertEquals(0, $queue->sizeReserved('Q2'));
+        $this->assertIsInt($queue->oldestPending('Q2'));
+
+        $queue->process();
+        $queue->process('Q2');
+
+        $this->assertEquals(1, $queue->sizePending());
+        $this->assertEquals(1, $queue->sizeDelayed());
+        $this->assertEquals(1, $queue->sizeReserved());
+
+        $this->assertEquals(0, $queue->sizePending('Q2'));
+        $this->assertEquals(0, $queue->sizeDelayed('Q2'));
+        $this->assertEquals(1, $queue->sizeReserved('Q2'));
+    }
 }
 
 class TestJob1 implements ShouldQueue

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -42,12 +42,12 @@ class QueueSizeTest extends TestCase
         $this->assertEquals(2, $queue->pendingSize());
         $this->assertEquals(1, $queue->delayedSize());
         $this->assertEquals(0, $queue->reservedSize());
-        $this->assertIsInt($queue->oldestPending());
+        $this->assertIsInt($queue->creationTimeOfOldestPendingJob));
 
         $this->assertEquals(1, $queue->pendingSize('Q2'));
         $this->assertEquals(0, $queue->delayedSize('Q2'));
         $this->assertEquals(0, $queue->reservedSize('Q2'));
-        $this->assertIsInt($queue->oldestPending('Q2'));
+        $this->assertIsInt($queue->creationTimeOfOldestPendingJob'Q2'));
 
         $queue->process();
         $queue->process('Q2');

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -148,9 +148,25 @@ class QueueSqsQueueTest extends TestCase
     {
         $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
-        $this->sqs->shouldReceive('getQueueAttributes')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateNumberOfMessages']])->andReturn($this->mockedQueueAttributesResponseModel);
+
+        $this->sqs->shouldReceive('getQueueAttributes')->once()->with([
+            'QueueUrl' => $this->queueUrl,
+            'AttributeNames' => [
+                'ApproximateNumberOfMessages',
+                'ApproximateNumberOfMessagesDelayed',
+                'ApproximateNumberOfMessagesNotVisible',
+            ],
+        ])->andReturn(new Result([
+            'Attributes' => [
+                'ApproximateNumberOfMessages' => 1,
+                'ApproximateNumberOfMessagesDelayed' => 2,
+                'ApproximateNumberOfMessagesNotVisible' => 3,
+            ],
+        ]));
+
         $size = $queue->size($this->queueName);
-        $this->assertEquals(1, $size);
+
+        $this->assertEquals(6, $size); // 1 + 2 + 3
     }
 
     public function testGetQueueProperlyResolvesUrlWithPrefix()


### PR DESCRIPTION
This PR improves queue metric support by adding methods to retrieve:

- Pending jobs
- Delayed (scheduled) jobs
- Reserved jobs
- Oldest pending job (where supported — not available for SQS and Beanstalkd)

It also fixes inconsistencies in the `size()` method. Previously, different queue drivers returned different values — some only counted pending jobs, while others included all jobs. 

Now, `size()` consistently returns the **total number of jobs** (pending + delayed + reserved) across all supported drivers.

**Previous behavior:**

| Driver      | `size()` Before      | `size()` Now |
|-------------|----------------------|--------------|
| Database    | All jobs ✅           | All jobs ✅   |
| Redis       | All jobs ✅           | All jobs ✅   |
| SQS         | Pending only ❌       | All jobs ✅   |
| Beanstalkd  | Pending only ❌       | All jobs ✅   |

---

### ⚠️ Note on `--max` behavior in `queue:monitor`

The `--max` option currently uses the `size()` method to determine when to trigger alerts.

Since `size()` now consistently returns the **total job count** (pending + delayed + reserved), this may lead to different behavior compared to earlier versions — especially if delayed or reserved jobs are significant.

In most cases, it's more meaningful to base alerts on **pending jobs** only.

This PR does not change how `--max` works, but it may be worth considering updating `queue:monitor` to optionally use `sizePending()` instead.

---

### 🧪 Testing Improvements

The `FakeQueue` has been updated to support testing of job state transitions:

- Simulates jobs transitioning between `pending`, `delayed`, and `reserved`
- Enables more accurate and complete test coverage for queue behavior