### PR TITLE
Add softDeleteResources method in Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -323,6 +323,20 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register an array of resource controllers that can be soft deleted.
+     *
+     * @param  array  $resources
+     * @param  array  $options
+     * @return void
+     */
+    public function softDeleteResources(array $resources, array $options = [])
+    {
+        foreach ($resources as $name => $controller) {
+            $this->resource($name, $controller, $options)->withTrashed();
+        }
+    }
+
+    /**
      * Route a resource to a controller.
      *
      * @param  string  $name

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -329,7 +329,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  array  $options
      * @return void
      */
-    public function softDeleteResources(array $resources, array $options = [])
+    public function softDeletableResources(array $resources, array $options = [])
     {
         foreach ($resources as $name => $controller) {
             $this->resource($name, $controller, $options)->withTrashed();


### PR DESCRIPTION
Add a `softDeletableResources` method for the Router class to register multiple resource controllers that all use the withTrashed method.

### Example
```php
Route::softDeletableResources([
    'permissions' => PermissionController::class,
    'roles' => RoleController::class,
]);
```

### Output:
Same as `Route::resources()`, but includes soft deleted models in the query for show, update, destroy and edit
```php
GET|HEAD        permissions ................................... permissions.index › PermissionController@index
POST            permissions ................................... permissions.store › PermissionController@store
GET|HEAD        permissions/create .......................... permissions.create › PermissionController@create
GET|HEAD        permissions/{permission} ........................ permissions.show › PermissionController@show
PUT|PATCH       permissions/{permission} .................... permissions.update › PermissionController@update
DELETE          permissions/{permission} .................. permissions.destroy › PermissionController@destroy
GET|HEAD        permissions/{permission}/edit ................... permissions.edit › PermissionController@edit
GET|HEAD        roles ..................................................... roles.index › RoleController@index
POST            roles ..................................................... roles.store › RoleController@store
GET|HEAD        roles/create ............................................ roles.create › RoleController@create
GET|HEAD        roles/{role} ................................................ roles.show › RoleController@show
PUT|PATCH       roles/{role} ............................................ roles.update › RoleController@update
DELETE          roles/{role} .......................................... roles.destroy › RoleController@destroy
GET|HEAD        roles/{role}/edit ........................................... roles.edit › RoleController@edit
```

### Benefit:
It would save from having to manually do the following for each resource controller where it uses the withTrashed scope:
```php
Route::resource('permissions', PermissionController::class)->withTrashed();
Route::resource('roles', RoleController::class)->withTrashed();
```

Edited to reflect the updated method name.