### PR TITLE
[12.x] Add middleware filter option to route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -266,9 +266,10 @@ class RouteListCommand extends Command
         if ($this->option('middleware')) {
             $middlewareFilter = $this->option('middleware');
 
-            if (!in_array($middlewareFilter, $route['middleware'] ?? [])) {
+            if (!in_array($middlewareFilter, (array) ($route['middleware'] ?? []))) {
                 return;
             }
+
         }
 
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -269,7 +269,6 @@ class RouteListCommand extends Command
             if (! in_array($middlewareFilter, (array) ($route['middleware'] ?? []))) {
                 return;
             }
-
         }
 
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -266,7 +266,7 @@ class RouteListCommand extends Command
         if ($this->option('middleware')) {
             $middlewareFilter = $this->option('middleware');
 
-            if (!in_array($middlewareFilter, (array) ($route['middleware'] ?? []))) {
+            if (! in_array($middlewareFilter, (array) ($route['middleware'] ?? []))) {
                 return;
             }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -263,6 +263,14 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
+        if ($this->option('middleware')) {
+            $middlewareFilter = $this->option('middleware');
+
+            if (!in_array($middlewareFilter, $route['middleware'] ?? [])) {
+                return;
+            }
+        }
+
         if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||
             ($this->option('action') && isset($route['action']) && is_string($route['action']) && ! Str::contains($route['action'], $this->option('action'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
@@ -500,6 +508,7 @@ class RouteListCommand extends Command
             ['action', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by action'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
+            ['middleware', null, InputOption::VALUE_OPTIONAL, 'Filter routes by middleware'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -190,4 +190,32 @@ class RouteListCommandTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
+    public function testFilterRoutesByMiddleware()
+    {
+        $this->app->call('route:list', ['--middleware' => 'auth', '--json' => true]);
+
+        $output = $this->app->output();
+
+        $expected = [
+            [
+                "domain" => null,
+                "method" => "GET|HEAD",
+                "uri" => "test1",
+                "name" => null,
+                "action" => "Closure",
+                "middleware" => ["auth"]
+            ],
+            [
+                "domain" => null,
+                "method" => "GET|HEAD",
+                "uri" => "test3",
+                "name" => null,
+                "action" => "Closure",
+                "middleware" => ["web", "auth"]
+            ]
+        ];
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), $output);
+    }
+
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -210,20 +210,20 @@ class RouteListCommandTest extends TestCase
 
         $expected = [
             [
-                "domain" => null,
-                "method" => "GET|HEAD",
-                "uri" => "test1",
-                "name" => null,
-                "action" => "Closure",
-                "middleware" => ["auth"]
+                'domain' => null,
+                'method' => 'GET|HEAD',
+                'uri' => 'test1',
+                'name' => null,
+                'action' => 'Closure',
+                'middleware' => ['auth'],
             ],
             [
-                "domain" => null,
-                "method" => "GET|HEAD",
-                "uri" => "test3",
-                "name" => null,
-                "action" => "Closure",
-                "middleware" => ["web", "auth"]
+                'domain' => null,
+                'method' => 'GET|HEAD',
+                'uri' => 'test3',
+                'name' => null,
+                'action' => 'Closure',
+                'middleware' => ['web', 'auth'],
             ]
         ];
 

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -206,28 +206,10 @@ class RouteListCommandTest extends TestCase
     public function testFilterRoutesByMiddleware()
     {
         $this->app->call('route:list', ['--middleware' => 'auth', '--json' => true]);
-
         $output = $this->app->output();
 
-        $expected = [
-            [
-                'domain' => null,
-                'method' => 'GET|HEAD',
-                'uri' => 'test1',
-                'name' => null,
-                'action' => 'Closure',
-                'middleware' => ['auth'],
-            ],
-            [
-                'domain' => null,
-                'method' => 'GET|HEAD',
-                'uri' => 'test2',
-                'name' => null,
-                'action' => 'Closure',
-                'middleware' => ['web', 'auth'],
-            ],
-        ];
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"test1","name":null,"action":"Closure","middleware":["auth"]},{"domain":null,"method":"GET|HEAD","uri":"test2","name":null,"action":"Closure","middleware":["web","auth"]}]';
 
-        $this->assertJsonStringEqualsJsonString(json_encode($expected), $output);
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -63,6 +63,18 @@ class RouteListCommandTest extends TestCase
             return 'Hello Group';
         })->middleware(['web', 'auth']);
 
+        $router->get('/test1', function () {
+            return 'Test 1';
+        })->middleware('auth');
+
+        $router->get('/test2', function () {
+            return 'Test 2';
+        })->middleware('web');
+
+        $router->get('/test3', function () {
+            return 'Test 3';
+        })->middleware(['web', 'auth']);
+
         $command = new RouteListCommand($router);
         $command->setLaravel($laravel);
 
@@ -217,5 +229,4 @@ class RouteListCommandTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), $output);
     }
-
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -202,6 +202,7 @@ class RouteListCommandTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
+
     public function testFilterRoutesByMiddleware()
     {
         $this->app->call('route:list', ['--middleware' => 'auth', '--json' => true]);

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -221,7 +221,7 @@ class RouteListCommandTest extends TestCase
             [
                 'domain' => null,
                 'method' => 'GET|HEAD',
-                'uri' => 'test3',
+                'uri' => 'test2',
                 'name' => null,
                 'action' => 'Closure',
                 'middleware' => ['web', 'auth'],

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -224,7 +224,7 @@ class RouteListCommandTest extends TestCase
                 'name' => null,
                 'action' => 'Closure',
                 'middleware' => ['web', 'auth'],
-            ]
+            ],
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), $output);


### PR DESCRIPTION

This PR introduces a new filtering option --middleware to the route:list Artisan command, allowing developers to filter the displayed routes by their assigned middleware(s).

Changes:

Added a new --middleware option to the route:list command.

Updated the route filtering logic to support filtering routes that use specific middleware.

Added relevant tests to verify middleware filtering functionality.

Ensured compatibility with Laravel 12's existing route:list features.

Why?

Filtering routes by middleware improves developer productivity by making it easier to inspect and debug routes that share middleware, especially in large applications.

Usage example:

php artisan route:list --middleware=auth
