### PR TITLE
[12.x] Fix model pruning when non model files are in the same directory

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -138,8 +138,7 @@ class PruneCommand extends Command
                 );
             })
             ->when(! empty($except), fn ($models) => $models->reject(fn ($model) => in_array($model, $except)))
-            ->filter(fn ($model) => class_exists($model) && is_a($model, Model::class, true))
-            ->filter(fn ($model) => $model::isPrunable())
+            ->filter(fn ($model) => $this->isPrunable($model))
             ->values();
     }
 
@@ -179,5 +178,19 @@ class PruneCommand extends Command
         } else {
             $this->components->info("{$count} [{$model}] records will be pruned.");
         }
+    }
+
+    /**
+     * Determine if the given model is prunable.
+     *
+     * @param  string  $model
+     * @return bool
+     */
+    private function isPrunable(string $model)
+    {
+        return class_exists($model)
+            && is_a($model, Model::class, true)
+            && ! (new \ReflectionClass($model))->isAbstract()
+            && $model::isPrunable();
     }
 }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\ModelPruningFinished;
 use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
@@ -137,7 +138,7 @@ class PruneCommand extends Command
                 );
             })
             ->when(! empty($except), fn ($models) => $models->reject(fn ($model) => in_array($model, $except)))
-            ->filter(fn ($model) => class_exists($model))
+            ->filter(fn ($model) => class_exists($model) && is_a($model, Model::class, true))
             ->filter(fn ($model) => $model::isPrunable())
             ->values();
     }

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -133,6 +133,23 @@ class PruneCommandTest extends TestCase
         );
     }
 
+    public function testNonModelFilesAreIgnoredTest()
+    {
+        $output = $this->artisan(['--path' => 'Models']);
+
+        $output = $output->fetch();
+
+        $this->assertStringNotContainsString(
+            'Illuminate\Tests\Database\Pruning\Models\SomeClass',
+            $output,
+        );
+
+        $this->assertStringNotContainsString(
+            'Illuminate\Tests\Database\Pruning\Models\SomeEnum',
+            $output,
+        );
+    }
+
     public function testTheCommandMayBePretended()
     {
         $db = new DB;

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -140,6 +140,11 @@ class PruneCommandTest extends TestCase
         $output = $output->fetch();
 
         $this->assertStringNotContainsString(
+            'No prunable [Illuminate\Tests\Database\Pruning\Models\AbstractPrunableModel] records found.',
+            $output,
+        );
+
+        $this->assertStringNotContainsString(
             'No prunable [Illuminate\Tests\Database\Pruning\Models\SomeClass] records found.',
             $output,
         );

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -140,12 +140,12 @@ class PruneCommandTest extends TestCase
         $output = $output->fetch();
 
         $this->assertStringNotContainsString(
-            'Illuminate\Tests\Database\Pruning\Models\SomeClass',
+            'No prunable [Illuminate\Tests\Database\Pruning\Models\SomeClass] records found.',
             $output,
         );
 
         $this->assertStringNotContainsString(
-            'Illuminate\Tests\Database\Pruning\Models\SomeEnum',
+            'No prunable [Illuminate\Tests\Database\Pruning\Models\SomeEnum] records found.',
             $output,
         );
     }

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -6,10 +6,6 @@ use Closure;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Console\PruneCommand;
-use Illuminate\Database\Eloquent\MassPrunable;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelPruningFinished;
 use Illuminate\Database\Events\ModelPruningStarting;
 use Illuminate\Database\Events\ModelsPruned;
