### PR TITLE
[12.x] Add enum functionality to morph map

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -552,7 +552,7 @@ abstract class Relation implements BuilderContract
         if (! is_string($className)) {
             throw new InvalidArgumentException('Class name cannot be an enum value when the morph map is not an enum!');
         }
-        
+
         return array_search($className, static::$morphMap, strict: true) ?: $className;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -15,9 +15,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
-use ReflectionClassConstant;
 use ReflectionEnum;
-use ReflectionEnumBackedCase;
 
 use function Illuminate\Support\enum_value;
 

--- a/tests/Integration/Database/EloquentRelationMorphMapTest.php
+++ b/tests/Integration/Database/EloquentRelationMorphMapTest.php
@@ -4,8 +4,6 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\TestWith;
 

--- a/tests/Integration/Database/EloquentRelationMorphMapTest.php
+++ b/tests/Integration/Database/EloquentRelationMorphMapTest.php
@@ -32,7 +32,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
         Relation::morphMap($fqn, true);
     }
 
-    #[TestWith([MorphMap::class, [ 'a' => A::class ]])]
+    #[TestWith([MorphMap::class, ['a' => A::class]])]
     public function testMorphMapEnumMergePrevious(string $first, array $second)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -49,7 +49,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
         Relation::morphMap($input);
     }
 
-    #[TestWith([[ A::class, B::class ], ['a_s' => A::class, 'b_s' => B::class]])]
+    #[TestWith([[A::class, B::class], ['a_s' => A::class, 'b_s' => B::class]])]
     public function testMorphMapList(array $input, array $output)
     {
         $map = Relation::morphMap($input);
@@ -57,7 +57,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
         $this->assertSame($output, Relation::morphMap());
     }
 
-    #[TestWith([[ 'a' => A::class ]])]
+    #[TestWith([['a' => A::class]])]
     public function testMorphMapAssociativeArray(array $map)
     {
         $res = Relation::morphMap($map);
@@ -77,7 +77,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
     #[TestWith(['b', null])]
     public function testGetMorphedModelArray(string $alias, ?string $model)
     {
-        Relation::morphMap([ 'a' => A::class ]);
+        Relation::morphMap(['a' => A::class]);
         $this->assertSame($model, Relation::getMorphedModel($alias));
     }
 
@@ -94,7 +94,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
     #[TestWith(['gibberish', 'gibberish'])]
     public function testGetMorphAliasArray(string $className, string $alias)
     {
-        Relation::morphMap([ 'a' => A::class ]);
+        Relation::morphMap(['a' => A::class]);
         $this->assertSame($alias, Relation::getMorphAlias($className));
     }
 
@@ -103,7 +103,7 @@ class EloquentRelationMorphMapTest extends DatabaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Class name cannot be an enum value when the morph map is not an enum!');
-        Relation::morphMap([ 'a' => A::class ]);
+        Relation::morphMap(['a' => A::class]);
         Relation::getMorphAlias($className);
     }
 }
@@ -114,5 +114,9 @@ enum MorphMap: string
     case B = B::class;
 }
 
-class A extends Model {}
-class B extends Model {}
+class A extends Model
+{
+}
+class B extends Model
+{
+}

