### PR TITLE
[12.x] Fix PHPDoc for Arr::sole method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -951,7 +951,7 @@ class Arr
      * Get the first item in the array, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  array  $array
-     * @param  callable|null  $callback
+     * @param  callable(mixed, array-key): array|null  $callback
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -948,10 +948,10 @@ class Arr
     }
 
     /**
-     * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
+     * Get the first item in the array, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException


### PR DESCRIPTION
Description
---
This PR corrects the PHPDoc comment for the `Illuminate\Support\Arr::sole` method.

- Updates the word `collection` to `array`, which better reflects the actual data type the method operates on.
- Updates the `@param` tag for the `$callback` argument to `callable|null` to match the method signature.

These changes improve code clarity and align the documentation with the method's actual behavior.