### PR TITLE
[12.x] Event Lifecycle Hooks

### DIFF
--- a/src/Illuminate/Events/EventHooks.php
+++ b/src/Illuminate/Events/EventHooks.php
@@ -1,0 +1,888 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * @property Container $container
+ */
+trait EventHooks
+{
+    /**
+     * The "before" event hook key.
+     */
+    protected const HOOK_BEFORE = 'before';
+
+    /**
+     * The "after" event hook key.
+     */
+    protected const HOOK_AFTER = 'after';
+
+    /**
+     * The "failure" event hook key.
+     */
+    protected const HOOK_FAILURE = 'failure';
+
+    /**
+     * The available event hooks.
+     */
+    protected const HOOKS = [self::HOOK_BEFORE, self::HOOK_AFTER, self::HOOK_FAILURE];
+
+    /**
+     * The wildcard event key.
+     */
+    protected const WILDCARD = '*';
+
+    /**
+     * The registered event callbacks.
+     *
+     * @var array<string, array<string, array<callable|string>>>
+     * */
+    protected array $callbacks = [];
+
+    /**
+     * Cache for results of expensive method operations.
+     *
+     * @var array{
+     *      has_callbacks?: array<string, bool>,
+     *      has_hierarchical_callbacks?: array<string, bool>,
+     *      hierarchical_callbacks?: array<string, array<callable|string>>,
+     *      aggregated_callbacks?: array<string, array<callable|string>>,
+     *      prepared_callbacks?: array<string, array<callable|string>>,
+     *      ordered_callbacks?: array<string, array<callable|string>>,
+     *      event_callbacks?: array<string, array<string, array<callable|string>>>,
+     *      hook_and_event_callbacks?: array<string, array<callable|string>>,
+     *      event_hierarchies?: array<string, array<string>>,
+     *      event_and_object_hierarchies?: array<string, array<string>>,
+     *  }
+     */
+    protected array $cache = [];
+
+    /**
+     * Get registered event callbacks, optionally filtered by a hook and/or event.
+     *
+     * @return array<string, array<string, array<callable|string>>>
+     *
+     * @throws InvalidArgumentException
+     */
+    public function callbacks(?string $hook = null, ?string $event = null): array
+    {
+        return match (true) {
+            // order here is important, as conditions of helper methods are evaluated in order
+            $this->wantsAllCallbacks($hook, $event) => $this->callbacks,
+            $this->wantsHookAndEventCallbacks($hook, $event) => $this->callbacksForHookAndEvent($hook, $event),
+            $this->wantsEventCallbacks($hook, $event) => $this->callbacksForEvent($hook),
+            $this->wantsHookCallbacks($hook, $event) => $this->callbacksForHook($hook)
+        };
+    }
+
+    /**
+     * Register callback(s) to be executed before event dispatch.
+     *
+     * @param  callable|string|array<callable|string>  $events
+     * @param  callable|string|array<callable|string>|null  $callbacks
+     *
+     * @throws InvalidArgumentException
+     */
+    public function before(callable|string|array $events, callable|string|array|null $callbacks = null): static
+    {
+        return tap($this, function () use ($events, $callbacks) {
+            $this->registerCallbacks(
+                static::HOOK_BEFORE,
+                $callbacks ?? $events,
+                (is_null($callbacks) || $events === static::WILDCARD)
+                    ? null
+                    : $events
+            );
+        });
+    }
+
+    /**
+     * Register callback(s) to be executed after event dispatch.
+     *
+     * @param  callable|string|array<callable|string>  $events
+     * @param  callable|string|array<callable|string>|null  $callbacks
+     *
+     * @throws InvalidArgumentException
+     */
+    public function after(callable|string|array $events, callable|string|array|null $callbacks = null): static
+    {
+        return tap($this, function () use ($events, $callbacks) {
+            $this->registerCallbacks(
+                static::HOOK_AFTER,
+                $callbacks ?? $events,
+                (is_null($callbacks) || $events === static::WILDCARD)
+                    ? null
+                    : $events
+            );
+        });
+    }
+
+    /**
+     * Register callback(s) to be executed if event dispatch fails.
+     *
+     * @param  callable|string|array<callable|string>  $events
+     * @param  callable|string|array<callable|string>|null  $callbacks
+     *
+     * @throws InvalidArgumentException
+     */
+    public function failure(callable|string|array $events, callable|string|array|null $callbacks = null): static
+    {
+        return tap($this, function () use ($events, $callbacks) {
+            $this->registerCallbacks(
+                static::HOOK_FAILURE,
+                $callbacks ?? $events,
+                (is_null($callbacks) || $events === static::WILDCARD)
+                    ? null
+                    : $events
+            );
+        });
+    }
+
+    /**
+     * Determine if the given string is a valid hook.
+     */
+    protected function isHook(?string $hook = null): bool
+    {
+        return in_array($hook, static::HOOKS, true);
+    }
+
+    /**
+     * Determine if callbacks() wants all callbacks.
+     */
+    protected function wantsAllCallbacks(?string $hook, ?string $event): bool
+    {
+        return is_null($hook) && is_null($event);
+    }
+
+    /**
+     * Determine if callbacks() wants callbacks for a specific hook and event.
+     */
+    protected function wantsHookAndEventCallbacks(?string $hook, ?string $event): bool
+    {
+        return ! is_null($hook)
+            && ! is_null($event);
+    }
+
+    /**
+     * Determine if callbacks() wants callbacks for a specific event.
+     */
+    protected function wantsEventCallbacks(string $hook, ?string $event): bool
+    {
+        return $hook === static::WILDCARD || (is_null($event) && ! $this->isHook($hook));
+    }
+
+    /**
+     * Determine if callbacks() wants callbacks for a specific hook.
+     */
+    protected function wantsHookCallbacks(string $hook, ?string $event): bool
+    {
+        return is_null($event) && $this->isHook($hook);
+    }
+
+    /**
+     * Get callbacks for a specific hook and event.
+     *
+     * @return array<string, array<callable|string>>
+     */
+    protected function callbacksForHookAndEvent(string $hook, string $event): array
+    {
+        $this->validateHook($hook);
+
+        return $this->cache['hook_and_event_callbacks'][$this->key($hook, $event)] ??=
+            array_merge(
+                [static::WILDCARD => $this->callbacks[$hook][static::WILDCARD] ?? []],
+                array_reduce(
+                    $this->eventHierarchy($event),
+                    fn ($carry, $key): array => isset($this->callbacks[$hook][$key])
+                        ? array_merge($carry, [$key => $this->callbacks[$hook][$key] ?? []])
+                        : $carry,
+                    []
+                )
+            );
+    }
+
+    /**
+     * Get callbacks for a specific hook.
+     *
+     * @return array<string, array<callable|string>>
+     */
+    protected function callbacksForHook(string $hook): array
+    {
+        $this->validateHook($hook);
+
+        return $this->callbacks[$hook] ?? [];
+    }
+
+    /**
+     * Get callbacks for a specific event.
+     *
+     * @return array<string, array<callable|string>>
+     */
+    protected function callbacksForEvent(string $event): array
+    {
+        return $this->cache['event_callbacks'][$event] ??= [
+            static::HOOK_BEFORE => $this->callbacksForHookAndEvent(static::HOOK_BEFORE, $event),
+            static::HOOK_AFTER => $this->callbacksForHookAndEvent(static::HOOK_AFTER, $event),
+            static::HOOK_FAILURE => $this->callbacksForHookAndEvent(static::HOOK_FAILURE, $event),
+        ];
+    }
+
+    /**
+     * Get the class hierarchy for a specific event string.
+     *
+     * @return array<string>
+     */
+    protected function eventHierarchy(string $event): array
+    {
+        return $this->cache['event_hierarchies'][$event] ??=
+            array_filter(
+                array_merge(
+                    [$event],
+                    class_exists($event)
+                        ? class_parents($event)
+                        : [],
+                    class_exists($event)
+                        ? class_implements($event)
+                        : []
+                )
+            );
+    }
+
+    /**
+     * Get the class hierarchy for a specific event string and object.
+     *
+     * @param  array<int, string|object>  $payload
+     */
+    protected function eventAndObjectHierarchy(string $event, array $payload): array
+    {
+        return $this->cache['event_and_object_hierarchies'][$event] ??=
+            array_merge(
+                [$event],
+                class_exists($event)
+                    ? $this->eventHierarchy($event)
+                    : [],
+                is_object(Arr::first($payload))
+                    ? $this->eventHierarchy(get_class(Arr::first($payload)))
+                    : []
+            );
+    }
+
+    /**
+     * Register event hook callbacks with the dispatcher.
+     *
+     * @param  callable|string|array<callable|string>  $callbacks
+     * @param  string|array<string>|null  $events
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function registerCallbacks(string $hook, callable|string|array $callbacks, string|array|null $events = null): void
+    {
+        $this->validateHook($hook);
+
+        is_null($events)
+            ? $this->registerGlobalCallbacks($hook, $callbacks)
+            : $this->registerEventCallbacks($hook, $callbacks, $events);
+    }
+
+    /**
+     * Register global event hook callbacks with the dispatcher.
+     *
+     * @param  $callbacks  callable|string|array<callable|string>
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function registerGlobalCallbacks(string $hook, callable|string|array $callbacks): void
+    {
+        $this->validateHook($hook);
+
+        foreach (Arr::wrap($callbacks) as $callback) {
+            $this->registerCallback($hook, static::WILDCARD, $callback);
+        }
+    }
+
+    /**
+     * Register event-specific event hook callbacks with the dispatcher.
+     *
+     * @param  callable|string|array<callable|string>  $callbacks
+     * @param  string|array<string>  $events
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function registerEventCallbacks(string $hook, callable|string|array $callbacks, string|array $events): void
+    {
+        $this->validateHook($hook);
+
+        foreach (Arr::wrap($events) as $event) {
+            if (! is_string($event)) {
+                throw new InvalidArgumentException('Event name must be a string, given: '.gettype($event));
+            }
+
+            foreach (Arr::wrap($callbacks) as $callback) {
+                $this->registerCallback($hook, $event, $callback);
+            }
+        }
+    }
+
+    /**
+     * Register an event hook callback.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function registerCallback(string $hook, string $event, callable|string $callback): static
+    {
+        $this->validateHook($hook);
+
+        is_callable($callback) ?: $this->validateCallback($callback);
+
+        return tap($this, function () use ($hook, $event, $callback): void {
+            $this->addCallbackToRegistry($hook, $event, $callback);
+            $this->updateHasCallbacksCache($hook, $event);
+        });
+    }
+
+    /**
+     * Add a callback to the registry for a specific hook and event.
+     *
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function addCallbackToRegistry(string $hook, string $event, callable|string $callback): void
+    {
+        $this->validateHook($hook);
+
+        $this->callbacks[$hook][$event][] = $callback;
+    }
+
+    /**
+     * Invoke the registered event callbacks for a specific hook.
+     *
+     * @param  array<int, mixed>  $payload
+     *
+     * @throws InvalidArgumentException
+     * @throws BindingResolutionException
+     */
+    protected function invokeCallbacks(string $hook, string $event, array $payload): void
+    {
+        $this->validateHook($hook);
+
+        foreach ($this->prepareCallbacks($hook, $event, $payload) as $callback) {
+            $this->invokeCallback($callback, $payload);
+        }
+    }
+
+    /**
+     * Determine if the given event/hook has callbacks (including hierarchical callbacks).
+     *
+     * @param  $payload  array<int, string|object>
+     */
+    protected function hasCallbacks(string $hook, string $event, array $payload): bool
+    {
+        $this->validateHook($hook);
+
+        return (is_object($object = Arr::first($payload)) && $this->checkObjectForCallbacks($hook, $object))
+            || $this->cache['has_callbacks'][$this->key($hook, $event)] ??=
+                $this->hasHierarchicalCallbacks($hook, $event, $payload)
+                    || ! empty($this->callbacks[$hook][$event] ?? [])
+                    || ! empty($this->callbacks[$hook][static::WILDCARD] ?? []);
+    }
+
+    /**
+     * Determine if the given event object has implemented the specified hook.
+     */
+    protected function checkObjectForCallbacks(string $hook, object $event): bool
+    {
+        $this->validateHook($hook);
+
+        return method_exists($event, $hook);
+    }
+
+    /**
+     * Determine if the given event/hook has callbacks registered for its parent(s)/interface(s).
+     *
+     * @param  array<int, string|object>  $payload
+     */
+    protected function hasHierarchicalCallbacks(string $hook, string $event, array $payload): bool
+    {
+        $this->validateHook($hook);
+
+        if (! $this->isHierarchicalEvent($event, $payload)) {
+            return false;
+        }
+
+        if ($this->checkCacheForHierarchicalCallbacks($hook, $event, $payload)) {
+            return true;
+        }
+
+        foreach ($this->eventAndObjectHierarchy($event, $payload) as $key) {
+            if (! empty($this->callbacks[$hook][$key])) {
+                return $this->cache['has_hierarchical_callbacks'][$this->key($hook, $key)] = true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the event has a possible hierarchy.
+     *
+     * @param  $payload  array<int, string|object>
+     */
+    protected function isHierarchicalEvent(string $event, array $payload): bool
+    {
+        return class_exists($event) || ! is_object(Arr::first($payload));
+    }
+
+    /**
+     * Determine if the cache has registered hierarchical callbacks for the given event/hook.
+     *
+     * @param  array<int, mixed>  $payload
+     */
+    protected function checkCacheForHierarchicalCallbacks(string $hook, string $event, array $payload): bool
+    {
+        $this->validateHook($hook);
+
+        return (! empty($this->cache['has_hierarchical_callbacks'][$this->key($hook, $event)]))
+            || (is_object($object = Arr::first($payload))
+                && (! empty($this->cache['has_hierarchical_callbacks'][$this->key($hook, get_class($object))])));
+    }
+
+    /**
+     * Update the cached results for the given hook and event.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function updateHasCallbacksCache(string $hook, string $event): void
+    {
+        $this->validateHook($hook);
+
+        $this->cache['has_callbacks'][$this->key($hook, $event)] = true;
+    }
+
+    /**
+     * Aggregates, formats, and orders callbacks for a specific hook and event.
+     *
+     * @param  array<int, mixed>  $payload
+     * @return array<callable|string>
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function prepareCallbacks(string $hook, string $event, array $payload): array
+    {
+        $this->validateHook($hook);
+
+        return $this->cache['prepared_callbacks'][$this->key($hook, $event)] ??=
+            $this->orderCallbacks($hook, $event, $this->aggregateCallbacks($hook, $event, $payload));
+    }
+
+    /**
+     * Aggregate callbacks for a specific hook and event, including wildcard callbacks.
+     *
+     * @param  array<int, mixed>  $payload
+     * @return array<callable|string>
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function aggregateCallbacks(string $hook, string $event, array $payload): array
+    {
+        $this->validateHook($hook);
+
+        return $this->cache['aggregated_callbacks'][$this->key($hook, $event)] ??=
+           array_unique(
+               array_merge(
+                   $this->callbacks[$hook][static::WILDCARD] ?? [],
+                   $this->aggregateHierarchicalCallbacks($hook, $event, $payload),
+                   (! empty($callback = $this->prepareEventObjectCallback($hook, $payload)))
+                       ? [$callback]
+                       : [],
+               ),
+               SORT_REGULAR
+           );
+    }
+
+    /**
+     * Aggregate hierarchical callbacks for a specific hook and event.
+     *
+     * @param  array<int, mixed>  $payload
+     * @return array<callable|string>
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function aggregateHierarchicalCallbacks(string $hook, string $event, array $payload): array
+    {
+        $this->validateHook($hook);
+
+        return $this->cache['hierarchical_callbacks'][$this->key($hook, $event)] ??=
+            array_reduce(
+                $this->eventAndObjectHierarchy($event, $payload),
+                fn ($carry, $key): array => isset($this->callbacks[$hook][$key])
+                    ? array_merge($carry, $this->callbacks[$hook][$key])
+                    : $carry,
+                []
+            );
+    }
+
+    /**
+     * Prepare the event object callback.
+     *
+     * @param  array<int, mixed>  $payload
+     * @return array{0: object, 1: string}|array{}
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function prepareEventObjectCallback(string $hook, array $payload): array
+    {
+        $this->validateHook($hook);
+
+        return (! empty($payload)
+            && is_object($event = Arr::first($payload))
+            && method_exists($event, $hook))
+                ? [$event, $hook]
+                : [];
+    }
+
+    /**
+     * Order the callbacks based on the hook type.
+     *
+     * @return array<callable|string>
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function orderCallbacks(string $hook, string $event, array $callbacks): array
+    {
+        $this->validateHook($hook);
+
+        // FIFO for setup hooks, LIFO for cleanup hooks
+        return $this->cache['ordered_callbacks'][$this->key($hook, $event)] ??=
+            in_array($hook, [static::HOOK_AFTER, static::HOOK_FAILURE], true)
+                ? array_reverse($callbacks)
+                : $callbacks;
+    }
+
+    /**
+     * Invoke the given callback with the provided payload.
+     *
+     * @param  array<int, object|string>  $payload
+     *
+     * @throws BindingResolutionException
+     */
+    protected function invokeCallback(callable|array|string $callback, array $payload): void
+    {
+        is_callable($callback) ?: $this->validateCallback($callback);
+
+        match (true) {
+            // the order of the following match cases is integral as we want to make callables that
+            // are neither closure nor functions via the container to auto-inject their dependencies
+            is_array($callback) => $this->invokeArrayCallback($callback, $payload),
+            is_string($callback) => $this->invokeStringCallback($callback, $payload),
+            is_callable($callback) => $callback(...$payload),
+            default => $this->invalidCallback(),
+        };
+    }
+
+    /**
+     * Invoke the given array callback with the provided payload.
+     *
+     * @param  array{0: object|string, 1: string}  $callback
+     * @param  array<int, object|string>  $payload
+     *
+     * @throws InvalidArgumentException
+     * @throws BindingResolutionException
+     */
+    protected function invokeArrayCallback(array $callback, array $payload): void
+    {
+        match (true) {
+
+            // [$object, 'method']
+            $this->isObjectArrayCallback($callback) => $this->invokeObjectArrayCallback($callback, $payload),
+
+            // ['classname', 'method']
+            $this->isStringArrayCallback($callback) => $this->invokeStringArrayCallback($callback, $payload),
+
+            default => $this->invalidCallback(),
+        };
+    }
+
+    /**
+     * Determine if the given array callback is a valid object method callback.
+     *
+     * @param  array{0: object, 1: string}  $callback
+     */
+    protected function isObjectArrayCallback(array $callback): bool
+    {
+        return is_object($object = Arr::first($callback))
+            && is_string($method = Arr::last($callback))
+            && method_exists($object, $method);
+    }
+
+    /**
+     * Invoke the given object array callback with the provided payload.
+     *
+     * @param  array{0: object, 1: string}  $callback
+     * @param  array<int, object|string>  $payload
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function invokeObjectArrayCallback(array $callback, array $payload): void
+    {
+        Arr::first($callback)->{Arr::last($callback)}(...$payload);
+    }
+
+    /**
+     * Determine if the given array callback is a valid object method callback.
+     *
+     * @param  array{0: string, 1: string}  $callback
+     */
+    protected function isStringArrayCallback(array $callback): bool
+    {
+        return is_string($class = Arr::first($callback))
+            && is_string($method = Arr::last($callback))
+            && class_exists($class)
+            && method_exists($class, $method);
+    }
+
+    /**
+     * Invoke the given string array callback with the provided payload.
+     *
+     * @param  array{0: string, 1: string}  $callback
+     * @param  array<int, object|string>  $payload
+     *
+     * @throws BindingResolutionException
+     */
+    protected function invokeStringArrayCallback(array $callback, array $payload): void
+    {
+        $this->container()
+            ->make(Arr::first(array: $callback))->{Arr::last($callback)}(...$payload);
+    }
+
+    /**
+     * Invoke the given string callback with the provided payload.
+     *
+     * @param  array<int, mixed>  $payload
+     *
+     * @throws InvalidArgumentException
+     * @throws BindingResolutionException
+     */
+    protected function invokeStringCallback(string $callback, array $payload): void
+    {
+        match (true) {
+            $this->isHandleableClassStringCallback($callback) => $this->invokeHandleableClassStringCallback($callback, $payload),
+            $this->isInvokableClassStringCallback($callback) => $this->invokeInvokableClassStringCallback($callback, $payload),
+            $this->isClassAndMethodStringCallback($callback) => $this->invokeClassAndMethodStringCallback($callback, $payload),
+            default => $this->invalidCallback(),
+        };
+    }
+
+    /**
+     * Determine if the given string callback is a valid class with a handle method.
+     */
+    protected function isHandleableClassStringCallback(string $callback): bool
+    {
+        return class_exists($callback)
+            && method_exists($callback, 'handle');
+    }
+
+    /**
+     * Make and invoke the handleable class string callback with the provided payload.
+     *
+     * @param  array<int, mixed>  $payload
+     *
+     * @throws BindingResolutionException
+     */
+    protected function invokeHandleableClassStringCallback(string $callback, array $payload): void
+    {
+        $this->container()->make($callback)->handle(...$payload);
+    }
+
+    /**
+     * Determine if the given string callback is a valid class with an __invoke method.
+     */
+    protected function isInvokableClassStringCallback(string $callback): bool
+    {
+        return class_exists($callback)
+            && method_exists($callback, '__invoke');
+    }
+
+    /**
+     * Make and invoke the invokable class string callback with the provided payload.
+     *
+     * @param  array<int, mixed>  $payload
+     *
+     * @throws BindingResolutionException
+     */
+    protected function invokeInvokableClassStringCallback(string $callback, array $payload): void
+    {
+        $this->container()->make($callback)(...$payload);
+    }
+
+    /**
+     * Determine if the given string callback is a valid class and method string callback.
+     */
+    protected function isClassAndMethodStringCallback(string $callback): bool
+    {
+        return ($callback = Str::of($callback)->replace('::', '@'))->contains('@')
+            && class_exists($class = ($segments = $callback->explode('@'))->first())
+            && method_exists($class, $segments->last());
+    }
+
+    /**
+     * Make and invoke the class and method string callback with the provided payload.
+     *
+     * @param  array<int, mixed>  $payload
+     *
+     * @throws BindingResolutionException
+     */
+    protected function invokeClassAndMethodStringCallback(string $callback, array $payload): void
+    {
+        $this->container()
+            ->make(Str::of($callback)->replace('::', '@')->explode('@')->first())
+            ->{Str::of($callback)->replace('::', '@')->explode('@')->last()}(...$payload);
+    }
+
+    /**
+     * Validate the given hook name.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateHook(string $hook): void
+    {
+        if (! $this->isHook($hook)) {
+            throw new InvalidArgumentException("Invalid hook: {$hook}");
+        }
+    }
+
+    /**
+     * Validate the given string/array callback.
+     *
+     * @param  array<int, mixed>|string  $callback
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateCallback(array|string $callback): void
+    {
+        is_array($callback)
+            ? $this->validateArrayCallback($callback)
+            : $this->validateStringCallback($callback);
+    }
+
+    /**
+     * Validate the given array callback.
+     *
+     * @param  array<int, mixed>  $callback
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateArrayCallback(array $callback): void
+    {
+        if (! $this->validateArrayCallbackStructure($callback) || ! $this->validateArrayCallbackTarget($callback)) {
+            $this->invalidCallback();
+        }
+    }
+
+    /**
+     * Validate the given array callback structure.
+     *
+     * @param  array<int, mixed>  $callback
+     */
+    protected function validateArrayCallbackStructure(array $callback): bool
+    {
+        return count($callback) === 2
+            && is_string(Arr::last($callback))
+            && (is_object($first = Arr::first($callback)) || is_string($first));
+    }
+
+    /**
+     * Validate the given array callback target.
+     *
+     * @param  array<int, mixed>  $callback
+     */
+    protected function validateArrayCallbackTarget(array $callback): bool
+    {
+        return is_object($first = Arr::first($callback))
+            ? method_exists($first, Arr::last($callback))
+            : (class_exists($first) && method_exists($first, Arr::last($callback)));
+    }
+
+    /**
+     * Validate the given string callback.
+     *
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateStringCallback(string $callback): void
+    {
+        match (($segments = Str::of($callback)->replace('::', '@')->explode('@'))->count()) {
+            1 => $this->validateOneSegmentStringCallback($segments),
+            2 => $this->validateTwoSegmentStringCallback($segments),
+            default => $this->invalidCallback(),
+        };
+    }
+
+    /**
+     * Validate the given one-segment string callback.
+     *
+     * @param  Collection<int, string>  $segments
+     **/
+    protected function validateOneSegmentStringCallback(Collection $segments): void
+    {
+        if (! class_exists($class = $segments->first())
+            || (! method_exists($class, '__invoke') && ! method_exists($class, 'handle'))
+        ) {
+            $this->invalidCallback();
+        }
+    }
+
+    /**
+     * Validate the given two-segment string callback.
+     *
+     * @param  Collection<int, string>  $segments
+     **/
+    protected function validateTwoSegmentStringCallback(Collection $segments): void
+    {
+        if (! class_exists($class = $segments->first()) || ! method_exists($class, $segments->last())) {
+            $this->invalidCallback();
+        }
+    }
+
+    /**
+     * Generate a cache key for the given hook and event.
+     */
+    protected function key(string $hook, string $event): string
+    {
+        return "$hook:$event";
+    }
+
+    /**
+     * Get the container instance.
+     *
+     * @throws RuntimeException
+     **/
+    protected function container(): Container
+    {
+        if (! isset($this->container)) {
+            throw new RuntimeException(
+                'Container instance is not set. '
+                .'Ensure the trait is used in a class that properly initializes the container.'
+            );
+        }
+
+        return $this->container;
+    }
+
+    /**
+     * Throw an exception for an invalid callback.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function invalidCallback(): never
+    {
+        throw new InvalidArgumentException('Invalid callback provided.');
+    }
+}

--- a/src/Illuminate/Events/EventPropagationException.php
+++ b/src/Illuminate/Events/EventPropagationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Events;
+
+use RuntimeException;
+
+class EventPropagationException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -35,6 +35,10 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static \Illuminate\Support\Collection dispatched(string $event, callable|null $callback = null)
  * @method static bool hasDispatched(string $event)
  * @method static array dispatchedEvents()
+ * @method static array callbacks(?string $hook = null, ?string $event = null)
+ * @method static \Illuminate\Events\Dispatcher before(callable|string|array $events, callable|string|array|null $callbacks = null)
+ * @method static \Illuminate\Events\Dispatcher after(callable|string|array $events, callable|string|array|null $callbacks = null)
+ * @method static \Illuminate\Events\Dispatcher failure(callable|string|array $events, callable|string|array|null $callbacks = null)
  *
  * @see \Illuminate\Events\Dispatcher
  * @see \Illuminate\Support\Testing\Fakes\EventFake

--- a/tests/Events/EventHooksTest.php
+++ b/tests/Events/EventHooksTest.php
@@ -1,0 +1,1251 @@
+<?php
+
+namespace Illuminate\Tests\Events;
+
+use Illuminate\Container\Container;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Events\EventPropagationException;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class EventHooksTest extends TestCase
+{
+    private TestDispatcher $dispatcher;
+
+    private array $invoked = [];
+
+    private array $order = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dispatcher = new TestDispatcher(new Container);
+    }
+
+    public function test_registers_wildcard_callbacks_correctly(): void
+    {
+        $this->dispatcher->before($callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::WILDCARD],
+            'One before callback should be registered for wildcard events.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::WILDCARD]), $callback,
+            'The expected before callback should be registered for wildcard events.');
+    }
+
+    public function test_registers_before_callbacks_correctly(): void
+    {
+        $this->dispatcher->before(static::EVENT, $callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT],
+            'One before callback should be registered for the event.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT]), $callback,
+            'The expected before callback should be registered for the event.');
+    }
+
+    public function test_registers_after_callbacks_correctly(): void
+    {
+        $this->dispatcher->after(static::EVENT, $callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_AFTER][static::EVENT],
+            'One after callback should be registered for the event.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_AFTER][static::EVENT]), $callback,
+            'The expected after callback should be registered for the event.');
+    }
+
+    public function test_registers_failure_callbacks_correctly(): void
+    {
+        $this->dispatcher->failure(static::EVENT, $callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_FAILURE][static::EVENT],
+            'One failure callback should be registered for the event.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_FAILURE][static::EVENT]), $callback,
+            'The expected failure callback should be registered for the event.');
+    }
+
+    public function test_registers_multiple_callbacks_for_single_event_correctly(): void
+    {
+        $this->dispatcher->before(static::EVENT, $callback1 = static fn (): string => static::VALID_CALLBACK.'1');
+        $this->dispatcher->before(static::EVENT, $callback2 = static fn (): string => static::VALID_CALLBACK.'2');
+
+        $this->assertCount(2, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT],
+            'Two before callbacks should be registered for the event.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT]), $callback1,
+            'The expected first before callback should be registered for the event.');
+        $this->assertEquals(Arr::last($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT]), $callback2,
+            'The expected second before callback should be registered for the event.');
+    }
+
+    public function test_registers_callbacks_for_multiple_events_correctly(): void
+    {
+        $this->dispatcher->before(static::EVENT.'1', $callback1 = static fn (): string => static::VALID_CALLBACK);
+        $this->dispatcher->before(static::EVENT.'2', $callback2 = static fn (): string => static::VALID_CALLBACK);
+
+        $callbacks1 = $this->dispatcher->callbacks(static::HOOK_BEFORE, static::EVENT.'1');
+        $callbacks2 = $this->dispatcher->callbacks(static::HOOK_BEFORE, static::EVENT.'2');
+
+        $this->assertCount(1, $callbacks1[static::EVENT.'1'],
+            'One before callback should be registered for event 1.');
+        $this->assertCount(1, $callbacks2[static::EVENT.'2'],
+            'One before callback should be registered for event 2.');
+        $this->assertEquals(Arr::first($callbacks1[static::EVENT.'1']), $callback1,
+            'The expected before callback should be registered for event 1.');
+        $this->assertEquals(Arr::first($callbacks2[static::EVENT.'2']), $callback2,
+            'The expected before callback should be registered for event 2.');
+    }
+
+    public function test_registers_array_of_callbacks_for_single_event_correctly(): void
+    {
+        $this->dispatcher->before(static::EVENT, [
+            $callback1 = static fn (): string => static::VALID_CALLBACK.'1',
+            $callback2 = static fn (): string => static::VALID_CALLBACK.'2',
+        ]);
+
+        $callbacks = $this->dispatcher->callbacks(static::HOOK_BEFORE, static::EVENT);
+
+        $this->assertCount(2, $callbacks[static::EVENT],
+            'Two before callbacks should be registered for the event.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT]), $callback1,
+            'The expected first before callback should be registered for the event.');
+        $this->assertEquals(Arr::last($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT]), $callback2,
+            'The expected second before callback should be registered for the event.');
+    }
+
+    public function test_registers_single_callback_for_array_of_events_correctly(): void
+    {
+        $this->dispatcher->before([static::EVENT.'1', static::EVENT.'2'], $callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT.'1'],
+            'One before callback should be registered for event 1.');
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT.'2'],
+            'One before callback should be registered for event 2.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT.'1']), $callback,
+            'The expected before callback should be registered for event 1.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT.'2']), $callback,
+            'The expected before callback should be registered for event 2.');
+    }
+
+    public function test_registers_global_callbacks_correctly(): void
+    {
+        $this->dispatcher->before($callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertArrayHasKey(static::WILDCARD, $this->dispatcher->callbacks(static::HOOK_BEFORE),
+            'The callback array should have an entry for the before hook for wildcard events.');
+        $this->assertCount(1, $this->dispatcher->callbacks()[static::HOOK_BEFORE][static::WILDCARD],
+            'One before callback should be registered for wildcard events.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::WILDCARD]), $callback,
+            'The expected before callback should be registered for wildcard events.');
+    }
+
+    public function test_registered_callbacks_can_be_accessed_correctly(): void
+    {
+        $this->dispatcher->before(static::EVENT.'1', $callback1 = static fn (): string => static::VALID_CALLBACK.'1');
+        $this->dispatcher->after(static::EVENT.'2', $callback2 = static fn (): string => static::VALID_CALLBACK.'2');
+        $this->dispatcher->failure($callback3 = static fn (): string => static::VALID_CALLBACK.'3');
+
+        $this->assertArrayHasKey(static::HOOK_BEFORE, $this->dispatcher->callbacks(),
+            'The callback array should have an entry for the before hook when calling the callbacks() method without arguments.');
+        $this->assertArrayHasKey(static::EVENT.'1', $this->dispatcher->callbacks(static::HOOK_BEFORE),
+            'The callback array should have an entry for the before hook for event 1 when calling the callbacks() method with the before hook argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_BEFORE][static::EVENT.'1']), $callback1,
+            'The expected before callback should be registered for event 1 when calling the callbacks() method without arguments.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::HOOK_BEFORE)[static::EVENT.'1']), $callback1,
+            'The expected before callback should be registered for event 1 when calling the callbacks() method with the before hook argument.');
+        $this->assertArrayHasKey(static::HOOK_BEFORE, $this->dispatcher->callbacks(static::EVENT.'1'),
+            'The callback array should have an entry for the before hook when calling the callbacks() method with the event argument.');
+        $this->assertArrayHasKey(static::EVENT.'1', $this->dispatcher->callbacks(static::EVENT.'1')[static::HOOK_BEFORE],
+            'The callback array should have an entry for the before hook for event 1 when calling the callbacks() method with the event argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::EVENT.'1')[static::HOOK_BEFORE][static::EVENT.'1']), $callback1,
+            'The expected before callback should be registered for event 1 when calling the callbacks() method with the event argument.');
+
+        $this->assertArrayHasKey(static::HOOK_AFTER, $this->dispatcher->callbacks(),
+            'The callback array should have an entry for the after hook when calling the callbacks() method without arguments.');
+        $this->assertArrayHasKey(static::EVENT.'2', $this->dispatcher->callbacks(static::HOOK_AFTER),
+            'The callback array should have an entry for the after hook for event 2 when calling the callbacks() method with the after hook argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_AFTER][static::EVENT.'2']), $callback2,
+            'The expected after callback should be registered for event 2 when calling the callbacks() method without arguments.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::HOOK_AFTER)[static::EVENT.'2']), $callback2,
+            'The expected after callback should be registered for event 2 when calling the callbacks() method with the after hook argument.');
+        $this->assertArrayHasKey(static::HOOK_AFTER, $this->dispatcher->callbacks(static::EVENT.'2'),
+            'The callback array should have an entry for the after hook when calling the callbacks() method with the event argument.');
+        $this->assertArrayHasKey(static::EVENT.'2', $this->dispatcher->callbacks(static::EVENT.'2')[static::HOOK_AFTER],
+            'The callback array should have an entry for the after hook for event 2 when calling the callbacks() method with the event argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::EVENT.'2')[static::HOOK_AFTER][static::EVENT.'2']), $callback2,
+            'The expected after callback should be registered for event 2 when calling the callbacks() method with the event argument.');
+
+        $this->assertArrayHasKey(static::HOOK_FAILURE, $this->dispatcher->callbacks(),
+            'The callback array should have an entry for the failure hook when calling the callbacks() method without arguments.');
+        $this->assertArrayHasKey(static::WILDCARD, $this->dispatcher->callbacks(static::HOOK_FAILURE),
+            'The callback array should have an entry for the failure hook for wildcard events when calling the callbacks() method with the failure hook argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks()[static::HOOK_FAILURE][static::WILDCARD]), $callback3,
+            'The expected failure callback should be registered for wildcard events when calling the callbacks() method without arguments.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::HOOK_FAILURE)[static::WILDCARD]), $callback3,
+            'The expected failure callback should be registered for wildcard events when calling the callbacks() method with the failure hook argument.');
+        $this->assertArrayHasKey(static::HOOK_FAILURE, $this->dispatcher->callbacks(static::WILDCARD),
+            'The callback array should have an entry for the failure hook when calling the callbacks() method with the event argument.');
+        $this->assertArrayHasKey(static::WILDCARD, $this->dispatcher->callbacks(static::WILDCARD)[static::HOOK_FAILURE],
+            'The callback array should have an entry for the failure hook for wildcard events when calling the callbacks() method with the event argument.');
+        $this->assertEquals(Arr::first($this->dispatcher->callbacks(static::WILDCARD)[static::HOOK_FAILURE][static::WILDCARD]), $callback3,
+            'The expected failure callback should be registered for wildcard events when calling the callbacks() method with the event argument.');
+    }
+
+    public function test_registered_hierarchical_callbacks_can_be_accessed_correctly(): void
+    {
+        $this->dispatcher->before(EventInterface::class, $interface = static fn (): string => static::VALID_CALLBACK.'interface');
+        $this->dispatcher->before(ParentEvent::class, $parent = static fn (): string => static::VALID_CALLBACK.'parent');
+        $this->dispatcher->before(ChildEvent::class, $child = static fn (): string => static::VALID_CALLBACK.'child');
+        $this->dispatcher->before(static::WILDCARD, $wildcard = static fn (): string => static::EVENT.static::WILDCARD);
+
+        $this->assertEquals($wildcard, Arr::first($this->dispatcher->callbacks(EventInterface::class)[static::HOOK_BEFORE][static::WILDCARD]),
+            'The expected interface before callback should be registered for the event when calling the callbacks() method with the event argument.');
+        $this->assertEquals($interface, Arr::first($this->dispatcher->callbacks(static::HOOK_BEFORE)[EventInterface::class]),
+            'The expected parent before callback should be registered for the event when calling the callbacks() method with the event argument.');
+        $this->assertEquals($parent, Arr::first($this->dispatcher->callbacks(static::HOOK_BEFORE)[ParentEvent::class]),
+            'The expected event before callback should be registered for the event when calling the callbacks() method with the event argument.');
+        $this->assertEquals($child, Arr::first($this->dispatcher->callbacks(static::HOOK_BEFORE)[ChildEvent::class]),
+            'The expected wildcard before callback should be registered for the event when calling the callbacks() method with the event argument.');
+    }
+
+    public function test_invalid_callback_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->dispatcher->before(static::EVENT, static::INVALID_CALLBACK);
+    }
+
+    public function test_callback_with_nonexistent_class_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->call('validateCallback', [static::INVALID_CLASS]);
+    }
+
+    public function test_callback_with_nonexistent_method_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->call('validateCallback', [MethodCallbackClass::class.'@'.static::INVALID_METHOD]);
+    }
+
+    public function test_invoking_invalid_callback_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->call('invokeCallback', [static::INVALID_CALLBACK, []]);
+    }
+
+    public function test_validates_callback_string_with_at_notation(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->call('validateCallback', [MethodCallbackClass::class.'@'.static::VALID_METHOD]);
+    }
+
+    public function test_validates_callback_string_with_double_colon_notation(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->call('validateCallback', [MethodCallbackClass::class.'::'.static::VALID_METHOD]);
+    }
+
+    public function test_invokes_object_and_method_format_callback_correctly(): void
+    {
+        $this->call('invokeCallback', [[$object = new MethodCallbackClass, static::VALID_METHOD], static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $object->payload,
+            'The callback registered with object and method should have been invoked correctly, receiving the expected payload.');
+    }
+
+    public function test_invokes_class_method_with_at_notation_correctly(): void
+    {
+        $container = tap($this->call('container'), static function (Container $container): void {
+            $container->singleton(MethodCallbackClass::class, static fn (): MethodCallbackClass => new MethodCallbackClass);
+        });
+
+        $this->call('invokeCallback', [MethodCallbackClass::class.'@'.static::VALID_METHOD, static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $container->make(MethodCallbackClass::class)->payload,
+            'The callback registered with classname@method notation should have been invoked correctly, receiving the expected payload.');
+    }
+
+    public function test_invokes_class_method_with_double_colon_notation_correctly(): void
+    {
+        $container = tap($this->call('container'), static function (Container $container): void {
+            $container->singleton(MethodCallbackClass::class, static fn (): MethodCallbackClass => new MethodCallbackClass);
+        });
+
+        $this->call('invokeCallback', [MethodCallbackClass::class.'::'.static::VALID_METHOD, static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $container->make(MethodCallbackClass::class)->payload,
+            'The callback registered with classname::method notation should have been invoked correctly, receiving the expected payload.');
+    }
+
+    public function test_invokes_class_handle_method_with_classname_notation_correctly(): void
+    {
+        $container = tap($this->call('container'), static function (Container $container): void {
+            $container->singleton(MethodCallbackClass::class, static fn (): MethodCallbackClass => new MethodCallbackClass);
+        });
+
+        $this->call('invokeCallback', [MethodCallbackClass::class, static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $container->make(MethodCallbackClass::class)->payload,
+            'The callback registered with classname notation having a handle() method should have been invoked correctly, receiving the expected payload.');
+    }
+
+    public function test_invokes_invokable_class_correctly(): void
+    {
+        $container = tap($this->call('container'), static function (Container $container): void {
+            $container->singleton(InvokableCallbackClass::class, static fn (): InvokableCallbackClass => new InvokableCallbackClass);
+        });
+
+        $this->call('invokeCallback', [InvokableCallbackClass::class, static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $container->make(InvokableCallbackClass::class)->payload,
+            'The callback registered with classname notation having an __invoke() method should have been invoked, receiving the expected payload.');
+    }
+
+    public function test_invokes_closure_callback_correctly(): void
+    {
+        $called = false;
+        $callback = static function (mixed $payload) use (&$called): void {
+            $called = $payload;
+        };
+
+        $this->call('invokeCallback', [$callback, static::PAYLOAD]);
+
+        $this->assertEquals(Arr::first(static::PAYLOAD), $called,
+            'The callback registered with a closure should have been invoked, receiving the expected payload.');
+    }
+
+    public function test_hierarchical_callbacks_are_called_correctly(): void
+    {
+        $parent = function (): void {
+            $this->invoked[] = static::VALID_CALLBACK.'parent';
+        };
+
+        $interface = function (): void {
+            $this->invoked[] = static::VALID_CALLBACK.'interface';
+        };
+
+        $this->dispatcher->before(EventInterface::class, $interface);
+        $this->dispatcher->before(ParentEvent::class, $parent);
+
+        $this->call('invokeCallbacks', [static::HOOK_BEFORE, ChildEvent::class, [new ChildEvent]]);
+
+        $this->assertCount(2, $this->invoked,
+            'Two callbacks should have been invoked.');
+        $this->assertEquals(static::VALID_CALLBACK.'parent', Arr::first($this->invoked),
+            'The hierarchical parent callback should have been invoked first.');
+        $this->assertEquals(static::VALID_CALLBACK.'interface', Arr::last($this->invoked),
+            'The hierarchical interface callback should have been invoked second.');
+    }
+
+    public function test_before_callbacks_are_called_before_listeners(): void
+    {
+        $callback = function (): void {
+            $this->order[] = static::VALID_CALLBACK;
+        };
+
+        $this->dispatcher->before(static::EVENT, $callback);
+
+        $this->dispatcher->listen(
+            static::EVENT,
+            function (): void {
+                $this->order[] = static::LISTENER;
+                $this->invoked[] = static::VALID_CALLBACK;
+            }
+        );
+
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertCount(1, $this->dispatcher->invoked,
+            'One before callback should have been invoked.');
+        $this->assertCount(1, $this->invoked,
+            'One listener should have been invoked.');
+        $this->assertEquals(static::VALID_CALLBACK, Arr::first($this->order),
+            'The expected before callback should have been invoked first.');
+        $this->assertEquals(static::LISTENER, Arr::last($this->order),
+            'The expected listener should have been invoked last.');
+    }
+
+    public function test_after_callbacks_are_called_after_listeners(): void
+    {
+        $callback = function (): void {
+            $this->order[] = static::VALID_CALLBACK;
+        };
+
+        $this->dispatcher->after(static::EVENT, $callback);
+
+        $this->dispatcher->listen(
+            static::EVENT,
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK;
+                $this->order[] = static::LISTENER;
+            }
+        );
+
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertCount(1, $this->invoked,
+            'One listener should have been invoked.');
+        $this->assertCount(1, $this->dispatcher->invoked,
+            'One after callback should have been invoked.');
+        $this->assertEquals(static::LISTENER, Arr::first($this->order),
+            'The expected listener should have been invoked first.');
+        $this->assertEquals(static::VALID_CALLBACK, Arr::last($this->order),
+            'The expected after callback should have been invoked last.');
+    }
+
+    public function test_failure_callbacks_are_called_on_listener_failure(): void
+    {
+        $callback = function (): void {
+            $this->order[] = static::VALID_CALLBACK;
+            $this->invoked[] = static::VALID_CALLBACK;
+        };
+
+        $this->dispatcher->failure(static::EVENT, $callback);
+
+        $listeners = [
+            function (): bool {
+                $this->order[] = static::LISTENER.'1';
+
+                return false;
+            },
+            function (): void {
+                $this->order[] = static::LISTENER.'2';
+            },
+        ];
+
+        foreach ($listeners as $listener) {
+            $this->dispatcher->listen(static::EVENT, $listener);
+        }
+
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        foreach ($this->dispatcher->invoked as $callback) {
+            $this->assertNotEquals(static::HOOK_AFTER, $callback['hook']);
+        }
+
+        $this->assertCount(1, $this->dispatcher->invoked,
+            'One failure callback should have been invoked.');
+        $this->assertCount(1, $this->invoked,
+            'One listener should have been invoked.');
+        $this->assertEquals(static::LISTENER.'1', Arr::first($this->order),
+            'The expected listener should have been invoked first.');
+        $this->assertEquals(static::VALID_CALLBACK, Arr::last($this->order),
+            'The expected failure callback should have been invoked last.');
+    }
+
+    public function test_event_propagation_exception_halts_callback_processing(): void
+    {
+        $callbacks = [
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK.'1';
+            },
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK.'2';
+                throw new EventPropagationException;
+            },
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK.'3';
+            },
+        ];
+
+        $this->dispatcher->before(static::EVENT, $callbacks);
+
+        try {
+            $this->call('invokeCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+            $this->fail('Expected EventPropagationException was not thrown');
+        } catch (EventPropagationException) {
+            $this->assertEquals([static::VALID_CALLBACK.'1', static::VALID_CALLBACK.'2'], $this->invoked,
+                'Only the expected before callbacks for the event should have been invoked.');
+        }
+    }
+
+    public function test_event_propagation_exception_prevents_listener_processing(): void
+    {
+        $callback = false;
+
+        $this->dispatcher->before(static::EVENT, [
+            static function () use (&$callback): void {
+                $callback = true;
+                throw new EventPropagationException;
+            },
+        ]);
+
+        $listener = false;
+
+        $this->dispatcher->listen(
+            static::EVENT,
+            static function () use (&$listener): void {
+                $listener = true;
+            }
+        );
+
+        $result = $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertNull($result, 'The result of listener dispatch should be null when propagation is halted.');
+        $this->assertTrue($callback, 'The before callback for the event should have been invoked.');
+        $this->assertFalse($listener, 'The listener for the event should not be invoked when propagation is halted.');
+    }
+
+    public function test_multiple_listeners_with_before_and_after_callbacks_execute_in_order(): void
+    {
+        $before = [
+            function (): void {
+                $this->order[] = static::VALID_CALLBACK.'-'.static::HOOK_BEFORE;
+            },
+        ];
+
+        $after = [
+            function (): void {
+                $this->order[] = static::VALID_CALLBACK.'-'.static::HOOK_AFTER;
+            },
+        ];
+
+        $this->dispatcher->before(static::EVENT, $before);
+        $this->dispatcher->after(static::EVENT, $after);
+
+        $listeners = [
+            function (): void {
+                $this->invoked[] = static::LISTENER.'1';
+                $this->order[] = static::LISTENER.'1';
+            },
+            function (): void {
+                $this->invoked[] = static::LISTENER.'2';
+                $this->order[] = static::LISTENER.'2';
+            },
+        ];
+
+        foreach ($listeners as $listener) {
+            $this->dispatcher->listen(static::EVENT, $listener);
+        }
+
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertCount(2, $this->dispatcher->invoked,
+            'Two callbacks should have been invoked.');
+        $this->assertCount(2, $this->invoked,
+            'Two listeners should have been invoked.');
+        $this->assertEquals(static::VALID_CALLBACK.'-'.static::HOOK_BEFORE, $this->order[0],
+            'The before callback should have been invoked first.');
+        $this->assertEquals(static::LISTENER.'1', $this->order[1],
+            'The first listener should have been invoked second.');
+        $this->assertEquals(static::LISTENER.'2', $this->order[2],
+            'The second listener should have been invoked third');
+        $this->assertEquals(static::VALID_CALLBACK.'-'.static::HOOK_AFTER, $this->order[3],
+            'The before callback should have been invoked fourth.');
+    }
+
+    public function test_event_hook_methods_are_called_during_dispatch_correctly(): void
+    {
+        $this->dispatcher->dispatch($event = new EventWithHooks);
+
+        $this->assertTrue($event->beforeCalled, 'Event::before() should be called.');
+        $this->assertTrue($event->afterCalled, 'Event::after() should be called.');
+        $this->assertFalse($event->failureCalled, 'Event::failure() should not be called.');
+    }
+
+    public function test_event_with_failure_method_is_called_when_listener_returns_false(): void
+    {
+        $this->dispatcher->listen(EventWithHooks::class, static fn (): bool => false);
+
+        $this->dispatcher->dispatch($event = new EventWithHooks);
+
+        $this->assertTrue($event->beforeCalled, 'Event::before() should be called.');
+        $this->assertFalse($event->afterCalled, 'Event::after() should not be called.');
+        $this->assertTrue($event->failureCalled, 'Event::failure() should be called.');
+    }
+
+    public function test_event_methods_are_called_in_correct_order(): void
+    {
+        $event = tap(
+            new EventWithHooks,
+            function (EventWithHooks $event): void {
+                $event->callback = function ($method): void {
+                    $this->invoked[] = $method;
+                };
+            }
+        );
+
+        $this->dispatcher->listen(
+            get_class($event),
+            function (): void {
+                $this->invoked[] = static::LISTENER;
+            }
+        );
+
+        $this->dispatcher->dispatch($event);
+
+        $this->assertEquals([static::HOOK_BEFORE, static::LISTENER, static::HOOK_AFTER], $this->invoked,
+            'The before, listener, and after callbacks should be called in that order.');
+    }
+
+    public function test_event_methods_are_called_with_correct_payload(): void
+    {
+        $this->dispatcher->dispatch($event = new EventWithHooks);
+
+        $this->assertSame($event, Arr::first($event->beforePayload),
+            'The before callback should receive the event payload.');
+        $this->assertSame($event, Arr::first($event->afterPayload),
+            'The after callback should receive the event payload.');
+    }
+
+    public function test_callback_aggregation_includes_both_wildcard_and_specific_callbacks(): void
+    {
+        $wildcardCallback = static fn (): string => static::WILDCARD;
+        $specificCallback = static fn (): string => static::EVENT;
+
+        $this->dispatcher->before($wildcardCallback);
+        $this->dispatcher->before(static::EVENT, $specificCallback);
+
+        $callbacks = $this->call('aggregateCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertCount(2, $callbacks,
+            'Two callbacks for the event should be aggregated.');
+        $this->assertSame(static::WILDCARD, Arr::first($callbacks)(),
+            'The wildcard callback should be first in the aggregation.');
+        $this->assertSame(static::EVENT, Arr::last($callbacks)(),
+            'The event-specific callback should be last in the aggregation.');
+    }
+
+    public function test_callback_aggregation_with_invalid_hook_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->call('aggregateCallbacks', [static::INVALID_HOOK, static::EVENT, []]);
+    }
+
+    public function test_callback_aggregation_includes_all_registered_callbacks(): void
+    {
+        $wildcard = [
+            $wildcard1 = function (): void {
+                $this->invoked[] = static::VALID_CALLBACK;
+            },
+            $wildcard2 = function (): void {
+                $this->invoked[] = static::VALID_CALLBACK;
+            },
+        ];
+
+        $event = [
+            $event1 = function (): void {
+                $this->invoked[] = static::VALID_CALLBACK;
+            },
+            $event2 = function (): void {
+                $this->invoked[] = static::VALID_CALLBACK;
+            },
+        ];
+
+        $this->dispatcher->before($wildcard);
+        $this->dispatcher->before(static::EVENT, $event);
+
+        $aggregated = $this->call('aggregateCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertCount(4, $aggregated,
+            'Four callbacks for the event should be aggregated.');
+        $this->assertSame($wildcard1, $aggregated[0],
+            'The wildcard1 callback should be first in the aggregation.');
+        $this->assertSame($wildcard2, $aggregated[1],
+            'The wildcard2 callback should be second in the aggregation.');
+        $this->assertSame($event1, $aggregated[2],
+            'The event1 callback should be third in the aggregation.');
+        $this->assertSame($event2, $aggregated[3],
+            'The event2 callback should be fourth in the aggregation.');
+    }
+
+    public function test_callback_aggregation_includes_event_object_hook_methods(): void
+    {
+        $aggregated = $this->call('aggregateCallbacks', [static::HOOK_BEFORE, EventWithHooks::class, [$event = new EventWithHooks]]);
+
+        $this->assertCount(1, $aggregated,
+            'One callback for the event should be aggregated.');
+        $this->assertSame([$event, static::HOOK_BEFORE], Arr::first($aggregated),
+            'The expected callback for the event should exist in the aggregation.');
+    }
+
+    public function test_callbacks_are_ordered_for_before_hook_correctly(): void
+    {
+        $registered = [
+            static::WILDCARD => [
+                function (): void {
+                    $this->invoked[] = static::WILDCARD;
+                },
+            ],
+            static::EVENT => [
+                function (): void {
+                    $this->invoked[] = static::EVENT;
+                },
+            ],
+            EventWithHooks::class => [
+                function (): void {
+                    $this->invoked[] = EventWithHooks::class;
+                },
+            ],
+        ];
+
+        $ordered = $this->call('orderCallbacks', [static::HOOK_BEFORE, static::EVENT, $registered]);
+
+        $this->assertSame($registered, $ordered,
+            'Before callbacks should be ordered as follows: wildcard, event-specific, and event object.');
+    }
+
+    public function test_callbacks_are_ordered_for_after_hook_correctly(): void
+    {
+        $registered = [
+            static::WILDCARD => [static fn (): string => static::VALID_CALLBACK],
+            static::EVENT => [static fn (): string => static::VALID_CALLBACK],
+            EventWithHooks::class => [static fn (): string => static::VALID_CALLBACK],
+        ];
+
+        $ordered = $this->call('orderCallbacks', [static::HOOK_AFTER, static::EVENT, $registered]);
+
+        $this->assertSame(array_reverse($registered), $ordered,
+            'After callbacks should be ordered as follows: event object, event-specific, and wildcard.');
+    }
+
+    public function test_callbacks_are_ordered_for_failure_hook_correctly(): void
+    {
+        $registered = [
+            static::WILDCARD => [static fn (): string => static::VALID_CALLBACK],
+            static::EVENT => [static fn (): string => static::VALID_CALLBACK],
+            EventWithHooks::class => [static fn (): string => static::VALID_CALLBACK],
+        ];
+
+        $ordered = $this->call('orderCallbacks', [static::HOOK_FAILURE, static::EVENT, $registered]);
+
+        $this->assertSame(array_reverse($registered), $ordered,
+            'Failure callbacks should be ordered as follows: event object, event-specific, and wildcard.');
+    }
+
+    public function test_callbacks_throw_exception_for_invalid_hook_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->call('orderCallbacks', [static::INVALID_CALLBACK, static::EVENT, []]);
+    }
+
+    public function test_callbacks_are_combined_and_ordered_correctly(): void
+    {
+        $wildcard = [
+            function (): void {
+                $this->invoked[] = static::WILDCARD.'1';
+            },
+            function (): void {
+                $this->invoked[] = static::WILDCARD.'2';
+            },
+        ];
+
+        $event = [
+            function (): void {
+                $this->invoked[] = static::EVENT.'1';
+            },
+            function (): void {
+                $this->invoked[] = static::EVENT.'2';
+            },
+        ];
+
+        $this->dispatcher->after($wildcard);
+        $this->dispatcher->after(static::EVENT.'1', $event);
+
+        $prepared = $this->call('prepareCallbacks', [static::HOOK_AFTER, static::EVENT.'1', []]);
+
+        foreach ($prepared as $callback) {
+            $callback();
+        }
+
+        $this->assertCount(4, $prepared,
+            'Four callbacks for the event should be prepared.');
+
+        $this->assertEquals([static::EVENT.'2', static::EVENT.'1', static::WILDCARD.'2', static::WILDCARD.'1'], $this->invoked,
+            'The expected after callbacks should be prepared, and ordered correctly: event-specific callbacks preceding wildcard callbacks.');
+    }
+
+    public function test_all_callbacks_are_invoked(): void
+    {
+        $callbacks = [
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK.'1';
+            },
+            function (): void {
+                $this->invoked[] = static::VALID_CALLBACK.'2';
+            },
+        ];
+
+        $this->dispatcher->before(static::EVENT, $callbacks);
+
+        $this->call('invokeCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertCount(2, $this->invoked,
+            'Two callbacks for the event should have been invoked.');
+        $this->assertEquals([static::VALID_CALLBACK.'1', static::VALID_CALLBACK.'2'], $this->invoked,
+            'The expected before callbacks should have been invoked.');
+    }
+
+    public function test_callbacks_receive_and_process_payload_correctly(): void
+    {
+        $callbacks = [
+            function (string $payload): void {
+                $this->invoked[] = static::VALID_CALLBACK."1-{$payload}";
+            },
+            function (string $payload): void {
+                $this->invoked[] = static::VALID_CALLBACK."2-{$payload}";
+            },
+        ];
+
+        $this->dispatcher->before(static::EVENT, $callbacks);
+
+        $this->call('invokeCallbacks', [static::HOOK_BEFORE, static::EVENT, static::PAYLOAD]);
+
+        $this->assertEquals(static::VALID_CALLBACK.'1-'.Arr::first(static::PAYLOAD), Arr::first($this->invoked),
+            'The first before callback for the event should have been invoked with its expected payload.');
+
+        $this->assertEquals(static::VALID_CALLBACK.'2-'.Arr::first(static::PAYLOAD), Arr::last($this->invoked),
+            'The second before callback for the event should have been invoked with its expected payload.');
+
+    }
+
+    public function test_callbacks_are_only_invoked_when_they_exist(): void
+    {
+        $this->set('callbacks', [static::HOOK_BEFORE => [static::EVENT => [static fn (): null => null]]]);
+
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertCount(1, $this->dispatcher->invoked,
+            'Only one callback for the event should have been invoked.');
+        $this->assertEquals(static::HOOK_BEFORE, Arr::first($this->dispatcher->invoked)['hook'],
+            'The before hook should have been invoked.');
+        $this->assertEquals(static::EVENT, Arr::first($this->dispatcher->invoked)['event'],
+            'The before callback should have been triggered by the specified event.');
+        $this->assertEquals(static::PAYLOAD, Arr::first($this->dispatcher->invoked)['payload'],
+            'The before callback should have received the expected event payload.');
+    }
+
+    public function test_no_callbacks_are_invoked_when_no_callbacks_exist_for_event(): void
+    {
+        $this->call('invokeListeners', [static::EVENT, static::PAYLOAD]);
+
+        $this->assertEmpty($this->dispatcher->invoked,
+            'No callbacks should have been invoked for the event.');
+    }
+
+    public function test_prepares_event_object_callback_when_present(): void
+    {
+        $callback = $this->call('prepareEventObjectCallback', [static::HOOK_BEFORE, [$event = new EventWithHooks]]);
+
+        $this->assertSame([$event, static::HOOK_BEFORE], $callback,
+            'The expected event object before callback should have been prepared.');
+    }
+
+    public function test_does_not_prepare_event_object_callbacks_when_hook_methods_are_missing(): void
+    {
+        $callback = $this->call('prepareEventObjectCallback', [static::HOOK_BEFORE, [new class {}]]);
+
+        $this->assertEmpty($callback, 'No callbacks should be prepared for the event object as no hook methods are present.');
+    }
+
+    public function test_callback_detection_recognizes_wildcard_callbacks(): void
+    {
+        $this->dispatcher->before(static fn (): null => null);
+
+        $this->assertTrue($this->call('hasCallbacks', [static::HOOK_BEFORE, static::EVENT, static::PAYLOAD]),
+            'The wildcard before callback should be detected for the event; Dispatcher::hasCallbacks() should return true.');
+    }
+
+    public function test_callback_detection_recognizes_event_specific_callbacks(): void
+    {
+        $this->dispatcher->before(static::EVENT, static fn (): null => null);
+
+        $this->assertTrue($this->call('hasCallbacks', [static::HOOK_BEFORE, static::EVENT, static::PAYLOAD]),
+            'The event-specific before callback should be detected for the event; Dispatcher::hasCallbacks() should return true.');
+    }
+
+    public function test_callback_detection_recognizes_hierarchical_parent_callbacks(): void
+    {
+        $this->dispatcher->before(ParentEvent::class, static fn (): null => null);
+
+        $this->assertTrue($this->call('hasCallbacks', [static::HOOK_BEFORE, ChildEvent::class, [new ChildEvent]]),
+            'The hierarchical parent before callback should be detected for the event; Dispatcher::hasCallbacks() should return true.');
+    }
+
+    public function test_callback_detection_recognizes_hierarchical_interface_callbacks(): void
+    {
+        $this->dispatcher->before(EventInterface::class, static fn (): null => null);
+
+        $this->assertTrue($this->call('hasCallbacks', [static::HOOK_BEFORE, ChildEvent::class, [new ChildEvent]]),
+            'The hierarchical interface before callback should be detected for the event; Dispatcher::hasCallbacks() should return true.');
+    }
+
+    public function test_callback_detection_returns_false_when_none_are_registered(): void
+    {
+        $this->assertFalse($this->call('hasCallbacks', [static::HOOK_BEFORE, static::INVALID_EVENT, static::PAYLOAD]),
+            'No callbacks should be detected for the event; Dispatcher::hasCallbacks() should return false.');
+    }
+
+    public function test_callback_detection_recognizes_event_object_callbacks(): void
+    {
+        $this->assertTrue($this->call('hasCallbacks', [static::HOOK_BEFORE, get_class($event = new EventWithHooks), [$event]]),
+            'The event object before callback should be detected for the event; Dispatcher::hasCallbacks() should return true.');
+    }
+
+    public function test_callback_detection_ignores_objects_without_hook_methods(): void
+    {
+        $this->assertFalse($this->call('hasCallbacks', [static::HOOK_BEFORE, get_class($event = new class {}), [$event]]),
+            'No callbacks should be detected for the event; Dispatcher::hasCallbacks() should return false.');
+    }
+
+    public function test_has_callbacks_utilizes_memoization_correctly(): void
+    {
+        $this->set('callbacks', []);
+        $this->set('cache', []);
+
+        $this->assertFalse(
+            $this->call('hasCallbacks', [static::HOOK_BEFORE, static::EVENT, static::PAYLOAD]),
+            '$Dispatcher::hasCallbacks() should return false for the given hook/event initially.');
+        $this->assertFalse(
+            $this->get('cache')['has_callbacks'][static::HOOK_BEFORE.':'.static::EVENT] ?? false,
+            "\$Dispatcher::\$cache['has_callbacks'] should reflect false for the given hook/event initially."
+        );
+
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertTrue(
+            $this->call('hasCallbacks', [static::HOOK_BEFORE, static::EVENT, static::PAYLOAD]),
+            'Dispatcher::hasCallbacks() should return true for the hook/event after first callback registration.'
+        );
+        $this->assertTrue(
+            $this->get('cache')['has_callbacks'][static::HOOK_BEFORE.':'.static::EVENT] ?? false,
+            "\$Dispatcher::\$cache['has_callbacks'] should reflect true for the hook/event after first callback registration."
+        );
+
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertTrue(
+            ($this->get('cache')['has_callbacks'] ?: [])[static::HOOK_BEFORE.':'.static::EVENT] ?? false,
+            "\$Dispatcher::\$cache['has_callbacks'] should remain true after registering additional callback."
+        );
+
+        $this->set('callbacks', []);
+        $this->set('cache', []);
+
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::VALID_CALLBACK);
+
+        $this->assertTrue(
+            ($this->get('cache')['has_callbacks'] ?: [])[static::HOOK_BEFORE.':'.static::EVENT] ?? false,
+            "\$Dispatcher::\$cache['has_callbacks'] should remain true after registering additional callback"
+            .'(even though the cache was cleared).'
+        );
+    }
+
+    public function test_aggregated_callbacks_are_cached(): void
+    {
+        $this->dispatcher->before(static::EVENT, $callback = static fn (): string => static::VALID_CALLBACK);
+
+        $this->call('aggregateCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertArrayHasKey(static::HOOK_BEFORE.':'.static::EVENT, $this->get('cache')['aggregated_callbacks'],
+            'Dispatcher::$cache should have an aggregated_callbacks entry for the hook/event.');
+        $this->assertSame($callback, Arr::first($this->get('cache')['aggregated_callbacks'][static::HOOK_BEFORE.':'.static::EVENT]),
+            'The expected aggregated callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_aggregated_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['aggregated_callbacks' => [static::HOOK_BEFORE.':'.static::EVENT => [static fn (): string => static::VALID_CALLBACK]]]);
+
+        $callbacks = $this->call('aggregateCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertSame($callbacks, $this->get('cache')['aggregated_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The Dispatcher::aggregateCallbacks() method should return the expected callback(s) from the cache.');
+    }
+
+    public function test_prepared_callbacks_are_cached(): void
+    {
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::WILDCARD);
+
+        $this->call('prepareCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertArrayHasKey(static::HOOK_BEFORE.':'.static::EVENT, $this->get('cache')['prepared_callbacks'],
+            'Dispatcher::$cache should have a prepared_callbacks key for the hook/event.');
+        $this->assertSame(static::WILDCARD, Arr::first($this->get('cache')['prepared_callbacks'][static::HOOK_BEFORE.':'.static::EVENT])(),
+            'The expected prepared callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_prepared_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['prepared_callbacks' => [static::HOOK_BEFORE.':'.static::EVENT => [static fn (): string => static::WILDCARD]]]);
+
+        $callbacks = $this->call('prepareCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertSame($callbacks, $this->get('cache')['prepared_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The Dispatcher::prepareCallbacks() method should return the expected callback(s) from the cache.');
+    }
+
+    public function test_ordered_callbacks_are_cached(): void
+    {
+        $callbacks = [
+            static fn (): string => static::VALID_CALLBACK.'1',
+            static fn (): string => static::VALID_CALLBACK.'2',
+        ];
+
+        $this->call('orderCallbacks', [static::HOOK_BEFORE, static::EVENT, $callbacks]);
+
+        $this->assertArrayHasKey(static::HOOK_BEFORE.':'.static::EVENT, $this->get('cache')['ordered_callbacks'],
+            'Dispatcher::$cache should have an ordered_callbacks entry for the hook/event.');
+        $this->assertSame($callbacks, $this->get('cache')['ordered_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The expected ordered callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_ordered_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['ordered_callbacks' => [static::HOOK_BEFORE.':'.static::EVENT => [static fn (): string => static::VALID_CALLBACK]]]);
+
+        $callbacks = $this->call('orderCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertSame($callbacks, $this->get('cache')['ordered_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The Dispatcher::orderCallbacks() method should return the expected callback(s) from the cache.');
+    }
+
+    public function test_hook_and_event_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['hook_and_event_callbacks' => [static::HOOK_BEFORE.':'.static::EVENT => [static::EVENT => [static fn (): string => static::VALID_CALLBACK]]]]);
+
+        $callbacks = $this->call('callbacksForHookAndEvent', [static::HOOK_BEFORE, static::EVENT]);
+
+        $this->assertSame($callbacks, $this->get('cache')['hook_and_event_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The Dispatcher::callbacksForHookAndEvent() method should return the expected callback(s) from the cache.');
+    }
+
+    public function test_hook_and_event_callbacks_are_cached(): void
+    {
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::VALID_CALLBACK);
+
+        $this->call('callbacksForHookAndEvent', [static::HOOK_BEFORE, static::EVENT]);
+
+        $this->assertArrayHasKey(static::EVENT, $this->get('cache')['hook_and_event_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'Dispatcher::$cache should have a hook_and_event_callbacks entry for the hook/event.');
+        $this->assertSame(static::VALID_CALLBACK, Arr::first($this->get('cache')['hook_and_event_callbacks'][static::HOOK_BEFORE.':'.static::EVENT][static::EVENT])(),
+            'The expected callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_event_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['event_callbacks' => [static::EVENT => [static::HOOK_BEFORE => [static::EVENT => [static fn (): string => static::VALID_CALLBACK]]]]]);
+
+        $callbacks = $this->call('callbacksForEvent', [static::EVENT]);
+
+        $this->assertSame($callbacks, $this->get('cache')['event_callbacks'][static::EVENT],
+            'The Dispatcher::callbacksForEvent() method should return the expected callback(s) from the cache.');
+    }
+
+    public function test_event_callbacks_are_cached(): void
+    {
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::VALID_CALLBACK);
+
+        $this->call('callbacksForEvent', [static::EVENT]);
+
+        $this->assertArrayHasKey(static::EVENT, $this->get('cache')['event_callbacks'],
+            'Dispatcher::$cache should have a event_callbacks entry for the hook/event.');
+
+        $this->assertSame(static::VALID_CALLBACK, Arr::first($this->get('cache')['event_callbacks'][static::EVENT][static::HOOK_BEFORE][static::EVENT])(),
+            'The expected callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_event_hierarchies_are_cached(): void
+    {
+        $this->call('eventHierarchy', [EventWithHooks::class]);
+
+        $this->assertArrayHasKey('event_hierarchies', $this->get('cache'),
+            'Dispatcher::$cache should have an event_hierarchies entry for the event.');
+        $this->assertSame(EventWithHooks::class, Arr::first($this->get('cache')['event_hierarchies'][EventWithHooks::class]),
+            'The expected hierarchical class(es) for the event should exist in the cache.');
+    }
+
+    public function test_event_hierarchies_are_read_from_cache(): void
+    {
+        $this->set('cache', ['event_hierarchies' => [EventWithHooks::class => ['cached']]]);
+
+        $hierarchy = $this->call('eventHierarchy', [EventWithHooks::class]);
+
+        $this->assertSame($hierarchy, $this->get('cache')['event_hierarchies'][EventWithHooks::class],
+            'The Dispatcher::eventHierarchy() method should return the expected hierarchy from the cache.');
+    }
+
+    public function test_hierarchical_callbacks_are_cached(): void
+    {
+        $this->dispatcher->before(static::EVENT, static fn (): string => static::WILDCARD);
+
+        $this->call('aggregateHierarchicalCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertArrayHasKey(static::HOOK_BEFORE.':'.static::EVENT, $this->get('cache')['hierarchical_callbacks'],
+            'Dispatcher::$cache should have a hierarchical_callbacks entry for the hook/event.');
+        $this->assertSame(static::WILDCARD, Arr::first($this->get('cache')['hierarchical_callbacks'][static::HOOK_BEFORE.':'.static::EVENT])(),
+            'The expected aggregated hierarchical callback(s) for the hook/event should exist in the cache.');
+    }
+
+    public function test_hierarchical_callbacks_are_read_from_cache(): void
+    {
+        $this->set('cache', ['hierarchical_callbacks' => [static::HOOK_BEFORE.':'.static::EVENT => [static fn (): string => static::WILDCARD]]]);
+
+        $callbacks = $this->call('aggregateHierarchicalCallbacks', [static::HOOK_BEFORE, static::EVENT, []]);
+
+        $this->assertSame($callbacks, $this->get('cache')['hierarchical_callbacks'][static::HOOK_BEFORE.':'.static::EVENT],
+            'The Dispatcher::aggregateHierarchicalCallbacks() method should return the expected callback(s) from the cache.');
+    }
+
+    private function call(string $method, array $args = []): mixed
+    {
+        return tap(
+            new ReflectionMethod($this->dispatcher, $method),
+            static function (ReflectionMethod $method): void {
+                $method->setAccessible(true);
+            }
+        )->invokeArgs($this->dispatcher, $args);
+    }
+
+    private function get(string $property): mixed
+    {
+        return tap(
+            (new ReflectionClass($this->dispatcher))->getProperty($property),
+            static function ($property): void {
+                $property->setAccessible(true);
+            }
+        )->getValue($this->dispatcher);
+    }
+
+    private function set(string $property, $value): void
+    {
+        tap(
+            new ReflectionProperty($this->dispatcher, $property),
+            static function (ReflectionProperty $property): void {
+                $property->setAccessible(true);
+            }
+        )->setValue($this->dispatcher, $value);
+    }
+
+    public const HOOK_BEFORE = 'before';
+
+    public const HOOK_AFTER = 'after';
+
+    public const HOOK_FAILURE = 'failure';
+
+    private const WILDCARD = '*';
+
+    private const EVENT = 'event';
+
+    private const INVALID_EVENT = 'invalid';
+
+    private const PAYLOAD = ['payload'];
+
+    private const LISTENER = 'listener';
+
+    private const INVALID_HOOK = 'invalid';
+
+    private const VALID_CALLBACK = 'callback';
+
+    private const INVALID_CALLBACK = 'invalid';
+
+    private const INVALID_CLASS = 'invalid';
+
+    private const VALID_METHOD = 'method';
+
+    private const INVALID_METHOD = 'invalid';
+}
+
+class TestDispatcher extends Dispatcher
+{
+    public array $invoked = [];
+
+    public bool $throw = false;
+
+    protected function invokeCallbacks(string $hook, string $event, array $payload): void
+    {
+        if ($this->throw && $hook === self::HOOK_BEFORE) {
+            throw new EventPropagationException;
+        }
+
+        $this->invoked[] = ['hook' => $hook, 'event' => $event, 'payload' => $payload];
+
+        parent::invokeCallbacks($hook, $event, $payload);
+    }
+}
+
+class MethodCallbackClass
+{
+    public string $payload = '';
+
+    public function handle(string $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    public function method(string $payload): void
+    {
+        $this->payload = $payload;
+    }
+}
+
+class InvokableCallbackClass
+{
+    public string $payload = '';
+
+    public function __invoke(string $payload): void
+    {
+        $this->payload = $payload;
+    }
+}
+
+class EventWithHooks
+{
+    public bool $beforeCalled = false;
+
+    public bool $afterCalled = false;
+
+    public bool $failureCalled = false;
+
+    public array $beforePayload = [];
+
+    public array $afterPayload = [];
+
+    public array $failurePayload = [];
+
+    public mixed $callback = null;
+
+    public function before(...$args): void
+    {
+        $this->beforeCalled = true;
+        $this->beforePayload = $args;
+
+        if ($this->callback) {
+            call_user_func($this->callback, EventHooksTest::HOOK_BEFORE);
+        }
+    }
+
+    public function after(...$args): void
+    {
+        $this->afterCalled = true;
+        $this->afterPayload = $args;
+
+        if ($this->callback) {
+            call_user_func($this->callback, EventHooksTest::HOOK_AFTER);
+        }
+    }
+
+    public function failure(...$args): void
+    {
+        $this->failureCalled = true;
+        $this->failurePayload = $args;
+
+        if ($this->callback) {
+            call_user_func($this->callback, EventHooksTest::HOOK_FAILURE);
+        }
+    }
+}
+interface EventInterface {}
+
+abstract class ParentEvent implements EventInterface {}
+
+class ChildEvent extends ParentEvent {}


### PR DESCRIPTION
## 💡 Description ##

This pull request introduces event lifecycle hooks -- the ability to register callbacks to be run before and after event dispatch, as well as on listener failure -- enabling developers to implement cross-cutting concerns like logging, metrics, validation, and error handling in a clean, reusable way across event-driven applications.

### + Primary Functionality ###

- The `before` hook allows callbacks to be registered against one or more (or all) events, to be run before the event is dispatched to listeners.
- The `after` hook allows callbacks to be registered against one or more (or all) events, to be run after all listeners have completed successfully.
- The `failure` hook allows callbacks to be registered against one or more (or all) events, to be run on listener failure.

### + Additional Functionality ###

- The `EventPropagationException` can be thrown in a `before` callback to prevent dispatch to subsequent callbacks or listeners.
- Event lifecycle callbacks may be callables or may be implemented directly on the event class.
- Event lifecycle callbacks are invoked in an order mimicking the familiar pipeline ordering -- `before` callbacks are invoked in FIFO order, those registered as wildcards (all events), followed by those registered against the specific event, and finally those implemented on the event itself, while `after` and `failure` are invoked in LIFO order those implemented on the event itself, followed by those registered against the specific event, and finally those registered as wildcards (all events).
- Event lifecycle callbacks respect event dispatch on transaction commit where indicated.
- Event lifecycle callbacks may be registered for both domain and framework events.
- Event lifecycle callbacks may be registered against an event name string or an event class name.
- Event lifecycle callbacks may also be registered for the class name of a parent class or interface; a callback registered for a parent event class will be triggered for any child event classes, and a callback registered for an interface will be triggered by any event that implements the interface.
- Class-based event lifecycle callbacks are resolved via the container, allowing dependencies to be auto-injected into the constructor.


## 🏗️ Usage ##

```php

// register event lifecycle callbacks using the event facade
Event::before(SomeEvent::class, function ($event) {/* action */})
    ->after(SomeEvent::class, function ($event) {/* action */})
    ->failure(SomeEvent::class, function ($event) {/* action */});

// register event lifecycle callbacks directly on the dispatcher
$dispatcher->before(SomeEvent::class, function ($event) {/* action */})
    ->after(SomeEvent::class, function ($event) {/* action */})
    ->failure(SomeEvent::class, function ($event) {/* action */});

// register a callback to execute before listener dispatch
$dispatcher->before(SomeEvent::class, function ($event) {/* action */});

// register a callback to execute after listener execution
$dispatcher->after(SomeEvent::class, function ($event) {/* action */});

// register a callback to execute on listener failure
$dispatcher->failure(SomeEvent::class, function ($event) {/* action */});

// register multiple event lifecycle callbacks for a single event
$dispatcher->before(SomeEvent::class, [
    function ($event) {/* action */},
    function ($event) {/* action */},
    function ($event) {/* action */},
]);

// register an event lifecycle callback for multiple events
$dispatcher->failure([Event1::class, Event2::class], function ($event) {/* action */});

// register multiple event lifecycle callbacks for multiple events
$dispatcher->before(
    [Event1::class, Event2::class],
    [
        function ($event) {/* action */},
        function ($event) {/* action */},
        function ($event) {/* action */},
    ]
);

// register an event lifecycle callback for all events
$dispatcher->before(function ($event) {/* action */});
$dispatcher->before('*', function ($event) {/* action */});

// register multiple event lifecycle callbacks for all events
$dispatcher->before([
    function ($event) {/* action */},
    function ($event) {/* action */},
    function ($event) {/* action */},
]);
$dispatcher->before('*', [
    function ($event) {/* action */},
    function ($event) {/* action */},
    function ($event) {/* action */},
]);

// register event lifecycle callbacks using various event formats
$dispatcher->before(Event::class, function ($event) {/* action */});
$dispatcher->before('event.happened', function ($event) {/* action */});

// register event lifecycle callbacks using various callback formats
$dispatcher->before(Event::class, function ($event) {/* action */});
$dispatcher->before(Event::class, someFunction(...));
$dispatcher->before(Event::class, SomeClass::class); // handle or __invoke
$dispatcher->before(Event::class, SomeClass::class.'::method');
$dispatcher->before(Event::class, SomeClass::class.'@method');
$dispatcher->before(Event::class, [SomeClass::class, 'method']);

// implement event lifecycle callbacks as a class
class DoSomethingBefore
{
    public function __invoke(object $event): void
    {
        // do something
    }
}

// implement event lifecycle callbacks directly on the event
class SomeEvent
{
    public function before(object $event): void
    {
        // do something
    }
}

// halt propagation to subsequent callbacks and listener dispatch
Event::before(
    SomeEvent::class,
    function ($event) {
        if ($condition) {
            throw new Event PropagationException;
        }
    }
);

// register an event lifecycle callback for all events extending a parent
Event::before(AbstractParent::class, function ($event) {/* action */});

// register an event lifecycle callback for all event implementing an interface
Event::before(SomeInterface::class, function ($event) {/* action */});

// get all callbacks registered with the dispatcher
$dispatcher->callbacks();

// get all callbacks registered with the dispatcher for an event & hook
$dispatcher->callbacks(static::HOOK:BEFORE, SomeEvent::class);

// get all callbacks registered with the dispatcher for a hook
$dispatcher->callbacks(static::HOOK:BEFORE);

// get all callbacks registered with the dispatcher for an event
$dispatcher->callbacks(SomeEvent::class);

// get all wildcard callbacks registered with the dispatcher 
$dispatcher->callbacks('*');

// get all wildcard callbacks registered with the dispatcher for a hook 
$dispatcher->callbacks(static::HOOK:BEFORE, '*');

// determine if an event has callbacks (registered or class implemented)
$dispatcher->hasCallbacks($event);

```

## ⚖️ Justification ##

### ？Event Hooks or Listeners? ###

Event lifecycle hooks solve a different problem than listeners. Listeners are about what happens when an event occurs, focused upon the business logic and domain-specific responses to the event. Hooks are about how the event system itself behaves for that event, focused upon the infrastructure and the operational concerns that should happen regardless of which specific listeners are registered.

Consider an example:

```php

// business logic: belongs in listeners
class SendWelcomeEmail implements ShouldQueue
{
    public function handle(UserRegistered $event)
    {
        Mail::to($event->user)->send(new WelcomeEmail());
    }
}

// infrastructural concerns: belongs in hooks
Event::before(
    UserRegistered::class,
    function($event) {
        // should happen regardless of what listeners exist
        RateLimiter::hit('user-registration:' . request()->ip());
    }
);

Event::after(
    UserRegistered::class,
    function($event) {
        // should happen after all listeners complete
        Metrics::timing('user.registration.total_time', $this->processingTime);
    }
);

```

A number of issues arise when attempting to implement infrastructural concerns as listeners:

* **Order Dependency Complications:** "Cleanup" listener must be registered last, "setup" listener must be first, creating fragile coupling between unrelated concerns.
* **Lack of Failure Guarantees:** If a business logic listener fails, monitoring/cleanup listeners never run. Hooks guarantee infrastructure code runs regardless of business logic failures.
* **Leaky Abstractions:** Domain events become polluted with infrastructure listeners which aren't really about the domain event itself.

For example:

```php

// with listeners - fragile and incomplete
class PerformanceMonitoringServiceProvider extends ServiceProvider
{
    public function boot()
    {
        // how do you ensure this runs first?
        Event::listen('*', StartTimingListener::class);
        // how do you ensure this runs last?
        Event::listen('*', EndTimingListener::class);
        // what if a listener fails?
    }
}

// with hooks - robust and complete
class PerformanceMonitoringServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Event::before(fn($event) => $this->startTiming($event));
        Event::after(fn($event) => $this->endTiming($event));
        Event::failure(fn($event, $exception) => $this->recordFailure($event, $exception));
    }
}