--- a/tests/Integration/Database/EloquentRelationMorphMapTest.php
+++ b/tests/Integration/Database/EloquentRelationMorphMapTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class EloquentRelationMorphMapTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Relation::morphMap([], false);
+    }
+
+    #[TestWith([MorphMap::class])]
+    public function testMorphMapEnum(string $fqn)
+    {
+        $map = Relation::morphMap($fqn);
+        $this->assertSame($fqn, $map);
+        $this->assertSame($fqn, Relation::morphMap());
+    }
+
+    #[TestWith([MorphMap::class])]
+    public function testMorphMapEnumMerge(string $fqn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Enum morph maps cannot be merged!');
+        Relation::morphMap($fqn, true);
+    }
+
+    #[TestWith([MorphMap::class, [ 'a' => A::class ]])]
+    public function testMorphMapEnumMergePrevious(string $first, array $second)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Enum morph maps cannot be merged!');
+        Relation::morphMap($first);
+        Relation::morphMap($second, true);
+    }
+
+    #[TestWith(['gibberish'])]
+    public function testMorphMapArbitraryString(string $input)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mapping must be a an array, null, or a backed enum!');
+        Relation::morphMap($input);
+    }
+
+    #[TestWith([[ A::class, B::class ], ['a_s' => A::class, 'b_s' => B::class]])]
+    public function testMorphMapList(array $input, array $output)
+    {
+        $map = Relation::morphMap($input);
+        $this->assertSame($output, $map);
+        $this->assertSame($output, Relation::morphMap());
+    }
+
+    #[TestWith([[ 'a' => A::class ]])]
+    public function testMorphMapAssociativeArray(array $map)
+    {
+        $res = Relation::morphMap($map);
+        $this->assertSame($res, $map);
+        $this->assertSame($res, Relation::morphMap());
+    }
+
+    #[TestWith(['A', A::class])]
+    #[TestWith(['C', null])]
+    public function testGetMorphedModelEnum(string $alias, ?string $model)
+    {
+        Relation::morphMap(MorphMap::class);
+        $this->assertSame($model, Relation::getMorphedModel($alias));
+    }
+
+    #[TestWith(['a', A::class])]
+    #[TestWith(['b', null])]
+    public function testGetMorphedModelArray(string $alias, ?string $model)
+    {
+        Relation::morphMap([ 'a' => A::class ]);
+        $this->assertSame($model, Relation::getMorphedModel($alias));
+    }
+
+    #[TestWith([A::class, 'A'])]
+    #[TestWith([MorphMap::A, 'A'])]
+    #[TestWith(['C', 'C'])]
+    public function testGetMorphAliasEnum(string|MorphMap $className, string|MorphMap|null $alias)
+    {
+        Relation::morphMap(MorphMap::class);
+        $this->assertSame($alias, Relation::getMorphAlias($className));
+    }
+
+    #[TestWith([A::class, 'a'])]
+    #[TestWith(['gibberish', 'gibberish'])]
+    public function testGetMorphAliasArray(string $className, string $alias)
+    {
+        Relation::morphMap([ 'a' => A::class ]);
+        $this->assertSame($alias, Relation::getMorphAlias($className));
+    }
+
+    #[TestWith([MorphMap::A, A::class])]
+    public function testGetMorphAliasArrayEnumClassName(string|MorphMap $className, string $alias)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class name cannot be an enum value when the morph map is not an enum!');
+        Relation::morphMap([ 'a' => A::class ]);
+        Relation::getMorphAlias($className);
+    }
+}
+
+enum MorphMap: string
+{
+    case A = A::class;
+    case B = B::class;
+}
+
+class A extends Model {}
+class B extends Model {}


### PR DESCRIPTION
Enums are a powerful addition to the PHP language and with the `enum_value()` helper, working with them in Laravel is like a charm. This PR adds the ability to pass an enum to another of Laravel's features: Morph maps. So, instead of a non-exhaustive array, we can now add an enumerated mapping and benefit from better IDE support.

# Examples
## Define morph map
```php
// Current functionality
Relation::morphMap([ 'App\Models\Post', 'App\Models\Video' ]); // results in ['posts' => 'App\Models\Post', 'videos' => 'App\Models\Video']
Relation::morphMap([ 'articles' => 'App\Models\Post', 'clips' => 'App\Models\Video' ]); // results in ['articles' => 'App\Models\Post', 'clips' => 'App\Models\Video']

// 🆕 functionality
enum MorphMap: string
{
    case Articles = 'App\Models\Post';
    case Clips = 'App\Models\Video';
}
Relation::morphMap(MorphMap::class); // results in MorphMap{Articles: 'App\Models\Post', Clips: 'App\Models\Video'}
```

## Get morph alias
```php
enum MorphMap: string
{
    case Articles = 'App\Models\Post';
    case Clips = 'App\Models\Video';
}
echo Relation::getMorphAlias(MorphMap::Articles); // results in 'Articles' (a little nonsensical)
echo Relation::getMorphAlias('App\Models\Post'); // results in 'Articles'
```

## Get morphed model
```php
enum MorphMap: string
{
    case Articles = 'App\Models\Post';
    case Clips = 'App\Models\Video';
}
echo Relation::getMorphedModel('Articles'); // results in App\Models\Post
```
