### PR TITLE
[12.x] Binary File Size Validation Support

### DIFF
--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -12,6 +12,7 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationFileRuleTest extends TestCase
@@ -245,6 +246,40 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testSizeWithBinaryUnits(): void
+    {
+        $this->passes(
+            File::default()->size('1MB', File::BINARY),
+            UploadedFile::fake()->create('foo.txt', 1024)
+        );
+
+        $this->fails(
+            File::default()->size('1MB', File::BINARY),
+            [
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 1025),
+            ],
+            ['validation.size.file']
+        );
+    }
+
+    public function testSizeWithInternationalUnits(): void
+    {
+        $this->passes(
+            File::default()->size('1MB', File::INTERNATIONAL),
+            UploadedFile::fake()->create('foo.txt', 1000)
+        );
+
+        $this->fails(
+            File::default()->size('1MB', File::INTERNATIONAL),
+            [
+                UploadedFile::fake()->create('foo.txt', 999),
+                UploadedFile::fake()->create('foo.txt', 1001),
+            ],
+            ['validation.size.file']
+        );
+    }
+
     public function testBetween()
     {
         $this->fails(
@@ -264,6 +299,48 @@ class ValidationFileRuleTest extends TestCase
                 UploadedFile::fake()->create('foo.txt', 1025),
                 UploadedFile::fake()->create('foo.txt', 2047),
             ]
+        );
+    }
+
+    public function testBetweenWithBinaryUnits(): void
+    {
+        $this->passes(
+            File::default()->between('1MB', '2MB', File::BINARY),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1500),
+                UploadedFile::fake()->create('foo.txt', 2048),
+            ]
+        );
+
+        $this->fails(
+            File::default()->between('1MB', '2MB', File::BINARY),
+            [
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 2049),
+            ],
+            ['validation.between.file']
+        );
+    }
+
+    public function testBetweenWithInternationalUnits(): void
+    {
+        $this->passes(
+            File::default()->between('1MB', '2MB', File::INTERNATIONAL),
+            [
+                UploadedFile::fake()->create('foo.txt', 1000),
+                UploadedFile::fake()->create('foo.txt', 1500),
+                UploadedFile::fake()->create('foo.txt', 2000),
+            ]
+        );
+
+        $this->fails(
+            File::default()->between('1MB', '2MB', File::INTERNATIONAL),
+            [
+                UploadedFile::fake()->create('foo.txt', 999),
+                UploadedFile::fake()->create('foo.txt', 2001),
+            ],
+            ['validation.between.file']
         );
     }
 
@@ -300,6 +377,42 @@ class ValidationFileRuleTest extends TestCase
                 UploadedFile::fake()->create('foo.txt', 1025),
                 UploadedFile::fake()->create('foo.txt', 2048),
             ]
+        );
+    }
+
+    public function testMinWithBinaryUnits(): void
+    {
+        $this->passes(
+            File::default()->min('1MB', File::BINARY),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 2048),
+            ]
+        );
+
+        $this->fails(
+            File::default()->min('1MB', File::BINARY),
+            UploadedFile::fake()->create('foo.txt', 1023),
+            ['validation.min.file']
+        );
+    }
+
+    public function testMinWithInternationalUnits(): void
+    {
+        $this->passes(
+            File::default()->min('1MB', File::INTERNATIONAL),
+            [
+                UploadedFile::fake()->create('foo.txt', 1000),
+                UploadedFile::fake()->create('foo.txt', 1001),
+                UploadedFile::fake()->create('foo.txt', 2000),
+            ]
+        );
+
+        $this->fails(
+            File::default()->min('1MB', File::INTERNATIONAL),
+            UploadedFile::fake()->create('foo.txt', 999),
+            ['validation.min.file']
         );
     }
 
@@ -354,6 +467,42 @@ class ValidationFileRuleTest extends TestCase
                 UploadedFile::fake()->create('foo.txt', 999),
                 UploadedFile::fake()->create('foo.txt', 512),
             ]
+        );
+    }
+
+    public function testMaxWithBinaryUnits(): void
+    {
+        $this->passes(
+            File::default()->max('1MB', File::BINARY),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 512),
+            ]
+        );
+
+        $this->fails(
+            File::default()->max('1MB', File::BINARY),
+            UploadedFile::fake()->create('foo.txt', 1025),
+            ['validation.max.file']
+        );
+    }
+
+    public function testMaxWithInternationalUnits(): void
+    {
+        $this->passes(
+            File::default()->max('1MB', File::INTERNATIONAL),
+            [
+                UploadedFile::fake()->create('foo.txt', 1000),
+                UploadedFile::fake()->create('foo.txt', 999),
+                UploadedFile::fake()->create('foo.txt', 500),
+            ]
+        );
+
+        $this->fails(
+            File::default()->max('1MB', File::INTERNATIONAL),
+            UploadedFile::fake()->create('foo.txt', 1001),
+            ['validation.max.file']
         );
     }
 
@@ -439,6 +588,530 @@ class ValidationFileRuleTest extends TestCase
         File::image()->size('10xyz');
     }
 