@@ -26,7 +22,15 @@ class PruneCommandTest extends TestCase
     {
         parent::setUp();
 
-        Application::setInstance($container = new Application);
+        Application::setInstance($container = new Application(__DIR__.'/Pruning'));
+
+        Closure::bind(
+            fn () => $this->namespace = 'Illuminate\\Tests\\Database\\Pruning\\',
+            $container,
+            Application::class,
+        )();
+
+        $container->useAppPath(__DIR__.'/Pruning');
 
         $container->singleton(DispatcherContract::class, function () {
             return new Dispatcher();
@@ -37,12 +41,12 @@ class PruneCommandTest extends TestCase
 
     public function testPrunableModelWithPrunableRecords()
     {
-        $output = $this->artisan(['--model' => PrunableTestModelWithPrunableRecords::class]);
+        $output = $this->artisan(['--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class]);
 
         $output = $output->fetch();
 
         $this->assertStringContainsString(
-            'Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords',
+            'Illuminate\Tests\Database\Pruning\Models\PrunableTestModelWithPrunableRecords',
             $output,
         );
 
@@ -52,7 +56,7 @@ class PruneCommandTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            'Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords',
+            'Illuminate\Tests\Database\Pruning\Models\PrunableTestModelWithPrunableRecords',
             $output,
         );
 
@@ -64,10 +68,10 @@ class PruneCommandTest extends TestCase
 
     public function testPrunableTestModelWithoutPrunableRecords()
     {
-        $output = $this->artisan(['--model' => PrunableTestModelWithoutPrunableRecords::class]);
+        $output = $this->artisan(['--model' => Pruning\Models\PrunableTestModelWithoutPrunableRecords::class]);
 
         $this->assertStringContainsString(
-            'No prunable [Illuminate\Tests\Database\PrunableTestModelWithoutPrunableRecords] records found.',
+            'No prunable [Illuminate\Tests\Database\Pruning\Models\PrunableTestModelWithoutPrunableRecords] records found.',
             $output->fetch()
         );
     }
@@ -92,12 +96,12 @@ class PruneCommandTest extends TestCase
             ['value' => 4, 'deleted_at' => '2021-12-02 00:00:00'],
         ]);
 
-        $output = $this->artisan(['--model' => PrunableTestSoftDeletedModelWithPrunableRecords::class]);
+        $output = $this->artisan(['--model' => Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::class]);
 
         $output = $output->fetch();
 
         $this->assertStringContainsString(
-            'Illuminate\Tests\Database\PrunableTestSoftDeletedModelWithPrunableRecords',
+            'Illuminate\Tests\Database\Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords',
             $output,
         );
 
@@ -106,22 +110,22 @@ class PruneCommandTest extends TestCase
             $output,
         );
 
-        $this->assertEquals(2, PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
+        $this->assertEquals(2, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
     }
 
     public function testNonPrunableTest()
     {
-        $output = $this->artisan(['--model' => NonPrunableTestModel::class]);
+        $output = $this->artisan(['--model' => Pruning\Models\NonPrunableTestModel::class]);
 
         $this->assertStringContainsString(
-            'No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.',
+            'No prunable [Illuminate\Tests\Database\Pruning\Models\NonPrunableTestModel] records found.',
             $output->fetch(),
         );
     }
 
     public function testNonPrunableTestWithATrait()
     {
-        $output = $this->artisan(['--model' => NonPrunableTrait::class]);
+        $output = $this->artisan(['--model' => Pruning\Models\NonPrunableTrait::class]);
 
         $this->assertStringContainsString(
             'No prunable models found.',
@@ -151,16 +155,16 @@ class PruneCommandTest extends TestCase
         ]);
 
         $output = $this->artisan([
-            '--model' => PrunableTestModelWithPrunableRecords::class,
+            '--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class,
             '--pretend' => true,
         ]);
 
         $this->assertStringContainsString(
-            '3 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.',
+            '3 [Illuminate\Tests\Database\Pruning\Models\PrunableTestModelWithPrunableRecords] records will be pruned.',
             $output->fetch(),
         );
 
-        $this->assertEquals(5, PrunableTestModelWithPrunableRecords::count());
+        $this->assertEquals(5, Pruning\Models\PrunableTestModelWithPrunableRecords::count());
     }
 
     public function testTheCommandMayBePretendedOnSoftDeletedModel()
@@ -184,16 +188,16 @@ class PruneCommandTest extends TestCase
         ]);
 
         $output = $this->artisan([
-            '--model' => PrunableTestSoftDeletedModelWithPrunableRecords::class,
+            '--model' => Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::class,
             '--pretend' => true,
         ]);
 
         $this->assertStringContainsString(
-            '2 [Illuminate\Tests\Database\PrunableTestSoftDeletedModelWithPrunableRecords] records will be pruned.',
+            '2 [Illuminate\Tests\Database\Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords] records will be pruned.',
             $output->fetch(),
         );
 
-        $this->assertEquals(4, PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
+        $this->assertEquals(4, Pruning\Models\PrunableTestSoftDeletedModelWithPrunableRecords::withTrashed()->count());
     }
 
     public function testTheCommandDispatchesEvents()
@@ -202,19 +206,19 @@ class PruneCommandTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
             return get_class($event) === ModelPruningStarting::class &&
-                $event->models === [PrunableTestModelWithPrunableRecords::class];
+                $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('listen')->once()->with(ModelsPruned::class, m::type(Closure::class));
         $dispatcher->shouldReceive('dispatch')->twice()->with(m::type(ModelsPruned::class));
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
             return get_class($event) === ModelPruningFinished::class &&
