### PR TITLE
[12.x] Adds safe/unsafe collection creation

### DIFF
--- a/src/Illuminate/Collections/InvalidCollectionException.php
+++ b/src/Illuminate/Collections/InvalidCollectionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Support;
+
+use RuntimeException;
+
+class InvalidCollectionException extends RuntimeException
+{
+}

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -219,14 +219,14 @@ trait EnumeratesValues
      * @template TMakeValue
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
-     * @return static<TMakeKey, TMakeValue>
+     * @return static<TMakeKey, TMakeValue>|null
      */
     public static function tryFrom($items)
     {
         try {
             return static::from($items);
         } catch (InvalidCollectionException) {
-            return static::empty();
+            return null;
         }
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use CachingIterator;
 use Closure;
 use Exception;
+use Illuminate\Support\InvalidCollectionException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
@@ -187,6 +188,46 @@ trait EnumeratesValues
     public static function fromJson($json, $depth = 512, $flags = 0)
     {
         return new static(json_decode($json, true, $depth, $flags));
+    }
+
+    /**
+     * Attempt to create a new collection from a list of items, or throw an exception.
+     *
+     * @template TMakeKey of array-key
+     * @template TMakeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return static<TMakeKey, TMakeValue>
+     *
+     * @throws \Illuminate\Support\InvalidCollectionException
+     */
+    public static function from($items)
+    {
+        $collection = new static($items);
+
+        if ($collection->first() === $items) {
+            throw new InvalidCollectionException('Trying to create a collection from an not enumerable list of items.');
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Attempt to create a new collection with items, or create a new empty instance when if fails.
+     *
+     * @template TMakeKey of array-key
+     * @template TMakeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return static<TMakeKey, TMakeValue>
+     */
+    public static function tryFrom($items)
+    {
+        try {
+            return static::from($items);
+        } catch (InvalidCollectionException) {
+            return static::empty();
+        }
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\InvalidCollectionException;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
@@ -2876,6 +2877,49 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEmpty($instance->toArray());
         $this->assertSame(JSON_ERROR_DEPTH, json_last_error());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFrom($collection)
+    {
+        $data = [1, 2, 3];
+
+        $instance = $collection::from($data);
+
+        $this->assertSame([1, 2, 3], $instance->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFromThrowsIfDataNotEnumerable($collection)
+    {
+        $data = 1;
+
+        $this->expectException(InvalidCollectionException::class);
+        $this->expectExceptionMessage('Trying to create a collection from an invalid list of items.');
+
+        $collection::from($data);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testTryFrom($collection)
+    {
+        $this->assertSame([1, 2, 3], $collection::tryFrom([1, 2, 3])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testTryFromReturnsEmptyCollectionWhenItemsNotEnumerable($collection)
+    {
+        $this->assertEmpty($collection::tryFrom(1));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testTryFromReturnsEmptyCollectionWhenInvalid($collection)
+    {
+        $data = [];
+
+        $collection::tryFrom($data);
+
+        $this->assertSame([], $collection->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2895,7 +2895,7 @@ class SupportCollectionTest extends TestCase
         $data = 1;
 
         $this->expectException(InvalidCollectionException::class);
-        $this->expectExceptionMessage('Trying to create a collection from an invalid list of items.');
+        $this->expectExceptionMessage('Trying to create a collection from an not enumerable list of items.');
 
         $collection::from($data);
     }
@@ -2907,19 +2907,9 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
-    public function testTryFromReturnsEmptyCollectionWhenItemsNotEnumerable($collection)
+    public function testTryFromReturnsNullWhenItemsNotEnumerable($collection)
     {
-        $this->assertEmpty($collection::tryFrom(1));
-    }
-
-    #[DataProvider('collectionClassProvider')]
-    public function testTryFromReturnsEmptyCollectionWhenInvalid($collection)
-    {
-        $data = [];
-
-        $collection::tryFrom($data);
-
-        $this->assertSame([], $collection->all());
+        $this->assertNull($collection::tryFrom(1));
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -561,6 +561,8 @@ class AssertTest extends TestCase
 
         $assert->where('bar', BackedEnum::test);
 
+        BackedEnum::fr
+
         $assert = AssertableJson::fromArray([
             'bar' => BackedEnum::test_empty->value,
         ]);


### PR DESCRIPTION
This PR allows to safely create a Collection instance to avoid unexpected scenarios where the Collections wraps an item when its non-enumerable. This logic is borrowed from the native `Enum::from()` and `Enum::tryFrom()`.

```php
// Before
$collection = Collection::make($object);

if ($collection->first() === $object) {
    throw new RuntimeException('The collection of items is invalid');
}

// After
$collection = Collection::from($object); // InvalidCollectionException!
```

Accompanying the `from()`, the `tryFrom()` works the same, but on failure it will return `null` instead of an empty collection, so the developer can do _something else_ if collection creation fails.

```php
// Before
$collection = Collection::make($object);

if ($collection->first() === $object) {
    $collection = Collection::make($defaultValues)
}

// After
$collection = Collection:tryFrom($object) ?? Collection::make($defaultValues);
```