### PR TITLE
[12.x] Fix queue fake cleanup to always restore original queue manager

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -120,9 +120,11 @@ class Queue extends Facade
 
         static::fake($jobsToFake);
 
-        return tap($callable(), function () use ($originalQueueManager) {
+        try {
+            return $callable();
+        } finally {
             static::swap($originalQueueManager);
-        });
+        }
     }
 
     /**
@@ -138,9 +140,11 @@ class Queue extends Facade
 
         static::fakeExcept($jobsToAllow);
 
-        return tap($callable(), function () use ($originalQueueManager) {
+        try {
+            return $callable();
+        } finally {
             static::swap($originalQueueManager);
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
The current implementations of `Queue::fakeFor()` and `Queue::fakeExceptFor()` use `tap()` to restore the original queue manager after running a callback. However, if the callback throws an exception—such as a failed assertion `(ExpectationFailedException)`— the restoration never happens. This leaves the fake queue active outside the intended scope, causing tests to leak state and behave unpredictably.

This PR replaces `tap()` with a `try...finally` block to guarantee the original queue manager is always restored, even if exceptions occur during the callback execution.