### PR TITLE
[12.x] Feat: adds password factory to str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1103,7 +1103,7 @@ class Str
      * @param  callable|null  $factory
      * @return void
      */
-    public static function createPasswordUsing(?callable $factory = null)
+    public static function createPasswordsUsing(?callable $factory = null)
     {
         static::$passwordFactory = $factory;
     }
@@ -1113,7 +1113,7 @@ class Str
      *
      * @return void
      */
-    public static function createPasswordNormally()
+    public static function createPasswordsNormally()
     {
         static::$passwordFactory = null;
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -75,6 +75,13 @@ class Str
     protected static $randomStringFactory;
 
     /**
+     * The callback that should be used to generate passwords.
+     *
+     * @var callable|null
+     */
+    protected static $passwordFactory;
+
+    /**
      * Get a new stringable object from the given string.
      *
      * @param  string  $string
@@ -1055,6 +1062,10 @@ class Str
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {
+        if (static::$passwordFactory) {
+            return (static::$passwordFactory)($length, $letters, $numbers, $symbols, $spaces);
+        }
+
         $password = new Collection();
 
         $options = (new Collection([
@@ -1084,6 +1095,27 @@ class Str
         return $password->merge($options->pipe(
             fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
+    }
+
+    /**
+     * Set the callable that will be used to generate passwords.
+     *
+     * @param  callable|null  $factory
+     * @return void
+     */
+    public static function createPasswordUsing(?callable $factory = null)
+    {
+        static::$passwordFactory = $factory;
+    }
+
+    /**
+     * Indicate that passwords should be created normally and not using a custom factory.
+     *
+     * @return void
+     */
+    public static function createPasswordNormally()
+    {
+        static::$passwordFactory = null;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1775,6 +1775,18 @@ class SupportStrTest extends TestCase
         );
     }
 
+    public function testPasswordFactoryCanBeSet()
+    {
+        Str::createPasswordUsing(fn () => 'custom-password');
+
+        $this->assertSame('custom-password', Str::password());
+        $this->assertSame('custom-password', Str::password(length: 7));
+
+        Str::createPasswordNormally();
+
+        $this->assertNotSame('custom-password', Str::password());
+    }
+
     public function testToBase64()
     {
         $this->assertSame(base64_encode('foo'), Str::toBase64('foo'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1777,12 +1777,12 @@ class SupportStrTest extends TestCase
 
     public function testPasswordFactoryCanBeSet()
     {
-        Str::createPasswordUsing(fn () => 'custom-password');
+        Str::createPasswordsUsing(fn () => 'custom-password');
 
         $this->assertSame('custom-password', Str::password());
         $this->assertSame('custom-password', Str::password(length: 7));
 
-        Str::createPasswordNormally();
+        Str::createPasswordsNormally();
 
         $this->assertNotSame('custom-password', Str::password());
     }


### PR DESCRIPTION
This pull request introduces a customizable password generation feature in the `Str` class and adds corresponding tests. The key changes include adding a new static property for a password factory, methods to set and reset the factory, and a test to validate this functionality.

### **Usage**

#### **Customizing Password Generation**
You can now define custom logic for generating random strings used in the `Str::password` method:

```php
// Set a custom factory
Str::createPasswordsUsing(function ($length, $letters, $numbers, $symbols, $spaces) {
    return 'password';
});

// Generate a password using the custom factory
$password = Str::password(8); // Output: 'password'

// Reset to default behavior
Str::createPasswordsNormally();

// Generate a password using the default logic
$password = Str::password(8); // Output: Random secure password
```

---

### **Why It Is Needed**

1. **Customizability**: Developers may have specific requirements for password generation, such as enforcing certain patterns or excluding specific characters. This feature allows them to define their own logic while still leveraging the `Str` class.

2. **Flexibility**: By providing a factory mechanism, the `Str::password` method becomes more adaptable to various use cases without requiring direct modifications to the core logic.

3. **Testing**: This feature is particularly useful in testing scenarios where deterministic or predictable password generation is required. For example, you can mock the random string generation to ensure consistent test results:

```php
Str::createPasswordsUsing(fn ($length) => 'test');

// Test password generation
$this->assertSame('test', Str::password(6));
``` 

4. **Consistency**: This aligns with Laravel's philosophy of providing extensible and developer-friendly APIs, ensuring that the framework remains flexible for diverse application needs.