### PR TITLE
[12.x] Fix hours and minutes extraction in scheduler `dailyAt()` method

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -345,7 +345,7 @@ trait ManagesFrequencies
         $segments = explode(':', $time);
 
         return $this->hourBasedSchedule(
-            count($segments) === 2 ? (int) $segments[1] : '0',
+            count($segments) >= 2 ? (int) $segments[1] : '0',
             (int) $segments[0]
         );
     }


### PR DESCRIPTION
This PR updates the logic in the `dailyAt()` method to correctly handle time strings containing hours, minutes, and seconds (e.g., "10:20:30").

Previously, if the `$time` string contained more than two segments, the minutes value would incorrectly default to `'0'`.
By changing the condition from `count($segments) === 2` to `count($segments) >= 2`, we ensure that the minutes value is preserved even when seconds are present. This does not change the existing behavior; seconds are still ignored exactly as before.

- This could be done using `count($segments) === 2 || count($segments) === 3`, but I think the above method is more performant than using two `count()` calls.