### PR TITLE
[12.x] Fix typehints for `partition()`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -508,8 +508,8 @@ trait EnumeratesValues
      * Partition the collection into two arrays using the given callback or key.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return static<int<0, 1>, static<TKey, TValue>>
      */
     public function partition($key, $operator = null, $value = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -706,8 +706,8 @@ class Collection extends BaseCollection implements QueueableCollection
      * Partition the collection into two arrays using the given callback or key.
      *
      * @param  (callable(TModel, TKey): bool)|TModel|string  $key
-     * @param  TModel|string|null  $operator
-     * @param  TModel|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return \Illuminate\Support\Collection<int<0, 1>, static<TKey, TModel>>
      */
     public function partition($key, $operator = null, $value = null)


### PR DESCRIPTION
This gives a PHPStan error:

```php
User::get()->partition('team_id', 100);
```
<img width="1224" height="170" alt="image" src="https://github.com/user-attachments/assets/d6df8d43-b2c1-4170-b356-c0ef15b2ec84" />

however the code runs just fine

<img width="568" height="207" alt="image" src="https://github.com/user-attachments/assets/410a3bf8-6f7d-4d64-94d6-fe40bca79254" />
