### PR TITLE
[12.x] Feat: ability to explicitly exclude factory relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -519,7 +519,7 @@ abstract class Factory
                 if (! $this->expandRelationships && $attribute instanceof self) {
                     $attribute = null;
                 } elseif ($attribute instanceof self && in_array($attribute->modelName(), $this->excludeRelationships)) {
-                   $attribute = null;
+                    $attribute = null;
                 } elseif ($attribute instanceof self) {
                     $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
                         ?? $attribute->recycle($this->recycle)->create()->getKey();

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -515,10 +515,11 @@ abstract class Factory
     protected function expandAttributes(array $definition)
     {
         return (new Collection($definition))
-            ->map($evaluateRelations = function ($attribute) {
+            ->map($evaluateRelations = function ($attribute, $key) use ($definition) {
                 if (! $this->expandRelationships && $attribute instanceof self) {
                     $attribute = null;
-                } elseif ($attribute instanceof self && in_array($attribute->modelName(), $this->excludeRelationships)) {
+                } elseif ($attribute instanceof self &&
+                    array_intersect([$attribute->modelName(), $key], $this->excludeRelationships)) {
                     $attribute = null;
                 } elseif ($attribute instanceof self) {
                     $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
@@ -534,7 +535,7 @@ abstract class Factory
                     $attribute = $attribute($definition);
                 }
 
-                $attribute = $evaluateRelations($attribute);
+                $attribute = $evaluateRelations($attribute, $key);
 
                 $definition[$key] = $attribute;
 
@@ -786,6 +787,7 @@ abstract class Factory
     /**
      * Indicate that related parent models should not be created.
      *
+     * @param  array<string|class-string<Model>>  $parents
      * @return static
      */
     public function withoutParents($parents = [])

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -92,7 +92,7 @@ abstract class Factory
     protected $expandRelationships = true;
 
     /**
-     * Relationships that should not be automatically created.
+     * The relationships that should not be automatically created.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -832,6 +832,7 @@ abstract class Factory
             'connection' => $this->connection,
             'recycle' => $this->recycle,
             'expandRelationships' => $this->expandRelationships,
+            'excludeRelationships' => $this->excludeRelationships,
         ], $arguments)));
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -515,7 +515,7 @@ abstract class Factory
     protected function expandAttributes(array $definition)
     {
         return (new Collection($definition))
-            ->map($evaluateRelations = function ($attribute, $key) use ($definition) {
+            ->map($evaluateRelations = function ($attribute, $key) {
                 if (! $this->expandRelationships && $attribute instanceof self) {
                     $attribute = null;
                 } elseif ($attribute instanceof self &&

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -832,7 +832,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertNull($post->user_id);
     }
 
-    public function test_can_disable_relationships_explicitly()
+    public function test_can_disable_relationships_explicitly_by_model_name()
     {
         $comment = FactoryTestCommentFactory::new()
             ->withoutParents([FactoryTestUser::class])
@@ -840,6 +840,26 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $this->assertNull($comment->user_id);
         $this->assertNotNull($comment->commentable->id);
+    }
+
+    public function test_can_disable_relationships_explicitly_by_attribute_name()
+    {
+        $comment = FactoryTestCommentFactory::new()
+            ->withoutParents(['user_id'])
+            ->make();
+
+        $this->assertNull($comment->user_id);
+        $this->assertNotNull($comment->commentable->id);
+    }
+
+    public function test_can_disable_relationships_explicitly_by_both_attribute_name_and_model_name()
+    {
+        $comment = FactoryTestCommentFactory::new()
+            ->withoutParents(['user_id', FactoryTestPost::class])
+            ->make();
+
+        $this->assertNull($comment->user_id);
+        $this->assertNull($comment->commentable->id);
     }
 
     public function test_can_default_to_without_parents()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -832,6 +832,16 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertNull($post->user_id);
     }
 
+    public function test_can_disable_relationships_explicitly()
+    {
+        $comment = FactoryTestCommentFactory::new()
+            ->withoutParents([FactoryTestUser::class])
+            ->make();
+
+        $this->assertNull($comment->user_id);
+        $this->assertNotNull($comment->commentable->id);
+    }
+
     public function test_can_default_to_without_parents()
     {
         FactoryTestPostFactory::dontExpandRelationshipsByDefault();


### PR DESCRIPTION
The `withoutParents` method is definitely a useful method but it's still missing some crucial capabilities. It's actually quite common for a table to have multiple relationship columns, where only some are nullable. In most cases, at least one relationship is mandatory.

For example: imagine an **Employee** model that has relationships with both **Department** and **Allowance** models. Interns aren’t assigned to any department until they complete a grace period, but they must have allowances(no one works for free).

In this case, I need to create an employee (intern) record without creating a department, but with an allowance. Unfortunately, `withoutParents` can’t handle this; it’s all or nothing. That makes it insufficient for this kind of use case.

However, with this new enhancement **we can define which relationships should be excluded** and  `withoutParents` method will be completed. I understand concerns about framework bloat, but I reckon this functionality will be useful to others too. And the best part: I implemented it without introducing any new method except just a small internal variable and  `withoutParents` **accept optional array to define the relationships that should be excluded.**

_Employee factory_

```php
  public function definition(): array
  {
      return [
          'name'                  =>  fake()->name(),
          'age'                     =>  rand(1, 60),
          'department_id'   =>  Department::factory(),
          'allowance_id'      =>  Allowance::factory(),
      ];
  }
```
_Create a employee with a allowance without a department_

```php
  Employee::factory()
    ->withoutParents([Department::class])
    ->create()
 ```

