### PR TITLE
[12.x] Clean up redundant type hints in docblocks

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -326,7 +326,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return bool
      */
     public function allows($ability, $arguments = [])
@@ -338,7 +338,7 @@ class Gate implements GateContract
      * Determine if any of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return bool
      */
     public function denies($ability, $arguments = [])
@@ -350,7 +350,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return bool
      */
     public function check($abilities, $arguments = [])
@@ -364,7 +364,7 @@ class Gate implements GateContract
      * Determine if any one of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return bool
      */
     public function any($abilities, $arguments = [])
@@ -376,7 +376,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return bool
      */
     public function none($abilities, $arguments = [])
@@ -388,7 +388,7 @@ class Gate implements GateContract
      * Determine if the given ability should be granted for the current user.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  array|mixed  $arguments
+     * @param  mixed  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -20,7 +20,7 @@ trait HandlesAuthorization
      * Throws an unauthorized exception.
      *
      * @param  string|null  $message
-     * @param  mixed|null  $code
+     * @param  mixed  $code
      * @return \Illuminate\Auth\Access\Response
      */
     protected function deny($message = null, $code = null)

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -150,7 +150,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Create a new batch of queueable jobs.
      *
-     * @param  \Illuminate\Support\Collection|array|mixed  $jobs
+     * @param  \Illuminate\Support\Collection|mixed  $jobs
      * @return \Illuminate\Bus\PendingBatch
      */
     public function batch($jobs)
@@ -187,7 +187,7 @@ class Dispatcher implements QueueingDispatcher
      * Retrieve the handler for a command.
      *
      * @param  mixed  $command
-     * @return bool|mixed
+     * @return mixed
      */
     public function getCommandHandler($command)
     {


### PR DESCRIPTION
This PR removes unnecessary type hints such as `array`, `bool`, and `null` when used alongside `mixed`, since `mixed` already covers all of them.

https://www.php.net/manual/en/language.types.mixed.php