### PR TITLE
[12.x] Consistent use of `mb_split()` to split strings into words

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1449,7 +1449,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = explode(' ', $value);
+        $parts = mb_split('/\s+/', $value);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1482,7 +1482,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $words = mb_split('/\s+/', $value);
 
         for ($i = 0; $i < count($words); $i++) {
             $lowercaseWord = mb_strtolower($words[$i]);
@@ -1697,7 +1697,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = explode(' ', static::replace(['-', '_'], ' ', $value));
+        $words = mb_split('/\s+/', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1449,7 +1449,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = mb_split('/\s+/', $value);
+        $parts = mb_split('\s+', $value);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1482,7 +1482,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = mb_split('/\s+/', $value);
+        $words = mb_split('\s+', $value);
 
         for ($i = 0; $i < count($words); $i++) {
             $lowercaseWord = mb_strtolower($words[$i]);
@@ -1697,7 +1697,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = mb_split('/\s+/', static::replace(['-', '_'], ' ', $value));
+        $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 


### PR DESCRIPTION
# Situation
Currently, we split strings into words differently within `\Illuminate\Support\Str`

# Downsides
This can, theoretically, lead to
* different results
* more maintenance

# Change
This PR unifies the splitting of strings into words to always use `mb_split()` with the regular expression `/\s+/`

# Alternatives
* use of [`intl`](https://www.php.net/manual/en/class.intlbreakiterator.php)
```php
    public static function extractWords($value, $locale = 'en')
    {
        $wordBreakIterator = IntlBreakIterator::createWordInstance($locale);
        $wordBreakIterator->setText($value);
        
        return array_filter([ ...$wordBreakIterator->getPartsIterator() ], trim(...));
    }
```
* split at ~word boundaries (`\b`)~ non-word characters (`\W+`)
<details>
<summary>patch</summary>

```patch
diff --git a/src/Illuminate/Support/Str.php b/src/Illuminate/Support/Str.php
index ffe670f6f9c5..consistent-word-splitting-in-string-helper 100644
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1449,7 +1449,7 @@ public static function title($value)
      */
     public static function headline($value)
     {
-        $parts = mb_split('\s+', $value);
+        $parts = mb_split('\W+', $value);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1482,7 +1482,7 @@ public static function apa($value)
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = mb_split('\s+', $value);
+        $words = mb_split('\W+', $value);
 
         for ($i = 0; $i < count($words); $i++) {
             $lowercaseWord = mb_strtolower($words[$i]);
@@ -1697,7 +1697,7 @@ public static function studly($value)
             return static::$studlyCache[$key];
         }
 
-        $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
+        $words = mb_split('\W+', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
```

</details>

# Follow-ups
* Extracting the functionality into a separate function ("`words()`" would be a good fit but this is, unfortunately, already in use; maybe `mb_split_words()` 🤔)
    * **Pro:** If made _public_, it can be used separately