### PR TITLE
[12.x] feat: Allow bulk policy generation for existing models

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
 
 #[AsCommand(name: 'make:policy')]
 class PolicyMakeCommand extends GeneratorCommand
@@ -35,6 +36,20 @@ class PolicyMakeCommand extends GeneratorCommand
      * @var string
      */
     protected $type = 'Policy';
+
+    /**
+     * The models that should have policies generated.
+     *
+     * @var array
+     */
+    protected $models = [];
+
+    /**
+     * Indicates whether to generate policies for all models.
+     *
+     * @var bool
+     */
+    protected $allModels = false;
 
     /**
      * Build the class with the given name.
@@ -119,7 +134,8 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $model = class_basename(trim($model, '\\'));
 
-        $dummyUser = class_basename($this->userProviderModel());
+        $userModel = $this->userProviderModel();
+        $dummyUser = class_basename($userModel);
 
         $dummyModel = Str::camel($model) === 'user' ? 'model' : $model;
 
@@ -137,6 +153,7 @@ class PolicyMakeCommand extends GeneratorCommand
             '{{ user }}' => $dummyUser,
             '{{user}}' => $dummyUser,
             '$user' => '$'.Str::camel($dummyUser),
+            '{{ namespacedUserModel }}' => $userModel,
         ];
 
         $stub = str_replace(
@@ -190,24 +207,280 @@ class PolicyMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command arguments.
+     * Get the console command options.
      *
      * @return array
      */
     protected function getOptions()
     {
         return [
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate policies for all existing models'],
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the policy already exists'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to'],
             ['guard', 'g', InputOption::VALUE_OPTIONAL, 'The guard that the policy relies on'],
         ];
     }
 
