### PR TITLE
[12.x] Use more specific route binding exception message for child routes

### DIFF
--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -58,7 +58,7 @@ trait DelegatesToResource
      */
     public function resolveChildRouteBinding($childType, $value, $field = null)
     {
-        throw new Exception('Resources may not be implicitly resolved from route bindings.');
+        throw new Exception('Resources may not be implicitly resolved from child route bindings.');
     }
 
     /**


### PR DESCRIPTION
While viewing the `Illuminate\Http\Resources\DelegatesToResource` trait, I noticed that both `resolveRouteBinding` and `resolveChildRouteBinding` currently throw identical exception messages.

To reduce confusion and to make it easier to distinguish between the two, this PR updates the message in `resolveChildRouteBinding` to explicitly mention that the error originated from _child_ route bindings.