### PR TITLE
[12.x] Add `__toString()` method to `Fluent` class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -320,4 +320,14 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     {
         $this->offsetUnset($key);
     }
+
+    /**
+     * Get the string representation of the fluent.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toJson();
+    }
 }

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use JsonSerializable;
+use Stringable;
 use Traversable;
 
 /**
@@ -20,7 +21,7 @@ use Traversable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
+class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable, Stringable
 {
     use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -471,6 +471,18 @@ class SupportFluentTest extends TestCase
             'role' => 'admin',
         ], $result);
     }
+
+    public function testItCanBeCastToString()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'roles' => ['admin', 'editor'],
+        ]);
+
+        $expected = $fluent->toJson();
+
+        $this->assertSame($expected, (string) $fluent);
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
This PR adds a `__toString()` method to the `Fluent` class, enabling instances to be safely cast to strings by returning their JSON representation. This prevents errors when `Fluent` objects are echoed, logged, or used in string interpolation, aligning the class with other Laravel core classes like Collection that implement `__toString()`.