### PR TITLE
[12.x] fix: qualifyColumns inconsistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2098,14 +2098,13 @@ class Builder implements BuilderContract
      */
     public function qualifyColumns($columns)
     {
-        return collect(Arr::wrap($columns))->map(function ($column) {
-            $column = $column instanceof Expression
+         $columns = Arr::map(Arr::wrap($columns), function ($column) {
+            return $column instanceof Expression
                 ? $column->getValue($this->getGrammar())
                 : $column;
+        });
 
-            return $this->model->qualifyColumn($column);
-        })
-        ->all();
+        return $this->model->qualifyColumns($columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2098,7 +2098,14 @@ class Builder implements BuilderContract
      */
     public function qualifyColumns($columns)
     {
-        return $this->model->qualifyColumns($columns);
+        return collect(Arr::wrap($columns))->map(function ($column) {
+            $column = $column instanceof Expression
+                ? $column->getValue($this->getGrammar())
+                : $column;
+
+            return $this->model->qualifyColumn($column);
+        })
+        ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2098,7 +2098,7 @@ class Builder implements BuilderContract
      */
     public function qualifyColumns($columns)
     {
-         $columns = Arr::map(Arr::wrap($columns), function ($column) {
+        $columns = Arr::map(Arr::wrap($columns), function ($column) {
             return $column instanceof Expression
                 ? $column->getValue($this->getGrammar())
                 : $column;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -315,7 +315,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo_table.column', 'foo_table.name'], $builder->qualifyColumns(['column', 'name']));
     }
 
-
     public function testQualifyColumnsWithRawExpression()
     {
         $query = m::mock(BaseBuilder::class);
@@ -329,7 +328,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertEquals(['foo_table.id'], $builder->qualifyColumns([$expr]));
     }
-
 
     public function testQualifyColumnsWithMixedExpressionsAndStrings()
     {
@@ -347,7 +345,6 @@ class DatabaseEloquentBuilderTest extends TestCase
             $builder->qualifyColumns([$expr, 'name'])
         );
     }
-
 
     public function testQualifyColumnsKeepsAlreadyQualifiedExpressionIntact()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -315,6 +315,57 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo_table.column', 'foo_table.name'], $builder->qualifyColumns(['column', 'name']));
     }
 
+
+    public function testQualifyColumnsWithRawExpression()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class));
+
+        $builder = new Builder($query);
+        $builder->setModel(new EloquentBuilderTestStubStringPrimaryKey);
+
+        $expr = new Expression('id');
+
+        $this->assertEquals(['foo_table.id'], $builder->qualifyColumns([$expr]));
+    }
+
+
+    public function testQualifyColumnsWithMixedExpressionsAndStrings()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class));
+
+        $builder = new Builder($query);
+        $builder->setModel(new EloquentBuilderTestStubStringPrimaryKey);
+
+        $expr = new Expression('id');
+
+        $this->assertEquals(
+            ['foo_table.id', 'foo_table.name'],
+            $builder->qualifyColumns([$expr, 'name'])
+        );
+    }
+
+
+    public function testQualifyColumnsKeepsAlreadyQualifiedExpressionIntact()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table');
+        $query->shouldReceive('getGrammar')->andReturn(m::mock(Grammar::class));
+
+        $builder = new Builder($query);
+        $builder->setModel(new EloquentBuilderTestStubStringPrimaryKey);
+
+        $expr = new Expression('SUM(foo_table.balance)');
+
+        $this->assertEquals(
+            ['SUM(foo_table.balance)'],
+            $builder->qualifyColumns([$expr])
+        );
+    }
+
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
     {
         $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
The `qualifyColumns` docblock says it accepts `array | Expression`, but the implementation just forwards to `Model::qualifyColumns($columns)` which expects an array of strings. Passing an Expression yields a fatal type error.

This PR ensures that `qualifyColumns` can handle Expressions the same way `qualifyColumn()` does.