### PR TITLE
Add `filter_and_reindex()` helper to simplify common array filtering pattern

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -362,8 +362,7 @@ if (! function_exists('str')) {
     function str($string = null)
     {
         if (func_num_args() === 0) {
-            return new class
-            {
+            return new class () {
                 public function __call($method, $parameters)
                 {
                     return Str::$method(...$parameters);
@@ -524,5 +523,19 @@ if (! function_exists('with')) {
     function with($value, ?callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
+    }
+}
+
+if (! function_exists('filter_and_reindex')) {
+    /**
+     * Filter an array using the given callback and reindex the result.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    function filter_and_reindex(array $array, callable $callback): array
+    {
+        return array_values(array_filter($array, $callback));
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -39,7 +39,7 @@ class SupportHelpersTest extends TestCase
         m::close();
 
         if (is_dir(__DIR__.'/tmp')) {
-            (new Filesystem)->deleteDirectory(__DIR__.'/tmp');
+            (new Filesystem())->deleteDirectory(__DIR__.'/tmp');
         }
 
         parent::tearDown();
@@ -90,8 +90,7 @@ class SupportHelpersTest extends TestCase
 
     public function testBlankDoesntJsonSerializeModels()
     {
-        $model = new class extends Model
-        {
+        $model = new class () extends Model {
             public function jsonSerialize(): mixed
             {
                 throw new RuntimeException('Model should not be serialized');
@@ -137,7 +136,7 @@ class SupportHelpersTest extends TestCase
         $this->assertNull(when(0, fn () => null));
         $this->assertEquals('True', when([1, 2, 3, 4], 'True')); // Array
         $this->assertNull(when([], 'True')); // Empty Array = Falsy
-        $this->assertEquals('True', when(new StdClass, fn () => 'True')); // Object
+        $this->assertEquals('True', when(new StdClass(), fn () => 'True')); // Object
         $this->assertEquals('World', when(false, 'Hello', 'World'));
         $this->assertEquals('World', when(1 === 0, 'Hello', 'World')); // strict types
         $this->assertEquals('World', when(1 == '0', 'Hello', 'World')); // loose types
@@ -170,8 +169,7 @@ class SupportHelpersTest extends TestCase
 
     public function testValue()
     {
-        $callable = new class
-        {
+        $callable = new class () {
             public function __call($method, $arguments)
             {
                 return $arguments;
@@ -190,8 +188,8 @@ class SupportHelpersTest extends TestCase
 
     public function testObjectGet()
     {
-        $class = new stdClass;
-        $class->name = new stdClass;
+        $class = new stdClass();
+        $class->name = new stdClass();
         $class->name->first = 'Taylor';
 
         $this->assertSame('Taylor', object_get($class, 'name.first'));
@@ -200,8 +198,8 @@ class SupportHelpersTest extends TestCase
 
     public function testObjectGetDefaultValue()
     {
-        $class = new stdClass;
-        $class->name = new stdClass;
+        $class = new stdClass();
+        $class->name = new stdClass();
         $class->name->first = 'Taylor';
 
         $this->assertSame('default', object_get($class, 'name.family', 'default'));
@@ -210,7 +208,7 @@ class SupportHelpersTest extends TestCase
 
     public function testObjectGetWhenKeyIsNullOrEmpty()
     {
-        $object = new stdClass;
+        $object = new stdClass();
 
         $this->assertEquals($object, object_get($object, null));
         $this->assertEquals($object, object_get($object, false));
@@ -741,7 +739,7 @@ class SupportHelpersTest extends TestCase
                 SupportTestTraitTwo::class => SupportTestTraitTwo::class,
                 SupportTestTraitOne::class => SupportTestTraitOne::class,
             ],
-            class_uses_recursive(new SupportTestClassTwo)
+            class_uses_recursive(new SupportTestClassTwo())
         );
     }
 
@@ -806,7 +804,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        throw_if(true, new LogicException);
+        throw_if(true, new LogicException());
     }
 
     public function testThrowDefaultException()
@@ -836,7 +834,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        throw_unless(false, new LogicException);
+        throw_unless(false, new LogicException());
     }
 
     public function testThrowUnlessDefaultException()
@@ -864,7 +862,7 @@ class SupportHelpersTest extends TestCase
 
     public function testThrowReturnIfNotThrown()
     {
-        $this->assertSame('foo', throw_unless('foo', new RuntimeException));
+        $this->assertSame('foo', throw_unless('foo', new RuntimeException()));
     }
 
     public function testThrowWithString()
@@ -879,8 +877,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->assertNull(optional(null)->something());
 
-        $this->assertEquals(10, optional(new class
-        {
+        $this->assertEquals(10, optional(new class () {
             public function something()
             {
                 return 10;
@@ -958,12 +955,10 @@ class SupportHelpersTest extends TestCase
 
         $this->assertNull(optional(null)->present()->something());
 
-        $this->assertSame('$10.00', optional(new class
-        {
+        $this->assertSame('$10.00', optional(new class () {
             public function present()
             {
-                return new class
-                {
+                return new class () {
                     public function something()
                     {
                         return '$10.00';
@@ -982,7 +977,7 @@ class SupportHelpersTest extends TestCase
                 return $attempts;
             }
 
-            throw new RuntimeException;
+            throw new RuntimeException();
         }, 100);
 
         // Make sure we made two attempts
@@ -1005,7 +1000,7 @@ class SupportHelpersTest extends TestCase
                 return $attempts;
             }
 
-            throw new RuntimeException;
+            throw new RuntimeException();
         }, function ($attempt, $exception) {
             $this->assertInstanceOf(RuntimeException::class, $exception);
 
@@ -1033,7 +1028,7 @@ class SupportHelpersTest extends TestCase
                 return $attempts;
             }
 
-            throw new RuntimeException;
+            throw new RuntimeException();
         }, 100, function ($ex) {
             return true;
         });
@@ -1058,7 +1053,7 @@ class SupportHelpersTest extends TestCase
                 return $attempts;
             }
 
-            throw new RuntimeException;
+            throw new RuntimeException();
         }, 100, function ($ex) {
             return false;
         });
@@ -1073,7 +1068,7 @@ class SupportHelpersTest extends TestCase
                 return $attempts;
             }
 
-            throw new RuntimeException;
+            throw new RuntimeException();
         });
 
         // Make sure we made four attempts
@@ -1228,7 +1223,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWriteArrayOfEnvVariablesToFile()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1269,7 +1264,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWriteArrayOfEnvVariablesToFileAndOverwrite()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1306,7 +1301,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWillNotOverwriteArrayOfVariables()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1343,7 +1338,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWriteVariableToFile()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1376,7 +1371,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWillNotOverwriteVariable()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1410,7 +1405,7 @@ class SupportHelpersTest extends TestCase
 
     public function testWriteVariableToFileAndOverwrite()
     {
-        $filesystem = new Filesystem;
+        $filesystem = new Filesystem();
         $path = __DIR__.'/tmp/env-test-file';
         $filesystem->put($path, implode(PHP_EOL, [
             'APP_NAME=Laravel',
@@ -1562,6 +1557,15 @@ trait SupportTestTraitArrayAccess
     public function offsetUnset($offset): void
     {
         unset($this->items[$offset]);
+    }
+
+    public function testFilterAndReindexReturnsReindexedFilteredArray(): void
+    {
+        $array = [1, 2, 3, 4, 5];
+
+        $result = filter_and_reindex($array, fn ($value) => $value % 2 === 0);
+
+        $this->assertSame([0 => 2, 1 => 4], $result);
     }
 }
 


### PR DESCRIPTION
### Description

This PR introduces a new global helper function: `filter_and_reindex()`.

```php
if (! function_exists('filter_and_reindex')) {
    /**
     * Filter an array using the given callback and reindex the result.
     *
     * @param  array  $array
     * @param  callable  $callback
     * @return array
     */
    function filter_and_reindex(array $array, callable $callback): array
    {
        return array_values(array_filter($array, $callback));
    }
}
```

### Why?

In PHP, it’s common to filter an array and then reset its numeric indices:

```php
$filtered = array_values(array_filter($array, $callback));
```

While expressive, this pattern is verbose and repeated frequently. Introducing `filter_and_reindex()` makes this intent more readable and concise:

```php
$filtered = filter_and_reindex($array, fn ($v) => $v !== null);
```

This improves:

- Readability: clear expression of intent ("filter and reindex")
- Developer experience: avoids boilerplate repetition
- Consistency with Laravel’s expressive helper philosophy

### Example

**Before:**

```php
$result = array_values(array_filter($items, fn ($item) => $item->isVisible()));
```

**After:**

```php
$result = filter_and_reindex($items, fn ($item) => $item->isVisible());
```

---

Let me know if this is too minor for inclusion, or if you'd prefer placing it inside `Illuminate\Support\Arr` instead.  
Happy to adapt direction based on your feedback.