### PR TITLE
[12.x] Add toStringable to Uri

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -358,7 +358,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      *
      * @return \Illuminate\Support\Stringable
      */
-    public function toStr()
+    public function toStringable()
     {
         return Str::of($this->value());
     }

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -354,6 +354,16 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Get content as a Stringable class.
+     *
+     * @return \Illuminate\Support\Stringable
+     */
+    public function toStr()
+    {
+        return Str::of($this->value());
+    }
+
+    /**
      * Get the decoded string representation of the URI.
      */
     public function decode(): string

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -333,7 +333,17 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
-     * Create an HTTP response that represents the object.
+     * Get the URI as a Stringable instance.
+     *
+     * @return \Illuminate\Support\Stringable
+     */
+    public function toStringable()
+    {
+        return Str::of($this->value());
+    }
+
+    /**
+     * Create an HTTP response that represents the URI object.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Symfony\Component\HttpFoundation\Response
@@ -344,23 +354,13 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
-     * Get content as a string of HTML.
+     * Get the URI as a string of HTML.
      *
      * @return string
      */
     public function toHtml()
     {
         return $this->value();
-    }
-
-    /**
-     * Get content as a Stringable instance.
-     *
-     * @return \Illuminate\Support\Stringable
-     */
-    public function toStringable()
-    {
-        return Str::of($this->value());
     }
 
     /**

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -354,7 +354,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
-     * Get content as a Stringable class.
+     * Get content as a Stringable instance.
      *
      * @return \Illuminate\Support\Stringable
      */


### PR DESCRIPTION
I want to manipulate the string using the Stringable helper in a cleaner way.
```php
// Before
Str::of(Uri::of('http://localhost')->withScheme('https'));

// After
Uri::of('http://localhost')->withScheme('https')->toStringable();
```