### PR TITLE
[12.x] Fix PHPStan Integrations

### DIFF
--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -62,7 +62,7 @@ function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
-    assertType('never', throw_unless(false, Exception::class));
+    rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
     assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
     assertType('int', $foo);
@@ -72,8 +72,8 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
     assertType('DateTime', $bar);
 
     // Truthy/falsey argument
-    assertType('never', throw_unless(null, Exception::class));
-    assertType('never', throw_unless('', Exception::class));
+    rescue(fn () => assertType('never', throw_unless(null, Exception::class)));
+    rescue(fn () => assertType('never', throw_unless('', Exception::class)));
     assertType("'foo'", throw_unless('foo', Exception::class));
 }
 

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -43,7 +43,7 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
-    assertType('never', throw_if(true, Exception::class));
+    rescue(fn () => assertType('never', throw_if(true, Exception::class)));
     assertType('false', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
@@ -56,7 +56,7 @@ function testThrowIf(float|int $foo, ?DateTime $bar = null): void
     assertType('null', $bar);
     assertType('null', throw_if(null, Exception::class));
     assertType("''", throw_if('', Exception::class));
-    assertType('never', throw_if('foo', Exception::class));
+    rescue(fn () => assertType('never', throw_if('foo', Exception::class)));
 }
 
 function testThrowUnless(float|int $foo, ?DateTime $bar = null): void


### PR DESCRIPTION
Static code tests now throws the actual exception, using rescue() prevents this:

Reference: https://github.com/phpstan/phpstan/issues/13290

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
