### PR TITLE
[12.x] Add env:copy Artisan Command for Copying Environment Files

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvCopyCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvCopyCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class EnvCopyCommand extends Command
+{
+    protected $signature = 'env:copy 
+        {--force : Overwrite the .env file if it already exists}
+        {--env= : Specify the source environment file (default: .env.example)}';
+
+    protected $description = 'Copy the specified environment file to .env';
+
+    protected $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle()
+    {
+        $source = trim($this->option('env') ?? '.env.example');
+        $destination = base_path('.env');
+
+        // Validate source file path
+        if (empty($source) || !Str::startsWith($source, '.')) {
+            $this->error('Invalid source file path. Please provide a valid file name starting with "." (e.g., .env.example).');
+            return self::FAILURE;
+        }
+
+        // Check if source file exists
+        if (!$this->files->exists(base_path($source))) {
+            $this->error("The source file {$source} does not exist in the project root.");
+            return self::FAILURE;
+        }
+
+        // Check if destination file exists and --force is not used
+        if ($this->files->exists($destination) && !$this->option('force')) {
+            $this->warn('The .env file already exists. Use --force to overwrite it.');
+            return self::FAILURE;
+        }
+
+        // Perform the copy operation
+        try {
+            $this->files->copy(base_path($source), $destination);
+            $this->info("Environment file copied successfully from {$source} to .env.");
+            return self::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error('Failed to copy environment file: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -88,6 +88,7 @@ use Illuminate\Foundation\Console\ViewCacheCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Foundation\Console\ViewMakeCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
+use Illuminate\Foundation\Console\EnvCopyCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
@@ -226,6 +227,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'TraitMake' => TraitMakeCommand::class,
         'VendorPublish' => VendorPublishCommand::class,
         'ViewMake' => ViewMakeCommand::class,
+        'EnvCopy' => EnvCopyCommand::class,
     ];
 
     /**

--- a/tests/Console/EnvCopyCommandTest.php
+++ b/tests/Console/EnvCopyCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Illuminate\Tests\Integration\Generators\TestCase;
+use Mockery as m;
+
+class EnvCopyCommandTest extends TestCase
+{
+    protected $tempPath;
+    protected $filesMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempPath = sys_get_temp_dir().'/'.uniqid('laravel_env_test_');
+        File::makeDirectory($this->tempPath);
+
+        $this->filesMock = m::mock(Filesystem::class);
+        $this->app->instance(Filesystem::class, $this->filesMock);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app->instance('path.base', $this->tempPath);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        File::deleteDirectory($this->tempPath);
+        parent::tearDown();
+    }
+
+    public function test_it_copies_env_example_to_env_successfully()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.example'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env'))
+                        ->andReturn(false);
+        $this->filesMock->shouldReceive('copy')
+                        ->with(base_path('.env.example'), base_path('.env'))
+                        ->andReturn(true);
+
+        $this->artisan('env:copy')
+             ->expectsOutput('Environment file copied successfully from .env.example to .env.')
+             ->assertExitCode(0);
+    }
+
+    public function test_it_overwrites_env_with_force_option()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.example'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('copy')
+                        ->with(base_path('.env.example'), base_path('.env'))
+                        ->andReturn(true);
+
+        $this->artisan('env:copy --force')
+             ->expectsOutput('Environment file copied successfully from .env.example to .env.')
+             ->assertExitCode(0);
+    }
+
+    public function test_it_copies_custom_env_file_with_env_option()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.staging'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env'))
+                        ->andReturn(false);
+        $this->filesMock->shouldReceive('copy')
+                        ->with(base_path('.env.staging'), base_path('.env'))
+                        ->andReturn(true);
+
+        $this->artisan('env:copy --env=.env.staging')
+             ->expectsOutput('Environment file copied successfully from .env.staging to .env.')
+             ->assertExitCode(0);
+    }
+
+    public function test_it_fails_if_env_exists_and_force_is_not_used()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.example'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env'))
+                        ->andReturn(true);
+
+        $this->artisan('env:copy')
+             ->expectsOutput('The .env file already exists. Use --force to overwrite it.')
+             ->assertExitCode(1);
+    }
+
+    public function test_it_fails_with_invalid_source_path()
+    {
+        $this->filesMock->shouldNotReceive('exists'); // Should not call exists for invalid path
+        $this->filesMock->shouldNotReceive('copy');
+
+        $this->artisan('env:copy --env=invalid_env_file.txt')
+             ->expectsOutput('Invalid source file path. Please provide a valid file name starting with "." (e.g., .env.example).')
+             ->assertExitCode(1);
+    }
+
+    public function test_it_fails_with_empty_source_path()
+    {
+        $this->filesMock->shouldNotReceive('exists');
+        $this->filesMock->shouldNotReceive('copy');
+
+        $this->artisan('env:copy --env=""')
+             ->expectsOutput('Invalid source file path. Please provide a valid file name starting with "." (e.g., .env.example).')
+             ->assertExitCode(1);
+    }
+
+    public function test_it_fails_if_source_file_does_not_exist()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.nonexistent'))
+                        ->andReturn(false);
+        $this->filesMock->shouldNotReceive('copy');
+
+        $this->artisan('env:copy --env=.env.nonexistent')
+             ->expectsOutput('The source file .env.nonexistent does not exist in the project root.')
+             ->assertExitCode(1);
+    }
+
+    public function test_it_fails_on_copy_exception()
+    {
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env.example'))
+                        ->andReturn(true);
+        $this->filesMock->shouldReceive('exists')
+                        ->with(base_path('.env'))
+                        ->andReturn(false);
+        $this->filesMock->shouldReceive('copy')
+                        ->with(base_path('.env.example'), base_path('.env'))
+                        ->andThrow(new \Exception('Copy failed for some reason.'));
+
+        $this->artisan('env:copy')
+             ->expectsOutput('Failed to copy environment file: Copy failed for some reason.')
+             ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
This commit introduces a new  Artisan command to the framework. This command allows developers to easily copy a specified environment file (e.g., ) to , with options to force overwrite and specify the source file.

- Adds .
- Registers  in .
- Includes comprehensive tests for  in , covering various scenarios including successful copy, force overwrite, custom source files, and error handling.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
