### PR TITLE
Use `Date` facade instead of `time()` for `password_confirmed_at` check

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth\Middleware;
 use Closure;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Date;
 
 class RequirePassword
 {
@@ -92,7 +93,7 @@ class RequirePassword
      */
     protected function shouldConfirmPassword($request, $passwordTimeoutSeconds = null)
     {
-        $confirmedAt = time() - $request->session()->get('auth.password_confirmed_at', 0);
+        $confirmedAt = Date::now()->unix() - $request->session()->get('auth.password_confirmed_at', 0);
 
         return $confirmedAt > ($passwordTimeoutSeconds ?? $this->passwordTimeout);
     }


### PR DESCRIPTION
In `Illuminate\Session\Store`, the `passwordConfirmed()` method [uses `Date::now()->unix()` to populate `auth.password_confirmed_at`](https://github.com/laravel/framework/blob/b108609adfd596a53982dc5c3951a265e2be8a44/src/Illuminate/Session/Store.php#L788). But in `Illuminate\Auth\Middleware\RequirePassword`, the PHP `time()` function is being used instead.

This can cause issues in testing, where `travelTo()` may have been used to mock the current time.

This PR changes `RequirePassword` to also use the `Date` facade to look up the current timestamp too.