### PR TITLE
Fix unsetting model castable attribute when cast to object (#56335)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2463,7 +2463,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function offsetUnset($offset): void
     {
-        unset($this->attributes[$offset], $this->relations[$offset], $this->attributeCastCache[$offset]);
+        unset(
+            $this->attributes[$offset],
+            $this->relations[$offset],
+            $this->attributeCastCache[$offset],
+            $this->classCastCache[$offset]
+        );
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2825,7 +2825,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($model->getCasts()['bar'], 'MyClass:myArgumentA,myArgumentB');
     }
 
-    public function testUnsetAttributes()
+    public function testUnsetCastAttributes()
     {
         $model = new EloquentModelCastingStub;
         $model->asToObjectCast = TestValueObject::make([

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -53,6 +53,8 @@ use Illuminate\Support\HtmlString;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
+use Illuminate\Tests\Database\stubs\TestCast;
+use Illuminate\Tests\Database\stubs\TestValueObject;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
@@ -2823,6 +2825,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($model->getCasts()['bar'], 'MyClass:myArgumentA,myArgumentB');
     }
 
+    public function testUnsetAttributes()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->asToObjectCast = TestValueObject::make([
+            'myPropertyA' => 'A',
+            'myPropertyB' => 'B',
+        ]);
+        unset($model->asToObjectCast);
+        $this->assertArrayNotHasKey('asToObjectCast', $model->getAttributes());
+    }
+
     public function testUpdatingNonExistentModelFails()
     {
         $model = new EloquentModelStub;
@@ -3837,6 +3850,7 @@ class EloquentModelCastingStub extends Model
             'asCustomEnumArrayObjectAttribute' => AsEnumArrayObject::of(StringStatus::class),
             'singleElementInArrayAttribute' => [AsCollection::class],
             'duplicatedAttribute' => 'int',
+            'asToObjectCast' => TestCast::class,
         ];
     }
 

--- a/tests/Database/stubs/TestCast.php
+++ b/tests/Database/stubs/TestCast.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Database\stubs;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+class TestCast implements CastsAttributes
+{
+    /**
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return TestValueObject|null
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (! json_validate($value)) {
+            return null;
+        }
+        $value = json_decode($value, true);
+        if (! is_array($value)) {
+            return null;
+        }
+
+        return TestValueObject::make($value);
+    }
+
+    /**
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (! $value instanceof TestValueObject) {
+            return [
+                $key => null,
+            ];
+        }
+
+        return [
+            $key => json_encode($value->toArray()),
+        ];
+    }
+}

--- a/tests/Database/stubs/TestValueObject.php
+++ b/tests/Database/stubs/TestValueObject.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Database\stubs;
+
+class TestValueObject
+{
+    private string $myPropertyA;
+    private string $myPropertyB;
+
+    public static function make(?array $test): self
+    {
+        $self = new self;
+        if (! empty($test['myPropertyA'])) {
+            $self->myPropertyA = $test['myPropertyA'];
+        }
+        if (! empty($test['myPropertyB'])) {
+            $self->myPropertyB = $test['myPropertyB'];
+        }
+
+        return $self;
+    }
+
+    public function toArray(): array
+    {
+        if (isset($this->myPropertyA)) {
+            $result['myPropertyA'] = $this->myPropertyA;
+        }
+        if (isset($this->myPropertyB)) {
+            $result['myPropertyB'] = $this->myPropertyB;
+        }
+
+        return $result ?? [];
+    }
+}


### PR DESCRIPTION
[Illuminate\Database\Eloquent\Model::offsetUnset is not cleanup classCastCache #56335](https://github.com/laravel/framework/issues/56335)

