### PR TITLE
[12.x] Add missing @throws annotation to Number

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -419,7 +419,7 @@ class Number
      *
      * @return void
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     protected static function ensureIntlExtensionIsInstalled()
     {

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -418,6 +418,8 @@ class Number
      * Ensure the "intl" PHP extension is installed.
      *
      * @return void
+     *
+     * @throws RuntimeException
      */
     protected static function ensureIntlExtensionIsInstalled()
     {


### PR DESCRIPTION
Description
---
This PR adds the `@throws RuntimeException` annotation to the  `protected` `ensureIntlExtensionIsInstalled()` method in `Illuminate\Support\Number`.