### PR TITLE
[12.x] fix method dependencies order

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -684,31 +684,31 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@oneArgument');
         $router->dispatch(Request::create($str.'/one/two', 'GET'));
-        $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments and receives two
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@twoArguments');
         $router->dispatch(Request::create($str.'/one/two', 'GET'));
-        $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments but with different names from the ones passed from the route
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@differentArgumentNames');
         $router->dispatch(Request::create($str.'/one/two', 'GET'));
-        $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
 
         // Has two arguments with same name but argument order is reversed
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'/{one}/{two}', RouteTestAnotherControllerWithParameterStub::class.'@reversedArguments');
         $router->dispatch(Request::create($str.'/one/two', 'GET'));
-        $this->assertEquals(['one' => 'one', 'two' => 'two'], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame(['two' => 'two', 'one' => 'one'], $_SERVER['__test.controller_callAction_parameters']);
 
         // No route parameters while method has parameters
         unset($_SERVER['__test.controller_callAction_parameters']);
         $router->get(($str = Str::random()).'', RouteTestAnotherControllerWithParameterStub::class.'@oneArgument');
         $router->dispatch(Request::create($str, 'GET'));
-        $this->assertEquals([], $_SERVER['__test.controller_callAction_parameters']);
+        $this->assertSame([], $_SERVER['__test.controller_callAction_parameters']);
 
         // With model bindings
         unset($_SERVER['__test.controller_callAction_parameters']);


### PR DESCRIPTION
Hello,

Fixes https://github.com/laravel/framework/issues/56047

In [the documentation](https://laravel.com/docs/12.x/routing#implicit-binding), we can read:

> Laravel automatically resolves Eloquent models defined in routes or controller actions whose type-hinted variable names match a route segment name.

What I understand:
As long as our controller action variable names matches with the routes segment names, the order of variables should not matter.

Unfortunately, this is not how it currently works, if our controller actions does not declare variables in the same order as the route, this simple example will fail:

```php
class UsersController extends Controller
{
    /**
     * Note: $company is nullable, so we can use the same action with multiple routes
     */
    public function show(User $user, ?Company $company = null)
    {
        var_dump($user);
        var_dump($company);
    }
}
```

With the following routes :

```php
// That route works as expected
Route::get('users/{user}/details', 'UsersController@show');
```

```php
// That route trigger an Exception
// Note that the company param is placed first in the URL, while it's in second position in the controller action
Route::get('companies/{company}/users/{user}/details', 'UsersController@show');
```

> `UsersController::show()`: Argument #1 (`$user`) must be of type `User`, `Company` given, called in ...

The exception shows that the params are not passed in the correct order, even if I am using the same param names.

With my PR, that issue is fixed by trying to resolve dependencies by param name first.