### PR TITLE
Fix app entry point adjustments in Echo installation

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -584,9 +584,9 @@ class BroadcastingInstallCommand extends Command
     }
 
     /**
-     * Detect if the user is using Vue.
+     * Detect if the user is using Inertia and return the import path if so.
      *
-     * @return bool
+     * @return string
      */
     protected function inertiaImport(): ?string
     {

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -312,9 +312,7 @@ class BroadcastingInstallCommand extends Command
             ];
         }
 
-        $filePath = array_filter($filePaths, function ($path) {
-            return file_exists($path);
-        })[0] ?? null;
+        $filePath = collect($filePaths)->filter(fn ($path) => file_exists($path))->first();
 
         if (! $filePath) {
             $this->components->warn("Could not find file [{$filePaths[0]}]. Skipping automatic Echo configuration.");

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -586,7 +586,7 @@ class BroadcastingInstallCommand extends Command
     /**
      * Detect if the user is using Inertia and return the import path if so.
      *
-     * @return string
+     * @return string|null
      */
     protected function inertiaImport(): ?string
     {


### PR DESCRIPTION
This PR addresses several small bugs:

- The `import` regex wasn't matching multi-line imports and imports that didn't end with a semi colon
- Fixed a bug where we weren't injecting the Echo code into non-TS files
- In order for the `->toOthers()` to work, we now add the websocket ID to all Inertia requests as follows:

```ts
router.on('before', (event) => {
    const id = echo().socketId();

    if (id) {
        event.detail.visit.headers['X-Socket-ID'] = id;
    }
});
```

Fixes https://github.com/laravel/echo/issues/447