### PR TITLE
[12.x] Add `config_or_fail` helper

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use RuntimeException;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -55,6 +56,19 @@ class Repository implements ArrayAccess, ConfigContract
         }
 
         return Arr::get($this->items, $key, $default);
+    }
+
+    /**
+     * Get the specified configuration value.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public function getOrFail(string $key)
+    {
+        return $this->get($key) ?? throw new RuntimeException("Configuration value for key [$key] is not set.");
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -316,6 +316,19 @@ if (! function_exists('config')) {
     }
 }
 
+if (! function_exists('config_or_fail')) {
+    /**
+     * Get the specified configuration value.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    function config_or_fail(string $key)
+    {
+        return app('config')->getOrFail($key);
+    }
+}
+
 if (! function_exists('config_path')) {
     /**
      * Get the configuration path.

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -6,6 +6,7 @@ use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class RepositoryTest extends TestCase
 {
@@ -149,6 +150,19 @@ class RepositoryTest extends TestCase
     public function testGetWithDefault()
     {
         $this->assertSame('default', $this->repository->get('not-exist', 'default'));
+    }
+
+    public function testGetOrFailGets()
+    {
+        $this->assertSame('bar', $this->repository->getOrFail('foo'));
+    }
+
+    public function testGetOrFailFails()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[not-exist\] is not set.#');
+
+        $this->repository->getOrFail('not-exist');
     }
 
     public function testSet()


### PR DESCRIPTION
Add `getOrFail()` to Config repository (with tests)
Add `config_or_fail()` helper in Foundation

The implementation should behave similarly to the
`\Illuminate\Support\Env::getOrFail()` method.

My use-case for this would be to quickly check, that the user did not forget to set some environment variables while deployment. Some configs may not have a good default value but are also not that important to block an entire deployment if just that small feature fails.

Example config:

```php
# services.php

return [
  'xyz' => [
    'active' => (bool) env('XYZ_ACTIVE', false),
    'domain' => env('XYZ_DOMAIN'),
  ],
];
```

With that, you may use it like so:

```php
if (config('services.xyz.active')) {
  Http::post(config_or_fail('services.xyz.domain').'/up');
}
```