### PR TITLE
[11.x] backport #56235

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -45,16 +45,16 @@ class Command extends SymfonyCommand
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * The console command help text.
      *
      * @var string
      */
-    protected $help;
+    protected $help = '';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.
@@ -103,13 +103,13 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        if (! isset($this->description)) {
-            $this->setDescription((string) static::getDefaultDescription());
-        } else {
-            $this->setDescription((string) $this->description);
+        if (! empty($this->description)) {
+            $this->setDescription($this->description);
         }
 
-        $this->setHelp((string) $this->help);
+        if (! empty($this->help)) {
+            $this->setHelp($this->help);
+        }
 
         $this->setHidden($this->isHidden());
 


### PR DESCRIPTION
Hello!

This backports https://github.com/laravel/framework/pull/56235 to 11.x.

We're getting **hundreds of pages** of the following logs even though all of our commands use the `AsCommand` attribute:

```
Since symfony/console 7.3: Method "Symfony\Component\Console\Command\Command::getDefaultDescription()" is deprecated and will be removed in Symfony 8.0, use the #[AsCommand] attribute instead. in /var/www/eaglesys/releases/629/vendor/symfony/deprecation-contracts/function.php on line 25
```

This is because the attribute description is not being used to set the command description due to Symfony's `=== ''` check on the parent constructor.


Thanks!