### PR TITLE
[12.x] Make the getTable method public in database failed job providers

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -164,7 +164,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function getTable()
+    public function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
     }

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -177,7 +177,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function getTable()
+    public function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
     }


### PR DESCRIPTION
Listing failed jobs in the terminal can be handy at times, particularly when we are already in the terminal.

In PR #53827, I have mentioned the limitations of the `queue:failed` command. It lacks a set of options to filter the failed jobs further.

Not a problem, we can make the `getTable` method public so we can create our own artisan command to check failed jobs.

```php
use Illuminate\Database\Query\Builder;

class CustomListFailed extends Command
{
    protected $name = 'queue:custom-list-failed
        {--today}
        {--queue : The queue the job is run on.}
        {--sort-direction=desc : Sort direction.}
        {--job-name : Sort direction.}
        {--limit=10 : Sort direction.}
    ';

    protected $description = 'Filter and list failed jobs.';

    protected Builder $query;

    public function handle(): void
    {
        $this->setQuery(
                app('queue.failer')->getTable()
            )
            ->today()
            ->queue()
            ->jobName()
            ->order()
            ->limit()
            ->query()
            ->get()
            // Format each record before display.
            ->map(fn ($record) => ...);
    }

    public function query(): Builder
    {
        return $this->query;
    }

    protected function setQuery(Builder $query): self
    {
        $this->query = $query;

        return $this;
    }

    protected function today(): self
    {
        if ($this->option('today')) {
            $this->query->whereDate('failed_at', now()->format('Y-m-d'));
        }

        return $this;
    }

    protected function queue(): self
    {
        if ($this->option('queue')) {
            $this->query->where('queue', $this->option('queue'));
        }

        return $this;
    }

    protected function jobName(): self
    {
        if ($this->option('job-name')) {
            $this->query->where('payload->displayName', $this->option('job-name'));
        }

        return $this;
    }

    protected function order(): self
    {
        $this->query->orderBy($this->option('sort-direction'));

        return $this;
    }

    protected function limit(): self
    {
        return $this->query->limit($this->option('limit'));

        return $this;
    }
}
```
Now, some of you might wonder `DB::table('failed_jobs')` will achieve the same results. I agree, we can definitely do so. But in a Laravel project, it is more like a responsibility of a failed job provider. And this tiny change surely does no harm.