### PR TITLE
Add env:diff command for comparing environment files

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDiffCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDiffCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'env:diff')]
+class EnvironmentDiffCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'env:diff
+                    {base? : The base environment file to compare against (default: .env.example)}
+                    {compare? : The environment file to compare (default: .env)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Compare environment files and show differences';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $baseFile = $this->argument('base') ?? '.env.example';
+        $compareFile = $this->argument('compare') ?? '.env';
+
+        $basePath = base_path($baseFile);
+        $comparePath = base_path($compareFile);
+
+        if (! File::exists($basePath)) {
+            $this->error("Base file '{$baseFile}' does not exist.");
+
+            return 1;
+        }
+
+        if (! File::exists($comparePath)) {
+            $this->error("Compare file '{$compareFile}' does not exist.");
+
+            return 1;
+        }
+
+        $baseEnv = $this->parseEnvFile($basePath);
+        $compareEnv = $this->parseEnvFile($comparePath);
+
+        $this->displayDifferences($baseEnv, $compareEnv, $baseFile, $compareFile);
+
+        return 0;
+    }
+
+    /**
+     * Parse an environment file and return an array of key-value pairs.
+     *
+     * @param  string  $filePath
+     * @return array
+     */
+    protected function parseEnvFile(string $filePath): array
+    {
+        $content = File::get($filePath);
+        $lines = explode("\n", $content);
+        $env = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            // Skip empty lines and comments
+            if (empty($line) || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            // Parse key=value pairs
+            if (str_contains($line, '=')) {
+                [$key, $value] = explode('=', $line, 2);
+                $env[trim($key)] = trim($value);
+            }
+        }
+
+        return $env;
+    }
+
+    /**
+     * Display the differences between two environment files.
+     *
+     * @param  array  $baseEnv
+     * @param  array  $compareEnv
+     * @param  string  $baseFile
+     * @param  string  $compareFile
+     * @return void
+     */
+    protected function displayDifferences(array $baseEnv, array $compareEnv, string $baseFile, string $compareFile): void
+    {
+        $this->info("Comparing {$baseFile} with {$compareFile}");
+        $this->newLine();
+
+        $added = array_diff_key($compareEnv, $baseEnv);
+        $removed = array_diff_key($baseEnv, $compareEnv);
+        $changed = [];
+
+        // Find changed values
+        foreach ($baseEnv as $key => $baseValue) {
+            if (isset($compareEnv[$key]) && $compareEnv[$key] !== $baseValue) {
+                $changed[$key] = [
+                    'base' => $baseValue,
+                    'compare' => $compareEnv[$key],
+                ];
+            }
+        }
+
+        $hasDifferences = ! empty($added) || ! empty($removed) || ! empty($changed);
+
+        if (! $hasDifferences) {
+            $this->info('No differences found between the environment files.');
+
+            return;
+        }
+
+        // Display added variables
+        if (! empty($added)) {
+            $this->warn('Added variables:');
+            foreach ($added as $key => $value) {
+                $this->line("  <fg=green>+ {$key}={$value}</>");
+            }
+            $this->newLine();
+        }
+
+        // Display removed variables
+        if (! empty($removed)) {
+            $this->warn('Removed variables:');
+            foreach ($removed as $key => $value) {
+                $this->line("  <fg=red>- {$key}={$value}</>");
+            }
+            $this->newLine();
+        }
+
+        // Display changed variables
+        if (! empty($changed)) {
+            $this->warn('Changed variables:');
+            foreach ($changed as $key => $values) {
+                $this->line("  <fg=yellow>~ {$key}</>");
+                $this->line("    <fg=red>- {$values['base']}</>");
+                $this->line("    <fg=green>+ {$values['compare']}</>");
+            }
+            $this->newLine();
+        }
+
+        // Summary
+        $this->info(sprintf(
+            'Summary: %d added, %d removed, %d changed',
+            count($added),
+            count($removed),
+            count($changed)
+        ));
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -47,6 +47,7 @@ use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnumMakeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\EnvironmentDecryptCommand;
+use Illuminate\Foundation\Console\EnvironmentDiffCommand;
 use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
 use Illuminate\Foundation\Console\EventCacheCommand;
 use Illuminate\Foundation\Console\EventClearCommand;
@@ -133,6 +134,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
         'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,
+        'EnvironmentDiff' => EnvironmentDiffCommand::class,
         'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,

--- a/tests/Integration/Console/EnvironmentDiffCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDiffCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Orchestra\Testbench\TestCase;
+
+class EnvironmentDiffCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_it_compares_environment_files()
+    {
+        // Create test environment files in the base path
+        $baseContent = "APP_NAME=Laravel\nAPP_ENV=local\nDB_CONNECTION=mysql\n";
+        $compareContent = "APP_NAME=MyApp\nAPP_ENV=production\nDB_CONNECTION=mysql\nCUSTOM_VAR=value\n";
+
+        $baseFile = base_path('test_base.env');
+        $compareFile = base_path('test_compare.env');
+
+        file_put_contents($baseFile, $baseContent);
+        file_put_contents($compareFile, $compareContent);
+
+        $this->artisan('env:diff', [
+            'base' => 'test_base.env',
+            'compare' => 'test_compare.env',
+        ])
+            ->expectsOutputToContain('Comparing')
+            ->expectsOutputToContain('Added variables:')
+            ->expectsOutputToContain('CUSTOM_VAR=value')
+            ->expectsOutputToContain('Changed variables:')
+            ->expectsOutputToContain('APP_NAME')
+            ->expectsOutputToContain('APP_ENV')
+            ->expectsOutputToContain('Summary:')
+            ->assertExitCode(0);
+
+        // Clean up
+        unlink($baseFile);
+        unlink($compareFile);
+    }
+
+    public function test_it_handles_missing_files()
+    {
+        $this->artisan('env:diff', [
+            'base' => 'nonexistent.env',
+            'compare' => 'also-nonexistent.env',
+        ])
+            ->expectsOutputToContain('does not exist')
+            ->assertExitCode(1);
+    }
+
+    public function test_it_shows_no_differences_when_files_are_identical()
+    {
+        $content = "APP_NAME=Laravel\nAPP_ENV=local\n";
+
+        $baseFile = base_path('test_identical_base.env');
+        $compareFile = base_path('test_identical_compare.env');
+
+        file_put_contents($baseFile, $content);
+        file_put_contents($compareFile, $content);
+
+        $this->artisan('env:diff', [
+            'base' => 'test_identical_base.env',
+            'compare' => 'test_identical_compare.env',
+        ])
+            ->expectsOutputToContain('No differences found')
+            ->assertExitCode(0);
+
+        // Clean up
+        unlink($baseFile);
+        unlink($compareFile);
+    }
+}


