### PR TITLE
[12.x] Support Passing `Htmlable` Instances to `Js::from()`

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -70,6 +70,10 @@ class Js implements Htmlable, Stringable
             return $data->toHtml();
         }
 
+        if ($data instanceof Htmlable) {
+            $data = $data->toHtml();
+        }
+
         if ($data instanceof UnitEnum) {
             $data = enum_value($data);
         }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Js;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
@@ -126,6 +127,19 @@ class SupportJsTest extends TestCase
             "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
             (string) Js::from($data)
         );
+    }
+
+    public function testHtmlable()
+    {
+        $data = new class implements Htmlable
+        {
+            public function toHtml(): string
+            {
+                return '<p>Hello, World!</p>';
+            }
+        };
+
+        $this->assertEquals("'\u003Cp\u003EHello, World!\u003C\/p\u003E'", (string) Js::from($data));
     }
 
     public function testBackedEnums()

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Js;
 use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
 use Illuminate\Tests\Support\Fixtures\StringBackedEnum;


### PR DESCRIPTION
This PR adds support for passing `Htmlable` instances to the `Js::from()` method. This change also affects the `@js()` Blade directive as it uses the same underlying method.

Previously, passing an `Htmlable` instance would result in an empty JSON object being returned:

```php
use Illuminate\Support\{HtmlString, Js};

$data = new HtmlString('<p>Hello, World!</p>');

echo Js::from($data);

// Output: "{}"
```

This is due to PHP's native `json_encode()` function not understanding how to convert the instance to a type it can work with (string, in this case).

To fix this, we check if `$data` is an instance of `Htmlable` and if so, call the `->toHtml()` method on it before encoding. This now gives us the expected result:

```php
use Illuminate\Support\{HtmlString, Js};

$data = new HtmlString('<p>Hello, World!</p>');

echo Js::from($data);

// Output: "'\u003Cp\u003EHello, World!\u003C\/p\u003E'"
```

I thought this would be useful as I recently needed to pass some sanitized HTML returned as an instance of `HtmlString` to an Alpine.js component. It removes the extra step of having to call `->toHtml()` directly, making the conversion much more seamless.