### PR TITLE
[12.x] Fix: Ensure scheduler `dailyAt()` method parses minutes and ignores seconds when seconds are provided

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -345,7 +345,7 @@ trait ManagesFrequencies
         $segments = explode(':', $time);
 
         return $this->hourBasedSchedule(
-            count($segments) === 2 ? (int) $segments[1] : '0',
+            count($segments) >= 2 ? (int) $segments[1] : '0',
             (int) $segments[0]
         );
     }

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -48,6 +48,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('8 13 * * *', $this->event->dailyAt('13:08')->getExpression());
     }
 
+    public function testDailyAtParsesMinutesAndIgnoresSecondsWhenSecondsAreDefined()
+    {
+        $this->assertSame('8 13 * * *', $this->event->dailyAt('13:08:10')->getExpression());
+    }
+
     public function testTwiceDaily()
     {
         $this->assertSame('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());


### PR DESCRIPTION
Re-submission of: https://github.com/laravel/framework/pull/56304

## Summary

This pull request updates the scheduler `dailyAt()` method to correctly handle time strings that include seconds. Previously, when a time string like `13:08:10` was passed, the method would default the minutes to `0` because it only checked for exactly two segments. This could lead to unexpected behavior.

**Before:**
```php
Schedule::command('myTask')->dailyAt('13:08:10'); // Results in "0 13 * * *"
```

**After:**
```php
Schedule::command('myTask')->dailyAt('13:08:10'); // Correctly results in "8 13 * * *"
```

## Benefits to End Users

- Developers can now use time strings in `HH:MM:SS` format **without accidentally resetting minutes to zero**.


## Why It Doesn’t Break Existing Features
- Existing functionality for `HH:MM` inputs remains unchanged.
- Additional handling for `HH:MM:SS` inputs extends the feature without modifying existing behavior.
