### PR TITLE
[12.x] Avoid unnecessary filtering when no callback is provided

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -469,12 +469,13 @@ class Factory
             return new Collection;
         }
 
-        $callback = $callback ?: function () {
-            return true;
-        };
+        $collect = new Collection($this->recorded);
 
-        return (new Collection($this->recorded))
-            ->filter(fn ($pair) => $callback($pair[0], $pair[1]));
+        if ($callback) {
+            return $collect->filter(fn ($pair) => $callback($pair[0], $pair[1]));
+        }
+
+        return $collect;
     }
 
     /**


### PR DESCRIPTION
Description
---
This PR refactors the `recorded()` method in the HTTP client to avoid an unnecessary call to `filter()` when no callback is provided.

Currently, when `$callback` is `null`, the method creates a default closure that always returns true, then filters the entire collection; effectively doing nothing but still iterating over the data.

This change short-circuits that path by simply returning the collection directly when no filtering is needed, resulting in slightly better performance and improved clarity, especially when dealing with large numbers of recorded request/response pairs.