### PR TITLE
Feature: doesntStartWith() and doesntEndWith() string methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -406,6 +406,18 @@ class Str
     }
 
     /**
+     * Determine if a given string doesn't end with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public static function doesntEndWith($haystack, $needles)
+    {
+        return ! static::endsWith($haystack, $needles);
+    }
+
+    /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
      * @param  string  $text

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1672,6 +1672,18 @@ class Str
     }
 
     /**
+     * Determine if a given string doesn't start with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public static function doesntStartWith($haystack, $needles)
+    {
+        return ! static::startsWith($haystack, $needles);
+    }
+
+    /**
      * Convert a value to studly caps case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -944,6 +944,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string doesn't start with a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public function doesntStartWith($needles)
+    {
+        return Str::doesntStartWith($this->value, $needles);
+    }
+
+    /**
      * Convert a value to studly caps case.
      *
      * @return static
@@ -1253,6 +1264,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function whenStartsWith($needles, $callback, $default = null)
     {
         return $this->when($this->startsWith($needles), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string doesn't start with a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenDoesntStartWith($needles, $callback, $default = null)
+    {
+        return $this->when($this->doesntStartWith($needles), $callback, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -268,6 +268,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string doesn't end with a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public function doesntEndWith($needles)
+    {
+        return Str::doesntEndWith($this->value, $needles);
+    }
+
+    /**
      * Determine if the string is an exact match with the given value.
      *
      * @param  \Illuminate\Support\Stringable|string  $value
@@ -1141,6 +1152,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function whenEndsWith($needles, $callback, $default = null)
     {
         return $this->when($this->endsWith($needles), $callback, $default);
+    }
+
+    /**
+     * Execute the given callback if the string doesn't end with a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenDoesntEndWith($needles, $callback, $default = null)
+    {
+        return $this->when($this->doesntEndWith($needles), $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -186,6 +186,41 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::startsWith('你好', 'a'));
     }
 
+    public function testDoesntStartWith()
+    {
+        $this->assertFalse(Str::doesntStartWith('jason', 'jas'));
+        $this->assertFalse(Str::doesntStartWith('jason', 'jason'));
+        $this->assertFalse(Str::doesntStartWith('jason', ['jas']));
+        $this->assertFalse(Str::doesntStartWith('jason', ['day', 'jas']));
+        $this->assertFalse(Str::doesntStartWith('jason', collect(['day', 'jas'])));
+        $this->assertTrue(Str::doesntStartWith('jason', 'day'));
+        $this->assertTrue(Str::doesntStartWith('jason', ['day']));
+        $this->assertTrue(Str::doesntStartWith('jason', null));
+        $this->assertTrue(Str::doesntStartWith('jason', [null]));
+        $this->assertTrue(Str::doesntStartWith('0123', [null]));
+        $this->assertFalse(Str::doesntStartWith('0123', 0));
+        $this->assertTrue(Str::doesntStartWith('jason', 'J'));
+        $this->assertTrue(Str::doesntStartWith('jason', ''));
+        $this->assertTrue(Str::doesntStartWith('', ''));
+        $this->assertTrue(Str::doesntStartWith('7', ' 7'));
+        $this->assertFalse(Str::doesntStartWith('7a', '7'));
+        $this->assertFalse(Str::doesntStartWith('7a', 7));
+        $this->assertFalse(Str::doesntStartWith('7.12a', 7.12));
+        $this->assertTrue(Str::doesntStartWith('7.12a', 7.13));
+        $this->assertFalse(Str::doesntStartWith(7.123, '7'));
+        $this->assertFalse(Str::doesntStartWith(7.123, '7.12'));
+        $this->assertTrue(Str::doesntStartWith(7.123, '7.13'));
+        $this->assertTrue(Str::doesntStartWith(null, 'Marc'));
+        // Test for multibyte string support
+        $this->assertFalse(Str::doesntStartWith('Jönköping', 'Jö'));
+        $this->assertFalse(Str::doesntStartWith('Malmö', 'Malmö'));
+        $this->assertTrue(Str::doesntStartWith('Jönköping', 'Jonko'));
+        $this->assertTrue(Str::doesntStartWith('Malmö', 'Malmo'));
+        $this->assertFalse(Str::doesntStartWith('你好', '你'));
+        $this->assertTrue(Str::doesntStartWith('你好', '好'));
+        $this->assertTrue(Str::doesntStartWith('你好', 'a'));
+    }
+
     public function testEndsWith()
     {
         $this->assertTrue(Str::endsWith('jason', 'on'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -219,6 +219,39 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('你好', 'a'));
     }
 
+    public function testDoesntEndWith()
+    {
+        $this->assertFalse(Str::doesntEndWith('jason', 'on'));
+        $this->assertFalse(Str::doesntEndWith('jason', 'jason'));
+        $this->assertFalse(Str::doesntEndWith('jason', ['on']));
+        $this->assertFalse(Str::doesntEndWith('jason', ['no', 'on']));
+        $this->assertFalse(Str::doesntEndWith('jason', collect(['no', 'on'])));
+        $this->assertTrue(Str::doesntEndWith('jason', 'no'));
+        $this->assertTrue(Str::doesntEndWith('jason', ['no']));
+        $this->assertTrue(Str::doesntEndWith('jason', ''));
+        $this->assertTrue(Str::doesntEndWith('', ''));
+        $this->assertTrue(Str::doesntEndWith('jason', [null]));
+        $this->assertTrue(Str::doesntEndWith('jason', null));
+        $this->assertTrue(Str::doesntEndWith('jason', 'N'));
+        $this->assertTrue(Str::doesntEndWith('7', ' 7'));
+        $this->assertFalse(Str::doesntEndWith('a7', '7'));
+        $this->assertFalse(Str::doesntEndWith('a7', 7));
+        $this->assertFalse(Str::doesntEndWith('a7.12', 7.12));
+        $this->assertTrue(Str::doesntEndWith('a7.12', 7.13));
+        $this->assertFalse(Str::doesntEndWith(0.27, '7'));
+        $this->assertFalse(Str::doesntEndWith(0.27, '0.27'));
+        $this->assertTrue(Str::doesntEndWith(0.27, '8'));
+        $this->assertTrue(Str::doesntEndWith(null, 'Marc'));
+        // Test for multibyte string support
+        $this->assertFalse(Str::doesntEndWith('Jönköping', 'öping'));
+        $this->assertFalse(Str::doesntEndWith('Malmö', 'mö'));
+        $this->assertTrue(Str::doesntEndWith('Jönköping', 'oping'));
+        $this->assertTrue(Str::doesntEndWith('Malmö', 'mo'));
+        $this->assertFalse(Str::doesntEndWith('你好', '好'));
+        $this->assertTrue(Str::doesntEndWith('你好', '你'));
+        $this->assertTrue(Str::doesntEndWith('你好', 'a'));
+    }
+
     public function testStrExcerpt()
     {
         $this->assertSame('...is a beautiful morn...', Str::excerpt('This is a beautiful morning', 'beautiful', ['radius' => 5]));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -277,6 +277,31 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenDoesntEndWith()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenDoesntEndWith('ark', function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['kra', 'ark'], function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['ark'], function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('TonyStark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['tony', 'xxx'], function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+    }
+
     public function testWhenExactly()
     {
         $this->assertSame('Nailed it...!', (string) $this->stringable('Tony Stark')->whenExactly('Tony Stark', function ($stringable) {
@@ -624,6 +649,34 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('Malmö')->endsWith('mö'));
         $this->assertFalse($this->stringable('Jönköping')->endsWith('oping'));
         $this->assertFalse($this->stringable('Malmö')->endsWith('mo'));
+    }
+
+    public function testDoesntEndWith()
+    {
+        $this->assertFalse($this->stringable('jason')->doesntEndWith('on'));
+        $this->assertFalse($this->stringable('jason')->doesntEndWith('jason'));
+        $this->assertFalse($this->stringable('jason')->doesntEndWith(['on']));
+        $this->assertFalse($this->stringable('jason')->doesntEndWith(['no', 'on']));
+        $this->assertFalse($this->stringable('jason')->doesntEndWith(collect(['no', 'on'])));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith('no'));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith(['no']));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith(''));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith([null]));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith(null));
+        $this->assertTrue($this->stringable('jason')->doesntEndWith('N'));
+        $this->assertTrue($this->stringable('7')->doesntEndWith(' 7'));
+        $this->assertFalse($this->stringable('a7')->doesntEndWith('7'));
+        $this->assertFalse($this->stringable('a7')->doesntEndWith(7));
+        $this->assertFalse($this->stringable('a7.12')->doesntEndWith(7.12));
+        $this->assertTrue($this->stringable('a7.12')->doesntEndWith(7.13));
+        $this->assertFalse($this->stringable(0.27)->doesntEndWith('7'));
+        $this->assertFalse($this->stringable(0.27)->doesntEndWith('0.27'));
+        $this->assertTrue($this->stringable(0.27)->doesntEndWith('8'));
+        // Test for multibyte string support
+        $this->assertFalse($this->stringable('Jönköping')->doesntEndWith('öping'));
+        $this->assertFalse($this->stringable('Malmö')->doesntEndWith('mö'));
+        $this->assertTrue($this->stringable('Jönköping')->doesntEndWith('oping'));
+        $this->assertTrue($this->stringable('Malmö')->doesntEndWith('mo'));
     }
 
     public function testExcerpt()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -291,8 +291,8 @@ class SupportStringableTest extends TestCase
             return $stringable->title();
         }));
 
-        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['ark'], function ($stringable) {
-            return $stringable->title();
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['xxx'], function ($stringable) {
+            return $stringable;
         }));
 
         $this->assertSame('TonyStark', (string) $this->stringable('tony stark')->whenDoesntEndWith(['tony', 'xxx'], function ($stringable) {
@@ -462,6 +462,31 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenDoesntStartWith()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenDoesntStartWith('ton', function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenDoesntStartWith(['ton', 'not'], function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenDoesntStartWith(['xxx'], function ($stringable) {
+            return $stringable;
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenDoesntStartWith(['tony', 'xxx'], function ($stringable) {
+            return $stringable->studly();
+        }, function ($stringable) {
+            return $stringable->title();
+        }));
+    }
+
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {
@@ -621,6 +646,36 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('Malmö')->startsWith('Malmö'));
         $this->assertFalse($this->stringable('Jönköping')->startsWith('Jonko'));
         $this->assertFalse($this->stringable('Malmö')->startsWith('Malmo'));
+    }
+
+    public function testDoesntStartWith()
+    {
+        $this->assertFalse($this->stringable('jason')->doesntStartWith('jas'));
+        $this->assertFalse($this->stringable('jason')->doesntStartWith('jason'));
+        $this->assertFalse($this->stringable('jason')->doesntStartWith(['jas']));
+        $this->assertFalse($this->stringable('jason')->doesntStartWith(['day', 'jas']));
+        $this->assertFalse($this->stringable('jason')->doesntStartWith(collect(['day', 'jas'])));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith('day'));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith(['day']));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith(null));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith([null]));
+        $this->assertTrue($this->stringable('0123')->doesntStartWith([null]));
+        $this->assertFalse($this->stringable('0123')->doesntStartWith(0));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith('J'));
+        $this->assertTrue($this->stringable('jason')->doesntStartWith(''));
+        $this->assertTrue($this->stringable('7')->doesntStartWith(' 7'));
+        $this->assertFalse($this->stringable('7a')->doesntStartWith('7'));
+        $this->assertFalse($this->stringable('7a')->doesntStartWith(7));
+        $this->assertFalse($this->stringable('7.12a')->doesntStartWith(7.12));
+        $this->assertTrue($this->stringable('7.12a')->doesntStartWith(7.13));
+        $this->assertFalse($this->stringable(7.123)->doesntStartWith('7'));
+        $this->assertFalse($this->stringable(7.123)->doesntStartWith('7.12'));
+        $this->assertTrue($this->stringable(7.123)->doesntStartWith('7.13'));
+        // Test for multibyte string support
+        $this->assertFalse($this->stringable('Jönköping')->doesntStartWith('Jö'));
+        $this->assertFalse($this->stringable('Malmö')->doesntStartWith('Malmö'));
+        $this->assertTrue($this->stringable('Jönköping')->doesntStartWith('Jonko'));
+        $this->assertTrue($this->stringable('Malmö')->doesntStartWith('Malmo'));
     }
 
     public function testEndsWith()


### PR DESCRIPTION
This pull request adds `doesntStartWith()` and `doesntEndWith()` methods to the `Illuminate\Support\Str` and `Illuminate\Support\Stringable` helper classes. It acts as a simple negation for the `startsWith()` and `endsWith()` methods without having to use something like `! Str::startsWith()` or `! Str::endsWith()`, which aligns with the existing `Str::doesntContain()` method.
