### PR TITLE
[12.x] add Attachment::fromUploadedFile method

### DIFF
--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -83,7 +83,7 @@ class Attachment
     /**
      * Create a mail attachment from an UploadedFile instance.
      *
-     * @param  UploadedFile  $file
+     * @param  \Illuminate\Http\UploadedFile  $file
      * @return static
      */
     public static function fromUploadedFile(UploadedFile $file)

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
@@ -77,6 +78,23 @@ class Attachment
         return (new static(
             fn ($attachment, $pathStrategy, $dataStrategy) => $dataStrategy($data, $attachment)
         ))->as($name);
+    }
+
+    /**
+     * Create a mail attachment from an UploadedFile instance.
+     *
+     * @param  UploadedFile  $file
+     * @return static
+     */
+    public static function fromUploadedFile(UploadedFile $file)
+    {
+        return new static(function ($attachment, $pathStrategy, $dataStrategy) use ($file) {
+            $attachment
+                ->as($file->getClientOriginalName())
+                ->withMime($file->getMimeType() ?? $file->getClientMimeType());
+
+            return $dataStrategy(fn () => $file->get(), $attachment);
+        });
     }
 
     /**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -38,6 +38,7 @@
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SES mail driver (^3.322.9).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
+        "illuminate/http": "Required to create an attachment from an UploadedFile instance.",
         "symfony/http-client": "Required to use the Symfony API mail transports (^7.2).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.2).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.2)."

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -37,7 +37,7 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SES mail driver (^3.322.9).",
-        "illuminate/http": "Required to create an attachment from an UploadedFile instance.",
+        "illuminate/http": "Required to create an attachment from an UploadedFile instance (^12.0).",
         "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
         "symfony/http-client": "Required to use the Symfony API mail transports (^7.2).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.2).",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -37,8 +37,8 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SES mail driver (^3.322.9).",
-        "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
         "illuminate/http": "Required to create an attachment from an UploadedFile instance.",
+        "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
         "symfony/http-client": "Required to use the Symfony API mail transports (^7.2).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.2).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.2)."

--- a/tests/Mail/AttachableTest.php
+++ b/tests/Mail/AttachableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Http\Testing\File;
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
 use PHPUnit\Framework\TestCase;
@@ -137,5 +138,35 @@ class AttachableTest extends TestCase
                 'mime' => 'application/pdf',
             ],
         ], $mailable->attachments[0]);
+    }
+
+    public function testFromUploadedFileMethod()
+    {
+        $mailable = new class extends Mailable
+        {
+            public function build()
+            {
+                $this->attach(new class implements Attachable
+                {
+                    public function toMailAttachment()
+                    {
+                        return Attachment::fromUploadedFile(
+                            File::createWithContent('example.pdf', 'content')
+                                ->mimeType('application/pdf')
+                        );
+                    }
+                });
+            }
+        };
+
+        $mailable->build();
+
+        $this->assertSame([
+            'data' => 'content',
+            'name' => 'example.pdf',
+            'options' => [
+                'mime' => 'application/pdf',
+            ],
+        ], $mailable->rawAttachments[0]);
     }
 }


### PR DESCRIPTION
Closes #55983 

Currently, there is no straightforward way to attach an `UploadedFile` instance to a mailable.

That is useful on contact forms that only forwards a form to an email.

`Attachment::fromData()` can be used, but:

- Requires the attachment name to be set manually by the developer
- Requires the developer to remember calling `$file->get()` to retrieve the uploaded file's content
- Does not set the attachment's mime type from the original file

This PR:

- Adds a new helper `Attachment::fromUploadedFile()`, which creates an `Attachment` instance from an `UploadedFile` instance, and sets its name from the `UploadedFile` original client name, and sets it mime-type from the inferred mime-type, or from the client mime-type.
- Adds a corresponding test case