### PR TITLE
[12.x] Make RouteRegistrar Conditionable

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -7,6 +7,7 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 
 /**
@@ -33,6 +34,7 @@ use InvalidArgumentException;
  */
 class RouteRegistrar
 {
+    use Conditionable;
     use CreatesRegularExpressionRouteConstraints;
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -34,8 +34,7 @@ use InvalidArgumentException;
  */
 class RouteRegistrar
 {
-    use Conditionable;
-    use CreatesRegularExpressionRouteConstraints;
+    use Conditionable, CreatesRegularExpressionRouteConstraints;
 
     /**
      * The router instance.


### PR DESCRIPTION
I need to conditionally include some constraints based on features etc.. over different environments 

Currently I'm doing the below, but it becomes a bit tedious when it's used all over the place within multiple groups etc:


```php 
Route::prefix('/example')->name('example.')->group(function () {
    Route::get('/{item}', [App\Http\Controllers\ExampleController::class, 'item'])
        ->can('some permission')
        ->name('item')
        ->when(someLogic(), fn($route) $route->whereUuid('item'));  // Im having to add this to each route.. the true would be a feature check for example..

    Route::get('/{item}/js', [App\Http\Controllers\ExampleController::class, 'js'])
        ->can('some permission')
        ->name('item.js')
        ->middleware('some.middleware')
        ->when((someLogic(), fn($route) $route->whereUuid('item'));  // Im having to add this to each route..
    // This could be a big route group.... so have to do it for each.
});
```

By making this conditionable.. we can do something nicer on the prefix, or group etc.. for example: 
```php 
Route::prefix('/example')->name('example.')->group(function () {
    Route::get('/{item}', [App\Http\Controllers\ExampleController::class, 'item'])
        ->can('some permission')
        ->name('item');
    // Other routes here...
})->when((someLogic(), fn($route) $route->whereUuid('item')); // much easier..
```

An if also works, but then I have to duplicate groups- and logic so this feels nicer. The idea being this means we can conditionally include some constraints to the whole group. 

I don't believe this is a breaking change 🙇🏻 
