### PR TITLE
Add array_merge_if helper function for conditional array merging

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -257,3 +257,23 @@ if (! function_exists('when')) {
         return value($default, $condition);
     }
 }
+
+
+if (! function_exists('array_merge_if')) {
+    /**
+     * Conditionally merge arrays based on a boolean condition.
+     *
+     * @param  bool  $condition
+     * @param  array  ...$arrays
+     * @return array
+     */
+    function array_merge_if($condition, ...$arrays)
+    {
+        if (! $condition) {
+            return $arrays[0] ?? [];
+        }
+
+        return array_merge(...$arrays);
+    }
+}
+

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1601,3 +1601,58 @@ class SupportTestCountable implements Countable
         return 0;
     }
 }
+
+class ArrayMergeIfTest
+{
+    public function testArrayMergeIfTrue()
+    {
+        $result = array_merge_if(true, [1, 2], [3, 4]);
+        assert($result === [1, 2, 3, 4]);
+
+        $result = array_merge_if(true, ['a' => 1], ['b' => 2]);
+        assert($result === ['a' => 1, 'b' => 2]);
+    }
+
+    public function testArrayMergeIfFalse()
+    {
+        $result = array_merge_if(false, [1, 2], [3, 4]);
+        assert($result === [1, 2]);
+
+        $result = array_merge_if(false, ['a' => 1], ['b' => 2]);
+        assert($result === ['a' => 1]);
+    }
+
+    public function testArrayMergeIfMultipleArrays()
+    {
+        $result = array_merge_if(true, [1], [2], [3], [4]);
+        assert($result === [1, 2, 3, 4]);
+
+        $result = array_merge_if(false, [1], [2], [3], [4]);
+        assert($result === [1]);
+    }
+
+    public function testArrayMergeIfEmptyArrays()
+    {
+        $result = array_merge_if(true);
+        assert($result === []);
+
+        $result = array_merge_if(false);
+        assert($result === []);
+    }
+
+    public function testArrayMergeIfWithCallable()
+    {
+        $user = (object) ['role' => 'admin'];
+
+        $basePermissions = ['read', 'write'];
+        $adminPermissions = ['delete', 'manage'];
+
+        $permissions = array_merge_if(
+            $user->role === 'admin',
+            $basePermissions,
+            $adminPermissions
+        );
+
+        assert($permissions === ['read', 'write', 'delete', 'manage']);
+    }
+}


### PR DESCRIPTION
This PR adds a new `array_merge_if` helper function that conditionally merges arrays based on a boolean condition.

## Motivation
Currently, conditional array merging requires verbose if-else blocks or ternary operators, making code less readable:

```php
// Current approach
$config = $isProduction 
    ? array_merge($baseConfig, $prodConfig) 
    : $baseConfig;

// With array_merge_if
$config = array_merge_if($isProduction, $baseConfig, $prodConfig);