### PR TITLE
[12.x] Add missing PHPDoc type in `JoinClause`

### DIFF
--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -16,7 +16,7 @@ class JoinClause extends Builder
     /**
      * The table the join clause is joining to.
      *
-     * @var string
+     * @var \Illuminate\Contracts\Database\Query\Expression|string
      */
     public $table;
 


### PR DESCRIPTION
This PR adds a missing PHPDoc type to the `$table` property of the `JoinClause` class.

The `$table` property will be of type `Illuminate\Database\Query\Expression` when `DB::table()->joinSub()` is called. Stack trace:

1. `function joinSub()`:
https://github.com/laravel/framework/blob/d8a5f1de8beb82e79087bf3a103a651de242499b/src/Illuminate/Database/Query/Builder.php#L613
2. `function join()`:
https://github.com/laravel/framework/blob/d8a5f1de8beb82e79087bf3a103a651de242499b/src/Illuminate/Database/Query/Builder.php#L549
3. `function newJoinClause()`:
https://github.com/laravel/framework/blob/d8a5f1de8beb82e79087bf3a103a651de242499b/src/Illuminate/Database/Query/Builder.php#L781
4. `function __construct()`:
https://github.com/laravel/framework/blob/d8a5f1de8beb82e79087bf3a103a651de242499b/src/Illuminate/Database/Query/JoinClause.php#L61