### PR TITLE
[12.x] Enhance ApiInstallCommand with regex-based file replacements for improved flexibility

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -248,7 +248,7 @@ class Filesystem
 
     /**
      * Replace a given string within a given file with a regular expression.
-     * 
+     *
      * @param  string|array  $pattern
      * @param  string|array  $replace
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -247,6 +247,19 @@ class Filesystem
     }
 
     /**
+     * Replace a given string within a given file with a regular expression.
+     * 
+     * @param  string|array  $pattern
+     * @param  string|array  $replace
+     * @param  string  $path
+     * @return void
+     */
+    public function regReplaceInFile($pattern, $replace, $path)
+    {
+        file_put_contents($path, preg_replace($pattern, $replace, file_get_contents($path)));
+    }
+
+    /**
      * Prepend to a file.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -97,14 +97,14 @@ class ApiInstallCommand extends Command
         $content = file_get_contents($appBootstrapPath);
 
         if (preg_match('/\/\/\s*api\s*:/i', $content)) {
-            (new Filesystem)->replaceInFile(
-                '// api: ',
+            (new Filesystem)->regReplaceInFile(
+                '/\/\/\s*api\s*:/',
                 'api: ',
                 $appBootstrapPath,
             );
         } elseif (preg_match('/web:\s*__DIR__\s*\.\s*[\'"]\/\.\.\/routes\/web\.php[\'"]\s*,/', $content)) {
-            (new Filesystem)->replaceInFile(
-                'web: __DIR__.\'/../routes/web.php\',',
+            (new Filesystem)->regReplaceInFile(
+                '/web:\s*__DIR__\s*\.\s*[\'"]\/\.\.\/routes\/web\.php[\'"]\s*,/',
                 'web: __DIR__.\'/../routes/web.php\','.PHP_EOL.'        api: __DIR__.\'/../routes/api.php\',',
                 $appBootstrapPath,
             );

--- a/src/Illuminate/Foundation/Console/ApiInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/ApiInstallCommand.php
@@ -96,13 +96,13 @@ class ApiInstallCommand extends Command
 
         $content = file_get_contents($appBootstrapPath);
 
-        if (str_contains($content, '// api: ')) {
+        if (preg_match('/\/\/\s*api\s*:/i', $content)) {
             (new Filesystem)->replaceInFile(
                 '// api: ',
                 'api: ',
                 $appBootstrapPath,
             );
-        } elseif (str_contains($content, 'web: __DIR__.\'/../routes/web.php\',')) {
+        } elseif (preg_match('/web:\s*__DIR__\s*\.\s*[\'"]\/\.\.\/routes\/web\.php[\'"]\s*,/', $content)) {
             (new Filesystem)->replaceInFile(
                 'web: __DIR__.\'/../routes/web.php\',',
                 'web: __DIR__.\'/../routes/web.php\','.PHP_EOL.'        api: __DIR__.\'/../routes/api.php\',',


### PR DESCRIPTION
## Description
This pull request improves the ApiInstallCommand by introducing regex-based file replacements, making the command more resilient to formatting variations in `bootstrap/app.php`.

### Why?
Laravel pint, can be configured to automattically adjust whitespace. As a result, even if the content in `bootstrap/app.php` was logically correct, the previous logic using strict string matching could fail to detect the relevant lines due to formatting differences. This prevented the api.php routes file from being properly integrated. By switching to regex-based replacements, this PR ensures compatibility with Pint-formatted code and improves the robustness of the install command.

## Key Changes
+ Add `regReplaceInFile` method to the `Filesystem` class to support reqular expression based replacements.
+ Update the `uncommentApiRoutesFile` method in `ApiInstallCommand` to use regex for more accurate pattern matching and replacement.
+ Replaced hardcoded string matches with regex to better handle variations in whitespace and formatting.