### PR TITLE
[12.x] Display job connection name when running `queue:work` with `--verbose` option

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -235,7 +235,7 @@ class WorkCommand extends Command
             $this->now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
             $isVerbose
-                ? sprintf('<fg=gray>%s</> <fg=blue>%s</>', $job->getJobId(), $job->getQueue())
+                ? sprintf('<fg=gray>%s</> <fg=blue>%s</> <fg=blue>%s</>', $job->getJobId(), $job->getConnectionName(), $job->getQueue())
                 : ''
         )));
 
@@ -243,8 +243,8 @@ class WorkCommand extends Command
             $this->latestStartedAt = microtime(true);
 
             $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-                $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getQueue()) + 2 : 0
-            ) - 33, 0);
+                $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
+                ) - 33, 0);
 
             $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
 
@@ -254,8 +254,8 @@ class WorkCommand extends Command
         $runTime = $this->runTimeForHumans($this->latestStartedAt);
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getQueue()) + 2 : 0
-        ) - mb_strlen($runTime) - 31, 0);
+            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
+            ) - mb_strlen($runTime) - 31, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -244,7 +244,7 @@ class WorkCommand extends Command
 
             $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
                 $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
-                ) - 33, 0);
+            ) - 33, 0);
 
             $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
 
@@ -255,7 +255,7 @@ class WorkCommand extends Command
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
             $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
-            ) - mb_strlen($runTime) - 31, 0);
+        ) - mb_strlen($runTime) - 31, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");


### PR DESCRIPTION
This PR continues the work started in [#56086](https://github.com/laravel/framework/pull/56086) by enhancing the log output to display both the job queue names and their connection names.

```bash
  2025-06-21 00:00:00 App\Jobs\TestJob 85 redis default ........
  2025-06-21 00:00:00 App\Jobs\TestJob 85 redis default ........
```