### PR TITLE
[12.x] when a method returns `$this` set the return type to `static`

### DIFF
--- a/src/Illuminate/Support/Defer/DeferredCallback.php
+++ b/src/Illuminate/Support/Defer/DeferredCallback.php
@@ -22,7 +22,7 @@ class DeferredCallback
      * @param  string  $name
      * @return $this
      */
-    public function name(string $name): self
+    public function name(string $name): static
     {
         $this->name = $name;
 
@@ -35,7 +35,7 @@ class DeferredCallback
      * @param  bool  $always
      * @return $this
      */
-    public function always(bool $always = true): self
+    public function always(bool $always = true): static
     {
         $this->always = $always;
 

--- a/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
+++ b/src/Illuminate/Support/Defer/DeferredCallbackCollection.php
@@ -76,7 +76,7 @@ class DeferredCallbackCollection implements ArrayAccess, Countable
      *
      * @return $this
      */
-    protected function forgetDuplicates(): self
+    protected function forgetDuplicates(): static
     {
         $this->callbacks = (new Collection($this->callbacks))
             ->reverse()

--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -80,7 +80,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    protected function scope(string $key, Closure $callback): self
+    protected function scope(string $key, Closure $callback): static
     {
         $props = $this->prop($key);
         $path = $this->dotPath($key);
@@ -100,7 +100,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    public function first(Closure $callback): self
+    public function first(Closure $callback): static
     {
         $props = $this->prop();
 
@@ -124,7 +124,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    public function each(Closure $callback): self
+    public function each(Closure $callback): static
     {
         $props = $this->prop();
 
@@ -150,7 +150,7 @@ class AssertableJson implements Arrayable
      * @param  array  $data
      * @return static
      */
-    public static function fromArray(array $data): self
+    public static function fromArray(array $data): static
     {
         return new static($data);
     }
@@ -161,7 +161,7 @@ class AssertableJson implements Arrayable
      * @param  \Illuminate\Testing\AssertableJsonString  $json
      * @return static
      */
-    public static function fromAssertableJsonString(AssertableJsonString $json): self
+    public static function fromAssertableJsonString(AssertableJsonString $json): static
     {
         return static::fromArray($json->json());
     }

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -14,7 +14,7 @@ trait Debugging
      * @param  string|null  $prop
      * @return $this
      */
-    public function dump(?string $prop = null): self
+    public function dump(?string $prop = null): static
     {
         dump($this->prop($prop));
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -15,7 +15,7 @@ trait Has
      * @param  int|null  $length
      * @return $this
      */
-    public function count($key, ?int $length = null): self
+    public function count($key, ?int $length = null): static
     {
         if (is_null($length)) {
             $path = $this->dotPath();
@@ -47,7 +47,7 @@ trait Has
      * @param  int|string  $max
      * @return $this
      */
-    public function countBetween(int|string $min, int|string $max): self
+    public function countBetween(int|string $min, int|string $max): static
     {
         $path = $this->dotPath();
 
@@ -80,7 +80,7 @@ trait Has
      * @param  \Closure|null  $callback
      * @return $this
      */
-    public function has($key, $length = null, ?Closure $callback = null): self
+    public function has($key, $length = null, ?Closure $callback = null): static
     {
         $prop = $this->prop();
 
@@ -125,7 +125,7 @@ trait Has
      * @param  array|string  $key
      * @return $this
      */
-    public function hasAll($key): self
+    public function hasAll($key): static
     {
         $keys = is_array($key) ? $key : func_get_args();
 
@@ -146,7 +146,7 @@ trait Has
      * @param  array|string  $key
      * @return $this
      */
-    public function hasAny($key): self
+    public function hasAny($key): static
     {
         $keys = is_array($key) ? $key : func_get_args();
 
@@ -168,7 +168,7 @@ trait Has
      * @param  array|string  $key
      * @return $this
      */
-    public function missingAll($key): self
+    public function missingAll($key): static
     {
         $keys = is_array($key) ? $key : func_get_args();
 
@@ -185,7 +185,7 @@ trait Has
      * @param  string  $key
      * @return $this
      */
-    public function missing(string $key): self
+    public function missing(string $key): static
     {
         PHPUnit::assertNotTrue(
             Arr::has($this->prop(), $key),

--- a/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
@@ -50,7 +50,7 @@ trait Interaction
      *
      * @return $this
      */
-    public function etc(): self
+    public function etc(): static
     {
         $this->interacted = array_keys($this->prop());
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -18,7 +18,7 @@ trait Matching
      * @param  mixed|\Closure  $expected
      * @return $this
      */
-    public function where(string $key, $expected): self
+    public function where(string $key, $expected): static
     {
         $this->has($key);
 
@@ -56,7 +56,7 @@ trait Matching
      * @param  mixed|\Closure  $expected
      * @return $this
      */
-    public function whereNot(string $key, $expected): self
+    public function whereNot(string $key, $expected): static
     {
         $this->has($key);
 
@@ -98,7 +98,7 @@ trait Matching
      * @param  string  $key
      * @return $this
      */
-    public function whereNull(string $key): self
+    public function whereNull(string $key): static
     {
         $this->has($key);
 
@@ -121,7 +121,7 @@ trait Matching
      * @param  string  $key
      * @return $this
      */
-    public function whereNotNull(string $key): self
+    public function whereNotNull(string $key): static
     {
         $this->has($key);
 
@@ -144,7 +144,7 @@ trait Matching
      * @param  array  $bindings
      * @return $this
      */
-    public function whereAll(array $bindings): self
+    public function whereAll(array $bindings): static
     {
         foreach ($bindings as $key => $value) {
             $this->where($key, $value);
@@ -160,7 +160,7 @@ trait Matching
      * @param  string|array  $expected
      * @return $this
      */
-    public function whereType(string $key, $expected): self
+    public function whereType(string $key, $expected): static
     {
         $this->has($key);
 
@@ -185,7 +185,7 @@ trait Matching
      * @param  array  $bindings
      * @return $this
      */
-    public function whereAllType(array $bindings): self
+    public function whereAllType(array $bindings): static
     {
         foreach ($bindings as $key => $value) {
             $this->whereType($key, $value);

--- a/src/Illuminate/Testing/TestResponseAssert.php
+++ b/src/Illuminate/Testing/TestResponseAssert.php
@@ -25,7 +25,7 @@ class TestResponseAssert
     /**
      * Create a new TestResponse assertion helper.
      */
-    public static function withResponse(TestResponse $response): self
+    public static function withResponse(TestResponse $response): static
     {
         return new static($response);
     }


### PR DESCRIPTION
while PHP is a little lenient here, the more accurate return type when returning `$this` is static, not self.

when returning `new static()` the return type should also be `static` over `self`.

this may be a little pedantic, but it should be slightly more accurate. also this is forward looking in case PHP ever decided to get more strict in their type checks regarding these return types.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
