### PR TITLE
[12.x] Improve constructor PHPDoc for controller middleware definition

### DIFF
--- a/src/Illuminate/Routing/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Middleware.php
@@ -11,6 +11,8 @@ class Middleware
      * Create a new controller middleware definition.
      *
      * @param  \Closure|string|array  $middleware
+     * @param  array<string>|null  $only
+     * @param  array<string>|null  $except
      */
     public function __construct(public Closure|string|array $middleware, public ?array $only = null, public ?array $except = null)
     {


### PR DESCRIPTION
Updated the docblock to accurately reflect parameter types and optional nature of only and except for better IDE support.