### PR TITLE
[12.x] optimize defaultNode() method with null coalescing assignment

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -72,10 +72,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
      */
     private function defaultNode()
     {
-        if (! isset($this->defaultNode)) {
-            $this->defaultNode = $this->client->_masters()[0] ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
-        }
-
-        return $this->defaultNode;
+        return $this->defaultNode ??= $this->client->_masters()[0]
+            ?? throw new InvalidArgumentException('Unable to determine default node. No master nodes found in the cluster.');
     }
 }


### PR DESCRIPTION
Refactored the defaultNode() method to use PHP's null coalescing assignment operator (??=) for cleaner, more efficient code while maintaining the same lazy initialization behavior.
