### PR TITLE
Add TimescaleDB hypertable support to PostgresBuilder::dropAllTables()

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -19,13 +19,13 @@ class PostgresBuilder extends Builder
         $hypertables = [];
 
         $excludedTables = $this->connection->getConfig('dont_drop') ?? ['spatial_ref_sys'];
-        $hasTimescaleDB = ! empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));
 
-        if ($hasTimescaleDB) {
-            $hypertables = $this->connection->select(
+        $hasTimescaleDb = ! empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));
+
+        if ($hasTimescaleDb) {
+            $hypertables = array_column($this->connection->select(
                 "SELECT hypertable_schema || '.' || hypertable_name as name FROM timescaledb_information.hypertables"
-            );
-            $hypertables = array_column($hypertables, 'name');
+            ), 'name');
         }
 
         foreach ($this->getTables($this->getCurrentSchemaListing()) as $table) {

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -19,7 +19,7 @@ class PostgresBuilder extends Builder
         $hypertables = [];
 
         $excludedTables = $this->connection->getConfig('dont_drop') ?? ['spatial_ref_sys'];
-        $hasTimescaleDB = !empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));
+        $hasTimescaleDB = ! empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));
         
         if ($hasTimescaleDB) {
             $hypertables = $this->connection->select(
@@ -29,7 +29,7 @@ class PostgresBuilder extends Builder
         }
 
         foreach ($this->getTables($this->getCurrentSchemaListing()) as $table) {
-            if (!in_array($table['name'], $excludedTables) && !in_array($table['schema_qualified_name'], $excludedTables)) {
+            if (! in_array($table['name'], $excludedTables) && ! in_array($table['schema_qualified_name'], $excludedTables)) {
                 if (in_array($table['schema_qualified_name'], $hypertables)) {
                     $this->connection->statement("DROP TABLE IF EXISTS {$table['schema_qualified_name']} CASCADE");
                 } else {

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -20,7 +20,7 @@ class PostgresBuilder extends Builder
 
         $excludedTables = $this->connection->getConfig('dont_drop') ?? ['spatial_ref_sys'];
         $hasTimescaleDB = ! empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));
-        
+
         if ($hasTimescaleDB) {
             $hypertables = $this->connection->select(
                 "SELECT hypertable_schema || '.' || hypertable_name as name FROM timescaledb_information.hypertables"


### PR DESCRIPTION
## Description

This change enhances the PostgreSQL schema builder to properly handle TimescaleDB hypertables when dropping all tables from the database.

## Problem

When using `php artisan migrate:fresh` or calling `dropAllTables()` on databases with TimescaleDB hypertables, the operation fails because hypertables require special handling and cannot be dropped using standard batch `DROP TABLE` operations. This results in migration errors and prevents developers from refreshing their database schema during development.

## Solution

- **TimescaleDB Detection**: Added detection for the TimescaleDB extension using `pg_extension` before attempting hypertable operations
- **Hypertable Identification**: Query `timescaledb_information.hypertables` to identify existing hypertables using correct column names (`hypertable_schema` and `hypertable_name`)
- **Separate Handling**: Drop hypertables individually with `CASCADE` option before processing regular tables
- **Graceful Fallback**: When TimescaleDB extension is not installed, the method continues with standard table dropping behavior

## Benefits to End Users

1. **Seamless Development Workflow**: Developers using TimescaleDB can now use `php artisan migrate:fresh` without manual intervention
2. **Zero Breaking Changes**: Maintains full backward compatibility with standard PostgreSQL databases
3. **Automatic Detection**: No configuration required - automatically detects and handles TimescaleDB when present
4. **Error Prevention**: Eliminates common migration failures in TimescaleDB environments

## Code Changes

### Modified Files
- `src/Illuminate/Database/Schema/PostgresBuilder.php`

### Key Changes
```php
// Added TimescaleDB extension detection
$hasTimescaleDB = !empty($this->connection->select("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'"));

// Query hypertables with correct column names
if ($hasTimescaleDB) {
    $hypertables = $this->connection->select(
        "SELECT hypertable_schema || '.' || hypertable_name as name FROM timescaledb_information.hypertables"
    );
    $hypertables = array_column($hypertables, 'name');
}

// Drop hypertables individually with CASCADE
if (in_array($table['schema_qualified_name'], $hypertables)) {
    $this->connection->statement("DROP TABLE IF EXISTS {$table['schema_qualified_name']} CASCADE");
}
```

## Compatibility

- **PostgreSQL**: 9.6+ (existing requirement)
- **TimescaleDB**: Optional extension support
- **Laravel**: No breaking changes to existing API
- **PHP**: Follows existing Laravel requirements
