### PR TITLE
Add mapTo method to FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -358,6 +358,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
     /**
      * Checks if the given target has the given property.
+     *
      * @param  object  $target
      * @param  string  $property
      * @return bool
@@ -381,6 +382,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         if ($target instanceof Model) {
             $target->{$property} = $value;
+
             return;
         }
 
@@ -404,6 +406,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $type = $reflection->getType();
         if ($type === null) {
             $target->{$property} = $value;
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -340,16 +340,22 @@ class FormRequest extends Request implements ValidatesWhenResolved
         foreach ($properties as $property => $value) {
             if ($this->targetHasProperty($target, $property)) {
                 $this->mapProperty($target, $property, $value);
+
+                continue;
             }
 
             $snakedProperty = Str::snake($property);
             if ($this->targetHasProperty($target, $snakedProperty)) {
                 $this->mapProperty($target, $snakedProperty, $value);
+
+                continue;
             }
 
             $camelProperty = Str::camel($property);
             if ($this->targetHasProperty($target, $camelProperty)) {
                 $this->mapProperty($target, $camelProperty, $value);
+
+                continue;
             }
         }
 
@@ -401,6 +407,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     private function mapObjectProperty(object $target, string $property, mixed $value): void
     {
+        $formattedValue = null;
         $valueIsArray = is_array($value);
         $reflection = new ReflectionProperty($target::class, $property);
         $type = $reflection->getType();

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -310,7 +310,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Maps the request data into the given target.
      *
      * @param  class-string|object  $target
-     * @return  object  An instance of the given target with the mapped data from the request.
+     * @return object An instance of the given target with the mapped data from the request.
      */
     public function mapTo(string|object $target): object
     {

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -316,6 +316,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @param  class-string|object  $target
      * @return object An instance of the given target with the mapped data from the request.
+     *
      * @throws ReflectionException
      */
     public function mapTo(string|object $target): object
@@ -331,6 +332,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  object  $target
      * @param  array  $properties
      * @return object An instance of the given target with the mapped data from the given properties.
+     *
      * @throws ReflectionException
      */
     private function mapToTarget(object $target, array $properties): object
@@ -355,7 +357,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Checks if the given target has the given property
+     * Checks if the given target has the given property.
      * @param  object  $target
      * @param  string  $property
      * @return bool
@@ -366,12 +368,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Maps the given value to the given property of the given target
+     * Maps the given value to the given property of the given target.
      *
      * @param  object  $target
      * @param  string  $property
      * @param  mixed  $value
      * @return void
+     *
      * @throws ReflectionException
      */
     private function mapProperty(object $target, string $property, mixed $value): void
@@ -385,12 +388,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Maps the given value to the given property of the given target object
+     * Maps the given value to the given property of the given target object.
      *
      * @param  object  $target
      * @param  string  $property
      * @param  mixed  $value
      * @return void
+     *
      * @throws ReflectionException
      */
     private function mapObjectProperty(object $target, string $property, mixed $value): void


### PR DESCRIPTION
## Changes

This PR adds a new method `mapTo` to the `FormRequest` class.
This method allows developers to directly map Request data into another class: DTOs, Models, etc.

It also allows matching between `snake_case` and `camelCase` variations.
So you can have the request receiving the data as one of these variations and having the target class with the other variation and it would work.

This also works with nested objects like having a DTO with a property being another DTO.

## Why this change?

Arrays are great for some things, but they also bring a lot of pain. The main issue where we use Associative Arrays is the same: you don't have any info about the data the array holds. It can be anything and even worse, each item in the array can be something completely different! The data has no context at all.

For more context on this you can check this article I wrote: https://wendelladriel.com/blog/avoid-the-aop-array-oriented-programming

## Examples

1 - You can map to a new instance of a class:
```php
class MyController
{
    public function store(AddUserRequest $request): JsonResponse
    {
        $user = $request->mapTo(User::class);
        $user->save();
        return $user;
    }
}
```

2 - You can map to an existing instance of a class:
```php
class MyController
{
    public function update(EditUserRequest $request, int $userId): JsonResponse
    {
        $user = $request->mapTo(User::query()->findOrFail($userId));
        $user->save();
        return $user;
    }
}
```

3 - It works with any types of classes like DTOs as well, not only with Models:

```php
class UserDTO
{
    public string $email;

    public string $password;
}

class MyController
{
    public function update(AdsUserRequest $request): JsonResponse
    {
        $userData = $request->mapTo(UserDTO::class);
        // Call action or service here
    }
}
```