### PR TITLE
[12.x] Cache isSoftDeletable(), isPrunable(), and isMassPrunable() directly in model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -251,6 +251,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static string $collectionClass = Collection::class;
 
     /**
+     * Whether it implements the SoftDeletes trait
+     */
+    protected static bool $isSoftDeletable;
+
+    /**
+     * Whether it implements the Prunable trait
+     */
+    protected static bool $isPrunable;
+
+    /**
+     * Whether it implements the MassPrunable trait
+     */
+    protected static bool $isMassPrunable;
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -2294,7 +2309,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function isSoftDeletable(): bool
     {
-        return in_array(SoftDeletes::class, class_uses_recursive(static::class));
+        return self::$isSoftDeletable ??= in_array(SoftDeletes::class, class_uses_recursive(static::class));
     }
 
     /**
@@ -2302,7 +2317,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isPrunable(): bool
     {
-        return in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
+        return self::$isPrunable ??= in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
     }
 
     /**
@@ -2310,7 +2325,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isMassPrunable(): bool
     {
-        return in_array(MassPrunable::class, class_uses_recursive(static::class));
+        return self::$isMassPrunable ??= in_array(MassPrunable::class, class_uses_recursive(static::class));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -251,21 +251,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static string $collectionClass = Collection::class;
 
     /**
-     * Whether it implements the SoftDeletes trait.
+     * Cache of soft deletable models.
      *
      * @var array<class-string<self>, bool>
      */
     protected static array $isSoftDeletable;
 
     /**
-     * Whether it implements the Prunable trait.
+     * Cache of prunable models.
      *
      * @var array<class-string<self>, bool>
      */
     protected static array $isPrunable;
 
     /**
-     * Whether it implements the MassPrunable trait.
+     * Cache of mass prunable models.
      *
      * @var array<class-string<self>, bool>
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -252,18 +252,24 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     /**
      * Whether it implements the SoftDeletes trait.
+     *
+     * @var array<class-string<self>, bool>
      */
-    protected static bool $isSoftDeletable;
+    protected static array $isSoftDeletable;
 
     /**
      * Whether it implements the Prunable trait.
+     *
+     * @var array<class-string<self>, bool>
      */
-    protected static bool $isPrunable;
+    protected static array $isPrunable;
 
     /**
      * Whether it implements the MassPrunable trait.
+     *
+     * @var array<class-string<self>, bool>
      */
-    protected static bool $isMassPrunable;
+    protected static array $isMassPrunable;
 
     /**
      * The name of the "created at" column.
@@ -2309,7 +2315,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function isSoftDeletable(): bool
     {
-        return self::$isSoftDeletable ??= in_array(SoftDeletes::class, class_uses_recursive(static::class));
+        return static::$isSoftDeletable[static::class] ??= in_array(SoftDeletes::class, class_uses_recursive(static::class));
     }
 
     /**
@@ -2317,7 +2323,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isPrunable(): bool
     {
-        return self::$isPrunable ??= in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
+        return self::$isPrunable[static::class] ??= in_array(Prunable::class, class_uses_recursive(static::class)) || static::isMassPrunable();
     }
 
     /**
@@ -2325,7 +2331,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function isMassPrunable(): bool
     {
-        return self::$isMassPrunable ??= in_array(MassPrunable::class, class_uses_recursive(static::class));
+        return self::$isMassPrunable[static::class] ??= in_array(MassPrunable::class, class_uses_recursive(static::class));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -251,17 +251,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static string $collectionClass = Collection::class;
 
     /**
-     * Whether it implements the SoftDeletes trait
+     * Whether it implements the SoftDeletes trait.
      */
     protected static bool $isSoftDeletable;
 
     /**
-     * Whether it implements the Prunable trait
+     * Whether it implements the Prunable trait.
      */
     protected static bool $isPrunable;
 
     /**
-     * Whether it implements the MassPrunable trait
+     * Whether it implements the MassPrunable trait.
      */
     protected static bool $isMassPrunable;
 


### PR DESCRIPTION
Classes rarely change at runtime, however, checking their dependencies every time we need them—sometimes even recursively—can be expensive. So, caching them makes sense.

Follow-up to #56060

as suggested in https://github.com/laravel/framework/pull/56069#issuecomment-2985330601