### PR TITLE
[12.x] Add support for expected exit codes in the scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 
 trait ManagesAttributes
@@ -98,6 +99,13 @@ trait ManagesAttributes
     public $description;
 
     /**
+     * The allowed exit codes additional to 0.
+     *
+     * @var array|true
+     */
+    public array|true $allowExitCodes = [];
+
+    /**
      * Set which user the command should run as.
      *
      * @param  string  $user
@@ -106,6 +114,31 @@ trait ManagesAttributes
     public function user($user)
     {
         $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Set which exit codes should be accepted additional to 0.
+     *
+     * @param  int|array  $exitCode
+     * @return $this
+     */
+    public function allowExitCode(int|array $exitCode): static
+    {
+        $this->allowExitCodes = Arr::wrap($exitCode);
+
+        return $this;
+    }
+
+    /**
+     * Accept all exit codes as successful.
+     *
+     * @return $this
+     */
+    public function allowFailure(): static
+    {
+        $this->allowExitCodes = true;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -203,7 +203,7 @@ class ScheduleRunCommand extends Command
 
                 $this->eventsRan = true;
 
-                if ($event->exitCode != 0 && ! $event->runInBackground) {
+                if ($this->shouldFailOnExitCode($event) && ! $event->runInBackground) {
                     throw new Exception("Scheduled command [{$event->command}] failed with exit code [{$event->exitCode}].");
                 }
             } catch (Throwable $e) {
@@ -285,5 +285,18 @@ class ScheduleRunCommand extends Command
     protected function clearInterruptSignal()
     {
         $this->cache->forget('illuminate:schedule:interrupt');
+    }
+
+    /**
+     * Determine if the scheduled command should be considered failed based on its exit code.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return bool
+     */
+    protected function shouldFailOnExitCode(Event $event): bool
+    {
+        return $event->allowExitCodes !== true &&
+               $event->exitCode != 0 &&
+               ! in_array($event->exitCode, $event->allowExitCodes);
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Exception;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\Events\ScheduledTaskFailed;
@@ -204,7 +203,7 @@ class ScheduleRunCommand extends Command
                 $this->eventsRan = true;
 
                 if ($this->shouldFailOnExitCode($event) && ! $event->runInBackground) {
-                    throw new Exception("Scheduled command [{$event->command}] failed with exit code [{$event->exitCode}].");
+                    throw new UnexpectedExitCodeException($event->command, $event->exitCode);
                 }
             } catch (Throwable $e) {
                 $this->dispatcher->dispatch(new ScheduledTaskFailed($event, $e));

--- a/src/Illuminate/Console/Scheduling/UnexpectedExitCodeException.php
+++ b/src/Illuminate/Console/Scheduling/UnexpectedExitCodeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use RuntimeException;
+
+class UnexpectedExitCodeException extends RuntimeException
+{
+    public function __construct(public string $command, public int $exitCode)
+    {
+        parent::__construct("Scheduled command [{$command}] failed with exit code [{$exitCode}].");
+    }
+}


### PR DESCRIPTION
### Description

Scheduled command return code checking was introduced in #55624, however sometimes non 0 return codes can also be considered successful (especially when running external programs with the `exec` call)

### Solution

This PR introduces two new methods on the scheduled event:
- `allowExitCode` which can be used to allow additional exit code(s) for the command
- `allowFailures` which can be used to accept all exit codes

Additionally a new exception is also introduced for the unexpected exit codes so it could be handled in the exception handler.

#### Examples
```php
// Considered successful if exit code is 0 or 1
$schedule->command('app:first')->daily()->allowExitCode(1);

// Considered successful if exit code is 0, 2 or 12
$schedule->command('app:first')->daily()->allowExitCode([2, 12]);

// All exit codes considered successful 
$schedule->command('app:first')->daily()->allowFailure();
```


### Backwards compatibility

- Without explicitly allowing exit codes the functionality is the same.
- The new exception extends RuntimeException, and uses the same message so any existing exception handling should also work after this PR

---

If required I can also make a PR for the docs after this is merged. Please also let me know if any naming should be changed or any type hints should be removed.