### PR TITLE
[12.x] Add diff() to Arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1177,4 +1177,20 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * @template ArrayAKeys
+     * @template ArrayBKeys
+     * @template ArrayAValues
+     * @template ArrayBValues
+     * 
+     * @param  array<ArrayAKeys, ArrayAValues>  $a
+     * @param  array<ArrayBKeys, ArrayBValues>  $b
+     * 
+     * @return  array<ArrayAKeys|ArrayBKeys, ArrayAValues|ArrayBValues>
+     */
+    public static function diff(array $a, array $b): array
+    {
+        return array_udiff($a, $b, fn () => $a <=> $b);
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1183,11 +1183,11 @@ class Arr
      * @template ArrayBKeys
      * @template ArrayAValues
      * @template ArrayBValues
-     * 
+     *
      * @param  array<ArrayAKeys, ArrayAValues>  $a
      * @param  array<ArrayBKeys, ArrayBValues>  $b
      * 
-     * @return  array<ArrayAKeys|ArrayBKeys, ArrayAValues|ArrayBValues>
+     * @return array<ArrayAKeys|ArrayBKeys, ArrayAValues|ArrayBValues>
      */
     public static function diff(array $a, array $b): array
     {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1186,7 +1186,6 @@ class Arr
      *
      * @param  array<ArrayAKeys, ArrayAValues>  $a
      * @param  array<ArrayBKeys, ArrayBValues>  $b
-     *
      * @return array<ArrayAKeys|ArrayBKeys, ArrayAValues|ArrayBValues>
      */
     public static function diff(array $a, array $b): array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1186,7 +1186,7 @@ class Arr
      *
      * @param  array<ArrayAKeys, ArrayAValues>  $a
      * @param  array<ArrayBKeys, ArrayBValues>  $b
-     * 
+     *
      * @return array<ArrayAKeys|ArrayBKeys, ArrayAValues|ArrayBValues>
      */
     public static function diff(array $a, array $b): array


### PR DESCRIPTION
# Why can't we just use `array_diff()`?
In most cases, you absolutely can. But there's one case where the function fails: When the arrays contain array values. This can be circumvented with a custom diffing callback, using the spaceship operator