### PR TITLE
Trim whitespace when validating required arguments in console commands

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -60,7 +60,7 @@ trait PromptsForMissingInput
                 $answer = text(
                     label: $label,
                     placeholder: $placeholder ?? '',
-                    validate: fn($value) => empty(trim($value)) ? "The {$argument->getName()} is required." : null,
+                    validate: fn ($value) => empty(trim($value)) ? "The {$argument->getName()} is required." : null,
                 );
 
                 $input->setArgument($argument->getName(), $argument->isArray() ? [$answer] : $answer);

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -60,7 +60,7 @@ trait PromptsForMissingInput
                 $answer = text(
                     label: $label,
                     placeholder: $placeholder ?? '',
-                    validate: fn ($value) => empty($value) ? "The {$argument->getName()} is required." : null,
+                    validate: fn($value) => empty(trim($value)) ? "The {$argument->getName()} is required." : null,
                 );
 
                 $input->setArgument($argument->getName(), $argument->isArray() ? [$answer] : $answer);


### PR DESCRIPTION
#  Improve Validation for Required Console Arguments

## Overview

This update enhances the behavior of Artisan commands when prompting for missing required arguments. It ensures that input values consisting solely of whitespace (e.g. `"   "`) are treated as empty, prompting the user again instead of accepting an invalid value.

## Problem

Previously, when prompting for a required argument, the validation logic used:

```php
validate: fn($value) => empty($value) ? "The {$argument->getName()} is required." : null,
```
This means that if a user entered only spaces, the input would pass validation because empty(" ") is false. As a result, commands could proceed with meaningless argument values.

## Solution

The validation was updated to use trim() before checking for emptiness:

```php
validate: fn($value) => empty(trim($value)) ? "The {$argument->getName()} is required." : null,
```
This ensures that inputs like " " are treated as empty and the user is prompted again with a proper message.

## Example

### Before

```sh
What is the name?
> [user enters only spaces]
# Accepted silently and assigned as a valid value.

```

### After

```sh
What is the name?
> [user enters only spaces]
The name is required.
What is the name?
> [user enters valid string]

```
