### PR TITLE
Make class_uses_recursive() and trait_uses_recursive() helpers onceable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2294,7 +2294,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function isSoftDeletable(): bool
     {
-        return in_array(SoftDeletes::class, class_uses_recursive(static::class));
+        return in_array(SoftDeletes::class, class_uses_recursive(static::class, true));
     }
 
     /**
@@ -2302,7 +2302,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isPrunable(): bool
     {
-        return in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
+        return in_array(Prunable::class, class_uses_recursive(static::class, true)) || static::isMassPrunable();
     }
 
     /**
@@ -2310,7 +2310,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isMassPrunable(): bool
     {
-        return in_array(MassPrunable::class, class_uses_recursive(static::class));
+        return in_array(MassPrunable::class, class_uses_recursive(static::class, true));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -100,19 +100,22 @@ if (! function_exists('class_uses_recursive')) {
      * @param  object|string  $class
      * @return array
      */
-    function class_uses_recursive($class)
+    function class_uses_recursive($class, bool $cache = false)
     {
-        if (is_object($class)) {
-            $class = get_class($class);
-        }
-
-        $results = [];
-
-        foreach (array_reverse(class_parents($class) ?: []) + [$class => $class] as $class) {
-            $results += trait_uses_recursive($class);
-        }
-
-        return array_unique($results);
+        $callback = function () use ($class, $cache) {
+            if (is_object($class)) {
+                $class = get_class($class);
+            }
+    
+            $results = [];
+    
+            foreach (array_reverse(class_parents($class) ?: []) + [$class => $class] as $class) {
+                $results += trait_uses_recursive($class, $cache);
+            }
+    
+            return array_unique($results);
+        };
+        return $cache ? once($callback) : call_user_func($callback);
     }
 }
 
@@ -459,15 +462,18 @@ if (! function_exists('trait_uses_recursive')) {
      * @param  object|string  $trait
      * @return array
      */
-    function trait_uses_recursive($trait)
+    function trait_uses_recursive($trait, bool $cache = false)
     {
-        $traits = class_uses($trait) ?: [];
+        $callback = function () use ($trait) {
+            $traits = class_uses($trait) ?: [];
 
-        foreach ($traits as $trait) {
-            $traits += trait_uses_recursive($trait);
-        }
+            foreach ($traits as $trait) {
+                $traits += trait_uses_recursive($trait);
+            }
 
-        return $traits;
+            return $traits;
+        };
+        return $cache ? once($callback) : call_user_func($callback);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -465,7 +465,7 @@ if (! function_exists('trait_uses_recursive')) {
      */
     function trait_uses_recursive($trait, bool $cache = false)
     {
-        $callback = function () use ($trait) {
+        $callback = function () use ($trait, $cache) {
             $traits = class_uses($trait) ?: [];
 
             foreach ($traits as $trait) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -106,15 +106,16 @@ if (! function_exists('class_uses_recursive')) {
             if (is_object($class)) {
                 $class = get_class($class);
             }
-    
+
             $results = [];
-    
+
             foreach (array_reverse(class_parents($class) ?: []) + [$class => $class] as $class) {
                 $results += trait_uses_recursive($class, $cache);
             }
-    
+
             return array_unique($results);
         };
+
         return $cache ? once($callback) : call_user_func($callback);
     }
 }
@@ -473,6 +474,7 @@ if (! function_exists('trait_uses_recursive')) {
 
             return $traits;
         };
+
         return $cache ? once($callback) : call_user_func($callback);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -469,7 +469,7 @@ if (! function_exists('trait_uses_recursive')) {
             $traits = class_uses($trait) ?: [];
 
             foreach ($traits as $trait) {
-                $traits += trait_uses_recursive($trait);
+                $traits += trait_uses_recursive($trait, $cache);
             }
 
             return $traits;


### PR DESCRIPTION
Classes rarely change at runtime, however, checking their dependencies every time we need them—sometimes even recursively—can be expensive. So, caching them makes sense.

Suggested by @cosmastech

See: https://github.com/laravel/framework/pull/56060#discussion_r2152151153
