### PR TITLE
[12.x] Improve PHPDoc blocks for array of arguments in Gate

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -18,6 +18,9 @@ use ReflectionFunction;
 
 use function Illuminate\Support\enum_value;
 
+/**
+ * @template TClass of object
+ */
 class Gate implements GateContract
 {
     use HandlesAuthorization;
@@ -326,7 +329,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return bool
      */
     public function allows($ability, $arguments = [])
@@ -338,7 +341,7 @@ class Gate implements GateContract
      * Determine if any of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return bool
      */
     public function denies($ability, $arguments = [])
@@ -350,7 +353,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return bool
      */
     public function check($abilities, $arguments = [])
@@ -364,7 +367,7 @@ class Gate implements GateContract
      * Determine if any one of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return bool
      */
     public function any($abilities, $arguments = [])
@@ -376,7 +379,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return bool
      */
     public function none($abilities, $arguments = [])
@@ -388,7 +391,7 @@ class Gate implements GateContract
      * Determine if the given ability should be granted for the current user.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
@@ -402,7 +405,7 @@ class Gate implements GateContract
      * Inspect the user for the given ability.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return \Illuminate\Auth\Access\Response
      */
     public function inspect($ability, $arguments = [])
@@ -426,7 +429,7 @@ class Gate implements GateContract
      * Get the raw result from the authorization callback.
      *
      * @param  string  $ability
-     * @param  array{class-string|object, ...}  $arguments
+     * @param  array{class-string<TClass>|TClass, ...}  $arguments
      * @return mixed
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -326,7 +326,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return bool
      */
     public function allows($ability, $arguments = [])
@@ -338,7 +338,7 @@ class Gate implements GateContract
      * Determine if any of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $ability
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return bool
      */
     public function denies($ability, $arguments = [])
@@ -350,7 +350,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return bool
      */
     public function check($abilities, $arguments = [])
@@ -364,7 +364,7 @@ class Gate implements GateContract
      * Determine if any one of the given abilities should be granted for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return bool
      */
     public function any($abilities, $arguments = [])
@@ -376,7 +376,7 @@ class Gate implements GateContract
      * Determine if all of the given abilities should be denied for the current user.
      *
      * @param  iterable|\UnitEnum|string  $abilities
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return bool
      */
     public function none($abilities, $arguments = [])
@@ -388,7 +388,7 @@ class Gate implements GateContract
      * Determine if the given ability should be granted for the current user.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return \Illuminate\Auth\Access\Response
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
@@ -402,7 +402,7 @@ class Gate implements GateContract
      * Inspect the user for the given ability.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  array|mixed  $arguments
+     * @param  array{class-string|object, ...} $arguments
      * @return \Illuminate\Auth\Access\Response
      */
     public function inspect($ability, $arguments = [])
@@ -426,7 +426,7 @@ class Gate implements GateContract
      * Get the raw result from the authorization callback.
      *
      * @param  string  $ability
-     * @param  array|mixed  $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return mixed
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -402,7 +402,7 @@ class Gate implements GateContract
      * Inspect the user for the given ability.
      *
      * @param  \UnitEnum|string  $ability
-     * @param  array{class-string|object, ...} $arguments
+     * @param  array{class-string|object, ...}  $arguments
      * @return \Illuminate\Auth\Access\Response
      */
     public function inspect($ability, $arguments = [])


### PR DESCRIPTION
Follow-up to #56411

We only know the type of the first argument