### PR TITLE
[12.x] Add `uri()` method to `InteractsWithData` trait

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -111,7 +111,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
-     * Retrieve data from the instance as a Uri instance.
+     * Get the value of the given key as a Uri instance.
      *
      * @param  string  $key
      * @param  string  $default

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -111,6 +111,18 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Retrieve data from the instance as a Uri instance.
+     *
+     * @param  string  $key
+     * @param  string  $default
+     * @return \Illuminate\Support\Uri
+     */
+    public function uri($key, $default = '')
+    {
+        return Uri::of($this->data($key, $default));
+    }
+
+    /**
      * Get the value of the given key as a new Fluent instance.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
-use Illuminate\Support\Uri;
 use stdClass;
 
 trait InteractsWithData

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -246,18 +246,6 @@ trait InteractsWithData
     }
 
     /**
-     * Retrieve data from the instance as a Uri instance.
-     *
-     * @param  string  $key
-     * @param  string  $default
-     * @return \Illuminate\Support\Uri
-     */
-    public function uri($key, $default = '')
-    {
-        return Uri::of($this->data($key, $default));
-    }
-
-    /**
      * Retrieve data as a boolean value.
      *
      * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
 use stdClass;
 
 trait InteractsWithData
@@ -242,6 +243,18 @@ trait InteractsWithData
     public function string($key, $default = null)
     {
         return Str::of($this->data($key, $default));
+    }
+
+    /**
+     * Retrieve data from the instance as a Uri instance.
+     *
+     * @param  string  $key
+     * @param  string  $default
+     * @return \Illuminate\Support\Uri
+     */
+    public function uri($key, $default = '')
+    {
+        return Uri::of($this->data($key, $default));
     }
 
     /**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
 use InvalidArgumentException;
 use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
@@ -179,6 +180,17 @@ class SupportFluentTest extends TestCase
         $this->assertSame('', $fluent->string('empty_str')->value());
         $this->assertSame('', $fluent->string('null')->value());
         $this->assertSame('', $fluent->string('unknown_key')->value());
+    }
+
+    public function testUriMethod()
+    {
+        $fluent = new Fluent([
+            'uri' => 'https://example.com',
+            'empty_str' => '',
+        ]);
+        $this->assertTrue($fluent->uri('uri') instanceof Uri);
+        $this->assertTrue($fluent->uri('empty_str') instanceof Uri);
+        $this->assertTrue($fluent->uri('unknown_key') instanceof Uri);
     }
 
     public function testBooleanMethod()


### PR DESCRIPTION
### Description

This PR adds a `uri()` method to the `Illuminate\Support\Traits\InteractsWithData` trait that creates a new `Illuminate\Support\Uri` instance.

### Usage with `Fluent`

```php
Fluent::make([
    'website' => 'https://laravel.com', 
])->uri('website');

// Result: Illuminate\Support\Uri {
//   #uri: League\Uri\Uri {
//     -scheme: "https"
//     -user: null
//     -pass: null
//     -userInfo: null
//     -host: "laravel.com"
//     -port: null
//     -authority: "laravel.com"
//     -path: ""
//     -query: null
//     -fragment: null
//     -uri: "https://laravel.com"
//   }
// }
```
