### PR TITLE
[12.x] Add `domain()` and `subdomain()` methods to `Illuminate\Support\Uri` class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -170,6 +170,30 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Get the domain from the URI.
+     */
+    public function domain(): ?string
+    {
+        if (! $host = $this->host()) {
+            return null;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return null;
+        }
+
+        if (count($parts = explode('.', $host)) < 2) {
+            return null;
+        }
+
+        if (count($parts) >= 3) {
+            return implode('.', array_slice($parts, 1));
+        }
+
+        return $host;
+    }
+
+    /**
      * Get the URI's port.
      */
     public function port(): ?int

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -150,6 +150,26 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Get the subdomain from the URI.
+     */
+    public function subdomain(): ?string
+    {
+        if (! $host = $this->host()) {
+            return null;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return null;
+        }
+
+        if (count($parts = explode('.', $host)) < 3) {
+            return null;
+        }
+
+        return $parts[0];
+    }
+
+    /**
      * Get the URI's port.
      */
     public function port(): ?int

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -221,6 +221,51 @@ class SupportUriTest extends TestCase
         $this->assertEquals(3, $uri->pathSegments()->count());
     }
 
+    public function test_subdomain_extraction()
+    {
+        $uri = Uri::of('https://api.laravel.com');
+        $this->assertEquals('api', $uri->subdomain());
+
+        $uri = Uri::of('https://www.laravel.com');
+        $this->assertEquals('www', $uri->subdomain());
+
+        $uri = Uri::of('https://admin.dashboard.laravel.com');
+        $this->assertEquals('admin', $uri->subdomain());
+
+        $uri = Uri::of('https://laravel.com');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('https://example.org');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('https://192.168.1.1');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('http://127.0.0.1:8080');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('http://localhost');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('http://localhost:3000');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('/path/only');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('');
+        $this->assertNull($uri->subdomain());
+
+        $uri = Uri::of('https://staging.api.laravel.com');
+        $this->assertEquals('staging', $uri->subdomain());
+
+        $uri = Uri::of('https://test-env.laravel.com');
+        $this->assertEquals('test-env', $uri->subdomain());
+
+        $uri = Uri::of('https://example.co.uk');
+        $this->assertEquals('example', $uri->subdomain());
+    }
+
     public function test_macroable()
     {
         Uri::macro('myMacro', function () {

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -266,6 +266,54 @@ class SupportUriTest extends TestCase
         $this->assertEquals('example', $uri->subdomain());
     }
 
+    public function test_domain_extraction()
+    {
+        $uri = Uri::of('https://api.laravel.com');
+        $this->assertEquals('laravel.com', $uri->domain());
+
+        $uri = Uri::of('https://www.laravel.com');
+        $this->assertEquals('laravel.com', $uri->domain());
+
+        $uri = Uri::of('https://admin.dashboard.laravel.com');
+        $this->assertEquals('dashboard.laravel.com', $uri->domain());
+
+        $uri = Uri::of('https://laravel.com');
+        $this->assertEquals('laravel.com', $uri->domain());
+
+        $uri = Uri::of('https://example.org');
+        $this->assertEquals('example.org', $uri->domain());
+
+        $uri = Uri::of('https://192.168.1.1');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('http://127.0.0.1:8080');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('http://localhost');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('http://localhost:3000');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('/path/only');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('');
+        $this->assertNull($uri->domain());
+
+        $uri = Uri::of('https://staging.api.laravel.com');
+        $this->assertEquals('api.laravel.com', $uri->domain());
+
+        $uri = Uri::of('https://test-env.example.co.uk');
+        $this->assertEquals('example.co.uk', $uri->domain());
+
+        $uri = Uri::of('https://example.co.uk');
+        $this->assertEquals('co.uk', $uri->domain());
+
+        $uri = Uri::of('https://hostname');
+        $this->assertNull($uri->domain());
+    }
+
     public function test_macroable()
     {
         Uri::macro('myMacro', function () {


### PR DESCRIPTION
### Description

This PR adds two new methods to the `Illuminate\Support\Uri` class to handle extracting the domain and subdomain components from URIs. This does simple parsing without using any external service, so there are edge cases listed below where the incorrect domain/subdomain will be retrieved.

### Usage

`domain()`:

```php
Uri::of('https://api.laravel.com')->domain(); // 'laravel.com'
Uri::of('https://laravel.com')->domain(); // 'laravel.com'
```

`subdomain()`:

```php
Uri::of('https://api.laravel.com')->subdomain(); // 'api'
Uri::of('https://laravel.com')->subdomain(); // null
```

### Resolved Edge Cases

- Invalid hostnames return `null`
- IP addresses and `localhost` return `null`
- Multi-level subdomains are handled correctly

### Unsolved Edge Cases

- Public suffix domains like `user.github.io` return `user` as subdomain
- Country-code/multipart domains like `example.co.uk` returns `example` as subdomain and `co.uk` as domain