### PR TITLE
[12.x] Fix handling of `Htmlable` objects in `Js::convertDataToJavaScriptExpression()`

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -70,7 +70,12 @@ class Js implements Htmlable, Stringable
             return $data->toHtml();
         }
 
-        if ($data instanceof Htmlable) {
+        if (
+            $data instanceof Htmlable
+            && ! $data instanceof Arrayable
+            && ! $data instanceof Jsonable
+            && ! $data instanceof JsonSerializable
+        ) {
             $data = $data->toHtml();
         }
 

--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -70,12 +70,10 @@ class Js implements Htmlable, Stringable
             return $data->toHtml();
         }
 
-        if (
-            $data instanceof Htmlable
-            && ! $data instanceof Arrayable
-            && ! $data instanceof Jsonable
-            && ! $data instanceof JsonSerializable
-        ) {
+        if ($data instanceof Htmlable && 
+            ! $data instanceof Arrayable && 
+            ! $data instanceof Jsonable && 
+            ! $data instanceof JsonSerializable) {
             $data = $data->toHtml();
         }
 

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -133,13 +133,67 @@ class SupportJsTest extends TestCase
     {
         $data = new class implements Htmlable
         {
-            public function toHtml(): string
+            public function toHtml()
             {
                 return '<p>Hello, World!</p>';
             }
         };
 
         $this->assertEquals("'\u003Cp\u003EHello, World!\u003C\/p\u003E'", (string) Js::from($data));
+
+        $data = new class implements Htmlable, Arrayable
+        {
+            public function toHtml()
+            {
+                return '<p>Hello, World!</p>';
+            }
+
+            public function toArray()
+            {
+                return ['foo' => 'hello', 'bar' => 'world'];
+            }
+        };
+
+        $this->assertEquals(
+            "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
+            (string) Js::from($data)
+        );
+
+        $data = new class implements Htmlable, Jsonable
+        {
+            public function toHtml()
+            {
+                return '<p>Hello, World!</p>';
+            }
+
+            public function toJson($options = 0)
+            {
+                return json_encode(['foo' => 'hello', 'bar' => 'world'], $options);
+            }
+        };
+
+        $this->assertEquals(
+            "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
+            (string) Js::from($data)
+        );
+
+        $data = new class implements Htmlable, JsonSerializable
+        {
+            public function toHtml()
+            {
+                return '<p>Hello, World!</p>';
+            }
+
+            public function jsonSerialize(): mixed
+            {
+                return ['foo' => 'hello', 'bar' => 'world'];
+            }
+        };
+
+        $this->assertEquals(
+            "JSON.parse('{\\u0022foo\\u0022:\\u0022hello\\u0022,\\u0022bar\\u0022:\\u0022world\\u0022}')",
+            (string) Js::from($data)
+        );
     }
 
     public function testBackedEnums()


### PR DESCRIPTION
This PR fixes #56252, which references a recent PR of mine, #56159, that added support for handling `Htmlable` objects in the `Js::convertDataToJavaScriptExpression()` method.

## The Problem

Some classes, including those in the framework like pagination, implement `Htmlable`, but may also implement any of `Arrayable`, `Jsonable`, and `JsonSerializable`, which have their own conversion logic. By converting the data to a string of HTML early on, it breaks functionality for developers who previously relied on the behavior of objects implementing these other interfaces.

## The Proposed Fix

I improved the handling of `Htmlable` objects by also checking if the object implements any of these other classes, and if so, it skips the conversion, reverting to the previous default behavior.

Of course, there are other ways to solve the problem. Such as reverting my change entirely, or only checking for instances of `HtmlString` instead (which is what "inspired" my original PR). It will be up to Taylor to decide what is best for the framework.