### PR TITLE
[12.x] Allow globally disabling Factory parent relationships via `Factory::dontExpandRelationshipsByDefault()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -962,6 +962,7 @@ abstract class Factory
         static::$modelNameResolvers = [];
         static::$factoryNameResolver = null;
         static::$namespace = 'Database\\Factories\\';
+        static::$defaultExpandRelationships = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -138,7 +138,7 @@ abstract class Factory
      *
      * @var bool
      */
-    protected static $defaultExpandRelationships = true;
+    protected static $expandRelationshipsByDefault = true;
 
     /**
      * Create a new factory instance.
@@ -173,7 +173,7 @@ abstract class Factory
         $this->connection = $connection;
         $this->recycle = $recycle ?? new Collection;
         $this->faker = $this->withFaker();
-        $this->expandRelationships = $expandRelationships ?? self::$defaultExpandRelationships;
+        $this->expandRelationships = $expandRelationships ?? self::$expandRelationshipsByDefault;
     }
 
     /**
@@ -903,14 +903,23 @@ abstract class Factory
     }
 
     /**
-     * Specify that relationships should not create parent relationships.
+     * Specify that relationships should create parent relationships by default.
      *
-     * @param  bool  $dontExpandRelationships
      * @return void
      */
-    public static function dontExpandRelationshipsByDefault(bool $dontExpandRelationships = true)
+    public static function expandRelationshipsByDefault()
     {
-        static::$defaultExpandRelationships = ! $dontExpandRelationships;
+        static::$expandRelationshipsByDefault = true;
+    }
+
+    /**
+     * Specify that relationships should not create parent relationships by default.
+     *
+     * @return void
+     */
+    public static function dontExpandRelationshipsByDefault()
+    {
+        static::$expandRelationshipsByDefault = false;
     }
 
     /**
@@ -973,7 +982,7 @@ abstract class Factory
         static::$modelNameResolvers = [];
         static::$factoryNameResolver = null;
         static::$namespace = 'Database\\Factories\\';
-        static::$defaultExpandRelationships = true;
+        static::$expandRelationshipsByDefault = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -138,7 +138,7 @@ abstract class Factory
      *
      * @var bool
      */
-    public static $defaultExpandRelationships = true;
+    protected static $defaultExpandRelationships = true;
 
     /**
      * Create a new factory instance.
@@ -900,6 +900,17 @@ abstract class Factory
     public static function guessFactoryNamesUsing(callable $callback)
     {
         static::$factoryNameResolver = $callback;
+    }
+
+    /**
+     * Specify that relationships should not create parent relationships.
+     *
+     * @param  bool  $dontExpandRelationships
+     * @return void
+     */
+    public static function dontExpandRelationshipsByDefault(bool $dontExpandRelationships = true)
+    {
+        static::$defaultExpandRelationships = ! $dontExpandRelationships;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -134,6 +134,13 @@ abstract class Factory
     protected static $factoryNameResolver;
 
     /**
+     * Whether to expand relationships by default.
+     *
+     * @var bool
+     */
+    public static $defaultExpandRelationships = true;
+
+    /**
      * Create a new factory instance.
      *
      * @param  int|null  $count
@@ -144,7 +151,7 @@ abstract class Factory
      * @param  \Illuminate\Support\Collection|null  $afterCreating
      * @param  string|null  $connection
      * @param  \Illuminate\Support\Collection|null  $recycle
-     * @param  bool  $expandRelationships
+     * @param  bool|null  $expandRelationships
      */
     public function __construct(
         $count = null,
@@ -155,7 +162,7 @@ abstract class Factory
         ?Collection $afterCreating = null,
         $connection = null,
         ?Collection $recycle = null,
-        bool $expandRelationships = true
+        ?bool $expandRelationships = null
     ) {
         $this->count = $count;
         $this->states = $states ?? new Collection;
@@ -166,7 +173,7 @@ abstract class Factory
         $this->connection = $connection;
         $this->recycle = $recycle ?? new Collection;
         $this->faker = $this->withFaker();
-        $this->expandRelationships = $expandRelationships;
+        $this->expandRelationships = $expandRelationships ?? self::$defaultExpandRelationships;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -831,6 +831,14 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertNull($post->user_id);
     }
 
+    public function test_can_default_to_without_parents()
+    {
+        FactoryTestPostFactory::$defaultExpandRelationships = false;
+
+        $post = FactoryTestPostFactory::new()->make();
+        $this->assertNull($post->user_id);
+    }
+
     public function test_factory_model_names_correct()
     {
         $this->assertEquals(FactoryTestUseFactoryAttribute::factory()->modelName(), FactoryTestUseFactoryAttribute::class);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -44,7 +44,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
-        Factory::$defaultExpandRelationships = true;
+        Factory::dontExpandRelationshipsByDefault(false);
     }
 
     /**
@@ -834,12 +834,12 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_can_default_to_without_parents()
     {
-        FactoryTestPostFactory::$defaultExpandRelationships = false;
+        FactoryTestPostFactory::dontExpandRelationshipsByDefault();
 
         $post = FactoryTestPostFactory::new()->make();
         $this->assertNull($post->user_id);
 
-        FactoryTestPostFactory::$defaultExpandRelationships = true;
+        FactoryTestPostFactory::dontExpandRelationshipsByDefault(false);
         $postWithParents = FactoryTestPostFactory::new()->create();
         $this->assertNotNull($postWithParents->user_id);
     }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -44,6 +44,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
+        Factory::$defaultExpandRelationships = true;
     }
 
     /**
@@ -837,6 +838,10 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $post = FactoryTestPostFactory::new()->make();
         $this->assertNull($post->user_id);
+
+        FactoryTestPostFactory::$defaultExpandRelationships = true;
+        $postWithParents = FactoryTestPostFactory::new()->create();
+        $this->assertNotNull($postWithParents->user_id);
     }
 
     public function test_factory_model_names_correct()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -44,7 +44,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
-        Factory::dontExpandRelationshipsByDefault(false);
+        Factory::expandRelationshipsByDefault();
     }
 
     /**
@@ -839,7 +839,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $post = FactoryTestPostFactory::new()->make();
         $this->assertNull($post->user_id);
 
-        FactoryTestPostFactory::dontExpandRelationshipsByDefault(false);
+        FactoryTestPostFactory::expandRelationshipsByDefault();
         $postWithParents = FactoryTestPostFactory::new()->create();
         $this->assertNotNull($postWithParents->user_id);
     }


### PR DESCRIPTION
A continuation of https://github.com/laravel/framework/pull/53450. This feature was added by @browner12 and it's been incredibly helpful for our team in speeding up tests.

That said, it requires us to write `->withoutParents()` on each factory make, which has led to bugs. Namely, we don't add the trait to refresh the database and then data gets left over between tests, which breaks expectations in other tests... but we don't discover it for a month 😆 😭 and then it's debug city.

It would be great if in the test's setup, we can just indicate no factory should create a parent relationship.

```diff
public function test_has_one_editor_permission_returns_true(): void
{
+    UserPermissionFactory::dontExpandRelationshipsByDefault();
+
    $collection = new UserPermissionCollection([
        UserPermission::factory()
-            ->withoutParents()
            ->make([
                'type' => 'viewer',
                'company_id' => 2,
                'product_id' => 789,
            ]),
        UserPermission::factory()
-            ->withoutParents()
            ->make([
                'type' => 'editor',
                'company_id' => 2,
                'product_id' => 432,
            ]),
    ]);

    $result = $collection->hasEditorForCompany(2);

    $this->assertTrue($result);
}
```

Even better, I would just add this to the class's `setUp()` method.