-                $event->models === [PrunableTestModelWithPrunableRecords::class];
+                $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('forget')->once()->with(ModelsPruned::class);
 
         Application::getInstance()->instance(DispatcherContract::class, $dispatcher);
 
-        $this->artisan(['--model' => PrunableTestModelWithPrunableRecords::class]);
+        $this->artisan(['--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class]);
     }
 
     protected function artisan($arguments)
@@ -237,58 +241,4 @@ class PruneCommandTest extends TestCase
 
         m::close();
     }
-}
-
-class PrunableTestModelWithPrunableRecords extends Model
-{
-    use MassPrunable;
-
-    protected $table = 'prunables';
-    protected $connection = 'default';
-
-    public function pruneAll()
-    {
-        event(new ModelsPruned(static::class, 10));
-        event(new ModelsPruned(static::class, 20));
-
-        return 20;
-    }
-
-    public function prunable()
-    {
-        return static::where('value', '>=', 3);
-    }
-}
-
-class PrunableTestSoftDeletedModelWithPrunableRecords extends Model
-{
-    use MassPrunable, SoftDeletes;
-
-    protected $table = 'prunables';
-    protected $connection = 'default';
-
-    public function prunable()
-    {
-        return static::where('value', '>=', 3);
-    }
-}
-
-class PrunableTestModelWithoutPrunableRecords extends Model
-{
-    use Prunable;
-
-    public function pruneAll()
-    {
-        return 0;
-    }
-}
-
-class NonPrunableTestModel extends Model
-{
-    // ..
-}
-
-trait NonPrunableTrait
-{
-    use Prunable;
 }

--- a/tests/Database/Pruning/Models/AbstractPrunableModel.php
+++ b/tests/Database/Pruning/Models/AbstractPrunableModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+
+abstract class AbstractPrunableModel extends Model
+{
+    use Prunable;
+}

--- a/tests/Database/Pruning/Models/NonPrunableTestModel.php
+++ b/tests/Database/Pruning/Models/NonPrunableTestModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonPrunableTestModel extends Model
+{
+    // ..
+}

--- a/tests/Database/Pruning/Models/NonPrunableTrait.php
+++ b/tests/Database/Pruning/Models/NonPrunableTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\Prunable;
+
+trait NonPrunableTrait
+{
+    use Prunable;
+}

--- a/tests/Database/Pruning/Models/PrunableTestModelWithPrunableRecords.php
+++ b/tests/Database/Pruning/Models/PrunableTestModelWithPrunableRecords.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Events\ModelsPruned;
+
+class PrunableTestModelWithPrunableRecords extends Model
+{
+    use MassPrunable;
+
+    protected $table = 'prunables';
+    protected $connection = 'default';
+
+    public function pruneAll()
+    {
+        event(new ModelsPruned(static::class, 10));
+        event(new ModelsPruned(static::class, 20));
+
+        return 20;
+    }
+
+    public function prunable()
+    {
+        return static::where('value', '>=', 3);
+    }
+}

--- a/tests/Database/Pruning/Models/PrunableTestModelWithoutPrunableRecords.php
+++ b/tests/Database/Pruning/Models/PrunableTestModelWithoutPrunableRecords.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+
+class PrunableTestModelWithoutPrunableRecords extends Model
+{
+    use Prunable;
+
+    public function pruneAll()
+    {
+        return 0;
+    }
+}

--- a/tests/Database/Pruning/Models/PrunableTestSoftDeletedModelWithPrunableRecords.php
+++ b/tests/Database/Pruning/Models/PrunableTestSoftDeletedModelWithPrunableRecords.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PrunableTestSoftDeletedModelWithPrunableRecords extends Model
+{
+    use MassPrunable, SoftDeletes;
+
+    protected $table = 'prunables';
+    protected $connection = 'default';
+
+    public function prunable()
+    {
+        return static::where('value', '>=', 3);
+    }
+}

--- a/tests/Database/Pruning/Models/SomeClass.php
+++ b/tests/Database/Pruning/Models/SomeClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+class SomeClass
+{
+}

--- a/tests/Database/Pruning/Models/SomeEnum.php
+++ b/tests/Database/Pruning/Models/SomeEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Database\Pruning\Models;
+
+enum SomeEnum
+{
+    case Foo;
+}


### PR DESCRIPTION
The changes introduced in #56060 broke the `model:prune` command since it doesn't check if the given class is actually an Eloquent model before calling one of it's methods. This PR fixes that by adding a simple type check while still using the newly introduced `isPrunable` method to perform the check.

Please note that for the most part this PR is setup code to allow testing for the error.

Related: #56068