### PR TITLE
[12.x] Introduce `assertContentType()` for improved readability in response tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -616,6 +616,17 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has the given Content-Type header value.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertContentType($value)
+    {
+        return $this->assertHeader('Content-Type', $value);
+    }
+
+    /**
      * Assert that the response was streamed.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1239,6 +1239,17 @@ class TestResponseTest extends TestCase
         $response->assertHeaderMissing('Location');
     }
 
+    public function testAssertContentType()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('Content-Type', 'application/json');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertContentType('application/json');
+    }
+
     public function testAssertPrecognitionSuccessfulWithMissingHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This adds a new method `assertContentType()` to the `TestResponse` class as a convenient and expressive way to check the response’s `Content-Type` header.

While you can already use `assertHeader('Content-Type', ...)`, this method improves test readability by making the intent explicit and clearer.

It helps tests be more self-explanatory and aligns with Laravel’s focus on expressive, developer-friendly APIs.