### PR TITLE
 [12.x] Improve `db:seed` command output formatting and add database connection name with `-v` option

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -85,7 +85,7 @@ class SeedCommand extends Command
 
         $this->output?->writeln('');
 
-        Model::unguarded(fn() => $seeder->__invoke());
+        Model::unguarded(fn () => $seeder->__invoke());
 
         $runTime = number_format((microtime(true) - $startTime) * 1000);
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -70,9 +70,11 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
+        $seeder = $this->getSeeder();
+
         $startTime = microtime(true);
 
-        $name = get_class($this->getSeeder());
+        $name = get_class($seeder);
 
         with(new TwoColumnDetail($this->output))->render(
             $isVerbose
@@ -83,8 +85,8 @@ class SeedCommand extends Command
 
         $this->output?->writeln('');
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
+        Model::unguarded(function () use ($seeder) {
+            $seeder->__invoke();
         });
 
         $runTime = number_format((microtime(true) - $startTime) * 1000);

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -85,9 +85,7 @@ class SeedCommand extends Command
 
         $this->output?->writeln('');
 
-        Model::unguarded(function () use ($seeder) {
-            $seeder->__invoke();
-        });
+        Model::unguarded(fn() => $seeder->__invoke());
 
         $runTime = number_format((microtime(true) - $startTime) * 1000);
 


### PR DESCRIPTION
This PR continues the work started in laravel/framework#56310, improving `php artisan db:seed` command output when using seeders, and adds the ability to show the database connection name next to each seeder when the `-v` flag is provided.

## Problem
When running `php artisan db:seed` command, if `DatabaseSeeder.php` calls multiple seeders using `$this->call()`, the output becomes difficult to follow. Specifically, the `RUNNING` and `DONE` lines from seeders appear in the middle of the `Database\Seeders\DatabaseSeeder` progress line:

Example (current behavior):

```php
class DatabaseSeeder extends Seeder
{
    /**
     * Seed the application's database.
     *
     * @return void
     */
    public function run()
    {
        $this->call([
            TestSeeder::class,
            TestSeeder2::class,
        ]);
    }
}
```

```shell
INFO  Seeding database.

  Database\Seeders\DatabaseSeeder   Database\Seeders\TestSeeder .......................................................... RUNNING
  Database\Seeders\TestSeeder .......................................................... 0 ms DONE
  Database\Seeders\TestSeeder2 .......................................................... RUNNING
  Database\Seeders\TestSeeder2 .......................................................... 0 ms DONE
.................................................................................................. 3.12ms DONE
```

## Solution
- Adjust `SeedCommand.php` so that output lines for seeders are clearly separated.
- Ensure each seeder's `RUNNING` and `DONE` messages wrap its own execution.
- Add display of the database connection name next to the seeder class when running with `-v` mode.

Example (improved behavior):

```shell
INFO  Seeding database.

  Database\Seeders\DatabaseSeeder .................................................................. RUNNING

  Database\Seeders\TestSeeder ...................................................................... RUNNING
  Database\Seeders\TestSeeder ...................................................................... 0 ms DONE

  Database\Seeders\TestSeeder2 ..................................................................... RUNNING
  Database\Seeders\TestSeeder2 ..................................................................... 0 ms DONE

  Database\Seeders\DatabaseSeeder .................................................................. 5 ms DONE
```

With `-v` flag:

```shell
INFO  Seeding database.

  Database\Seeders\DatabaseSeeder mysql ............................................................ RUNNING

  Database\Seeders\TestSeeder ...................................................................... RUNNING
  Database\Seeders\TestSeeder ...................................................................... 0 ms DONE

  Database\Seeders\TestSeeder2 ..................................................................... RUNNING
  Database\Seeders\TestSeeder2 ..................................................................... 0 ms DONE

  Database\Seeders\DatabaseSeeder mysql .......................................................... 4 ms DONE
  ```
  
## Benefits:
- Cleaner CLI output for developers running seeders.
- Easier debugging and monitoring of which seeders ran and on which connection (especially useful in multi-database environments).
