### PR TITLE
[12.x] Pass `LoggerInterface` when constructing `RoundrobinTransport` instance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "symfony/finder": "^7.2.0",
         "symfony/http-foundation": "^7.2.0",
         "symfony/http-kernel": "^7.2.0",
-        "symfony/mailer": "^7.2.0",
+        "symfony/mailer": "^7.4.0",
         "symfony/mime": "^7.2.0",
         "symfony/polyfill-php83": "^1.33",
         "symfony/polyfill-php84": "^1.33",

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -430,7 +430,7 @@ class MailManager implements FactoryContract
                 : $this->createSymfonyTransport($config);
         }
 
-        return new $class($transports, $config['retry_after'] ?? 60);
+        return new $class($transports, $config['retry_after'] ?? 60, $this->app->make(LoggerInterface::class));
     }
 
     /**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -22,7 +22,7 @@
         "illuminate/support": "^12.0",
         "league/commonmark": "^2.7",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/mailer": "^7.2.0",
+        "symfony/mailer": "^7.4.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.5"
     },
     "autoload": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
As a follow-up to https://github.com/symfony/symfony/pull/60110 which introduces an additional constructor property `logger` to the `RoundRobinTransport` class, this PR ensures the app-bound `LoggerInterface` will be passed when constructing such a class.

Note that this will require Symfony 7.4.0 or higher, which is [due for release in November 2025](https://symfony.com/releases/7.4). Given that passing additional parameters to constructors is allowed in PHP (they are just silently ignored), this PR as such is both backwards and forwards compatible, however at current would do effectively nothing. If therefore it is preferable to keep this as draft until (near) the release of Symfony 7.4, that is also perfectly fine with me.

I've already tested to ensure tests still pass with the following `composer.json` patch:
```diff
         "symfony/finder": "^7.2.0",
         "symfony/http-foundation": "^7.2.0",
         "symfony/http-kernel": "^7.2.0",
-        "symfony/mailer": "^7.2.0",
+        "symfony/mailer": "7.4.x-dev as 7.4.0",
         "symfony/mime": "^7.2.0",
         "symfony/polyfill-php83": "^1.31",
         "symfony/process": "^7.2.0",
```