### PR TITLE
Improve PHPDoc block parameter typing in Exceptions::dontReportWhen()

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Exceptions.php
+++ b/src/Illuminate/Foundation/Configuration/Exceptions.php
@@ -153,7 +153,7 @@ class Exceptions
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  \Closure  $dontReportWhen
+     * @param  (\Closure(\Throwable): bool)  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(Closure $dontReportWhen)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -289,7 +289,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Register a callback to determine if an exception should not be reported.
      *
-     * @param  callable  $dontReportWhen
+     * @param  (callable(\Throwable): bool)  $dontReportWhen
      * @return $this
      */
     public function dontReportWhen(callable $dontReportWhen)


### PR DESCRIPTION
Follow-up to #56435