### PR TITLE
[12.x] Add acronym to strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -766,6 +766,28 @@ class Str
     }
 
     /**
+     * Converts the given string into an acronym.
+     *
+     * @param  string  $string
+     * @param  string  $separator
+     * @return string
+     */
+    public static function acronym($string, $separator = '')
+    {
+        if (empty($string)) {
+            return '';
+        }
+
+        $separator = in_array($separator, ['.', '-', '_', '/', ' ']) ? $separator : '';
+
+        preg_match_all('/\b[a-zA-Z]/', $string, $matches);
+
+        $acronym = implode($separator, $matches[0]);
+
+        return static::upper($acronym);
+    }
+
+    /**
      * Converts GitHub flavored Markdown into HTML.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1305,6 +1305,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Converts the given string into an acronym.
+     *
+     * @param  string  $separator
+     * @return static
+     */
+    public function acronym($separator = '')
+    {
+        return new static(Str::acronym($this->value, $separator));
+    }
+
+    /**
      * Get the number of words a string contains.
      *
      * @param  string|null  $characters

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1883,7 +1883,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
 
-    public function testAcronym() : void
+    public function testAcronym()
     {
         $this->assertSame('ASAP', Str::acronym('As soon as possible'));
         $this->assertSame('A.S.A.P', Str::acronym('As soon as possible', '.'));
@@ -1897,9 +1897,9 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('L', Str::acronym('laravel'));
         $this->assertSame('L', Str::acronym('laravel', '.'));
-        
+
         $this->assertSame('L', Str::acronym('l', '.'));
-        
+
         $this->assertSame('', Str::acronym(''));
         $this->assertSame('', Str::acronym(null));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1882,6 +1882,27 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testAcronym() : void
+    {
+        $this->assertSame('ASAP', Str::acronym('As soon as possible'));
+        $this->assertSame('A.S.A.P', Str::acronym('As soon as possible', '.'));
+        $this->assertSame('A-S-A-P', Str::acronym('As soon as possible', '-'));
+        $this->assertSame('A_S_A_P', Str::acronym('As soon as possible', '_'));
+        $this->assertSame('A/S/A/P', Str::acronym('As soon as possible', '/'));
+        $this->assertSame('A S A P', Str::acronym('As soon as possible', ' '));
+
+        // Unaccepted separator
+        $this->assertSame('ASAP', Str::acronym('As soon as possible', '*'));
+
+        $this->assertSame('L', Str::acronym('laravel'));
+        $this->assertSame('L', Str::acronym('laravel', '.'));
+        
+        $this->assertSame('L', Str::acronym('l', '.'));
+        
+        $this->assertSame('', Str::acronym(''));
+        $this->assertSame('', Str::acronym(null));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1562,4 +1562,25 @@ class SupportStringableTest extends TestCase
         $this->assertNotSame('foo', $encrypted->value());
         $this->assertSame('foo', $encrypted->decrypt()->value());
     }
+
+    public function testAcronym() : void
+    {
+        $this->assertSame('ASAP', $this->stringable('As soon as possible')->acronym()->toString());
+        $this->assertSame('A.S.A.P', $this->stringable('As soon as possible')->acronym('.')->toString());
+        $this->assertSame('A-S-A-P', $this->stringable('As soon as possible')->acronym('-')->toString());
+        $this->assertSame('A_S_A_P', $this->stringable('As soon as possible')->acronym('_')->toString());
+        $this->assertSame('A/S/A/P', $this->stringable('As soon as possible')->acronym('/')->toString());
+        $this->assertSame('A S A P', $this->stringable('As soon as possible')->acronym(' ')->toString());
+
+        // Unaccepted separator
+        $this->assertSame('ASAP', $this->stringable('As soon as possible')->acronym('*')->toString());
+
+        $this->assertSame('L', $this->stringable('laravel')->acronym()->toString());
+        $this->assertSame('L', $this->stringable('laravel')->acronym('.')->toString());
+        
+        $this->assertSame('L', $this->stringable('l')->acronym('.')->toString());
+        
+        $this->assertSame('', $this->stringable('')->acronym()->toString());
+        $this->assertSame('', $this->stringable(null)->acronym()->toString());
+    }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1563,7 +1563,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo', $encrypted->decrypt()->value());
     }
 
-    public function testAcronym() : void
+    public function testAcronym()
     {
         $this->assertSame('ASAP', $this->stringable('As soon as possible')->acronym()->toString());
         $this->assertSame('A.S.A.P', $this->stringable('As soon as possible')->acronym('.')->toString());
@@ -1577,9 +1577,9 @@ class SupportStringableTest extends TestCase
 
         $this->assertSame('L', $this->stringable('laravel')->acronym()->toString());
         $this->assertSame('L', $this->stringable('laravel')->acronym('.')->toString());
-        
+
         $this->assertSame('L', $this->stringable('l')->acronym('.')->toString());
-        
+
         $this->assertSame('', $this->stringable('')->acronym()->toString());
         $this->assertSame('', $this->stringable(null)->acronym()->toString());
     }


### PR DESCRIPTION
This PR introduces a method that converts a given string into its acronym, with support for customizable separators.

Accepted separators: `['.', '-', '_', '/', ' ']`

```php
Str::acronym('As soon as possible');         // 'ASAP'
Str::acronym('As soon as possible', '.');    // 'A.S.A.P'
```
