### PR TITLE
[12.x] Enhance the test coverage for Pipeline::through()

### DIFF
--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -124,6 +124,29 @@ class PipelineTest extends TestCase
         $this->assertEquals(2, $object->value);
     }
 
+    public function testPipelineThroughMethodOverwritesPreviouslySetAndAppendedPipes()
+    {
+        $object = new stdClass();
+
+        $object->value = 0;
+
+        $function = function ($object, $next) {
+            $object->value++;
+
+            return $next($object);
+        };
+
+        $result = (new Pipeline(new Container))
+            ->send($object)
+            ->through([$function])
+            ->pipe([$function])
+            ->through([$function])
+            ->then(fn ($piped) => $piped);
+
+        $this->assertSame($object, $result);
+        $this->assertEquals(1, $object->value);
+    }
+
     public function testPipelineUsageWithInvokableClass()
     {
         $result = (new Pipeline(new Container))


### PR DESCRIPTION
Hi,
This PR enhances the test coverage for the Pipeline::through() method to ensure that it overwrites previously set or appended pipes.

```php
$object = new stdClass();
$object->value = 1;

$pipeline
    ->through([MultiplyByTwo::class])  // Would make it 2
    ->pipe([AddFive::class])          // Would make it 7
    ->through([AddFour::class])       // Should reset and make it 5
    ->thenReturn();

```