### PR TITLE
Add eventStream signature to ResponseFactory contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -58,6 +58,16 @@ interface ResponseFactory
     public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0);
 
     /**
+     * Create a new event stream response.
+     *
+     * @param  \Closure  $callback
+     * @param  array  $headers
+     * @param  \Illuminate\Http\StreamedEvent|string|null  $endStreamWith
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function eventStream($callback, array $headers = [], $endStreamWith = '</stream>');
+
+    /**
      * Create a new streamed response instance.
      *
      * @param  callable  $callback


### PR DESCRIPTION
**Commit description**

Adds `eventStream` to `Illuminate\Contracts\Routing\ResponseFactory` in order to add type support for this method, aligning this with the same behavior that we have for `stream` of which `eventStream` is a convenient wrapper.

**Why this change**

At this time the `ResponseFactory` contract does not include a signature for the `eventStream` method. However, the function does exist on the underlying concrete implementation returned by the `response()` helper.

Not having this included can cause some false positive warnings and errors when statically analyzing a codebase using the `eventStream` function, such as when using intellisense in VS Code. Additionally, this can throw off AI agents from using the method, even if directly instructed to (tested using Claude Sonnet 4).

The method is already described on the `Response` facade–this PR would align the response helper with the facade.

This is a additive feature and does not introduce breaking changes.

**Of note:**

I do not see any existing tests for `eventStream`, but here is additionally PRs for context on the function.

- https://github.com/laravel/framework/pull/54776
- https://github.com/laravel/framework/pull/55141