### PR TITLE
[12.x] Add linkHeader() method to HTTP client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use GuzzleHttp\Psr7\Header;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -173,6 +173,7 @@ class Response implements ArrayAccess, Stringable
         $parsed = Header::parse($this->header($headerName));
         $links = array_reduce($parsed, function (array $carry, array $link) {
             $carry[$link['rel']][] = Uri::of(Str::unwrap($link['0'], '<', '>'));
+
             return $carry;
         }, []);
     }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -171,6 +171,7 @@ class Response implements ArrayAccess, Stringable
     public function linkHeader(string $headerName = 'Link'): array
     {
         $parsed = Header::parse($this->header($headerName));
+
         return array_reduce($parsed, function (array $carry, array $link) {
             $carry[$link['rel']][] = Uri::of(Str::unwrap($link['0'], '<', '>'));
 

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -164,9 +164,9 @@ class Response implements ArrayAccess, Stringable
 
     /**
      * Get the Link header fully parsed into an associative array with
-     * the `rel` as key and the URL as an Uri instance.
+     * the `rel` as key and the URL(s) as a list of Uri instances.
      *
-     * @return array<string, \Illuminate\Support\Uri>
+     * @return array<string, \Illuminate\Support\Uri[]>
      */
     public function linkHeader(string $headerName = 'Link'): array
     {

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -171,12 +171,10 @@ class Response implements ArrayAccess, Stringable
     public function linkHeader(string $headerName = 'Link'): array
     {
         $parsed = Header::parse($this->header($headerName));
-        $links = array_combine(
-            array_column($parsed, 'rel'),
-            array_column($parsed, '0'),
-        );
-
-        return array_map(fn (string $value) => Uri::of(Str::unwrap($value, '<', '>')), $links);
+        $links = array_reduce($parsed, function (array $carry, array $link) {
+            $carry[$link['rel']][] = Uri::of(Str::unwrap($link['0'], '<', '>'));
+            return $carry;
+        }, []);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -171,7 +171,7 @@ class Response implements ArrayAccess, Stringable
     public function linkHeader(string $headerName = 'Link'): array
     {
         $parsed = Header::parse($this->header($headerName));
-        $links = array_reduce($parsed, function (array $carry, array $link) {
+        return array_reduce($parsed, function (array $carry, array $link) {
             $carry[$link['rel']][] = Uri::of(Str::unwrap($link['0'], '<', '>'));
 
             return $carry;

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -6,7 +6,9 @@ use ArrayAccess;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use LogicException;
 use Stringable;
 
@@ -157,6 +159,23 @@ class Response implements ArrayAccess, Stringable
     public function headers()
     {
         return $this->response->getHeaders();
+    }
+
+    /**
+     * Get the Link header fully parsed into an associative array with
+     * the `rel` as key and the URL as an Uri instance
+     *
+     * @return array<string, \Illuminate\Support\Uri>
+     */
+    public function linkHeader(string $headerName = 'Link'): array
+    {
+        $parsed = Header::parse($this->header($headerName));
+        $links = array_combine(
+            array_column($parsed, 'rel'),
+            array_column($parsed, '0'),
+        );
+
+        return array_map(fn (string $value) => Uri::of(Str::unwrap($value, '<', '>')), $links);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -163,7 +163,7 @@ class Response implements ArrayAccess, Stringable
 
     /**
      * Get the Link header fully parsed into an associative array with
-     * the `rel` as key and the URL as an Uri instance
+     * the `rel` as key and the URL as an Uri instance.
      *
      * @return array<string, \Illuminate\Support\Uri>
      */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -34,6 +34,7 @@ use Illuminate\Support\Fluent;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
 use JsonSerializable;
 use Mockery as m;
 use OutOfBoundsException;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3778,7 +3778,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake([
             '*' => $this->factory::response(headers: [
-                'Link' => '<https:://example.com/posts/1>; rel="first", <https:://example.com/posts/2>; rel="prev", <https:://example.com/posts/3>; rel="current", <https:://example.com/posts/4>; rel="next", <https:://example.com/posts/42>; rel="last", <https:://example.com/posts/3/edit>; rel="edit"',
+                'Link' => '<https://example.com/posts/1>; rel="first", <https://example.com/posts/2>; rel="prev", <https://example.com/posts/3>; rel="current", <https://example.com/posts/4>; rel="next", <https://example.com/posts/42>; rel="last", <https://example.com/posts/3/edit>; rel="edit"',
             ]),
         ]);
 
@@ -3791,7 +3791,7 @@ class HttpClientTest extends TestCase
             'next' => Uri::of('https:://example.com/posts/4'),
             'last' => Uri::of('https:://example.com/posts/42'),
             'edit' => Uri::of('https:://example.com/posts/3/edit'),
-        )]);
+        ]);
     }
 
     public static function methodsReceivingArrayableDataProvider()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3792,7 +3792,7 @@ class HttpClientTest extends TestCase
             'next' => [Uri::of('https://example.com/posts/4')],
             'last' => [Uri::of('https://example.com/posts/42')],
             'edit' => [Uri::of('https://example.com/posts/3/edit')],
-            'author' => [Uri::of('https://example.com/authors/jane-doe'), Uri::of('https://example.com/authors/jane-doe')],
+            'author' => [Uri::of('https://example.com/authors/jane-doe'), Uri::of('https://example.com/authors/john-doe')],
         ], $response->linkHeader());
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3786,12 +3786,12 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('https://example.com/posts/3');
 
         $this->assertSame([
-            'first' => Uri::of('https:://example.com/posts/1'),
-            'prev' => Uri::of('https:://example.com/posts/2'),
-            'current' => Uri::of('https:://example.com/posts/3'),
-            'next' => Uri::of('https:://example.com/posts/4'),
-            'last' => Uri::of('https:://example.com/posts/42'),
-            'edit' => Uri::of('https:://example.com/posts/3/edit'),
+            'first' => Uri::of('https://example.com/posts/1'),
+            'prev' => Uri::of('https://example.com/posts/2'),
+            'current' => Uri::of('https://example.com/posts/3'),
+            'next' => Uri::of('https://example.com/posts/4'),
+            'last' => Uri::of('https://example.com/posts/42'),
+            'edit' => Uri::of('https://example.com/posts/3/edit'),
         ], $response->linkHeader());
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3785,7 +3785,7 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->get('https://example.com/posts/3');
 
-        $this->assertSame([
+        $this->assertEquals([
             'first' => Uri::of('https://example.com/posts/1'),
             'prev' => Uri::of('https://example.com/posts/2'),
             'current' => Uri::of('https://example.com/posts/3'),

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3779,19 +3779,20 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake([
             '*' => $this->factory::response(headers: [
-                'Link' => '<https://example.com/posts/1>; rel="first", <https://example.com/posts/2>; rel="prev", <https://example.com/posts/3>; rel="current", <https://example.com/posts/4>; rel="next", <https://example.com/posts/42>; rel="last", <https://example.com/posts/3/edit>; rel="edit"',
+                'Link' => '<https://example.com/posts/1>; rel="first", <https://example.com/posts/2>; rel="prev", <https://example.com/posts/3>; rel="current", <https://example.com/posts/4>; rel="next", <https://example.com/posts/42>; rel="last", <https://example.com/posts/3/edit>; rel="edit", <https://example.com/authors/jane-doe>; rel="author", <https://example.com/authors/john-doe>; rel="author"',
             ]),
         ]);
 
         $response = $this->factory->get('https://example.com/posts/3');
 
         $this->assertEquals([
-            'first' => Uri::of('https://example.com/posts/1'),
-            'prev' => Uri::of('https://example.com/posts/2'),
-            'current' => Uri::of('https://example.com/posts/3'),
-            'next' => Uri::of('https://example.com/posts/4'),
-            'last' => Uri::of('https://example.com/posts/42'),
-            'edit' => Uri::of('https://example.com/posts/3/edit'),
+            'first' => [Uri::of('https://example.com/posts/1')],
+            'prev' => [Uri::of('https://example.com/posts/2')],
+            'current' => [Uri::of('https://example.com/posts/3')],
+            'next' => [Uri::of('https://example.com/posts/4')],
+            'last' => [Uri::of('https://example.com/posts/42')],
+            'edit' => [Uri::of('https://example.com/posts/3/edit')],
+            'author' => [Uri::of('https://example.com/authors/jane-doe'), Uri::of('https://example.com/authors/jane-doe')],
         ], $response->linkHeader());
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3774,6 +3774,26 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(PendingRequest::class, $factory->createPendingRequest());
     }
 
+    public function testLinkHeader()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(headers: [
+                'Link' => '<https:://example.com/posts/1>; rel="first", <https:://example.com/posts/2>; rel="prev", <https:://example.com/posts/3>; rel="current", <https:://example.com/posts/4>; rel="next", <https:://example.com/posts/42>; rel="last", <https:://example.com/posts/3/edit>; rel="edit"',
+            ]),
+        ]);
+
+        $response = $this->factory->get('https://example.com/posts/3');
+
+        $this->assertSame([
+            'first' => Uri::of('https:://example.com/posts/1'),
+            'prev' => Uri::of('https:://example.com/posts/2'),
+            'current' => Uri::of('https:://example.com/posts/3'),
+            'next' => Uri::of('https:://example.com/posts/4'),
+            'last' => Uri::of('https:://example.com/posts/42'),
+            'edit' => Uri::of('https:://example.com/posts/3/edit'),
+        )]);
+    }
+
     public static function methodsReceivingArrayableDataProvider()
     {
         return [

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3791,7 +3791,7 @@ class HttpClientTest extends TestCase
             'next' => Uri::of('https:://example.com/posts/4'),
             'last' => Uri::of('https:://example.com/posts/42'),
             'edit' => Uri::of('https:://example.com/posts/3/edit'),
-        ]);
+        ], $response->linkHeader());
     }
 
     public static function methodsReceivingArrayableDataProvider()


