### PR TITLE
#56124 Properly escape column defaults

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -478,12 +478,12 @@ abstract class Grammar extends BaseGrammar
         }
 
         if ($value instanceof BackedEnum) {
-            return "'{$value->value}'";
+            return "'".str_replace("'", "''", $value->value)."'";
         }
 
         return is_bool($value)
             ? "'".(int) $value."'"
-            : "'".(string) $value."'";
+            : "'".str_replace("'", "''", $value)."'";
     }
 
     /**


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/56124 for details.

This PR adds apostrophe escaping to literal strings and string backed enumerations. Currently these are quoted when passed through to the DBMS, but any apostrophes contained in them are not escaped, leading to SQL syntax errors (and potentially SQL injection, though the risk of this in column defaults is pretty slim).