### PR TITLE
Add 'dontReportUsing' to filter exceptions to be reported

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -153,12 +153,12 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param callable $using
-     * @return Exceptions
+     * @param  callable  $using
+     * @return $this
      */
-    public function dontReportUsing(Closure $dontReportUsing)
+    public function dontReportWhen(Closure $dontReportWhen)
     {
-        $this->handler->dontReportUsing($dontReportUsing);
+        $this->handler->dontReportWhen($dontReportWhen);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -151,6 +151,19 @@ class Exceptions
     }
 
     /**
+     * Register a callback to determine if an exception should not be reported.
+     *
+     * @param callable $using
+     * @return Exceptions
+     */
+    public function dontReportUsing(Closure $dontReportUsing)
+    {
+        $this->handler->dontReportUsing($dontReportUsing);
+
+        return $this;
+    }
+
+    /**
      * Do not report duplicate exceptions.
      *
      * @return $this

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -78,7 +78,7 @@ class Handler implements ExceptionHandlerContract
      *
      * @var callable|null
      */
-    protected $dontReportCallback = null;
+    protected $dontReportCallback = [];
 
     /**
      * The callbacks that should be used during reporting.
@@ -299,7 +299,7 @@ class Handler implements ExceptionHandlerContract
             $dontReportUsing = Closure::fromCallable($dontReportUsing);
         }
 
-        $this->dontReportCallback = $dontReportUsing;
+        $this->dontReportCallback[] = $dontReportUsing;
 
         return $this;
     }
@@ -438,8 +438,10 @@ class Handler implements ExceptionHandlerContract
             return true;
         }
 
-        if ($this->dontReportCallback && $this->container->call($this->dontReportCallback, [$e])) {
-            return true;
+        foreach ($this->dontReportCallback as $dontReportCallback) {
+            if ($dontReportCallback($e) === true) {
+                return true;
+            }
         }
 
         return rescue(fn () => with($this->throttle($e), function ($throttle) use ($e) {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -74,11 +74,11 @@ class Handler implements ExceptionHandlerContract
 
 
     /**
-     * A callback that inspects exceptions to determine if they should be reported.
+     * The callbacks that inspect exceptions to determine if they should be reported.
      *
-     * @var callable|null
+     * @var array
      */
-    protected $dontReportCallback = [];
+    protected $dontReportCallbacks = [];
 
     /**
      * The callbacks that should be used during reporting.
@@ -290,16 +290,16 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  callable $dontReportUsing
+     * @param  callable  $dontReportWhen
      * @return $this
      */
-    public function dontReportUsing(callable $dontReportUsing)
+    public function dontReportWhen(callable $dontReportWhen)
     {
-        if (! $dontReportUsing instanceof Closure) {
-            $dontReportUsing = Closure::fromCallable($dontReportUsing);
+        if (! $dontReportWhen instanceof Closure) {
+            $dontReportWhen = Closure::fromCallable($dontReportWhen);
         }
 
-        $this->dontReportCallback[] = $dontReportUsing;
+        $this->dontReportCallbacks[] = $dontReportWhen;
 
         return $this;
     }
@@ -438,7 +438,7 @@ class Handler implements ExceptionHandlerContract
             return true;
         }
 
-        foreach ($this->dontReportCallback as $dontReportCallback) {
+        foreach ($this->dontReportCallbacks as $dontReportCallback) {
             if ($dontReportCallback($e) === true) {
                 return true;
             }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -72,6 +72,14 @@ class Handler implements ExceptionHandlerContract
      */
     protected $dontReport = [];
 
+
+    /**
+     * A callback that inspects exceptions to determine if they should be reported.
+     *
+     * @var callable|null
+     */
+    protected $dontReportCallback = null;
+
     /**
      * The callbacks that should be used during reporting.
      *
@@ -280,6 +288,17 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Register a callback to determine if an exception should not be reported.
+     *
+     * @param  array|string  $class
+     * @return $this
+     */
+    public function dontReportUsing(callable $dontReportUsing)
+    {
+        $this->dontReportCallback = $dontReportUsing;
+    }
+
+    /**
      * Indicate that the given exception type should not be reported.
      *
      * @param  array|string  $exceptions
@@ -410,6 +429,10 @@ class Handler implements ExceptionHandlerContract
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
         if (! is_null(Arr::first($dontReport, fn ($type) => $e instanceof $type))) {
+            return true;
+        }
+
+        if ($this->dontReportCallback && $this->container->call($this->dontReportCallback, [$e])) {
             return true;
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -290,12 +290,18 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  array|string  $class
+     * @param  callable $dontReportUsing
      * @return $this
      */
     public function dontReportUsing(callable $dontReportUsing)
     {
+        if (! $dontReportUsing instanceof Closure) {
+            $dontReportUsing = Closure::fromCallable($dontReportUsing);
+        }
+
         $this->dontReportCallback = $dontReportUsing;
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -648,10 +648,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         });
 
         $this->handler->dontReportUsing(function (\Throwable $e) {
-            if ($e->getMessage() === 'foo') {
-                return true;
-            }
-            return false;
+            return $e->getMessage() === 'foo';
         });
 
         $this->handler->report($e1);

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -647,7 +647,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return false;
         });
 
-        $this->handler->dontReportUsing(function (\Throwable $e) {
+        $this->handler->dontReportWhen(function (\Throwable $e) {
             return $e->getMessage() === 'foo';
         });
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -635,6 +635,32 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertSame($reported, [$one, $two]);
     }
 
+    public function testItCanSkipExceptionReportingUsingCallback()
+    {
+        $reported = [];
+        $e1 = new RuntimeException('foo');
+        $e2 = new RuntimeException('bar');
+
+        $this->handler->reportable(function (\Throwable $e) use (&$reported) {
+            $reported[] = $e;
+
+            return false;
+        });
+
+        $this->handler->dontReportUsing(function (\Throwable $e) {
+            if ($e->getMessage() === 'foo') {
+                return true;
+            }
+            return false;
+        });
+
+        $this->handler->report($e1);
+        $this->handler->report($e2);
+        $this->handler->report($e1);
+
+        $this->assertSame($reported, [$e2]);
+    }
+
     public function testItDoesNotThrottleExceptionsByDefault()
     {
         $reported = [];


### PR DESCRIPTION
Sometimes it is not enough to only filter exceptions by exception class. 

This adds `dontReportUsing` to the Exceptions class to allow you to register a callback that can inspect exceptions to determine if you want them to be reported. 

**Example usage:**
```php
// In bootstrap/app.php

$app = Application::configure(basePath: dirname(__DIR__))
    ->withExceptions(function (Exceptions $exceptions) {
        $exceptions->dontReportUsing(function (Throwable $e) {
            if ($e instanceof PaymentErrorApiException && in_array($e->getErrorCode(), [
                'incorrect_card_number',
                'incorrect_cvc',
                'insufficient_funds',
                'transaction_not_allowed',
                'card_expired',
                'card_not_supported',
            ], true)) {
                return true;
            }
        });
    })->create();
```

I'll also add documentation for this if accepted. 