### PR TITLE
feat: add WithMiddleware and WithoutMiddleware attributes

### DIFF
--- a/src/Illuminate/Routing/Attributes/WithMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithMiddleware.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Routing;
 
 #[\Attribute(Attribute::TARGET_METHOD)]
-class WithMiddleware {
+class WithMiddleware
+{
     /**
      * Create a new attribute instance.
      *
-     * @param  class-string|array<class-string> $middleware
+     * @param  class-string|array<class-string>  $middleware
      */
     public function __construct(public string|array $middleware)
     {

--- a/src/Illuminate/Routing/Attributes/WithMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithMiddleware.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Illuminate\Routing;
+namespace Illuminate\Routing\Attributes;
+
+use Attribute;
 
 #[\Attribute(Attribute::TARGET_METHOD)]
 class WithMiddleware

--- a/src/Illuminate/Routing/Attributes/WithMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Routing;
+
+#[\Attribute(Attribute::TARGET_METHOD)]
+class WithMiddleware {
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string|array<class-string> $middleware
+     */
+    public function __construct(public string|array $middleware)
+    {
+    }
+}

--- a/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Illuminate\Routing;
+namespace Illuminate\Routing\Attributes;
+
+use Attribute;
 
 #[\Attribute(Attribute::TARGET_METHOD)]
 class WithoutMiddleware

--- a/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Routing;
 
 #[\Attribute(Attribute::TARGET_METHOD)]
-class WithoutMiddleware {
+class WithoutMiddleware
+{
     /**
      * Create a new attribute instance.
      *
-     * @param  class-string|array<class-string> $middleware
+     * @param  class-string|array<class-string>  $middleware
      */
     public function __construct(public string|array $middleware)
     {

--- a/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
+++ b/src/Illuminate/Routing/Attributes/WithoutMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Routing;
+
+#[\Attribute(Attribute::TARGET_METHOD)]
+class WithoutMiddleware {
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string|array<class-string> $middleware
+     */
+    public function __construct(public string|array $middleware)
+    {
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -333,7 +333,6 @@ class Route
     /**
      * Determine if the route matches a given request.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  bool  $includingMethod
      * @return bool
      */
@@ -371,7 +370,6 @@ class Route
     /**
      * Bind the route to a given request for execution.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return $this
      */
     public function bind(Request $request)
@@ -571,7 +569,6 @@ class Route
     /**
      * Set the binding fields for the route.
      *
-     * @param  array  $bindingFields
      * @return $this
      */
     public function setBindingFields(array $bindingFields)
@@ -638,7 +635,6 @@ class Route
     /**
      * Set the default values for the route.
      *
-     * @param  array  $defaults
      * @return $this
      */
     public function setDefaults(array $defaults)
@@ -679,7 +675,6 @@ class Route
     /**
      * Set a list of regular expression requirements on the route.
      *
-     * @param  array  $wheres
      * @return $this
      */
     public function setWheres(array $wheres)
@@ -996,7 +991,6 @@ class Route
     /**
      * Set the action array for the route.
      *
-     * @param  array  $action
      * @return $this
      */
     public function setAction(array $action)
@@ -1122,6 +1116,10 @@ class Route
             );
         }
 
+        if ( $middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod) ){
+            return $middleware;
+        }
+
         if (method_exists($controllerClass, 'getMiddleware')) {
             return $this->controllerDispatcher()->getMiddleware(
                 $this->getController(), $controllerMethod
@@ -1132,10 +1130,54 @@ class Route
     }
 
     /**
+     * Get the attribute provided middleware for the given class and method.
+     *
+     * @return array
+     */
+    protected function applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod)
+    {
+        $methodReflection = (new \ReflectionClass($controllerClass))
+            ->getMethod($controllerMethod);
+
+        $withoutMiddlewareAttribute = $methodReflection->getAttributes(WithoutMiddleware::class);
+        $withMiddlewareAttribute = $methodReflection->getAttributes(WithMiddleware::class);
+
+        if (! empty($withoutMiddlewareAttribute)) {
+            $middleware = $withoutMiddlewareAttribute[0]->getArguments();
+
+            if (is_array($middleware[0])) {
+                return collect($middleware)->each(function ($middleware) {
+                    $this->withoutMiddleware($middleware);
+                })->all();
+            }
+
+            if (is_string($middleware[0])) {
+                $this->withoutMiddleware($middleware);
+            }
+        }
+
+        if (! empty($withMiddlewareAttribute)) {
+            $middleware = $withMiddlewareAttribute[0]->getArguments();
+
+            if (is_array($middleware[0])) {
+                return collect($middleware)->each(function ($middleware) {
+                    $this->middleware($middleware);
+                })->all();
+            }
+
+            if (is_string($middleware[0])) {
+                $this->middleware($middleware);
+
+                return $middleware;
+            }
+        }
+
+        return [];
+    }
+
+    /**
      * Get the statically provided controller middleware for the given class and method.
      *
-     * @param  string  $class
-     * @param  string  $method
      * @return array
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
@@ -1347,7 +1389,6 @@ class Route
     /**
      * Set the router instance on the route.
      *
-     * @param  \Illuminate\Routing\Router  $router
      * @return $this
      */
     public function setRouter(Router $router)
@@ -1360,7 +1401,6 @@ class Route
     /**
      * Set the container instance on the route.
      *
-     * @param  \Illuminate\Container\Container  $container
      * @return $this
      */
     public function setContainer(Container $container)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1154,17 +1154,11 @@ class Route
         $withMiddlewareAttribute = $methodReflection->getAttributes(WithMiddleware::class);
 
         if (! empty($withoutMiddlewareAttribute)) {
-            $middleware = $withoutMiddlewareAttribute[0]->getArguments();
+            $middleware = Arr::wrap($withoutMiddlewareAttribute[0]->getArguments());
 
-            if (is_array($middleware[0])) {
-                return collect($middleware)->each(function ($middleware) {
-                    $this->withoutMiddleware($middleware);
-                })->all();
-            }
-
-            if (is_string($middleware[0])) {
+            return collect($middleware)->each(function ($middleware) {
                 $this->withoutMiddleware($middleware);
-            }
+            })->all();
         }
 
         if (! empty($withMiddlewareAttribute)) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1124,8 +1124,8 @@ class Route
 
         if (
             method_exists($controllerClass, $controllerMethod) &&
-            $middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod
-        )) {
+            $middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod)
+        ) {
             return $middleware;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1116,7 +1116,7 @@ class Route
             );
         }
 
-        if ( $middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod) ){
+        if ($middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod)) {
             return $middleware;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1122,7 +1122,10 @@ class Route
             );
         }
 
