### PR TITLE
[12.x] Use MissingValue as default to distinguish between omitted and explicit null

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -100,13 +100,13 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function when($condition, $value, $default = null)
+    protected function when($condition, $value, $default = new MissingValue)
     {
         if ($condition) {
             return value($value);
         }
 
-        return func_num_args() === 3 ? value($default) : new MissingValue;
+        return func_num_args() === 3 ? value($default) : $default;
     }
 
     /**
@@ -117,7 +117,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function unless($condition, $value, $default = null)
+    public function unless($condition, $value, $default = new MissingValue)
     {
         $arguments = func_num_args() === 2 ? [$value] : [$value, $default];
 
@@ -143,13 +143,13 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MergeValue|mixed
      */
-    protected function mergeWhen($condition, $value, $default = null)
+    protected function mergeWhen($condition, $value, $default = new MissingValue)
     {
         if ($condition) {
             return new MergeValue(value($value));
         }
 
-        return func_num_args() === 3 ? new MergeValue(value($default)) : new MissingValue();
+        return func_num_args() === 3 ? new MergeValue(value($default)) : $default;
     }
 
     /**
@@ -160,7 +160,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MergeValue|mixed
      */
-    protected function mergeUnless($condition, $value, $default = null)
+    protected function mergeUnless($condition, $value, $default = new MissingValue)
     {
         $arguments = func_num_args() === 2 ? [$value] : [$value, $default];
 
@@ -188,12 +188,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenHas($attribute, $value = null, $default = null)
+    public function whenHas($attribute, $value = null, $default = new MissingValue)
     {
-        if (func_num_args() < 3) {
-            $default = new MissingValue;
-        }
-
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
             return value($default);
         }
@@ -210,7 +206,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenNull($value, $default = null)
+    protected function whenNull($value, $default = new MissingValue)
     {
         $arguments = func_num_args() == 1 ? [$value] : [$value, $default];
 
@@ -224,7 +220,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenNotNull($value, $default = null)
+    protected function whenNotNull($value, $default = new MissingValue)
     {
         $arguments = func_num_args() == 1 ? [$value] : [$value, $default];
 
@@ -239,13 +235,13 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenAppended($attribute, $value = null, $default = null)
+    protected function whenAppended($attribute, $value = null, $default = new MissingValue)
     {
         if ($this->resource->hasAppended($attribute)) {
             return func_num_args() >= 2 ? value($value) : $this->resource->$attribute;
         }
 
-        return func_num_args() === 3 ? value($default) : new MissingValue;
+        return func_num_args() === 3 ? value($default) : $default;
     }
 
     /**
@@ -256,12 +252,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenLoaded($relationship, $value = null, $default = null)
+    protected function whenLoaded($relationship, $value = null, $default = new MissingValue)
     {
-        if (func_num_args() < 3) {
-            $default = new MissingValue;
-        }
-
         if (! $this->resource->relationLoaded($relationship)) {
             return value($default);
         }
@@ -291,12 +283,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenCounted($relationship, $value = null, $default = null)
+    public function whenCounted($relationship, $value = null, $default = new MissingValue)
     {
-        if (func_num_args() < 3) {
-            $default = new MissingValue;
-        }
-
         $attribute = (new Stringable($relationship))->snake()->finish('_count')->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
@@ -328,12 +316,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenAggregated($relationship, $column, $aggregate, $value = null, $default = null)
+    public function whenAggregated($relationship, $column, $aggregate, $value = null, $default = new MissingValue)
     {
-        if (func_num_args() < 5) {
-            $default = new MissingValue;
-        }
-
         $attribute = (new Stringable($relationship))->snake()->append('_')->append($aggregate)->append('_')->finish($column)->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
@@ -363,12 +347,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    public function whenExistsLoaded($relationship, $value = null, $default = null)
+    public function whenExistsLoaded($relationship, $value = null, $default = new MissingValue)
     {
-        if (func_num_args() < 3) {
-            $default = new MissingValue;
-        }
-
         $attribute = (new Stringable($relationship))->snake()->finish('_exists')->value();
 
         if (! array_key_exists($attribute, $this->resource->getAttributes())) {
@@ -394,7 +374,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenPivotLoaded($table, $value, $default = null)
+    protected function whenPivotLoaded($table, $value, $default = new MissingValue)
     {
         return $this->whenPivotLoadedAs('pivot', ...func_get_args());
     }
@@ -408,12 +388,8 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenPivotLoadedAs($accessor, $table, $value, $default = null)
+    protected function whenPivotLoadedAs($accessor, $table, $value, $default = new MissingValue)
     {
-        if (func_num_args() === 3) {
-            $default = new MissingValue;
-        }
-
         return $this->when(
             $this->hasPivotLoadedAs($accessor, $table),
             $value,
@@ -443,7 +419,7 @@ trait ConditionallyLoadsAttributes
     {
         return isset($this->resource->$accessor) &&
             ($this->resource->$accessor instanceof $table ||
-            $this->resource->$accessor->getTable() === $table);
+                $this->resource->$accessor->getTable() === $table);
     }
 
     /**
@@ -454,10 +430,10 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return mixed
      */
-    protected function transform($value, callable $callback, $default = null)
+    protected function transform($value, callable $callback, $default = new MissingValue)
     {
         return transform(
-            $value, $callback, func_num_args() === 3 ? $default : new MissingValue
+            $value, $callback, $default
         );
     }
 }


### PR DESCRIPTION
# Replace null defaults with MissingValue to make behavior more explicit and IDE-friendly
## Problem
When using helper methods like:
```php
->when($condition, $value, null)
```
many IDEs (e.g., PhpStorm) suggest that the third argument is redundant because it matches the default (null).
If a developer removes it (trusting the IDE), the behavior changes silently:

* ```->when(..., null)``` → the field is included in the response with value null
* ```->when(...)``` → the field is skipped entirely (because MissingValue is used internally)
This leads to non-obvious bugs, especially when the difference between null and "not passed at all" is significant.

## Solution
This PR changes the default value from null to new MissingValue in affected helper methods.

Why this matters:
* Makes the distinction between null and "not provided" explicit
* Prevents IDEs from suggesting misleading simplifications
* Improves developer experience and reduces potential bugs
* Encourages conscious handling of optional parameters

After this change, the difference is clearly reflected in the method signature. IDEs will no longer suggest removing null without warning.