### PR TITLE
[12.x] fix: Collection::transform() and Paginator::through() return types

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1732,7 +1732,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TMapValue
      *
      * @param  callable(TValue, TKey): TMapValue  $callback
-     * @return $this<TKey, TMapValue>
+     * @return $this
+     *
+     * @phpstan-this-out static<TKey, TMapValue>
      */
     public function transform(callable $callback)
     {

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -406,7 +406,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      * @template TThroughValue
      *
      * @param  callable(TValue, TKey): TThroughValue  $callback
-     * @return $this<TKey, TThroughValue>
+     * @return $this
      *
      * @phpstan-this-out static<TKey, TThroughValue>
      */

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -356,7 +356,9 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
      * @template TMapValue
      *
      * @param  callable(TValue, TKey): TMapValue  $callback
-     * @return $this<TKey, TMapValue>
+     * @return $this
+     *
+     * @phpstan-this-out static<TKey, TMapValue>
      */
     public function through(callable $callback)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1049,18 +1049,18 @@ assertType(
 assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1, 1, [new User]));
 
-assertType('mixed', $collection->transform(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
-
-    return new User;
-}));
-
-assertType('mixed', $collection->transform(function ($user, $int): int {
+assertType('Illuminate\Support\Collection<int, int>', $collection->transform(function ($user, $int): int {
     assertType('User', $user);
     assertType('int', $int);
 
     return $int * 2;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->transform(function ($value, $key) {
+    assertType('int', $value);
+    assertType('int', $key);
+
+    return new User;
 }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->add(new User));


### PR DESCRIPTION
Hello!

This fixes the syntax errors introduced by https://github.com/laravel/framework/pull/56105 in the `Collection::transform()` and `Paginator::through()` return types.

Because the types are smarter, I had to move a test around so the rest of the tests would continue to have the expected types.

Thanks!

CC: @glamorous 