### PR TITLE
[12.x] Clean up redundant PHPDoc

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -21,7 +21,6 @@ class Exceptions
     /**
      * Register a reportable callback.
      *
-     * @param  callable  $using
      * @return \Illuminate\Foundation\Exceptions\ReportableHandler
      */
     public function report(callable $using)
@@ -32,7 +31,6 @@ class Exceptions
     /**
      * Register a reportable callback.
      *
-     * @param  callable  $reportUsing
      * @return \Illuminate\Foundation\Exceptions\ReportableHandler
      */
     public function reportable(callable $reportUsing)
@@ -43,7 +41,6 @@ class Exceptions
     /**
      * Register a renderable callback.
      *
-     * @param  callable  $using
      * @return $this
      */
     public function render(callable $using)
@@ -56,7 +53,6 @@ class Exceptions
     /**
      * Register a renderable callback.
      *
-     * @param  callable  $renderUsing
      * @return $this
      */
     public function renderable(callable $renderUsing)
@@ -69,7 +65,6 @@ class Exceptions
     /**
      * Register a callback to prepare the final, rendered exception response.
      *
-     * @param  callable  $using
      * @return $this
      */
     public function respond(callable $using)
@@ -82,7 +77,6 @@ class Exceptions
     /**
      * Specify the callback that should be used to throttle reportable exceptions.
      *
-     * @param  callable  $throttleUsing
      * @return $this
      */
     public function throttle(callable $throttleUsing)
@@ -125,7 +119,6 @@ class Exceptions
     /**
      * Register a closure that should be used to build exception context data.
      *
-     * @param  \Closure  $contextCallback
      * @return $this
      */
     public function context(Closure $contextCallback)
@@ -138,7 +131,6 @@ class Exceptions
     /**
      * Indicate that the given exception type should not be reported.
      *
-     * @param  array|string  $class
      * @return $this
      */
     public function dontReport(array|string $class)
@@ -153,7 +145,6 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  callable  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(Closure $dontReportWhen)
@@ -178,7 +169,6 @@ class Exceptions
     /**
      * Indicate that the given attributes should never be flashed to the session on validation errors.
      *
-     * @param  array|string  $attributes
      * @return $this
      */
     public function dontFlash(array|string $attributes)
@@ -217,7 +207,6 @@ class Exceptions
     /**
      * Set the truncation length for request exception messages.
      *
-     * @param  int  $length
      * @return $this
      */
     public function truncateRequestExceptionsAt(int $length)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -214,7 +214,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a reportable callback.
      *
-     * @param  callable  $reportUsing
      * @return \Illuminate\Foundation\Exceptions\ReportableHandler
      */
     public function reportable(callable $reportUsing)
@@ -231,7 +230,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a renderable callback.
      *
-     * @param  callable  $renderUsing
      * @return $this
      */
     public function renderable(callable $renderUsing)
@@ -278,7 +276,6 @@ class Handler implements ExceptionHandlerContract
      *
      * Alias of "ignore".
      *
-     * @param  array|string  $exceptions
      * @return $this
      */
     public function dontReport(array|string $exceptions)
@@ -289,7 +286,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  callable  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(callable $dontReportWhen)
@@ -306,7 +302,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Indicate that the given exception type should not be reported.
      *
-     * @param  array|string  $exceptions
      * @return $this
      */
     public function ignore(array|string $exceptions)
@@ -321,7 +316,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Indicate that the given attributes should never be flashed to the session on validation errors.
      *
-     * @param  array|string  $attributes
      * @return $this
      */
     public function dontFlash(array|string $attributes)
@@ -350,7 +344,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Report or log an exception.
      *
-     * @param  \Throwable  $e
      * @return void
      *
      * @throws \Throwable
@@ -369,7 +362,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Reports error based on report method on exception or to logger.
      *
-     * @param  \Throwable  $e
      * @return void
      *
      * @throws \Throwable
@@ -407,7 +399,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Determine if the exception should be reported.
      *
-     * @param  \Throwable  $e
      * @return bool
      */
     public function shouldReport(Throwable $e)
@@ -418,7 +409,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Determine if the exception is in the "do not report" list.
      *
-     * @param  \Throwable  $e
      * @return bool
      */
     protected function shouldntReport(Throwable $e)
@@ -464,7 +454,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Throttle the given exception.
      *
-     * @param  \Throwable  $e
      * @return \Illuminate\Support\Lottery|\Illuminate\Cache\RateLimiting\Limit|null
      */
     protected function throttle(Throwable $e)
@@ -487,7 +476,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Specify the callback that should be used to throttle reportable exceptions.
      *
-     * @param  callable  $throttleUsing
      * @return $this
      */
     public function throttleUsing(callable $throttleUsing)
@@ -504,7 +492,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Remove the given exception class from the list of exceptions that should be ignored.
      *
-     * @param  array|string  $exceptions
      * @return $this
      */
     public function stopIgnoring(array|string $exceptions)
@@ -527,7 +514,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Create the context array for logging the given exception.
      *
-     * @param  \Throwable  $e
      * @return array
      */
     protected function buildExceptionContext(Throwable $e)
@@ -542,7 +528,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Get the default exception context variables for logging.
      *
