### PR TITLE
[12.x] Add context remember functions

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -250,6 +250,42 @@ class Repository
     }
 
     /**
+     * Add a context value if it does not exist yet, and return the value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function remember($key, $value)
+    {
+        if ($this->has($key)) {
+            return $this->get($key);
+        }
+
+        return tap(value($value), function ($value) use ($key) {
+            $this->add($key, $value);
+        });
+    }
+
+    /**
+     * Add a hidden context value if it does not exist yet, and return the value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function rememberHidden($key, #[\SensitiveParameter] $value)
+    {
+        if ($this->hasHidden($key)) {
+            return $this->getHidden($key);
+        }
+
+        return tap(value($value), function ($value) use ($key) {
+            $this->addHidden($key, $value);
+        });
+    }
+
+    /**
      * Forget the given context key.
      *
      * @param  string|array<int, string>  $key
@@ -658,41 +694,5 @@ class Repository
         ));
 
         return $this;
-    }
-
-    /**
-     * Add a context value if it does not exist yet, and return the value.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function remember($key, $value)
-    {
-        if ($this->has($key)) {
-            return $this->get($key);
-        }
-
-        return tap(value($value), function ($value) use ($key) {
-            $this->add($key, $value);
-        });
-    }
-
-    /**
-     * Add a hidden context value if it does not exist yet, and return the value.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function rememberHidden($key, $value)
-    {
-        if ($this->hasHidden($key)) {
-            return $this->getHidden($key);
-        }
-
-        return tap(value($value), function ($value) use ($key) {
-            $this->addHidden($key, $value);
-        });
     }
 }

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -664,16 +664,16 @@ class Repository
      * Add a context value if it does not exist yet, and return the value.
      *
      * @param  string  $key
-     * @param  Closure  $value
+     * @param  mixed  $value
      * @return mixed $value
      */
