### PR TITLE
[12.x] Ensure database connection is always restored

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -354,9 +354,11 @@ class DatabaseManager implements ConnectionResolverInterface
 
         $this->setDefaultConnection($name);
 
-        return tap($callback(), function () use ($previousName) {
+        try {
+            return $callback();
+        } finally {
             $this->setDefaultConnection($previousName);
-        });
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -662,7 +662,11 @@ class Migrator
 
         $this->setConnection($name);
 
-        return tap($callback(), fn () => $this->setConnection($previousConnection));
+        try {
+            return $callback();
+        } finally {
+            $this->setConnection($previousConnection);
+        }
     }
 
     /**


### PR DESCRIPTION
⚠️ **Please avoid using `tap()` when working with mutable or global state that needs to be restored after an operation.**  
If the callback throws an exception, `tap()` will not invoke its final callback — leading to inconsistent or corrupted state.  
In such cases, always use a `try...finally` block instead.

Related to: https://github.com/laravel/framework/pull/56234, https://github.com/laravel/framework/pull/56189, https://github.com/laravel/framework/pull/56165
This PR ensures the previous database connection is always restored in `usingConnection()` methods, even if the callback throws an exception.