### PR TITLE
[12.x] use `offset()` and `limit()` in tests

### DIFF
--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -86,7 +86,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false);
 
-        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('limit')->andReturnSelf();
         $builder->shouldReceive('get')->andReturn(collect([['title' => 'Forge']]));
 
         $this->assertDatabaseHas($this->table, $this->data);
@@ -100,7 +100,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(false, countResult: [5, 5]);
 
-        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('limit')->andReturnSelf();
         $builder->shouldReceive('get')->andReturn(
             collect(array_fill(0, 3, 'data'))
         );
@@ -142,7 +142,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder = $this->mockCountBuilder(true);
 
-        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('limit')->andReturnSelf();
         $builder->shouldReceive('get')->andReturn(collect([$this->data]));
 
         $this->assertDatabaseMissing($this->table, $this->data);


### PR DESCRIPTION
we should not be testing the alias methods `skip()` and `take()` in our tests, but rather directly the actual methods performing the logic.

if someone wanted to add a test for `skip()` and `take()` that'd be great, it'd be 1 method each ensuring they just pass along to their aliased counterparts.

follow up to #56080 and #56081 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
