### PR TITLE
[12.x] Add `@blank` and `@filled` Blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -233,6 +233,48 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-blank statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileBlank($expression)
+    {
+        return "<?php if(blank{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-blank statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndBlank()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the if-filled statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileFilled($expression)
+    {
+        return "<?php if(filled{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-filled statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndFilled()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the switch statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIfBlankFilledStatementsTest.php
+++ b/tests/View/Blade/BladeIfBlankFilledStatementsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfBlankFilledStatementsTest extends AbstractBladeTestCase
+{
+    public function testBlankStatementsAreCompiled()
+    {
+        $string = '@blank ($test)
+breeze
+@endblank';
+        $expected = '<?php if(blank($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testFilledStatementsAreCompiled()
+    {
+        $string = '@filled ($test)
+breeze
+@endfilled';
+        $expected = '<?php if(filled($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
This PR add 2 new Blade directives: `@blank` and `@filled` who works as a shortcuts of Laravel [blank](https://laravel.com/docs/12.x/helpers#method-blank) and [filled](https://laravel.com/docs/12.x/helpers#method-filled) functions.

These directives are particularly useful when you have `Countable` or `Stringable` object and want to display/hide something as you can't use `@isset` or `@empty` directives to check statement.

### Before this PR 
You need to call `isEmpty`/ `isNotEmpty`

```blade
@if($collection->isEmpty())
    Display something
@endif

// or 

@if($collection->isNotEmpty())
    Display something
@endif
```

---

### With this PR
Simply call 
```blade
@blank($collection)
    Display something 
@endblank

// or 

@filled($collection)
    Display something
@endfilled
```