### PR TITLE
[12.x] Add unified enum support across framework docs

### DIFF
--- a/src/Illuminate/Broadcasting/InteractsWithBroadcasting.php
+++ b/src/Illuminate/Broadcasting/InteractsWithBroadcasting.php
@@ -18,7 +18,7 @@ trait InteractsWithBroadcasting
     /**
      * Broadcast the event using a specific broadcaster.
      *
-     * @param  array|string|null|\UnitEnum  $connection
+     * @param  \UnitEnum|array|string|null  $connection
      * @return $this
      */
     public function broadcastVia($connection = null)

--- a/src/Illuminate/Broadcasting/InteractsWithBroadcasting.php
+++ b/src/Illuminate/Broadcasting/InteractsWithBroadcasting.php
@@ -4,6 +4,8 @@ namespace Illuminate\Broadcasting;
 
 use Illuminate\Support\Arr;
 
+use function Illuminate\Support\enum_value;
+
 trait InteractsWithBroadcasting
 {
     /**
@@ -16,11 +18,13 @@ trait InteractsWithBroadcasting
     /**
      * Broadcast the event using a specific broadcaster.
      *
-     * @param  array|string|null  $connection
+     * @param  array|string|null|\UnitEnum  $connection
      * @return $this
      */
     public function broadcastVia($connection = null)
     {
+        $connection = enum_value($connection);
+
         $this->broadcastConnection = is_null($connection)
             ? [null]
             : Arr::wrap($connection);

--- a/src/Illuminate/Broadcasting/PendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/PendingBroadcast.php
@@ -37,7 +37,7 @@ class PendingBroadcast
     /**
      * Broadcast the event using a specific broadcaster.
      *
-     * @param  string|null|\UnitEnum  $connection
+     * @param  \UnitEnum|string|null $connection
      * @return $this
      */
     public function via($connection = null)

--- a/src/Illuminate/Broadcasting/PendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/PendingBroadcast.php
@@ -37,7 +37,7 @@ class PendingBroadcast
     /**
      * Broadcast the event using a specific broadcaster.
      *
-     * @param  \UnitEnum|string|null $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return $this
      */
     public function via($connection = null)

--- a/src/Illuminate/Broadcasting/PendingBroadcast.php
+++ b/src/Illuminate/Broadcasting/PendingBroadcast.php
@@ -4,6 +4,8 @@ namespace Illuminate\Broadcasting;
 
 use Illuminate\Contracts\Events\Dispatcher;
 
+use function Illuminate\Support\enum_value;
+
 class PendingBroadcast
 {
     /**
@@ -35,13 +37,13 @@ class PendingBroadcast
     /**
      * Broadcast the event using a specific broadcaster.
      *
-     * @param  string|null  $connection
+     * @param  string|null|\UnitEnum  $connection
      * @return $this
      */
     public function via($connection = null)
     {
         if (method_exists($this->event, 'broadcastVia')) {
-            $this->event->broadcastVia($connection);
+            $this->event->broadcastVia(enum_value($connection));
         }
 
         return $this;

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -5,6 +5,8 @@ namespace Illuminate\Console\Scheduling;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 trait ManagesFrequencies
 {
     /**
@@ -639,12 +641,12 @@ trait ManagesFrequencies
     /**
      * Set the timezone the date should be evaluated on.
      *
-     * @param  \DateTimeZone|string  $timezone
+     * @param  \UnitEnum|\DateTimeZone|string  $timezone
      * @return $this
      */
     public function timezone($timezone)
     {
-        $this->timezone = $timezone;
+        $this->timezone = enum_value($timezone);
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -172,8 +172,8 @@ class Schedule
      * Add a new job callback event to the schedule.
      *
      * @param  object|string  $job
-     * @param  string|null|\UnitEnum  $queue
-     * @param  string|null|\UnitEnum  $connection
+     * @param  \UnitEnum|string|null  $queue
+     * @param  \UnitEnum|string|null  $connection
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
     public function job($job, $queue = null, $connection = null)

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -19,6 +19,8 @@ use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Console\Scheduling\PendingEventAttributes
  */
@@ -170,13 +172,16 @@ class Schedule
      * Add a new job callback event to the schedule.
      *
      * @param  object|string  $job
-     * @param  string|null  $queue
-     * @param  string|null  $connection
+     * @param  string|null|\UnitEnum  $queue
+     * @param  string|null|\UnitEnum  $connection
      * @return \Illuminate\Console\Scheduling\CallbackEvent
      */
     public function job($job, $queue = null, $connection = null)
     {
         $jobName = $job;
+
+        $queue = enum_value($queue);
+        $connection = enum_value($connection);
 
         if (! is_string($job)) {
             $jobName = method_exists($job, 'displayName')

--- a/src/Illuminate/Contracts/Filesystem/Factory.php
+++ b/src/Illuminate/Contracts/Filesystem/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a filesystem implementation.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function disk($name = null);

--- a/src/Illuminate/Contracts/Filesystem/Factory.php
+++ b/src/Illuminate/Contracts/Filesystem/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a filesystem implementation.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function disk($name = null);

--- a/src/Illuminate/Contracts/Redis/Factory.php
+++ b/src/Illuminate/Contracts/Redis/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a Redis connection by name.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection($name = null);

--- a/src/Illuminate/Contracts/Redis/Factory.php
+++ b/src/Illuminate/Contracts/Redis/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a Redis connection by name.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection($name = null);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -25,6 +25,8 @@ use PDO;
 use PDOStatement;
 use RuntimeException;
 
+use function Illuminate\Support\enum_value;
+
 class Connection implements ConnectionInterface
 {
     use DetectsConcurrencyErrors,
@@ -307,13 +309,13 @@ class Connection implements ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|\UnitEnum  $table
      * @param  string|null  $as
      * @return \Illuminate\Database\Query\Builder
      */
     public function table($table, $as = null)
     {
-        return $this->query()->from($table, $as);
+        return $this->query()->from(enum_value($table), $as);
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -309,7 +309,7 @@ class Connection implements ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|\UnitEnum  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|\UnitEnum|string  $table
      * @param  string|null  $as
      * @return \Illuminate\Database\Query\Builder
      */

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -9,7 +9,7 @@ interface ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string|\UnitEnum  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\UnitEnum|string  $table
      * @param  string|null  $as
      * @return \Illuminate\Database\Query\Builder
      */

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -9,7 +9,7 @@ interface ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string|\UnitEnum  $table
      * @param  string|null  $as
      * @return \Illuminate\Database\Query\Builder
      */

--- a/src/Illuminate/Database/ConnectionResolverInterface.php
+++ b/src/Illuminate/Database/ConnectionResolverInterface.php
@@ -7,7 +7,7 @@ interface ConnectionResolverInterface
     /**
      * Get a database connection instance.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Database\ConnectionInterface
      */
     public function connection($name = null);

--- a/src/Illuminate/Database/ConnectionResolverInterface.php
+++ b/src/Illuminate/Database/ConnectionResolverInterface.php
@@ -7,7 +7,7 @@ interface ConnectionResolverInterface
     /**
      * Get a database connection instance.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Database\ConnectionInterface
      */
     public function connection($name = null);

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -87,7 +87,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Get a database connection instance.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Database\Connection
      */
     public function connection($name = null)

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -13,6 +13,8 @@ use InvalidArgumentException;
 use PDO;
 use RuntimeException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Database\Connection
  */
@@ -85,12 +87,12 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Get a database connection instance.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Database\Connection
      */
     public function connection($name = null)
     {
-        $name = $name ?: $this->getDefaultConnection();
+        $name = enum_value($name) ?: $this->getDefaultConnection();
 
         [$database, $type] = $this->parseConnectionName($name);
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -21,6 +21,8 @@ use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Contracts\Filesystem\Filesystem
  * @mixin \Illuminate\Filesystem\FilesystemAdapter
@@ -72,12 +74,12 @@ class FilesystemManager implements FactoryContract
     /**
      * Get a filesystem instance.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function disk($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = enum_value($name) ?: $this->getDefaultDriver();
 
         return $this->disks[$name] = $this->get($name);
     }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -74,7 +74,7 @@ class FilesystemManager implements FactoryContract
     /**
      * Get a filesystem instance.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function disk($name = null)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -624,7 +624,7 @@ if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.
      *
-     * @param  \DateTimeZone|string|null|\UnitEnum  $tz
+     * @param  \DateTimeZone|\UnitEnum|string|null  $tz
      * @return \Illuminate\Support\Carbon
      */
     function now($tz = null)
@@ -970,7 +970,7 @@ if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.
      *
-     * @param  \DateTimeZone|string|null|\UnitEnum  $tz
+     * @param  \DateTimeZone|\UnitEnum|string|null  $tz
      * @return \Illuminate\Support\Carbon
      */
     function today($tz = null)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -27,6 +27,8 @@ use Illuminate\Support\Uri;
 use League\Uri\Contracts\UriInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+use function Illuminate\Support\enum_value;
+
 if (! function_exists('abort')) {
     /**
      * Throw an HttpException with the given data.
@@ -622,12 +624,12 @@ if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.
      *
-     * @param  \DateTimeZone|string|null  $tz
+     * @param  \DateTimeZone|string|null|\UnitEnum  $tz
      * @return \Illuminate\Support\Carbon
      */
     function now($tz = null)
     {
-        return Date::now($tz);
+        return Date::now(enum_value($tz));
     }
 }
 
@@ -968,12 +970,12 @@ if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.
      *
-     * @param  \DateTimeZone|string|null  $tz
+     * @param  \DateTimeZone|string|null|\UnitEnum  $tz
      * @return \Illuminate\Support\Carbon
      */
     function today($tz = null)
     {
-        return Date::today($tz);
+        return Date::today(enum_value($tz));
     }
 }
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -77,7 +77,7 @@ class RedisManager implements Factory
     /**
      * Get a Redis connection by name.
      *
-     * @param  string|null|\UnitEnum  $name
+     * @param  \UnitEnum|string|null  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection($name = null)

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @mixin \Illuminate\Redis\Connections\Connection
  */
@@ -75,12 +77,12 @@ class RedisManager implements Factory
     /**
      * Get a Redis connection by name.
      *
-     * @param  string|null  $name
+     * @param  string|null|\UnitEnum  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection($name = null)
     {
-        $name = $name ?: 'default';
+        $name = enum_value($name) ?: 'default';
 
         if (isset($this->connections[$name])) {
             return $this->connections[$name];

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 use Illuminate\Database\Console\WipeCommand;
 
 /**
- * @method static \Illuminate\Database\Connection connection(string|null|\UnitEnum $name = null)
+ * @method static \Illuminate\Database\Connection connection(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Database\ConnectionInterface build(array $config)
  * @method static string calculateDynamicConnectionName(array $config)
  * @method static \Illuminate\Database\ConnectionInterface connectUsing(string $name, array $config, bool $force = false)
@@ -35,7 +35,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static void useDefaultSchemaGrammar()
  * @method static void useDefaultPostProcessor()
  * @method static \Illuminate\Database\Schema\Builder getSchemaBuilder()
- * @method static \Illuminate\Database\Query\Builder table(\Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|\UnitEnum $table, string|null $as = null)
+ * @method static \Illuminate\Database\Query\Builder table(\Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|\UnitEnum|string $table, string|null $as = null)
  * @method static \Illuminate\Database\Query\Builder query()
  * @method static mixed selectOne(string $query, array $bindings = [], bool $useReadPdo = true)
  * @method static mixed scalar(string $query, array $bindings = [], bool $useReadPdo = true)

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Console\Migrations\RollbackCommand;
 use Illuminate\Database\Console\WipeCommand;
 
 /**
- * @method static \Illuminate\Database\Connection connection(string|null $name = null)
+ * @method static \Illuminate\Database\Connection connection(string|null|\UnitEnum $name = null)
  * @method static \Illuminate\Database\ConnectionInterface build(array $config)
  * @method static string calculateDynamicConnectionName(array $config)
  * @method static \Illuminate\Database\ConnectionInterface connectUsing(string $name, array $config, bool $force = false)
@@ -35,7 +35,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static void useDefaultSchemaGrammar()
  * @method static void useDefaultPostProcessor()
  * @method static \Illuminate\Database\Schema\Builder getSchemaBuilder()
- * @method static \Illuminate\Database\Query\Builder table(\Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string $table, string|null $as = null)
+ * @method static \Illuminate\Database\Query\Builder table(\Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|\UnitEnum $table, string|null $as = null)
  * @method static \Illuminate\Database\Query\Builder query()
  * @method static mixed selectOne(string $query, array $bindings = [], bool $useReadPdo = true)
  * @method static mixed scalar(string $query, array $bindings = [], bool $useReadPdo = true)

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Redis\Connections\Connection connection(string|null|\UnitEnum $name = null)
+ * @method static \Illuminate\Redis\Connections\Connection connection(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Redis\Connections\Connection resolve(string|null $name = null)
  * @method static array connections()
  * @method static void enableEvents()

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Redis\Connections\Connection connection(string|null $name = null)
+ * @method static \Illuminate\Redis\Connections\Connection connection(string|null|\UnitEnum $name = null)
  * @method static \Illuminate\Redis\Connections\Connection resolve(string|null $name = null)
  * @method static array connections()
  * @method static void enableEvents()

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -169,7 +169,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool boolean(string|null $key = null, bool $default = false)
  * @method static int integer(string $key, int $default = 0)
  * @method static float float(string $key, float $default = 0)
- * @method static \Illuminate\Support\Carbon|null date(string $key, string|null $format = null, string|null $tz = null)
+ * @method static \Illuminate\Support\Carbon|null date(string $key, string|null $format = null, \UnitEnum|string|null $tz = null)
  * @method static \BackedEnum|null enum(string $key, string $enumClass, \BackedEnum|null $default = null)
  * @method static \BackedEnum[] enums(string $key, string $enumClass)
  * @method static array array(array|string|null $key = null)

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
 /**
  * @method static \Illuminate\Console\Scheduling\CallbackEvent call(string|callable $callback, array $parameters = [])
  * @method static \Illuminate\Console\Scheduling\Event command(string $command, array $parameters = [])
- * @method static \Illuminate\Console\Scheduling\CallbackEvent job(object|string $job, string|null $queue = null, string|null $connection = null)
+ * @method static \Illuminate\Console\Scheduling\CallbackEvent job(object|string $job, string|null|\UnitEnum $queue = null, string|null|\UnitEnum $connection = null)
  * @method static \Illuminate\Console\Scheduling\Event exec(string $command, array $parameters = [])
  * @method static void group(\Closure $events)
  * @method static string compileArrayInput(string|int $key, array $value)

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -81,7 +81,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes yearly()
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes yearlyOn(int $month = 1, int|string $dayOfMonth = 1, string $time = '0:0')
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes days(array|mixed $days)
- * @method static \Illuminate\Console\Scheduling\PendingEventAttributes timezone(\DateTimeZone|string $timezone)
+ * @method static \Illuminate\Console\Scheduling\PendingEventAttributes timezone(\UnitEnum|\DateTimeZone|string $timezone)
  *
  * @see \Illuminate\Console\Scheduling\Schedule
  */

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
 /**
  * @method static \Illuminate\Console\Scheduling\CallbackEvent call(string|callable $callback, array $parameters = [])
  * @method static \Illuminate\Console\Scheduling\Event command(string $command, array $parameters = [])
- * @method static \Illuminate\Console\Scheduling\CallbackEvent job(object|string $job, string|null|\UnitEnum $queue = null, string|null|\UnitEnum $connection = null)
+ * @method static \Illuminate\Console\Scheduling\CallbackEvent job(object|string $job, \UnitEnum|string|null $queue = null, \UnitEnum|string|null $connection = null)
  * @method static \Illuminate\Console\Scheduling\Event exec(string $command, array $parameters = [])
  * @method static void group(\Closure $events)
  * @method static string compileArrayInput(string|int $key, array $value)

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 /**
  * @method static \Illuminate\Contracts\Filesystem\Filesystem drive(string|null $name = null)
- * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(string|null $name = null)
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(string|null|\UnitEnum $name = null)
  * @method static \Illuminate\Contracts\Filesystem\Cloud cloud()
  * @method static \Illuminate\Contracts\Filesystem\Filesystem build(string|array $config)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem createLocalDriver(array $config, string $name = 'local')

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 /**
  * @method static \Illuminate\Contracts\Filesystem\Filesystem drive(string|null $name = null)
- * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(string|null|\UnitEnum $name = null)
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(\UnitEnum|string|null $name = null)
  * @method static \Illuminate\Contracts\Filesystem\Cloud cloud()
  * @method static \Illuminate\Contracts\Filesystem\Filesystem build(string|array $config)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem createLocalDriver(array $config, string $name = 'local')

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use stdClass;
 
+use function Illuminate\Support\enum_value;
+
 trait InteractsWithData
 {
     /**
@@ -287,13 +289,15 @@ trait InteractsWithData
      *
      * @param  string  $key
      * @param  string|null  $format
-     * @param  string|null  $tz
+     * @param  \UnitEnum|string|null  $tz
      * @return \Illuminate\Support\Carbon|null
      *
      * @throws \Carbon\Exceptions\InvalidFormatException
      */
     public function date($key, $format = null, $tz = null)
     {
+        $tz = enum_value($tz);
+
         if ($this->isNotFilled($key)) {
             return null;
         }


### PR DESCRIPTION
As per feedback from @taylorotwell on a previous pull request (https://github.com/laravel/framework/pull/56101), this PR aims to provide a unified and consistent approach to supporting PHP Enums **across all documented areas** in the Laravel framework **where it makes sense to use them**.

### Summary of Changes

- **Requests:**  
  - `date()`: https://laravel.com/docs/12.x/requests#retrieving-date-input-values  

- **Broadcasting:**  
  - `via()` and `broadcastVia()`: https://laravel.com/docs/12.x/broadcasting#customizing-the-connection  

- **Scheduling:**  
  - `job()`: https://laravel.com/docs/12.x/scheduling#scheduling-queued-jobs  
  - `timezone()`: https://laravel.com/docs/12.x/scheduling#schedule-frequency-options

- **Database:**  
  - `connection()`: https://laravel.com/docs/12.x/database#using-multiple-database-connections  
  - `table()`: https://laravel.com/docs/12.x/queries#retrieving-all-rows-from-a-table 

- **Filesystem:**  
  - `disk()`: https://laravel.com/docs/12.x/filesystem#the-local-driver  

- **Helpers:**  
  - `now()`: https://laravel.com/docs/12.x/helpers#method-now  
  - `today()`: https://laravel.com/docs/12.x/helpers#method-today

- **Redis:**  
  - `connection()`: https://laravel.com/docs/12.x/redis#using-multiple-redis-connections
