### PR TITLE
[12.x] Fix `Collection::pop()` so it mirrors `shift()` semantics on edge-cases 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -993,19 +993,25 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $count
      * @return static<int, TValue>|TValue|null
+     * 
+     * @throws \InvalidArgumentException
      */
     public function pop($count = 1)
     {
-        if ($count < 1) {
+        if ($count < 0) {
+            throw new InvalidArgumentException('Number of popped items may not be less than zero.');
+        }
+
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        if ($count === 0) {
             return new static;
         }
 
         if ($count === 1) {
             return array_pop($this->items);
-        }
-
-        if ($this->isEmpty()) {
-            return new static;
         }
 
         $results = [];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -993,7 +993,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $count
      * @return static<int, TValue>|TValue|null
-     * 
+     *
      * @throws \InvalidArgumentException
      */
     public function pop($count = 1)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -343,7 +343,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(new Collection(['baz', 'bar', 'foo']), (new Collection(['foo', 'bar', 'baz']))->pop(6));
     }
 
-     public function testPopReturnsEmptyCollectionWhenCountIsZero()
+    public function testPopReturnsEmptyCollectionWhenCountIsZero()
     {
         $c = new Collection(['foo', 'bar', 'baz']);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -343,6 +343,28 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(new Collection(['baz', 'bar', 'foo']), (new Collection(['foo', 'bar', 'baz']))->pop(6));
     }
 
+     public function testPopReturnsEmptyCollectionWhenCountIsZero()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+
+        $result = $c->pop(0);
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+        $this->assertEquals(['foo', 'bar', 'baz'], $c->all());
+    }
+
+    public function testPopThrowsExceptionWhenCountIsNegative()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new Collection(['foo']))->pop(-1);
+    }
+
+    public function testPopReturnsNullOnEmptyCollection()
+    {
+        $this->assertNull((new Collection)->pop());
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);


### PR DESCRIPTION
This PR brings `Collection::pop()` in line with both `Collection::shift()` and PHP’s native `array_pop()` when it comes to edge-cases.

`shift()` and `pop()` are conceptual opposites, so they should respond identically in identical situations.

### Current behaviour

| Call | Result |
|------|--------|
| `collect()->pop()`     | `Collection([])` &nbsp;*(whereas `collect()->shift()` -> `null`)* |
| `collect()->pop(0)`    | `Collection([])` |
| `collect()->pop(-1)`   | `Collection([])` &nbsp;*(silently ignores bad input)* |

### What changes with this PR

1. Empty collection -> `null` – mirrors `shift()` and native `array_pop([])`.
2. Negative `$count` -> `InvalidArgumentException` – same guard rail already present in `shift()`.

All other behaviour (counts of `0`, `1`, or `>1`) is untouched.