+    protected function getArguments()
+    {
+        return [
+            ['name', \Symfony\Component\Console\Input\InputArgument::OPTIONAL, 'The name of the policy'],
+        ];
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->allModels = $this->option('all');
+
+        if (! $this->argument('name')) {
+            if ($this->allModels) {
+                $this->input->setArgument('name', 'DummyPolicyName');
+            } else {
+                $name = text(
+                    label: 'What should the policy be named?',
+                    placeholder: 'E.g. PostPolicy',
+                    required: true,
+                    validate: fn ($value) => match (true) {
+                        empty($value) => 'The policy name is required.',
+                        $this->isReservedName($value) => 'The name "'.$value.'" is reserved by PHP.',
+                        default => null,
+                    }
+                );
+                $this->input->setArgument('name', $name);
+            }
+        }
+
+        if ($this->allModels) {
+            return $this->handleAllModels();
+        }
+
+        return parent::handle();
+    }
+
+    /**
+     * Handle generating policies for all models.
+     *
+     * @return int
+     */
+    protected function handleAllModels()
+    {
+        if (! $this->argument('name')) {
+            $this->input->setArgument('name', 'DummyPolicyName');
+        }
+
+        $this->models = $this->getAllModels();
+
+        if (empty($this->models)) {
+            $this->components->error('No models found to generate policies for.');
+
+            return 1;
+        }
+
+        $successCount = 0;
+
+        foreach ($this->models as $model) {
+            if ($this->generatePolicyForModel($model)) {
+                $successCount++;
+            }
+        }
+
+        $this->components->info("Generated policies for {$successCount} models.");
+
+        return 0;
+    }
+
+    /**
+     * Generate a policy for the given model.
+     *
+     * @param  string  $model
+     * @return bool
+     */
+    protected function generatePolicyForModel($model)
+    {
+        $name = class_basename($model).'Policy';
+        $this->input->setArgument('name', $name);
+        $this->input->setOption('model', $model);
+
+        $qualifiedName = $this->qualifyClass($name);
+
+        if ($this->isReservedName($name)) {
+            $this->components->error('The name "'.$name.'" is reserved by PHP.');
+
+            return false;
+        }
+
+        $path = $this->getPath($qualifiedName);
+
+        if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($name)) {
+            $this->components->warn("Skipped {$name} (already exists).");
+
+            return false;
+        }
+
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->sortImports($this->buildClass($qualifiedName)));
+
+        $this->components->info($this->type.' '.$name.' created successfully.');
+
+        return true;
+    }
+
+    /**
+     * Get all the model classes in the application.
+     *
+     * @return array
+     */
+    protected function getAllModels()
+    {
+        $models = [];
+        $modelPath = app_path('Models');
+
+        if (! is_dir($modelPath)) {
+            return $models;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($modelPath, \RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $modelClasses = $this->getModelsFromFile($file);
+                $models = array_merge($models, $modelClasses);
+            }
+        }
+
+        return array_unique($models);
+    }
+
+    /**
+     * Get model classes from a file using token parsing.
+     *
+     * @param  \SplFileInfo  $file
+     * @return array
+     */
+    protected function getModelsFromFile($file)
+    {
+        $path = $file->getRealPath();
+        $content = file_get_contents($path);
+
+        if (! preg_match('/extends\s+Model|extends\s+Authenticatable|Illuminate\\\\Database\\\\Eloquent/', $content)) {
+            return [];
+        }
+
+        $tokens = token_get_all($content);
+        $namespace = '';
+        $classes = [];
+        $i = 0;
+
+        while (isset($tokens[$i])) {
+            if ($tokens[$i][0] === T_NAMESPACE) {
+                $namespace = $this->extractNamespace($tokens, $i);
+            }
+
+            if ($tokens[$i][0] === T_CLASS && $this->isClassDeclaration($tokens, $i)) {
+                $className = $this->extractClassName($tokens, $i);
+                if ($className && $this->isModelClass($content)) {
+                    $fullClassName = $namespace ? $namespace.'\\'.$className : $className;
+                    $classes[] = $fullClassName;
+                }
+            }
+
+            $i++;
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Extract namespace from tokens.
+     *
+     * @param  array  $tokens
+     * @param  int  &$i
+     * @return string
+     */
+    protected function extractNamespace($tokens, &$i)
+    {
+        $namespace = '';
+        $i++;
+
+        while (isset($tokens[$i]) && $tokens[$i] !== ';' && $tokens[$i] !== '{') {
+            if (is_array($tokens[$i]) && in_array($tokens[$i][0], [T_STRING, T_NS_SEPARATOR])) {
+                $namespace .= $tokens[$i][1];
+            }
+            $i++;
+        }
+
+        return trim($namespace);
+    }
+
+    /**
+     * Check if this is a class declaration (not a class reference).
+     *
+     * @param  array  $tokens
+     * @param  int  $i
+     * @return bool
+     */
+    protected function isClassDeclaration($tokens, $i)
+    {
+        return $i === 0 || $tokens[$i - 1][0] !== T_DOUBLE_COLON;
+    }
+
+    /**
+     * Extract class name from tokens.
+     *
+     * @param  array  $tokens
+     * @param  int  $i
+     * @return string|null
+     */
+    protected function extractClassName($tokens, $i)
+    {
+        for ($j = $i + 1; isset($tokens[$j]); $j++) {
+            if (is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                return $tokens[$j][1];
+            }
+
+            if (! is_array($tokens[$j]) || ! in_array($tokens[$j][0], [T_WHITESPACE])) {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if a class is a model by examining the file content.
+     *
+     * @param  string  $content
+     * @return bool
+     */
+    protected function isModelClass($content)
+    {
+        $patterns = [
+            '/extends\s+Model/',
+            '/extends\s+Authenticatable/',
+            '/use\s+Illuminate\\\\Database\\\\Eloquent\\\\Model/',
+            '/use\s+Illuminate\\\\Foundation\\\\Auth\\\\User\s+as\s+Authenticatable/',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $content)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Interact further with the user if they were prompted for missing arguments.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
@@ -216,13 +489,33 @@ class PolicyMakeCommand extends GeneratorCommand
             return;
         }
 
+        $choices = array_merge(['All Models'], $this->possibleModels());
+
         $model = suggest(
-            'What model should this policy apply to? (Optional)',
-            $this->possibleModels(),
+            label: 'What model should this policy apply to?',
+            options: $choices,
+            placeholder: 'Start typing to search...',
+            required: false,
+            hint: 'Leave empty to create a plain policy or select "All Models" to generate for all models',
+            scroll: min(10, count($choices)),
+            validate: function ($value) use ($choices) {
+                if ($value && ! in_array($value, $choices)) {
+                    return 'The selected model is not valid.';
+                }
+
+                return null;
+            }
         );
 
-        if ($model) {
+        if ($model === 'All Models') {
+            $input->setOption('all', true);
+            $input->setArgument('name', 'DummyPolicyName');
+        } elseif ($model) {
             $input->setOption('model', $model);
+
+            if (! $this->argument('name')) {
+                $input->setArgument('name', class_basename($model).'Policy');
+            }
         }
     }
 }

--- a/tests/Integration/Generators/PolicyMakeCommandTest.php
+++ b/tests/Integration/Generators/PolicyMakeCommandTest.php
@@ -2,11 +2,32 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Illuminate\Support\Facades\File;
+
 class PolicyMakeCommandTest extends TestCase
 {
     protected $files = [
         'app/Policies/FooPolicy.php',
+        'app/Policies/BarPolicy.php',
+        'app/Policies/UserPolicy.php',
+        'app/Policies/BazPolicy.php',
+        'app/Models/Bar.php',
+        'app/Models/User.php',
+        'app/Models/Baz.php',
     ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::ensureDirectoryExists(app_path('Models'));
+
+        File::put(app_path('Models/Bar.php'), '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Bar extends Model {}');
+
+        File::put(app_path('Models/User.php'), '<?php namespace App\Models; use Illuminate\Foundation\Auth\User as Authenticatable; class User extends Authenticatable {}');
+
+        File::put(app_path('Models/Baz.php'), '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Baz extends Model {}');
+    }
 
     public function testItCanGeneratePolicyFile()
     {
@@ -22,21 +43,128 @@ class PolicyMakeCommandTest extends TestCase
 
     public function testItCanGeneratePolicyFileWithModelOption()
     {
-        $this->artisan('make:policy', ['name' => 'FooPolicy', '--model' => 'Post'])
+        $this->artisan('make:policy', ['name' => 'FooPolicy', '--model' => 'Bar'])
             ->assertExitCode(0);
 
         $this->assertFileContains([
             'namespace App\Policies;',
-            'use App\Models\Post;',
+            'use App\Models\Bar;',
             'use Illuminate\Foundation\Auth\User;',
             'class FooPolicy',
             'public function viewAny(User $user)',
-            'public function view(User $user, Post $post)',
+            'public function view(User $user, Bar $bar)',
             'public function create(User $user)',
-            'public function update(User $user, Post $post)',
-            'public function delete(User $user, Post $post)',
-            'public function restore(User $user, Post $post)',
-            'public function forceDelete(User $user, Post $post)',
+            'public function update(User $user, Bar $bar)',
+            'public function delete(User $user, Bar $bar)',
+            'public function restore(User $user, Bar $bar)',
+            'public function forceDelete(User $user, Bar $bar)',
         ], 'app/Policies/FooPolicy.php');
+    }
+    public function testItCanGeneratePolicyFileWithoutNameWhenModelIsProvided()
+    {
+        $this->artisan('make:policy', ['--model' => 'Foo'])
+            ->expectsQuestion('What should the policy be named?', 'FooPolicy')
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Policies;',
+            'use Illuminate\Foundation\Auth\User;',
+            'class FooPolicy',
+        ], 'app/Policies/FooPolicy.php');
+    }
+
+    public function testItCanGeneratePolicyWithShortAllFlag()
+    {
+        $modelsPath = app_path('Models');
+        $policiesPath = app_path('Policies');
+
+        if (! is_dir($modelsPath)) {
+            mkdir($modelsPath, 0755, true);
+        }
+
+        if (! is_dir($policiesPath)) {
+            mkdir($policiesPath, 0755, true);
+        }
+
+        $models = [
+            'Bar' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Bar extends Model {}',
+            'User' => '<?php namespace App\Models; use Illuminate\Foundation\Auth\User as Authenticatable; class User extends Authenticatable {}',
+            'Baz' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Baz extends Model {}',
+        ];
+
+        foreach ($models as $name => $content) {
+            $modelPath = app_path("Models/{$name}.php");
+            file_put_contents($modelPath, $content);
+            $this->assertFileExists($modelPath, "Model file {$name}.php was not created");
+        }
+
+        $this->artisan('make:policy', ['-a' => true])
+            ->assertExitCode(0);
+
+        foreach (array_keys($models) as $name) {
+            $policyFile = app_path("Policies/{$name}Policy.php");
+            $this->assertFileExists($policyFile, "Policy file {$name}Policy.php was not created");
+
+            if (file_exists($policyFile)) {
+                unlink($policyFile);
+            }
+
+            $modelFile = app_path("Models/{$name}.php");
+            if (file_exists($modelFile)) {
+                unlink($modelFile);
+            }
+        }
+
+        if (is_dir($modelsPath) && count(glob("$modelsPath/*")) === 0) {
+            rmdir($modelsPath);
+        }
+        if (is_dir($policiesPath) && count(glob("$policiesPath/*")) === 0) {
+            rmdir($policiesPath);
+        }
+    }
+
+    public function testItCanGeneratePoliciesForAllModels()
+    {
+        $models = [
+            'Bar' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Bar extends Model {}',
+            'User' => '<?php namespace App\Models; use Illuminate\Foundation\Auth\User as Authenticatable; class User extends Authenticatable {}',
+            'Baz' => '<?php namespace App\Models; use Illuminate\Database\Eloquent\Model; class Baz extends Model {}',
+        ];
+
+        foreach ($models as $name => $content) {
+            $modelPath = app_path("Models/{$name}.php");
+            file_put_contents($modelPath, $content);
+            $this->assertFileExists($modelPath, "Model file {$name}.php was not created");
+        }
+
+        $this->artisan('make:policy', ['--all' => true])
+            ->assertExitCode(0);
+
+        foreach (array_keys($models) as $name) {
+            $policyFile = app_path("Policies/{$name}Policy.php");
+            $this->assertFileExists($policyFile, "Policy file {$name}Policy.php was not created");
+
+            if (file_exists($policyFile)) {
+                unlink($policyFile);
+            }
+
+            $modelFile = app_path("Models/{$name}.php");
+            if (file_exists($modelFile)) {
+                unlink($modelFile);
+            }
+        }
+    }
+
+
+    /**
+     * @return void
+     */
+    public function testItShowsErrorWhenNoModelsFoundForAllFlag()
+    {
+        File::deleteDirectory(app_path('Models'));
+
+        $this->artisan('make:policy', ['--all' => true])
+            ->expectsOutputToContain('No models found to generate policies for.')
+            ->assertExitCode(1);
     }
 }


### PR DESCRIPTION
This PR introduces an improvement to the `make:policy` Artisan command, allowing users to generate policies for all models if desired, thereby allowing an override for policy name prompt by default.

To achieve this, users will have to pass `--all` option to the command.
```php
php artisan make:policy --all
```
This command generates policies for all the models in the model namespace