### PR TITLE
Fix AsEnumCollection casting: validate enum values and normalize request input types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -71,10 +71,12 @@ class AsEnumCollection implements Castable
 
             protected function getStorableEnumValue($value)
             {
-                $enumClass = $this->arguments[0];
-                $enum = is_subclass_of($enumClass, BackedEnum::class)
-                    ? $enumClass::from($value)
-                    : constant($enumClass.'::'.$value);
+                if (is_string($enum) || is_int($enum)) {
+                    $enumClass = $this->arguments[0];
+                    $enum = is_subclass_of($enumClass, BackedEnum::class)
+                        ? $enumClass::from($enum)
+                        : constant($enumClass.'::'.$enum);
+                }
 
                 return enum_value($enum);
             }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -69,7 +69,7 @@ class AsEnumCollection implements Castable
                 })->toArray();
             }
 
-            protected function getStorableEnumValue($value)
+            protected function getStorableEnumValue($enum)
             {
                 if (is_string($enum) || is_int($enum)) {
                     $enumClass = $this->arguments[0];

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -69,11 +69,12 @@ class AsEnumCollection implements Castable
                 })->toArray();
             }
 
-            protected function getStorableEnumValue($enum)
+            protected function getStorableEnumValue($value)
             {
-                if (is_string($enum) || is_int($enum)) {
-                    return $enum;
-                }
+                $enumClass = $this->arguments[0];
+                $enum = is_subclass_of($enumClass, BackedEnum::class)
+                    ? $enumClass::from($value)
+                    : constant($enumClass.'::'.$value);
 
                 return enum_value($enum);
             }


### PR DESCRIPTION
### 🧩 Context & Issues
- When using AsEnumCollection cast, the field currently accepts any integer or string, allowing invalid values to be assigned without error.
- Incoming data from HTTP requests (like "1" or "2" as strings) are stored as strings, not converted to ints early, leading to type mismatches and broken behavior.

### 🔧 Changes Made
- Convert incoming values to the proper type (e.g., cast strings to ints) before assignment.
- Explicitly check if each value belongs to the enum