### PR TITLE
[12.x] Introduce `#[Bind]` attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -3,15 +3,42 @@
 namespace Illuminate\Container\Attributes;
 
 use Attribute;
+use InvalidArgumentException;
 
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Bind
 {
     /**
-     * @param  class-string  $concrete  The concrete class to bind to.
+     * The concrete class to bind to.
+     *
+     * @var class-string
+     */
+    public string $concrete;
+
+    /**
+     * Only use the bindings in this environment.
+     *
+     * @var array<int, string>
+     */
+    public array $environments = [];
+
+    /**
+     * @param  class-string  $concrete
+     * @param  array<int, string>|string  $environments
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $concrete,
+        string $concrete,
+        string|array $environments = ['*'],
     ) {
+        $environments = is_array($environments) ? $environments : [$environments];
+
+        if ($environments === []) {
+            throw new InvalidArgumentException('The environment property must be set and cannot be empty.');
+        }
+
+        $this->concrete = $concrete;
+        $this->environments = $environments;
     }
 }

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Bind
+{
+    /**
+     * @param  class-string  $concrete
+     */
+    public function __construct(
+        public string $concrete,
+    ) {
+    }
+}

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -24,7 +24,7 @@ class Bind
 
     /**
      * @param  class-string  $concrete
-     * @param  non-empty-array<int, string>|non-empty-string  $environments
+     * @param  non-empty-array<int, non-empty-string>|non-empty-string  $environments
      *
      * @throws \InvalidArgumentException
      */
