### PR TITLE
[12.x] Align PHPDoc style in Number::parseFloat with the rest of the class

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -80,8 +80,8 @@ class Number
     /**
      * Parse a string into a float according to the specified locale.
      *
-     * @param  string  $string  The string to parse
-     * @param  string|null  $locale  The locale to use
+     * @param  string  $string
+     * @param  string|null  $locale
      * @return float|false
      */
     public static function parseFloat(string $string, ?string $locale = null): float


### PR DESCRIPTION
Description
---
The `@param` PHPDoc comments in `parseFloat` are inconsistent with the rest of the class, where the parameters are usually listed without inline descriptions. For consistency, it's better to remove those inline comments.