### PR TITLE
[12.x] Add a new model cast named asFluent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Fluent;
+
+class AsFluent implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Fluent, string>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                return isset($value) ? new Fluent(Json::decode($value)) : null;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return isset($value) ? [$key => Json::encode($value)] : null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Hi, 
Since the Fluent class was added to Laravel, I have been using the Fluent cast on some of my applications where I need to deal with JSON values in different ways. I think it would be great to have it in the framework.

Example:

```php
namespace App\Models;

use Illuminate\Database\Eloquent\Casts\AsFluent;
use Illuminate\Database\Eloquent\Model;

class Passenger extends Model
{
    protected function casts(): array
    {
        return [
            'address' => AsFluent::class,
        ];
    }
}
```

It can be used:
```php
 $passanger = Passenger::first();
 
 $passenger->address->get('office.street');
 $passenger->address->get('home.street');
```

It can be updated by passing the fluent object or array

```php
use Illuminate\Support\Fluent;

 $passanger = Passenger::first();
 
 $passenger->address = new Fluent([
           'office' => ['street' => 'new street'],
           'office' => ['home' => 'new street']
])
 
 // by array
 $passenger->address = [
           'office' => ['street' => 'new street'],
           'office' => ['home' => 'new street']
]
```

I tried to follow the naming convention. Please let me know if there's anything wrong or if I can improve it.
