### PR TITLE
[12.x] Added `Route::hasParameterName()` to check if a parameter exists in the route, even if not bound

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -412,6 +412,18 @@ class Route
     }
 
     /**
+     * Check if the route has a specific parameter in the route definition
+     * Note: hasParameter() checks if the parameter is bound on the route.
+     *
+     * @param  string  $parameter
+     * @return bool
+     */
+    public function hasParameterName($parameter)
+    {
+        return in_array($parameter, $this->parameterNames());
+    }
+
+    /**
      * Get a given parameter from the route.
      *
      * @param  string  $name

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -605,6 +605,22 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($route->hasParameters());
     }
 
+    public function testHasParameterName()
+    {
+        $route = new Route('GET', 'images/{id}.{ext}', function () {
+            //
+        });
+        $this->assertFalse($route->hasParameters());
+
+        // parameters were not bound
+        $this->assertFalse($route->hasParameter('id'));
+        $this->assertFalse($route->hasParameter('ext'));
+
+        // but parameters were defined
+        $this->assertTrue($route->hasParameterName('id'));
+        $this->assertTrue($route->hasParameterName('ext'));
+    }
+
     public function testForgetParameter()
     {
         $route = new Route('GET', 'images/{id}.{ext}', function () {


### PR DESCRIPTION
In some cases—such as within middleware—it may be necessary to determine whether a given route expects a specific parameter before performing a redirect. This ensures that the redirect target can accept the parameter, preventing potential binding or routing errors.

The route parameters, if not defined within the route, will be sent as query parameters.

Here's an example of how you might conditionally choose between a route parameter and a query parameter based on the route's definition:

```
$parameterKey = $route->hasParameterName('someParameter')
    ? 'someParameter'
    : 'someQueryParameter';

return redirect()->route($route->getName(), [
    $parameterKey => 'some value',
]);
```

This approach allows for graceful fallback behavior when the route does not define the expected parameter, ensuring compatibility and avoiding runtime issues.

