### PR TITLE
[12.x] Add RequestStarted event

### DIFF
--- a/src/Illuminate/Foundation/Http/Events/RequestStarted.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestStarted.php
@@ -14,7 +14,7 @@ class RequestStarted
     /**
      * When the request started.
      *
-     * @var \Carbon\CarbonImmutable
+     * @var \Illuminate\Support\Carbon|null
      */
     public $startedAt;
 
@@ -22,7 +22,7 @@ class RequestStarted
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Carbon\CarbonImmutable  $startedAt
+     * @param  \Illuminate\Support\Carbon|null  $startedAt
      */
     public function __construct($request, $startedAt)
     {

--- a/src/Illuminate/Foundation/Http/Events/RequestStarted.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestStarted.php
@@ -11,7 +11,6 @@ class RequestStarted
      */
     public $request;
 
-
     /**
      * When the request started.
      *

--- a/src/Illuminate/Foundation/Http/Events/RequestStarted.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestStarted.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Events;
+
+class RequestStarted
+{
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+
+    /**
+     * When the request started.
+     *
+     * @var \Carbon\CarbonImmutable
+     */
+    public $startedAt;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Carbon\CarbonImmutable  $startedAt
+     */
+    public function __construct($request, $startedAt)
+    {
+        $this->request = $request;
+        $this->startedAt = $startedAt;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -171,7 +171,7 @@ class Kernel implements KernelContract
         $this->bootstrap();
 
         $this->app['events']->dispatch(
-            new RequestStarted($request, $this->requestStartedAt())
+            new RequestStarted($request, $this->requestStartedAt)
         );
 
         return (new Pipeline($this->app))

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -171,7 +171,7 @@ class Kernel implements KernelContract
         $this->bootstrap();
 
         $this->app['events']->dispatch(
-            new RequestStarted($request, $this->requestStartedAt)
+            new RequestStarted($request, $this->requestStartedAt())
         );
 
         return (new Pipeline($this->app))

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Foundation\Http\Events\RequestStarted;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
@@ -168,6 +169,10 @@ class Kernel implements KernelContract
         Facade::clearResolvedInstance('request');
 
         $this->bootstrap();
+
+        $this->app['events']->dispatch(
+            new RequestStarted($request, $this->requestStartedAt)
+        );
 
         return (new Pipeline($this->app))
             ->send($request)


### PR DESCRIPTION
I use a listener to monitor various events - this includes the [`RequestHandled`](https://github.com/laravel/framework/blob/d493d6f6ed042c0b13621627a12df87429982ed4/src/Illuminate/Foundation/Http/Events/RequestHandled.php#L5) event, so I can do things like calculate how many queries it's made etc during that request etc. 

It would be nice to add a RequestStarted event too, rather than relying on middleware I can keep my logic in one place, and we can access the time the request actually started, I thought it may be useful, so opened this PR. 🫡 

I've had to put it under the bootstrap method  (events require it to be bootstrapped) to make sure nothing is affected, as didn't want to cause any breaking changes, I've passed in the request and the started at time.

This is not the same as the ResponsePrepared event as it's purely about when the request started.  


Basic example could be: 

<details> 


```php 
    public function started(RequestStarted $event): void
    {
        $this->prepared = $event->startedAt?->getTimeStampMs();
    }

    public function subscribe(Dispatcher $events): void
    {
        $events->listen(RequestStarted::class, [$this, 'started']);
    } 
    
    // More logic here based on when the requested started...

```
</details> 

As far as I know there's no breaking changes as it's all opt in.

We could move the bootstrap method up as well as the new dispatch and target master, but may introduce breaking changes so leaving that up to you.

Thanks