### PR TITLE
[12.x] Display job queue names when running queue:work with --verbose option

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -228,20 +228,22 @@ class WorkCommand extends Command
      */
     protected function writeOutputForCli(Job $job, $status)
     {
-        $this->output->write(sprintf(
-            '  <fg=gray>%s</> %s%s',
+        $isVerbose = $this->output->isVerbose();
+
+        $this->output->write(rtrim(sprintf(
+            '  <fg=gray>%s</> %s %s',
             $this->now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
-            $this->output->isVerbose()
-                ? sprintf(' <fg=gray>%s</>', $job->getJobId())
+            $isVerbose
+                ? sprintf('<fg=gray>%s</> <fg=blue>%s</>', $job->getJobId(), $job->getQueue())
                 : ''
-        ));
+        )));
 
         if ($status == 'starting') {
             $this->latestStartedAt = microtime(true);
 
             $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-                $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
+                $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getQueue()) + 2 : 0
             ) - 33, 0);
 
             $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
@@ -252,7 +254,7 @@ class WorkCommand extends Command
         $runTime = $this->runTimeForHumans($this->latestStartedAt);
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-            $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
+            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getQueue()) + 2 : 0
         ) - mb_strlen($runTime) - 31, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));


### PR DESCRIPTION
On development, I usually run a worker to handle jobs from different queues. I sometimes need to check if jobs are handled by correct workers. So, I'd like to display queue names. They comes right after job IDs when running queue:work with --verbose option. See the image below for more details.

![laravel-queue](https://github.com/user-attachments/assets/5452a527-c322-4944-8501-3dabde24e43e)
