### PR TITLE
[12.x] Add `throws` docblock

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -146,6 +146,8 @@ class NotificationSender
      * @param  mixed  $notification
      * @param  string  $channel
      * @return void
+     *
+     * @throws \Throwable
      */
     protected function sendToNotifiable($notifiable, $id, $notification, $channel)
     {

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -54,6 +54,8 @@ class CompilerEngine extends PhpEngine
      * @param  string  $path
      * @param  array  $data
      * @return string
+     *
+     * @throws ViewException
      */
     public function get($path, array $data = [])
     {

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -55,7 +55,7 @@ class CompilerEngine extends PhpEngine
      * @param  array  $data
      * @return string
      *
-     * @throws ViewException
+     * @throws \Illuminate\View\ViewException
      */
     public function get($path, array $data = [])
     {


### PR DESCRIPTION
This PR completes the addition of `@throws` docblocks for all functions in the framework containing `throw` keyword.