### PR TITLE
[12.x] Add mergeMetadata method to the Mailable class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1184,26 +1184,17 @@ class Mailable implements MailableContract, Renderable
     /**
      * Add a metadata header to the message when supported by the underlying transport.
      *
-     * @param  string  $key
-     * @param  string  $value
+     * @param  array|string  $key
+     * @param  string|null  $value
      * @return $this
      */
-    public function metadata($key, $value)
+    public function metadata($key, $value = null)
     {
-        $this->metadata[$key] = $value;
-
-        return $this;
-    }
-
-    /**
-     * Merge an array of metadata headers to the message when supported by the underlying transport.
-     *
-     * @param  array  $metadata
-     * @return $this
-     */
-    public function mergeMetadata($metadata)
-    {
-        $this->metadata = array_merge($this->metadata, $metadata);
+        if (is_array($key)) {
+            $this->metadata = array_merge($this->metadata, $key);
+        } else {
+            $this->metadata[$key] = $value;
+        }
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1196,6 +1196,19 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Merge an array of metadata headers to the message when supported by the underlying transport.
+     *
+     * @param  array  $metadata
+     * @return $this
+     */
+    public function mergeMetadata($metadata)
+    {
+        $this->metadata = array_merge($this->metadata, $metadata);
+
+        return $this;
+    }
+
+    /**
      * Determine if the mailable has the given metadata.
      *
      * @param  string  $key

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -641,7 +641,7 @@ class MailMailableTest extends TestCase
         $mailable->from('taylor@laravel.com');
         $mailable->html('test content');
 
-        $mailable->mergeMetadata([
+        $mailable->metadata([
             'template_id' => 'external-template-id',
             'customer_id' => 101,
             'order_id' => 1000,

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -642,7 +642,7 @@ class MailMailableTest extends TestCase
         $mailable->html('test content');
 
         $mailable->mergeMetadata([
-            'origin' => 'test-suite',
+            'template_id' => 'external-template-id',
             'customer_id' => 101,
             'order_id' => 1000,
             'subtotal' => 1500,
@@ -651,7 +651,7 @@ class MailMailableTest extends TestCase
             'total' => 1670,
         ]);
 
-        $this->assertTrue($mailable->hasMetadata('origin', 'test-suite'));
+        $this->assertTrue($mailable->hasMetadata('template_id', 'external-template-id'));
         $this->assertTrue($mailable->hasMetadata('customer_id', 101));
         $this->assertTrue($mailable->hasMetadata('order_id', 1000));
         $this->assertTrue($mailable->hasMetadata('subtotal', 1500));
@@ -664,7 +664,7 @@ class MailMailableTest extends TestCase
         $mailer = new Mailer('array', $view, new ArrayTransport);
 
         $sentMessage = $mailer->send($mailable);
-        $this->assertStringContainsString('X-Metadata-origin: test-suite', $sentMessage->toString());
+        $this->assertStringContainsString('X-Metadata-template_id: external-template-id', $sentMessage->toString());
         $this->assertStringContainsString('X-Metadata-customer_id: 101', $sentMessage->toString());
         $this->assertStringContainsString('X-Metadata-order_id: 1000', $sentMessage->toString());
         $this->assertStringContainsString('X-Metadata-subtotal: 1500', $sentMessage->toString());


### PR DESCRIPTION
Email providers such as Sendgrid and Mailjet allow us to design email templates with placeholders in their dashboards. So we don't have to design the blade files for our emails. We only need to send an API request containing the template ID and data to be put on the placeholders.

I don't think Laravel has officially supported sending emails this way with mailables. The best approach that we can think of is to save the request payload to the metadata of a mailable. Then in a transport, we can extract the payload from the metadata (at this point headers) and send an API request.

It would be a bit nicer to use that `mergeMetadata` method instead of calling the `metadata` method multiple times.

```php
use App\Models\Order;

class Receipt extends Mailable
{
    public string $templateId = 'external_template_id';

    function __construct(public Order $order)
    {}

    public function build()
    {
        $this->view('dummy_blade_file_to_bypass_the_mailer')
            ->mergeMetadata([
                'template_id' => $this->templateId,
                'customer_name' => $this->order->customer->name;
                'order_id' => $this->order->id,
                'total' => $this->order->total,
            ]);
    }
}
```
Then in our custom transport:

```php
use Symfony\Component\Mailer\Transport\AbstractTransport;

class MailjetTransport extends AbstractTransport
{
    function __construct(protected MailjetClient $client)
    {}

    protected function doSend(SentMessage $message): void
    {
        $this
            ->client
            ->send($this->payload($message));
    }

    protected function payload(SentMessage $message): array
    {
        return collect($message->getHeaders())
            ->filter(fn ($header) => Str::startsWith($header, 'X-Metadata'))
            ->map(fn ($header) => Str::chopStart($header, 'X-Metadata'))
            ->toArray();
    }
}
```