### PR TITLE
 [12.x] added return type to docblock of migration stubs 

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -8,6 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
+     *
+     * @return void
      */
     public function up(): void
     {
@@ -19,6 +21,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
+     *
+     * @return void
      */
     public function down(): void
     {

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -8,6 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
+     *
+     * @return void
      */
     public function up(): void
     {
@@ -16,6 +18,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
+     *
+     * @return void
      */
     public function down(): void
     {

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -8,6 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
+     *
+     * @return void
      */
     public function up(): void
     {
@@ -18,6 +20,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
+     *
+     * @return void
      */
     public function down(): void
     {


### PR DESCRIPTION
### Context

When I need to create one or more migrations, I always find myself writing the return type in the docblock.
It's a minor detail, but it comes up often enough that I think it's worth submitting a change request.

### Modification

The changes in this merge request are the addition of the return type `@return void` in each stub docblock related to migrations.