### PR TITLE
[12.x] Resolve issue with Factory make when automatic eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -396,7 +396,7 @@ abstract class Factory
     {
         $autoEagerLoadingEnabled = Model::isAutomaticallyEagerLoadingRelationships();
 
-        if($autoEagerLoadingEnabled) {
+        if ($autoEagerLoadingEnabled) {
             Model::automaticallyEagerLoadRelationships(false);
         }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -394,27 +394,38 @@ abstract class Factory
      */
     public function make($attributes = [], ?Model $parent = null)
     {
-        if (! empty($attributes)) {
-            return $this->state($attributes)->make([], $parent);
+        $autoEagerLoadingEnabled = Model::isAutomaticallyEagerLoadingRelationships();
+
+        if($autoEagerLoadingEnabled){
+            Model::automaticallyEagerLoadRelationships(false);
         }
 
-        if ($this->count === null) {
-            return tap($this->makeInstance($parent), function ($instance) {
-                $this->callAfterMaking(new Collection([$instance]));
-            });
+        try {
+            if (! empty($attributes)) {
+                return $this->state($attributes)->make([], $parent);
+            }
+
+            if ($this->count === null) {
+                return tap($this->makeInstance($parent), function ($instance) {
+                    $this->callAfterMaking(new Collection([$instance]));
+                });
+            }
+
+            if ($this->count < 1) {
+                return $this->newModel()->newCollection();
+            }
+
+            $instances = $this->newModel()->newCollection(array_map(function () use ($parent) {
+                return $this->makeInstance($parent);
+            }, range(1, $this->count)));
+
+            $this->callAfterMaking($instances);
+
+            return $instances;
+
+        } finally {
+            Model::automaticallyEagerLoadRelationships($autoEagerLoadingEnabled);
         }
-
-        if ($this->count < 1) {
-            return $this->newModel()->newCollection();
-        }
-
-        $instances = $this->newModel()->newCollection(array_map(function () use ($parent) {
-            return $this->makeInstance($parent);
-        }, range(1, $this->count)));
-
-        $this->callAfterMaking($instances);
-
-        return $instances;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -396,7 +396,7 @@ abstract class Factory
     {
         $autoEagerLoadingEnabled = Model::isAutomaticallyEagerLoadingRelationships();
 
-        if($autoEagerLoadingEnabled){
+        if($autoEagerLoadingEnabled) {
             Model::automaticallyEagerLoadRelationships(false);
         }
 
@@ -422,7 +422,6 @@ abstract class Factory
             $this->callAfterMaking($instances);
 
             return $instances;
-
         } finally {
             Model::automaticallyEagerLoadRelationships($autoEagerLoadingEnabled);
         }


### PR DESCRIPTION
With automatic eager loading enabled, any tests that use make() would begin to fail - if they were linked with events (ie an observer or model booted etc). 

I've added a test to prove it works, and it will fail if you revert the make changes. 


The logic turns off automatic eager loading, if its enabled and then is turned back on. I've wrapped it in a try and finally to ensure the automatic eager loading will always be restored. This seemed the most logical approach  - but open to suggestions.

