### PR TITLE
[12.x] Easily run pipelines inside of a transactions with `Pipeline::withinTransaction()`

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -49,11 +49,11 @@ class Pipeline implements PipelineContract
     protected $finally;
 
     /**
-     * Whether to wrap the pipeline in a database transaction.
+     * Indicates whether to wrap the pipeline in a database transaction.
      *
      * @var bool
      */
-    protected $inTransaction = false;
+    protected $withinTransactions = false;
 
     /**
      * Create a new class instance.
@@ -130,7 +130,7 @@ class Pipeline implements PipelineContract
         );
 
         try {
-            return $this->inTransaction
+            return $this->withinTransactions
                 ? $this->container->make('db')->transaction(fn () => $pipeline($this->passable))
                 : $pipeline($this->passable);
         } finally {
@@ -255,6 +255,19 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Execute each pipeline step within a database transaction.
+     *
+     * @param  bool  $withinTransactions
+     * @return $this
+     */
+    public function withinTransactions(bool $withinTransactions = true)
+    {
+        $this->withinTransactions = $withinTransactions;
+
+        return $this;
+    }
+
+    /**
      * Get the container instance.
      *
      * @return \Illuminate\Contracts\Container\Container
@@ -279,19 +292,6 @@ class Pipeline implements PipelineContract
     public function setContainer(Container $container)
     {
         $this->container = $container;
-
-        return $this;
-    }
-
-    /**
-     * Wrap the pipeline in a database transaction.
-     *
-     * @param  bool  $inTransaction
-     * @return $this
-     */
-    public function inTransaction(bool $inTransaction = true)
-    {
-        $this->inTransaction = $inTransaction;
 
         return $this;
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -49,6 +49,13 @@ class Pipeline implements PipelineContract
     protected $finally;
 
     /**
+     * Whether to wrap the pipeline in a database transaction.
+     *
+     * @var bool
+     */
+    protected $inTransaction = false;
+
+    /**
      * Create a new class instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -123,7 +130,9 @@ class Pipeline implements PipelineContract
         );
 
         try {
-            return $pipeline($this->passable);
+            return $this->inTransaction
+                ? $this->container->make('db')->transaction(fn () => $pipeline($this->passable))
+                : $pipeline($this->passable);
         } finally {
             if ($this->finally) {
                 ($this->finally)($this->passable);
@@ -270,6 +279,19 @@ class Pipeline implements PipelineContract
     public function setContainer(Container $container)
     {
         $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Wrap the pipeline in a database transaction.
+     *
+     * @param  bool  $inTransaction
+     * @return $this
+     */
+    public function inTransaction(bool $inTransaction = true)
+    {
+        $this->inTransaction = $inTransaction;
 
         return $this;
     }

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -23,6 +23,9 @@
             "Illuminate\\Pipeline\\": ""
         }
     },
+    "suggest": {
+        "illuminate/database": "Required to use database transactions (^12.0)."
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "12.x-dev"

--- a/tests/Pipeline/PipelineTransactionTest.php
+++ b/tests/Pipeline/PipelineTransactionTest.php
@@ -16,7 +16,7 @@ class PipelineTransactionTest extends TestCase
     {
         Event::fake();
 
-        $result = Pipeline::inTransaction()
+        $result = Pipeline::withinTransactions()
             ->send('some string')
             ->through([function ($value, $next) {
                 return $next($value);
@@ -34,7 +34,7 @@ class PipelineTransactionTest extends TestCase
 
         $finallyRan = false;
         try {
-            Pipeline::inTransaction()
+            Pipeline::withinTransactions()
                 ->send('some string')
                 ->through([
                     function ($value, $next) {

--- a/tests/Pipeline/PipelineTransactionTest.php
+++ b/tests/Pipeline/PipelineTransactionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Pipeline;
+
+use Exception;
+use Illuminate\Database\Events\TransactionBeginning;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Pipeline;
+use Orchestra\Testbench\TestCase;
+
+class PipelineTransactionTest extends TestCase
+{
+    public function testPipelineTransaction()
+    {
+        Event::fake();
+
+        $result = Pipeline::inTransaction()
+            ->send('some string')
+            ->through([function ($value, $next) {
+                return $next($value);
+            }])
+            ->thenReturn();
+
+        $this->assertEquals('some string', $result);
+        Event::assertDispatched(TransactionBeginning::class);
+        Event::assertDispatched(TransactionCommitted::class);
+    }
+
+    public function testExceptionThrownRollsBackTransaction()
+    {
+        Event::fake();
+
+        $finallyRan = false;
+        try {
+            Pipeline::inTransaction()
+                ->send('some string')
+                ->through([
+                    function ($value, $next) {
+                        throw new Exception('I was thrown');
+                    },
+                ])
+                ->finally(function () use (&$finallyRan) {
+                    $finallyRan = true;
+                })
+                ->thenReturn();
+            $this->fail('No exception was thrown');
+        } catch (Exception) {
+        }
+
+        $this->assertTrue($finallyRan);
+        Event::assertDispatched(TransactionBeginning::class);
+        Event::assertDispatched(TransactionRolledBack::class);
+    }
+}


### PR DESCRIPTION
I feel like it's an incredibly common occurrence to need each of the pipes inside of a Pipeline wrapped inside of a database transaction.

To simplify this, I am suggesting adding a helper method to the Pipeline class so that it wraps pipeline in a transaction.

```php
Pipeline::withinTransaction()
    ->send($user)
    ->through([
        DisableTeamAccessAction::class,
        DisableSchoolAccessAction::class,
        RemoveUserFromGamesAction::class
    ])
    ->then(fn (User $user) => AccountDeactivatedNotification::send($user));
```