### PR TITLE
[12.x] Throws not throw

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -399,7 +399,7 @@ class PendingProcess
      * @param  \Closure  $fake
      * @return \Illuminate\Process\FakeInvokedProcess
      *
-     * @throw \LogicException
+     * @throws \LogicException
      */
     protected function resolveAsynchronousFake(string $command, ?callable $output, Closure $fake)
     {

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -42,7 +42,7 @@ class Composer
      * @param  string  $package
      * @return bool
      *
-     * @throw \RuntimeException
+     * @throws \RuntimeException
      */
     public function hasPackage($package)
     {
@@ -116,7 +116,7 @@ class Composer
      * @param  callable(array):array  $callback
      * @return void
      *
-     * @throw \RuntimeException
+     * @throws \RuntimeException
      */
     public function modify(callable $callback)
     {
@@ -182,7 +182,7 @@ class Composer
      *
      * @return string
      *
-     * @throw \RuntimeException
+     * @throws \RuntimeException
      */
     protected function findComposerFile()
     {


### PR DESCRIPTION
Description
---
I think the `@throws` tag is the correct PHPDoc tag.