### PR TITLE
[12.x] Remove extra code from `storePasswordHashInSession` method

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -78,10 +78,6 @@ class AuthenticateSession implements AuthenticatesSessions
      */
     protected function storePasswordHashInSession($request)
     {
-        if (! $request->user()) {
-            return;
-        }
-
         $request->session()->put([
             'password_hash_'.$this->auth->getDefaultDriver() => $request->user()->getAuthPassword(),
         ]);


### PR DESCRIPTION
Since this condition is checked and excluded at the beginning of the `handle` method, there is no need to check it down the road again in the `storePasswordHashInSession `.

As shown here:
![image](https://github.com/user-attachments/assets/0a0c49ee-c71b-4cb4-b0e4-98f33f59e4ac)

