### PR TITLE
[12.x] Allows using `--model` and `--except` via `PruneCommand` command

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -115,16 +115,17 @@ class PruneCommand extends Command
      */
     protected function models()
     {
-        if (! empty($models = $this->option('model'))) {
-            return (new Collection($models))->filter(function ($model) {
-                return class_exists($model);
-            })->values();
-        }
-
+        $models = $this->option('model');
         $except = $this->option('except');
 
-        if (! empty($models) && ! empty($except)) {
+        if ($models && $except) {
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
+        }
+
+        if ($models) {
+            return (new Collection($models))
+                ->filter(static fn (string $model) => class_exists($model))
+                ->values();
         }
 
         return (new Collection(Finder::create()->in($this->getPath())->files()->name('*.php')))

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -39,6 +39,17 @@ class PruneCommandTest extends TestCase
         $container->alias(DispatcherContract::class, 'events');
     }
 
+    public function testPrunableModelAndExceptWithEachOther(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The --models and --except options cannot be combined.');
+
+        $this->artisan([
+            '--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class,
+            '--except' => Pruning\Models\PrunableTestModelWithPrunableRecords::class,
+        ]);
+    }
+
     public function testPrunableModelWithPrunableRecords()
     {
         $output = $this->artisan(['--model' => Pruning\Models\PrunableTestModelWithPrunableRecords::class]);


### PR DESCRIPTION
See: https://github.com/laravel/framework/issues/56139

This will fix unreachable code when using both `--model` and `--except` at the same time on `PruneCommand`