+    public function testFileConstants(): void
+    {
+        $this->assertEquals('binary', File::BINARY);
+        $this->assertEquals('international', File::INTERNATIONAL);
+    }
+
+
+    public function testGlobalBinaryPrecedence(): void
+    {
+        $file1010 = UploadedFile::fake()->create('test.txt', 1010);
+
+        $rule = File::default()->binary();
+
+        $this->passes(
+            $rule->max('1MB'),
+            $file1010
+        );
+
+        $this->fails(
+            $rule->min('1MB'),
+            $file1010,
+            ['validation.size.file'] // when min=max, validation.size.file instead of validation.max.file
+        );
+    }
+
+    public function testGlobalInternationalPrecedence(): void
+    {
+        $file1010 = UploadedFile::fake()->create('test.txt', 1010);
+
+        $rule = File::default()->international();
+
+        $this->passes(
+            $rule->min('1MB'),
+            $file1010
+        );
+
+        $this->fails(
+            $rule->max('1MB'),
+            $file1010,
+            ['validation.size.file'] // when min=max, validation.size.file instead of validation.max.file
+        );
+    }
+
+    public function testExplicitParameterOverridesGlobalSetting(): void
+    {
+        $file1010 = UploadedFile::fake()->create('test.txt', 1010);
+
+        $this->fails(
+            File::default()->binary()->max('1MB', File::INTERNATIONAL),
+            $file1010,
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->international()->max('1MB', File::BINARY),
+            $file1010
+        );
+    }
+
+    public function testDefaultsToInternationalWhenNoGlobalSetting(): void
+    {
+        $file1010 = UploadedFile::fake()->create('test.txt', 1010);
+
+        $this->fails(
+            File::default()->max('1MB'),
+            $file1010,
+            ['validation.max.file']
+        );
+    }
+
+    public function testBinaryVsInternationalDifference(): void
+    {
+        $file1010 = UploadedFile::fake()->create('boundary.txt', 1010);
+
+        $this->passes(
+            File::default()->max('1MB', File::BINARY),
+            $file1010
+        );
+
+        $this->fails(
+            File::default()->max('1MB', File::INTERNATIONAL),
+            $file1010,
+            ['validation.max.file']);
+    }
+
+    public function testNumericSizesWorkWithoutUnits(): void
+    {
+        $file1000 = UploadedFile::fake()->create('numeric.txt', 1000);
+
+        $this->passes(File::default()->max(1000), $file1000);
+        $this->passes(File::default()->binary()->max(1000), $file1000);
+        $this->passes(File::default()->international()->max(1000), $file1000);
+    }
+
+    public function testDecimalSizes(): void
+    {
+        $file512 = UploadedFile::fake()->create('half.txt', 512);
+        $file500 = UploadedFile::fake()->create('half.txt', 500);
+
+        $this->passes(
+            File::default()->size('0.5MB', File::BINARY),
+            $file512
+        );
+
+        $this->fails(File::default()->size('0.5MB', File::BINARY),
+            $file500,
+            ['validation.size.file']
+        );
+
+        $this->passes(
+            File::default()->size('0.5MB', File::INTERNATIONAL),
+            $file500
+        );
+
+        $this->fails(
+            File::default()->size('0.5MB', File::INTERNATIONAL),
+            $file512,
+            ['validation.size.file']
+        );
+    }
+
+    public function testLargerUnits(): void
+    {
+        $file1048576 = UploadedFile::fake()->create('big.txt', 1048576);
+        $file1000000 = UploadedFile::fake()->create('big.txt', 1000000);
+
+        $this->passes(
+            File::default()->size('1GB', File::BINARY),
+            $file1048576
+        );
+
+        $this->passes(
+            File::default()->size('1GB', File::INTERNATIONAL),
+            $file1000000
+        );
+    }
+
+    public function testBinaryIntegerPrecisionForLargeFileSizes(): void
+    {
+        $file999999 = UploadedFile::fake()->create('large999999.txt', 999999);
+        
+        $this->passes(
+            File::default()->binary()->max('1000000KB'),
+            $file999999
+        );
+        
+        $this->fails(
+            File::default()->binary()->max('999998KB'),
+            $file999999,
+            ['validation.max.file']
+        );
+    }
+
+    public function testInternationalIntegerPrecisionForLargeFileSizes(): void
+    {
+        $file999999 = UploadedFile::fake()->create('large999999.txt', 999999);
+        
+        $this->passes(
+            File::default()->international()->max('1000000KB'),
+            $file999999
+        );
+        
+        $this->fails(
+            File::default()->international()->max('999998KB'),
+            $file999999,
+            ['validation.max.file']
+        );
+    }
+
+    public function testFloatPrecisionForFractionalSizes(): void
+    {
+        $file512 = UploadedFile::fake()->create('fractional512.txt', 512);
+        $file500 = UploadedFile::fake()->create('fractional500.txt', 500);
+        
+        $this->passes(
+            File::default()->binary()->size('0.5MB'),
+            $file512
+        );
+        
+        $this->passes(
+            File::default()->international()->size('0.5MB'),
+            $file500
+        );
+        
+        $this->fails(
+            File::default()->binary()->size('0.5MB'),
+            $file500,
+            ['validation.size.file']
+        );
+        
+        $this->fails(
+            File::default()->international()->size('0.5MB'),
+            $file512,
+            ['validation.size.file']
+        );
+    }
+
+    public function testBinaryVsInternationalCalculationAccuracy(): void
+    {
+        $file1010 = UploadedFile::fake()->create('boundary1010.txt', 1010);
+        
+        $this->passes(
+            File::default()->binary()->max('1MB'),
+            $file1010
+        );
+        
+        $this->fails(
+            File::default()->international()->max('1MB'),
+            $file1010,
+            ['validation.max.file']
+        );
+        
+        $file900 = UploadedFile::fake()->create('small900.txt', 900);
+        
+        $this->passes(
+            File::default()->binary()->max('1MB'),
+            $file900
+        );
+        
+        $this->passes(
+            File::default()->international()->max('1MB'),
+            $file900
+        );
+    }
+
+    public function testBinaryLargeFileSizePrecision(): void
+    {
+        $file500000 = UploadedFile::fake()->create('huge500000.txt', 500000);
+        
+        $this->passes(
+            File::default()->binary()->between('400MB', '600MB'),
+            $file500000
+        );
+        
+        $this->passes(
+            File::default()->binary()->max('1GB'),
+            $file500000
+        );
+        
+        $this->fails(
+            File::default()->binary()->max('488MB'),
+            $file500000,
+            ['validation.max.file']
+        );
+    }
+
+    public function testInternationalLargeFileSizePrecision(): void
+    {
+        $file500000 = UploadedFile::fake()->create('huge500000.txt', 500000);
+        
+        $this->passes(
+            File::default()->international()->between('400MB', '600MB'),
+            $file500000
+        );
+        
+        $this->passes(
+            File::default()->international()->max('1GB'),
+            $file500000
+        );
+        
+        $this->fails(
+            File::default()->international()->max('499MB'),
+            $file500000,
+            ['validation.max.file']
+        );
+    }
+
+    public function testOverflowProtectionForLargeIntegerValues(): void
+    {
+        $fileLarge = UploadedFile::fake()->create('overflow.txt', 2000000000);
+        
+        $this->passes(
+            File::default()->binary()->max('2000000MB'),
+            $fileLarge
+        );
+        
+        $this->passes(
+            File::default()->international()->max('2000000MB'),
+            $fileLarge
+        );
+    }
+
+    public function testOverflowProtectionWithFractionalValues(): void
+    {
+        $file1536 = UploadedFile::fake()->create('fractional.txt', 1536);
+        
+        $this->passes(
+            File::default()->binary()->size('1.5MB'),
+            $file1536
+        );
+        
+        $file1500 = UploadedFile::fake()->create('fractional.txt', 1500);
+        
+        $this->passes(
+            File::default()->international()->size('1.5MB'),
+            $file1500
+        );
+    }
+
+    public function testCaseInsensitiveSuffixes(): void
+    {
+        $file1024 = UploadedFile::fake()->create('case.txt', 1024);
+
+        $this->passes(File::default()->binary()->size('1MB'), $file1024);
+        $this->passes(File::default()->binary()->size('1mb'), $file1024);
+        $this->passes(File::default()->binary()->size('1Mb'), $file1024);
+        $this->passes(File::default()->binary()->size('1mB'), $file1024);
+    }
+
+    public function testInvalidSizeSuffixThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid file size suffix.');
+
+        File::default()->max('5xyz');
+    }
+
+    public function testZeroAndVerySmallFileSizes(): void
+    {
+        $fileZero = UploadedFile::fake()->create('zero.txt', 0);
+        $fileOne = UploadedFile::fake()->create('tiny.txt', 1);
+        
+        $this->passes(
+            File::default()->min('0KB'),
+            $fileZero
+        );
+        
+        $this->passes(
+            File::default()->size('1KB'),
+            $fileOne
+        );
+        
+        $this->passes(
+            File::default()->binary()->max('0.001MB'),
+            $fileOne
+        );
+    }
+
+    public function testWhitespaceHandlingInFileSizes(): void
+    {
+        $file2048 = UploadedFile::fake()->create('whitespace.txt', 2048);
+        $file2000 = UploadedFile::fake()->create('whitespace.txt', 2000);
+        
+        $this->passes(
+            File::default()->binary()->size(' 2MB '),
+            $file2048
+        );
+        
+        $this->passes(
+            File::default()->international()->size(' 2MB '),
+            $file2000
+        );
+        
+        $this->passes(
+            File::default()->binary()->size('2 MB'),
+            $file2048
+        );
+    }
+
+    public function testCommaSeparatedNumberParsing(): void
+    {
+        $file1024 = UploadedFile::fake()->create('comma.txt', 1024);
+        $file10240 = UploadedFile::fake()->create('large.txt', 10240);
+        
+        $this->passes(
+            File::default()->binary()->size('1,024KB'),
+            $file1024
+        );
+        
+        $this->passes(
+            File::default()->binary()->size('10,240KB'),
+            $file10240
+        );
+        
+        $this->passes(
+            File::default()->international()->size('1,024KB'),
+            $file1024
+        );
+    }
+
+    public function testNegativeFileSizeThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid numeric value in file size.');
+
+        File::default()->max('-5MB');
+    }
+
+    public function testBinaryFluentChaining(): void
+    {
+        $file1024 = UploadedFile::fake()->create('chain.txt', 1024);
+
+        $rule = File::default()->binary()
+            ->types(['txt'])
+            ->min('1MB')
+            ->max('2MB');
+
+        $this->passes($rule, $file1024);
+    }
+
+    public function testInternationalFluentChaining(): void
+    {
+        $file1000 = UploadedFile::fake()->create('chain.txt', 1000);
+
+        $rule = File::default()->international()
+            ->types(['txt'])
+            ->min('1MB')
+            ->max('2MB');
+
+        $this->passes($rule, $file1000);
+    }
+
+    public function testMixedUnitsInSameRule(): void
+    {
+        $file1500 = UploadedFile::fake()->create('mixed.txt', 1500);
+
+        $rule = File::default()->binary()
+            ->min('1MB')
+            ->max('2MB', File::INTERNATIONAL);
+
+        $this->passes($rule, $file1500);
+    }
+
+    public function testComplexUnitsScenarioWithMultipleConstraints(): void
+    {
+        $file1500 = UploadedFile::fake()->create('complex.txt', 1500);
+
+        $rule = File::default()->binary()
+            ->types(['txt'])
+            ->min('1MB', File::INTERNATIONAL)
+            ->max('1.4MB', File::BINARY);
+
+        $this->fails($rule, $file1500, ['validation.between.file']);
+    }
+
+    public function testUnitsMethodsReturnNewInstances(): void
+    {
+        $binary1 = File::default()->binary();
+        $binary2 = File::default()->binary();
+        $international1 = File::default()->international();
+
+        $this->assertNotSame($binary1, $binary2);
+        $this->assertNotSame($binary1, $international1);
+    }
+
+    public function testUnitsBackwardsCompatibility(): void
+    {
+        $file1000 = UploadedFile::fake()->create('compat.txt', 1000);
+
+        $this->passes(
+            File::types(['txt'])->max('1MB'),
+            $file1000
+        );
+
+        $this->passes(
+            File::default()->between(500, 1500),
+            $file1000
+        );
+
+        $this->passes(
+            File::default()->size(1000),
+            $file1000
+        );
+    }
+
+    public function testBinaryFluentMethod(): void
+    {
+        $file1024 = UploadedFile::fake()->create('binary.txt', 1024);
+
+        // Create instance then call binary() method
+        $rule = File::default()
+            ->types(['txt'])
+            ->binary()
+            ->size('1MB');
+
+        $this->passes($rule, $file1024);
+    }
+
+    public function testInternationalFluentMethod(): void
+    {
+        $file1000 = UploadedFile::fake()->create('international.txt', 1000);
+
+        // Create instance then call international() method
+        $rule = File::default()
+            ->types(['txt'])
+            ->international()
+            ->size('1MB');
+
+        $this->passes($rule, $file1000);
+    }
+
+    public function testUnitsMethodChaining(): void
+    {
+        $file1024 = UploadedFile::fake()->create('chaining.txt', 1024);
+
+        // Test switching between binary and international on same instance
+        $rule = File::default()
+            ->types(['txt'])
+            ->international()  // Start with international
+            ->binary()         // Switch to binary
+            ->size('1MB');        // 1MB binary = 1024KB
+
+        $this->passes($rule, $file1024);
+    }
+
+    public function testInstanceMethodsReturnSameObject(): void
+    {
+        $originalRule = File::default()->types(['txt']);
+        
+        // Instance methods should return the same object
+        $binaryRule = $originalRule->binary();
+        $internationalRule = $originalRule->international();
+        
+        $this->assertSame($originalRule, $binaryRule);
+        $this->assertSame($originalRule, $internationalRule);
+        
+        // Creating new instances should return different objects
+        $newBinary = File::default()->binary();
+        $newInternational = File::default()->international();
+        
+        $this->assertNotSame($originalRule, $newBinary);
+        $this->assertNotSame($originalRule, $newInternational);
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();
@@ -461,5 +1134,7 @@ class ValidationFileRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
+
+        File::$defaultCallback = null;
     }
 }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -671,7 +671,9 @@ class ValidationFileRuleTest extends TestCase
     public function test_invalid_size_suffix_throws_exception(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid file size suffix.');
+        $this->expectExceptionMessage(
+            'Invalid file size; units must be one of [kib, mib, gib, tib, kb, mb, gb, tb]. Given: 5xyz.'
+        );
 
         File::default()->max('5xyz');
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationFileRuleTest extends TestCase
 {
-    public function testBasic()
+    public function test_basic()
     {
         $this->fails(
             File::default(),
@@ -63,7 +63,7 @@ class ValidationFileRuleTest extends TestCase
         $this->assertValidationRules($rule, $values, true, []);
     }
 
-    public function testSingleMimetype()
+    public function test_single_mimetype()
     {
         $this->fails(
             File::types('text/plain'),
@@ -77,7 +77,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMultipleMimeTypes()
+    public function test_multiple_mime_types()
     {
         $this->fails(
             File::types(['text/plain', 'image/jpeg']),
@@ -91,7 +91,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testSingleMime()
+    public function test_single_mime()
     {
         $this->fails(
             File::types('txt'),
@@ -105,7 +105,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMultipleMimes()
+    public function test_multiple_mimes()
     {
         $this->fails(
             File::types(['png', 'jpg', 'jpeg', 'svg']),
@@ -122,7 +122,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMixOfMimetypesAndMimes()
+    public function test_mix_of_mimetypes_and_mimes()
     {
         $this->fails(
             File::types(['png', 'image/png']),
@@ -136,7 +136,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testSingleExtension()
+    public function test_single_extension()
     {
         $this->fails(
             File::default()->extensions('png'),
@@ -162,7 +162,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMultipleExtensions()
+    public function test_multiple_extensions()
     {
         $this->fails(
             File::default()->extensions(['png', 'jpeg', 'jpg']),
@@ -182,7 +182,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testImage()
+    public function test_image()
     {
         $this->fails(
             File::image(),
@@ -196,7 +196,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testImageFailsOnSvgByDefault()
+    public function test_image_fails_on_svg_by_default()
     {
         $maliciousSvgFileWithXSS = UploadedFile::fake()->createWithContent(
             name: 'foo.svg',
@@ -229,7 +229,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testSize()
+    public function test_size()
     {
         $this->fails(
             File::default()->size(1024),
@@ -246,41 +246,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testSizeWithBinaryUnits(): void
-    {
-        $this->passes(
-            File::default()->size('1MB', File::BINARY),
-            UploadedFile::fake()->create('foo.txt', 1024)
-        );
-
-        $this->fails(
-            File::default()->size('1MB', File::BINARY),
-            [
-                UploadedFile::fake()->create('foo.txt', 1023),
-                UploadedFile::fake()->create('foo.txt', 1025),
-            ],
-            ['validation.size.file']
-        );
-    }
-
-    public function testSizeWithInternationalUnits(): void
-    {
-        $this->passes(
-            File::default()->size('1MB', File::INTERNATIONAL),
-            UploadedFile::fake()->create('foo.txt', 1000)
-        );
-
-        $this->fails(
-            File::default()->size('1MB', File::INTERNATIONAL),
-            [
-                UploadedFile::fake()->create('foo.txt', 999),
-                UploadedFile::fake()->create('foo.txt', 1001),
-            ],
-            ['validation.size.file']
-        );
-    }
-
-    public function testBetween()
+    public function test_between()
     {
         $this->fails(
             File::default()->between(1024, 2048),
@@ -302,49 +268,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testBetweenWithBinaryUnits(): void
-    {
-        $this->passes(
-            File::default()->between('1MB', '2MB', File::BINARY),
-            [
-                UploadedFile::fake()->create('foo.txt', 1024),
-                UploadedFile::fake()->create('foo.txt', 1500),
-                UploadedFile::fake()->create('foo.txt', 2048),
-            ]
-        );
-
-        $this->fails(
-            File::default()->between('1MB', '2MB', File::BINARY),
-            [
-                UploadedFile::fake()->create('foo.txt', 1023),
-                UploadedFile::fake()->create('foo.txt', 2049),
-            ],
-            ['validation.between.file']
-        );
-    }
-
-    public function testBetweenWithInternationalUnits(): void
-    {
-        $this->passes(
-            File::default()->between('1MB', '2MB', File::INTERNATIONAL),
-            [
-                UploadedFile::fake()->create('foo.txt', 1000),
-                UploadedFile::fake()->create('foo.txt', 1500),
-                UploadedFile::fake()->create('foo.txt', 2000),
-            ]
-        );
-
-        $this->fails(
-            File::default()->between('1MB', '2MB', File::INTERNATIONAL),
-            [
-                UploadedFile::fake()->create('foo.txt', 999),
-                UploadedFile::fake()->create('foo.txt', 2001),
-            ],
-            ['validation.between.file']
-        );
-    }
-
-    public function testMin()
+    public function test_min()
     {
         $this->fails(
             File::default()->min(1024),
@@ -362,7 +286,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMinWithHumanReadableSize()
+    public function test_min_with_human_readable_size()
     {
         $this->fails(
             File::default()->min('1024kb'),
@@ -380,43 +304,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMinWithBinaryUnits(): void
-    {
-        $this->passes(
-            File::default()->min('1MB', File::BINARY),
-            [
-                UploadedFile::fake()->create('foo.txt', 1024),
-                UploadedFile::fake()->create('foo.txt', 1025),
-                UploadedFile::fake()->create('foo.txt', 2048),
-            ]
-        );
-
-        $this->fails(
-            File::default()->min('1MB', File::BINARY),
-            UploadedFile::fake()->create('foo.txt', 1023),
-            ['validation.min.file']
-        );
-    }
-
-    public function testMinWithInternationalUnits(): void
-    {
-        $this->passes(
-            File::default()->min('1MB', File::INTERNATIONAL),
-            [
-                UploadedFile::fake()->create('foo.txt', 1000),
-                UploadedFile::fake()->create('foo.txt', 1001),
-                UploadedFile::fake()->create('foo.txt', 2000),
-            ]
-        );
-
-        $this->fails(
-            File::default()->min('1MB', File::INTERNATIONAL),
-            UploadedFile::fake()->create('foo.txt', 999),
-            ['validation.min.file']
-        );
-    }
-
-    public function testMax()
+    public function test_max()
     {
         $this->fails(
             File::default()->max(1024),
@@ -434,7 +322,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMaxWithHumanReadableSize()
+    public function test_max_with_human_readable_size()
     {
         $this->fails(
             File::default()->max('1024kb'),
@@ -452,7 +340,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMaxWithHumanReadableSizeAndMultipleValue()
+    public function test_max_with_human_readable_size_and_multiple_value()
     {
         $this->fails(
             File::default()->max('1mb'),
@@ -470,43 +358,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testMaxWithBinaryUnits(): void
-    {
-        $this->passes(
-            File::default()->max('1MB', File::BINARY),
-            [
-                UploadedFile::fake()->create('foo.txt', 1024),
-                UploadedFile::fake()->create('foo.txt', 1023),
-                UploadedFile::fake()->create('foo.txt', 512),
-            ]
-        );
-
-        $this->fails(
-            File::default()->max('1MB', File::BINARY),
-            UploadedFile::fake()->create('foo.txt', 1025),
-            ['validation.max.file']
-        );
-    }
-
-    public function testMaxWithInternationalUnits(): void
-    {
-        $this->passes(
-            File::default()->max('1MB', File::INTERNATIONAL),
-            [
-                UploadedFile::fake()->create('foo.txt', 1000),
-                UploadedFile::fake()->create('foo.txt', 999),
-                UploadedFile::fake()->create('foo.txt', 500),
-            ]
-        );
-
-        $this->fails(
-            File::default()->max('1MB', File::INTERNATIONAL),
-            UploadedFile::fake()->create('foo.txt', 1001),
-            ['validation.max.file']
-        );
-    }
-
-    public function testMacro()
+    public function test_macro()
     {
         File::macro('toDocument', function () {
             return static::default()->rules('mimes:txt,csv');
@@ -527,7 +379,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testItUsesTheCorrectValidationMessageForFile(): void
+    public function test_it_uses_the_correct_validation_message_for_file(): void
     {
         file_put_contents($path = __DIR__.'/test.json', 'this-is-a-test');
 
@@ -542,7 +394,7 @@ class ValidationFileRuleTest extends TestCase
         unlink($path);
     }
 
-    public function testItCanSetDefaultUsing()
+    public function test_it_can_set_default_using()
     {
         $this->assertInstanceOf(File::class, File::default());
 
@@ -567,7 +419,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testFileSizeConversionWithDifferentUnits()
+    public function test_file_size_conversion_with_different_units()
     {
         $this->passes(
             File::image()->size('5MB'),
@@ -588,32 +440,25 @@ class ValidationFileRuleTest extends TestCase
         File::image()->size('10xyz');
     }
 
-    public function testFileConstants(): void
-    {
-        $this->assertEquals('binary', File::BINARY);
-        $this->assertEquals('international', File::INTERNATIONAL);
-    }
-
-
-    public function testGlobalBinaryPrecedence(): void
+    public function test_global_binary_precedence(): void
     {
         $file1010 = UploadedFile::fake()->create('test.txt', 1010);
 
         $rule = File::default()->binary();
 
         $this->passes(
-            $rule->max('1MB'),
+            $rule->max(1024),
             $file1010
         );
 
         $this->fails(
-            $rule->min('1MB'),
+            $rule->max(1000),
             $file1010,
-            ['validation.size.file'] // when min=max, validation.size.file instead of validation.max.file
+            ['validation.max.file']
         );
     }
 
-    public function testGlobalInternationalPrecedence(): void
+    public function test_global_international_precedence(): void
     {
         $file1010 = UploadedFile::fake()->create('test.txt', 1010);
 
@@ -627,27 +472,11 @@ class ValidationFileRuleTest extends TestCase
         $this->fails(
             $rule->max('1MB'),
             $file1010,
-            ['validation.size.file'] // when min=max, validation.size.file instead of validation.max.file
+            ['validation.size.file']
         );
     }
 
-    public function testExplicitParameterOverridesGlobalSetting(): void
-    {
-        $file1010 = UploadedFile::fake()->create('test.txt', 1010);
-
-        $this->fails(
-            File::default()->binary()->max('1MB', File::INTERNATIONAL),
-            $file1010,
-            ['validation.max.file']
-        );
-
-        $this->passes(
-            File::default()->international()->max('1MB', File::BINARY),
-            $file1010
-        );
-    }
-
-    public function testDefaultsToInternationalWhenNoGlobalSetting(): void
+    public function test_defaults_to_international_when_no_global_setting(): void
     {
         $file1010 = UploadedFile::fake()->create('test.txt', 1010);
 
@@ -658,22 +487,7 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testBinaryVsInternationalDifference(): void
-    {
-        $file1010 = UploadedFile::fake()->create('boundary.txt', 1010);
-
-        $this->passes(
-            File::default()->max('1MB', File::BINARY),
-            $file1010
-        );
-
-        $this->fails(
-            File::default()->max('1MB', File::INTERNATIONAL),
-            $file1010,
-            ['validation.max.file']);
-    }
-
-    public function testNumericSizesWorkWithoutUnits(): void
+    public function test_numeric_sizes_work_without_units(): void
     {
         $file1000 = UploadedFile::fake()->create('numeric.txt', 1000);
 
@@ -682,58 +496,15 @@ class ValidationFileRuleTest extends TestCase
         $this->passes(File::default()->international()->max(1000), $file1000);
     }
 
-    public function testDecimalSizes(): void
-    {
-        $file512 = UploadedFile::fake()->create('half.txt', 512);
-        $file500 = UploadedFile::fake()->create('half.txt', 500);
-
-        $this->passes(
-            File::default()->size('0.5MB', File::BINARY),
-            $file512
-        );
-
-        $this->fails(File::default()->size('0.5MB', File::BINARY),
-            $file500,
-            ['validation.size.file']
-        );
-
-        $this->passes(
-            File::default()->size('0.5MB', File::INTERNATIONAL),
-            $file500
-        );
-
-        $this->fails(
-            File::default()->size('0.5MB', File::INTERNATIONAL),
-            $file512,
-            ['validation.size.file']
-        );
-    }
-
-    public function testLargerUnits(): void
-    {
-        $file1048576 = UploadedFile::fake()->create('big.txt', 1048576);
-        $file1000000 = UploadedFile::fake()->create('big.txt', 1000000);
-
-        $this->passes(
-            File::default()->size('1GB', File::BINARY),
-            $file1048576
-        );
-
-        $this->passes(
-            File::default()->size('1GB', File::INTERNATIONAL),
-            $file1000000
-        );
-    }
-
-    public function testBinaryIntegerPrecisionForLargeFileSizes(): void
+    public function test_binary_integer_precision_for_large_file_sizes(): void
     {
         $file999999 = UploadedFile::fake()->create('large999999.txt', 999999);
-        
+
         $this->passes(
             File::default()->binary()->max('1000000KB'),
             $file999999
         );
-        
+
         $this->fails(
             File::default()->binary()->max('999998KB'),
             $file999999,
@@ -741,15 +512,15 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testInternationalIntegerPrecisionForLargeFileSizes(): void
+    public function test_international_integer_precision_for_large_file_sizes(): void
     {
         $file999999 = UploadedFile::fake()->create('large999999.txt', 999999);
-        
+
         $this->passes(
             File::default()->international()->max('1000000KB'),
             $file999999
         );
-        
+
         $this->fails(
             File::default()->international()->max('999998KB'),
             $file999999,
@@ -757,76 +528,76 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testFloatPrecisionForFractionalSizes(): void
+    public function test_float_precision_for_fractional_sizes(): void
     {
         $file512 = UploadedFile::fake()->create('fractional512.txt', 512);
         $file500 = UploadedFile::fake()->create('fractional500.txt', 500);
-        
+
         $this->passes(
-            File::default()->binary()->size('0.5MB'),
+            File::default()->size('0.5MiB'),
             $file512
         );
-        
+
         $this->passes(
-            File::default()->international()->size('0.5MB'),
+            File::default()->size('0.5MB'),
             $file500
         );
-        
+
         $this->fails(
-            File::default()->binary()->size('0.5MB'),
+            File::default()->size('0.5MiB'),
             $file500,
             ['validation.size.file']
         );
-        
+
         $this->fails(
-            File::default()->international()->size('0.5MB'),
+            File::default()->size('0.5MB'),
             $file512,
             ['validation.size.file']
         );
     }
 
-    public function testBinaryVsInternationalCalculationAccuracy(): void
+    public function test_binary_vs_international_calculation_accuracy(): void
     {
         $file1010 = UploadedFile::fake()->create('boundary1010.txt', 1010);
-        
+
         $this->passes(
-            File::default()->binary()->max('1MB'),
+            File::default()->max('1MiB'),
             $file1010
         );
-        
+
         $this->fails(
-            File::default()->international()->max('1MB'),
+            File::default()->max('1MB'),
             $file1010,
             ['validation.max.file']
         );
-        
+
         $file900 = UploadedFile::fake()->create('small900.txt', 900);
-        
+
         $this->passes(
-            File::default()->binary()->max('1MB'),
+            File::default()->max('1MiB'),
             $file900
         );
-        
+
         $this->passes(
-            File::default()->international()->max('1MB'),
+            File::default()->max('1MB'),
             $file900
         );
     }
 
-    public function testBinaryLargeFileSizePrecision(): void
+    public function test_binary_large_file_size_precision(): void
     {
         $file500000 = UploadedFile::fake()->create('huge500000.txt', 500000);
-        
+
         $this->passes(
             File::default()->binary()->between('400MB', '600MB'),
             $file500000
         );
-        
+
         $this->passes(
             File::default()->binary()->max('1GB'),
             $file500000
         );
-        
+
         $this->fails(
             File::default()->binary()->max('488MB'),
             $file500000,
@@ -834,20 +605,20 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testInternationalLargeFileSizePrecision(): void
+    public function test_international_large_file_size_precision(): void
     {
         $file500000 = UploadedFile::fake()->create('huge500000.txt', 500000);
-        
+
         $this->passes(
             File::default()->international()->between('400MB', '600MB'),
             $file500000
         );
-        
+
         $this->passes(
             File::default()->international()->max('1GB'),
             $file500000
         );
-        
+
         $this->fails(
             File::default()->international()->max('499MB'),
             $file500000,
@@ -855,49 +626,49 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testOverflowProtectionForLargeIntegerValues(): void
+    public function test_overflow_protection_for_large_integer_values(): void
     {
         $fileLarge = UploadedFile::fake()->create('overflow.txt', 2000000000);
-        
+
         $this->passes(
             File::default()->binary()->max('2000000MB'),
             $fileLarge
         );
-        
+
         $this->passes(
             File::default()->international()->max('2000000MB'),
             $fileLarge
         );
     }
 
-    public function testOverflowProtectionWithFractionalValues(): void
+    public function test_overflow_protection_with_fractional_values(): void
     {
         $file1536 = UploadedFile::fake()->create('fractional.txt', 1536);
-        
+
         $this->passes(
-            File::default()->binary()->size('1.5MB'),
+            File::default()->size('1.5MiB'),
             $file1536
         );
-        
+
         $file1500 = UploadedFile::fake()->create('fractional.txt', 1500);
-        
+
         $this->passes(
-            File::default()->international()->size('1.5MB'),
+            File::default()->size('1.5MB'),
             $file1500
         );
     }
 
-    public function testCaseInsensitiveSuffixes(): void
+    public function test_case_insensitive_suffixes(): void
     {
         $file1024 = UploadedFile::fake()->create('case.txt', 1024);
 
-        $this->passes(File::default()->binary()->size('1MB'), $file1024);
-        $this->passes(File::default()->binary()->size('1mb'), $file1024);
-        $this->passes(File::default()->binary()->size('1Mb'), $file1024);
-        $this->passes(File::default()->binary()->size('1mB'), $file1024);
+        $this->passes(File::default()->size('1MiB'), $file1024);
+        $this->passes(File::default()->size('1mib'), $file1024);
+        $this->passes(File::default()->size('1Mib'), $file1024);
+        $this->passes(File::default()->size('1MIB'), $file1024);
     }
 
-    public function testInvalidSizeSuffixThrowsException(): void
+    public function test_invalid_size_suffix_throws_exception(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid file size suffix.');
@@ -905,70 +676,70 @@ class ValidationFileRuleTest extends TestCase
         File::default()->max('5xyz');
     }
 
-    public function testZeroAndVerySmallFileSizes(): void
+    public function test_zero_and_very_small_file_sizes(): void
     {
         $fileZero = UploadedFile::fake()->create('zero.txt', 0);
         $fileOne = UploadedFile::fake()->create('tiny.txt', 1);
-        
+
         $this->passes(
             File::default()->min('0KB'),
             $fileZero
         );
-        
+
         $this->passes(
             File::default()->size('1KB'),
             $fileOne
         );
-        
+
         $this->passes(
             File::default()->binary()->max('0.001MB'),
             $fileOne
         );
     }
 
-    public function testWhitespaceHandlingInFileSizes(): void
+    public function test_whitespace_handling_in_file_sizes(): void
     {
         $file2048 = UploadedFile::fake()->create('whitespace.txt', 2048);
         $file2000 = UploadedFile::fake()->create('whitespace.txt', 2000);
-        
+
         $this->passes(
-            File::default()->binary()->size(' 2MB '),
+            File::default()->size(' 2MiB '),
             $file2048
         );
-        
+
         $this->passes(
-            File::default()->international()->size(' 2MB '),
+            File::default()->size(' 2MB '),
             $file2000
         );
-        
+
         $this->passes(
-            File::default()->binary()->size('2 MB'),
+            File::default()->size('2 MiB'),
             $file2048
         );
     }
 
-    public function testCommaSeparatedNumberParsing(): void
+    public function test_comma_separated_number_parsing(): void
     {
         $file1024 = UploadedFile::fake()->create('comma.txt', 1024);
         $file10240 = UploadedFile::fake()->create('large.txt', 10240);
-        
+
         $this->passes(
             File::default()->binary()->size('1,024KB'),
             $file1024
         );
-        
+
         $this->passes(
             File::default()->binary()->size('10,240KB'),
             $file10240
         );
-        
+
         $this->passes(
             File::default()->international()->size('1,024KB'),
             $file1024
         );
     }
 
-    public function testNegativeFileSizeThrowsException(): void
+    public function test_negative_file_size_throws_exception(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid numeric value in file size.');
@@ -976,7 +747,7 @@ class ValidationFileRuleTest extends TestCase
         File::default()->max('-5MB');
     }
 
-    public function testBinaryFluentChaining(): void
+    public function test_binary_fluent_chaining(): void
     {
         $file1024 = UploadedFile::fake()->create('chain.txt', 1024);
 
@@ -988,7 +759,7 @@ class ValidationFileRuleTest extends TestCase
         $this->passes($rule, $file1024);
     }
 
-    public function testInternationalFluentChaining(): void
+    public function test_international_fluent_chaining(): void
     {
         $file1000 = UploadedFile::fake()->create('chain.txt', 1000);
 
@@ -1000,30 +771,7 @@ class ValidationFileRuleTest extends TestCase
         $this->passes($rule, $file1000);
     }
 
-    public function testMixedUnitsInSameRule(): void
-    {
-        $file1500 = UploadedFile::fake()->create('mixed.txt', 1500);
-
-        $rule = File::default()->binary()
-            ->min('1MB')
-            ->max('2MB', File::INTERNATIONAL);
-
-        $this->passes($rule, $file1500);
-    }
-
-    public function testComplexUnitsScenarioWithMultipleConstraints(): void
-    {
-        $file1500 = UploadedFile::fake()->create('complex.txt', 1500);
-
-        $rule = File::default()->binary()
-            ->types(['txt'])
-            ->min('1MB', File::INTERNATIONAL)
-            ->max('1.4MB', File::BINARY);
-
-        $this->fails($rule, $file1500, ['validation.between.file']);
-    }
-
-    public function testUnitsMethodsReturnNewInstances(): void
+    public function test_units_methods_return_new_instances(): void
     {
         $binary1 = File::default()->binary();
         $binary2 = File::default()->binary();
@@ -1033,7 +781,7 @@ class ValidationFileRuleTest extends TestCase
         $this->assertNotSame($binary1, $international1);
     }
 
-    public function testUnitsBackwardsCompatibility(): void
+    public function test_units_backwards_compatibility(): void
     {
         $file1000 = UploadedFile::fake()->create('compat.txt', 1000);
 
@@ -1053,24 +801,22 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testBinaryFluentMethod(): void
+    public function test_binary_fluent_method(): void
     {
         $file1024 = UploadedFile::fake()->create('binary.txt', 1024);
 
-        // Create instance then call binary() method
         $rule = File::default()
             ->types(['txt'])
             ->binary()
-            ->size('1MB');
+            ->size('1MiB');
 
         $this->passes($rule, $file1024);
     }
 
-    public function testInternationalFluentMethod(): void
+    public function test_international_fluent_method(): void
     {
         $file1000 = UploadedFile::fake()->create('international.txt', 1000);
 
-        // Create instance then call international() method
         $rule = File::default()
             ->types(['txt'])
             ->international()
@@ -1079,37 +825,102 @@ class ValidationFileRuleTest extends TestCase
         $this->passes($rule, $file1000);
     }
 
-    public function testUnitsMethodChaining(): void
+    public function test_units_method_chaining(): void
     {
         $file1024 = UploadedFile::fake()->create('chaining.txt', 1024);
 
-        // Test switching between binary and international on same instance
         $rule = File::default()
             ->types(['txt'])
-            ->international()  // Start with international
-            ->binary()         // Switch to binary
-            ->size('1MB');        // 1MB binary = 1024KB
+            ->international()
+            ->binary()
+            ->size('1MiB');
 
         $this->passes($rule, $file1024);
     }
 
-    public function testInstanceMethodsReturnSameObject(): void
+    public function test_instance_methods_return_same_object(): void
     {
         $originalRule = File::default()->types(['txt']);
-        
-        // Instance methods should return the same object
+
         $binaryRule = $originalRule->binary();
         $internationalRule = $originalRule->international();
-        
+
         $this->assertSame($originalRule, $binaryRule);
         $this->assertSame($originalRule, $internationalRule);
-        
-        // Creating new instances should return different objects
+
         $newBinary = File::default()->binary();
         $newInternational = File::default()->international();
-        
+
         $this->assertNotSame($originalRule, $newBinary);
         $this->assertNotSame($originalRule, $newInternational);
+    }
+
+    public function test_suffix_precedence_over_instance_methods(): void
+    {
+        $file1000 = UploadedFile::fake()->create('test.txt', 1000);
+        $file1030 = UploadedFile::fake()->create('test.txt', 1030);
+
+        $this->passes(
+            File::default()->binary()->max('1MB'),
+            $file1000
+        );
+
+        $this->fails(
+            File::default()->international()->max('1MiB'),
+            $file1030,
+            ['validation.max.file']
+        );
+    }
+
+    public function test_naked_values_fallback_to_instance_methods(): void
+    {
+        $file1000 = UploadedFile::fake()->create('numeric.txt', 1000);
+
+        $this->passes(
+            File::default()->binary()->max(1024),
+            $file1000
+        );
+
+        $this->passes(
+            File::default()->international()->max(1000),
+            $file1000
+        );
+
+        $this->fails(
+            File::default()->international()->max(999),
+            $file1000,
+            ['validation.max.file']
+        );
+    }
+
+    public function test_comprehensive_binary_suffixes(): void
+    {
+        $file1 = UploadedFile::fake()->create('1kb.txt', 1);
+        $file1024 = UploadedFile::fake()->create('1mb.txt', 1024);
+        $file1048576 = UploadedFile::fake()->create('1gb.txt', 1048576);
+
+        $this->passes(File::default()->size('1KiB'), $file1);
+        $this->passes(File::default()->size('1MiB'), $file1024);
+        $this->passes(File::default()->size('1GiB'), $file1048576);
+    }
+
+    public function test_mixed_unit_constraints(): void
+    {
+        $file1500 = UploadedFile::fake()->create('mixed.txt', 1500);
+
+        $rule = File::default()
+            ->min('1MB')
+            ->max('2MiB');
+
+        $this->passes($rule, $file1500);
+
+        $file500 = UploadedFile::fake()->create('small.txt', 500);
+
+        $this->fails(
+            $rule,
+            $file500,
+            ['validation.between.file']
+        );
     }
 
     protected function setUp(): void


### PR DESCRIPTION
# 💡 Description

This PR introduces **hybrid file size validation** that automatically detects binary vs international units from suffixes while providing instance method fallbacks, solving the long-standing confusion between 1024-based and 1000-based file size calculations in Laravel applications.

## Problem

Laravel's file validation exclusively uses international units (1000-based), creating confusion and validation failures when developers expect binary units (1024-based) that match operating system file displays.

**Industry Standards Conflict:**
* **Binary Units** (1024-based): Operating systems, memory allocation, developer tools, file managers
* **International Units** (1000-based): Storage manufacturers, web applications, Laravel (current)

**Real-World Impact:**
* Files showing as "1.0 MB" in OS appear larger than `File::default()->max('1MB')` validation
* Migration difficulties from systems using binary calculations  
* Inconsistent behavior across Laravel vs system tools
* Developer confusion requiring manual size conversions

## Solution

**Hybrid Suffix Detection** automatically determines unit system from IEC/ISO standard suffixes, with instance method fallbacks for naked numeric values.

```php
// Automatic binary detection (IEC standard)
File::default()->max('1MiB');  // 1,048,576 bytes 
File::default()->max('5GiB');  // 5,368,709,120 bytes

// Automatic international detection (SI standard)  
File::default()->max('1MB');   // 1,000,000 bytes
File::default()->max('5GB');   // 5,000,000,000 bytes

// Instance methods for naked values
File::default()->binary()->max(1024);        // Binary interpretation
File::default()->international()->max(1000); // International interpretation

// Mixed constraints for complex scenarios
File::default()->min('1MB')->max('2MiB');    // 1,000,000 to 2,097,152 bytes
```

**Precedence Logic:**
1. **Suffix Detection** (highest) - `MiB`/`GiB`/`TiB` forces Binary, `MB`/`GB`/`TB` forces International
2. **Instance Setting** (medium) - `binary()` or `international()` method calls  
3. **Framework Default** (lowest) - International Units (maintains backward compatibility)

## ⚙️ Usage Examples

### Real-World Scenarios

```php
// File upload matching OS display (binary)
File::default()->max('10MiB');  // Matches "10.0 MB" shown in file manager

// Storage limit matching disk specs (international)  
File::default()->max('5GB');    // Matches "5GB" drive capacity

// Professional document workflow
File::default()
    ->types(['pdf', 'docx'])
    ->between('100KiB', '50MiB');  // 102,400 to 52,428,800 bytes

// Image optimization pipeline
File::default()
    ->types(['jpg', 'png', 'webp'])
    ->max('2MB')               // 2,000,000 bytes (web standard)
    ->extensions(['jpg', 'png', 'webp']);

// Video processing with mixed constraints
File::default()
    ->types(['mp4', 'mov'])
    ->min('10MB')              // 10,000,000 bytes minimum file size
    ->max('2GiB');             // 2,147,483,648 bytes maximum (binary)
```

### Migration Support

```php
// Legacy systems using binary calculations
File::default()->binary()          // Set binary as instance default
    ->types(['backup', 'archive'])
    ->min(1024)                     // 1024 bytes (binary interpretation)
    ->max(524288);                  // 512 KiB (binary interpretation)

// Modern cloud storage (international)
File::default()->international()   // Set international as instance default  
    ->types(['media'])
    ->between(1000, 100000);        // 1KB to 100KB (international)
```

### Backward Compatibility

```php
// ALL EXISTING CODE WORKS UNCHANGED
File::default()->max('1MB');           // Still: 1,000,000 bytes
File::default()->between(1000, 5000);  // Still: raw byte values  
File::default()->size('500KB');        // Still: 500,000 bytes
```

## 🏗️ Technical Implementation

### Core Architecture

**Intelligent Suffix Detection:**
```php
protected function detectUnits(string $size): string
{
    return match (true) {
        is_numeric($size) => $this->units,  // Fallback to instance setting
        in_array(strtolower(substr(trim($size), -3)), ['kib', 'mib', 'gib', 'tib']) => self::BINARY,
        in_array(strtolower(substr(trim($size), -2)), ['kb', 'mb', 'gb', 'tb']) => self::INTERNATIONAL,
        default => $this->units,  // Fallback for unrecognized
    };
}
```

**Multiplier Methods:**
```php
protected function getBinaryMultiplier(string $size): int
{
    return match (substr($size, -3)) {
        'kib' => 1, 'mib' => 1_024, 'gib' => 1_048_576, 'tib' => 1_073_741_824,
        default => throw new InvalidArgumentException('Invalid file size suffix.'),
    };
}
```

### Mathematical Precision

**Integer Precision Preservation:**
```php
protected function prepareValueForPrecision(float $value): float|int
{
    return $value > PHP_INT_MAX || $value < PHP_INT_MIN || ((float) (int) $value) !== $value
        ? $value      // Keep as float for precision or overflow
        : (int) $value; // Convert to int for exact arithmetic
}
```

**Overflow Protection:**
```php  
protected function protectValueFromOverflow(float|int $value, int $multiplier): float|int
{
    return $value > PHP_INT_MAX / $multiplier || $value < PHP_INT_MIN / $multiplier || is_float($value)
        ? (float) $value * $multiplier  // Use float arithmetic to prevent overflow
        : (int) $value * $multiplier;   // Use integer arithmetic for precision
}
```

**Enhanced Input Parsing:**
- Comma-separated values: `"1,024MB"`, `"2,048KiB"`
- Whitespace handling: `" 2GB "`, `"1.5 MB "`
- Case insensitive: `mb`, `MB`, `Mb`, `mB`
- Fractional sizes: `"0.5MiB"`, `"1.5GB"`

### Supported Units

| **Binary (IEC)** | **Bytes** | **International (SI)** | **Bytes** |
|:---:|:---:|:---:|:---:|
| `KiB` | 1,024 | `KB` | 1,000 |
| `MiB` | 1,048,576 | `MB` | 1,000,000 |
| `GiB` | 1,073,741,824 | `GB` | 1,000,000,000 |
| `TiB` | 1,099,511,627,776 | `TB` | 1,000,000,000,000 |

## 🪵 Changelog

| **File** | **Changes** |
|:---:|:---:|
| `src/Illuminate/Validation/Rules/File.php` | Added hybrid suffix detection, simplified method signatures, enhanced mathematical precision, made constants protected, updated docblocks |
| `tests/Validation/ValidationFileRuleTest.php` | Added 30 comprehensive tests: suffix precedence validation, binary/international unit tests, precision arithmetic tests, backward compatibility verification |

## ♻️ Backward Compatibility

**Zero breaking changes** - purely additive enhancement:

* **All existing code unchanged** - Current validation rules continue working identically
* **Default behavior preserved** - International units remain default for naked values  
* **Method signatures simplified** - Removed optional parameters for cleaner API
* **Progressive enhancement** - New binary support available when needed

```php
// BEFORE & AFTER - identical behavior
File::default()->max('1MB');           // 1,000,000 bytes
File::default()->between(1000, 5000);  // Raw byte validation
File::default()->binary()->max(1024);  // Instance method still works

// NEW - binary suffix support  
File::default()->max('1MiB');          // 1,048,576 bytes (binary)
```

## ✅ Testing

**Added 30 new tests** covering comprehensive scenarios:

### Hybrid Functionality
✓ **Suffix precedence** - Confirms `MiB`/`GiB` override instance settings
✓ **Naked value fallback** - Instance methods work for numeric values
✓ **Mixed unit constraints** - Complex international + binary combinations
✓ **All binary suffixes** - `KiB`, `MiB`, `GiB`, `TiB` validation

### Mathematical Precision  
✓ **Integer precision** - Exact arithmetic for whole numbers
✓ **Overflow protection** - Large values on 32-bit systems
✓ **Fractional calculations** - `0.5MiB`, `1.5GB` decimal handling
✓ **Boundary testing** - Files at exact size limits

### Input Processing
✓ **Case insensitive** - `mb`, `MB`, `Mb`, `mB` all supported
✓ **Whitespace tolerance** - `" 2GB "`, `"1.5 MB "` handled correctly  
✓ **Comma parsing** - `"1,024MB"` with locale awareness
✓ **Error validation** - Invalid suffixes and negative values rejected

### Framework Integration
✓ **Fluent chaining** - All method combinations work seamlessly
✓ **Backward compatibility** - Existing validation rules unchanged
✓ **Production scenarios** - Real-world file size boundaries tested
✓ **Cross-platform** - 32-bit and 64-bit system compatibility

---

*💁🏼‍♂️ The author is available for hire -- inquire at [yitzwillroth@gmail.com](mailto:yitzwillroth@gmail.com).*