### PR TITLE
[12.x] Clear repository when extending Env

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -65,6 +65,8 @@ class Env
         } else {
             static::$customAdapters[] = $callback;
         }
+
+        static::$repository = null;
     }
 
     /**


### PR DESCRIPTION
Currently when extending `Env` with a custom adapter, the repository is not set to `null`, which can lead to the adapter not being used depending on when the adapter was registered.

This fixes the issue by setting the `static::$repository` variable to `null` like the `enablePutenv()` and `disablePutenv()` methods do.