### PR TITLE
[12.x] Improve typehints for `AbstractCursorPaginator@through()`

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -403,8 +403,12 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Transform each item in the slice of items using a callback.
      *
-     * @param  callable  $callback
-     * @return $this
+     * @template TThroughValue
+     *
+     * @param  callable(TValue, TKey): TThroughValue  $callback
+     * @return $this<TKey, TThroughValue>
+     *
+     * @phpstan-this-out static<TKey, TThroughValue>
      */
     public function through(callable $callback)
     {

--- a/types/Pagination/Paginator.php
+++ b/types/Pagination/Paginator.php
@@ -49,3 +49,16 @@ $cursorPaginator->each(function ($post) {
 foreach ($cursorPaginator as $post) {
     assertType('Post', $post);
 }
+
+$throughPaginator = clone $cursorPaginator;
+$throughPaginator->through(function ($post, $key): array {
+    assertType('int', $key);
+    assertType('Post', $post);
+
+    return [
+        'id' => $key,
+        'post' => $post,
+    ];
+});
+
+assertType('Illuminate\Pagination\CursorPaginator<int, array{id: int, post: Post}>', $throughPaginator);


### PR DESCRIPTION
While I still don't have a good solution to the problems of the `through` method (https://github.com/laravel/framework/pull/55524), this improves static analysis for the method.