### PR TITLE
Add int to allowed types of value in DatabaseRule

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -111,7 +111,7 @@ trait DatabaseRule
      * Set a "where not" constraint on the query.
      *
      * @param  string  $column
-     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string|int  $value
      * @return $this
      */
     public function whereNot($column, $value)


### PR DESCRIPTION
Add int to allowed types of $value argument for whereNot method in DatabaseRule.

Right now it allows only string, which is incorrect. PHPStan reports this as error, but the validation works as expected.

Code snippet with example:
```php
fn (Unique $rule): Unique => $rule
    ->whereNot('morph_id', $record->id)
    ->whereNot('morph_type', $record->getMorphClass())
```
