### PR TITLE
[12.x] Improve grammar in comments and docs

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -164,7 +164,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | By setting this option to true, session cookies will only be sent back
-    | to the server if the browser has a HTTPS connection. This will keep
+    | to the server if the browser has an HTTPS connection. This will keep
     | the cookie from being sent to you when it can't be done securely.
     |
     */

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -29,7 +29,7 @@ trait HandlesAuthorization
     }
 
     /**
-     * Deny with a HTTP status code.
+     * Deny with an HTTP status code.
      *
      * @param  int  $status
      * @param  string|null  $message

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -74,7 +74,7 @@ class Response implements Arrayable, Stringable
     }
 
     /**
-     * Create a new "deny" Response with a HTTP status code.
+     * Create a new "deny" Response with an HTTP status code.
      *
      * @param  int  $status
      * @param  string|null  $message

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -174,7 +174,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $id = $this->session->get($this->getName());
 
         // First we will try to load the user using the identifier in the session if
-        // one exists. Otherwise we will check for a "remember me" cookie in this
+        // one exists. Otherwise, we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
         if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
             $this->fireAuthenticatedEvent($this->user);

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -266,7 +266,7 @@ class DatabaseStore implements LockProvider, Store
             $cache = $this->table()->where('key', $prefixed)
                 ->lockForUpdate()->first();
 
-            // If there is no value in the cache, we will return false here. Otherwise the
+            // If there is no value in the cache, we will return false here. Otherwise, the
             // value will be decrypted and we will proceed with this function to either
             // increment or decrement this value based on the given action callbacks.
             if (is_null($cache)) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -703,7 +703,7 @@ class Arr
                 : data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
-            // looping. Otherwise we will key the array using the value of the key we
+            // looping. Otherwise, we will key the array using the value of the key we
             // received from the developer. Then we'll return the final array form.
             if (is_null($key)) {
                 $results[] = $itemValue;

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -44,7 +44,7 @@ trait InteractsWithIO
     protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
     /**
-     * The mapping between human readable verbosity levels and Symfony's OutputInterface.
+     * The mapping between human-readable verbosity levels and Symfony's OutputInterface.
      *
      * @var array
      */
@@ -153,7 +153,7 @@ trait InteractsWithIO
     }
 
     /**
-     * Prompt the user for input with auto completion.
+     * Prompt the user for input with auto-completion.
      *
      * @param  string  $question
      * @param  array|callable  $choices
@@ -166,7 +166,7 @@ trait InteractsWithIO
     }
 
     /**
-     * Prompt the user for input with auto completion.
+     * Prompt the user for input with auto-completion.
      *
      * @param  string  $question
      * @param  array|callable  $choices

--- a/src/Illuminate/Console/Scheduling/ManagesAttributes.php
+++ b/src/Illuminate/Console/Scheduling/ManagesAttributes.php
@@ -91,7 +91,7 @@ trait ManagesAttributes
     protected $rejects = [];
 
     /**
-     * The human readable description of the event.
+     * The human-readable description of the event.
      *
      * @var string|null
      */

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -337,7 +337,7 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run daily at a given time (10:00, 19:30, etc).
+     * Schedule the event to run daily at a given time (10:00, 19:30, etc.).
      *
      * @param  string  $time
      * @return $this

