### PR TITLE
[12.x] Add whereLike and whereNotLike methods to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -743,7 +743,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items such that the given string matches the value of the given key using SQL LIKE pattern matching
+     * Filter items such that the given string matches the value of the given key using SQL LIKE pattern matching.
      *
      * @param  string  $key
      * @param  string  $pattern
@@ -754,17 +754,15 @@ trait EnumeratesValues
     {
         $regex = $this->parseSqlLikeRegex($pattern, $caseSensitive);
 
-
         return $this->filter(function ($item) use ($key, $regex) {
             $value = data_get($item, $key);
-
 
             return is_string($value) && preg_match($regex, $value);
         });
     }
 
     /**
-     * Filter items such that the given string does not match the value of the given key using SQL LIKE pattern matching
+     * Filter items such that the given string does not match the value of the given key using SQL LIKE pattern matching.
      *
      * @param  string  $key
      * @param  string  $pattern
@@ -775,10 +773,8 @@ trait EnumeratesValues
     {
         $regex = $this->parseSqlLikeRegex($pattern, $caseSensitive);
 
-
         return $this->reject(function ($item) use ($key, $regex) {
             $value = data_get($item, $key);
-
 
             return is_string($value) && preg_match($regex, $value);
         });
@@ -1227,24 +1223,22 @@ trait EnumeratesValues
      * @param  bool  $caseSensitive
      * @return string
      */
