### PR TITLE
[12.x] Return early on belongs-to-many relationship `syncWithoutDetaching` method when empty values are given

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -87,7 +87,9 @@ trait InteractsWithPivotTable
             'attached' => [], 'detached' => [], 'updated' => [],
         ];
 
-        if (empty($ids) && ! $detaching) {
+        $records = $this->formatRecordsList($this->parseIds($ids));
+
+        if (empty($records) && ! $detaching) {
             return $changes;
         }
 
@@ -96,8 +98,6 @@ trait InteractsWithPivotTable
         // if they exist in the array of current ones, and if not we will insert.
         $current = $this->getCurrentlyAttachedPivots()
             ->pluck($this->relatedPivotKey)->all();
-
-        $records = $this->formatRecordsList($this->parseIds($ids));
 
         // Next, we will take the differences of the currents and given IDs and detach
         // all of the entities that exist in the "current" array but are not in the

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -87,6 +87,10 @@ trait InteractsWithPivotTable
             'attached' => [], 'detached' => [], 'updated' => [],
         ];
 
+        if (empty($ids) && ! $detaching) {
+            return $changes;
+        }
+
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -926,6 +926,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         }
 
         $this->assertEmpty(DB::getQueryLog());
+
+        DB::disableQueryLog();
     }
 
     public function testToggleMethod()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -915,7 +915,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         DB::enableQueryLog();
 
-        foreach ([collect(), [], null, false, 0, ''] as $value) {
+        foreach ([collect(), [], null] as $value) {
             $result = $post->tags()->sync($value, false);
 
             $this->assertEquals([
@@ -925,9 +925,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             ], $result);
         }
 
-        $queries = DB::getQueryLog();
-
-        $this->assertCount(0, $queries);
+        $this->assertEmpty(DB::getQueryLog());
     }
 
     public function testToggleMethod()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -909,21 +909,23 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
-    public function testSyncMethodWithEmptyArrayDoesNotQueryWhenDetachingDisabled()
+    public function testSyncMethodWithEmptyValueDoesNotQueryWhenDetachingDisabled()
     {
         $post = Post::create(['title' => Str::random()]);
 
         DB::enableQueryLog();
 
-        $result = $post->tags()->sync([], false);
+        foreach ([collect(), [], null, false, 0, ''] as $value) {
+            $result = $post->tags()->sync($value, false);
+
+            $this->assertEquals([
+                'attached' => [],
+                'detached' => [],
+                'updated' => [],
+            ], $result);
+        }
 
         $queries = DB::getQueryLog();
-
-        $this->assertEquals([
-            'attached' => [],
-            'detached' => [],
-            'updated' => [],
-        ], $result);
 
         $this->assertCount(0, $queries);
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -909,6 +909,25 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
+    public function testSyncMethodWithEmptyArrayDoesNotQueryWhenDetachingDisabled()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::enableQueryLog();
+
+        $result = $post->tags()->sync([], false);
+
+        $queries = DB::getQueryLog();
+
+        $this->assertEquals([
+            'attached' => [],
+            'detached' => [],
+            'updated' => [],
+        ], $result);
+
+        $this->assertCount(0, $queries);
+    }
+
     public function testToggleMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
This is a small change to prevent an unnecessary query from being executed when calling `syncWithoutDetaching` with an empty value or collection (`collect()`, `[]`, or `null`).

Without this, we have to check every time to ensure the values are present instead of the framework automatically handling this. Over time, this can reduce a lot of conditions from being created unnecessarily, as well as SQL queries.

**Before**:
```php
if ($tags->isNotEmpty()) {
    $post->tags()->syncWithoutDetaching($tags);
}
```

**After**:
```php
$post->tags()->syncWithoutDetaching($tags);
```