### PR TITLE
[12.x] Add Prompt output override when using PendingCommand for testing

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Laravel\Prompts\Prompt;
 
 class PendingCommand
 {
@@ -405,9 +406,14 @@ class PendingCommand
      */
     protected function mockConsoleOutput()
     {
+        $bufferedOutputMock = $this->createABufferedOutputMock();
         $mock = Mockery::mock(OutputStyle::class.'[askQuestion]', [
-            new ArrayInput($this->parameters), $this->createABufferedOutputMock(),
+            new ArrayInput($this->parameters), $bufferedOutputMock,
         ]);
+
+        if (class_exists(Prompt::class)) {
+            Prompt::setOutput($bufferedOutputMock);
+        }
 
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
+use Laravel\Prompts\Prompt;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -19,7 +20,6 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Laravel\Prompts\Prompt;
 
 class PendingCommand
 {


### PR DESCRIPTION
At Present when you are calling the artisan check to create a PendingCommand for testing a command, all prompts use a variant output buffer than the one created/mocked within the PendingCommand's run aspect.

this update checks to see if the Laravel Prompt class exists and if so, then calls it to set the output to the mocked buffered output created for checks.

This override allows for the following macro to pass on the test (FQN classes used here for full clarity)
```php
\Illuminate\Testing\PendingCommand::macro(
        'expectsPromptTable',
        function (array|Collection $headers, array|Collection $rows): \Illuminate\Testing\PendingCommand {
            $promptTable = new \Laravel\Prompts\Table($headers, $rows);
            $promptTable->setOutput($output = new \Symfony\Component\Console\Output\BufferedOutput);
            $promptTable->display();

            $lines = array_filter(
                explode(PHP_EOL, $output->fetch())
            );

            foreach ($lines as $line) {
                $this->expectsOutput($line);
            }

            return $this;
        }
    );
```

example of test
```php
test('prompt table is shown', function () {
    artisan('app:prompt-test')
        ->expectsPromptTable(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ],
        )
        ->assertExitCode(0);
});
```

example of command
```php
<?php

declare(strict_types=1);

namespace App\Console\Commands;

use Illuminate\Console\Command;
use function Laravel\Prompts\table;

class PromptTest extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @inheritdoc
     */
    protected $signature = 'app:prompt-test';

    /**
     * The console command description.
     *
     * @inheritdoc
     */
    protected $description = 'test prompt';

    /**
     * Execute the console command.
     */
    public function handle(): void
    {
        table(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ]
        );
    }
}
```