### PR TITLE
Add 'isEmpty' and 'isNotEmpty' to Fluent

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -204,6 +204,26 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     }
 
     /**
+     * Determine if the fluent instance is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->attributes);
+    }
+
+    /**
+     * Determine if the fluent instance is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
      * Determine if the given offset exists.
      *
      * @param  TKey  $offset

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -471,6 +471,25 @@ class SupportFluentTest extends TestCase
             'role' => 'admin',
         ], $result);
     }
+
+    public function testFluentIsEmpty()
+    {
+        $fluent = new Fluent;
+
+        $this->assertTrue($fluent->isEmpty());
+        $this->assertFalse($fluent->isNotEmpty());
+    }
+
+    public function testFluentIsNotEmpty()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ]);
+
+        $this->assertTrue($fluent->isNotEmpty());
+        $this->assertFalse($fluent->isEmpty());
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
At the moment, a Fluent instance cannot be checked directly to see whether it is empty or not. 

While it may be possible to check the `all()` or `getAttributes()` methods for elements, built-in methods would be better for readability.

For this reason, I've added `isEmpty()` and `isNotEmpty()` to the Fluent class.

```php
$fluent = new Fluent([
    'name' => 'Taylor',
    'role' => 'admin',
]);

$fluent->isEmpty();    // Returns false
$fluent->isNotEmpty(); // Returns true

```
