### PR TITLE
Add onStatus for cleaner and more expressive HTTP response handling

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1682,7 +1682,7 @@ class PendingRequest
     /**
      * Listen to specific statusCode.
      *
-     * @return Closure
+     * @return $this
      */
     public function onStatus(int $statusCode, Closure $callback)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -201,9 +201,9 @@ class PendingRequest
     protected $request;
 
     /**
-     * all status code listeners
+     * all status code listeners.
      *
-     * @var array 
+     * @var array
      */
     public $listeners = [];
 
@@ -1681,23 +1681,25 @@ class PendingRequest
     }
 
     /**
-     * Listen to specific statusCode
+     * Listen to specific statusCode.
      * 
      * @return Closure
      */
-    public function onStatus(int $statusCode, Closure $callback){
+    public function onStatus(int $statusCode, Closure $callback)
+    {
         $this->listeners[$statusCode] = $callback;
         return $this;
     }
 
     /**
-     * Dispatch the status code listener if exists
+     * Dispatch the status code listener if exists.
      * 
      * @param Response $response
      * 
      */
-    public function dispatchStatusCodeListener(Response $response){
-        if(isset($this->listeners[$response->status()])){
+    public function dispatchStatusCodeListener(Response $response)
+    {
+        if(isset($this->listeners[$response->status()])) {
             return $this->listeners[$response->status()]($response);
         }
         return $response;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -207,7 +207,6 @@ class PendingRequest
      */
     public $listeners = [];
 
-
     /**
      * The Guzzle request options that are mergeable via array_merge_recursive.
      *
@@ -1688,14 +1687,14 @@ class PendingRequest
     public function onStatus(int $statusCode, Closure $callback)
     {
         $this->listeners[$statusCode] = $callback;
+
         return $this;
     }
 
     /**
      * Dispatch the status code listener if exists.
      * 
-     * @param Response $response
-     * 
+     * @param  Response  $response
      */
     public function dispatchStatusCodeListener(Response $response)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1681,7 +1681,7 @@ class PendingRequest
 
     /**
      * Listen to specific statusCode.
-     * 
+     *
      * @return Closure
      */
     public function onStatus(int $statusCode, Closure $callback)
@@ -1693,7 +1693,7 @@ class PendingRequest
 
     /**
      * Dispatch the status code listener if exists.
-     * 
+     *
      * @param  Response  $response
      */
     public function dispatchStatusCodeListener(Response $response)
@@ -1701,6 +1701,7 @@ class PendingRequest
         if (isset($this->listeners[$response->status()])) {
             return $this->listeners[$response->status()]($response);
         }
+
         return $response;
     }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1698,7 +1698,7 @@ class PendingRequest
      */
     public function dispatchStatusCodeListener(Response $response)
     {
-        if(isset($this->listeners[$response->status()])) {
+        if (isset($this->listeners[$response->status()])) {
             return $this->listeners[$response->status()]($response);
         }
         return $response;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -917,7 +917,7 @@ class PendingRequest
 
         return retry($this->tries ?? 1, function ($attempt) use ($method, $url, $options, &$shouldRetry) {
             try {
-                return $this->dispatchStatsCodeListener(tap($this->newResponse($this->sendRequest($method, $url, $options)), function ($response) use ($attempt, &$shouldRetry) {
+                return $this->dispatchStatusCodeListener(tap($this->newResponse($this->sendRequest($method, $url, $options)), function ($response) use ($attempt, &$shouldRetry) {
                     $this->populateResponse($response);
 
                     $this->dispatchResponseReceivedEvent($response);
@@ -1696,7 +1696,7 @@ class PendingRequest
      * @param Response $response
      * 
      */
-    public function dispatchStatsCodeListener(Response $response){
+    public function dispatchStatusCodeListener(Response $response){
         if(isset($this->listeners[$response->status()])){
             return $this->listeners[$response->status()]($response);
         }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1063,6 +1063,7 @@ class PendingRequest
                 return tap($this->newResponse($message), function ($response) {
                     $this->populateResponse($response);
                     $this->dispatchResponseReceivedEvent($response);
+                    $this->dispatchStatusCodeListener($response);
                 });
             })
             ->otherwise(function (OutOfBoundsException|TransferException|StrayRequestException $e) {


### PR DESCRIPTION
### Laravel HTTP Client - `onStatus` Enhancement

This enhancement introduces a more expressive and fluent way to handle specific HTTP response status codes in the Laravel HTTP client using the new `onStatus` method.

### 🚀 What’s New?

Instead of writing multiple conditional checks (`if`, `else if`, etc.) after sending a request, you can now handle status codes **inline** using chained, status-specific callbacks.

This makes the code:
- Cleaner ✅
- Easier to read ✅
- Easier to scale ✅
- More Laravel-like ✅

### Quick Example

```php
$status = null;

// $r is the response of your API call
Http::onStatus(200, fn ($r) => $this->ok($r)) // calling a class function
    ->onStatus(400, function ($r) use (&$status) {
        $status = 'Bad request';
    })  // changing a function scoped variable,
    ->onStatus(500, fn ($r) => report($r->body())) // do anything else...
    ->get('https://api.example.com');
```

That’s it—clean, readable, and 100 % Laravel‑style. 🎉