### PR TITLE
[12.x] Add fakeFor and fakeExceptFor methods to Queue facade

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -97,6 +97,53 @@ class Queue extends Facade
     }
 
     /**
+     * Replace the bound instance with a fake that fakes all jobs except the given jobs.
+     *
+     * @param  string[]|string  $jobsToAllow
+     * @return \Illuminate\Support\Testing\Fakes\QueueFake
+     */
+    public static function fakeExcept($jobsToAllow)
+    {
+        return static::fake()->except($jobsToAllow);
+    }
+
+    /**
+     * Replace the bound instance with a fake during the given callable's execution.
+     *
+     * @param  callable  $callable
+     * @param  array  $jobsToFake
+     * @return mixed
+     */
+    public static function fakeFor(callable $callable, array $jobsToFake = [])
+    {
+        $originalQueueManager = static::getFacadeRoot();
+
+        static::fake($jobsToFake);
+
+        return tap($callable(), function () use ($originalQueueManager) {
+            static::swap($originalQueueManager);
+        });
+    }
+
+    /**
+     * Replace the bound instance with a fake during the given callable's execution.
+     *
+     * @param  callable  $callable
+     * @param  array  $jobsToAllow
+     * @return mixed
+     */
+    public static function fakeExceptFor(callable $callable, array $jobsToAllow = [])
+    {
+        $originalQueueManager = static::getFacadeRoot();
+
+        static::fakeExcept($jobsToAllow);
+
+        return tap($callable(), function () use ($originalQueueManager) {
+            static::swap($originalQueueManager);
+        });
+    }
+
+    /**
      * Get the registered name of the component.
      *
      * @return string

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+
+class QueueFakeTest extends TestCase
+{
+    public function testFakeFor()
+    {
+        Queue::fakeFor(function () {
+            Queue::push(new TestJob);
+            Queue::assertPushed(TestJob::class);
+        });
+    }
+
+    public function testFakeExceptFor()
+    {
+        Queue::fakeExceptFor(function () {
+            Queue::push(new TestJob);
+            Queue::push(new OtherTestJob);
+
+            Queue::assertNotPushed(TestJob::class);
+            Queue::assertPushed(OtherTestJob::class);
+        }, [TestJob::class]);
+    }
+
+    public function testFakeExcept()
+    {
+        $fake = Queue::fakeExcept([TestJob::class]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Testing\Fakes\QueueFake::class, $fake);
+    }
+
+    public function testFakeForReturnValue()
+    {
+        $result = Queue::fakeFor(function () {
+            return 'test-value';
+        });
+
+        $this->assertEquals('test-value', $result);
+    }
+
+    public function testFakeExceptForReturnValue()
+    {
+        $result = Queue::fakeExceptFor(function () {
+            return 'test-value';
+        }, []);
+
+        $this->assertEquals('test-value', $result);
+    }
+}
+
+class TestJob
+{
+    use Queueable;
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class OtherTestJob
+{
+    use Queueable;
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -9,6 +9,11 @@ use Orchestra\Testbench\TestCase;
 
 class QueueFakeTest extends TestCase
 {
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('queue.default', 'sync');
+    }
+
     public function testFakeFor()
     {
         Queue::fakeFor(function () {

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Testing\Fakes\QueueFake;
 use Orchestra\Testbench\TestCase;
 
 class QueueFakeTest extends TestCase
@@ -31,7 +32,7 @@ class QueueFakeTest extends TestCase
     {
         $fake = Queue::fakeExcept([TestJob::class]);
 
-        $this->assertInstanceOf(\Illuminate\Support\Testing\Fakes\QueueFake::class, $fake);
+        $this->assertInstanceOf(QueueFake::class, $fake);
     }
 
     public function testFakeForReturnValue()

--- a/tests/Support/SupportFacadesQueueTest.php
+++ b/tests/Support/SupportFacadesQueueTest.php
@@ -35,6 +35,7 @@ class SupportFacadesQueueTest extends TestCase
 
         m::close();
     }
+
     public function testFakeFor()
     {
         Queue::fakeFor(function () {
@@ -56,6 +57,7 @@ class SupportFacadesQueueTest extends TestCase
 
         $this->assertSame($this->queueManager, Queue::getFacadeRoot());
     }
+
     public function testFakeExcept()
     {
         $fake = Queue::fakeExcept(QueueJobStub::class);

--- a/tests/Support/SupportFacadesQueueTest.php
+++ b/tests/Support/SupportFacadesQueueTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Factory as QueueContract;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Testing\Fakes\QueueFake;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class SupportFacadesQueueTest extends TestCase
+{
+    private $queueManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queueManager = m::mock(\Illuminate\Contracts\Queue\Factory::class);
+
+        $container = new Container;
+        $container->instance('queue', $this->queueManager);
+        $container->alias('queue', QueueContract::class);
+
+        Facade::setFacadeApplication($container);
+    }
+
+    protected function tearDown(): void
+    {
+        Queue::clearResolvedInstances();
+        Queue::setFacadeApplication(null);
+
+        m::close();
+    }
+    public function testFakeFor()
+    {
+        Queue::fakeFor(function () {
+            (new QueueForStub)->pushJob();
+
+            Queue::assertPushed(QueueJobStub::class);
+        });
+
+        $this->queueManager->shouldReceive('push')->once();
+
+        (new QueueForStub)->pushJob();
+    }
+
+    public function testFakeForSwapsQueueManager()
+    {
+        Queue::fakeFor(function () {
+            $this->assertInstanceOf(QueueFake::class, Queue::getFacadeRoot());
+        });
+
+        $this->assertSame($this->queueManager, Queue::getFacadeRoot());
+    }
+    public function testFakeExcept()
+    {
+        $fake = Queue::fakeExcept(QueueJobStub::class);
+
+        $this->assertInstanceOf(QueueFake::class, $fake);
+        $this->assertSame($fake, Queue::getFacadeRoot());
+    }
+
+    public function testFakeExceptFor()
+    {
+        Queue::fakeExceptFor(function () {
+            $this->assertInstanceOf(QueueFake::class, Queue::getFacadeRoot());
+        }, [QueueJobStub::class]);
+
+        $this->assertSame($this->queueManager, Queue::getFacadeRoot());
+    }
+
+    public function testFakeExceptForSwapsQueueManager()
+    {
+        Queue::fakeExceptFor(function () {
+            $this->assertInstanceOf(QueueFake::class, Queue::getFacadeRoot());
+        }, []);
+
+        $this->assertSame($this->queueManager, Queue::getFacadeRoot());
+    }
+
+    public function testFakeExceptForReturnValue()
+    {
+        $result = Queue::fakeExceptFor(function () {
+            return 'test-result';
+        });
+
+        $this->assertSame('test-result', $result);
+    }
+
+    public function testFakeForReturnValue()
+    {
+        $result = Queue::fakeFor(function () {
+            return 'test-result';
+        });
+
+        $this->assertSame('test-result', $result);
+    }
+}
+
+class QueueJobStub
+{
+    use Queueable;
+}
+
+class OtherQueueJobStub
+{
+    use Queueable;
+}
+
+class QueueForStub
+{
+    public function pushJob()
+    {
+        Queue::push(new QueueJobStub);
+    }
+}

--- a/tests/Support/SupportFacadesQueueTest.php
+++ b/tests/Support/SupportFacadesQueueTest.php
@@ -19,7 +19,7 @@ class SupportFacadesQueueTest extends TestCase
     {
         parent::setUp();
 
-        $this->queueManager = m::mock(\Illuminate\Contracts\Queue\Factory::class);
+        $this->queueManager = m::mock(Factory::class);
 
         $container = new Container;
         $container->instance('queue', $this->queueManager);


### PR DESCRIPTION
This PR adds temporary testing methods to the Queue facade, following the same pattern established by the Event facade in #24230.

### What's Added

**New Queue Facade Methods:**

- `Queue::fakeExcept($jobsToAllow)` - Creates a fake that allows certain jobs to be queued normally while faking others
- `Queue::fakeFor($callable, $jobsToFake = [])` - Temporarily replaces the queue with a fake during the execution of a callable
- `Queue::fakeExceptFor($callable, $jobsToAllow = [])` - Temporarily replaces the queue with a fake that allows certain jobs through during the execution of a callable

### Benefits

**Improved Test Isolation:**
```php
// Before: Fake affects the entire test
Queue::fake();
// ... test code ...
// Manual cleanup required

// After: Fake is automatically scoped
Queue::fakeFor(function () {
    Queue::push(new ProcessPayment);
    Queue::assertPushed(ProcessPayment::class);
}); // Original queue automatically restored
````
**Selective Job Faking:**
```php
<?php
// Allow critical jobs to be queued normally, fake others
Queue::fakeExceptFor(function () {
    Queue::push(new CriticalSystemJob);  // Actually queued
    Queue::push(new EmailNotification);  // Faked
    
    Queue::assertNotPushed(CriticalSystemJob::class);
    Queue::assertPushed(EmailNotification::class);
}, [CriticalSystemJob::class]);
```