### PR TITLE
Add `withHttps()` method to `Uri` class

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -206,6 +206,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Specify the scheme of the URI as HTTPS.
+     */
+    public function withHttps(): static
+    {
+        return $this->withScheme('https');
+    }
+
+    /**
      * Specify the user and password for the URI.
      */
     public function withUser(Stringable|string|null $user, #[SensitiveParameter] Stringable|string|null $password = null): static


### PR DESCRIPTION
**Before:**

```
// Current way to set HTTPS scheme
$uri = Uri::of('http://example.com/path');
$httpsUri = $uri->withScheme('https');
```

**After:**

```
// New convenient method
$uri = Uri::of('http://example.com/path');
$httpsUri = $uri->withHttps();
```