### PR TITLE
[12.x] `route_path()` helper

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -70,6 +70,14 @@ interface Application extends Container
     public function resourcePath($path = '');
 
     /**
+     * Get the path to the routes directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function routePath($path = '');
+
+    /**
      * Get the path to the storage directory.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -419,6 +419,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.resources', $this->resourcePath());
+        $this->instance('path.routes', $this->routePath());
         $this->instance('path.storage', $this->storagePath());
 
         $this->useBootstrapPath(value(function () {
@@ -654,6 +655,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function resourcePath($path = '')
     {
         return $this->joinPaths($this->basePath('resources'), $path);
+    }
+
+    /**
+     * Get the path to the routes directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function routePath($path = '')
+    {
+        return $this->joinPaths($this->basePath('routes'), $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -47,7 +47,7 @@ class ApiInstallCommand extends Command
             $this->installSanctum();
         }
 
-        if (file_exists($apiRoutesPath = $this->laravel->basePath('routes/api.php')) &&
+        if (file_exists($apiRoutesPath = $this->laravel->routePath('api.php')) &&
             ! $this->option('force')) {
             $this->components->error('API routes file already exists.');
         } else {

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -45,7 +45,7 @@ class BroadcastingInstallCommand extends Command
         $this->call('config:publish', ['name' => 'broadcasting']);
 
         // Install channel routes file...
-        if (! file_exists($broadcastingRoutesPath = $this->laravel->basePath('routes/channels.php')) || $this->option('force')) {
+        if (! file_exists($broadcastingRoutesPath = $this->laravel->routePath('channels.php')) || $this->option('force')) {
             $this->components->info("Published 'channels' route file.");
 
             copy(__DIR__.'/stubs/broadcasting-routes.stub', $broadcastingRoutesPath);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -670,6 +670,19 @@ if (! function_exists('public_path')) {
     }
 }
 
+if (! function_exists('route_path')) {
+    /**
+     * Get the path to the public folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function route_path($path = '')
+    {
+        return app()->routePath($path);
+    }
+}
+
 if (! function_exists('redirect')) {
     /**
      * Get an instance of the redirector.


### PR DESCRIPTION
I was configuring my routes on `bootstrap/app.php` and thought that `route_path()` should exist in Laravel but found that it's not, so I have add it on this PR.

Instead of using `base_path()` and rewrite the routes folder every time `/routes`.
```php
Route::middleware('admin')
    ->name('admin.')
    ->group(base_path('routes/admin.php'));
```

We can use `route_path()`.
```php
Route::middleware('admin')
    ->name('admin.')
    ->group(route_path('admin.php'));
```