### PR TITLE
Support array to string conversion in `InteractsWithData`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -241,7 +241,9 @@ trait InteractsWithData
      */
     public function string($key, $default = null)
     {
-        return Str::of($this->data($key, $default));
+        $value = $this->data($key, $default);
+
+        return Str::of(is_array($value) ? json_encode($value) : $value);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -603,6 +603,8 @@ class HttpRequestTest extends TestCase
             'str' => 'abc',
             'empty_str' => '',
             'null' => null,
+            'list' => ['value'],
+            'array' => ['key' => 'value'],
         ]);
         $this->assertTrue($request->string('int') instanceof Stringable);
         $this->assertTrue($request->string('unknown_key') instanceof Stringable);
@@ -615,6 +617,8 @@ class HttpRequestTest extends TestCase
         $this->assertSame('', $request->string('empty_str')->value());
         $this->assertSame('', $request->string('null')->value());
         $this->assertSame('', $request->string('unknown_key')->value());
+        $this->assertSame('["value"]', $request->string('list')->value());
+        $this->assertSame('{"key":"value"}', $request->string('array')->value());
     }
 
     public function testBooleanMethod()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -167,6 +167,8 @@ class SupportFluentTest extends TestCase
             'str' => 'abc',
             'empty_str' => '',
             'null' => null,
+            'list' => ['value'],
+            'array' => ['key' => 'value'],
         ]);
         $this->assertTrue($fluent->string('int') instanceof Stringable);
         $this->assertTrue($fluent->string('unknown_key') instanceof Stringable);
@@ -179,6 +181,8 @@ class SupportFluentTest extends TestCase
         $this->assertSame('', $fluent->string('empty_str')->value());
         $this->assertSame('', $fluent->string('null')->value());
         $this->assertSame('', $fluent->string('unknown_key')->value());
+        $this->assertSame('["value"]', $fluent->string('list')->value());
+        $this->assertSame('{"key":"value"}', $fluent->string('array')->value());
     }
 
     public function testBooleanMethod()


### PR DESCRIPTION
This PR proposed a change that gracefully converts arrays to strings when using the `string()` method on `Illuminate\Support\Traits\InteractsWithData`.

Currently, when using `string()` and the retrieved value happens to be an array, PHP generates an "Array to string conversion" warning, which is then converted to an `ErrorException` by Laravel. This can lead to unexpected 500s, when the developer, for example, is using `request()->string('q')` to retrieve a value from the query string or request body, and the user input is `q[0]=value`.