### PR TITLE
Remove unnecessary `strtolower` calls in Encrypter 

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -75,11 +75,13 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function supported($key, $cipher)
     {
-        if (! isset(self::$supportedCiphers[strtolower($cipher)])) {
+        $cipher = strtolower($cipher);
+
+        if (! isset(self::$supportedCiphers[$cipher])) {
             return false;
         }
 
-        return mb_strlen($key, '8bit') === self::$supportedCiphers[strtolower($cipher)]['size'];
+        return mb_strlen($key, '8bit') === self::$supportedCiphers[$cipher]['size'];
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -75,11 +75,11 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function supported($key, $cipher)
     {
-        if (! isset(self::$supportedCiphers[$cipher])) {
+        if (! isset(self::$supportedCiphers[strtolower($cipher)])) {
             return false;
         }
 
-        return mb_strlen($key, '8bit') === self::$supportedCiphers[$cipher]['size'];
+        return mb_strlen($key, '8bit') === self::$supportedCiphers[strtolower($cipher)]['size'];
     }
 
     /**
@@ -90,7 +90,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function generateKey($cipher)
     {
-        return random_bytes(self::$supportedCiphers[$cipher]['size'] ?? 32);
+        return random_bytes(self::$supportedCiphers[strtolower($cipher)]['size'] ?? 32);
     }
 
     /**
@@ -322,7 +322,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function shouldValidateMac()
     {
-        return ! self::$supportedCiphers[strtolower($this->cipher)]['aead'];
+        return ! self::$supportedCiphers[$this->cipher]['aead'];
     }
 
     /**


### PR DESCRIPTION
This PR improves the `Encrypter` class by normalizing the `cipher` name to lowercase once in the constructor, instead of calling strtolower($this->cipher) repeatedly throughout the class. After this adjustment, the number of strtolower calls is reduced from `11` to `3`. I fail to understand what benefit multiple calls to strtolower bring in this context, and it runs counter to Laravel’s philosophy of clean and elegant code.

Actually, there was already a PR submitted quite some time ago addressing this issue (https://github.com/laravel/framework/pull/40198). However, Taylor Otwell previously rejected it,  I’m not sure if Taylor Otwell has changed his stance on this matter yet.