### PR TITLE
[12.x] Allow passing an enum to `Builder::orderBy()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2675,7 +2675,7 @@ class Builder implements BuilderContract
      * Add an "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $direction
+     * @param  string|UnitEnum  $direction
      * @return $this
      *
      * @throws \InvalidArgumentException
@@ -2690,7 +2690,7 @@ class Builder implements BuilderContract
             $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
         }
 
-        $direction = strtolower($direction);
+        $direction = strtolower(enum_value($direction));
 
         if (! in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2675,7 +2675,7 @@ class Builder implements BuilderContract
      * Add an "order by" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string|UnitEnum  $direction
+     * @param  string|\UnitEnum  $direction
      * @return $this
      *
      * @throws \InvalidArgumentException

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2075,6 +2075,10 @@ class DatabaseQueryBuilderTest extends TestCase
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);
         $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('age', SortDirection::Ascending)->orderBy('email', SortDirection::Descending);
+        $this->assertSame('select * from "users" order by "age" asc, "email" desc', $builder->toSql());
     }
 
     public function testLatest()
@@ -7184,4 +7188,10 @@ SQL;
             m::mock(Processor::class),
         ])->makePartial();
     }
+}
+
+enum SortDirection: string
+{
+    case Ascending = 'asc';
+    case Descending = 'DESC';
 }


### PR DESCRIPTION
At work, we have three or four separate projects, each which has a SortDirection enum. We use the enum to validate against in HTTP requests, but always have to remember to add `->value` when sorting, eg) `Athlete::query()->orderBy('last_name', $request->sort->direction->value)`.

I believe it is a mathematical impossibility that we are the only folks who have this issue. This is certainly not broken as-is, just adding a small quality of life improvement for improved DX.