### PR TITLE
[12.x] add prompts based expectations to PendingCommand

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -354,6 +354,20 @@ class PendingCommand
     }
 
     /**
+     * Render the given prompt and add the output to the expectations.
+     *
+     * @return void
+     */
+    protected function expectOutputToContainPrompt(BasePrompt $prompt)
+    {
+        $prompt->setOutput($output = new BufferedOutput);
+
+        $prompt->display();
+
+        $this->expectsOutputToContain(trim($output->fetch()));
+    }
+
+    /**
      * Assert that the command has the given exit code.
      *
      * @param  int  $exitCode
@@ -623,20 +637,6 @@ class PendingCommand
         $this->test->expectedTables = [];
         $this->test->expectedQuestions = [];
         $this->test->expectedChoices = [];
-    }
-
-    /**
-     * Render specific prompt to new output to add to expectation.
-     *
-     * @return void
-     */
-    protected function expectOutputToContainPrompt(BasePrompt $prompt)
-    {
-        $prompt->setOutput($output = new BufferedOutput);
-
-        $prompt->display();
-
-        $this->expectsOutputToContain(trim($output->fetch()));
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -338,9 +338,11 @@ class PendingCommand
     /**
      * Specify a Prompts table that should be printed when the command runs.
      *
-     * @param  string[]|Collection<string>  $headers
-     * @param  string[]|Collection<string>|null  $rows
+     * @param  array<int, string|array<int, string>>|Collection<int, string|array<int, string>>  $headers
+     * @param  array<int, array<int, string>>|Collection<int, array<int, string>>|null  $rows
      * @return $this
+     *
+     * @phpstan-param ($rows is null ? list<list<string>>|Collection<int, list<string>> : list<string|list<string>>|Collection<int, string|list<string>>) $headers
      */
     public function expectsPromptsTable(array|Collection $headers, array|Collection|null $rows)
     {

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -8,9 +8,13 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
+use Laravel\Prompts\Note as PromptsNote;
+use Laravel\Prompts\Prompt as BasePrompt;
+use Laravel\Prompts\Table as PromptsTable;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -243,6 +247,106 @@ class PendingCommand
         foreach ($lines as $line) {
             $this->expectsOutput($line);
         }
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts info message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsInfo(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'info')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts warning message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsWarning(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'warning')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts error message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsError(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'error')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts alert message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsAlert(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'alert')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts intro message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsIntro(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'intro')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify that the given Prompts outro message should be contained in the command output.
+     *
+     * @return $this
+     */
+    public function expectsPromptsOutro(string $message)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsNote($message, 'outro')
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify a Prompts table that should be printed when the command runs.
+     *
+     * @param  string[]|Collection<string>  $headers
+     * @param  string[]|Collection<string>|null  $rows
+     * @return $this
+     */
+    public function expectsPromptsTable(array|Collection $headers, array|Collection|null $rows)
+    {
+        $this->expectOutputToContainPrompt(
+            new PromptsTable($headers, $rows)
+        );
 
         return $this;
     }
@@ -517,6 +621,20 @@ class PendingCommand
         $this->test->expectedTables = [];
         $this->test->expectedQuestions = [];
         $this->test->expectedChoices = [];
+    }
+
+    /**
+     * Render specific prompt to new output to add to expectation.
+     *
+     * @return void
+     */
+    protected function expectOutputToContainPrompt(BasePrompt $prompt)
+    {
+        $prompt->setOutput($output = new BufferedOutput);
+
+        $prompt->display();
+
+        $this->expectsOutputToContain(trim($output->fetch()));
     }
 
     /**


### PR DESCRIPTION
### Details
This PR augments the PendingCommand with methods targeting the direct output methods of Laravel Prompts

This follows up from the closed PR on Laravel Prompts - https://github.com/laravel/prompts/pull/196

### Whats New

this adds the following methods to the PendingCommand class
- expectsPromptsInfo
- expectsPromptsWarning
- expectsPromptsError
- expectsPromptsAlert
- expectsPromptsIntro
- expectsPromptsOutro
- expectsPromptsTable

along with a protected shared method that all of these use to reduce repetition of code.

### Example usage

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use function Laravel\Prompts\info;
use function Laravel\Prompts\alert;
use function Laravel\Prompts\error;
use function Laravel\Prompts\outro;
use function Laravel\Prompts\table;
use function Laravel\Prompts\warning;

class PromptTest extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @inheritdoc
     */
    protected $signature = 'app:prompt-test';

    /**
     * The console command description.
     *
     * @inheritdoc
     */
    protected $description = 'test prompt';

    /**
     * Execute the console command.
     */
    public function handle(): void
    {
        outro('Test Prompt - outro');

        info('Test Prompt - information');

        alert('Test Prompt - information ALERT!');

        table(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ]
        );

        warning('Test Prompt - warning');

        error('Test Prompt - error');

        outro('Test Prompt - outro');
    }
}

``` 

for PHPUnit:
```php
<?php

namespace Tests\Unit;

use Tests\TestCase;
use Laravel\Prompts\Testing\InteractsWithPrompts;

class MyCommandTest extends TestCase
{
    public function testCommand(): void
    {
        $this->artisan('app:prompt-test')
            ->expectsPromptIntro('Test Prompt - intro')
            ->expectsPromptTable(
                headers: ['ABC', 'DEF', 'GHI'],
                rows: [
                    ['123', '456', '789'],
                    ['234', '567', '890'],
                ]
            )
            ->assertExitCode(0);
    }
}
```

for Pest (`MyCommandTest.php`)
```php
<?php

use function Pest\Laravel\artisan;

test('command prompts', function () {
    artisan('app:prompt-test')
        ->expectsPromptOutro('Test Prompt - outro')
        ->expectsPromptInfo('Test Prompt - information')
        ->expectsPromptTable(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ]
        )
        ->assertExitCode(0);
});

``` 
