### PR TITLE
Improve job serialization error message with job class name

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -17,6 +17,8 @@ use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
 
 abstract class Queue
 {
@@ -171,8 +173,8 @@ abstract class Queue
             $command = $this->jobShouldBeEncrypted($job) && $this->container->bound(Encrypter::class)
                 ? $this->container[Encrypter::class]->encrypt(serialize(clone $job))
                 : serialize(clone $job);
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(
+        } catch (Throwable $e) {
+            throw new RuntimeException(
                 sprintf('Failed to serialize job of type [%s]: %s', get_class($job), $e->getMessage()),
                 0,
                 $e


### PR DESCRIPTION
This PR improves the error message when a queued job fails to serialize (usually due to Closure or resource property).  
Instead of the generic `Serialization of 'Closure' is not allowed`, this will show which job caused the error.

In large projects with many jobs, debugging such errors becomes very time-consuming.
This small improvement helps identify the problematic job instantly.

This PR does not break anything. It only adds a try/catch around serialize(...) to enrich the error message.

### Before
'Serialization of 'Closure' is not allowed'

### After
'Failed to serialize job of type [App\Jobs\UpdateSomething]: Serialization of 'Closure' is not allowed'
