### PR TITLE
[12.x] fix: add type to $markdown property

### DIFF
--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -64,7 +64,7 @@ class Content
      *
      * @named-arguments-supported
      */
-    public function __construct(?string $view = null, ?string $html = null, ?string $text = null, $markdown = null, array $with = [], ?string $htmlString = null)
+    public function __construct(?string $view = null, ?string $html = null, ?string $text = null, ?string $markdown = null, array $with = [], ?string $htmlString = null)
     {
         $this->view = $view;
         $this->html = $html;


### PR DESCRIPTION
This PR adds a `?string` type to the `$markdown` property to the construct of the `Illuminate\Mail\Mailables\Content`-class. It makes the entire constructor typed.