### PR TITLE
[12.x] Add scoped macros to Macroable

### DIFF
--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -76,6 +76,7 @@ class SupportMacroableTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         $otherMacroable::{__METHOD__}();
     }
+
     public function testParentClassDoesNotHaveScopedMacro()
     {
         $macroable = $this->macroable;

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -65,8 +65,7 @@ class SupportMacroableTest extends TestCase
     public function testExtendedClassDoesNotHaveScopedMacro()
     {
         $macroable = $this->macroable;
-        $otherMacroable = new class extends EmptyMacroable
-        {
+        $otherMacroable = new class extends EmptyMacroable {
         };
         $macroable::scopedMacro(__METHOD__, function () {
             return 'Scoped Macro';
@@ -80,8 +79,7 @@ class SupportMacroableTest extends TestCase
     public function testParentClassDoesNotHaveScopedMacro()
     {
         $macroable = $this->macroable;
-        $otherMacroable = new class extends EmptyMacroable
-        {
+        $otherMacroable = new class extends EmptyMacroable {
         };
         $otherMacroable::scopedMacro(__METHOD__, function () {
             return 'Scoped Macro';

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -39,6 +39,60 @@ class SupportMacroableTest extends TestCase
         $this->assertFalse($macroable::hasMacro('bar'));
     }
 
+    public function testRegisterScopedMacro()
+    {
+        $macroable = $this->macroable;
+        $macroable::scopedMacro(__METHOD__, function () {
+            return 'Scoped Macro';
+        });
+
+        $this->assertSame('Scoped Macro', $macroable::{__METHOD__}());
+    }
+
+    public function testHasScopedMacro()
+    {
+        $macroable = $this->macroable;
+
+        $macroable::scopedMacro(__METHOD__, function () {
+            return 'Scoped Macro';
+        });
+
+        $this->assertTrue($macroable::hasScopedMacro(__METHOD__));
+        $this->assertFalse($macroable::hasGlobalMacro(__METHOD__));
+        $this->assertFalse($macroable::hasScopedMacro(__METHOD__.'_NoneExistent'));
+    }
+
+    public function testExtendedClassDoesNotHaveScopedMacro()
+    {
+        $macroable = $this->macroable;
+        $otherMacroable = new class extends EmptyMacroable
+        {
+        };
+        $macroable::scopedMacro(__METHOD__, function () {
+            return 'Scoped Macro';
+        });
+
+        $this->assertSame('Scoped Macro', $macroable::{__METHOD__}());
+        $this->assertFalse($otherMacroable::hasScopedMacro(__METHOD__));
+        $this->expectException(BadMethodCallException::class);
+        $otherMacroable::{__METHOD__}();
+    }
+    public function testParentClassDoesNotHaveScopedMacro()
+    {
+        $macroable = $this->macroable;
+        $otherMacroable = new class extends EmptyMacroable
+        {
+        };
+        $otherMacroable::scopedMacro(__METHOD__, function () {
+            return 'Scoped Macro';
+        });
+
+        $this->assertSame('Scoped Macro', $otherMacroable::{__METHOD__}());
+        $this->assertFalse($macroable::hasScopedMacro(__METHOD__));
+        $this->expectException(BadMethodCallException::class);
+        $macroable::{__METHOD__}();
+    }
+
     public function testRegisterMacroAndCallWithoutStatic()
     {
         $macroable = $this->macroable;


### PR DESCRIPTION
This adds the ability to scope macros to the class on which they were defined.

I've added separate `scopedMacro` and `hasScopedMacro` methods to make it clearly distinguishable when used and `hasGlobalMacro` as a method to check the contents of the `$macros` property specifically.

`hasMacro` will check both the default macros and `$scopedMacros` for the given macro

If a `scopedMacro` is present when the method is invoked, it will be preferred over a global one (which has the effect of also allowing a user to override a macro for a given implementation without breaking others).

The benefit of this is the ability to add a macro to a class and have it *not* invokable on another class which extends it.

For example:

A package "Ape" provides a base class which extends `Livewire/Component` (which is macroable)
Another package "Baboon" extends this package's base class to provide its own functionality and implements a method whereby macros defined using a specific name e.g. `afterRender` 

If I define `afterRender` on a class which extends "Ape", that macro is also available on "Baboon" which may be unintended.

A more real world example can bee seen in the FilamentPHP PR here https://github.com/filamentphp/filament/pull/16763 where implementing the `beforeFill` macro on `EditPage` results in it being invoked on `ViewPage` also since that extends `BasePage` and uses the same form for display.