-        if ($middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod)) {
+        if (
+            method_exists($controllerClass, $controllerMethod) &&
+            $middleware = $this->applyRouteMiddlewareFromAttribute($controllerClass, $controllerMethod
+        )) {
             return $middleware;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -333,6 +333,7 @@ class Route
     /**
      * Determine if the route matches a given request.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  bool  $includingMethod
      * @return bool
      */
@@ -370,6 +371,7 @@ class Route
     /**
      * Bind the route to a given request for execution.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return $this
      */
     public function bind(Request $request)
@@ -569,6 +571,7 @@ class Route
     /**
      * Set the binding fields for the route.
      *
+     * @param  array  $bindingFields
      * @return $this
      */
     public function setBindingFields(array $bindingFields)
@@ -635,6 +638,7 @@ class Route
     /**
      * Set the default values for the route.
      *
+     * @param  array  $defaults
      * @return $this
      */
     public function setDefaults(array $defaults)
@@ -675,6 +679,7 @@ class Route
     /**
      * Set a list of regular expression requirements on the route.
      *
+     * @param  array  $wheres
      * @return $this
      */
     public function setWheres(array $wheres)
@@ -991,6 +996,7 @@ class Route
     /**
      * Set the action array for the route.
      *
+     * @param  array  $action
      * @return $this
      */
     public function setAction(array $action)
@@ -1014,10 +1020,10 @@ class Route
         $missing = $this->action['missing'] ?? null;
 
         return is_string($missing) &&
-            Str::startsWith($missing, [
-                'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
-                'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
-            ]) ? unserialize($missing) : $missing;
+               Str::startsWith($missing, [
+                   'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
+                   'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
+               ]) ? unserialize($missing) : $missing;
     }
 
     /**
@@ -1178,6 +1184,8 @@ class Route
     /**
      * Get the statically provided controller middleware for the given class and method.
      *
+     * @param  string  $class
+     * @param  string  $method
      * @return array
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
@@ -1389,6 +1397,7 @@ class Route
     /**
      * Set the router instance on the route.
      *
+     * @param  \Illuminate\Routing\Router  $router
      * @return $this
      */
     public function setRouter(Router $router)
@@ -1401,6 +1410,7 @@ class Route
     /**
      * Set the container instance on the route.
      *
+     * @param  \Illuminate\Container\Container  $container
      * @return $this
      */
     public function setContainer(Container $container)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -210,7 +210,6 @@ class RoutingRouteTest extends TestCase
 
     public function testMiddlewareCanBeAddedWithWithMiddlewareAttribute()
     {
-
         $router = $this->getRouter();
         $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
 
@@ -221,7 +220,6 @@ class RoutingRouteTest extends TestCase
 
     public function testMiddlewareCanBeSkippedWithWithoutMiddlewareAttribute()
     {
-
         $router = $this->getRouter();
         $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
 
@@ -230,6 +228,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
+
     public function testMiddlewareCanBeSkipped()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2345,7 +2345,7 @@ class RouteTestControllerWithMiddlewareStub implements HasMiddleware
     public static function middleware()
     {
         return [
-            'web2'
+            'web2',
         ];
     }
 }
@@ -2583,7 +2583,7 @@ class RoutingTestMiddlewareGroupFour
 {
     public function handle($request, $next)
     {
-        return new Response('caught ' . $request->request->get('hello', ''));
+        return new Response('caught '.$request->request->get('hello', ''));
     }
 }
 class RoutingTestUserModel extends Model

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -208,7 +208,8 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
-    public function testMiddlewareCanBeAddedWithWithMiddlewareAttribute(){
+    public function testMiddlewareCanBeAddedWithWithMiddlewareAttribute()
+    {
 
         $router = $this->getRouter();
         $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
@@ -218,7 +219,8 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('caught ', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
-    public function testMiddlewareCanBeSkippedWithWithoutMiddlewareAttribute(){
+    public function testMiddlewareCanBeSkippedWithWithoutMiddlewareAttribute()
+    {
 
         $router = $this->getRouter();
         $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -37,6 +37,8 @@ use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\RouteGroup;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Routing\WithMiddleware;
+use Illuminate\Routing\WithoutMiddleware;
 use Illuminate\Support\Str;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -206,6 +208,26 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testMiddlewareCanBeAddedWithWithMiddlewareAttribute(){
+
+        $router = $this->getRouter();
+        $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
+
+        $router->resource('foo', RouteTestControllerWithMiddlewareStub::class);
+
+        $this->assertSame('caught ', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
+    public function testMiddlewareCanBeSkippedWithWithoutMiddlewareAttribute(){
+
+        $router = $this->getRouter();
+        $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
+
+        $router->resource('foo', RouteTestControllerWithoutMiddlewareStub::class)
+           ->middleware('web');
+
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
     public function testMiddlewareCanBeSkipped()
     {
         $router = $this->getRouter();
@@ -2301,6 +2323,24 @@ class RouteTestControllerMiddlewareGroupStub extends Controller
         $this->middleware('web');
     }
 
+    public function index()
+    {
+        return 'Hello World';
+    }
+}
+
+class RouteTestControllerWithMiddlewareStub extends Controller
+{
+    #[WithMiddleware('web')]
+    public function index()
+    {
+        return 'Hello World';
+    }
+}
+
+class RouteTestControllerWithoutMiddlewareStub extends Controller
+{
+    #[WithoutMiddleware('web')]
     public function index()
     {
         return 'Hello World';


### PR DESCRIPTION
Hello,

This PR introduces `WithMiddleware` and `WithoutMiddleware` attributes to Laravel 12, enabling developers to apply or exclude middleware on specific controller methods using PHP attributes.

This PR aligns with the current trend of attribute-driven features such as UsePolicy, UseBuilder, and similar, offering a more declarative and streamlined approach for managing route middleware.

## Example Usage
```php
// web.php
Route::resource('example', ExampleController::class)->middleware('auth')

// ExampleController.php
use Illuminate\Routing\Attributes\WithMiddleware;
use Illuminate\Routing\Attributes\WithoutMiddleware;

class ExampleController {
  #[WithoutMiddleware('auth')]
  #[WithMiddleware('throttle')]
  public function show()
  {
      return response('...');
  }
}
```

## Notes about backwards compatibility and edge cases:

The following scenarios/edge-cases are covered:
1. The middleware provided with WithoutMiddleware() is merged with the middleware provided using the middleware() method (if exists). ✅.
2. If a middleware is provided in the middleware() method (if exists), and the callback contains it via WithoutMiddleware(), then that middleware will be skipped/excluded. ✅.