### PR TITLE
[12.x]: Add UseEloquentBuilder attribute to register custom Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/UseEloquentBuilder.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseEloquentBuilder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseEloquentBuilder
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Builder>  $builderClass
+     */
+    public function __construct(public string $builderClass)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonException;
 use JsonSerializable;
 use LogicException;
+use ReflectionClass;
 use ReflectionMethod;
 use Stringable;
 
@@ -1662,24 +1663,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Resolve the custom Eloquent builder class from model attributes.
+     * Resolve the custom Eloquent builder class from the model attributes.
      *
      * @return class-string<\Illuminate\Database\Eloquent\Builder>|false
      */
     protected function resolveCustomBuilderClass()
     {
-        $reflection = new \ReflectionClass($this);
+        $attributes = (new ReflectionClass($this))
+            ->getAttributes(UseEloquentBuilder::class);
 
-        $attributes = $reflection->getAttributes(UseEloquentBuilder::class);
-
-        if (! empty($attributes)) {
-            /** @var \Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder $attribute */
-            $attribute = $attributes[0]->newInstance();
-
-            return $attribute->builderClass;
-        }
-
-        return false;
+        return ! empty($attributes)
+            ? $attributes[0]->newInstance()->builderClass
+            : false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1654,7 +1654,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $builderClass = $this->resolveCustomBuilderClass();
 
-        if ($builderClass !== null && is_subclass_of($builderClass, Builder::class)) {
+        if ($builderClass && is_subclass_of($builderClass, Builder::class)) {
             return new $builderClass($query);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3350,7 +3350,34 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelWithUseFactoryAttribute::class, $factory->modelName());
         $this->assertEquals('test name', $instance->name); // Small smoke test to ensure the factory is working
     }
+
+    public function testUseCustomBuilderWithUseEloquentBuilderAttribute()
+    {
+        $model = new EloquentModelWithUseEloquentBuilderAttributeStub();
+
+        $query = $this->createMock(\Illuminate\Database\Query\Builder::class);
+        $eloquentBuilder = $model->newEloquentBuilder($query);
+
+        $this->assertInstanceOf(CustomBuilder::class, $eloquentBuilder);
+    }
+
+    public function testDefaultBuilderIsUsedWhenUseEloquentBuilderAttributeIsNotPresent()
+    {
+        $model = new EloquentModelWithoutUseEloquentBuilderAttributeStub();
+
+        $query = $this->createMock(\Illuminate\Database\Query\Builder::class);
+        $eloquentBuilder = $model->newEloquentBuilder($query);
+
+        $this->assertNotInstanceOf(CustomBuilder::class, $eloquentBuilder);
+    }
 }
+
+class CustomBuilder extends Builder {}
+
+#[\Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder(CustomBuilder::class)]
+class EloquentModelWithUseEloquentBuilderAttributeStub extends Model {}
+
+class EloquentModelWithoutUseEloquentBuilderAttributeStub extends Model {}
 
 class EloquentTestObserverStub
 {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3372,12 +3372,18 @@ class DatabaseEloquentModelTest extends TestCase
     }
 }
 
-class CustomBuilder extends Builder {}
+class CustomBuilder extends Builder
+{
+}
 
 #[\Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder(CustomBuilder::class)]
-class EloquentModelWithUseEloquentBuilderAttributeStub extends Model {}
+class EloquentModelWithUseEloquentBuilderAttributeStub extends Model
+{
+}
 
-class EloquentModelWithoutUseEloquentBuilderAttributeStub extends Model {}
+class EloquentModelWithoutUseEloquentBuilderAttributeStub extends Model
+{
+}
 
 class EloquentTestObserverStub
 {


### PR DESCRIPTION
Hello!

This pull request introduces a new attribute, #[UseEloquentBuilder], defined in Illuminate\Database\Eloquent\Attributes, to simplify the registration of custom Eloquent Query Builders for models in Laravel.

Currently, to use a custom query builder, you need to override the newEloquentBuilder method in your model, like this:
```
class MyModel extends Model
{
    // ...
    public function newEloquentBuilder($query)
    {
        return new CustomBuilder($query);
    }
}
```

With this new attribute, we can achieve the same result more elegantly:
```
#[UseEloquentBuilder(CustomBuilder::class)]
class MyModel extends Model
{
    // ...
}
```