### PR TITLE
[12.x] Allow array in the `withPath` method of `Uri`

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -238,7 +238,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     {
         $paths = implode('',
             Arr::map(
-                Arr::flatten(func_get_args()),
+                Arr::flatten($paths),
                 fn (Stringable|string $segment) => Str::start((string) $segment, '/')
             )
         );

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -230,11 +230,20 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
-     * Specify the path of the URI.
+     * Specify the paths of the URI.
+     *
+     * @param  Stringable|string|array<int, Stringable|string>  ...$paths
      */
-    public function withPath(Stringable|string $path): static
+    public function withPath(Stringable|string|array ...$paths): static
     {
-        return new static($this->uri->withPath(Str::start((string) $path, '/')));
+        $paths = implode('',
+            Arr::map(
+                Arr::flatten(func_get_args()),
+                fn (Stringable|string $segment) => Str::start((string) $segment, '/')
+            )
+        );
+
+        return new static($this->uri->withPath($paths));
     }
 
     /**

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -202,6 +202,7 @@ class SupportUriTest extends TestCase
         $uri = Uri::of('https://laravel.com');
 
         $this->assertEquals('https://laravel.com', (string) $uri->withPath([]));
+        $this->assertEquals('https://laravel.com/one', (string) $uri->withPath('one'));
         $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath(['one', 'two', 'three']));
         $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath('one', 'two', 'three'));
         $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath(['one', 'two'], 'three'));

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -197,6 +197,16 @@ class SupportUriTest extends TestCase
         $this->assertEquals('https://laravel.com', (string) $uri->withQuery([]));
     }
 
+    public function test_with_path_array()
+    {
+        $uri = Uri::of('https://laravel.com');
+
+        $this->assertEquals('https://laravel.com', (string) $uri->withPath([]));
+        $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath(['one', 'two', 'three']));
+        $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath('one', 'two', 'three'));
+        $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath(['one', 'two'], 'three'));
+    }
+
     public function test_path_segments()
     {
         $uri = Uri::of('https://laravel.com');

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -201,6 +201,7 @@ class SupportUriTest extends TestCase
     {
         $uri = Uri::of('https://laravel.com');
 
+        $this->assertEquals('https://laravel.com', (string) $uri->withPath());
         $this->assertEquals('https://laravel.com', (string) $uri->withPath([]));
         $this->assertEquals('https://laravel.com/one', (string) $uri->withPath('one'));
         $this->assertEquals('https://laravel.com/one/two/three', (string) $uri->withPath(['one', 'two', 'three']));


### PR DESCRIPTION
In the variables context, rather than concatenating path segments like:

```php
->withPath('path1/'.$path2)
```

I'd prefer to call it like:
```php
->withPath('path1', $path2)

// or
->withPath(['path1', $path2])
```