```

Event lifecycle hooks enable framework-level features that can't be as cleanly implemented via listeners, for instance:

```php
// :

// telescope integration
Event::before(function($event) { Telescope::startRecording($event); });
Event::after(function($event) { Telescope::stopRecording($event); });

// queue failure handling
Event::failure(
    QueuedEvent::class,
    function($event, $exception) {
        if ($exception instanceof MaxAttemptsExceededException) {
            FailedJobNotification::dispatch($event, $exception);
        }
    }
);

```

Package authors can also leverage event lifecycle hooks to provide infrastructure without interfering with application logic, as in the following:

```php

// a monitoring package
Event::before(fn($event) => Monitor::start($event);
Event::after(fn($event) => Monitor::end($event));

// a caching package  
Event::after(CachedModel::class, fn($e) => Cache::invalidateModel($event->model));

// a security package
Event::before(fn($event) => SecurityLog::record($event));

```

Not only do event lifecycle hooks and listeners peacefully coexist, but the result of using them in concert is cleaner separation of concerns, more reliable infrastructure code, and packages that can enhance the event system without stepping on application logic.

### ？Event Hooks or Dispatcher Middleware? ###

Event lifecycle hooks also solve a different problem than dispatcher middleware. Dispatcher middleware, as the name implies, operates at the dispatcher level, wrapping the entire dispatch process. Event lifecycle hooks, on the other hand, operate at the event class level, tied to specific event types. This creates two distinct layers of control that solve different problems.

Consider an example:

```php

// dispatcher middleware: "how should all event dispatching behave?"
class EventSecurityMiddleware {
    public function handle($event, $next)
    {
        SecurityLog::startEventDispatch($event);
        
        try {
            $result = $next($event);
            SecurityLog::eventDispatchSuccess($event);
            return $result;
        } catch (\Exception $exception) {
            SecurityLog::eventDispatchFailure($event, $exception);
            throw $exception;
        }
    }
}

// event lifecycle hooks: "how should this specific event type behave?"
Event::before(
    PaymentProcessed::class,
    function($event) {
        if ($event->amount > 10000) {
            FraudDetection::flagForReview($event);
        }
    }
);

```

The following illustrates how the two systems compose beautifully: 

```php

// dispatcher middleware
Event::middleware([
    SecurityMiddleware::class,
    PerformanceMiddleware::class,
    LoggingMiddleware::class,
]);

// event lifecycle hooks
Event::before(SensitiveDataAccessed::class, fn($event) => AuditTrail::record($event));
Event::after(CacheCleared::class, fn($event) => Artisan::call('route:cache'));
Event::failure(CriticalProcess::class, fn($event, $exception) => PagerDuty::alert($event));

```

Middleware is about the system, while hooks are about the events. Trying to force one to do the other's job results in either bloated middleware full of conditionals, or a lack of system-wide control, as in this example:

```php

// dispatcher middleware trying to do event-specific work: messy
class EventMiddleware
{
    public function handle($event, $next)
    {
        if ($event instanceof UserRegistered) {
            RateLimiter::hit('registration:' . request()->ip());
        } elseif ($event instanceof PaymentProcessed) {
            if ($event->amount > 1000) {
                AuditLog::record($event);
            }
        } elseif ($event instanceof OrderShipped) {
            // ...more conditions
        }
        
        $result = $next($event);
        
        if ($event instanceof UserRegistered) {
            Metrics::increment('user.registrations');
        }
        
        return $result;
    }
}

// event lifecycle hooks: clean & declarative
Event::before(
    UserRegistered::class,
    fn($event) => RateLimiter::hit('registration:' . request()->ip())
);
Event::before(
    PaymentProcessed::class,
    fn($event) => $event->amount > 1000 ? AuditLog::record($event) : null
);
Event::after(
    UserRegistered::class
    fn($event) => Metrics::increment('user.registrations')
);

```

Using dispatcher middleware for cross-cutting infrastructural event concerns and event lifecycle hooks for those that are event-specific simply feels intuitive:

```php

// dispatcher middleware: universal concerns that apply to all events
class PerformanceMiddleware {
    public function handle($event, $next)
    {
        $start = microtime(true);
        
        try {
            $result = $next($event);
            Metrics::timing('events.dispatch_time', microtime(true) - $start);
            return $result;
        } catch (\Exception $e) {
            Metrics::increment('events.dispatch_failures');
            throw $e;
        }
    }
}

// event lifecycle hooks: event-specific behavior
Event::before(
    UserRegistered::class,
    function($event) {
        // only relevant to user registration
        if (User::where('email', $event->user->email)->count() > 1) {
            throw new DuplicateRegistrationException();
        }
    }
);

Event::after(
    OrderShipped::class,
    function($event) {
        // only relevant to order shipping
        $event->order->update(['tracking_sent_at' => now()]);
    }
);

```

Complementary usage of event lifecycle hooks and dispatcher middleware can yield elegant package integration patterns:

```php

// a monitoring package uses dispatcher middleware for universal metrics
class MonitoringMiddleware
{
    public function handle($event, $next)
    {
        Monitor::eventStarted(get_class($event));
        $result = $next($event);
        Monitor::eventCompleted(get_class($event));
        return $result;
    }
}

// but uses event lifecycle hooks for event-specific insights
Event::after(DatabaseQueryExecuted::class, fn($event) => Monitor::queryTime($event->time));
Event::failure(JobFailed::class, fn($event, $exception) => Monitor::jobFailure($event->job, $exception));

```

As with listeners, not only is there a peaceful coexistence between event lifecycle hooks and dispatcher middleware, their use together provides fine-grain control of event infrastructural concerns while avoiding awkward conditional logic, and provides for more robust package integration patterns. 

### ！Conclusion ###

This feature follows Laravel's layered approach, with each layer having clear responsibilities which doesn't step on the others:

- **Dispatcher Middleware**
  - Defines cross-cutting event dispatch behavior.
  - Answers the question: *“How should the event dispatching process behave?”.*
- **Event Lifecycle Hooks**
  - Defines event-specific infrastructural behavior.
  - Answers the question: *”How should the event system process this event?”.*
- **Event Listeners**
  - Defines event-specific logical behavior.
  - Answers the question: *“What business process should happen when this event occurs?.”*
  
Laravel's strength has always been providing the right tool for each level of abstraction; Event lifecycle hooks complete the event system's architecture by giving developers event-specific control that complements, rather than competes with, both listeners and dispatcher middleware.


## 🪵 Changelog ##

| File          | Change |
| ---           | --- |
| src/Illuminate/Events/EventHooks.php | New trait to manage before, after, and failure event lifecycle hooks, including registration, retrieval, validation, and invocation; add `getContainer()`.|
| src/Illuminate/Events/Dispatcher.php | Added `EventHooks` trait, enhanced `invokeListeners()` to trigger event lifecycle callbacks when present, replaced container calls with `getContainer()`. |
| src/Illuminate/Support/Facades/Event.php | Added method annotations for new event hooks methods -- `before()`, `after()`, and `failure()` as well as `callbacks()`. |
| src/Illuminate/Events/EventPropagationException.php | New exception allowing halting event propagation from a lifecycle callback. |
| tests/Illuminate/Events/EventHooksTest.php | New test class for `EventHooks` and `Dispatcher` integration, covering registration, invocation, and error handling. |


## ♻ Backward Compatibility ##

The feature is 100% opt-in and fully backward compatible, introducing no breaking changes:

- With the exception of its narrow integration point (`Dispatcher::invokeListeners()`), the code is entirely additive; the behavior of `Dispatcher::invokeListeners()` is unchanged if the feature is not utilized.
- No public interfaces are modified.
- No public method signatures are modified.


## 💥 Performance ##

Several mechanisms have been included to minimize any performance impact of the feature:

* Fast-failure (via `hasCallbacks()` is utilized at the integration point in `Dispatcher::invokeListeners()` to skip the more expensive callback aggregation when none exist for the hook/event.
* Caching via a class array is utilized to enhance the performance of `prepareCallbacks()`, `aggregateCalllbacks()`, `aggregateHierarchicalCallbacks()`, `hierachicalEvents()`, `callbacksForEvent()`, and `callbacksForHookAndEvent()`.
* Memoization via a class array is utilized to enhance the performance of `hasCallbacks()` and `hasHierarchicalCallbacks()`.

## ✅ Testing ##

A robust set of tests is included with the feature:

#### ✓ Callback Registration ####

* test_registers_wildcard_callbacks_correctly
* test_registers_before_callbacks_correctly
* test_registers_after_callbacks_correctly
* test_registers_failure_callbacks_correctly
* test_registers_multiple_callbacks_for_single_event_correctly
* test_registers_callbacks_for_multiple_events_correctly
* test_registers_array_of_callbacks_for_single_event_correctly
* test_registers_single_callback_for_array_of_events_correctly
* test_registers_global_callbacks_correctly
* test_registered_callbacks_can_be_accessed_correctly
* test_registered_hierarchical_callbacks_can_be_accessed_correctly

#### ✓ Callback Aggregation ####

* test_callback_aggregation_includes_both_wildcard_and_specific_callbacks
* test_callback_aggregation_caches_results
* test_callback_aggregation_with_invalid_hook_throws_exception
* test_callback_aggregation_includes_all_registered_callbacks
* test_callback_aggregation_includes_event_object_hook_methods
* test_prepares_event_object_callback_when_present
* test_does_not_prepare_event_object_callbacks_when_hook_methods_are_missing
* test_callbacks_are_ordered_for_before_hook_correctly
* test_callbacks_are_ordered_for_after_hook_correctly
* test_callbacks_are_ordered_for_failure_hook_correctly
* test_callbacks_are_combined_and_ordered_correctly

#### ✓ Callback Invocation ####

* test_all_callbacks_are_invoked
* test_before_callbacks_are_called_before_listeners
* test_after_callbacks_are_called_after_listeners
* test_failure_callbacks_are_called_on_listener_failure
* test_invokes_object_and_method_format_callback_correctly
* test_invokes_class_method_with_at_notation_correctly
* test_invokes_class_method_with_double_colon_notation_correctly
* test_invokes_class_handle_method_with_classname_notation_correctly
* test_invokes_invokable_class_correctly
* test_invokes_closure_callback_correctly
* test_hierarchical_callbacks_are_called_correctly
* test_callbacks_receive_and_process_payload_correctly
* test_callbacks_are_only_invoked_when_they_exist
* test_no_callbacks_are_invoked_when_no_callbacks_exist_for_event
* test_multiple_listeners_with_before_and_after_callbacks_execute_in_order
* test_event_methods_are_called_in_correct_order
* test_event_hook_methods_are_called_during_dispatch_correctly
* test_event_methods_are_called_with_correct_payload
* test_event_with_failure_method_is_called_when_listener_returns_false

#### ✓ Event Propagation ####

* test_event_propagation_exception_halts_callback_processing
* test_event_propagation_exception_prevents_listener_processing

#### ✓ Callback Validation ####

* test_invalid_callback_throws_exception
* test_callback_with_nonexistent_class_throws_exception
* test_callback_with_nonexistent_method_throws_exception
* test_invoking_invalid_callback_throws_exception
* test_validates_callback_string_with_at_notation
* test_validates_callback_string_with_double_colon_notation

#### ✓ Callback Detection ####

* test_callback_detection_recognizes_wildcard_callbacks
* test_callback_detection_recognizes_event_specific_callbacks
* test_callback_detection_recognizes_hierarchical_parent_callbacks
* test_callback_detection_recognizes_hierarchical_interface_callbacks
* test_callback_detection_returns_false_when_none_are_registered
* test_callback_detection_recognizes_event_object_callbacks
* test_callback_detection_ignores_objects_without_hook_methods

#### ✓ Caching & Memoization ####
* test_has_callbacks_utilizes_memoization_correctly
* test_aggregated_callbacks_are_cached
* test_aggregated_callbacks_are_read_from_cache
* test_hook_and_event_callbacks_are_cached
* test_hook_and_event_callbacks_are_read_from_cache
* test_event_callbacks_are_cached
* test_event_callbacks_are_read_from_cache
* test_event_hierarchies_are_cached
* test_event_hierarchies_are_read_from_cache
* test_hierarchical_callbacks_are_cached
* test_hierarchical_callbacks_are_read_from_cache
* test_prepared_callbacks_are_cached
* test_prepared_callbacks_are_read_from_cache

## ⚙️ Behavior ##

```mermaid
sequenceDiagram
    participant Client
    participant Dispatcher
    participant EventHooks
    participant Container
    participant BeforeCallback
    participant Listener
    participant AfterCallback
    participant FailureCallback

    Note over Client,FailureCallback: Hook Registration Phase
    Client->>Dispatcher: before(event, callback)
    Dispatcher->>EventHooks: registerBeforeHook(event, callback)
    EventHooks->>EventHooks: validateCallback(callback)
    EventHooks-->>Dispatcher: hook registered

    Client->>Dispatcher: after(event, callback)
    Dispatcher->>EventHooks: registerAfterHook(event, callback)
    EventHooks-->>Dispatcher: hook registered

    Client->>Dispatcher: failure(event, callback)
    Dispatcher->>EventHooks: registerFailureHook(event, callback)
    EventHooks-->>Dispatcher: hook registered

    Note over Client,FailureCallback: Event Dispatch Phase
    Client->>Dispatcher: dispatch(event, payload, halt)
    
    Dispatcher->>EventHooks: invokeCallbacks('before', event, payload)
    EventHooks->>Container: resolveCallback(callback)
    Container-->>EventHooks: resolved callback
    EventHooks->>BeforeCallback: invoke(event, payload)
    
    alt EventPropagationException thrown
        BeforeCallback-->>EventHooks: throw EventPropagationException
        EventHooks-->>Dispatcher: propagation stopped
        Dispatcher-->>Client: return null (aborted)
    else Normal flow continues
        BeforeCallback-->>EventHooks: callback completed
        EventHooks-->>Dispatcher: before hooks completed
        
        loop For each listener
            Dispatcher->>Listener: invoke(event, payload)
            Listener-->>Dispatcher: response
            
            alt halt=true AND response !== null
                alt response === false
                    Dispatcher->>EventHooks: invokeCallbacks('failure', event, payload)
                    EventHooks->>Container: resolveCallback(failureCallback)
                    Container-->>EventHooks: resolved callback
                    EventHooks->>FailureCallback: invoke(event, payload, response)
                    FailureCallback-->>EventHooks: callback completed
                    EventHooks-->>Dispatcher: failure hooks completed
                    Dispatcher-->>Client: return false
                else response !== false
                    Dispatcher->>EventHooks: invokeCallbacks('after', event, payload)
                    EventHooks->>Container: resolveCallback(afterCallback)
                    Container-->>EventHooks: resolved callback
                    EventHooks->>AfterCallback: invoke(event, payload, response)
                    AfterCallback-->>EventHooks: callback completed
                    EventHooks-->>Dispatcher: after hooks completed
                    Dispatcher-->>Client: return response
                end
            end
        end
        
        Note over Dispatcher,AfterCallback: All listeners completed
        Dispatcher->>EventHooks: invokeCallbacks('after', event, payload)
        EventHooks->>Container: resolveCallback(afterCallback)
        Container-->>EventHooks: resolved callback
        EventHooks->>AfterCallback: invoke(event, payload, responses)
        AfterCallback-->>EventHooks: callback completed
        EventHooks-->>Dispatcher: after hooks completed
        Dispatcher-->>Client: return responses
    end
```


## 🔮 Future Possibilities ##

* Callback Prioritization -- current implementation guarantees only FIFO/LIFO invocation (depending upon hook).
* Artisan Command -- list event lifecycle callback registrations.
* Testing Enhancements -- assertions on the `Event` facade allowing simpler testing of event lifecycle callbacks.
* Callback Groups -- the ability to group callbacks to be invoked together, even if an `EventPropagationException` is thrown.
* ~~Advanced Callback Registration -- the ability to register callbacks not only by event name, but also by event classname (even when it differs from the the event name), as well as any classnames the event extends or implements.~~ (since implemented)

___

*💁🏼‍♂️ The author is available for hire -- inquire at yitzwillroth@gmail.com.*

