### PR TITLE
[12.x] Fix `guessColumnForQuery` to correctly handle attributes in an array

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1135,7 +1135,7 @@ trait ValidatesAttributes
      */
     public function guessColumnForQuery($attribute)
     {
-        if (in_array($attribute, Arr::collapse($this->implicitAttributes))
+        if (str_contains($attribute, '.')
                 && ! is_numeric($last = last(explode('.', $attribute)))) {
             return $last;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4173,12 +4173,38 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['user' => ['email' => 'foo', 'type' => 'bar']], [
+            'user.email' => 'unique:users', 'user.type' => 'exists:user_types',
+        ]);
+        $mock = m::mock(DatabasePresenceVerifierInterface::class);
+        $mock->shouldReceive('setConnection')->twice()->with(null);
+        $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
+        $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
+        $v->setPresenceVerifier($mock);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
         $closure = function () {
             //
         };
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
             '*.email' => (new Unique('users'))->where($closure),
             '*.type' => (new Exists('user_types'))->where($closure),
+        ]);
+        $mock = m::mock(DatabasePresenceVerifierInterface::class);
+        $mock->shouldReceive('setConnection')->twice()->with(null);
+        $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
+        $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
+        $v->setPresenceVerifier($mock);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $closure = function () {
+            //
+        };
+        $v = new Validator($trans, ['user' => ['email' => 'foo', 'type' => 'bar']], [
+            'user.email' => (new Unique('users'))->where($closure),
+            'user.type' => (new Exists('user_types'))->where($closure),
         ]);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->twice()->with(null);


### PR DESCRIPTION
The `guessColumnForQuery` function cannot resolve the correct column name from array attributes (eg: `key.field_name`), as the previous logic only supports the `*.field_name` format.

```
$input = [
    'user' => [
        'name' => 'testuser',
    ],
];

$validator = Validator::make($input, [
    'user.name' => 'exists:users',
]);
```

Got an error: `SQLSTATE[42P01]: Undefined table: 7 ERROR: missing FROM-clause entry for table "user" LINE 1: select count(*) as aggregate from "users" where "user"."name... `