### PR TITLE
[12.x] Add support for triggering update events for a arrayable of IDs

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1097,7 +1097,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $ids = $ids->all();
         }
 
-        $ids = is_array($ids) ? $ids : func_get_args();
+        if (! is_array($ids)) {
+            $ids = [$ids];
+        }
 
         if (count($ids) === 0) {
             return 0;

--- a/tests/Integration/Database/EloquentPatchTest.php
+++ b/tests/Integration/Database/EloquentPatchTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\Fixtures\Post;
+use Illuminate\Tests\Integration\Database\Fixtures\PostStringyKey;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentPatchTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function testPatch()
+    {
+        Schema::create('my_posts', function (Blueprint $table) {
+            $table->increments('my_id');
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+
+        Model::unguard();
+
+        Post::query()->create(['title' => 'title1']);
+        Post::query()->create(['title' => 'title2']);
+
+        Post::updated(fn ($model) => $_SERVER['update']['updated'][] = $model->id);
+        Post::updating(fn ($model) => $_SERVER['update']['updating'][] = $model->id);
+
+        Post::patch([1, 2], ['title' => 'title3']);
+
+        $this->assertEquals([1, 2], $_SERVER['update']['updating']);
+        $this->assertEquals([1, 2], $_SERVER['update']['updated']);
+        $this->assertEquals(Post::query()->pluck('title')->all(), ['title3', 'title3']);
+
+        PostStringyKey::query()->create(['title' => 'title1']);
+        PostStringyKey::query()->create(['title' => 'title2']);
+
+        unset($_SERVER['update']);
+        PostStringyKey::updated(fn ($model) => $_SERVER['update']['updated'][] = $model->my_id);
+        PostStringyKey::updating(fn ($model) => $_SERVER['update']['updating'][] = $model->my_id);
+
+        PostStringyKey::patch([1, 2], ['title' => 'title3']);
+
+        $this->assertEquals([1, 2], $_SERVER['update']['updating']);
+        $this->assertEquals([1, 2], $_SERVER['update']['updated']);
+        $this->assertEquals(PostStringyKey::query()->pluck('title')->all(), ['title3', 'title3']);
+    }
+}

--- a/tests/Integration/Database/EloquentPatchTest.php
+++ b/tests/Integration/Database/EloquentPatchTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
 use Illuminate\Tests\Integration\Database\Fixtures\PostStringyKey;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentPatchTest extends DatabaseTestCase
 {


### PR DESCRIPTION
# Introduction
This PR makes an update the model class by adding a `patch` static method for updating multiple models and triggering events for each when passing in ids, collections, eloquent collections, or a string.

This is essentially `Model::destroy` but for updating models.

I believe this will provide a convince method for easily updating multiple models while still triggering an event for each one of them. I also think it makes sense to have `patch` work the same way as `destroy` for making sure the triggered events have the full model.

It doesn't break any existing features, just adds another nice way of updating and triggering model events while you're at it.

_I put patch as the method name because it was one of the synonyms to update that made sense to me_

# Problem

When updating models, there's only an option to update individually if you want events to happen per update.

This PR will fix that by providing the `patch` method

# Usage

```php
$ids = [1, 2, 3];

Post::patch($ids, ['published_at' => now()]);
```

The patch method would then trigger the updated and updating model events for each ID passed in.