### PR DESCRIPTION
# Add env:diff command for comparing environment files

This PR adds a new Artisan command `env:diff` that allows developers to compare environment files and see the differences between them.

## Features

- Compare any two environment files (defaults to `.env.example` and `.env`)
- Shows added, removed, and changed variables
- Color-coded output for better readability
- Summary with counts of changes
- Handles missing files gracefully

## Usage Examples

### Basic usage (compares .env.example with .env):
```bash
php artisan env:diff
```

### Compare specific files:
```bash
php artisan env:diff .env.example .env.testing
php artisan env:diff .env.production .env.staging
```

### Example Output:
```
Comparing .env.example with .env.testing

Added variables:
  + TESTING_MODE=true
  + API_VERSION=v2

Changed variables:
  ~ APP_NAME
    - Laravel
    + MyApp
  ~ APP_ENV
    - local
    + testing

Summary: 2 added, 0 removed, 2 changed
```

## Benefits

- Helps developers identify configuration differences between environments
- Useful for debugging environment-specific issues
- Assists in maintaining consistent environment configurations
- Provides clear visual feedback on what has changed

## Implementation Details

- Added `EnvironmentDiffCommand` class following Laravel's naming conventions
- Registered command in `ArtisanServiceProvider`
- Added comprehensive test coverage
- Tests cover file comparison, missing files, and identical files scenarios

## Testing

The command includes thorough test coverage:
- ✅ File comparison with differences
- ✅ Handling missing files
- ✅ Identical files (no differences)
- ✅ Proper error handling
