### PR TITLE
[11.x] Pass the limiter to the when & report callbacks

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -104,11 +104,11 @@ class ThrottlesExceptions
 
             $this->limiter->clear($jobKey);
         } catch (Throwable $throwable) {
-            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable)) {
+            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
                 throw $throwable;
             }
 
-            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable)) {
+            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable, $this->limiter)) {
                 report($throwable);
             }
 

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -50,11 +50,11 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
 
             $this->limiter->clear();
         } catch (Throwable $throwable) {
-            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable)) {
+            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
                 throw $throwable;
             }
 
-            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable)) {
+            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable, $this->limiter)) {
                 report($throwable);
             }
 


### PR DESCRIPTION
It would be nice to have the limiter in the when & report callbacks to expand the logic in the closures to give a bit more control.

Here is a use case:

I want to give the job the maxAttempts to recover, but on that last try, it would be nice to report what is happening.  I would like not to report the attempts 1...(max - 1), but on max, I would like to report.  If I had the limiter in my closure, then I would know when to return true.  This would keep the logs clean for the occasional exception that self-recover.

I have started a discussion on this at #56128, but then I thought that would make the simple PR.

I did not see where the tests were making any assertions about the parameters being passed, so I did not make any test changes. However, I will be happy to expand them if needed.