### PR TITLE
[12.x] Inconsistent use of @return type

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -234,7 +234,7 @@ class Number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @param  bool  $abbreviate
-     * @return false|string
+     * @return string|false
      */
     public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
     {


### PR DESCRIPTION
Description
---
Some PHPDoc use `string|false`, others use `false|string`. While both are technically valid, I think Laravel uses success type first. Here's where it’s inconsistent:

- `forHumans()` currently uses `false|string`.
- `format()`, `percentage()`, `currency()`, and `summarize()` uses `string|false`.

So let's refine them.