### PR TITLE
[12.x] Optimise join and set functions in Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -607,11 +607,13 @@ class Arr
             return implode($glue, $array);
         }
 
-        if (count($array) === 0) {
+        $countArray = count($array);
+
+        if ($countArray === 0) {
             return '';
         }
 
-        if (count($array) === 1) {
+        if ($countArray === 1) {
             return end($array);
         }
 
@@ -913,6 +915,12 @@ class Arr
         }
 
         $keys = explode('.', $key);
+
+        if (count($keys) === 1) {
+            $array[$keys[0]] = $value;
+
+            return $array;
+        }
 
         foreach ($keys as $i => $key) {
             if (count($keys) === 1) {


### PR DESCRIPTION
**Improve `Arr::set` and `Arr::join` for clarity and performance**

* Optimized `Arr::set` to handle single-key cases early, reducing unnecessary loop execution and improving readability.
* Optimized `Arr::join` by storing the count of the array once instead of calling `count()` multiple times, improving performance slightly and making the logic cleaner.