### PR TITLE
[12.x] Add Singleton and Scoped attributes to Container

### DIFF
--- a/src/Illuminate/Container/Attributes/Scoped.php
+++ b/src/Illuminate/Container/Attributes/Scoped.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Scoped
+{
+}

--- a/src/Illuminate/Container/Attributes/Singleton.php
+++ b/src/Illuminate/Container/Attributes/Singleton.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Singleton
+{
+}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -269,10 +269,6 @@ class Container implements ArrayAccess, ContainerContract
         $reflection = new ReflectionClass($abstract);
 
         if (! empty($reflection->getAttributes(Singleton::class))) {
-            if (! in_array($abstract, $this->instances, true)) {
-                $this->instances[] = $abstract;
-            }
-
             return true;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -269,6 +269,10 @@ class Container implements ArrayAccess, ContainerContract
         $reflection = new ReflectionClass($abstract);
 
         if (! empty($reflection->getAttributes(Singleton::class))) {
+            if (! in_array($abstract, $this->instances, true)) {
+                $this->instances[] = $abstract;
+            }
+
             return true;
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Container;
 
 use Attribute;
+use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -740,6 +742,30 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationStub::class, $result);
     }
 
+    public function testContainerSingletonAttribute()
+    {
+        $container = new Container;
+        $firstInstantiation = $container->get(ContainerSingletonAttribute::class);
+
+        $secondInstantiation = $container->get(ContainerSingletonAttribute::class);
+
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+    }
+
+    public function testContainerScopedAttribute()
+    {
+        $container = new Container;
+        $firstInstantiation = $container->get(ContainerScopedAttribute::class);
+        $secondInstantiation = $container->get(ContainerScopedAttribute::class);
+
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+
+        $container->forgetScopedInstances();
+
+        $thirdInstantiation = $container->get(ContainerScopedAttribute::class);
+        $this->assertNotSame($firstInstantiation, $thirdInstantiation);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -898,4 +924,14 @@ class ContainerCurrentResolvingConcrete
     ) {
         $this->currentlyResolving = $currentlyResolving;
     }
+}
+
+#[Singleton]
+class ContainerSingletonAttribute
+{
+}
+
+#[Scoped]
+class ContainerScopedAttribute
+{
 }


### PR DESCRIPTION
## Changes

This adds two new attributes to the container attributes: `#[Singleton]` & `#[Scoped]`. These can be added directly to a class you're resolving through the container, without needing to manually register them as a singleton or scoped instance through the container.

```php
#[Singleton]
class MyService {
}
```
