### PR TITLE
[12.x] Reverts 56310

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -68,12 +68,8 @@ class SeedCommand extends Command
         $this->resolver->setDefaultConnection($this->getDatabase());
 
         Model::unguarded(function () {
-            $seeder = $this->getSeeder();
-
-            $this->components->task(get_class($seeder), $seeder);
+            $this->getSeeder()->__invoke();
         });
-
-        $this->output?->writeln('');
 
         if ($previousConnection) {
             $this->resolver->setDefaultConnection($previousConnection);


### PR DESCRIPTION
Description
---
This PR reverts the changes introduced in #56310, as it broke the output formatting when calling a seeder from within another seeder.

For example, the following code:

```php
<?php

namespace Database\Seeders;

use App\Models\User;
use Illuminate\Database\Seeder;

class DatabaseSeeder extends Seeder
{
    /**
     * Seed the application's database.
     */
    public function run(): void
    {
        $this->call([
            UserSeeder::class,
        ]);
    }
}
```

Produces incorrect or undesirable output, as shown below:

<img width="1452" height="183" alt="Screenshot 2025-07-25 084220" src="https://github.com/user-attachments/assets/53470764-0779-48ec-9867-b2a47546c107" />

Given this regression, reverting to the previous behavior is more appropriate. The original implementation handled nested seeders more gracefully.
