### PR TITLE
[12.x] Feat: Add --before option to make:migration command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -123,7 +123,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         }
 
         $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $timestamp
         );
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -49,11 +49,12 @@ class MigrationCreator
      * @param  string  $path
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  string|null  $timestamp
      * @return string
      *
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $timestamp = null)
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
@@ -62,7 +63,7 @@ class MigrationCreator
         // various place-holders, save the file, and run the post create event.
         $stub = $this->getStub($table, $create);
 
-        $path = $this->getPath($name, $path);
+        $path = $this->getPath($name, $path, $timestamp);
 
         $this->files->ensureDirectoryExists(dirname($path));
 
@@ -166,11 +167,14 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
+     * @param  string|null  $timestamp
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getPath($name, $path, $timestamp = null)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        $datePrefix = $timestamp ?: $this->getDatePrefix();
+
+        return $path.'/'.$datePrefix.'_'.$name.'.php';
     }
 
     /**

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -44,7 +44,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -60,7 +60,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
@@ -76,7 +76,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
@@ -92,7 +92,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
@@ -108,7 +108,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, null)
             ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
     }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -113,6 +113,137 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
     }
 
+    public function testCreateWithBeforeOption()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+
+        $migrationDir = __DIR__.'/migrations';
+        if (!is_dir($migrationDir)) {
+            mkdir($migrationDir, 0755, true);
+        }
+        $testMigration = $migrationDir.'/2025_07_25_145000_create_foo_table.php';
+        file_put_contents($testMigration, '<?php // test migration');
+
+        $creator->shouldReceive('create')->once()
+            ->withArgs(function ($name, $path, $table, $create) use ($migrationDir) {
+                return $name === 'create_bar_table'
+                    && realpath($path) === realpath($migrationDir)
+                    && $table === 'bar'
+                    && $create === true;
+            })
+            ->andReturn($migrationDir.'/2025_07_25_144959_create_bar_table.php');
+
+        $this->runCommand($command, [
+            'name' => 'create_bar_table',
+            '--before' => 'foo'
+        ]);
+
+        if (file_exists($testMigration)) {
+            unlink($testMigration);
+        }
+        if (is_dir($migrationDir)) {
+            rmdir($migrationDir);
+        }
+    }
+
+    public function testCreateWithBeforeOptionWhenMigrationNotFound()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+
+        $creator->shouldNotReceive('create');
+
+        $result = $this->runCommand($command, [
+            'name' => 'create_bar_table',
+            '--before' => 'nonexistent_foo'
+        ]);
+
+        // The command should return without creating anything
+        $this->assertEquals(0, $result);
+    }
+
+    public function testTimestampCalculationWithValidMigration()
+    {
+        $command = new MigrateMakeCommand(
+            m::mock(MigrationCreator::class),
+            m::mock(Composer::class)
+        );
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('calculateTimestampBefore');
+        $method->setAccessible(true);
+
+        $tempDir = sys_get_temp_dir().'/laravel_test_migrations_'.uniqid();
+        mkdir($tempDir, 0755, true);
+
+        $testMigrationFile = $tempDir.'/2025_07_25_145000_create_foo_table.php';
+        file_put_contents($testMigrationFile, '<?php // test migration');
+
+        $timestamp = $method->invoke($command, $tempDir, 'foo');
+
+        $this->assertEquals('2025_07_25_144959', $timestamp);
+
+        unlink($testMigrationFile);
+        rmdir($tempDir);
+    }
+
+    public function testTimestampCalculationWithInvalidMigration()
+    {
+        $command = new MigrateMakeCommand(
+            m::mock(MigrationCreator::class),
+            m::mock(Composer::class)
+        );
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('calculateTimestampBefore');
+        $method->setAccessible(true);
+
+        $tempDir = sys_get_temp_dir().'/laravel_test_migrations_'.uniqid();
+        mkdir($tempDir, 0755, true);
+
+        $testMigrationFile = $tempDir.'/invalid_migration_name.php';
+        file_put_contents($testMigrationFile, '<?php // test migration');
+
+        $timestamp = $method->invoke($command, $tempDir, 'invalid_foo');
+
+        $this->assertNull($timestamp);
+
+        unlink($testMigrationFile);
+        rmdir($tempDir);
+    }
+
+    public function testTimestampCalculationWithEmptyDirectory()
+    {
+        $command = new MigrateMakeCommand(
+            m::mock(MigrationCreator::class),
+            m::mock(Composer::class)
+        );
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('calculateTimestampBefore');
+        $method->setAccessible(true);
+
+        $tempDir = sys_get_temp_dir().'/laravel_test_migrations_'.uniqid();
+        mkdir($tempDir, 0755, true);
+
+        $timestamp = $method->invoke($command, $tempDir, 'foo');
+
+        $this->assertNull($timestamp);
+
+        rmdir($tempDir);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new ArrayInput($input), new NullOutput);


### PR DESCRIPTION
### **Overview:**

This PR adds a `--before` option to the make:migration command.
When generating a new migration, you can now use --before to have the new migration’s timestamp set just before an existing migration. This ensures your migration will run in the correct order, without manually editing timestamps.

### **Example:**

Generate migration as usual:
`php artisan make:migration create_orders_table`

This will create a file such as:
`2025_07_25_100001_create_orders_table.php`

Generate another migration that should run before the previous one:
`php artisan make:migration create_order_statuses_table --before=orders`

This will create a migration file with a timestamp just before the `create_orders_table` migration. Something like the following:
`2025_07_25_100000_create_order_statuses_table.php`

### **Why:**
- Often, I find myself needing to add a migration that should run before one I already created, which meant manually editing migration filenames.
- This feature removes the need to manually adjust filenames to control execution order.
- Simplifies adding missing or dependent migrations to existing projects.




