### PR TITLE
[12.x] Resolve issue with creating event and automatic eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -208,8 +208,6 @@ trait HasEvents
             return true;
         }
 
-        // If we have automatic eager loading enabled for the creating event unset any null relations
-        // as it can cause issues and set the relations to null even if they exist.
         if (static::isAutomaticallyEagerLoadingRelationships() && $event == 'creating') {
             $this->setRelations(array_filter($this->getRelations()));
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -210,6 +210,7 @@ trait HasEvents
 
         if (static::isAutomaticallyEagerLoadingRelationships() && $event == 'creating') {
             $this->setRelations(array_filter($this->getRelations()));
+            $this->withRelationshipAutoloading();
         }
 
         // First, we will get the proper method to call on the event dispatcher, and then we

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -208,6 +208,12 @@ trait HasEvents
             return true;
         }
 
+        // If we have automatic eager loading enabled for the creating event unset any null relations
+        // as it can cause issues and set the relations to null even if they exist.
+        if (static::isAutomaticallyEagerLoadingRelationships() && $event == 'creating') {
+            $this->setRelations(array_filter($this->getRelations()));
+        }
+
         // First, we will get the proper method to call on the event dispatcher, and then we
         // will attempt to fire a custom, object based event for the given event. If that
         // returns a result we can return that result, or we'll call the string events.

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -225,33 +225,6 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         DB::disableQueryLog();
     }
 
-    public function testDoesntCauseNQueryIssueUsingGetMethod()
-    {
-        Model::automaticallyEagerLoadRelationships();
-
-        DB::enableQueryLog();
-
-        $post = Post::create();
-
-        $video = Video::create();
-        $video2 = Video::create();
-        $video3 = Video::create();
-
-        Tag::create(['post_id' => $post->id, 'video_id' => $video->id]);
-        Tag::create(['post_id' => $post->id, 'video_id' => $video2->id]);
-        Tag::create(['post_id' => $post->id, 'video_id' => $video3->id]);
-
-        $videos = [];
-        foreach ($post->tags()->get() as $tag) {
-            $videos[] = $tag->video;
-        }
-
-        $this->assertCount(12, DB::getQueryLog());
-        $this->assertCount(3, $videos);
-
-        Model::automaticallyEagerLoadRelationships(false);
-    }
-
     public function testRelationAutoloadWorksOnCreatingEvent()
     {
         Model::automaticallyEagerLoadRelationships();
@@ -260,7 +233,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
 
         $tags = Tag::factory()->times(3)->make();
 
-        $post = Post::factory()->create();
+        $post = Post::create();
 
         $post->tags()->saveMany($tags);
 
@@ -337,15 +310,6 @@ class Comment extends Model
     }
 }
 
-class PostFactory extends Factory
-{
-    protected $model = Post::class;
-
-    public function definition()
-    {
-        return [];
-    }
-}
 class Post extends Model
 {
     use HasFactory;
@@ -370,11 +334,6 @@ class Post extends Model
     public function likes()
     {
         return $this->morphMany(Like::class, 'likeable');
-    }
-
-    protected static function newFactory()
-    {
-        return PostFactory::new();
     }
 
     public function tags()

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -19,7 +19,6 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
             $table->string('name')->nullable();
             $table->string('status')->nullable();
             $table->unsignedInteger('post_id')->nullable();
-            $table->unsignedInteger('video_id')->nullable();
         });
 
         Schema::create('posts', function (Blueprint $table) {
@@ -281,11 +280,6 @@ class Tag extends Model
     {
         return $this->belongsTo(Post::class);
     }
-
-    public function video()
-    {
-        return $this->belongsTo(Video::class);
-    }
 }
 
 class Comment extends Model
@@ -312,8 +306,6 @@ class Comment extends Model
 
 class Post extends Model
 {
-    use HasFactory;
-
     public $timestamps = false;
 
     public function shouldApplyStatus()

--- a/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
+++ b/tests/Integration/Database/EloquentModelRelationAutoloadTest.php
@@ -225,7 +225,7 @@ class EloquentModelRelationAutoloadTest extends DatabaseTestCase
         DB::disableQueryLog();
     }
 
-    public function testDoesntCauseNQueryIssueUsingGet()
+    public function testDoesntCauseNQueryIssueUsingGetMethod()
     {
         Model::automaticallyEagerLoadRelationships();
 


### PR DESCRIPTION
When eager loading automatically, when the creating event & others occur via observers, or models.  I noticed during tests that relationships would be set as null when using saveMany etc- where as previously without eager loading automatically they would work.

This means tests would begin to fail. 

I've added a test for this behavior & removing the HasEvent changes I've made it fails.   

The logic I've added removes any relations that have been set as null before the creating event, and call the eager loading chain again meaning those relations will be set properly.  Because it's the first event called (I believe) it means other events no longer suffer this too.

Perhaps there's a better way, but open to ideas.