### PR TITLE
[12.x] fix: Models having inconsistent guarding behaviour

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -14,7 +14,7 @@ trait GuardsAttributes
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array<string>|bool
+     * @var array<string>
      */
     protected $guarded = ['*'];
 
@@ -28,7 +28,7 @@ trait GuardsAttributes
     /**
      * The actual columns that exist on the database and can be guarded.
      *
-     * @var array<string>
+     * @var array<class-string,list<string>>
      */
     protected static $guardableColumns = [];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -75,7 +75,7 @@ trait GuardsAttributes
      */
     public function getGuarded()
     {
-        return $this->guarded === false
+        return self::$unguarded === true
             ? []
             : $this->guarded;
     }


### PR DESCRIPTION
Fixing an issue with the Models having inconsistent guarding behaviour when `$guarded` is empty, but `$fillable` is populated, which causes a  MassAssignmentException to be thrown. this happens because `getGuarded` in
`GuardsAttributes` has two different mechanisms for unguarding a model.

1. $unguarded boolean property (default: false)
2. $guarded array property (default: ['*'])

`getGuarded()` uses the `$guarded` and checks if it's false to return an empty array.

`fillableFromArray()` uses `$unguarded` and `$fillable` properties to test if the model is unguarded.

Both methods should use $unguarded for consistent behaviour.

closes #56380