### PR TITLE
[12.x] Refactor: Remove unnecessary parentheses

### DIFF
--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -32,7 +32,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testDenyHasNullStatus()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -53,7 +53,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testItCanDenyWithStatus()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -73,7 +73,7 @@ class AuthHandlesAuthorizationTest extends TestCase
             $this->assertSame(0, $e->getCode());
         }
 
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -96,7 +96,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testItCanDenyAsNotFound()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -116,7 +116,7 @@ class AuthHandlesAuthorizationTest extends TestCase
             $this->assertSame(0, $e->getCode());
         }
 
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -283,7 +283,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testFirstOrCreateMethodFallsBackToCreateOrFirst(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {
@@ -354,7 +354,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testUpdateOrCreateMethodCreatesNewRelated(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {
@@ -396,7 +396,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testUpdateOrCreateMethodUpdatesExistingRelated(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -288,7 +288,7 @@ class DatabaseEloquentInverseRelationTest extends TestCase
             [],
             new HasInverseRelationRelatedStub(),
             'foo',
-            new class() {
+            new class {
             },
             new HasInverseRelationRelatedStub(),
         ]);

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -221,7 +221,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     public function testForceDeleteDoesntUpdateExistsPropertyIfFailed()
     {
-        $user = new class() extends SoftDeletesTestUser
+        $user = new class extends SoftDeletesTestUser
         {
             public $exists = true;
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2358,7 +2358,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having(
-            new class() implements ConditionExpression
+            new class implements ConditionExpression
             {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {
@@ -6470,7 +6470,7 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where(
-            new class() implements ConditionExpression
+            new class implements ConditionExpression
             {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -248,10 +248,10 @@ class EncrypterTest extends TestCase
 
         return [
             [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
-            [['iv' => new class() {
+            [['iv' => new class {
             }, 'value' => '', 'mac' => '']],
             [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
-            [['iv' => $validIv, 'value' => new class() {
+            [['iv' => $validIv, 'value' => new class {
             }, 'mac' => '']],
             [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
             [['iv' => $validIv, 'value' => '', 'mac' => null]],

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -26,14 +26,14 @@ class JoinPathsHelperTest extends TestCase
         yield ['Empty/0/1/Segments/00/Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1/2/3', join_paths(1, 0, 2, 3)];
-        yield ['app/objecty', join_paths('app', new class()
+        yield ['app/objecty', join_paths('app', new class
         {
             public function __toString()
             {
                 return 'objecty';
             }
         })];
-        yield ['app/0', join_paths('app', new class()
+        yield ['app/0', join_paths('app', new class
         {
             public function __toString()
             {
@@ -58,14 +58,14 @@ class JoinPathsHelperTest extends TestCase
         yield ['Empty\0\1\Segments\00\Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1\2\3', join_paths(1, 2, 3)];
-        yield ['app\\objecty', join_paths('app', new class()
+        yield ['app\\objecty', join_paths('app', new class
         {
             public function __toString()
             {
                 return 'objecty';
             }
         })];
-        yield ['app\\0', join_paths('app', new class()
+        yield ['app\\0', join_paths('app', new class
         {
             public function __toString()
             {

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -472,7 +472,7 @@ class LogManagerTest extends TestCase
             'driver' => 'single',
         ]);
 
-        $factory = new class()
+        $factory = new class
         {
             public function __invoke()
             {

--- a/tests/Mail/AttachableTest.php
+++ b/tests/Mail/AttachableTest.php
@@ -17,7 +17,7 @@ class AttachableTest extends TestCase
         });
         $mailable = new Mailable;
 
-        $mailable->attach(new class() implements Attachable
+        $mailable->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -41,7 +41,7 @@ class AttachableTest extends TestCase
         Attachment::macro('size', function () {
             return 99;
         });
-        $notification = new class()
+        $notification = new class
         {
             public $pathArgs;
 
@@ -50,7 +50,7 @@ class AttachableTest extends TestCase
                 $this->pathArgs = func_get_args();
             }
         };
-        $attachable = new class() implements Attachable
+        $attachable = new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -78,7 +78,7 @@ class AttachableTest extends TestCase
         Attachment::macro('size', function () {
             return 99;
         });
-        $notification = new class()
+        $notification = new class
         {
             public $pathArgs;
 
@@ -89,7 +89,7 @@ class AttachableTest extends TestCase
                 $this->dataArgs = func_get_args();
             }
         };
-        $attachable = new class() implements Attachable
+        $attachable = new class implements Attachable
         {
             public function toMailAttachment()
             {

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -675,7 +675,7 @@ class MailMailableTest extends TestCase
         $mailable->attachMany([
             '/forge.svg',
             '/vapor.svg' => ['as' => 'Vapor Logo.svg', 'mime' => 'text/css'],
-            new class() implements Attachable
+            new class implements Attachable
             {
                 public function toMailAttachment()
                 {
@@ -709,7 +709,7 @@ class MailMailableTest extends TestCase
     {
         $mailable = new WelcomeMailableStub;
 
-        $mailable->attach(new class() implements Attachable
+        $mailable->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -730,7 +730,7 @@ class MailMailableTest extends TestCase
     {
         $mailable = new WelcomeMailableStub;
 
-        $mailable->attach(new class() implements Attachable
+        $mailable->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -750,7 +750,7 @@ class MailMailableTest extends TestCase
     public function testItCanJitNameAttachments()
     {
         $mailable = new WelcomeMailableStub;
-        $unnamedAttachable = new class() implements Attachable
+        $unnamedAttachable = new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -772,7 +772,7 @@ class MailMailableTest extends TestCase
     public function testHasAttachmentWithJitNamedAttachment()
     {
         $mailable = new WelcomeMailableStub;
-        $unnamedAttachable = new class() implements Attachable
+        $unnamedAttachable = new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -804,7 +804,7 @@ class MailMailableTest extends TestCase
                 ];
             }
         };
-        $unnamedAttachable = new class() implements Attachable
+        $unnamedAttachable = new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -988,7 +988,7 @@ class MailMailableTest extends TestCase
     {
         $this->stubMailer();
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1003,7 +1003,7 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1018,7 +1018,7 @@ class MailMailableTest extends TestCase
     {
         $this->stubMailer();
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1033,7 +1033,7 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1046,7 +1046,7 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachmentFromStorage()
     {
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1061,7 +1061,7 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1076,7 +1076,7 @@ class MailMailableTest extends TestCase
     {
         $this->stubMailer();
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1091,7 +1091,7 @@ class MailMailableTest extends TestCase
             $this->assertStringContainsString("Email subject does not match expected value.\nExpected: [Foo Subject]\nActual:", $e->getMessage());
         }
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {
@@ -1130,7 +1130,7 @@ class MailMailableTest extends TestCase
     {
         $this->stubMailer();
 
-        $mailable = new class() extends Mailable
+        $mailable = new class extends Mailable
         {
             public function build()
             {

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -119,7 +119,7 @@ class MailMessageTest extends TestCase
     {
         file_put_contents($path = __DIR__.'/foo.jpg', 'expected attachment body');
 
-        $this->message->attach(new class() implements Attachable
+        $this->message->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -141,7 +141,7 @@ class MailMessageTest extends TestCase
 
     public function testItAttachesFilesViaAttachableContractFromData()
     {
-        $this->message->attach(new class() implements Attachable
+        $this->message->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -193,7 +193,7 @@ class MailMessageTest extends TestCase
     {
         file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
 
-        $cid = $this->message->embed(new class() implements Attachable
+        $cid = $this->message->embed(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -216,7 +216,7 @@ class MailMessageTest extends TestCase
     {
         file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
 
-        $cid = $this->message->embed(new class() implements Attachable
+        $cid = $this->message->embed(new class implements Attachable
         {
             public function toMailAttachment()
             {

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -307,7 +307,7 @@ class NotificationMailMessageTest extends TestCase
     {
         $message = new MailMessage;
 
-        $message->attach(new class() implements Attachable
+        $message->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -328,7 +328,7 @@ class NotificationMailMessageTest extends TestCase
     {
         $mailMessage = new MailMessage();
 
-        $mailMessage->attach(new class() implements Attachable
+        $mailMessage->attach(new class implements Attachable
         {
             public function toMailAttachment()
             {
@@ -348,7 +348,7 @@ class NotificationMailMessageTest extends TestCase
     public function testItAttachesManyFiles()
     {
         $mailMessage = new MailMessage();
-        $attachable = new class() implements Attachable
+        $attachable = new class implements Attachable
         {
             public function toMailAttachment()
             {

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -87,7 +87,7 @@ class OnceTest extends TestCase
 
     public function testIsNotMemoizedWhenCallableUsesChanges()
     {
-        $instance = new class()
+        $instance = new class
         {
             public function rand(string $letter)
             {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3286,7 +3286,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection($payload = [
             ['name' => new Stringable('Laravel'), 'url' => '1'],
             ['name' => new HtmlString('Laravel'), 'url' => '1'],
-            ['name' => new class()
+            ['name' => new class
             {
                 public function __toString()
                 {

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -54,7 +54,7 @@ class SupportJsTest extends TestCase
     {
         // JsonSerializable should take precedence over Arrayable, so we'll
         // implement both and make sure the correct data is used.
-        $data = new class() implements JsonSerializable, Arrayable
+        $data = new class implements JsonSerializable, Arrayable
         {
             public $foo = 'not hello';
 
@@ -81,7 +81,7 @@ class SupportJsTest extends TestCase
     {
         // Jsonable should take precedence over JsonSerializable and Arrayable, so we'll
         // implement all three and make sure the correct data is used.
-        $data = new class() implements Jsonable, JsonSerializable, Arrayable
+        $data = new class implements Jsonable, JsonSerializable, Arrayable
         {
             public $foo = 'not hello';
 
@@ -111,7 +111,7 @@ class SupportJsTest extends TestCase
 
     public function testArrayable()
     {
-        $data = new class() implements Arrayable
+        $data = new class implements Arrayable
         {
             public $foo = 'not hello';
 

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -16,7 +16,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanPass()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -33,7 +33,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanFail()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -54,7 +54,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanReturnMultipleErrorMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -78,7 +78,7 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'Translated error message.'], 'en');
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -100,7 +100,7 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute input: :input position: :position index: :index baz: :baz'], 'en');
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -127,7 +127,7 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'attribute: :attribute'], 'en');
         $trans->addLines(['validation.attributes.foo' => 'email address'], 'en');
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -152,7 +152,7 @@ class ValidationInvokableRuleTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'English'], 'en');
         $trans->addLines(['validation.translated-error' => 'French'], 'fr');
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -175,7 +175,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanAccessDataDuringValidation()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule, DataAwareRule
+        $rule = new class implements ValidationRule, DataAwareRule
         {
             public $data = [];
 
@@ -205,7 +205,7 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $rule = new class() implements ValidationRule, ValidatorAwareRule
+        $rule = new class implements ValidationRule, ValidatorAwareRule
         {
             public $validator = null;
 
@@ -231,7 +231,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeExplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public $implicit = false;
 
@@ -250,7 +250,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeImplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public $implicit = true;
 
@@ -273,7 +273,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItIsExplicitByDefault()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -290,7 +290,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanSpecifyTheValidationErrorKeyForTheErrorMessage()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -316,7 +316,7 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'There is one error.|There are many errors.'], 'en');
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {
@@ -337,7 +337,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testExplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public $implicit = false;
 
@@ -369,7 +369,7 @@ class ValidationInvokableRuleTest extends TestCase
     public function testImplicitRuleCanUseInlineValidationMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public $implicit = true;
 
@@ -400,7 +400,7 @@ class ValidationInvokableRuleTest extends TestCase
 
     public function testItCanReturnInvokableRule()
     {
-        $rule = new class() implements ValidationRule
+        $rule = new class implements ValidationRule
         {
             public function validate($attribute, $value, $fail): void
             {

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -80,7 +80,7 @@ class ComponentTest extends TestCase
         $this->viewFactory->shouldReceive('exists')->once()->andReturn(false);
         $this->viewFactory->shouldReceive('addNamespace')->once()->with('__components', '/tmp');
 
-        $component = new class() extends Component
+        $component = new class extends Component
         {
             protected $title;
 


### PR DESCRIPTION
This refactors all class instantiations that do not require constructor arguments 
by removing the unnecessary parentheses, following modern PHP style 
and improving code readability.

This change requires PHP 8.0+ for compatibility.