@@ -32,7 +32,7 @@ class Bind
         string $concrete,
         string|array $environments = ['*'],
     ) {
-        $environments = is_array($environments) ? $environments : [$environments];
+        $environments = array_filter(is_array($environments) ? $environments : [$environments]);
 
         if ($environments === []) {
             throw new InvalidArgumentException('The environment property must be set and cannot be empty.');

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -18,13 +18,13 @@ class Bind
     /**
      * Only use the bindings in this environment.
      *
-     * @var array<int, string>
+     * @var non-empty-array<int, string>
      */
     public array $environments = [];
 
     /**
      * @param  class-string  $concrete
-     * @param  array<int, string>|string  $environments
+     * @param  non-empty-array<int, string>|non-empty-string  $environments
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Container\Attributes;
 
 use Attribute;
+use BackedEnum;
 use InvalidArgumentException;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Bind
@@ -16,15 +18,17 @@ class Bind
     public string $concrete;
 
     /**
-     * Only use the bindings in this environment.
+     * The environments the binding should apply for.
      *
      * @var non-empty-array<int, string>
      */
     public array $environments = [];
 
     /**
+     * Create a new attribute instance.
+     *
      * @param  class-string  $concrete
-     * @param  non-empty-array<int, non-empty-string>|non-empty-string  $environments
+     * @param  non-empty-array<int, \BackedEnum|\UnitEnum|non-empty-string>|non-empty-string  $environments
      *
      * @throws \InvalidArgumentException
      */
@@ -39,6 +43,11 @@ class Bind
         }
 
         $this->concrete = $concrete;
-        $this->environments = $environments;
+
+        $this->environments = array_map(fn ($environment) => match (true) {
+            $environment instanceof BackedEnum => $environment->value,
+            $environment instanceof UnitEnum => $environment->name,
+            default => $environment,
+        }, $environments);
     }
 }

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -8,7 +8,7 @@ use Attribute;
 class Bind
 {
     /**
-     * @param  class-string  $concrete
+     * @param  class-string  $concrete  The concrete class to bind to.
      */
     public function __construct(
         public string $concrete,

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -976,11 +976,7 @@ class Container implements ArrayAccess, ContainerContract
             return $this->bindings[$abstract]['concrete'];
         }
 
-        if (($this->checkedForBindings[$abstract] ?? false) || ! is_string($abstract)) {
-            return $abstract;
-        }
-
-        if ($this->environmentResolver === null) {
+        if ($this->environmentResolver === null || ($this->checkedForBindings[$abstract] ?? false) || ! is_string($abstract)) {
             return $abstract;
         }
 
@@ -1646,7 +1642,9 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * @param  (callable(array<int, string>): bool)|null  $callback
+     * Set the callback which determines the current Container environment.
+     *
+     * @param  (callable(array<int, string>|string): bool|string)|null  $callback
      * @return void
      */
     public function resolveEnvironmentUsing(?callable $callback)

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1007,7 +1007,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $concrete = $maybeConcrete = null;
 
-        foreach($reflectedAttributes as $reflectedAttribute) {
+        foreach ($reflectedAttributes as $reflectedAttribute) {
             $instance = $reflectedAttribute->newInstance();
             if ($instance->environments === ['*']) {
                 $maybeConcrete = $instance->concrete;

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -980,6 +980,10 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
+        if ($this->environmentResolver === null) {
+            return $abstract;
+        }
+
         $attributes = [];
 
         try {
@@ -989,7 +993,7 @@ class Container implements ArrayAccess, ContainerContract
 
         $this->checkedForBindings[$abstract] = true;
 
-        if ($attributes === [] || $this->environmentResolver === null) {
+        if ($attributes === []) {
             return $abstract;
         }
 
@@ -1009,8 +1013,13 @@ class Container implements ArrayAccess, ContainerContract
 
         foreach ($reflectedAttributes as $reflectedAttribute) {
             $instance = $reflectedAttribute->newInstance();
+
+            // If the attribute indicates it is for all environments, then we keep
+            // this as the potential concrete, but check the rest of
+            // attributes to see if there is a more specific match.
             if ($instance->environments === ['*']) {
                 $maybeConcrete = $instance->concrete;
+
                 continue;
             }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container;
 use ArrayAccess;
 use Closure;
 use Exception;
+use Illuminate\Container\Attributes\Bind;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -961,7 +962,19 @@ class Container implements ArrayAccess, ContainerContract
             return $this->bindings[$abstract]['concrete'];
         }
 
-        return $abstract;
+        $attributes = [];
+        try {
+            $attributes = (new ReflectionClass($abstract))->getAttributes(Bind::class);
+        } catch (ReflectionException) {
+        }
+
+        if ($attributes === []) {
+            return $abstract;
+        }
+
+        $this->bind($abstract, $attributes[0]->newInstance()->concrete);
+
+        return $this->bindings[$abstract]['concrete'];
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -180,7 +180,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $afterResolvingAttributeCallbacks = [];
 
     /**
-     * Whether an abstract class has already had its attributes checked for binding.
+     * Whether an abstract class has already had its attributes checked for bindings.
      *
      * @var array<class-string, true>
      */
@@ -974,6 +974,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         $attributes = [];
+
         try {
             $attributes = (new ReflectionClass($abstract))->getAttributes(Bind::class);
         } catch (ReflectionException) {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -43,6 +43,7 @@ class LoadConfiguration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
         $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
+
         $app->resolveEnvironmentUsing($app->environment(...));
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -43,6 +43,7 @@ class LoadConfiguration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
         $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
+        $app->resolveEnvironmentUsing($app->environment(...));
 
         date_default_timezone_set($config->get('app.timezone', 'UTC'));
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1045,9 +1045,14 @@ class ContainerScopedAttribute
 {
 }
 
-#[Bind(ContainerSingletonAttribute::class, environments: ['foo', 'bar'])]
+#[Bind(ContainerSingletonAttribute::class, environments: ['foo', ContainerTestEnvironments::Bar])]
 interface ContainerBindSingletonTestInterface
 {
+}
+
+enum ContainerTestEnvironments: string
+{
+    case Bar = 'bar';
 }
 
 #[Bind(ContainerScopedAttribute::class, environments: ['test'])]

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -770,6 +770,7 @@ class ContainerTest extends TestCase
     public function testBindInterfaceToSingleton()
     {
         $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($arr) => true);
         $firstInstantiation = $container->get(ContainerBindSingletonTestInterface::class);
         $secondInstantiation = $container->get(ContainerBindSingletonTestInterface::class);
 
@@ -779,10 +780,16 @@ class ContainerTest extends TestCase
     public function testBindInterfaceToScoped()
     {
         $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($arr) => $arr === ['test']);
         $firstInstantiation = $container->get(ContainerBindScopedTestInterface::class);
         $secondInstantiation = $container->get(ContainerBindScopedTestInterface::class);
 
         $this->assertSame($firstInstantiation, $secondInstantiation);
+
+        // With a different environment
+        $container->resolveEnvironmentUsing(fn ($arr) => $arr === ['test2']);
+        $thirdInstantiation = $container->get(ContainerBindScopedTestInterface::class);
+        $this->assertSame($firstInstantiation, $thirdInstantiation);
 
         $container->forgetScopedInstances();
 
@@ -960,12 +967,13 @@ class ContainerScopedAttribute
 {
 }
 
-#[Bind(ContainerSingletonAttribute::class)]
+#[Bind(ContainerSingletonAttribute::class, environments: ['foo', 'bar'])]
 interface ContainerBindSingletonTestInterface
 {
 }
 
-#[Bind(ContainerScopedAttribute::class)]
+#[Bind(ContainerScopedAttribute::class, environments: ['test'])]
+#[Bind(ContainerScopedAttribute::class, environments: ['test2'])]
 interface ContainerBindScopedTestInterface
 {
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Container;
 
 use Attribute;
+use Illuminate\Container\Attributes\Bind;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Container\Container;
@@ -766,6 +767,29 @@ class ContainerTest extends TestCase
         $this->assertNotSame($firstInstantiation, $thirdInstantiation);
     }
 
+    public function testBindInterfaceToSingleton()
+    {
+        $container = new Container;
+        $firstInstantiation = $container->get(ContainerBindSingletonTestInterface::class);
+        $secondInstantiation = $container->get(ContainerBindSingletonTestInterface::class);
+
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+    }
+
+    public function testBindInterfaceToScoped()
+    {
+        $container = new Container;
+        $firstInstantiation = $container->get(ContainerBindScopedTestInterface::class);
+        $secondInstantiation = $container->get(ContainerBindScopedTestInterface::class);
+
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+
+        $container->forgetScopedInstances();
+
+        $thirdInstantiation = $container->get(ContainerBindScopedTestInterface::class);
+        $this->assertNotSame($firstInstantiation, $thirdInstantiation);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -933,5 +957,15 @@ class ContainerSingletonAttribute
 
 #[Scoped]
 class ContainerScopedAttribute
+{
+}
+
+#[Bind(ContainerSingletonAttribute::class)]
+interface ContainerBindSingletonTestInterface
+{
+}
+
+#[Bind(ContainerScopedAttribute::class)]
+interface ContainerBindScopedTestInterface
 {
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1105,7 +1105,7 @@ interface ProdEnvOnlyInterface
 }
 
 #[Bind(ProdConcrete::class, environments: 'prod')]
-#[Bind(DevConcrete::class,  environments: 'dev')]
+#[Bind(DevConcrete::class, environments: 'dev')]
 interface MultiEnvInterface
 {
 }
@@ -1113,7 +1113,6 @@ interface MultiEnvInterface
 class DevConcrete implements MultiEnvInterface
 {
 }
-
 
 #[Bind(OriginalConcrete::class)]
 interface OverrideInterface

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Foundation\Bootstrap;
 
+use Closure;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class LoadConfigurationTest extends TestCase
 {
@@ -16,6 +18,19 @@ class LoadConfigurationTest extends TestCase
         (new LoadConfiguration)->bootstrap($app);
 
         $this->assertSame('Laravel', $app['config']['app.name']);
+    }
+
+    public function testSetsEnvironmentResolver()
+    {
+        $app = new Application();
+        $this->assertNull((new ReflectionClass($app))->getProperty('environmentResolver')->getValue($app));
+
+        (new LoadConfiguration)->bootstrap($app);
+
+        $this->assertInstanceOf(
+            Closure::class,
+            (new ReflectionClass($app))->getProperty('environmentResolver')->getValue($app)
+        );
     }
 
     public function testDontLoadBaseConfiguration()


### PR DESCRIPTION
Similar to https://github.com/laravel/framework/pull/56334, now a developer can bind a specific concrete implementation to an interface via an attribute.

```php
#[Bind(TwChatService::class, environments: ['staging', 'production'])]
#[Bind(FakeTwChatService::class, environments: ['*'])]
interface ChatServiceInterface
{
    public function getMessages($user): array;

    public function sendMessage($user, $message): Response;
}
```
In the above scenario, if the environment is staging or production, then calling `app(ChatServiceInterface::class)` will return `TwChatService`. For all other environments (eg: dev or testing), `FakeTwChatService` would be returned.

### Why?
Our biggest use of interfaces is to provide a production version of the code, and then inside of tests, we swap out with a test implementation. All of our code type-hints the interface, but in order to figure out which concrete implementation it is, we have to jump back to the service provider to see where it's bound. This keeps it tidy and in one place.

### Technical Decisions
We are keeping a cache of class strings which we have already checked for the `Bind` attribute. This cuts down on repeated reflection if we already know the class does not have the attribute. While it will increase the memory footprint of the Container class slightly, it should improve performance on repeated instantiation of objects. Maybe this should be a static property instead? 🤔 

If using the container outside of the Laravel Application, then you must manually set the environment resolver. If none is set, then the attributes will be ignored.

#### Wildcards
We are using fuzzy-matching (via the `Str::is()` method). If all environments are passed, then we will still compare all of the attributes to see if there is a more specific match.

```php
#[Bind(MyDummyClass::class, ['*'])]
#[Bind(MyProdClass::class, ['production'])]
interface MyInterface { }
```

For the above, `app(MyInterface::class)` will return `MyProdClass` if the environment is production, but `MyDummyClass` for all other environments.

### Improvements
The scoped/singleton property could possibly be shoe-horned in here.