### PR TITLE
Add ToReadonlyArray support for DTOs and value objects

### DIFF
--- a/src/Illuminate/Contracts/Support/ToReadonlyArray.php
+++ b/src/Illuminate/Contracts/Support/ToReadonlyArray.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface ToReadonlyArray
+{
+    public function toReadonlyArray(): array;
+
+}

--- a/src/Illuminate/Contracts/Support/ToReadonlyArray.php
+++ b/src/Illuminate/Contracts/Support/ToReadonlyArray.php
@@ -5,5 +5,4 @@ namespace Illuminate\Contracts\Support;
 interface ToReadonlyArray
 {
     public function toReadonlyArray(): array;
-
 }

--- a/src/Illuminate/Support/Traits/CastsToReadonlyArray.php
+++ b/src/Illuminate/Support/Traits/CastsToReadonlyArray.php
@@ -6,6 +6,6 @@ trait CastsToReadonlyArray
 {
     public function toReadonlyArray(): array
     {
-        return get_object_vars($this);
+        return \get_object_vars($this);
     }
 }

--- a/src/Illuminate/Support/Traits/CastsToReadonlyArray.php
+++ b/src/Illuminate/Support/Traits/CastsToReadonlyArray.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait CastsToReadonlyArray
+{
+    public function toReadonlyArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/tests/Support/ReadonlyArrayTest.php
+++ b/tests/Support/ReadonlyArrayTest.php
@@ -2,22 +2,22 @@
 
 namespace Illuminate\Tests\Support;
 
+use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Support\ToReadonlyArray;
 use Illuminate\Support\Traits\CastsToReadonlyArray;
-use PHPUnit\Framework\TestCase;
 
 class ReadonlyArrayTest extends TestCase
 {
-    public function test_can_convert_to_readonly_array(): void
+    public function testToReadonlyArray()
     {
-        $dto = new class implements ToReadonlyArray
-        {
+        $dto = new class() implements ToReadonlyArray {
             use CastsToReadonlyArray;
 
             public function __construct(
                 public readonly string $name = 'Zoran',
-                public readonly int $age = 33,
-            ) {}
+                public readonly int $age = 33
+            ) {
+            }
         };
 
         $this->assertEquals([

--- a/tests/Support/ReadonlyArrayTest.php
+++ b/tests/Support/ReadonlyArrayTest.php
@@ -2,14 +2,15 @@
 
 namespace Illuminate\Tests\Support;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Contracts\Support\ToReadonlyArray;
 use Illuminate\Support\Traits\CastsToReadonlyArray;
+use PHPUnit\Framework\TestCase;
 
 class ReadonlyArrayTest extends TestCase
 {
     public function testToReadonlyArray()
     {
+
         $dto = new class() implements ToReadonlyArray {
             use CastsToReadonlyArray;
 

--- a/tests/Support/ReadonlyArrayTest.php
+++ b/tests/Support/ReadonlyArrayTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Contracts\Support\ToReadonlyArray;
+use Illuminate\Support\Traits\CastsToReadonlyArray;
+use PHPUnit\Framework\TestCase;
+
+class ReadonlyArrayTest extends TestCase
+{
+    public function test_can_convert_to_readonly_array(): void
+    {
+        $dto = new class implements ToReadonlyArray
+        {
+            use CastsToReadonlyArray;
+
+            public function __construct(
+                public readonly string $name = 'Zoran',
+                public readonly int $age = 33,
+            ) {}
+        };
+
+        $this->assertEquals([
+            'name' => 'Zoran',
+            'age' => 33,
+        ], $dto->toReadonlyArray());
+    }
+}

--- a/tests/Support/ReadonlyArrayTest.php
+++ b/tests/Support/ReadonlyArrayTest.php
@@ -10,7 +10,6 @@ class ReadonlyArrayTest extends TestCase
 {
     public function testToReadonlyArray()
     {
-
         $dto = new class() implements ToReadonlyArray
         {
             use CastsToReadonlyArray;

--- a/tests/Support/ReadonlyArrayTest.php
+++ b/tests/Support/ReadonlyArrayTest.php
@@ -11,7 +11,8 @@ class ReadonlyArrayTest extends TestCase
     public function testToReadonlyArray()
     {
 
-        $dto = new class() implements ToReadonlyArray {
+        $dto = new class() implements ToReadonlyArray
+        {
             use CastsToReadonlyArray;
 
             public function __construct(


### PR DESCRIPTION
### Summary

This pull request introduces two additions to the Laravel framework:

- `Illuminate\Contracts\Support\ToReadonlyArray` – a new contract for defining objects that can be converted to readonly arrays.
- `Illuminate\Support\Traits\CastsToReadonlyArray` – a reusable trait that automatically converts public readonly properties to an array using `get_object_vars($this)`.

These additions are inspired by real-world usage patterns in Laravel applications where developers increasingly rely on **readonly DTOs**, **event payloads**, **job data**, and **resource objects** that benefit from an immutable, array-based representation.

---

### Motivation

This contribution originates from my own experience building DTO-based modular Laravel systems. I’ve consistently found the need to convert DTOs and other readonly objects to arrays — especially in the following use cases:

- Mass-assignment in Eloquent (`Model::create($dto->toReadonlyArray())`)
- Queue jobs and event broadcasting with immutable data
- API resources and frontend hydration (e.g., Inertia, Livewire)
- Logging/auditing with predictable, structured data

Until now, every DTO needed a manually written `toArray()` or `fromArray()` method. The provided trait eliminates that boilerplate and offers a clean, standardized way to extract readonly data.

---

### Example Usage

```php
use Illuminate\Contracts\Support\ToReadonlyArray;
use Illuminate\Support\Traits\CastsToReadonlyArray;

readonly class ProductDTO implements ToReadonlyArray
{
    use CastsToReadonlyArray;

    public function __construct(
        public int $id,
        public string $name,
        public float $price,
    ) {}
}

$product = new ProductDTO(1, 'T-Shirt', 29.99);
$data = $product->toReadonlyArray(); // ['id' => 1, 'name' => 'T-Shirt', 'price' => 29.99]

Product::create($data);
