### PR TITLE
[12.x] feat(queue): add worker name to verbose and json output

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -173,6 +173,16 @@ class WorkCommand extends Command
     }
 
     /**
+     * Get the queue worker name.
+     *
+     * @return string
+     */
+    protected function getWorkerName()
+    {
+        return $this->option('name');
+    }
+
+    /**
      * Listen for the queue events in order to update the console output.
      *
      * @return void
@@ -235,7 +245,12 @@ class WorkCommand extends Command
             $this->now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
             $isVerbose
-                ? sprintf('<fg=gray>%s</> <fg=blue>%s</> <fg=blue>%s</>', $job->getJobId(), $job->getConnectionName(), $job->getQueue())
+                ? sprintf('<fg=gray>%s</>  <fg=magenta>%s</> <fg=blue>%s</> <fg=blue>%s</>', 
+                    $job->getJobId(), 
+                    $this->getWorkerName(),
+                    $job->getConnectionName(), 
+                    $job->getQueue()
+                )
                 : ''
         )));
 
@@ -243,8 +258,8 @@ class WorkCommand extends Command
             $this->latestStartedAt = microtime(true);
 
             $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-                $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
-            ) - 33, 0);
+                $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($this->getWorkerName()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
+            ) - 35, 0);
 
             $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
 
@@ -254,8 +269,8 @@ class WorkCommand extends Command
         $runTime = $this->runTimeForHumans($this->latestStartedAt);
 
         $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
-            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
-        ) - mb_strlen($runTime) - 31, 0);
+            $isVerbose ? mb_strlen($job->getJobId()) + mb_strlen($this->getWorkerName()) + mb_strlen($job->getConnectionName()) + mb_strlen($job->getQueue()) + 2 : 0
+        ) - mb_strlen($runTime) - 33, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");
@@ -281,6 +296,7 @@ class WorkCommand extends Command
             'level' => $status === 'starting' || $status === 'success' ? 'info' : 'warning',
             'id' => $job->getJobId(),
             'uuid' => $job->uuid(),
+            'worker' => $this->getWorkerName(),
             'connection' => $job->getConnectionName(),
             'queue' => $job->getQueue(),
             'job' => $job->resolveName(),

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -245,10 +245,10 @@ class WorkCommand extends Command
             $this->now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
             $isVerbose
-                ? sprintf('<fg=gray>%s</>  <fg=magenta>%s</> <fg=blue>%s</> <fg=blue>%s</>', 
-                    $job->getJobId(), 
+                ? sprintf('<fg=gray>%s</>  <fg=magenta>%s</> <fg=blue>%s</> <fg=blue>%s</>',
+                    $job->getJobId(),
                     $this->getWorkerName(),
-                    $job->getConnectionName(), 
+                    $job->getConnectionName(),
                     $job->getQueue()
                 )
                 : ''


### PR DESCRIPTION
## Changes

- Show the queue worker name that executed the job when using `verbose` output or `json` format.  
- Increase default lengths by two characters each to avoid breaking the terminal output in some cases.

![image](https://github.com/user-attachments/assets/5c2f9e38-330a-4ff4-ad25-274d0e76b656)

### Background

I am a core developer at [Coolify](https://github.com/coollabsio/coolify) (large Laravel project) and needed a way to test/ compare a new supervision implementation and ensure all workers were processing jobs correctly. Unfortunately, I found no way to display the worker name in either the `json` or `verbose` output, so I added it myself. It looks super clean and allows for much easier debugging.
