### PR TITLE
[12.x] Add hasMailer method to the mailable class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1812,6 +1812,17 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the mailable will be sent by the given mailer.
+     *
+     * @param  string  $mailer
+     * @return bool
+     */
+    public function usesMailer($mailer)
+    {
+        return $this->mailer === $mailer;
+    }
+
+    /**
      * Set the name of the mailer that should send the message.
      *
      * @param  string  $mailer
@@ -1822,17 +1833,6 @@ class Mailable implements MailableContract, Renderable
         $this->mailer = $mailer;
 
         return $this;
-    }
-
-    /**
-     * Determine if the mailable will be sent by the given mailer or driver.
-     *
-     * @param  string  $mailer
-     * @return bool
-     */
-    public function hasMailer($mailer)
-    {
-        return $this->mailer === $mailer;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1825,6 +1825,17 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the mailable will be sent by the given mailer or driver.
+     *
+     * @param  string  $mailer
+     * @return bool
+     */
+    public function hasMailer($mailer)
+    {
+        return $this->mailer === $mailer;
+    }
+
+    /**
      * Register a callback to be called with the Symfony message instance.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -55,6 +55,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function __construct(MailManager $manager)
     {
         $this->manager = $manager;
+        $this->currentMailer = $manager->getDefaultDriver();
     }
 
     /**

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -573,11 +573,11 @@ class MailMailableTest extends TestCase
         $mailable = new WelcomeMailableStub;
 
         $mailable->mailer('array');
-        $this->assertTrue($mailable->hasMailer('array'));
+        $this->assertTrue($mailable->usesMailer('array'));
 
         $mailable->mailer('smtp');
-        $this->assertTrue($mailable->hasMailer('smtp'));
-        $this->assertFalse($mailable->hasMailer('ses'));
+        $this->assertTrue($mailable->usesMailer('smtp'));
+        $this->assertFalse($mailable->usesMailer('ses'));
     }
 
     public function testMailablePriorityGetsSent()

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -573,10 +573,11 @@ class MailMailableTest extends TestCase
         $mailable = new WelcomeMailableStub;
 
         $mailable->mailer('array');
+        $this->assertTrue($mailable->hasMailer('array'));
 
-        $mailable = unserialize(serialize($mailable));
-
-        $this->assertSame('array', $mailable->mailer);
+        $mailable->mailer('smtp');
+        $this->assertTrue($mailable->hasMailer('smtp'));
+        $this->assertFalse($mailable->hasMailer('ses'));
     }
 
     public function testMailablePriorityGetsSent()

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -31,7 +31,10 @@ class SupportTestingMailFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailManager = m::mock(MailManager::class);
+        $this->mailManager = m::mock(MailManager::class, function ($mock) {
+            $mock->shouldReceive('getDefaultDriver')
+                ->andReturn('smtp');
+        });
         $this->fake = new MailFake($this->mailManager);
         $this->mailable = new MailableStub;
     }
@@ -379,6 +382,33 @@ class SupportTestingMailFakeTest extends TestCase
         $this->mailManager->shouldReceive('foo')->andReturn('bar');
 
         $this->assertEquals('bar', $this->fake->foo());
+    }
+
+    public function testAssertMailer()
+    {
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasMailer('smtp');
+        });
+
+        $this->fake->mailer('ses')->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasMailer('ses');
+        });
+
+        $this->fake->mailer('sendgrid')->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
+            return $mail->hasMailer('sendgrid');
+        });
+
+        $this->fake->mailer('mailjet')->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
+            return $mail->hasMailer('mailjet');
+        });
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -389,25 +389,25 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class, function ($mail) {
-            return $mail->hasMailer('smtp');
+            return $mail->usesMailer('smtp');
         });
 
         $this->fake->mailer('ses')->to('taylor@laravel.com')->send($this->mailable);
 
         $this->fake->assertSent(MailableStub::class, function ($mail) {
-            return $mail->hasMailer('ses');
+            return $mail->usesMailer('ses');
         });
 
         $this->fake->mailer('sendgrid')->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class, function ($mail) {
-            return $mail->hasMailer('sendgrid');
+            return $mail->usesMailer('sendgrid');
         });
 
         $this->fake->mailer('mailjet')->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class, function ($mail) {
-            return $mail->hasMailer('mailjet');
+            return $mail->usesMailer('mailjet');
         });
     }
 }


### PR DESCRIPTION
We are migrating our emails from our current mailer, SES, to a new one, Sendgrid. Sendgrid has features that are more suitable for our business.

During this transition, which could be more than a month, I want to assert what emails are being sent by which driver in our test cases:

```php
Mail::assertQueued(OneTimePassword::class, function ($email) {
    return $email->hasMailer('sendgrid');
});

Mail::assertSent(OrderCompleted::class, function ($email) {
    return $email->hasMailer('ses');
});
```

I don't know any, but there could be businesses that use multiple drivers for emails.

With this change, I also want to set the `$currentMailer` to be the default driver in the `MailFake` class. I think this variable is currently always null, unless being set deliberately.


