### PR TITLE
Fixes bug with ShouldBeUniqueUntilProcessing locks getting stuck due to Middleware

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -117,27 +117,23 @@ class CallQueuedHandler
 
         $lockReleased = false;
 
-        $then = function ($command) use ($job, &$lockReleased) {
-            if ($command instanceof ShouldBeUniqueUntilProcessing) {
-                $this->ensureUniqueJobLockIsReleased($command);
-                $lockReleased = true;
-            }
-
-            return $this->dispatcher->dispatchNow(
-                $command, $this->resolveHandler($job, $command)
-            );
-        };
-
-        $finally = function ($command) use (&$lockReleased) {
-            if (! $lockReleased && $command instanceof ShouldBeUniqueUntilProcessing) {
-                $this->ensureUniqueJobLockIsReleased($command);
-            }
-        };
-
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
-            ->finally($finally)
-            ->then($then);
+            ->finally(function ($command) use (&$lockReleased) {
+                if (! $lockReleased && $command instanceof ShouldBeUniqueUntilProcessing) {
+                    $this->ensureUniqueJobLockIsReleased($command);
+                }
+            })
+            ->then(function ($command) use ($job, &$lockReleased) {
+                if ($command instanceof ShouldBeUniqueUntilProcessing) {
+                    $this->ensureUniqueJobLockIsReleased($command);
+                    $lockReleased = true;
+                }
+
+                return $this->dispatcher->dispatchNow(
+                    $command, $this->resolveHandler($job, $command)
+                );
+            });
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -120,7 +120,7 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
             ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
             ->finally(function ($command) use (&$lockReleased) {
-                if (! $lockReleased && $command instanceof ShouldBeUniqueUntilProcessing) {
+                if (! $lockReleased && $command instanceof ShouldBeUniqueUntilProcessing && ! $command->job->isReleased()) {
                     $this->ensureUniqueJobLockIsReleased($command);
                 }
             })

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -127,6 +127,7 @@ class CallQueuedHandler
             ->then(function ($command) use ($job, &$lockReleased) {
                 if ($command instanceof ShouldBeUniqueUntilProcessing) {
                     $this->ensureUniqueJobLockIsReleased($command);
+
                     $lockReleased = true;
                 }
 


### PR DESCRIPTION
This PR addresses https://github.com/laravel/framework/issues/56317

The `finally()` method was added to the pipeline, and a variable indicating whether a job was successfully unlocked so we aren't blindly calling it. 
