### PR TITLE
[12.x] Add support for APP_LOCAL_SITES_PATH and APP_REMOTE_SITES_PATH to map to editor file paths

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -70,7 +70,7 @@ return [
     | even a remote VPS, it will be necessary to specify your path mapping.
     |
     | Leaving one, or both of these, empty or null will not trigger the remote
-    | URL changes and Ignition will treat your editor links as local files.
+    | URL changes and application will treat your editor links as local files.
     |
     | "remote_sites_path" is an absolute base path for your sites or projects
     | in Homestead, Vagrant, Docker, or another remote development server.

--- a/config/app.php
+++ b/config/app.php
@@ -63,6 +63,33 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Remote Path Mapping
+    |--------------------------------------------------------------------------
+    |
+    | If you are using a remote dev server, like Laravel Homestead, Docker, or
+    | even a remote VPS, it will be necessary to specify your path mapping.
+    |
+    | Leaving one, or both of these, empty or null will not trigger the remote
+    | URL changes and Ignition will treat your editor links as local files.
+    |
+    | "remote_sites_path" is an absolute base path for your sites or projects
+    | in Homestead, Vagrant, Docker, or another remote development server.
+    |
+    | Example value: "/home/vagrant/Code"
+    |
+    | "local_sites_path" is an absolute base path for your sites or projects
+    | on your local computer where your IDE or code editor is running on.
+    |
+    | Example values: "/Users/<name>/Code", "C:\Users\<name>\Documents\Code"
+    |
+    */
+
+    'remote_sites_path' => env('APP_REMOTE_SITES_PATH', base_path()),
+
+    'local_sites_path' => env('APP_LOCAL_SITES_PATH', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -158,6 +158,8 @@ trait ResolvesDumpSource
             return;
         }
 
+        $file = $this->mapToLocalPath($file);
+
         $href = is_array($editor) && isset($editor['href'])
             ? $editor['href']
             : ($this->editorHrefs[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
@@ -171,6 +173,31 @@ trait ResolvesDumpSource
             [$file, is_null($line) ? 1 : $line],
             $href,
         );
+    }
+
+    /**
+     * Map a remote path to a local path.
+     *
+     * This method is used to convert paths from a remote server to the local environment.
+     * It uses configuration values for the remote and local site paths.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function mapToLocalPath($path)
+    {
+        $remoteRoot = config('app.remote_sites_path');
+        $hostRoot = config('app.local_sites_path');
+
+        if (! $remoteRoot || ! $hostRoot || ! $path) {
+            return $path; // Return original path if config is not set
+        }
+
+        if (str_starts_with($path, $remoteRoot)) {
+            return $hostRoot.substr($path, strlen($remoteRoot));
+        }
+
+        return $path;
     }
 
     /**

--- a/tests/Foundation/Concerns/ResolvesDumpSourceTest.php
+++ b/tests/Foundation/Concerns/ResolvesDumpSourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Configuration;
+
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Concerns\ResolvesDumpSource;
+use PHPUnit\Framework\TestCase;
+
+class ResolvesDumpSourceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $container = Container::setInstance(new Container);
+
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        // Set config values to simulate Docker path mapping
+        $app['config']->set('app.local_sites_path', '/path/to/my-app');
+        $app['config']->set('app.remote_sites_path', '/var/www/html');
+    }
+
+    public function testItMapsRemotePathToLocalPath()
+    {
+        $mock = new class
+        {
+            use ResolvesDumpSource;
+
+            public function testMap($path)
+            {
+                return $this->mapToLocalPath($path);
+            }
+        };
+
+        $originalPath = '/var/www/html/app/Http/Controllers/HomeController.php';
+        $expectedPath = '/path/to/my-app/app/Http/Controllers/HomeController.php';
+
+        $mapped = $mock->testMap($originalPath);
+        $this->assertEquals($expectedPath, $mapped);
+    }
+
+    public function testItReturnsOriginalPathWhenNoConfigIsSet()
+    {
+        config()->set('app.local_sites_path', null);
+        config()->set('app.remote_sites_path', null);
+
+        $mock = new class
+        {
+            use ResolvesDumpSource;
+
+            public function testMap($path)
+            {
+                return $this->mapToLocalPath($path);
+            }
+        };
+
+        $path = '/var/www/html/app/Console/Kernel.php';
+
+        $this->assertEquals($path, $mock->testMap($path));
+    }
+
+    public function testItReturnsOriginalPathWhenPathDoesNotMatchRemote()
+    {
+        $mock = new class
+        {
+            use ResolvesDumpSource;
+
+            public function testMap($path)
+            {
+                return $this->mapToLocalPath($path);
+            }
+        };
+
+        $nonMatchingPath = '/srv/other/path/SomeFile.php';
+
+        $this->assertEquals($nonMatchingPath, $mock->testMap($nonMatchingPath));
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'app' => [
+                'remote_sites_path' => '/var/www/html',
+                'local_sites_path' => '/path/to/my-app',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/56185
### Summary

This PR introduces support for two environment variables:

- `APP_LOCAL_SITES_PATH`
- `APP_REMOTE_SITES_PATH`

These allow mapping container paths to host paths in editor links shown on Laravel’s exception pages, similar to the `IGNITION_LOCAL_SITES_PATH` and `IGNITION_REMOTE_SITES_PATH` previously available via Ignition.

### Use Case

When Laravel is running inside a Docker container, file paths shown in error pages point to the container’s file system (`/var/www/html/...`), which does not exist on the host machine. This makes editor links like `vscode://file/...` fail to open.

With this feature, developers can map paths:

```env
APP_LOCAL_SITES_PATH=/Users/dev/code/myapp
APP_REMOTE_SITES_PATH=/var/www/html