### PR TITLE
Change return types of through (pagination) and transform (collection)

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1729,8 +1729,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Transform each item in the collection using a callback.
      *
-     * @param  callable(TValue, TKey): TValue  $callback
-     * @return $this
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @return $this<TKey, TMapValue>
      */
     public function transform(callable $callback)
     {

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -353,8 +353,10 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     /**
      * Transform each item in the slice of items using a callback.
      *
-     * @param  callable  $callback
-     * @return $this
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @return $this<TKey, TMapValue>
      */
     public function through(callable $callback)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1049,11 +1049,18 @@ assertType(
 assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1, 1, [new User]));
 
-assertType('Illuminate\Support\Collection<int, User>', $collection->transform(function ($user, $int) {
+assertType('mixed', $collection->transform(function ($user, $int) {
     assertType('User', $user);
     assertType('int', $int);
 
     return new User;
+}));
+
+assertType('mixed', $collection->transform(function ($user, $int): int {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return $int * 2;
 }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->add(new User));


### PR DESCRIPTION
The two docblocks where not correct or not enough for typehinting and static analysis (phpstan).

This piece of code (which is working) had a false static analysis:

```
    /**
     * @return LengthAwarePaginator<int, PriceResource>
     */
    protected function getPrices(Article $article): LengthAwarePaginator
    {
        return $article->prices()
            ->paginate(10)
            ->through(fn(Price $price) => PriceResource::make($price));
    }
```

It was complaining that it wanted a Price instead of PriceResource, but the paginator can change the items their types (it uses the transform in the background).

These fixes in de docblocks make it possible to write this code and pass the static analysis without to use ignore statements.

If some extra files needed an update or a change should be made, feel free to guide me in the right direction. It's up for discussion.

The issue https://github.com/laravel/framework/issues/46487 already mentioned the problem in the past.
