### PR TITLE
[12.x] Pass TransportException to NotificationFailed event

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -12,6 +12,8 @@ use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Localizable;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Throwable;
 
 class NotificationSender
@@ -159,6 +161,10 @@ class NotificationSender
             $response = $this->manager->driver($channel)->send($notifiable, $notification);
         } catch (Throwable $exception) {
             if (! $this->failedEventWasDispatched) {
+                if ($exception instanceof HttpTransportException) {
+                    $exception = new TransportException($exception->getMessage(), $exception->getCode());
+                }
+
                 $this->events->dispatch(
                     new NotificationFailed($notifiable, $notification, $channel, ['exception' => $exception])
                 );


### PR DESCRIPTION
This fixes #56058.

When the Postmark mail driver receives a non-200 response, it throws an `HttpTransportException` that contains a `CurlResponse` object that is not serializable.  This causes dispatching the `NotificationFailed` event to fail when attempting to place it on the Queue.  This PR checks for an `HttpTransportException` and converts it to a `TransportException` without the `Response` object before attaching it to the 'NotificationFailed' event.
