### PR TITLE
Add dropColumns method to Blueprint.php

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -416,6 +416,21 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given columns should be dropped.
+     *
+     * Alias for self::dropColumn().
+     *
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropColumns($columns)
+    {
+        $columns = is_array($columns) ? $columns : func_get_args();
+
+        return $this->addCommand('dropColumn', compact('columns'));
+    }
+
+    /**
      * Indicate that the given columns should be renamed.
      *
      * @param  string  $from


### PR DESCRIPTION
When needing to drop multiple columns within a migration, I always find myself writing `dropColumns()` rather than `dropColumn()`. This is a minor paper cut but something that happens often enough that I felt it was worth submitting a PR to add this alias method to the schema builder.