### PR TITLE
[12.x] Make `Boolean:strict` validation case-insensitive for parameter value

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -493,7 +493,7 @@ trait ValidatesAttributes
     {
         $acceptable = [true, false, 0, 1, '0', '1'];
 
-        if (strtolower($parameters[0] ?? null) === 'strict') {
+        if (isset($parameters[0]) && strtolower($parameters[0]) === 'strict') {
             $acceptable = [true, false];
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -493,7 +493,7 @@ trait ValidatesAttributes
     {
         $acceptable = [true, false, 0, 1, '0', '1'];
 
-        if (($parameters[0] ?? null) === 'strict') {
+        if (strtolower($parameters[0] ?? null) === 'strict') {
             $acceptable = [true, false];
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3154,6 +3154,44 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateBooleanStrictWithUpperCase()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => false], ['foo' => 'Boolean:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => true], ['foo' => 'Boolean:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, [], ['foo' => 'Boolean:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 0], ['foo' => 'Boolean:STRICT']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateBool()
     {
         $trans = $this->getIlluminateArrayTranslator();
@@ -3226,6 +3264,44 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Bool:strict']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateBoolStrictWithUpperCase()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => false], ['foo' => 'Bool:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => true], ['foo' => 'Bool:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Bool']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, [], ['foo' => 'Bool:STRICT']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 1], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0'], ['foo' => 'Bool:STRICT']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 0], ['foo' => 'Bool:STRICT']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
## Changes
- Adjusts the `validateBoolean()` method in `ValidatesAttributes` to handle `strict` parameter value in a case-insensitive manner.
- Supports values like `Boolean:STRICT` or `Boolean:Strict`.

## Why?
Currently, `Boolean:strict` validation is case-sensitive.
If a developer uses `Boolean:STRICT` (or any other casing variation like `BOOLEAN:STRICT`) — which is a common habit when writing validation rules — the validation silently falls back to `non-strict` behavior instead of producing an error.

## Examples
```php
$v = new Validator($trans, ['foo' => true], ['foo' => 'Boolean:strict']); // Passes
$v = new Validator($trans, ['foo' => true], ['foo' => 'Boolean:STRICT']); // Now also passes
$v = new Validator($trans, ['foo' => '1'], ['foo' => 'Boolean:STRICT']);  // Fails as expected
```