--- a/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
+++ b/src/Illuminate/Database/Concerns/BuildsWhereDateClauses.php
@@ -96,7 +96,7 @@ trait BuildsWhereDateClauses
     }
 
     /**
-     * Add an "where" clause to determine if a "date" column is in the past or future.
+     * Add a "where" clause to determine if a "date" column is in the past or future.
      *
      * @param  array|string  $columns
      * @param  string  $operator

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -58,7 +58,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function getDsn(array $config)
     {
-        // First we will create the basic DSN setup as well as the port if it is in
+        // First we will create the basic DSN setup as well as the port if it is
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
         extract($config, EXTR_SKIP);

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -64,7 +64,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function getDsn(array $config)
     {
-        // First we will create the basic DSN setup as well as the port if it is in
+        // First we will create the basic DSN setup as well as the port if it is
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
         if ($this->prefersOdbc($config)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -648,7 +648,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if a "Attribute" return type marked mutator exists for an attribute.
+     * Determine if an "Attribute" return type marked mutator exists for an attribute.
      *
      * @param  string  $key
      * @return bool
@@ -1151,7 +1151,7 @@ trait HasAttributes
     }
 
     /**
-     * Set the value of a "Attribute" return type marked attribute using its mutator.
+     * Set the value of an "Attribute" return type marked attribute using its mutator.
      *
      * @param  string  $key
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -13,7 +13,7 @@ trait InteractsWithPivotTable
     /**
      * Toggles a model (or models) from the parent.
      *
-     * Each existing model is detached, and non existing ones are attached.
+     * Each existing model is detached, and non-existing ones are attached.
      *
      * @param  mixed  $ids
      * @param  bool  $touch

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -289,7 +289,7 @@ class Dispatcher implements DispatcherContract
 
             // If a response is returned from the listener and event halting is enabled
             // we will just return this response, and not call the rest of the event
-            // listeners. Otherwise we will add the response on the response list.
+            // listeners. Otherwise, we will add the response on the response list.
             if ($halt && ! is_null($response)) {
                 return $response;
             }

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -22,7 +22,7 @@ class LoadConfiguration
         $items = [];
 
         // First we will see if we have a cache configuration file. If we do, we'll load
-        // the configuration items from that file so that it is very quick. Otherwise
+        // the configuration items from that file so that it is very quick. Otherwise,
         // we will need to spin through every configuration file and load them all.
         if (file_exists($cached = $app->getCachedConfigPath())) {
             $items = require $cached;

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -364,7 +364,7 @@ class DocsCommand extends Command
     }
 
     /**
-     * Open the URL via the built in strategy.
+     * Open the URL via the built-in strategy.
      *
      * @param  string  $url
      * @return void

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -21,7 +21,7 @@ class HtmlDumper extends BaseHtmlDumper
     const EXPANDED_SEPARATOR = 'class=sf-dump-expanded>';
 
     /**
-     * Where the source should be placed on "non expanded" kind of dumps.
+     * Where the source should be placed on "non-expanded" kind of dumps.
      *
      * @var string
      */

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -901,7 +901,7 @@ if (! function_exists('secure_asset')) {
 
 if (! function_exists('secure_url')) {
     /**
-     * Generate a HTTPS url for the application.
+     * Generate an HTTPS url for the application.
      *
      * @param  string  $path
      * @param  mixed  $parameters

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -39,7 +39,7 @@ trait InteractsWithContentTypes
     }
 
     /**
-     * Determines whether the current requests accepts a given content type.
+     * Determines whether the current requests accept a given content type.
      *
      * @param  string|array  $contentTypes
      * @return bool

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -34,7 +34,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $with = [];
 
     /**
-     * The additional meta data that should be added to the resource response.
+     * The additional metadata that should be added to the resource response.
      *
      * Added during response construction by the developer.
      *
@@ -165,7 +165,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Add additional meta data to the resource response.
+     * Add additional metadata to the resource response.
      *
      * @param  array  $data
      * @return $this

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -75,7 +75,7 @@ class PaginatedResourceResponse extends ResourceResponse
     }
 
     /**
-     * Gather the meta data for the response.
+     * Gather the metadata for the response.
      *
      * @param  array  $paginated
      * @return array

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -61,7 +61,7 @@ class Envelope
     public $tags = [];
 
     /**
-     * The message's meta data.
+     * The message's metadata.
      *
      * @var array
      */

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -25,7 +25,7 @@ class MailChannel
     protected $mailer;
 
     /**
-     * The markdown implementation.
+     * The Markdown implementation.
      *
      * @var \Illuminate\Mail\Markdown
      */

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -684,7 +684,7 @@ class ResourceRegistrar
 
         // If a global prefix has been assigned to all names for this resource, we will
         // grab that so we can prepend it onto the name when we create this name for
-        // the resource action. Otherwise we'll just use an empty string for here.
+        // the resource action. Otherwise, we'll just use an empty string for here.
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -28,7 +28,7 @@ class RouteAction
 
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
-        // it is available. Otherwise we will need to find it in the action list.
+        // it is available. Otherwise, we will need to find it in the action list.
         if (Reflector::isCallable($action, true)) {
             return ! is_array($action) ? ['uses' => $action] : [
                 'uses' => $action[0].'@'.$action[1],

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -156,7 +156,7 @@ class RouteCollection extends AbstractRouteCollection
 
         // First, we will see if we can find a matching route for this current request
         // method. If we can, great, we can just return it so that it can be called
-        // by the consumer. Otherwise we will check for routes with another verb.
+        // by the consumer. Otherwise, we will check for routes with another verb.
         $route = $this->matchAgainstRoutes($routes, $request);
 
         return $this->handleMatchedRoute($request, $route);

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -96,7 +96,7 @@ class RouteUrlGenerator
 
         // Once we have ensured that there are no missing parameters in the URI we will encode
         // the URI and prepare it for returning to the developer. If the URI is supposed to
-        // be absolute, we will return it as-is. Otherwise we will remove the URL's root.
+        // be absolute, we will return it as-is. Otherwise, we will remove the URL's root.
         $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         if (! $absolute) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -547,7 +547,7 @@ class Str
     }
 
     /**
-     * Determine if a given string is 7 bit ASCII.
+     * Determine if a given string is 7-bit ASCII.
      *
      * @param  string  $value
      * @return bool

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -360,7 +360,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Determine if a given string is 7 bit ASCII.
+     * Determine if a given string is 7-bit ASCII.
      *
      * @return bool
      */
@@ -1218,7 +1218,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Execute the given callback if the string is 7 bit ASCII.
+     * Execute the given callback if the string is 7-bit ASCII.
      *
      * @param  callable  $callback
      * @param  callable|null  $default

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Schema;
 trait TestDatabases
 {
     /**
-     * Indicates if the test database schema is up to date.
+     * Indicates if the test database schema is up-to-date.
      *
      * @var bool
      */
@@ -101,7 +101,7 @@ trait TestDatabases
     }
 
     /**
-     * Ensure the current database test schema is up to date.
+     * Ensure the current database test schema is up-to-date.
      *
      * @return void
      */

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -183,7 +183,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
+        // from the application's language files. Otherwise, we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
     }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -420,7 +420,7 @@ trait FormatsMessages
     }
 
     /**
-     * Get the word for a index or position segment.
+     * Get the word for an index or position segment.
      *
      * @param  int  $value
      * @return string

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -151,7 +151,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is 7 bit ASCII.
+     * Validate that an attribute is 7-bit ASCII.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -5,7 +5,7 @@ namespace Illuminate\View\Compilers\Concerns;
 trait CompilesIncludes
 {
     /**
-     * Compile the each statements into valid PHP.
+     * Compile each statement into valid PHP.
      *
      * @param  string  $expression
      * @return string


### PR DESCRIPTION
This PR improves the clarity and correctness of various comments and documentation strings in the Laravel framework by fixing grammar, hyphenation, and adding commas.