### PR TITLE
[12.x] Correct how base options for missing config files are preloaded

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Bootstrap;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Collection;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
@@ -69,7 +70,7 @@ class LoadConfiguration
             ? $this->getBaseConfiguration()
             : [];
 
-        foreach (array_diff(array_keys($base), array_keys($files)) as $name => $config) {
+        foreach (Collection::make($base)->diffKeys($files) as $name => $config) {
             $repository->set($name, $config);
         }
 

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -12,7 +12,7 @@ class LoadConfigurationTest extends TestCase
     {
         $app = new Application();
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertSame('Laravel', $app['config']['app.name']);
     }
@@ -22,7 +22,7 @@ class LoadConfigurationTest extends TestCase
         $app = new Application();
         $app->dontMergeFrameworkConfiguration();
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertNull($app['config']['app.name']);
     }
@@ -32,7 +32,7 @@ class LoadConfigurationTest extends TestCase
         $app = new Application(__DIR__.'/../fixtures');
         $app->useConfigPath(__DIR__.'/../fixtures/config');
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertNull($app['config']['bar.foo']);
         $this->assertSame('bar', $app['config']['custom.foo']);


### PR DESCRIPTION
Issue introduced by PR https://github.com/laravel/framework/pull/51619 and present since Laravel 11.10

---

### Offending code

https://github.com/laravel/framework/blob/c0955af55f216ba0b864a3819acb435859957f0a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php#L71-L75

### Given the config

|`$baseArrayKeys`|`$filesArrayKeys`|
|---|---|
|<pre>[<br>    'app',<br>    'auth',<br>    'broadcasting',<br>    'cache',<br>    'concurrency',<br>    'cors',<br>    'database',<br>    'filesystems',<br>    'hashing',<br>    'logging',<br>    'mail',<br>    'queue',<br>    'services',<br>    'session',<br>    'view',<br>];<br></pre>|<pre>[<br>    'app',<br>    'broadcasting',<br>    'cache',<br>    'custom',<br>    'database',<br>    'filesystems',<br>    'logging',<br>    'mail',<br>    'queue',<br>];</pre>|

### You get

```php
// array_diff(array_keys($base), array_keys($files)

$keysArrayDiff = [
    1 => 'auth',
    4 => 'concurrency',
    5 => 'cors',
    8 => 'hashing',
    12 => 'services',
    13 => 'session',
    14 => 'view',
];
```

- This means you're setting a config item with `$name = 1` and `$config = 'auth'`, etc. which isn't the intention.
- Test added to demo the issue/fix

### Instead switch to

```diff
+use Illuminate\Support\Collection;

-foreach (array_diff(array_keys($base), array_keys($files)) as $name => $config) {
+foreach (Collection::make($base)->diffKeys($files) as $name => $config) {
    $repository->set($name, $config);
}
```