### PR TITLE
[12.x] Localize “Pagination Navigation” aria-label

### DIFF
--- a/src/Illuminate/Pagination/resources/views/simple-bootstrap-5.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-bootstrap-5.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="Pagination Navigation">
+    <nav role="navigation" aria-label="{!! __('Pagination Navigation') !!}">
         <ul class="pagination">
             {{-- Previous Page Link --}}
             @if ($paginator->onFirstPage())

--- a/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+    <nav role="navigation" aria-label="{!! __('Pagination Navigation') !!}" class="flex justify-between">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md dark:text-gray-600 dark:bg-gray-800 dark:border-gray-600">


### PR DESCRIPTION
Fixes #56102.

This localizes the “Pagination Navigation” aria-label text for the simple Tailwind and simple Bootstrap 5 views, bringing them inline with the Tailwind view.