### PR TITLE
Add failWhen method to ThrottlesExceptions job middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -62,6 +62,10 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
                 return $job->delete();
             }
 
+            if ($this->shouldFail($throwable)) {
+                return $job->fail($throwable);
+            }
+
             $this->limiter->acquire();
 
             return $job->release($this->retryAfterMinutes * 60);

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -123,7 +123,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('hasFailed')->once()->andReturn(true);
         $job->shouldReceive('fail')->once();
         $job->shouldReceive('isDeleted')->andReturn(true);
-        $job->shouldReceive('isReleased')->twice()->andReturn(false);
+        $job->shouldReceive('isReleased')->once()->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `failWhen` method to the `ThrottlesExceptions` job middleware. Currently, this middleware only allows for deleting the job when a specific exception is thrown. There are occasions were you would want to mark the job as failed instead. For instance: in the context of a job chain it may be desirable to fail a job when an exception is thrown so that the chain stops executing. With the current `deleteWhen` method this is not possible.

See discussion #56174 for more context.
