### PR TITLE
[12.x] Add `@​context` Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -21,6 +21,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,
+        Concerns\CompilesContexts,
         Concerns\CompilesEchos,
         Concerns\CompilesErrors,
         Concerns\CompilesFragments,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesContexts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesContexts.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesContexts
+{
+    /**
+     * Compile the context statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileContext($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return '<?php $__contextArgs = ['.$expression.'];
+if (context()->has($__contextArgs[0])) :
+if (isset($value)) { $__contextPrevious[] = $value; }
+$value = context()->get($__contextArgs[0]); ?>';
+    }
+
+    /**
+     * Compile the endcontext statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndcontext($expression)
+    {
+        return '<?php unset($value);
+if (isset($__contextPrevious) && !empty($__contextPrevious)) { $value = array_pop($__contextPrevious); }
+if (isset($__contextPrevious) && empty($__contextPrevious)) { unset($__contextPrevious); }
+endif;
+unset($__contextArgs); ?>';
+    }
+}

--- a/tests/View/Blade/BladeContextTest.php
+++ b/tests/View/Blade/BladeContextTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeContextTest extends AbstractBladeTestCase
+{
+    public function testContextsAreCompiled()
+    {
+        $string = '
+@context(\'foo\')
+    <span>{{ $value }}</span>
+@endcontext';
+        $expected = '
+<?php $__contextArgs = [\'foo\'];
+if (context()->has($__contextArgs[0])) :
+if (isset($value)) { $__contextPrevious[] = $value; }
+$value = context()->get($__contextArgs[0]); ?>
+    <span><?php echo e($value); ?></span>
+<?php unset($value);
+if (isset($__contextPrevious) && !empty($__contextPrevious)) { $value = array_pop($__contextPrevious); }
+if (isset($__contextPrevious) && empty($__contextPrevious)) { unset($__contextPrevious); }
+endif;
+unset($__contextArgs); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Adds a new `@context` Blade directive, that operates similar to the existing [`@session`](https://laravel.com/docs/blade#session-directives) directive.

---

## Context Directives

The @context directive may be used to determine if a [context](https://laravel.com/docs/context) value exists. If the context value exists, the template contents within the `@context` and `@endcontext` directives will be evaluated. Within the `@context` directive’s contents, you may echo the `$value` variable to display the context value:

```blade
@context('foo')
    <div>{{ $value }}</div>
@endcontext
```

---

This makes it easy to check if a context value is set and if so, to obtain its value, in Blade templates. My particular use case:

```blade
@context('canonical')
    <link href="{{ $value }}" rel="canonical">
@endcontext
```