### PR TITLE
[12.x] removed usage of useless `ReflectionProperty::setAccessible()`

### DIFF
--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -27,7 +27,6 @@ class RateLimiterTest extends TestCase
     public function testRegisterNamedRateLimiter(mixed $name, string $expected): void
     {
         $reflectedLimitersProperty = new ReflectionProperty(RateLimiter::class, 'limiters');
-        $reflectedLimitersProperty->setAccessible(true);
 
         $rateLimiter = new RateLimiter($this->createMock(Cache::class));
         $rateLimiter->for($name, fn () => Limit::perMinute(100));


### PR DESCRIPTION
As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. L12 requires PHP 8.2+.

https://www.php.net/manual/en/reflectionproperty.setaccessible.php