-    public function remember($key, Closure $value)
+    public function remember($key, $value)
     {
         if ($this->has($key)) {
             return $this->get($key);
         }
 
-        return tap($value(), function ($value) use ($key) {
+        return tap(value($value), function ($value) use ($key) {
             $this->add($key, $value);
         });
     }
@@ -682,16 +682,16 @@ class Repository
      * Add a hidden context value if it does not exist yet, and return the value.
      *
      * @param  string  $key
-     * @param  Closure  $value
+     * @param  mixed  $value
      * @return mixed $value
      */
-    public function rememberHidden($key, Closure $value)
+    public function rememberHidden($key, $value)
     {
         if ($this->hasHidden($key)) {
             return $this->getHidden($key);
         }
 
-        return tap($value(), function ($value) use ($key) {
+        return tap(value($value), function ($value) use ($key) {
             $this->addHidden($key, $value);
         });
     }

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -659,4 +659,40 @@ class Repository
 
         return $this;
     }
+
+    /**
+     * Add a context value if it does not exist yet, and returns the value.
+     *
+     * @param  string  $key
+     * @param  Closure  $value
+     * @return mixed $value
+     */
+    public function remember($key, Closure $value)
+    {
+        if ($this->has($key)) {
+            return $this->get($key);
+        }
+
+        return tap($value(), function ($value) use ($key) {
+            $this->add($key, $value);
+        });
+    }
+
+    /**
+     * Add a hidden context value if it does not exist yet, and returns the value.
+     *
+     * @param  string  $key
+     * @param  Closure  $value
+     * @return mixed $value
+     */
+    public function rememberHidden($key, Closure $value)
+    {
+        if ($this->hasHidden($key)) {
+            return $this->getHidden($key);
+        }
+
+        return tap($value(), function ($value) use ($key) {
+            $this->addHidden($key, $value);
+        });
+    }
 }

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -661,7 +661,7 @@ class Repository
     }
 
     /**
-     * Add a context value if it does not exist yet, and returns the value.
+     * Add a context value if it does not exist yet, and return the value.
      *
      * @param  string  $key
      * @param  Closure  $value
@@ -679,7 +679,7 @@ class Repository
     }
 
     /**
-     * Add a hidden context value if it does not exist yet, and returns the value.
+     * Add a hidden context value if it does not exist yet, and return the value.
      *
      * @param  string  $key
      * @param  Closure  $value

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -665,7 +665,7 @@ class Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed $value
+     * @return mixed
      */
     public function remember($key, $value)
     {
@@ -683,7 +683,7 @@ class Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed $value
+     * @return mixed
      */
     public function rememberHidden($key, $value)
     {

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -44,8 +44,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  * @method static \Illuminate\Database\Eloquent\Model restoreModel(\Illuminate\Contracts\Database\ModelIdentifier $value)
- * @method static mixed remember(string $key, \Closure $value)
- * @method static mixed rememberHidden(string $key, \Closure $value)
+ * @method static mixed remember(string $key, mixed $value)
+ * @method static mixed rememberHidden(string $key, mixed $value)
  *
  * @see \Illuminate\Log\Context\Repository
  */

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -44,6 +44,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  * @method static \Illuminate\Database\Eloquent\Model restoreModel(\Illuminate\Contracts\Database\ModelIdentifier $value)
+ * @method static mixed remember(string $key, \Closure $value)
+ * @method static mixed rememberHidden(string $key, \Closure $value)
  *
  * @see \Illuminate\Log\Context\Repository
  */

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -662,6 +662,36 @@ class ContextTest extends TestCase
         Context::decrement('foo', 2);
         $this->assertSame(0, Context::get('foo'));
     }
+
+    public function test_it_remembers_a_value()
+    {
+        $closureRunCount = 0;
+        $closure = function () use (&$closureRunCount) {
+            $closureRunCount++;
+            return 'bar';
+        };
+
+        $this->assertSame('bar', Context::remember('foo', $closure));
+        $this->assertSame('bar', Context::get('foo'));
+
+        Context::remember('foo', $closure);
+        $this->assertSame(1, $closureRunCount);
+    }
+
+    public function test_it_remembers_a_hidden_value()
+    {
+        $closureRunCount = 0;
+        $closure = function () use (&$closureRunCount) {
+            $closureRunCount++;
+            return 'bar';
+        };
+
+        $this->assertSame('bar', Context::rememberHidden('foo', $closure));
+        $this->assertSame('bar', Context::getHidden('foo'));
+
+        Context::rememberHidden('foo', $closure);
+        $this->assertSame(1, $closureRunCount);
+    }
 }
 
 enum Suit

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -665,6 +665,8 @@ class ContextTest extends TestCase
 
     public function test_it_remembers_a_value()
     {
+        $this->assertSame(1, Context::remember('int', 1));
+
         $closureRunCount = 0;
         $closure = function () use (&$closureRunCount) {
             $closureRunCount++;
@@ -681,6 +683,8 @@ class ContextTest extends TestCase
 
     public function test_it_remembers_a_hidden_value()
     {
+        $this->assertSame(1, Context::rememberHidden('int', 1));
+
         $closureRunCount = 0;
         $closure = function () use (&$closureRunCount) {
             $closureRunCount++;

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -668,6 +668,7 @@ class ContextTest extends TestCase
         $closureRunCount = 0;
         $closure = function () use (&$closureRunCount) {
             $closureRunCount++;
+
             return 'bar';
         };
 
@@ -683,6 +684,7 @@ class ContextTest extends TestCase
         $closureRunCount = 0;
         $closure = function () use (&$closureRunCount) {
             $closureRunCount++;
+
             return 'bar';
         };
 


### PR DESCRIPTION
Inspired by the `Cache::remember` function, adding `Context::remember` and `Context::rememberHidden` functions. 

`Context::remember` will add the result of the provided closure function to the context if not already present, and always return the result

```php
// Before
if (Context::has('user-permissions')) {
    $permissions = Context::get('user-permissions');
} else {
    $permissions = auth()->user()->permissions;
    Context::set('user-permissions', $permissions);
}

// After
$permissions = Context::remember('user-permissions', fn() => auth()->user()->permissions)
```

Useful when storing complicated values, or the result of DB queries, that you may need to access again elsewhere