### PR TITLE
[12.x] Update PHPDoc annotations in `Validation`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1118,7 +1118,7 @@ trait ValidatesAttributes
      *
      * @param  array<int, int|string>  $parameters
      * @param  string  $attribute
-     * @return bool
+     * @return int|string
      */
     public function getQueryColumn($parameters, $attribute)
     {

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -250,7 +250,7 @@ class Rule
     /**
      * Get an "any of" rule builder instance.
      *
-     * @param  array
+     * @param  array  $rules
      * @return \Illuminate\Validation\Rules\AnyOf
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -19,7 +19,7 @@ class ArrayRule implements Stringable
     /**
      * Create a new array rule instance.
      *
-     * @param  array|null  $keys
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|null  $keys
      */
     public function __construct($keys = null)
     {


### PR DESCRIPTION
This PR update 3 PHPDoc annotations for clarity and accuracy
- add `$rules` in `Rule.php`
- change `bool` to `string` in `getQueryColumn` function
- add `Arrayable` in `ArrayRule.php`