### PR TITLE
[12.x] Revert "Trim whitespace when validating required arguments in console commands"

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -60,7 +60,7 @@ trait PromptsForMissingInput
                 $answer = text(
                     label: $label,
                     placeholder: $placeholder ?? '',
-                    validate: fn ($value) => empty(trim($value)) ? "The {$argument->getName()} is required." : null,
+                    validate: fn ($value) => empty($value) ? "The {$argument->getName()} is required." : null,
                 );
 
                 $input->setArgument($argument->getName(), $argument->isArray() ? [$answer] : $answer);


### PR DESCRIPTION
Reverts laravel/framework#56427 as it is a breaking change. there are use cases where people would want whitespace only arguments, like for inputting indentation style into a command that asks for that to do code formatting.