### PR TITLE
[12.x] Make `Fluent` class iterable

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -3,12 +3,15 @@
 namespace Illuminate\Support;
 
 use ArrayAccess;
+use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
+use IteratorAggregate;
 use JsonSerializable;
+use Traversable;
 
 /**
  * @template TKey of array-key
@@ -17,7 +20,7 @@ use JsonSerializable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
+class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, IteratorAggregate
 {
     use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;
@@ -243,6 +246,16 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
+    }
+
+    /**
+     * Get an iterator for the attributes.
+     *
+     * @return ArrayIterator<TKey, TValue>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->attributes);
     }
 
     /**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -20,7 +20,7 @@ use Traversable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, IteratorAggregate
+class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
 {
     use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -452,6 +452,25 @@ class SupportFluentTest extends TestCase
             'baz' => 'zal',
         ], $fluent->foo()->all());
     }
+
+    public function testFluentIsIterable()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ]);
+
+        $result = [];
+
+        foreach ($fluent as $key => $value) {
+            $result[$key] = $value;
+        }
+
+        $this->assertSame([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ], $result);
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
Currently, while Fluent supports array-style access (ArrayAccess) and dynamic property access, it cannot be directly iterated. This gap often causes inconvenience in Laravel applications, especially when working with Eloquent attribute casting such as:

```php

protected function casts(): array
{
    return [
        'settings' => \Illuminate\Database\Eloquent\Casts\AsFluent::class
    ];
}
```

Without this enhancement, developers must call ->toArray() before iterating over casted attributes

```php

foreach ($user->settings->toArray() as $key => $value) {
    // 
}
```

By enabling native iteration, this change simplifies and cleans up common usage patterns, allowing

```php

foreach ($user->settings as $key => $value) {
    //
}
