### PR TITLE
[12.x] Adds fingerprinting to `Str`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1793,6 +1793,31 @@ class Str
     }
 
     /**
+     * Returns the fingerprint of the string in BASE 64.
+     *
+     * @param  string  $string
+     * @param  string|null  $algorithm
+     * @return string
+     */
+    public static function checksum($string, $algorithm = null)
+    {
+        return static::toBase64(hash($algorithm ?? 'crc32c', $string, true));
+    }
+
+    /**
+     * Determine if the string is equal to the given checksum encoded in BASE 64.
+     *
+     * @param  string  $string
+     * @param  string  $checksum
+     * @param  string|null  $algorithm
+     * @return bool
+     */
+    public static function isChecksum($string, $checksum, $algorithm = null)
+    {
+        return hash_equals(static::checksum($string, $algorithm), $checksum);
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -337,6 +337,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Returns the fingerprint of the string.
+     *
+     * @param  string|null  $algorithm
+     * @return static
+     */
+    public function checksum($algorithm = null)
+    {
+        return new static(Str::checksum($this->value, $algorithm));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern
@@ -356,6 +367,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function isAscii()
     {
         return Str::isAscii($this->value);
+    }
+
+    /**
+     * Determine if the string is equal to given checksum.
+     *
+     * @param  string  $checksum
+     * @param  string|null  $algorithm
+     * @return bool
+     */
+    public function isChecksum($checksum, $algorithm = null)
+    {
+        return Str::isChecksum($this->value, $checksum, $algorithm);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1719,6 +1719,25 @@ class SupportStrTest extends TestCase
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
 
+    public function testChecksum()
+    {
+        $this->assertSame('z8SuHQ==', Str::checksum('foo'));
+        $this->assertSame('pcT+SQ==', Str::checksum('foo', 'crc32'));
+        $this->assertSame('jHNlIQ==', Str::checksum('foo', 'crc32b'));
+        $this->assertSame('z8SuHQ==', Str::checksum('foo', 'crc32c'));
+        $this->assertSame('rL0Y20zC+Fzt72VPzMSk2A==', Str::checksum('foo', 'md5'));
+    }
+
+    public function testIsChecksum()
+    {
+        $this->assertTrue(Str::isChecksum('foo', 'z8SuHQ=='));
+        $this->assertTrue(Str::isChecksum('foo', 'z8SuHQ==', 'crc32c'));
+        $this->assertTrue(Str::isChecksum('foo', 'rL0Y20zC+Fzt72VPzMSk2A==', 'md5'));
+
+        $this->assertFalse(Str::isChecksum('foo', 'invalid'));
+        $this->assertFalse(Str::isChecksum('foo', 'invalid', 'md5'));
+    }
+
     public function testChopStart()
     {
         foreach ([

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -786,6 +786,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
     }
 
+    public function testChecksum()
+    {
+        $this->assertSame('z8SuHQ==', (string) $this->stringable('foo')->checksum());
+        $this->assertSame('pcT+SQ==', (string) $this->stringable('foo')->checksum('crc32'));
+        $this->assertSame('jHNlIQ==', (string) $this->stringable('foo')->checksum('crc32b'));
+        $this->assertSame('z8SuHQ==', (string) $this->stringable('foo')->checksum('crc32c'));
+        $this->assertSame('rL0Y20zC+Fzt72VPzMSk2A==', (string) $this->stringable('foo')->checksum('md5'));
+    }
+
     public function testIs()
     {
         $this->assertTrue($this->stringable('/')->is('/'));
@@ -862,6 +871,16 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable($multilineValue)->is('use Exception;'));
         $this->assertFalse($this->stringable($multilineValue)->is('use Exception;*'));
         $this->assertTrue($this->stringable($multilineValue)->is('*use Exception;'));
+    }
+
+    public function testIsChecksum()
+    {
+        $this->assertTrue($this->stringable('foo')->isChecksum('z8SuHQ=='));
+        $this->assertTrue($this->stringable('foo')->isChecksum('z8SuHQ==', 'crc32c'));
+        $this->assertTrue($this->stringable('foo')->isChecksum('rL0Y20zC+Fzt72VPzMSk2A==', 'md5'));
+
+        $this->assertFalse($this->stringable('foo')->isChecksum('invalid'));
+        $this->assertFalse($this->stringable('foo')->isChecksum('invalid', 'md5'));
     }
 
     public function testKebab()


### PR DESCRIPTION
## What?

It includes some convenience methods to handle checksums (because "fingerprint" and "hash" sound like cryptographically secure when these are not). By default, it uses CRC32C which should be [hardware accelerated on modern hardware](https://www.intel.com/content/www/us/en/docs/ipp/developer-guide-reference/2021-10/crc32-crc32c.html). The checksum output is always BASE 64, and accepts all algorithms supported by `hash()`.

```php
$checksum = Str::checksum('big text...');
```

It also includes a method to compare two checksums, assuming the compared is also BASE 64, using `hash_equals()` to avoid timing attacks.

```php
$isSame = Str::isChecksum('text...', $checksum);
```

This can be handy in some cases, like calculating the hash in models to compare with others, especially when the value to hash is giant (like comparing two big articles).

```php
if ($article->fingerprint === $savingArticle->fingerprint) {
    return 'Both articles are the same, aborting save';
}
```