### PR TITLE
[12.x] Align PHPDoc parameter with method signature

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -153,7 +153,7 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  \Closure  $dontReportWhen
+     * @param  \Closure  $dontReportWhen 
      * @return $this
      */
     public function dontReportWhen(Closure $dontReportWhen)

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -153,7 +153,7 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  \Closure  $dontReportWhen 
+     * @param  \Closure  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(Closure $dontReportWhen)

--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -153,7 +153,7 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  callable  $dontReportWhen
+     * @param  \Closure  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(Closure $dontReportWhen)


### PR DESCRIPTION
Description
---
This PR updates the PHPDoc block to ensure parameter names are consistent between the method signature and its associated doc comment.