### PR TITLE
[12.x] Str::splitWords()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1708,7 +1708,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = static::splitWords('\s+', static::replace(['-', '_'], ' ', $value));
+        $words = static::splitWords(static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1442,6 +1442,17 @@ class Str
     }
 
     /**
+     * Splits the given string into an array of words.
+     *
+     * @param  string  $value
+     * @return string[]
+     */
+    public static function splitWords($value): array
+    {
+        return mb_split('\s+', $value);
+    }
+
+    /**
      * Convert the given string to proper case for each word.
      *
      * @param  string  $value
@@ -1449,7 +1460,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = mb_split('\s+', $value);
+        $parts = static::splitWords($value);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1482,7 +1493,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = mb_split('\s+', $value);
+        $words = static::splitWords($value);
 
         for ($i = 0; $i < count($words); $i++) {
             $lowercaseWord = mb_strtolower($words[$i]);
@@ -1697,7 +1708,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
+        $words = static::splitWords('\s+', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -866,6 +866,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return new static(Str::title($this->value));
     }
 
+
+    /**
+     * Splits the given string into an array of words.
+     *
+     * @param  string  $value
+     * @return string[]
+     */
+    public static function splitWords($value): array
+    {
+        return Str::splitWords($this->value);
+    }
+
     /**
      * Convert the given string to proper case for each word.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -866,7 +866,6 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return new static(Str::title($this->value));
     }
 
-
     /**
      * Splits the given string into an array of words.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -873,7 +873,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  string  $value
      * @return string[]
      */
-    public static function splitWords($value): array
+    public function splitWords($value): array
     {
         return Str::splitWords($this->value);
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1882,6 +1882,11 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testSplitWords(): void
+    {
+        $this->assertSame(['foo', 'bar'], Str::splitWords('foo  bar'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
Follow-up to #56338

# Changes
* Moved word splitting functionality to separate method
* Add new method to `Stringable` as well
* Add test for new method

# Alternatives
* adding `mb_split_words()` to `helpers.php` or a dedicated `multi-byte.php`