### PR TITLE
Fix incorrect docblock for custom builder resolvers

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -30,7 +30,7 @@ class Builder
     /**
      * The Blueprint resolver callback.
      *
-     * @var \Closure(\Illuminate\Database\Connection, string, \Closure): \Illuminate\Database\Schema\Blueprint
+     * @var \Closure(\Illuminate\Database\Connection, string, \Closure|null): \Illuminate\Database\Schema\Blueprint
      */
     protected $resolver;
 
@@ -698,7 +698,7 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  \Closure(\Illuminate\Database\Connection, string, \Closure): \Illuminate\Database\Schema\Blueprint  $resolver
+     * @param  \Closure(\Illuminate\Database\Connection, string, \Closure|null): \Illuminate\Database\Schema\Blueprint  $resolver
      * @return void
      */
     public function blueprintResolver(Closure $resolver)

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -30,7 +30,8 @@ class Builder
     /**
      * The Blueprint resolver callback.
      *
-     * @var \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint|null
+     * @var \Closure(\Illuminate\Database\Connection, string, \Closure): \Illuminate\Database\Schema\Blueprint
+     *
      */
     protected $resolver;
 
@@ -698,7 +699,7 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  \Closure(string, \Closure, string): \Illuminate\Database\Schema\Blueprint|null  $resolver
+     * @param  \Closure(\Illuminate\Database\Connection, string, \Closure): \Illuminate\Database\Schema\Blueprint  $resolver
      * @return void
      */
     public function blueprintResolver(Closure $resolver)

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -31,7 +31,6 @@ class Builder
      * The Blueprint resolver callback.
      *
      * @var \Closure(\Illuminate\Database\Connection, string, \Closure): \Illuminate\Database\Schema\Blueprint
-     *
      */
     protected $resolver;
 


### PR DESCRIPTION
Fixes #56152 which was caused by the incorrect parameters being used for a more specific type hint docblock merged in #55687. 

This currently causes issues with projects that use static analysis and make use of the $builder->blueprintResolver() method to resolve custom blueprints.

See https://github.com/LukeTowers/framework/blob/patch-1/src/Illuminate/Database/Schema/Builder.php#L621-L637 for the proof of the corrected typehints.

Example below:

```
 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   Database/DatabaseServiceProvider.php                                                                      
 ------ ---------------------------------------------------------------------------------------------------------- 
  :109   Parameter #1 $connection of class Winter\Storm\Database\Schema\Blueprint constructor expects              
         Illuminate\Database\Connection, string given.                                                             
         🪪  argument.type                                                                                         
  :109   Parameter #2 $table of class Winter\Storm\Database\Schema\Blueprint constructor expects string, Closure   
         given.                                                                                                    
         🪪  argument.type                                                                                         
  :109   Parameter #3 $callback of class Winter\Storm\Database\Schema\Blueprint constructor expects Closure|null,  
         string given.                                                                                             
         🪪  argument.type                                                                                         
 ------ ----------------------------------------------------------------------------------------------------------
```