### PR TITLE
[12.x] add migrate:redo command (alias of migrate:refresh --step=1)

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RedoCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RedoCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Database\Console\Migrations;
+
+class RedoCommand extends RefreshCommand
+{
+    /**
+     * The console command name & signature.
+     *
+     * The redo command rolls back the last migration batch and re-runs it.
+     *
+     * We expose the same options as Refresh, but default --step to 1.
+     *
+     * @see RefreshCommand
+     */
+    protected $signature = 'migrate:redo
+        {--database= : The database connection to use}
+        {--force : Run without confirmation}
+        {--path=* : Paths to migration files to be executed}
+        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+        {--seed : Re-run the database seeds}
+        {--seeder= : The class name of the root seeder}
+        {--step=1 : Number of migrations to be rolled back and re-run (default 1)}
+        {--pretend : Dump the SQL instead of running the command}';
+
+    protected $description = 'Rollback the last migration batch and immediately re-run it';
+
+    public function handle(): int
+    {
+        // Ensure the default is always 1 when no --step supplied
+        if (! $this->input->getOption('step')) {
+            $this->input->setOption('step', 1);
+        }
+
+        return parent::handle();   // RefreshCommand already does the heavy lifting
+    }
+}

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Console\Migrations\FreshCommand;
 use Illuminate\Database\Console\Migrations\InstallCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Console\Migrations\RedoCommand;
 use Illuminate\Database\Console\Migrations\RefreshCommand;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
@@ -28,6 +29,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         'Migrate' => MigrateCommand::class,
         'MigrateFresh' => FreshCommand::class,
         'MigrateInstall' => InstallCommand::class,
+        'MigrateRedo' => RedoCommand::class,
         'MigrateRefresh' => RefreshCommand::class,
         'MigrateReset' => ResetCommand::class,
         'MigrateRollback' => RollbackCommand::class,
@@ -166,6 +168,16 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
 
             return new MigrateMakeCommand($creator, $composer);
         });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateRedoCommand()
+    {
+        $this->app->singleton(RedoCommand::class);
     }
 
     /**

--- a/tests/Database/DatabaseMigrationRedoCommandTest.php
+++ b/tests/Database/DatabaseMigrationRedoCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
+use Illuminate\Database\Console\Migrations\RedoCommand;
+use Illuminate\Database\Console\Migrations\RollbackCommand;
+use Illuminate\Database\Events\DatabaseRefreshed;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class DatabaseMigrationRedoCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testRedoCommandRollsBackOneStepAndRunsMigrations()
+    {
+        $command = new RedoCommand;
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $rollbackCommand = m::mock(RollbackCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
+
+        $quote = DIRECTORY_SEPARATOR === '\\' ? '"' : "'";
+
+        // Expect: migrate:rollback --step=1 --force then migrate --force
+        $rollbackCommand->shouldReceive('run')
+            ->with(new InputMatcher("--step=1 --force=1 {$quote}migrate:rollback{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')
+            ->with(new InputMatcher('--force=1 migrate'), m::any());
+
+        $this->runCommand($command);
+    }
+
+    public function testRedoCommandHonoursCustomStepOption()
+    {
+        $command = new RedoCommand;
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $rollbackCommand = m::mock(RollbackCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
+
+        $quote = DIRECTORY_SEPARATOR === '\\' ? '"' : "'";
+
+        // Expect passed step value (e.g. 3)
+        $rollbackCommand->shouldReceive('run')
+            ->with(new InputMatcher("--step=3 --force=1 {$quote}migrate:rollback{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')
+            ->with(new InputMatcher('--force=1 migrate'), m::any());
+
+        $this->runCommand($command, ['--step' => 3]);
+    }
+
+    public function testRedoCommandExitsWhenProhibited()
+    {
+        $command = new RedoCommand;
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        // Re-use the global prohibition flag defined in RefreshCommand
+        \Illuminate\Database\Console\Migrations\RefreshCommand::prohibit();
+
+        $code = $this->runCommand($command);
+
+        $this->assertSame(1, $code);
+
+        $console->shouldNotHaveBeenCalled();
+        $dispatcher->shouldNotReceive('dispatch');
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}


### PR DESCRIPTION
One-line alias for `migrate:refresh --step=1` that mirrors Rails’ `db:migrate:redo`, saves keystrokes when iterating on a single migration.

New `RedoCommand` extending `RefreshCommand`, registered in `MigrationServiceProvider`.

3 console tests added in `tests\Database\DatabaseMigrationRedoCommandTest.php` mirroring the Refresh command.

Non-breaking backwards compatibility.

The alternative is using the existing `migrate:refresh --step=1`; this alias is for convenience.

The docs would need to be updated under `src/docs/12.x/migrations.md`:
```md
### Redo

`php artisan migrate:redo`

Rolls back the most recent batch and immediately re-runs it.  
It is equivalent to `migrate:refresh --step=1`.
```