### PR TITLE
[12.x] Adds the Concrete attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Concrete.php
+++ b/src/Illuminate/Container/Attributes/Concrete.php
@@ -10,5 +10,7 @@ final class Concrete
     /**
      * @param  string  $class  The class to be used for the contract, should a binding not exist.
      */
-    public function __construct(public $class) {}
+    public function __construct(public $class)
+    {
+    }
 }

--- a/src/Illuminate/Container/Attributes/Concrete.php
+++ b/src/Illuminate/Container/Attributes/Concrete.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Concrete
+{
+    /**
+     * @param  string  $class  The class to be used for the contract, should a binding not exist.
+     */
+    public function __construct(public $class) {}
+}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -981,7 +981,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $reflection = new ReflectionClass($abstract);
 
-        if (! $reflection->isInterface()) {
+        if (! $reflection->isInterface() && ! $reflection->isAbstract()) {
             return null;
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -770,9 +770,11 @@ class ContainerTest extends TestCase
     public function testContainerConcreteAttribute()
     {
         $container = new Container;
-        $instantiation = $container->get(ContractWithConcreteAttribute::class);
+        $instantiation1 = $container->get(ContractWithConcreteAttribute::class);
+        $instantiation2 = $container->get(AbstractStub::class);
 
-        $this->assertInstanceOf(ConcreteStub::class, $instantiation);
+        $this->assertInstanceOf(ConcreteStub::class, $instantiation1);
+        $this->assertInstanceOf(ConcreteStub::class, $instantiation2);
     }
 
     // public function testContainerCanCatchCircularDependency()
@@ -950,6 +952,11 @@ interface ContractWithConcreteAttribute
 {
 }
 
-class ConcreteStub implements ContractWithConcreteAttribute
+#[Concrete(ConcreteStub::class)]
+abstract class AbstractStub
+{
+}
+
+class ConcreteStub extends AbstractStub implements ContractWithConcreteAttribute
 {
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -946,6 +946,10 @@ class ContainerScopedAttribute
 }
 
 #[Concrete(ConcreteStub::class)]
-interface ContractWithConcreteAttribute {}
+interface ContractWithConcreteAttribute
+{
+}
 
-class ConcreteStub implements ContractWithConcreteAttribute {}
+class ConcreteStub implements ContractWithConcreteAttribute
+{
+}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Container;
 
 use Attribute;
+use Illuminate\Container\Attributes\Concrete;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Container\Container;
@@ -766,6 +767,14 @@ class ContainerTest extends TestCase
         $this->assertNotSame($firstInstantiation, $thirdInstantiation);
     }
 
+    public function testContainerConcreteAttribute()
+    {
+        $container = new Container;
+        $instantiation = $container->get(ContractWithConcreteAttribute::class);
+
+        $this->assertInstanceOf(ConcreteStub::class, $instantiation);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -935,3 +944,8 @@ class ContainerSingletonAttribute
 class ContainerScopedAttribute
 {
 }
+
+#[Concrete(ConcreteStub::class)]
+interface ContractWithConcreteAttribute {}
+
+class ConcreteStub implements ContractWithConcreteAttribute {}


### PR DESCRIPTION
# Changes

- Adds a `Concrete` attribute to allow for default to be set on contracts & abstract classes, to be used if no binding exists.
- Allows the Container to resolve the Concrete from the Abstract if it uses the Concrete attribute.
- Adds an appropriate test.

# Why

The idea is this would be useful when writing contracts within an application to have a default that can be set in the interface/abstract class file itself instead of having to add the binding to the container via a service provider.

Example use:

```php
#[Concrete(ConcreteStub::class)]
interface ContractWithConcreteAttribute {}

class ConcreteStub implements ContractWithConcreteAttribute {}
```

Using the container would automatically resolve the instance based on the concrete attribute.

```php
// Returns an instance of ConcreteStub instead of failing with an 
// "Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Tests\Container\ContractWithConcreteAttribute] is not instantiable." error.
$container->get(ContractWithConcreteAttribute::class); 
```

# Notes

`Concrete` attribute has a `$class` argument that isn't type hinted. Ideally it would be a `readonly string` but I wasn't sure if there would be an issue as often Laravel code bases don't type hint things. That said I made the attribute class `final` as both `Singleton` and `Scoped` are.

Happy to document the feature if approved.

## Naming

I felt `Concrete` was the right name, but my other suggestion would be `Binding`.
