### PR TITLE
[12.x] fix: AsCommand properties not being set on commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -45,16 +45,16 @@ class Command extends SymfonyCommand
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * The console command help text.
      *
      * @var string
      */
-    protected $help;
+    protected $help = '';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.
@@ -101,11 +101,13 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        if (isset($this->description)) {
-            $this->setDescription((string) $this->description);
+        if (! empty($this->description)) {
+            $this->setDescription($this->description);
         }
 
-        $this->setHelp((string) $this->help);
+        if (! empty($this->help)) {
+            $this->setHelp($this->help);
+        }
 
         $this->setHidden($this->isHidden());
 


### PR DESCRIPTION
Hello!

The Symfony Command uses the AsCommand attribute to set properties on the command class. However, the properties are only set if they are identical to an empty string. The Laravel Command class overrides the properties and removes the default value which causes the properties to be null and therefore not set.

See:
- https://github.com/symfony/symfony/blob/a04357de0fd1374d0d81c52e42d4af5cf7263fdc/src/Symfony/Component/Console/Command/Command.php#L48-L49
- https://github.com/symfony/symfony/blob/a04357de0fd1374d0d81c52e42d4af5cf7263fdc/src/Symfony/Component/Console/Command/Command.php#L142-L156

Thanks!