### PR TITLE
Improve Mailable assertion error messages with expected vs actual values

### DIFF
--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -1170,7 +1170,7 @@ class MailMailableTest extends TestCase
                 ->assertHasSubject('Test Subject!');
         });
     }
-    
+
     protected function stubMailer()
     {
         Container::getInstance()->instance('mailer', new class

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -55,7 +55,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasTo('taylor@laravel.com', 'Taylor Otwell');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected recipient [taylor@laravel.com (Taylor Otwell)] in email 'to' recipients.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected recipient in email 'to' recipients.\nExpected: [taylor@laravel.com (Taylor Otwell)]\nActual: [taylor@laravel.com]\nFailed asserting that false is true.", $e->getMessage());
         }
 
         $mailable = new WelcomeMailableStub;
@@ -101,7 +101,7 @@ class MailMailableTest extends TestCase
                 if (! is_string($address)) {
                     $address = json_encode($address);
                 }
-                $this->assertSame("Did not see expected recipient [{$address}] in email 'to' recipients.\nFailed asserting that false is true.", $e->getMessage());
+                $this->assertSame("Did not see expected recipient in email 'to' recipients.\nExpected: [{$address}]\nActual: [none]\nFailed asserting that false is true.", $e->getMessage());
             }
         }
     }
@@ -134,7 +134,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasCc('taylor@laravel.com', 'Taylor Otwell');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected recipient [taylor@laravel.com (Taylor Otwell)] in email 'cc' recipients.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected recipient in email 'cc' recipients.\nExpected: [taylor@laravel.com (Taylor Otwell)]\nActual: [taylor@laravel.com]\nFailed asserting that false is true.", $e->getMessage());
         }
 
         $mailable = new WelcomeMailableStub;
@@ -192,7 +192,7 @@ class MailMailableTest extends TestCase
                 if (! is_string($address)) {
                     $address = json_encode($address);
                 }
-                $this->assertSame("Did not see expected recipient [{$address}] in email 'cc' recipients.\nFailed asserting that false is true.", $e->getMessage());
+                $this->assertSame("Did not see expected recipient in email 'cc' recipients.\nExpected: [{$address}]\nActual: [none]\nFailed asserting that false is true.", $e->getMessage());
             }
         }
     }
@@ -225,7 +225,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasBcc('taylor@laravel.com', 'Taylor Otwell');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected recipient [taylor@laravel.com (Taylor Otwell)] in email 'bcc' recipients.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected recipient in email 'bcc' recipients.\nExpected: [taylor@laravel.com (Taylor Otwell)]\nActual: [taylor@laravel.com]\nFailed asserting that false is true.", $e->getMessage());
         }
 
         $mailable = new WelcomeMailableStub;
@@ -283,7 +283,7 @@ class MailMailableTest extends TestCase
                 if (! is_string($address)) {
                     $address = json_encode($address);
                 }
-                $this->assertSame("Did not see expected recipient [{$address}] in email 'bcc' recipients.\nFailed asserting that false is true.", $e->getMessage());
+                $this->assertSame("Did not see expected recipient in email 'bcc' recipients.\nExpected: [{$address}]\nActual: [none]\nFailed asserting that false is true.", $e->getMessage());
             }
         }
     }
@@ -316,7 +316,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasReplyTo('taylor@laravel.com', 'Taylor Otwell');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected address [taylor@laravel.com (Taylor Otwell)] as email 'reply to' recipient.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected address as email 'reply to' recipient.\nExpected: [taylor@laravel.com (Taylor Otwell)]\nActual: [taylor@laravel.com]\nFailed asserting that false is true.", $e->getMessage());
         }
 
         $mailable = new WelcomeMailableStub;
@@ -363,7 +363,7 @@ class MailMailableTest extends TestCase
                 if (! is_string($address)) {
                     $address = json_encode($address);
                 }
