### PR TITLE
feat: Add ability to override NotificationSender class

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -58,7 +58,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             $this->container->make(Dispatcher::class),
             $this->locale,
         ])->sendNow($notifiables, $notification, $channels);
-
     }
 
     /**

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -34,9 +34,12 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function send($notifiables, $notification)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->send($notifiables, $notification);
+        $this->container->make(NotificationSender::class, [
+            $this,
+            $this->container->make(Bus::class),
+            $this->container->make(Dispatcher::class),
+            $this->locale,
+        ])->send($notifiables, $notification);
     }
 
     /**
@@ -49,9 +52,13 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->sendNow($notifiables, $notification, $channels);
+        $this->container->make(NotificationSender::class, [
+            $this,
+            $this->container->make(Bus::class),
+            $this->container->make(Dispatcher::class),
+            $this->locale,
+        ])->sendNow($notifiables, $notification, $channels);
+
     }
 
     /**


### PR DESCRIPTION
This change adds support for binding a custom NotificationSender instance in the dependency injection container, enabling individual class to override the default notification sending logic with their own implementation
