### PR TITLE
[12.x] Add support `ddCurl` and `ddPrettyCurl` to HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/HttpClientCurlBuilder.php
+++ b/src/Illuminate/Http/Client/HttpClientCurlBuilder.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Illuminate\Support\Str;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\VarDumper\VarDumper;
+
+class HttpClientCurlBuilder
+{
+    /**
+     * The underlying PSR-7 request instance.
+     *
+     * @var  \Psr\Http\Message\RequestInterface
+     */
+    protected $request;
+
+    /**
+     * The individual components that make up the cURL command.
+     *
+     * @var  array|string[]
+     */
+    protected $parts = [];
+
+    /**
+     * Determines whether to format the cURL command for readability.
+     *
+     * @var  bool
+     */
+    protected $pretty = false;
+
+    /**
+     * Create a new Http Client Curl builder instance.
+     *
+     * @param  \Psr\Http\Message\RequestInterface  $request
+     */
+    private function __construct(RequestInterface $request)
+    {
+        $this->request = $request;
+
+        $this->parts [] = 'curl';
+    }
+
+    /**
+     * Create a new builder instance for the given request.
+     *
+     * @param  RequestInterface  $request
+     * @return $this
+     */
+    public static function forRequest(RequestInterface $request)
+    {
+        return new self($request);
+    }
+
+    /**
+     * Specify the format of the cURL command for readability.
+     *
+     * @param  bool  $prettyFormat
+     * @return $this
+     */
+    public function pretty(bool $prettyFormat = true)
+    {
+        $this->pretty = $prettyFormat;
+
+        return $this;
+    }
+
+    /**
+     * Build and return the cURL command.
+     *
+     * @return string
+     */
+    public function build()
+    {
+        return $this
+            ->addMethod()
+            ->addUrl()
+            ->addHeaders()
+            ->addBody()
+            ->generate();
+    }
+
+    /**
+     * Build and dump the curl command and end the script
+     *
+     * @return never
+     */
+    public function dd()
+    {
+        VarDumper::dump($this->build());
+
+        exit(1);
+    }
+
+    /**
+     * Add the HTTP request method to the cURL command.
+     *
+     * @return $this
+     */
+    private function addMethod()
+    {
+        $this->parts[] = '--request '.escapeshellarg($this->request->getMethod());
+
+        return $this;
+    }
+
+    /**
+     * Add the URL to the cURL command.
+     *
+     * @return $this
+     */
+    private function addUrl()
+    {
+        $this->parts[] = '--url '.escapeshellarg((string) $this->request->getUri());
+
+        return $this;
+    }
+
+    /**
+     * Add all relevant headers to the cURL command.
+     *
+     * @return $this
+     */
+    private function addHeaders()
+    {
+        foreach ($this->request->getHeaders() as $name => $values) {
+            $headerName = Str::lower($name);
+
+            if (in_array($headerName, ['content-length', 'host'])) {
+                continue;
+            }
+
+            if ($headerName === 'content-type'
+                && str_starts_with($this->request->getHeaderLine($name), 'multipart/form-data')) {
+                $this->parts[] = '--header '.escapeshellarg('content-type: multipart/form-data');
+
+                continue;
+            }
+
+            $headerLine = $name.': '.implode(', ', $values);
+            $this->parts[] = '--header '.escapeshellarg($headerLine);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add the request body to the cURL command.
+     *
+     * @return $this
+     */
+    private function addBody()
+    {
+        $bodyContent = $this->request->getBody()->getContents();
+        $contentType = $this->request->getHeaderLine('Content-Type');
+
+        if (str_contains($contentType, 'multipart/form-data')) {
+            $this->parts = array_merge($this->parts, $this->buildMultipartParts($contentType, $bodyContent));
+        } elseif ($bodyContent !== '' && $bodyContent !== '0') {
+            $this->parts[] = "--data ".escapeshellarg($bodyContent);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Parse and build multipart form data parts for the cURL command.
+     *
+     * @param  string  $contentType
+     * @param  string  $body
+     * @return array
+     */
+    private function buildMultipartParts(string $contentType, string $body)
+    {
+        $formParts = [];
+
+        if (in_array(preg_match('/boundary=(.*)$/', $contentType, $matches), [0, false], true)) {
+            foreach (json_decode($body, true) as $name => $value) {
+                $formParts [] = '--form '.escapeshellarg("$name=$value");
+            }
+
+            return $formParts;
+        }
+
+        $boundary = $matches[1];
+        $sections = explode("--$boundary", $body);
+
+        foreach ($sections as $section) {
+            $section = trim($section);
+
+            if ($section === '') {
+                continue;
+            }
+
+            if ($section === '--') {
+                continue;
+            }
+
+            $this->parseMultipartSection($section, $formParts);
+        }
+
+        return $formParts;
+    }
+
+    /**
+     * Parse an individual multipart form data section.
+     *
+     * @param  string  $section
+     * @param  array  $formParts
+     * @return void
+     */
+    private function parseMultipartSection(string $section, array &$formParts)
+    {
+        if (in_array(preg_match('/name="([^"]+)"/', $section, $nameMatches), [0, false], true)) {
+            return;
+        }
+
+        $name = $nameMatches[1];
+
+        if (preg_match('/filename="([^"]+)"/', $section, $fileMatches)) {
+            $filename = $fileMatches[1];
+            $formParts[] = '--form '.escapeshellarg("$name=@$filename");
+        } elseif (preg_match('/\r\n\r\n(.*?)(\r\n--|$)/s', $section, $valueMatches)) {
+            $value = trim($valueMatches[1]);
+            $formParts[] = '--form '.escapeshellarg("$name=$value");
+        }
+    }
+
+    /**
+     * Generate the final cURL command string.
+     *
+     * @return string
+     */
+    private function generate()
+    {
+        return $this->pretty
+            ? $this->buildPretty()
+            : $this->buildInline();
+    }
+
+    /**
+     * Format the cURL command with newlines and indentation for readability.
+     *
+     * @return string
+     */
+    private function buildPretty()
+    {
+        $command = array_shift($this->parts);
+
+        foreach ($this->parts as $part) {
+            $command .= " \\\n  ".$part;
+        }
+
+        return $command;
+    }
+
+    /**
+     * Format the cURL command as a single line string.
+     *
+     * @return string
+     */
+    private function buildInline()
+    {
+        return implode(' ', $this->parts);
+    }
+}

--- a/src/Illuminate/Http/Client/Middleware/HttpClientCurlGenerator.php
+++ b/src/Illuminate/Http/Client/Middleware/HttpClientCurlGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Http\Client\Middleware;
+
+use Closure;
+use Illuminate\Http\Client\HttpClientCurlBuilder;
+use Psr\Http\Message\RequestInterface;
+
+class HttpClientCurlGenerator
+{
+    /**
+     * Handle an outgoing HTTP request.
+     *
+     * @param  bool  $pretty
+     * @return Closure
+     */
+    public function handle(bool $pretty = false)
+    {
+        return function () use ($pretty): Closure {
+            return function (RequestInterface $request) use ($pretty) {
+               HttpClientCurlBuilder::forRequest($request)->pretty($pretty)->dd();
+            };
+        };
+    }
+}

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Middleware\HttpClientCurlGenerator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -761,6 +762,27 @@ class PendingRequest
 
             exit(1);
         });
+    }
+
+    /**
+     * Dump the curl before sending and end the script.
+     *
+     * @param  bool  $pretty
+     * @return $this
+     */
+    public function ddCurl(bool $pretty = false)
+    {
+        return $this->withMiddleware((new HttpClientCurlGenerator)->handle($pretty));
+    }
+
+    /**
+     * Dump the pretty curl before sending and end the script.
+     *
+     * @return $this
+     */
+    public function ddPrettyCurl()
+    {
+        return $this->ddCurl(true);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -70,6 +70,8 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(callable|bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
+ * @method static \Illuminate\Http\Client\PendingRequest ddCurl(bool $pretty = false)
+ * @method static \Illuminate\Http\Client\PendingRequest ddPrettyCurl()
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response head(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response post(string $url, array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable $data = [])

--- a/tests/Http/HttpClientCurlBuilderTest.php
+++ b/tests/Http/HttpClientCurlBuilderTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Utils;
+use Illuminate\Http\Client\HttpClientCurlBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientCurlBuilderTest extends TestCase
+{
+    #[DataProvider('methodsReceivingArrayableDataProvider')]
+    public function testItCanGeneratesCurlWithArrayableRequestMethods(string $method)
+    {
+        $request = new GuzzleRequest($method, 'https://laravel.com');
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("curl ", $curl);
+        $this->assertStringContainsString("--request '$method' ", $curl);
+        $this->assertStringContainsString("--url 'https://laravel.com'", $curl);
+    }
+
+    public function testItCanGeneratesCurlForPostWithBody()
+    {
+        $data = json_encode(['title' => 'Hello', 'body' => 'World']);
+        $request = new GuzzleRequest(
+            'POST',
+            'https://laravel.com',
+            [
+                'Content-Type' => 'application/json',
+            ],
+            $data
+        );
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("curl ", $curl);
+        $this->assertStringContainsString("--request 'POST' ", $curl);
+        $this->assertStringContainsString("--url 'https://laravel.com' ", $curl);
+        $this->assertStringContainsString("--header 'Content-Type: application/json' ", $curl);
+        $this->assertStringContainsString("--data '$data'", $curl);
+    }
+
+    public function testItCanGeneratesCurlForPostWithoutBody()
+    {
+        $request = new GuzzleRequest('POST', 'https://laravel.com');
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("curl ", $curl);
+        $this->assertStringContainsString("--request 'POST' ", $curl);
+        $this->assertStringContainsString("--url 'https://laravel.com'", $curl);
+        $this->assertStringNotContainsString("--data", $curl);
+    }
+
+    public function testItCanGeneratesCurlForGetWithQueryParameters()
+    {
+        $request = new GuzzleRequest('GET', 'https://laravel.com?q=taylor&page=2');
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("--url 'https://laravel.com?q=taylor&page=2", $curl);
+    }
+
+    public function testItCanGeneratesCurlForGetWithBody()
+    {
+        $data = json_encode(['title' => 'Hello', 'body' => 'World']);
+        $request = new GuzzleRequest('GET', 'https://laravel.com', body: $data);
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("curl ", $curl);
+        $this->assertStringContainsString("--request 'GET' ", $curl);
+        $this->assertStringContainsString("--url 'https://laravel.com' ", $curl);
+        $this->assertStringContainsString("--data '$data'", $curl);
+    }
+
+    public function testItCanGeneratesCurlAsFormData(): void
+    {
+        $body = http_build_query(['name' => 'Taylor', 'title' => 'Laravel Developer']);
+        $request = new GuzzleRequest(
+            'POST',
+            'https://laravel.com/form-data',
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            $body
+        );
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("--header 'Content-Type: application/x-www-form-urlencoded'", $curl);
+        $this->assertStringContainsString("--data 'name=Taylor&title=Laravel+Developer'", $curl);
+    }
+
+    public function testItCanGeneratesCurlAsMultipartFormData()
+    {
+        $request = new GuzzleRequest(
+            'POST',
+            'https://example.com/multipart',
+            ['Content-Type' => 'multipart/form-data', 'X-Test-Header' => 'foo'],
+            json_encode(['first_name'=>'Taylor','last_name'=> 'Otwell'])
+        );
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("--request 'POST' ", $curl);
+        $this->assertStringContainsString("--header 'content-type: multipart/form-data' ", $curl);
+        $this->assertStringContainsString("--header 'X-Test-Header: foo' ", $curl);
+        $this->assertStringContainsString("--form 'first_name=Taylor' ", $curl);
+        $this->assertStringContainsString("--form 'last_name=Otwell'", $curl);
+    }
+
+    public function testItCanGeneratesCurlForMultipartStream()
+    {
+        $multipart = new MultipartStream([
+            [
+                'name' => 'first_name',
+                'contents' => 'taylor',
+            ],
+            [
+                'name' => 'attachment',
+                'contents' => Utils::tryFopen(__DIR__ . '/fixtures/test.txt', 'r'),
+                'filename' => 'test.txt',
+            ]
+        ]);
+
+        $request = new GuzzleRequest(
+            'POST',
+            'https://example.com/upload',
+            ['Content-Type' => 'multipart/form-data; boundary=' . $multipart->getBoundary()],
+            $multipart
+        );
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->build();
+
+        $this->assertStringContainsString("--request 'POST' ", $curl);
+        $this->assertStringContainsString("--header 'content-type: multipart/form-data' ", $curl);
+        $this->assertStringContainsString("--form 'first_name=taylor' ", $curl);
+        $this->assertStringContainsString("--form 'attachment=@test.txt'", $curl);
+    }
+
+    public function testItCanGeneratesPrettyCurl()
+    {
+        $data = json_encode(['title' => 'Hello', 'body' => 'World']);
+
+        $request = new GuzzleRequest(
+            'POST',
+            'https://laravel.com/pretty-output',
+            [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer token',
+                'Accept-Language' => 'en-US,en;q=0.9,fa;q=0.8',
+                'User-Agent' => 'Laravel'
+            ],
+            $data
+        );
+
+        $curl = HttpClientCurlBuilder::forRequest($request)->pretty()->build();
+
+        $this->assertStringContainsString("curl \\\n", $curl);
+        $this->assertStringContainsString("--request 'POST' \\\n", $curl);
+        $this->assertStringContainsString("--url 'https://laravel.com/pretty-output' \\\n", $curl);
+        $this->assertStringContainsString("--header 'Content-Type: application/json' \\\n", $curl);
+        $this->assertStringContainsString("--header 'Accept: application/json' \\\n", $curl);
+        $this->assertStringContainsString("--header 'Authorization: Bearer token' \\\n", $curl);
+        $this->assertStringContainsString("--header 'Accept-Language: en-US,en;q=0.9,fa;q=0.8' \\\n", $curl);
+        $this->assertStringContainsString("--header 'User-Agent: Laravel' \\\n", $curl);
+        $this->assertStringContainsString("--data '$data'", $curl);
+    }
+
+    public function testItCanCreateCurlBuilder()
+    {
+        $this->assertInstanceOf(
+            HttpClientCurlBuilder::class,
+            HttpClientCurlBuilder::forRequest(new GuzzleRequest('GET', 'https://laravel.com'))
+        );
+    }
+
+    public static function methodsReceivingArrayableDataProvider()
+    {
+        return [
+            'patch' => ['PATCH'],
+            'put' => ['PUT'],
+            'post' => ['POST'],
+            'get' => ['GET'],
+            'delete' => ['DELETE'],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces two new debugging methods to the PendingRequest class in Laravel's HTTP client:

1. `ddCurl()` – Generates and dumps a cURL command equivalent to the outgoing HTTP request.
2. `ddPrettyCurl()` – Outputs a formatted, human-readable cURL command for better debugging readability.

#### Use Cases:
- Debugging API requests – Quickly test or replicate HTTP calls outside Laravel.
- Third-party troubleshooting – Share the exact cURL command with providers for validation.
- Readable output – ddPrettyCurl() improves readability for complex requests.

#### Example Usage:
```php
<?php

use Illuminate\Support\Facades\Http;

/**
  curl --request 'GET' --url 'https://laravel.com' --header 'User-Agent: GuzzleHttp/7'
**/
Http::ddCurl()->get('https://laravel.com');

/** 
curl \
  --request 'POST' \
  --url 'https://api.example.com' \
  --header 'User-Agent: GuzzleHttp/7' \
  --header 'Content-Type: application/json' \
  --data '{"foo":"bar"}'
**/
Http::ddPrettyCurl()->post('https://api.example.com', ['foo'=>'bar']);

/**
curl \
  --request 'POST' \
  --url 'https://api.example.com' \
  --header 'User-Agent: GuzzleHttp/7' \
  --header 'content-type: multipart/form-data' \
  --form 'foo=bar'
**/
Http::ddPrettyCurl()->asMultipart()->post('https://api.example.com', ['foo'=>'bar']);

/**
curl \
  --request 'POST' \
  --url 'http://foo.com/file' \
  --header 'User-Agent: GuzzleHttp/7' \
  --header 'content-type: multipart/form-data' \
  --form 'foo=bar' \
  --form 'foo=@file.txt'
**/
Http::ddCurl(true)
    ->attach('foo', 'data', 'file.txt', ['X-Test-Header' => 'foo'])
    ->post('http://foo.com/file', ['foo'=> 'bar']);

```

#### Benefits:
- No external tools needed to inspect requests.
- Works seamlessly with Laravel's existing HTTP client methods.
- Encourages better debugging practices for API integrations.

This feature is particularly useful for developers working with external APIs, where verifying the raw request format is critical.

