### PR TITLE
[12.x] Added `JsonSerializable` interface to `Uri` Class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -411,20 +411,20 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
-     * Get the string representation of the URI.
-     */
-    public function __toString(): string
-    {
-        return $this->uri->toString();
-    }
-
-    /**
-     * Convert the object into something JSON serializable.
+     * Convert the object into a value that is JSON serializable.
      *
      * @return string
      */
     public function jsonSerialize(): string
     {
         return $this->value();
+    }
+
+    /**
+     * Get the string representation of the URI.
+     */
+    public function __toString(): string
+    {
+        return $this->uri->toString();
     }
 }

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -421,9 +421,9 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return string
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize(): string
     {
         return $this->value();
     }

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -11,12 +11,13 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
+use JsonSerializable;
 use League\Uri\Contracts\UriInterface;
 use League\Uri\Uri as LeagueUri;
 use SensitiveParameter;
 use Stringable;
 
-class Uri implements Htmlable, Responsable, Stringable
+class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
 {
     use Conditionable, Dumpable, Macroable, Tappable;
 
@@ -415,5 +416,15 @@ class Uri implements Htmlable, Responsable, Stringable
     public function __toString(): string
     {
         return $this->uri->toString();
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->value();
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Relates to https://github.com/laravel/framework/issues/56094

---

This PR aims to ensure the `Uri` class is converted to JSON, fixing the issue: https://github.com/laravel/framework/issues/56094

Before this PR, an API that uses the `url` attribute as using the [new `AsUri` cast](https://github.com/laravel/framework/pull/55909), will respond like this:

```php
Route::get('/testing', function () {
    return User::first()->only('id', 'url');
});
```

Will result in it:

```
{
    "id": 1,
    "url": {}
}
```

After this PR, the value will be correctly converted to the expected `Uri` output:

```
{
    "id": 1,
    "url": "https://sanford.biz/..."
}
```
