### PR TITLE
[12.x] Add setMinutes() to Session Handlers for Dynamic Expiration

### DIFF
--- a/src/Illuminate/Contracts/Session/LaravelSessionHandlerInterface.php
+++ b/src/Illuminate/Contracts/Session/LaravelSessionHandlerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Session;
+
+use SessionHandlerInterface;
+
+interface LaravelSessionHandlerInterface extends SessionHandlerInterface
+{
+    /**
+     * Set the number of minutes the session should be valid.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes);
+}

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Session;
 
+use Illuminate\Contracts\Session\LaravelSessionHandlerInterface;
 use Illuminate\Support\InteractsWithTime;
-use SessionHandlerInterface;
 
-class ArraySessionHandler implements SessionHandlerInterface
+class ArraySessionHandler implements LaravelSessionHandlerInterface
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -135,4 +135,15 @@ class ArraySessionHandler implements SessionHandlerInterface
     {
         return $this->currentTime() - $seconds;
     }
+
+    /**
+     * Set the expiration time of the session.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes): void
+    {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Session;
 
 use Illuminate\Contracts\Cache\Repository as CacheContract;
-use SessionHandlerInterface;
+use Illuminate\Contracts\Session\LaravelSessionHandlerInterface;
 
-class CacheBasedSessionHandler implements SessionHandlerInterface
+class CacheBasedSessionHandler implements LaravelSessionHandlerInterface
 {
     /**
      * The cache repository instance.

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -102,4 +102,15 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     {
         return $this->cache;
     }
+
+    /**
+     * Set the expiration time of the session.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes): void
+    {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -137,4 +137,15 @@ class CookieSessionHandler implements SessionHandlerInterface
     {
         $this->request = $request;
     }
+
+    /**
+     * Set the expiration time of the session.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes): void
+    {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Session;
 
 use Illuminate\Contracts\Cookie\QueueingFactory as CookieJar;
+use Illuminate\Contracts\Session\LaravelSessionHandlerInterface;
 use Illuminate\Support\InteractsWithTime;
-use SessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class CookieSessionHandler implements SessionHandlerInterface
+class CookieSessionHandler implements LaravelSessionHandlerInterface
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -4,14 +4,14 @@ namespace Illuminate\Session;
 
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Session\LaravelSessionHandlerInterface;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
-use SessionHandlerInterface;
 
-class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerInterface
+class DatabaseSessionHandler implements ExistenceAwareInterface, LaravelSessionHandlerInterface
 {
     use InteractsWithTime;
 

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -315,4 +315,15 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
         return $this;
     }
+
+    /**
+     * Set the expiration time of the session.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes): void
+    {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -125,4 +125,15 @@ class FileSessionHandler implements SessionHandlerInterface
 
         return $deletedSessions;
     }
+
+    /**
+     * Set the expiration time of the session.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function setMinutes(int $minutes): void
+    {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Session;
 
+use Illuminate\Contracts\Session\LaravelSessionHandlerInterface;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
-use SessionHandlerInterface;
 use Symfony\Component\Finder\Finder;
 
-class FileSessionHandler implements SessionHandlerInterface
+class FileSessionHandler implements LaravelSessionHandlerInterface
 {
     /**
      * The filesystem instance.

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -114,4 +114,21 @@ class ArraySessionHandlerTest extends TestCase
         $this->assertSame('', $handler->read('foo'));
         $this->assertSame('qux', $handler->read('baz'));
     }
+
+    public function test_it_expires_correctly()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $handler->setMinutes(2);
+        $handler->write('foo', 'bar');
+
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(1));
+
+        $this->assertSame('bar', $handler->read('foo'));
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(3));
+
+        $this->assertSame('', $handler->read('foo'));
+    }
 }

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -122,7 +122,6 @@ class ArraySessionHandlerTest extends TestCase
         $handler->setMinutes(2);
         $handler->write('foo', 'bar');
 
-
         Carbon::setTestNow(Carbon::now()->addMinutes(1));
 
         $this->assertSame('bar', $handler->read('foo'));

--- a/tests/Session/FileSessionHandlerTest.php
+++ b/tests/Session/FileSessionHandlerTest.php
@@ -162,7 +162,7 @@ class FileSessionHandlerTest extends TestCase
             ->with('/path/to/sessions/'.$sessionId)
             ->andReturn('');
 
-        $this->sessionHandler->setMinutes(2); // Set expiration time to 2 minutes
+        $this->sessionHandler->setMinutes(2); // Set expiration time to 2 minutes.
         $this->sessionHandler->write($sessionId, $data);
 
         Carbon::setTestNow(Carbon::now()->addMinutes(1));


### PR DESCRIPTION

✨ Summary
This PR introduces a new interface and implementation updates that allow Laravel session handlers to accept a dynamic session expiration time at runtime.

Changes Introduced
New Interface: LaravelSessionHandlerInterface extends SessionHandlerInterface with a setMinutes(int $minutes) method.

Updated Handler: All session handlers now implements the new interface and capable to set $minutes dynamically, otherwise fallback to the default provided by the config,

This lays the foundation for dynamically adjusting session expiration logic, such as based on user role, route sensitivity, or login context.

💡 Why This Is Needed
Laravel currently relies on static configuration values (config/session.php) for session lifetime. This enhancement makes it possible to:

- Programmatically set session expiration per user/session.

- Build flexible security policies (e.g., shorter sessions for admins or critical actions).

-  Allows long sessions for logged in users, while not polluting the session storage with sessions from one-time visitors

🔒 Backward Compatibility
This change is non-breaking:

- By default it will fallback to the default value provided by the config.



