### PR TITLE
[13.x] Add specific encryption exceptions for invalid payloads and unsupported ciphers

### DIFF
--- a/src/Illuminate/Contracts/Encryption/InvalidPayloadException.php
+++ b/src/Illuminate/Contracts/Encryption/InvalidPayloadException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Encryption;
+
+use RuntimeException;
+
+class InvalidPayloadException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Contracts/Encryption/UnsupportedCipherException.php
+++ b/src/Illuminate/Contracts/Encryption/UnsupportedCipherException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Encryption;
+
+use RuntimeException;
+
+class UnsupportedCipherException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -5,7 +5,9 @@ namespace Illuminate\Encryption;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\Encryption\EncryptException;
+use Illuminate\Contracts\Encryption\InvalidPayloadException;
 use Illuminate\Contracts\Encryption\StringEncrypter;
+use Illuminate\Contracts\Encryption\UnsupportedCipherException;
 use RuntimeException;
 
 class Encrypter implements EncrypterContract, StringEncrypter
@@ -58,7 +60,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         if (! static::supported($key, $cipher)) {
             $ciphers = implode(', ', array_keys(self::$supportedCiphers));
 
-            throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
+            throw new UnsupportedCipherException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
         }
 
         $this->key = $key;
@@ -232,7 +234,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     protected function getJsonPayload($payload)
     {
         if (! is_string($payload)) {
-            throw new DecryptException('The payload is invalid.');
+            throw new InvalidPayloadException('The payload is invalid.');
         }
 
         $payload = json_decode(base64_decode($payload), true);
@@ -241,7 +243,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // assume it is invalid and bail out of the routine since we will not be able
         // to decrypt the given value. We'll also check the MAC for this encryption.
         if (! $this->validPayload($payload)) {
-            throw new DecryptException('The payload is invalid.');
+            throw new InvalidPayloadException('The payload is invalid.');
         }
 
         return $payload;
@@ -366,7 +368,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             if (! static::supported($key, $this->cipher)) {
                 $ciphers = implode(', ', array_keys(self::$supportedCiphers));
 
-                throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
+                throw new UnsupportedCipherException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
             }
         }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\InvalidPayloadException;
 use Illuminate\Contracts\Encryption\StringEncrypter;
 use Illuminate\Contracts\Encryption\UnsupportedCipherException;
-use RuntimeException;
 
 class Encrypter implements EncrypterContract, StringEncrypter
 {

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Encryption;
 
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\InvalidPayloadException;
+use Illuminate\Contracts\Encryption\UnsupportedCipherException;
 use Illuminate\Encryption\Encrypter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -156,7 +158,7 @@ class EncrypterTest extends TestCase
 
     public function testDoNoAllowLongerKey()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(UnsupportedCipherException::class);
         $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('z', 32));
@@ -164,7 +166,7 @@ class EncrypterTest extends TestCase
 
     public function testWithBadKeyLength()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(UnsupportedCipherException::class);
         $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('a', 5));
@@ -172,7 +174,7 @@ class EncrypterTest extends TestCase
 
     public function testWithBadKeyLengthAlternativeCipher()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(UnsupportedCipherException::class);
         $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('a', 16), 'AES-256-GCM');
@@ -180,7 +182,7 @@ class EncrypterTest extends TestCase
 
     public function testWithUnsupportedCipher()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(UnsupportedCipherException::class);
         $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
@@ -188,7 +190,7 @@ class EncrypterTest extends TestCase
 
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
-        $this->expectException(DecryptException::class);
+        $this->expectException(InvalidPayloadException::class);
         $this->expectExceptionMessage('The payload is invalid.');
 
         $e = new Encrypter(str_repeat('a', 16));
@@ -221,7 +223,7 @@ class EncrypterTest extends TestCase
 
     public function testExceptionThrownWhenIvIsTooLong()
     {
-        $this->expectException(DecryptException::class);
+        $this->expectException(InvalidPayloadException::class);
         $this->expectExceptionMessage('The payload is invalid.');
 
         $e = new Encrypter(str_repeat('a', 16));
@@ -263,7 +265,7 @@ class EncrypterTest extends TestCase
     #[DataProvider('provideTamperedData')]
     public function testTamperedPayloadWillGetRejected($payload)
     {
-        $this->expectException(DecryptException::class);
+        $this->expectException(InvalidPayloadException::class);
         $this->expectExceptionMessage('The payload is invalid.');
 
         $enc = new Encrypter(str_repeat('x', 16));

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Encryption\UnsupportedCipherException;
 use Illuminate\Encryption\Encrypter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 class EncrypterTest extends TestCase
 {

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\InvalidPayloadException;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -50,7 +51,7 @@ class JobEncryptionTest extends DatabaseTestCase
     {
         Bus::dispatch(new JobEncryptionTestNonEncryptedJob);
 
-        $this->expectException(DecryptException::class);
+        $this->expectException(InvalidPayloadException::class);
         $this->expectExceptionMessage('The payload is invalid');
 
         $this->assertInstanceOf(JobEncryptionTestNonEncryptedJob::class,

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\InvalidPayloadException;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;


### PR DESCRIPTION
This PR introduces two specific exception classes for encryption errors:

- `InvalidPayloadException` – thrown when the encrypted payload is malformed or invalid.
- `UnsupportedCipherException` – thrown when the provided cipher or key length is not supported.

Previously, it was difficult to determine the type of encryption error except by inspecting the error message.  
With these exceptions, developers can now easily identify and handle specific encryption error types programmatically.