### PR DESCRIPTION
Compared to a lot of other headers, the `Link` header fulfills two important criteria:
* it's **well-known** and **standardized**
* it allows for **multiple values** in a **structured format** that **needs to be parsed**

This PR therefore introduces a method to easily get the links from the header as a map. This is especially helpful for REST APIs, e.g. those who use header-based pagination

# Example
A call to
```php
Http::get('https://example.com/posts/3')->linkHeader()
```
which responds with
```http
HTTP/1.1 200 OK
Date: Mon, 27 Jul 2009 12:28:53 GMT
Server: Apache/2.2.14 (Win32)
Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
Content-Length: 42
Content-Type: application/json
Connection: Closed
Link: <https://example.com/posts/1>; rel="first", <https://example.com/posts/2>; rel="prev", <https://example.com/posts/3>; rel="current", <https://example.com/posts/4>; rel="next", <https://example.com/posts/42>; rel="last", <https://example.com/posts/3/edit>; rel="edit", <https://example.com/authors/jane-doe>; rel="author", <https://example.com/authors/john-doe>; rel="author"
```
will return
```php
[
    'first' => [Uri::of('https:://example.com/posts/1')],
    'prev' => [Uri::of('https:://example.com/posts/2')],
    'current' => [Uri::of('https:://example.com/posts/3')],
    'next' => [Uri::of('https:://example.com/posts/4')],
    'last' => [Uri::of('https:://example.com/posts/42')],
    'edit' => [Uri::of('https:://example.com/posts/3/edit')],
    'author' => [
		Uri::of('https://example.com/authors/jane-doe'),
		Uri::of('https://example.com/authors/john-doe'),
	],
]
```

# Follow-up
* Add `Header::parse()` shorthand to `\Illuminate\Http\Client\Response` for headers
* Add `Header` collection class
    * Add `Link` subclass (see **§ Considerations**)

# Considerations
* Maybe, we want to return a `Collection` instead (so that we would have `has()` for example)
* Metadata currently isn't preserved
    * the `Uri[]` could turn into `array<string, array{url: Uri}&array<string, string>`
    * we could create a `Link` class that could
        * implement `ArrayAccess`
        * `__toString()` to just the plain url