### PR TITLE
[12.x] Add `percentile` method to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -162,9 +162,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return $values->first();
         }
 
-        $index    = $p * ($count - 1);
-        $lower    = (int) floor($index);
-        $upper    = (int) ceil($index);
+        $index = $p * ($count - 1);
+        $lower = (int) floor($index);
+        $upper = (int) ceil($index);
         $fraction = $index - $lower;
 
         return $lower === $upper

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -172,8 +172,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             : $values->get($lower) + $fraction * ($values->get($upper) - $values->get($lower));
     }
 
-
-
     /**
      * Collapse the collection of items into a single array.
      *

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -133,6 +133,48 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the value at a given percentile.
+     *
+     * @param  float  $p  A number between 0 (exclusive) and 1 (inclusive).
+     * @param  string|array<array-key, string>|null  $key
+     * @return float|int|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function percentile(float $p, $key = null)
+    {
+        if ($p <= 0 || $p > 1) {
+            throw new InvalidArgumentException('Percentile must be greater than 0 and at most 1.');
+        }
+
+        $values = (isset($key) ? $this->pluck($key) : $this)
+            ->reject(fn ($v) => is_null($v))
+            ->sort()
+            ->values();
+
+        $count = $values->count();
+
+        if ($count === 0) {
+            return;
+        }
+
+        if ($count === 1) {
+            return $values->first();
+        }
+
+        $index    = $p * ($count - 1);
+        $lower    = (int) floor($index);
+        $upper    = (int) ceil($index);
+        $fraction = $index - $lower;
+
+        return $lower === $upper
+            ? $values->get($lower)
+            : $values->get($lower) + $fraction * ($values->get($upper) - $values->get($lower));
+    }
+
+
+
+    /**
      * Collapse the collection of items into a single array.
      *
      * @return static<int, mixed>

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -110,6 +110,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function mode($key = null);
 
     /**
+     * Get the value at a given percentile.
+     *
+     * @param  float  $p  A number between 0 (exclusive) and 1 (inclusive).
+     * @param  string|array<array-key, string>|null  $key
+     * @return float|int|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function percentile(float $p, $key = null);
+
+    /**
      * Collapse the items into a single enumerable.
      *
      * @return static<int, mixed>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -181,6 +181,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the value at a given percentile.
+     *
+     * @param  float  $p  A number between 0 (exclusive) and 1 (inclusive).
+     * @param  string|array<array-key, string>|null  $key
+     * @return float|int|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function percentile(float $p, $key = null)
+    {
+        return $this->collect()->percentile($p, $key);
+    }
+
+    /**
      * Collapse the collection of items into a single array.
      *
      * @return static<int, mixed>

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4763,7 +4763,7 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testPercentileOnLargerDataSetMatchesMedian($collection)
     {
-        $data = new $collection(range(1, 101)); 
+        $data = new $collection(range(1, 101));
 
         $this->assertSame(51, $data->percentile(0.5));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4751,6 +4751,63 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testPercentileLinearInterpolation($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $this->assertEquals(1.75, $data->percentile(0.25));
+        $this->assertEquals(2.5, $data->percentile(0.5));
+        $this->assertEquals(3.25, $data->percentile(0.75));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileOnLargerDataSetMatchesMedian($collection)
+    {
+        $data = new $collection(range(1, 101)); 
+
+        $this->assertSame(51, $data->percentile(0.5));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileWithKeyExtraction($collection)
+    {
+        $data = new $collection([
+            ['score' => 10],
+            ['score' => 20],
+            ['score' => 30],
+            ['score' => 40],
+        ]);
+
+        $this->assertEquals(25, $data->percentile(0.5, 'score'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileReturnsNullForEmptyCollection($collection)
+    {
+        $this->assertNull((new $collection)->percentile(0.75));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileReturnsTheOnlyElementForSingletonCollection($collection)
+    {
+        $this->assertSame(42, (new $collection([42]))->percentile(0.1));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileThrowsExceptionWhenPIsOutOfRange($collection)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new $collection([1, 2, 3]))->percentile(1.5);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testPercentileThrowsExceptionWhenPIsZeroOrNegative($collection)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new $collection([1, 2, 3]))->percentile(0);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testSliceOffset($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION

### Summary

This PR introduces a `percentile()` helper to `Illuminate\Support\Collection`, filling the gap between the existing [`median()`](https://laravel.com/docs/12.x/collections#method-median) and [`mode()`](https://laravel.com/docs/12.x/collections#method-mode) statistics helpers.  

By computing percentiles, we can quickly understand the distribution of a dataset - whether it’s latency measurements, order totals, or any numeric series—and make decisions based on relative standing.



---

### Why?
*  Dashboards, alerts, and reports frequently rely on *P95 latency*, *P90 response time*, or *top-10% spenders* - all straightforward percentile queries.  
*  Collections already ship with *mean*, *median*, and *mode*. Percentiles are the logical missing metric in the basic descriptive-statistics toolkit.  


---

## Usage

```php

// 1) P90 of students’ average grades:
$students = collect([
    ['name' => 'Alice', 'grades' => [88, 92, 85]],
    ['name' => 'Bob',   'grades' => [75, 78, 82]],
    ['name' => 'Cara',  'grades' => [95, 98, 100]],
]);

$p90Avg = $students
    ->map(fn($s) => collect($s['grades'])->avg())
    ->percentile(0.9);  // ≈ 95.9

// 2) Top-20% order totals:
$orderTotals = collect([45.00, 79.99, 120.00, 55.50, 65.00]);
$threshold   = $orderTotals->percentile(0.8); // e.g. 75.00

