### PR TITLE
[12.x] Add URL signature macros to `Request` docblock

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -22,6 +22,9 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  * @method array validate(array $rules, ...$params)
  * @method array validateWithBag(string $errorBag, array $rules, ...$params)
  * @method bool hasValidSignature(bool $absolute = true)
+ * @method bool hasValidRelativeSignature()
+ * @method bool hasValidSignatureWhileIgnoring($ignoreQuery = [], $absolute = true)
+ * @method bool hasValidRelativeSignatureWhileIgnoring($ignoreQuery = [])
  */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While source diving, I noticed that the [`FoundationServiceProvider`](https://github.com/laravel/framework/blob/e2fdcd734bbf4d7bf254faa17ad8ad601b6aa24b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php#L174-L191) registers four URL signature related macros, however, the `Request` docblock only includes one of them.

This PR adds the other three to the docblock:

* `hasValidRelativeSignature`
* `hasValidSignatureWhileIgnoring`
* `hasValidRelativeSignatureWhileIgnoring`