### PR TITLE
[12.x] create a `Pagination` component

### DIFF
--- a/src/Illuminate/Pagination/Pagination.php
+++ b/src/Illuminate/Pagination/Pagination.php
@@ -27,7 +27,6 @@ class Pagination extends Component
     {
         //length aware paginator
         if ($this->paginator instanceof LengthAwarePaginator) {
-
             //get elements
             $window = UrlWindow::make($this->paginator);
 
@@ -50,7 +49,7 @@ class Pagination extends Component
             ->with([
                 ...$this->data,
                 'paginator' => $this->paginator,
-                'elements'  => $elements ?? [],
+                'elements' => $elements ?? [],
             ]);
     }
 }

--- a/src/Illuminate/Pagination/Pagination.php
+++ b/src/Illuminate/Pagination/Pagination.php
@@ -15,9 +15,10 @@ class Pagination extends Component
      */
     public function __construct(
         protected LengthAwarePaginator|Paginator $paginator,
-        protected string|null                    $view = null,
-        protected array                          $data = [],
-    ) {}
+        protected ?string $view = null,
+        protected array $data = [],
+    ) {
+    }
 
     /**
      * Get the view / contents that represent the component.

--- a/src/Illuminate/Pagination/Pagination.php
+++ b/src/Illuminate/Pagination/Pagination.php
@@ -15,6 +15,8 @@ class Pagination extends Component
      */
     public function __construct(
         protected LengthAwarePaginator|Paginator $paginator,
+        protected string|null                    $view = null,
+        protected array                          $data = [],
     ) {}
 
     /**
@@ -38,13 +40,14 @@ class Pagination extends Component
         }
 
         //determine view
-        $view = $this->paginator instanceof LengthAwarePaginator
+        $view = $this->view ?? $this->paginator instanceof LengthAwarePaginator
             ? AbstractPaginator::$defaultView
             : AbstractPaginator::$defaultSimpleView;
 
         //load view
         return view($view)
             ->with([
+                ...$this->data,
                 'paginator' => $this->paginator,
                 'elements'  => $elements ?? [],
             ]);

--- a/src/Illuminate/Pagination/Pagination.php
+++ b/src/Illuminate/Pagination/Pagination.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use Closure;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Pagination extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        protected LengthAwarePaginator|Paginator $paginator,
+    ) {}
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        //length aware paginator
+        if ($this->paginator instanceof LengthAwarePaginator) {
+
+            //get elements
+            $window = UrlWindow::make($this->paginator);
+
+            $elements = array_filter([
+                $window['first'],
+                is_array($window['slider']) ? '...' : null,
+                $window['slider'],
+                is_array($window['last']) ? '...' : null,
+                $window['last'],
+            ]);
+        }
+
+        //determine view
+        $view = $this->paginator instanceof LengthAwarePaginator
+            ? AbstractPaginator::$defaultView
+            : AbstractPaginator::$defaultSimpleView;
+
+        //load view
+        return view($view)
+            ->with([
+                'paginator' => $this->paginator,
+                'elements'  => $elements ?? [],
+            ]);
+    }
+}

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Pagination;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class PaginationServiceProvider extends ServiceProvider
@@ -14,6 +15,8 @@ class PaginationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->loadViewsFrom(__DIR__.'/resources/views', 'pagination');
+
+        Blade::component('pagination', Pagination::class, 'laravel');
 
         if ($this->app->runningInConsole()) {
             $this->publishes([

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -16,7 +16,7 @@ class PaginationServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/resources/views', 'pagination');
 
-        Blade::component('pagination', Pagination::class, 'laravel');
+        Blade::component('laravel::pagination', Pagination::class);
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
This component generates the same output as `->links()`, but provides the more familiar component pattern for declaring it.   I believe this is better because:

- it allows consistent usage of components throughout user's codebase
- opens up the opportunity for the framework to easily provide more controlled customization of the output of the pagination. for example, you could pass an attribute to disable the "Showing X to X of X results". 

Previously:

```blade
{{ $blogs->links() }}
```

New:

```blade
<x-laravel::pagination :paginator="$blogs"></x-laravel::pagination>
```

Users still have the ability to pass their own custom view and data to the component:


```blade
<x-laravel::pagination
    :paginator="$blogs"
    view="/my/custom/view"
    :data="['foo', 'bar', 'baz']"
></x-laravel::pagination>
```

I have not added any additional customization in this PR, but opted to wait to see if this would be accepted.