### PR TITLE
[12.x] Correct PHPDoc for Arr::sole callable type to avoid return type ambiguity

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -951,7 +951,7 @@ class Arr
      * Get the first item in the array, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  array  $array
-     * @param  callable(mixed, array-key): array|null  $callback
+     * @param  (callable(mixed, array-key): array)|null  $callback
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException


### PR DESCRIPTION
Description
---
This PR updates the `@param` annotation for the `$callback` argument in `Arr::sole` to avoid ambiguity in the callable return type.

The current state can be misinterpreted as a callable returning `array` or `null`, which is not accurate. The parameter itself is nullable, not the return type of the callable.

This ensures that static analyzers and readers correctly interpret the type as either a callable (with defined signature and array return type) or null.