### PR TITLE
[12.x] Fix Possible Undefined Variables

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1612,9 +1612,11 @@ class PendingRequest
      */
     protected function marshalRequestExceptionWithResponse(RequestException $e)
     {
+        $response = $this->populateResponse($this->newResponse($e->getResponse()));
+
         $this->factory?->recordRequestResponsePair(
             new Request($e->getRequest()),
-            $response = $this->populateResponse($this->newResponse($e->getResponse()))
+            $response
         );
 
         throw $response->toException() ?? new ConnectionException($e->getMessage(), 0, $e);

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1572,8 +1572,10 @@ class PendingRequest
     {
         $exception = new ConnectionException($e->getMessage(), 0, $e);
 
+        $request = new Request($e->getRequest());
+
         $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
+            $request, null
         );
 
         $this->dispatchConnectionFailedEvent($request, $exception);
@@ -1591,8 +1593,10 @@ class PendingRequest
     {
         $exception = new ConnectionException($e->getMessage(), 0, $e);
 
+        $request = new Request($e->getRequest());
+
         $this->factory?->recordRequestResponsePair(
-            $request = new Request($e->getRequest()), null
+            $request, null
         );
 
         $this->dispatchConnectionFailedEvent($request, $exception);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Exception;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Middleware;
@@ -2608,6 +2609,82 @@ class HttpClientTest extends TestCase
         $this->expectExceptionMessage('cURL error 60: SSL certificate problem: unable to get local issuer certificate');
 
         $this->factory->head('https://ssl-error.laravel.example');
+    }
+
+    public function testConnectExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
+    {
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('cURL error 60: SSL certificate problem');
+
+        $pendingRequest = new PendingRequest();
+        $mockGuzzleRequest = new GuzzleRequest('HEAD', 'https://ssl-error.laravel.example');
+
+        $pendingRequest->setHandler(function () use ($mockGuzzleRequest) {
+            throw new ConnectException(
+                'cURL error 60: SSL certificate problem: unable to get local issuer certificate',
+                $mockGuzzleRequest
+            );
+        });
+
+        $pendingRequest->head('https://ssl-error.laravel.example');
+    }
+
+    public function testRequestExceptionWithoutResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
+    {
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+
+        $pendingRequest = new PendingRequest();
+        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://timeout-laravel.example');
+
+        $pendingRequest->setHandler(function () use ($mockGuzzleRequest) {
+            throw new \GuzzleHttp\Exception\RequestException(
+                'cURL error 28: Operation timed out',
+                $mockGuzzleRequest
+            );
+        });
+
+        $pendingRequest->get('https://timeout-laravel.example');
+    }
+
+    public function testRequestExceptionWithResponseIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
+    {
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('cURL error 28: Operation timed out');
+
+        $pendingRequest = new PendingRequest();
+        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://timeout-laravel.example');
+        $mockGuzzleResponse = new Psr7Response(301);
+
+        $pendingRequest->setHandler(function () use ($mockGuzzleRequest, $mockGuzzleResponse) {
+            throw new \GuzzleHttp\Exception\RequestException(
+                'cURL error 28: Operation timed out',
+                $mockGuzzleRequest,
+                $mockGuzzleResponse
+            );
+        });
+
+        $pendingRequest->get('https://timeout-laravel.example');
+    }
+
+    public function testTooManyRedirectsExceptionIsConvertedToConnectionExceptionEvenWhenWithoutFactory()
+    {
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
+
+        $pendingRequest = new PendingRequest();
+        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://redirect.laravel.example');
+        $mockGuzzleResponse = new Psr7Response(301);
+
+        $pendingRequest->setHandler(function () use ($mockGuzzleRequest, $mockGuzzleResponse) {
+            throw new TooManyRedirectsException(
+                'Maximum number of redirects (5) exceeded',
+                $mockGuzzleRequest,
+                $mockGuzzleResponse
+            );
+        });
+
+        $pendingRequest->maxRedirects(5)->get('https://redirect.laravel.example');
     }
 
     public function testTooManyRedirectsExceptionConvertedToConnectionException()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2380,7 +2380,7 @@ class HttpClientTest extends TestCase
 
     public function testHandleRequestExeptionWithNoResponseInPoolConsideredConnectionException()
     {
-        $requestException = new \GuzzleHttp\Exception\RequestException('Error', new \GuzzleHttp\Psr7\Request('GET', '/'));
+        $requestException = new GuzzleRequestException('Error', new \GuzzleHttp\Psr7\Request('GET', '/'));
         $this->factory->fake([
             'noresponse.com' => new RejectedPromise($requestException),
         ]);
@@ -2617,12 +2617,11 @@ class HttpClientTest extends TestCase
         $this->expectExceptionMessage('cURL error 60: SSL certificate problem');
 
         $pendingRequest = new PendingRequest();
-        $mockGuzzleRequest = new GuzzleRequest('HEAD', 'https://ssl-error.laravel.example');
 
-        $pendingRequest->setHandler(function () use ($mockGuzzleRequest) {
+        $pendingRequest->setHandler(function () {
             throw new ConnectException(
                 'cURL error 60: SSL certificate problem: unable to get local issuer certificate',
-                $mockGuzzleRequest
+                new GuzzleRequest('HEAD', 'https://ssl-error.laravel.example')
             );
         });
 
@@ -2635,12 +2634,11 @@ class HttpClientTest extends TestCase
         $this->expectExceptionMessage('cURL error 28: Operation timed out');
 
         $pendingRequest = new PendingRequest();
-        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://timeout-laravel.example');
 
-        $pendingRequest->setHandler(function () use ($mockGuzzleRequest) {
-            throw new \GuzzleHttp\Exception\RequestException(
+        $pendingRequest->setHandler(function () {
+            throw new GuzzleRequestException(
                 'cURL error 28: Operation timed out',
-                $mockGuzzleRequest
+                new GuzzleRequest('GET', 'https://timeout-laravel.example')
             );
         });
 
@@ -2653,14 +2651,12 @@ class HttpClientTest extends TestCase
         $this->expectExceptionMessage('cURL error 28: Operation timed out');
 
         $pendingRequest = new PendingRequest();
-        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://timeout-laravel.example');
-        $mockGuzzleResponse = new Psr7Response(301);
 
-        $pendingRequest->setHandler(function () use ($mockGuzzleRequest, $mockGuzzleResponse) {
-            throw new \GuzzleHttp\Exception\RequestException(
+        $pendingRequest->setHandler(function () {
+            throw new GuzzleRequestException(
                 'cURL error 28: Operation timed out',
-                $mockGuzzleRequest,
-                $mockGuzzleResponse
+                new GuzzleRequest('GET', 'https://timeout-laravel.example'),
+                new Psr7Response(301)
             );
         });
 
@@ -2673,14 +2669,12 @@ class HttpClientTest extends TestCase
         $this->expectExceptionMessage('Maximum number of redirects (5) exceeded');
 
         $pendingRequest = new PendingRequest();
-        $mockGuzzleRequest = new GuzzleRequest('GET', 'https://redirect.laravel.example');
-        $mockGuzzleResponse = new Psr7Response(301);
 
-        $pendingRequest->setHandler(function () use ($mockGuzzleRequest, $mockGuzzleResponse) {
+        $pendingRequest->setHandler(function () {
             throw new TooManyRedirectsException(
                 'Maximum number of redirects (5) exceeded',
-                $mockGuzzleRequest,
-                $mockGuzzleResponse
+                new GuzzleRequest('GET', 'https://redirect.laravel.example'),
+                new Psr7Response(301)
             );
         });
 


### PR DESCRIPTION
**Bug**
This PR fixes a few minor bugs resulting from the use of inline variable assignment within nullsafe method chains in `PendingRequest.php` class. When `$this->factory` is `null`, the inline assignment never occurs, leading to variable undefined errors.

**Fix**
This PR moves the assignment of these variables outside of the factory call to ensure that they are always defined, regardless of whether `$this->factory` is null.

**Tests**
There are also accompanying tests that assert that each of the updated methods behaves correctly when called without a factory. These tests fail pre-PR updates.