### PR TITLE
[12.x] Ensure `withLocale` and `withCurrency` always restore previous state

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -353,7 +353,11 @@ class Number
 
         static::useLocale($locale);
 
-        return tap($callback(), fn () => static::useLocale($previousLocale));
+        try {
+            return $callback();
+        } finally {
+            static::useLocale($previousLocale);
+        }
     }
 
     /**
@@ -369,7 +373,11 @@ class Number
 
         static::useCurrency($currency);
 
-        return tap($callback(), fn () => static::useCurrency($previousCurrency));
+        try {
+            return $callback();
+        } finally {
+            static::useCurrency($previousCurrency);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR replaces the use of `tap()` with `try...finally` in the `Number::withLocale()` and `Number::withCurrency()` methods to ensure that the previous static state is always restored, even if the callback throws an exception.
Currently, if an exception is thrown inside the callback passed to `withLocale()` or `withCurrency()`, the previous locale or currency is not restored. This can lead to inconsistent formatting behavior in subsequent operations.