### PR TITLE
[12.x] Fix @param docblock to allow string

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1059,7 +1059,7 @@ class Arr
     /**
      * Conditionally compile classes from an array into a CSS class list.
      *
-     * @param  array  $array
+     * @param  array|string  $array
      * @return string
      */
     public static function toCssClasses($array)
@@ -1082,7 +1082,7 @@ class Arr
     /**
      * Conditionally compile styles from an array into a style list.
      *
-     * @param  array  $array
+     * @param  array|string  $array
      * @return string
      */
     public static function toCssStyles($array)


### PR DESCRIPTION
Description
---
The `Arr::toCssClasses()` and `Arr::toCssStyles()` methods accepts both `array` and `string` as input. If a string is passed, it is wrapped into an array using `Arr::wrap()`.

This PR ensures that the `@param` docblock more accurately reflects the method’s accepted input types.