### PR TITLE
[12.x] We can now run HTTP tests who were originated by AJAX

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -354,6 +354,16 @@ trait MakesHttpRequests
     }
 
     /**
+     * Set the X-Requested-With header to "XMLHttpRequest".
+     *
+     * @return $this
+     */
+    public function withAjax()
+    {
+        return $this->withHeader('X-Requested-With', 'XMLHttpRequest');
+    }
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  \Illuminate\Support\Uri|string  $uri

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -239,6 +239,12 @@ class MakesHttpRequestsTest extends TestCase
             ->assertHeader('Precognition', 'true')
             ->assertHeader('Precognition-Success', 'true');
     }
+
+    public function testWithAjax()
+    {
+        $this->withAjax();
+        $this->assertSame('XMLHttpRequest', $this->defaultHeaders['X-Requested-With']);
+    }
 }
 
 class MyMiddleware


### PR DESCRIPTION
**Description**

Add new method `->withAjax()` for HTTP testing to let us simulate that a call was originated by AJAX.