### PR TITLE
[12.x] Allow class-strings in Collection's `ensure` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -353,19 +353,20 @@ trait EnumeratesValues
      * @template TEnsureOfType
      *
      * @param  class-string<TEnsureOfType>|array<array-key, class-string<TEnsureOfType>>|'string'|'int'|'float'|'bool'|'array'|'null'  $type
+     * @param  bool  $allow_string
      * @return static<TKey, TEnsureOfType>
      *
      * @throws \UnexpectedValueException
      */
-    public function ensure($type)
+    public function ensure($type, $allow_string = false)
     {
         $allowedTypes = is_array($type) ? $type : [$type];
 
-        return $this->each(function ($item, $index) use ($allowedTypes) {
+        return $this->each(function ($item, $index) use ($allowedTypes, $allow_string) {
             $itemType = get_debug_type($item);
 
             foreach ($allowedTypes as $allowedType) {
-                if ($itemType === $allowedType || $item instanceof $allowedType) {
+                if ($itemType === $allowedType || is_a($item, $allowedType, $allow_string)) {
                     return true;
                 }
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5649,6 +5649,18 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testEnsureForObjectsClassStrings($collection)
+    {
+        $data = $collection::make([new stdClass, stdClass::class, stdClass::class]);
+        $data->ensure(stdClass::class, true);
+
+        $data = $collection::make([new stdClass, stdClass::class, stdClass::class]);
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype(stdClass::class), 3));
+        $data->ensure(stdClass::class);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testEnsureForInheritance($collection)
     {
         $data = $collection::make([new \Error, new \Error]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5651,10 +5651,10 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testEnsureForObjectsClassStrings($collection)
     {
-        $data = $collection::make([new stdClass, stdClass::class, stdClass::class]);
+        $data = $collection::make([new stdClass, new stdClass, new stdClass, stdClass::class]);
         $data->ensure(stdClass::class, true);
 
-        $data = $collection::make([new stdClass, stdClass::class, stdClass::class]);
+        $data = $collection::make([new stdClass, new stdClass, new stdClass, stdClass::class]);
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', class_basename(new stdClass()), gettype(stdClass::class), 3));
         $data->ensure(stdClass::class);


### PR DESCRIPTION
This PR adds the ability to optionally have class strings pass in the `ensure` method by changing `instanceof` with `is_a()` with optional `allow_string` useful when you want to verify a list of classes are of a specific type.

```php
use App\Models\User;
use App\Models\Post;
use Illuminate\Database\Eloquent\Model;

collect([User::class, Post::class])
    ->ensure(Model::class, true);
    
// as a side affect this can also work
collect([User::class, Post::class, new User])
    ->ensure(Model::class, true);
```

Unless devs explicitly add `allow_string: true` then this PR will have no change on existing projects

Performance difference between `is_a` and `instanceof` is minimal with `is_a` being about 1-1.5ms slower (on my M1) over 1M iterations

```php
use Illuminate\Support\Benchmark;

$object = new stdClass;

Benchmark::measure([
    'instanceof' => fn () => $object instanceof stdClass,
    'is_a with actual string' => fn () => is_a(stdClass::class, stdClass::class, true),
    'is_a' => fn () => is_a($object, stdClass::class),
    'is_a with allowed string' => fn () => is_a($object, stdClass::class, true),
], 1_000_000)
```