### PR TITLE
[12.x] Update Castable contract to accept string array

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Castable.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Castable.php
@@ -7,7 +7,7 @@ interface Castable
     /**
      * Get the name of the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
+     * @param  string[]  $arguments
      * @return class-string<CastsAttributes|CastsInboundAttributes>|CastsAttributes|CastsInboundAttributes
      */
     public static function castUsing(array $arguments);


### PR DESCRIPTION
The changes update the `castUsing` method in the `Castable` contract to accept an array of strings as arguments, rather than a generic array. This ensures that the method signature is more specific and provides better type safety for the arguments passed to the method.