### PR TITLE
feat(collection): add "contains any" filter

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -196,6 +196,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if one or multiple items exists in the collection.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function containsAny($value = null)
+    {
+        return $this->contains(fn ($item) => in_array($item, Arr::wrap($value)));
+    }
+
+    /**
      * Determine if an item exists, using strict comparison.
      *
      * @param  (callable(TValue): bool)|TValue|array-key  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -249,6 +249,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if one or multiple items exists in the collection.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function containsAny($value = null)
+    {
+        return $this->contains(fn ($item) => in_array($item, Arr::wrap($value)));
+    }
+
+    /**
      * Determine if an item exists, using strict comparison.
      *
      * @param  (callable(TValue): bool)|TValue|array-key  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -251,7 +251,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if one or multiple items exists in the collection.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      * @return bool
      */
     public function containsAny($value = null)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3567,6 +3567,18 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testContainsAny($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAny(1));
+        $this->assertTrue($c->containsAny([1, 3]));
+        $this->assertFalse($c->containsAny(2));
+        $this->assertFalse($c->containsAny([2, 4]));
+        $this->assertTrue($c->containsAny([2, 5]));
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testDoesntContain($collection)
     {
         $c = new $collection([1, 3, 5]);


### PR DESCRIPTION
```
// before if we want to check 1 or 3 exists...
$collection = collect([1,3,5]);
$collection->contains(1) && $collection->contains(3);

//after
collect([1,3,5])->containsAny([1,3]); // return true
collect([2,4])->containsAny([2,5]); // return true

// real world use case example
$user->abilities->add(['*']);
$user2->abilities->add(['server:create']);

function checkAbility($user): bool
{
   return $user->abilities->containsAny(['*', 'server:create']);
}
```