### PR TITLE
feat(support): add config option to skip transliteration in Str::slug

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -112,6 +112,31 @@ return [
     */
 
     'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Skip Transliteration for Specific Languages
+    |--------------------------------------------------------------------------
+    |
+    | This option lets you specify a comma-separated list of language codes
+    | (ISO 639-1 or 639-2) for which Str::slug will skip ASCII transliteration.
+    | For these languages, the slug will preserve native (Unicode) characters.
+    |
+    | This is useful for applications that require slugs to retain
+    | characters in scripts like Arabic, Persian, Urdu, etc.
+    |
+    | To configure, set APP_SLUG_SKIP_TRANSLITERATION in your .env file.
+    |
+    | Example .env:
+    | APP_SLUG_SKIP_TRANSLITERATION=ar,fa,ur,ps
+    |
+    */
+
+    'slug_skip_transliteration' => [
+        ...array_filter(
+            explode(',', (string) env('APP_SLUG_SKIP_TRANSLITERATION', ''))
+        ),
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -112,7 +112,7 @@ return [
     */
 
     'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Skip Transliteration for Specific Languages

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1533,6 +1533,13 @@ class Str
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
     {
+        // Get the list of languages to skip transliteration from config
+        $skipLanguages = config('app.slug_skip_transliteration', []);
+
+        // If the current language is in the skip list, keep native characters
+        if (in_array($language, $skipLanguages)) {
+            $language = ''; // Disable transliteration for this language
+        }
         $title = $language ? static::ascii($title, $language) : $title;
 
         // Convert all dashes/underscores into separator


### PR DESCRIPTION
##  Summary

This pull request introduces a new configuration option `slug_skip_transliteration` that allows developers to define a list of language codes for which `Str::slug` will **skip ASCII transliteration**.

For these languages, native Unicode characters are preserved in generated slugs instead of being converted to ASCII. This provides better support for multilingual applications and enhances readability for languages that use non-Latin scripts.

For all other languages not listed in the configuration, the original transliteration behavior remains unchanged.

---

##  Changes

- Added `slug_skip_transliteration` configuration key in `config/app.php`
- Supports defining a comma-separated list of ISO 639-1/639-2 language codes via `.env` using `APP_SLUG_SKIP_TRANSLITERATION`
- Updated `Str::slug()` to check this configuration before applying transliteration
- Preserves native scripts (e.g., Arabic, Persian, Urdu) for specified languages

---

##  Example Configuration

### .env
```dotenv
APP_SLUG_SKIP_TRANSLITERATION=ar,fa,ur
```

### config/app.php
```php
'slug_skip_transliteration' => [
    ...array_filter(
        explode(',', (string) env('APP_SLUG_SKIP_TRANSLITERATION', ''))
    ),
],
```

---

##  Usage Examples

| Input                      | Language | Config                   | Result                 |
|----------------------------|----------|--------------------------|------------------------|
| مرحبا بك في Laravel        | ar       | ar,fa,ur                 | مرحبا-بك-في-laravel    |
| سلام دنیا                  | fa       | ar,fa,ur                 | سلام-دنیا              |
| Привет мир                 | ru       | ar,fa,ur                 | privet-mir             |
| Laravel is Awesome!        | en       | ar,fa,ur                 | laravel-is-awesome     |

---

##  Why?

Many Laravel developers working with Arabic-script or other non-Latin languages need slugs to preserve native characters for better readability and SEO in their target audience’s language.

Previously, `Str::slug` always applied ASCII transliteration, which removed native characters for these languages. This change gives developers the flexibility to control which languages should skip transliteration.

---

##  Backward Compatibility

This change is fully backward compatible.  

- If `slug_skip_transliteration` is **not set** in `.env` or left empty, `Str::slug` behaves exactly as before.
- Only languages explicitly listed in `slug_skip_transliteration` are affected.

---

##  Related Improvements

This enhancement extends the flexibility of `Str::slug()` for multilingual and internationalized Laravel applications.

---

## 🏁 Summary of Behavior

- ✅ **Languages in skip list:** Native characters preserved
- ✅ **Languages not in skip list:** ASCII transliteration applied
- ✅ **No config set:** Default Laravel behavior remains
