### PR TITLE
[12.x] Improve docblocks for $columns parameter in `BuildsQueries` methods

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -358,7 +358,7 @@ trait BuildsQueries
     /**
      * Execute the query and get the first result.
      *
-     * @param  array|string  $columns
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @return TValue|null
      */
     public function first($columns = ['*'])
@@ -369,7 +369,7 @@ trait BuildsQueries
     /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array|string  $columns
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  string|null  $message
      * @return TValue
      *
@@ -387,7 +387,7 @@ trait BuildsQueries
     /**
      * Execute the query and get the first result if it's the sole matching record.
      *
-     * @param  array|string  $columns
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @return TValue
      *
      * @throws \Illuminate\Database\RecordsNotFoundException
@@ -414,7 +414,7 @@ trait BuildsQueries
      * Paginate the given query using a cursor paginator.
      *
      * @param  int  $perPage
-     * @param  array|string  $columns
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  string  $cursorName
      * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
      * @return \Illuminate\Contracts\Pagination\CursorPaginator


### PR DESCRIPTION
This PR adds clearer type annotations for the $columns parameter in the `BuildsQueries` trait to improve consistency and IDE support.