### PR TITLE
Limit index key length to avoid errors generating tables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1706,7 +1706,9 @@ class Blueprint
 
         $index = strtolower($table.'_'.implode('_', $columns).'_'.$type);
 
-        return str_replace(['-', '.'], '_', $index);
+        $index = str_replace(['-', '.'], '_', $index);
+        
+        return substr($index, 0, 64);
     }
 
     /**


### PR DESCRIPTION
While postgres truncates the index identifier automatically without generate an error, mysql doesn't do that and in case of complex indexes it will just skip the index creation returning an error in the migration. This small fix should avoid that.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