-                $this->assertSame("Did not see expected address [{$address}] as email 'reply to' recipient.\nFailed asserting that false is true.", $e->getMessage());
+                $this->assertSame("Did not see expected address as email 'reply to' recipient.\nExpected: [{$address}]\nActual: [none]\nFailed asserting that false is true.", $e->getMessage());
             }
         }
     }
@@ -396,7 +396,7 @@ class MailMailableTest extends TestCase
             $mailable->assertFrom('taylor@laravel.com', 'Taylor Otwell');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Email was not from expected address [taylor@laravel.com (Taylor Otwell)].\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Email was not from expected address.\nExpected: [taylor@laravel.com (Taylor Otwell)]\nActual: [taylor@laravel.com]\nFailed asserting that false is true.", $e->getMessage());
         }
 
         $mailable = new WelcomeMailableStub;
@@ -443,7 +443,7 @@ class MailMailableTest extends TestCase
                 if (! is_string($address)) {
                     $address = json_encode($address);
                 }
-                $this->assertSame("Email was not from expected address [{$address}].\nFailed asserting that false is true.", $e->getMessage());
+                $this->assertSame("Email was not from expected address.\nExpected: [{$address}]\nActual: [none]\nFailed asserting that false is true.", $e->getMessage());
             }
         }
     }
@@ -629,7 +629,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasMetadata('test', 'test');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected key [test] and value [test] in email metadata.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Email metadata does not match expected value.\nExpected: [test] => [test]\nActual: key [test] not found\nFailed asserting that false is true.", $e->getMessage());
         }
     }
 
@@ -664,7 +664,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasTag('bar');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected tag [bar] in email tags.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertSame("Did not see expected tag in email tags.\nExpected: [bar]\nActual: [test, foo]\nFailed asserting that false is true.", $e->getMessage());
         }
     }
 
@@ -1088,7 +1088,7 @@ class MailMailableTest extends TestCase
             $mailable->assertHasSubject('Foo Subject');
             $this->fail();
         } catch (AssertionFailedError $e) {
-            $this->assertSame("Did not see expected text [Foo Subject] in email subject.\nFailed asserting that false is true.", $e->getMessage());
+            $this->assertStringContainsString("Email subject does not match expected value.\nExpected: [Foo Subject]\nActual:", $e->getMessage());
         }
 
         $mailable = new class() extends Mailable
@@ -1170,7 +1170,7 @@ class MailMailableTest extends TestCase
                 ->assertHasSubject('Test Subject!');
         });
     }
-
+    
     protected function stubMailer()
     {
         Container::getInstance()->instance('mailer', new class


### PR DESCRIPTION
Currently, when mailable assertions fail, developers only see generic error messages that don't show what was actually found vs what was expected. This forces developers to dig through code to understand why tests are failing.


### Changes:

- `assertHasSubject()` - Shows expected vs actual subject
- `assertFrom()` - Shows expected vs actual sender information  
- `assertTo()` / `assertHasTo()` - Shows expected vs actual recipients
- `assertHasCc()` - Shows expected vs actual CC recipients
- `assertHasBcc()` - Shows expected vs actual BCC recipients
- `assertHasReplyTo()` - Shows expected vs actual reply-to addresses
- `assertHasTag()` - Shows expected tag vs actual tags list
- `assertHasMetadata()` - Shows expected vs actual metadata values


### Usage:

```php
$mailable->assertHasSubject('Welcome to Laravel!');

// Before:
// "Did not see expected text [Welcome to Laravel!] in email subject."

// After:
// "Email subject does not match expected value.
// Expected: [Welcome to Laravel!]
// Actual: [Order Confirmation Email]"
```

```php
$mailable->assertTo('john@example.com', 'John Doe');

// Before:
// "Did not see expected recipient [john@example.com (John Doe)] in email 'to' recipients."

// After:
// "Did not see expected recipient in email 'to' recipients.
// Expected: [john@example.com (John Doe)]
// Actual: [jane@example.com (Jane Smith)]"
```
