### PR TITLE
[12.x] Add `collection()` to Config repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,6 +5,7 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
@@ -175,6 +176,18 @@ class Repository implements ArrayAccess, ConfigContract
         }
 
         return $value;
+    }
+
+    /**
+     * Get the specified array configuration value as a collection.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return Collection<array-key, mixed>
+     */
+    public function collection(string $key, $default = null): Collection
+    {
+        return collect($this->array($key, $default));
     }
 
     /**

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -187,7 +187,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function collection(string $key, $default = null): Collection
     {
-        return collect($this->array($key, $default));
+        return new Collection($this->array($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static float float(string $key, \Closure|float|null $default = null)
  * @method static bool boolean(string $key, \Closure|bool|null $default = null)
  * @method static array array(string $key, \Closure|array|null $default = null)
+ * @method static \Illuminate\Support\Collection collection(string $key, \Closure|array|null $default = null)
  * @method static void set(array|string $key, mixed $value = null)
  * @method static void prepend(string $key, mixed $value)
  * @method static void push(string $key, mixed $value)

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -317,6 +318,14 @@ class RepositoryTest extends TestCase
         $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
 
         $this->repository->array('a.b');
+    }
+
+    public function testItGetsAsCollection(): void
+    {
+        $collection = $this->repository->collection('array');
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame(['aaa', 'zzz'], $collection->toArray());
     }
 
     public function testItGetsAsBoolean(): void


### PR DESCRIPTION
I'm constantly seeing a pattern where I use `collect(Config::array('my_file.my_key'))`, which is totally fine.

But, what about improving the developer experience by adding a `collection()` method?

```php
Config::collection('my_file.my_key')
```

