### PR TITLE
[12.x] Add `deleteLastLines` method to the `InteractsWithIO` trait

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -458,4 +458,17 @@ trait InteractsWithIO
     {
         return $this->components;
     }
+
+    /**
+     * Delete the last written lines.
+     *
+     * @param  positive-int  $count
+     * @return void
+     */
+    public function deleteLastLines($count = 1)
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->output->write("\x1b[1A\x1b[1G\x1b[2K");
+        }
+    }
 }


### PR DESCRIPTION
Laravel offers nice handy methods to print text into the console like: `info`, `error`, etc, when it comes to writing console commands, but there is no easy way of deleting what is no longer needed and cleaning up the console output.  

### How it works:
The code comes from the `Symfony\Component\Console\Cursor` class, which is used by the progress bar to delete and re-print the bar as it advances. (see `moveToColumn`, `clearLine`, and `moveUp` methods.)
Here, we actually do three consecutive steps to delete each line:
1 - `\x1b[1A`   Moves the cursor up one line.
2 - `\x1b[1G` Moves the cursor to the beginning of the line (column 1).
3 - `\x1b[2K` Clears the entire line.

### Use cases:
- This method can also be used internally by Laravel to remove the prompt question after the user answers.