### PR TITLE
[12.x] Add Arr::intval helper to convert and optionally filter integer values

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1177,4 +1177,22 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Convert each item in the given array to an integer.
+     * Optionally filters out zero values.
+     *
+     * @param  array  $value        The array of values to convert.
+     * @param  bool   $filterZeros  Whether to filter out zero values after conversion. Default is true.
+     * @return array                The array of converted integers, optionally with zeros filtered out.
+     */
+    public static function intval($value, $filterZeros = true) {
+        if(!is_array($value)) {
+            return [];
+        }
+
+        $convertedItems = array_map('intval', $value);
+
+        return $filterZeros ? static::where($convertedItems, fn ($value) => $value > 0) : $convertedItems;
+    }
 }


### PR DESCRIPTION
feat(arr): Arr::intval helper in Array helpers

- Adds a static Arr::intval(array $value, bool $filterZeros = true): array method
- Converts array values to integers using array_map
- Optionally filters out zero values using Arr::where
- Useful for sanitizing input arrays (e.g., form inputs, query params)

### 🧪 Example: Using `Arr::intval` to Convert and Optionally Filter Integer Values

```php
use App\Support\Arr;

// ✅ Default: filter out zero values (0 and '0')
$result = Arr::intval(['10', '0', '25', 0, 'abc']);
// Result: [10, 25]

// ❌ Disable filtering: keep all values including zeros
$result = Arr::intval(['10', '0', '25', 0, 'abc'], false);
// Result: [10, 0, 25, 0, 0]

