### PR TITLE
[12.x] Add `authorizeSingletonResource` method to `AuthorizesRequests`

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -106,6 +106,28 @@ trait AuthorizesRequests
     }
 
     /**
+     * Authorize a singleton resource action based on the incoming request.
+     *
+     * @param  string|array  $model
+     * @param  array  $options
+     * @return void
+     */
+    public function authorizeSingletonResource($model, array $options = [])
+    {
+        $model = is_array($model) ? implode(',', $model) : $model;
+
+        $middleware = [];
+
+        foreach ($this->resourceAbilityMap() as $method => $ability) {
+            $middleware["can:{$ability},{$model}"][] = $method;
+        }
+
+        foreach ($middleware as $middlewareName => $methods) {
+            $this->middleware($middlewareName, $options)->only($methods);
+        }
+    }
+
+    /**
      * Get the map of resource methods to ability names.
      *
      * @return array<string, string>

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -23,6 +23,17 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User,App\Post');
     }
 
+    public function testSingletonCreateMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'create', 'can:create,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'create', 'can:create,App\Profile,App\Settings');
+    }
+
     public function testStoreMethod()
     {
         $controller = new AuthorizesResourcesController;
@@ -32,6 +43,17 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User,App\Post');
+    }
+
+    public function testSingletonStoreMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'store', 'can:create,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'store', 'can:create,App\Profile,App\Settings');
     }
 
     public function testShowMethod()
@@ -45,6 +67,17 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'show', 'can:view,user,post');
     }
 
+    public function testSingletonShowMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'show', 'can:view,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'show', 'can:view,App\Profile,App\Settings');
+    }
+
     public function testEditMethod()
     {
         $controller = new AuthorizesResourcesController;
@@ -54,6 +87,17 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user,post');
+    }
+
+    public function testSingletonEditMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'edit', 'can:update,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'edit', 'can:update,App\Profile,App\Settings');
     }
 
     public function testUpdateMethod()
@@ -67,6 +111,17 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'update', 'can:update,user,post');
     }
 
+    public function testSingletonUpdateMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'update', 'can:update,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'update', 'can:update,App\Profile,App\Settings');
+    }
+
     public function testDestroyMethod()
     {
         $controller = new AuthorizesResourcesController;
@@ -76,6 +131,17 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user,post');
+    }
+
+    public function testSingletonDestroyMethod()
+    {
+        $controller = new AuthorizesSingletonResourcesController;
+
+        $this->assertHasMiddleware($controller, 'destroy', 'can:delete,App\Profile');
+
+        $controller = new AuthorizesSingletonResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'destroy', 'can:delete,App\Profile,App\Settings');
     }
 
     /**
@@ -153,6 +219,96 @@ class AuthorizesResourcesWithArrayController extends Controller
     public function __construct()
     {
         $this->authorizeResource(['App\User', 'App\Post'], ['user', 'post']);
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store()
+    {
+        //
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update()
+    {
+        //
+    }
+
+    public function destroy()
+    {
+        //
+    }
+}
+
+class AuthorizesSingletonResourcesController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct()
+    {
+        $this->authorizeSingletonResource('App\Profile');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store()
+    {
+        //
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update()
+    {
+        //
+    }
+
+    public function destroy()
+    {
+        //
+    }
+}
+
+class AuthorizesSingletonResourcesWithArrayController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct()
+    {
+        $this->authorizeSingletonResource(['App\Profile', 'App\Settings']);
     }
 
     public function index()


### PR DESCRIPTION
This PR introduces a new method `authorizeSingletonResource()` to the `AuthorizesRequests` trait, enhancing Laravel's authorization capabilities for singleton resources.

**Purpose**

The existing `authorizeResource()` method works well for standard RESTful resources that use route model binding with parameters. However, it doesn't provide an elegant solution for singleton resources - resources that represent a single entity per user/context rather than a collection (like a user profile, dashboard settings, or account preferences).