### PR TITLE
[13.x] Use exception object in JobAttempted event

### DIFF
--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -9,12 +9,12 @@ class JobAttempted
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @param  bool  $exceptionOccurred  Indicates if an exception occurred while processing the job.
+     * @param  \Throwable|null  $exception  The exception, if one occurred while processing the job.
      */
     public function __construct(
         public $connectionName,
         public $job,
-        public $exceptionOccurred = false,
+        public $exception = null,
     ) {
     }
 
@@ -25,6 +25,6 @@ class JobAttempted
      */
     public function successful(): bool
     {
-        return ! $this->job->hasFailed() && ! $this->exceptionOccurred;
+        return ! $this->job->hasFailed() && is_null($this->exception);
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -445,12 +445,12 @@ class Worker
 
             $this->raiseAfterJobEvent($connectionName, $job);
         } catch (Throwable $e) {
-            $exceptionOccurred = true;
+            $exceptionOccurred = $e;
 
             $this->handleJobException($connectionName, $job, $options, $e);
         } finally {
             $this->events->dispatch(new JobAttempted(
-                $connectionName, $job, $exceptionOccurred ?? false
+                $connectionName, $job, $exceptionOccurred ?? null
             ));
         }
     }


### PR DESCRIPTION
The `/Illuminate/Queue/Events/JobAttempted` event is very useful to track job completions/failures, however in its current form it only passes down an exception that occurred as a `bool`.

This PR changes this to pass down the complete `Throwable $e` so we have more data to work with in the event itself.

Since this is a breaking change I targeted `13.x`. Existing userland code that listens to this event might need to be updated.