-     * @param  \Throwable  $e
      * @return array
      */
     protected function exceptionContext(Throwable $e)
@@ -579,7 +564,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a closure that should be used to build exception context data.
      *
-     * @param  \Closure  $contextCallback
      * @return $this
      */
     public function buildContextUsing(Closure $contextCallback)
@@ -593,7 +577,6 @@ class Handler implements ExceptionHandlerContract
      * Render an exception into an HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Throwable
@@ -633,7 +616,6 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  \Throwable  $e
      * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function finalizeRenderedResponse($request, $response, Throwable $e)
@@ -659,7 +641,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Prepare exception for rendering.
      *
-     * @param  \Throwable  $e
      * @return \Throwable
      */
     protected function prepareException(Throwable $e)
@@ -682,7 +663,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Map the exception using a registered mapper if possible.
      *
-     * @param  \Throwable  $e
      * @return \Throwable
      */
     protected function mapException(Throwable $e)
@@ -705,7 +685,6 @@ class Handler implements ExceptionHandlerContract
      * Try to render a response from request and exception via render callbacks.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return mixed
      *
      * @throws \ReflectionException
@@ -729,7 +708,6 @@ class Handler implements ExceptionHandlerContract
      * Render a default exception response if any.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     protected function renderExceptionResponse($request, Throwable $e)
@@ -743,7 +721,6 @@ class Handler implements ExceptionHandlerContract
      * Convert an authentication exception into a response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Auth\AuthenticationException  $exception
      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     protected function unauthenticated($request, AuthenticationException $exception)
@@ -756,7 +733,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Create a response object from the given validation exception.
      *
-     * @param  \Illuminate\Validation\ValidationException  $e
      * @param  \Illuminate\Http\Request  $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
@@ -775,7 +751,6 @@ class Handler implements ExceptionHandlerContract
      * Convert a validation exception into a response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Validation\ValidationException  $exception
      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     protected function invalid($request, ValidationException $exception)
@@ -789,7 +764,6 @@ class Handler implements ExceptionHandlerContract
      * Convert a validation exception into a JSON response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Validation\ValidationException  $exception
      * @return \Illuminate\Http\JsonResponse
      */
     protected function invalidJson($request, ValidationException $exception)
@@ -804,7 +778,6 @@ class Handler implements ExceptionHandlerContract
      * Determine if the exception handler response should be JSON.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return bool
      */
     protected function shouldReturnJson($request, Throwable $e)
@@ -831,7 +804,6 @@ class Handler implements ExceptionHandlerContract
      * Prepare a response for the given exception.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     protected function prepareResponse($request, Throwable $e)
@@ -852,7 +824,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Create a Symfony response for the given exception.
      *
-     * @param  \Throwable  $e
      * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function convertExceptionToResponse(Throwable $e)
@@ -867,7 +838,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Get the response content for the given exception.
      *
-     * @param  \Throwable  $e
      * @return string
      */
     protected function renderExceptionContent(Throwable $e)
@@ -890,7 +860,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Render an exception to a string using the registered `ExceptionRenderer`.
      *
-     * @param  \Throwable  $e
      * @return string
      */
     protected function renderExceptionWithCustomRenderer(Throwable $e)
@@ -901,7 +870,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Render an exception to a string using Symfony.
      *
-     * @param  \Throwable  $e
      * @param  bool  $debug
      * @return string
      */
@@ -915,7 +883,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Render the given HttpException.
      *
-     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
      * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function renderHttpException(HttpExceptionInterface $e)
@@ -951,7 +918,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Get the view used to render HTTP exceptions.
      *
-     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
      * @return string|null
      */
     protected function getHttpExceptionView(HttpExceptionInterface $e)
@@ -975,7 +941,6 @@ class Handler implements ExceptionHandlerContract
      * Map the given exception into an Illuminate response.
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  \Throwable  $e
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
     protected function toIlluminateResponse($response, Throwable $e)
@@ -997,7 +962,6 @@ class Handler implements ExceptionHandlerContract
      * Prepare a JSON response for the given exception.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $e
      * @return \Illuminate\Http\JsonResponse
      */
     protected function prepareJsonResponse($request, Throwable $e)
@@ -1013,7 +977,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Convert the given exception to an array.
      *
-     * @param  \Throwable  $e
      * @return array
      */
     protected function convertExceptionToArray(Throwable $e)
@@ -1033,7 +996,6 @@ class Handler implements ExceptionHandlerContract
      * Render an exception to the console.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @param  \Throwable  $e
      * @return void
      *
      * @internal This method is not meant to be used or overwritten outside the framework.
@@ -1075,7 +1037,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Determine if the given exception is an HTTP exception.
      *
-     * @param  \Throwable  $e
      * @return bool
      */
     protected function isHttpException(Throwable $e)
@@ -1086,7 +1047,6 @@ class Handler implements ExceptionHandlerContract
     /**
      * Map the exception to a log level.
      *
-     * @param  \Throwable  $e
      * @return \Psr\Log\LogLevel::*
      */
     protected function mapLogLevel(Throwable $e)


### PR DESCRIPTION
Description
---
Clean up PHPDoc by removing redundant `@param` tags already covered by type hints.