### PR TITLE
[12.x] Handle Enums in findOrFail Exceptions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -23,6 +23,8 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
 use ReflectionMethod;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
  *
@@ -582,6 +584,8 @@ class Builder implements BuilderContract
      */
     public function findOrFail($id, $columns = ['*'])
     {
+        $id = enum_value($id);
+
         $result = $this->find($id, $columns);
 
         $id = $id instanceof Arrayable ? $id->toArray() : $id;

--- a/tests/Database/DatabaseEloquentBuilderFindOrFailWithEnumTest.php
+++ b/tests/Database/DatabaseEloquentBuilderFindOrFailWithEnumTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class DatabaseEloquentBuilderFindOrFailWithEnumTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::drop('test_models');
+
+        parent::tearDown();
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testing');
+    }
+
+    public function testItFindsExistingModelWhenUsingEnumId()
+    {
+        EloquentBuilderFindOrFailWithEnumTestModel::create(['id' => 1, 'name' => 'one']);
+
+        $model = EloquentBuilderFindOrFailWithEnumTestModel::findOrFail(EloquentBuilderFindOrFailWithEnumTestBackedEnum::One);
+
+        $this->assertInstanceOf(EloquentBuilderFindOrFailWithEnumTestModel::class, $model);
+        $this->assertTrue($model->exists);
+        $this->assertEquals(1, $model->id);
+    }
+
+    public function testItThrowsExceptionWhenEnumIdDoesNotExist()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model ['.EloquentBuilderFindOrFailWithEnumTestModel::class.'] '.EloquentBuilderFindOrFailWithEnumTestBackedEnum::Ten->value);
+
+        EloquentBuilderFindOrFailWithEnumTestModel::findOrFail(EloquentBuilderFindOrFailWithEnumTestBackedEnum::Ten);
+    }
+
+    protected function createSchema()
+    {
+        Schema::create('test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+}
+
+class EloquentBuilderFindOrFailWithEnumTestModel extends Model
+{
+    protected $table = 'test_models';
+    public $timestamps = false;
+    protected $guarded = [];
+}
+
+enum EloquentBuilderFindOrFailWithEnumTestBackedEnum: int
+{
+    case One = 1;
+    case Ten = 10;
+}


### PR DESCRIPTION
Fixes #55977

When a dev uses an enum for a model id that does not exist, this crashes with a fatal error instead of throwing the expected ModelNotFoundException. It forces devs to write boilerplate code to manually pull the value from the enum before passing it to findOrFail

**Before:**
```php
// This code crashes with a fatal error
// Error: Object of class App\Enums\UserEnum could not be converted to string.
User::findOrFail(UserEnum::NonExistent);
// Developers have to write this instead:
User::findOrFail(UserEnum::NonExistent-&gt;value);
```

**After:**
With this change, the framework deals with the enum just like it does anywhere else in the query builder (like the where statement). This makes building apps easier by letting us write less, and write it more directly.
```php
// This code now throws a ModelNotFoundException, as we want.
User::findOrFail(UserEnum::NonExistent);
```
This method follows the good idea by @jtheuerkauf in the original issue discussion, which provides consistency with how enums are handled elsewhere in the framework. A dedicated test has been added to cover this behavior and prevent regressions.