### PR TITLE
[12.x] remove the "prefix" option for cache password resets

### DIFF
--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -40,7 +40,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
         $token = hash_hmac('sha256', Str::random(40), $this->hashKey);
 
         $this->cache->put(
-            $this->makeCacheKey($user),
+            $this->cacheKey($user),
             [$this->hasher->make($token), Carbon::now()->format($this->format)],
             $this->expires,
         );
@@ -57,7 +57,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function exists(CanResetPasswordContract $user, #[\SensitiveParameter] $token)
     {
-        [$record, $createdAt] = $this->cache->get($this->makeCacheKey($user));
+        [$record, $createdAt] = $this->cache->get($this->cacheKey($user));
 
         return $record
             && ! $this->tokenExpired($createdAt)
@@ -83,7 +83,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
-        [$record, $createdAt] = $this->cache->get($this->makeCacheKey($user));
+        [$record, $createdAt] = $this->cache->get($this->cacheKey($user));
 
         return $record && $this->tokenRecentlyCreated($createdAt);
     }
@@ -113,7 +113,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function delete(CanResetPasswordContract $user)
     {
-        $this->cache->forget($this->makeCacheKey($user));
+        $this->cache->forget($this->cacheKey($user));
     }
 
     /**
@@ -126,12 +126,12 @@ class CacheTokenRepository implements TokenRepositoryInterface
     }
 
     /**
-     * Determine the cache key to use.
+     * Determine the cache key for the given user.
      *
      * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
      * @return string
      */
-    public function makeCacheKey(CanResetPasswordContract $user): string
+    public function cacheKey(CanResetPasswordContract $user): string
     {
         return hash('sha256', $user->getEmailForPasswordReset());
     }

--- a/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/CacheTokenRepository.php
@@ -24,7 +24,6 @@ class CacheTokenRepository implements TokenRepositoryInterface
         protected string $hashKey,
         protected int $expires = 3600,
         protected int $throttle = 60,
-        protected string $prefix = '',
     ) {
     }
 
@@ -41,7 +40,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
         $token = hash_hmac('sha256', Str::random(40), $this->hashKey);
 
         $this->cache->put(
-            $this->prefix.$user->getEmailForPasswordReset(),
+            $this->makeCacheKey($user),
             [$this->hasher->make($token), Carbon::now()->format($this->format)],
             $this->expires,
         );
@@ -58,7 +57,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function exists(CanResetPasswordContract $user, #[\SensitiveParameter] $token)
     {
-        [$record, $createdAt] = $this->cache->get($this->prefix.$user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->makeCacheKey($user));
 
         return $record
             && ! $this->tokenExpired($createdAt)
@@ -84,7 +83,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
-        [$record, $createdAt] = $this->cache->get($this->prefix.$user->getEmailForPasswordReset());
+        [$record, $createdAt] = $this->cache->get($this->makeCacheKey($user));
 
         return $record && $this->tokenRecentlyCreated($createdAt);
     }
@@ -114,7 +113,7 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function delete(CanResetPasswordContract $user)
     {
-        $this->cache->forget($this->prefix.$user->getEmailForPasswordReset());
+        $this->cache->forget($this->makeCacheKey($user));
     }
 
     /**
@@ -124,5 +123,16 @@ class CacheTokenRepository implements TokenRepositoryInterface
      */
     public function deleteExpired()
     {
+    }
+
+    /**
+     * Determine the cache key to use.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return string
+     */
+    public function makeCacheKey(CanResetPasswordContract $user): string
+    {
+        return hash('sha256', $user->getEmailForPasswordReset());
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -95,7 +95,6 @@ class PasswordBrokerManager implements FactoryContract
                 $key,
                 ($config['expire'] ?? 60) * 60,
                 $config['throttle'] ?? 0,
-                $config['prefix'] ?? '',
             );
         }
 


### PR DESCRIPTION
this is mostly a rollback of #53448 per Taylor's request. rather than allowing an optional prefix, we'll use a deterministic hash of the user's email for our cache key.  this should make the chance of a collision if no dedicated store is used statistically insignificant.

I've also opted to extract out a `makeCacheKey()` method here mainly to reduce the duplicated code and help prevent bugs from divergence. however, this could possibly help userland override the cache key generation. maybe I'm overthinking that, maybe it's honestly not a problem.

Please be aware that this change on a minor or patch release will technically break existing users of cache password resets. However, it will likely be very short lived due to password resets usually only being valid for 60 minutes. Also, we have never documented the feature, so adoption is probably very low.

Taylor, I think this is what you were asking for in https://github.com/laravel/docs/pull/10032#issuecomment-2486886833, lmk if I was understanding correctly.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
