### PR TITLE
[12.x] Make Model::currentEncrypter public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1436,7 +1436,7 @@ trait HasAttributes
      *
      * @return \Illuminate\Contracts\Encryption\Encrypter
      */
-    protected static function currentEncrypter()
+    public static function currentEncrypter()
     {
         return static::$encrypter ?? Crypt::getFacadeRoot();
     }


### PR DESCRIPTION
I'm working on custom casts that encrypt their value. To make the integration with the other encrypted casts seamless, I'm using the encrypter defined on the model. However, that can be `null`, so I have to fall back to the "default" encrypter. The model itself has a handy method to do this, but that's protected. By making this method public, we give users access to it, making their lives a little easier.

**Before**
```php
$encrypted = ($model::$encrypter ?? Crypt::getFacadeRoot())->encrypt($value, false);
```

**After**
```php
$encrypted = $model::currentEncrypter()->encrypt($value, false);
```