### PR TITLE
[12.x] Fix Possible Undefined Variables

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1612,9 +1612,11 @@ class PendingRequest
      */
     protected function marshalRequestExceptionWithResponse(RequestException $e)
     {
+        $response = $this->populateResponse($this->newResponse($e->getResponse()));
+
         $this->factory?->recordRequestResponsePair(
             new Request($e->getRequest()),
-            $response = $this->populateResponse($this->newResponse($e->getResponse()))
+            $response
         );
 
         throw $response->toException() ?? new ConnectionException($e->getMessage(), 0, $e);

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1572,8 +1572,10 @@ class PendingRequest
     {
         $exception = new ConnectionException($e->getMessage(), 0, $e);
 
+        $request = new Request($e->getRequest());
+
         $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
+            $request, null
         );
 
         $this->dispatchConnectionFailedEvent($request, $exception);
@@ -1591,8 +1593,10 @@ class PendingRequest
     {
         $exception = new ConnectionException($e->getMessage(), 0, $e);
 
+        $request = new Request($e->getRequest());
+
         $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
+            $request, null
         );
 
         $this->dispatchConnectionFailedEvent($request, $exception);


### PR DESCRIPTION
This PR fixes a few minor bugs resulting from the use of inline variable assignment within nullsafe method chains in `PendingRequest.php` class. When `$this->factory` is `null`, the inline assignment never occurs, leading to variable undefined errors.

This PR moves the assignment of these variables outside of the factory call to ensure that they are always defined, regardless of whether `$this->factory` is `null`.