### PR TITLE
[Feature] Add DataRequest base class for auto-mapping validated request data to properties

### DIFF
--- a/src/Illuminate/Http/DataRequest.php
+++ b/src/Illuminate/Http/DataRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Http;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+abstract class DataRequest extends FormRequest
+{
+    protected function passedValidation(): void
+    { 
+        foreach ($this->validated() as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
+        }
+    }
+}

--- a/tests/Http/DataRequestTest.php
+++ b/tests/Http/DataRequestTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Tests\Unit;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\DataRequest;
+use Illuminate\Container\Container;
+use Illuminate\Validation\Factory;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Validation\Factory as ValidatorFactoryContract;
+
+
+class DataRequestTest extends TestCase
+{
+    public function testPassedValidationAssignsProperties()
+    {
+
+        $request = new class extends DataRequest {
+            public $name;
+            public $email;
+
+            public function rules()
+            {
+                return [
+                    'name' => 'required|string',
+                    'email' => 'required|email',
+                ];
+            }
+        };
+
+        // Simulate base input
+        $input = [
+            'name' => 'Test Name',
+            'email' => 'test@example.com',
+        ];
+
+        // Create base Illuminate Request
+        $base = Request::create('/create-dto-user-test', 'POST', $input);
+
+        // Merge input into our custom request
+        $request->initialize(
+            $base->query->all(),
+            $base->request->all(),
+            $base->attributes->all(),
+            $base->cookies->all(),
+            $base->files->all(),
+            $base->server->all(),
+            $base->getContent()
+        );
+
+        // Inject container and validator
+        $container = new Container();
+        $loader = new ArrayLoader();
+        $translator = new Translator($loader, 'en');
+        $validatorFactory = new Factory($translator, $container);
+
+        $container->bind(ValidatorFactoryContract::class, function () use ($validatorFactory) {
+            return $validatorFactory;
+        });        
+        $request->setContainer($container);
+
+        // Call validateResolved() to run validation and passedValidation()
+        $request->validateResolved();
+
+        // Now test the assignment
+        $this->assertSame('Test Name', $request->name);
+        $this->assertSame('test@example.com', $request->email);
+    }
+}


### PR DESCRIPTION
This PR introduces a new abstract class `DataRequest` that extends Laravel’s `FormRequest`. It overrides the `passedValidation()` method to assign validated data to corresponding class properties automatically, improving DX (Developer Experience) and reducing boilerplate in request classes.

## Key Features:

1. Iterates over validated input.
2. Checks for matching class properties using `property_exists`. 
3. Assigns values directly to those properties.

## Example Usage:

```php
class RegisterUserRequest extends DataRequest
{
    public string $name;
    public string $email;
    public string $password;

    public function rules()
    {
        return [
            'name' => 'required|string',
            'email' => 'required|email',
            'password' => 'required|min:8',
        ];
    }
}
```
In controllers:
```php
public function register(RegisterUserRequest $request)
{
    // $request->name, $request->email, $request->password are already assigned
}
```

### Motivation:
This pattern reduces the need for repetitive `$this->name = $request->input('name')` assignments and aligns with DTO-style request handling.