### PR TITLE
[12.x] run prepareBindings before passing bindings to Grammar::substituteBindingsIntoRawSql

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -851,7 +851,7 @@ class Connection implements ConnectionInterface
         $this->event(new QueryExecuted($query, $bindings, $time, $this));
 
         $query = $this->pretending === true
-            ? $this->queryGrammar?->substituteBindingsIntoRawSql($query, $bindings) ?? $query
+            ? $this->queryGrammar?->substituteBindingsIntoRawSql($query, $this->prepareBindings($bindings)) ?? $query
             : $query;
 
         if ($this->loggingQueries) {

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\MultipleColumnsSelectedException;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Builder;
@@ -511,9 +512,18 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection();
         $args = [1, 1.1, true, 'a', new DateTime('2025-01-01'), null];
         $query = implode(' ', array_fill(0, count($args), '?'));
+        $expected = "1 1.1 1 'a' '2025-01-01 00:00:00' null";
+
+        $queryGrammar = $this->createMock(Grammar::class);
+        $queryGrammar->expects($this->once())
+            ->method('substituteBindingsIntoRawSql')
+            ->with($query, $connection->prepareBindings($args))
+            ->willReturn($expected);
+        $connection->setQueryGrammar($queryGrammar);
+
         $queries = $connection->pretend(fn () => $connection->select($query, $args));
 
-        $this->assertSame("1 1.1 1 'a' '2025-01-01 00:00:00' null", $queries[0]['query']);
+        $this->assertSame($expected, $queries[0]['query']);
         $this->assertEquals($args, $queries[0]['bindings']);
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -506,6 +506,17 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(['baz'], $queries[0]['bindings']);
     }
 
+    public function testPretendProducesSqlWithSubstitutedBindings()
+    {
+        $connection = $this->getMockConnection();
+        $args = [1, 1.1, true, 'a', new DateTime('2025-01-01'), null];
+        $query = implode(' ', array_fill(0, count($args), '?'));
+        $queries = $connection->pretend(fn() => $connection->select($query, $args));
+
+        $this->assertSame("1 1.1 1 'a' '2025-01-01 00:00:00' null", $queries[0]['query']);
+        $this->assertEquals($args, $queries[0]['bindings']);
+    }
+
     public function testSchemaBuilderCanBeCreated()
     {
         $connection = $this->getMockConnection();

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\MultipleColumnsSelectedException;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;
-use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Builder;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -511,7 +511,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection();
         $args = [1, 1.1, true, 'a', new DateTime('2025-01-01'), null];
         $query = implode(' ', array_fill(0, count($args), '?'));
-        $queries = $connection->pretend(fn() => $connection->select($query, $args));
+        $queries = $connection->pretend(fn () => $connection->select($query, $args));
 
         $this->assertSame("1 1.1 1 'a' '2025-01-01 00:00:00' null", $queries[0]['query']);
         $this->assertEquals($args, $queries[0]['bindings']);


### PR DESCRIPTION
All bindings passed to `Grammar::substituteBindingsIntoRawSql(...)` run through `Connection::prepareBindings()` except for this one. 

I believe this is a bug.

---

Examples of other places that call `Grammar::substituteBindingsIntoRawSql(...)`

`Builder::toRawSql()`
https://github.com/laravel/framework/blob/071a9d3cef72ff64e1475b2fce5e62355f9d315b/src/Illuminate/Database/Query/Builder.php#L3025

`QueryExecuted::toRawSql()`
https://github.com/laravel/framework/blob/071a9d3cef72ff64e1475b2fce5e62355f9d315b/src/Illuminate/Database/Events/QueryExecuted.php#L69

`Connection::getRawQueryLog()`
https://github.com/laravel/framework/blob/071a9d3cef72ff64e1475b2fce5e62355f9d315b/src/Illuminate/Database/Connection.php#L1522-L1525