### PR TITLE
[12.x] Refactor Unify DocBlock return types for functions with possib…

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -654,7 +654,7 @@ class Gate implements GateContract
      * Get a policy instance for a given class.
      *
      * @param  object|string  $class
-     * @return mixed
+     * @return mixed|void
      */
     public function getPolicyFor($class)
     {
@@ -805,7 +805,7 @@ class Gate implements GateContract
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string  $ability
      * @param  array  $arguments
-     * @return mixed
+     * @return mixed|void
      */
     protected function callPolicyBefore($policy, $user, $ability, $arguments)
     {
@@ -825,7 +825,7 @@ class Gate implements GateContract
      * @param  string  $method
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $arguments
-     * @return mixed
+     * @return mixed|void
      */
     protected function callPolicyMethod($policy, $method, $user, array $arguments)
     {

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -200,7 +200,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Pull a user from the repository by its "remember me" cookie token.
      *
      * @param  \Illuminate\Auth\Recaller  $recaller
-     * @return mixed
+     * @return mixed|void
      */
     protected function userFromRecaller($recaller)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -231,7 +231,7 @@ trait HasEvents
      *
      * @param  string  $event
      * @param  string  $method
-     * @return mixed|null
+     * @return mixed|void
      */
     protected function fireCustomModelEvent($event, $method)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -530,7 +530,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Filter the given array of files, removing any empty values.
      *
      * @param  mixed  $files
-     * @return mixed
+     * @return mixed|void
      */
     protected function filterFiles($files)
     {


### PR DESCRIPTION
Some functions in Laravel have a return type of mixed, while the function may also work as void. To make this clearer, I changed the Doc Blocks to be more explicit. Although I have seen that in one place in the framework this situation is written as `mixed|null`, in my opinion it is better to have a consistent style everywhere, meaning either use `mixed|void` or `mixed|null`. 
If this style is not correct, please let me know so I can change it to something else.

Sample One:
https://github.com/laravel/framework/blob/2c682e4eb531eae6439579f25d29429ecc0a66ca/src/Illuminate/Console/Concerns/InteractsWithIO.php#L248-L278

Sample Two:
https://github.com/laravel/framework/blob/2c682e4eb531eae6439579f25d29429ecc0a66ca/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php#L229-L247
