### PR TITLE
Revert "[11.x] Pass the limiter to the when & report callbacks"

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -104,11 +104,11 @@ class ThrottlesExceptions
 
             $this->limiter->clear($jobKey);
         } catch (Throwable $throwable) {
-            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
+            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable)) {
                 throw $throwable;
             }
 
-            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable, $this->limiter)) {
+            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable)) {
                 report($throwable);
             }
 

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -50,11 +50,11 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
 
             $this->limiter->clear();
         } catch (Throwable $throwable) {
-            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable, $this->limiter)) {
+            if ($this->whenCallback && ! call_user_func($this->whenCallback, $throwable)) {
                 throw $throwable;
             }
 
-            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable, $this->limiter)) {
+            if ($this->reportCallback && call_user_func($this->reportCallback, $throwable)) {
                 report($throwable);
             }
 


### PR DESCRIPTION
Reverts laravel/framework#56129. 11.x is closed to new features. We should re-merge the PR into 12.x