### PR TITLE
[12.x] Add `Closure`-support to `$key`/`$value` in Collection `pluck()` method

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -777,12 +777,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             [$value, $key] = $this->explodePluckParameters($value, $key);
 
             foreach ($this as $item) {
-                $itemValue = data_get($item, $value);
+                $itemValue = $value instanceof Closure
+                    ? $value($item)
+                    : data_get($item, $value);
 
                 if (is_null($key)) {
                     yield $itemValue;
                 } else {
-                    $itemKey = data_get($item, $key);
+                    $itemKey = $key instanceof Closure
+                        ? $key($item)
+                        : data_get($item, $key);
 
                     if (is_object($itemKey) && method_exists($itemKey, '__toString')) {
                         $itemKey = (string) $itemKey;
@@ -1869,7 +1873,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        $key = is_null($key) || is_array($key) || $key instanceof Closure ? $key : explode('.', $key);
 
         return [$value, $key];
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Closure;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
@@ -717,8 +718,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get an array with the values of a given key.
      *
-     * @param  string|array<array-key, string>|null  $value
-     * @param  string|null  $key
+     * @param  string|array<array-key, string>|Closure|null  $value
+     * @param  string|Closure|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function pluck($value, $key = null)

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -732,6 +732,26 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertSame($bar, $collection->except($fooKey)->first());
     }
 
+    public function testPluck()
+    {
+        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1, 'name' => 'John', 'country' => 'US']);
+        $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2, 'name' => 'Jane', 'country' => 'NL']);
+        $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3, 'name' => 'Taylor', 'country' => 'US']);
+
+        $c = new Collection;
+
+        $c->push($model1)->push($model2)->push($model3);
+
+        $this->assertInstanceOf(BaseCollection::class, $c->pluck('id'));
+        $this->assertEquals([1, 2, 3], $c->pluck('id')->all());
+
+        $this->assertInstanceOf(BaseCollection::class, $c->pluck('id', 'id'));
+        $this->assertEquals([1 => 1, 2 => 2, 3 => 3], $c->pluck('id', 'id')->all());
+        $this->assertInstanceOf(BaseCollection::class, $c->pluck('test'));
+
+        $this->assertEquals(['John (US)', 'Jane (NL)', 'Taylor (US)'], $c->pluck(fn (TestEloquentCollectionModel $model) => "{$model->name} ({$model->country})")->all());
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2324,6 +2324,28 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testPluckWithClosure($collection)
+    {
+        $data = new $collection([
+            [
+                'name' => 'amir',
+                'skill' => [
+                    'backend' => ['php', 'python'],
+                ],
+            ],
+            [
+                'name' => 'taylor',
+                'skill' => [
+                    'backend' => ['php', 'asp', 'java'],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(["amir (verified)", "taylor (verified)"], $data->pluck(fn (array $row) => "{$row['name']} (verified)")->all());
+        $this->assertEquals(["php/python" => "amir", "php/asp/java" => "taylor"], $data->pluck('name', fn (array $row) => implode('/', $row['skill']['backend']))->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testPluckDuplicateKeysExist($collection)
     {
         $data = new $collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2341,8 +2341,8 @@ class SupportCollectionTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(["amir (verified)", "taylor (verified)"], $data->pluck(fn (array $row) => "{$row['name']} (verified)")->all());
-        $this->assertEquals(["php/python" => "amir", "php/asp/java" => "taylor"], $data->pluck('name', fn (array $row) => implode('/', $row['skill']['backend']))->all());
+        $this->assertEquals(['amir (verified)', 'taylor (verified)'], $data->pluck(fn (array $row) => "{$row['name']} (verified)")->all());
+        $this->assertEquals(['php/python' => 'amir', 'php/asp/java' => 'taylor'], $data->pluck('name', fn (array $row) => implode('/', $row['skill']['backend']))->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR adds closure support to the `$key`/`$value` parameters of the `pluck()` methods. Very often I have that I almost can use `pluck()`, but I cannot because I need to make a slight modification to e.g. the key or value. I then need to solve this with `mapWithKeys()`, but that repeats the `id` and makes it way more verbose if you only just want to apply some formatting to the key and/or value.

After this PR, you can now do the following:

```php
Country::get()
    ->pluck(fn (Country $country) => "{$country->flag} {$country->name}", 'id')
```

This would result in a collection keyed by `id` with the concatenated name as value. Eloquent collections are a common use case, but this also works on regular collections and the `Arr` class.

Thanks!