### PR TITLE
[12.x] Determine queue worker memory usage with getrusage if possible

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -763,7 +763,13 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return $memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= $memoryLimit;
+        if ($memoryLimit > 0) {
+            $usage = (getrusage()['ru_maxrss'] ?? (memory_get_usage(true) / 1024)) / 1024;
+
+            return $usage >= $memoryLimit;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
I found that `memory_get_usage()` does not report the actual memory usage of the process, e.g. if packages such as jcupitt/vips for image processing are used. The value reported in `ru_maxrss` represents the actual memory usage and should be preferred if available.

Maybe related to https://github.com/laravel/framework/issues/25738