-    protected function parseSqlLikeRegex($pattern, $caseSensitive) {
+    protected function parseSqlLikeRegex($pattern, $caseSensitive)
+    {
         $pattern = preg_quote($pattern, '/');
 
-
-        $pattern = preg_replace_callback("/\\\\[%_]|(?<!\\\\)[%_]/", function ($matches) {
+        $pattern = preg_replace_callback('/\\\\[%_]|(?<!\\\\)[%_]/', function ($matches) {
             return match ($matches[0]) {
-                "\%" => "%",
-                "\_" => "_",
-                "%" => ".*",
-                "_" => ".",
+                "\%" => '%',
+                "\_" => '_',
+                '%' => '.*',
+                '_' => '.',
                 default => $matches[0]
             };
         }, $pattern);
 
-
-        $regex = "/^" . $pattern . '$/' . ($caseSensitive ? "" : 'i');
+        $regex = '/^'.$pattern.'$/'.($caseSensitive ? '' : 'i');
 
         return $regex;
-
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1122,16 +1122,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['email' => 'test@example.org']], $c->whereLike('email', '%@ex__ple.o_g%')->values()->all());
         $this->assertEquals([['email' => 'test@example.net']], $c->whereLike('email', 'test@example.net')->values()->all());
 
-
         $c = new $collection([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']]);
         $this->assertEquals([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']], $c->whereLike('name', '%otwell%', false)->values()->all());
         $this->assertEquals([['name' => 'taylor otWeLl']], $c->whereLike('name', '%taylor%', true)->values()->all());
 
-
         $c = new $collection([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]]);
         $this->assertEquals([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']]], $c->whereLike('contact.email', 'test@%.co_')->values()->all());
         $this->assertEquals([['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']]], $c->whereLike('contact.email', 'test\_1@ex_mple.%')->values()->all());
-
 
         $c = new $collection([['percent' => '99%'], ['percent' => '70.70%'], ['percent' => '59%']]);
         $this->assertEquals([['percent' => '99%']], $c->whereLike('percent', '99\%')->values()->all());
@@ -1147,16 +1144,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['email' => 'test@example.com'], ['email' => 'test@example.net']], $c->whereNotLike('email', '%@ex__ple.o_g%')->values()->all());
         $this->assertEquals([['email' => 'test@example.com'], ['email' => 'test@example.org']], $c->whereNotLike('email', 'test@example.net')->values()->all());
 
-
         $c = new $collection([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']]);
         $this->assertEquals([], $c->whereNotLike('name', '%otwell%', false)->values()->all());
         $this->assertEquals([['name' => 'Taylor Otwell']], $c->whereNotLike('name', '%taylor%', true)->values()->all());
 
-
         $c = new $collection([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]]);
         $this->assertEquals([['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]], $c->whereNotLike('contact.email', 'test@%.co_')->values()->all());
         $this->assertEquals([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]], $c->whereNotLike('contact.email', 'test\_1@ex_mple.%')->values()->all());
-
 
         $c = new $collection([['percent' => '99%'], ['percent' => '70.70%'], ['percent' => '59%']]);
         $this->assertEquals([['percent' => '70.70%'], ['percent' => '59%']], $c->whereNotLike('percent', '99\%')->values()->all());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1115,6 +1115,56 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testWhereLike($collection)
+    {
+        $c = new $collection([['email' => 'test@example.com'], ['email' => 'test@example.org'], ['email' => 'test@example.net']]);
+        $this->assertEquals([['email' => 'test@example.com']], $c->whereLike('email', '%@example.com%')->values()->all());
+        $this->assertEquals([['email' => 'test@example.org']], $c->whereLike('email', '%@ex__ple.o_g%')->values()->all());
+        $this->assertEquals([['email' => 'test@example.net']], $c->whereLike('email', 'test@example.net')->values()->all());
+
+
+        $c = new $collection([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']]);
+        $this->assertEquals([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']], $c->whereLike('name', '%otwell%', false)->values()->all());
+        $this->assertEquals([['name' => 'taylor otWeLl']], $c->whereLike('name', '%taylor%', true)->values()->all());
+
+
+        $c = new $collection([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]]);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']]], $c->whereLike('contact.email', 'test@%.co_')->values()->all());
+        $this->assertEquals([['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']]], $c->whereLike('contact.email', 'test\_1@ex_mple.%')->values()->all());
+
+
+        $c = new $collection([['percent' => '99%'], ['percent' => '70.70%'], ['percent' => '59%']]);
+        $this->assertEquals([['percent' => '99%']], $c->whereLike('percent', '99\%')->values()->all());
+        $this->assertEquals([['percent' => '99%'], ['percent' => '59%']], $c->whereLike('percent', '_9\%')->values()->all());
+        $this->assertEquals([['percent' => '70.70%']], $c->whereLike('percent', '70.__\%')->values()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testWhereNotLike($collection)
+    {
+        $c = new $collection([['email' => 'test@example.com'], ['email' => 'test@example.org'], ['email' => 'test@example.net']]);
+        $this->assertEquals([['email' => 'test@example.org'], ['email' => 'test@example.net']], $c->whereNotLike('email', '%@example.com%')->values()->all());
+        $this->assertEquals([['email' => 'test@example.com'], ['email' => 'test@example.net']], $c->whereNotLike('email', '%@ex__ple.o_g%')->values()->all());
+        $this->assertEquals([['email' => 'test@example.com'], ['email' => 'test@example.org']], $c->whereNotLike('email', 'test@example.net')->values()->all());
+
+
+        $c = new $collection([['name' => 'Taylor Otwell'], ['name' => 'taylor otWeLl']]);
+        $this->assertEquals([], $c->whereNotLike('name', '%otwell%', false)->values()->all());
+        $this->assertEquals([['name' => 'Taylor Otwell']], $c->whereNotLike('name', '%taylor%', true)->values()->all());
+
+
+        $c = new $collection([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]]);
+        $this->assertEquals([['name' => 'Abigail Otwell', 'contact' => ['email' => 'test_1@example.org']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]], $c->whereNotLike('contact.email', 'test@%.co_')->values()->all());
+        $this->assertEquals([['name' => 'Taylor Otwell', 'contact' => ['email' => 'test@example.com']], ['name' => 'Joe Dixon', 'contact' => ['email' => 'test@example.net']]], $c->whereNotLike('contact.email', 'test\_1@ex_mple.%')->values()->all());
+
+
+        $c = new $collection([['percent' => '99%'], ['percent' => '70.70%'], ['percent' => '59%']]);
+        $this->assertEquals([['percent' => '70.70%'], ['percent' => '59%']], $c->whereNotLike('percent', '99\%')->values()->all());
+        $this->assertEquals([['percent' => '70.70%']], $c->whereNotLike('percent', '_9\%')->values()->all());
+        $this->assertEquals([['percent' => '99%'], ['percent' => '59%']], $c->whereNotLike('percent', '70.__\%')->values()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testValues($collection)
     {
         $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1651,11 +1651,9 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['name' => 'Taylor Otwell'], ['name' => 'Abigail Otwell'], ['name' => 'Joe Dixon'], ['name' => 'John Doe']]);
 
-
         $this->assertDoesNotEnumerateCollection($data, function ($collection) {
             $collection->whereLike('name', '%Otw_ll%');
         });
-
 
         $this->assertEnumeratesCollection($data, 3, function ($collection) {
             $collection->whereLike('name', 'Jo%')->take(1)->all();
@@ -1666,11 +1664,9 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['name' => 'Taylor Otwell'], ['name' => 'Abigail Otwell'], ['name' => 'Joe Dixon'], ['name' => 'John Doe']]);
 
-
         $this->assertDoesNotEnumerateCollection($data, function ($collection) {
             $collection->whereNotLike('name', '%Otw_ll%');
         });
-
 
         $this->assertEnumeratesCollection($data, 2, function ($collection) {
             $collection->whereNotLike('name', '%Taylor%')->take(1)->all();

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1647,6 +1647,36 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testWhereLikeIsLazy()
+    {
+        $data = $this->make([['name' => 'Taylor Otwell'], ['name' => 'Abigail Otwell'], ['name' => 'Joe Dixon'], ['name' => 'John Doe']]);
+
+
+        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+            $collection->whereLike('name', '%Otw_ll%');
+        });
+
+
+        $this->assertEnumeratesCollection($data, 3, function ($collection) {
+            $collection->whereLike('name', 'Jo%')->take(1)->all();
+        });
+    }
+
+    public function testWhereNotLikeIsLazy()
+    {
+        $data = $this->make([['name' => 'Taylor Otwell'], ['name' => 'Abigail Otwell'], ['name' => 'Joe Dixon'], ['name' => 'John Doe']]);
+
+
+        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+            $collection->whereNotLike('name', '%Otw_ll%');
+        });
+
+
+        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+            $collection->whereNotLike('name', '%Taylor%')->take(1)->all();
+        });
+    }
+
     public function testWhereNotNullIsLazy()
     {
         $data = $this->make([['a' => 1], ['a' => null], ['a' => 2], ['a' => 3]]);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -477,6 +477,12 @@ assertType("Illuminate\Support\Collection<int, array{string: int}>", $collection
 assertType("Illuminate\Support\Collection<int, array{string: int}>", $collection::make([['string' => 2]])
     ->whereNotInStrict('string', [2]));
 
+assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+    ->whereLike('string', '%str%'));
+
+assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+    ->whereNotLike('string', '%int%'));
+
 assertType('Illuminate\Support\Collection<int, User>', $collection::make([new User, 1])
     ->whereInstanceOf(User::class));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -373,6 +373,12 @@ assertType("Illuminate\Support\LazyCollection<int, array{string: int}>", $collec
 assertType("Illuminate\Support\LazyCollection<int, array{string: int}>", $collection::make([['string' => 2]])
     ->whereNotInStrict('string', [2]));
 
+assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+    ->whereLike('string', '%str%'));
+
+assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+    ->whereNotLike('string', '%int%'));
+
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection::make([new User, 1])
     ->whereInstanceOf(User::class));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -373,10 +373,10 @@ assertType("Illuminate\Support\LazyCollection<int, array{string: int}>", $collec
 assertType("Illuminate\Support\LazyCollection<int, array{string: int}>", $collection::make([['string' => 2]])
     ->whereNotInStrict('string', [2]));
 
-assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+assertType("Illuminate\Support\LazyCollection<int, array{string: string}>", $collection::make([['string' => 'string']])
     ->whereLike('string', '%str%'));
 
-assertType("Illuminate\Support\Collection<int, array{string: string}>", $collection::make([['string' => 'string']])
+assertType("Illuminate\Support\LazyCollection<int, array{string: string}>", $collection::make([['string' => 'string']])
     ->whereNotLike('string', '%int%'));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection::make([new User, 1])


### PR DESCRIPTION
This PR adds `whereLike()` and `whereNotLike()` methods to the Collection class, providing SQL-like pattern matching capabilities similar to the `whereLike()` method available in the query builder.

These methods allow filtering a collection by applying a LIKE or NOT LIKE pattern match to the value of a given key. The pattern supports wildcards, % (any sequence of characters) and _ (a single character), and also respects escaped wildcards (`\%`, `\_`). Optional case sensitivity is also supported via. a third parameter (`$caseSensitive`, defaulting to false).

Moreover, both methods support nested keys using dot notation via. `data_get()` helper.

Query builder and collections support various where methods (`where()`, `whereIn()`, `whereBetween()`, etc.). But, `whereLike()` was notably missing from the Collection class, which I realized while working in one of my recent Laravel projects. This PR fills that void by introducing `whereLike()` and `whereNotLike()` methods, enhancing the collection filtering using familiar SQL-style patterns.