### PR TITLE
feat: allow to rename xsrf-token

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -201,7 +201,7 @@ class VerifyCsrfToken
     protected function newCookie($request, $config)
     {
         return new Cookie(
-            'XSRF-TOKEN',
+            $config['xsrf-token'] ?? 'XSRF-TOKEN',
             $request->session()->token(),
             $this->availableAt(60 * $config['lifetime']),
             $config['path'],
@@ -234,7 +234,9 @@ class VerifyCsrfToken
      */
     public static function serialized()
     {
-        return EncryptCookies::serialized('XSRF-TOKEN');
+        $config = config('session');
+
+        return EncryptCookies::serialized($config['xsrf-token'] ?? 'XSRF-TOKEN');
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello 👋,

This is a following PR to the issue https://github.com/laravel/framework/issues/56238.

It introduces a new configuration option `xsrf-token` in the `session.php` configuration file, allowing developers to customize the name of the XSRF token cookie. I'm unsure about the name of this field.

Also, I had to read the config from the static method `serialized` in the `VerifyCsrfToken` middleware. I'm unsure if this is the best way to do it, but it works.
