### PR TITLE
[12.x] Add `except` method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -393,6 +393,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Exclude the given models from the query results.
+     *
+     * @param  iterable|mixed  $models
+     * @return static
+     */
+    public function except($models): static
+    {
+        $keys = is_iterable($models) ? array_values($models->modelKeys()) : $models->getKey();
+        return $this->whereKeyNot($keys);
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -400,7 +400,9 @@ class Builder implements BuilderContract
      */
     public function except($models): static
     {
-        $keys = is_iterable($models) ? array_values($models->modelKeys()) : $models->getKey();
+        $keys = $models instanceof Model
+            ? $models->getKey()
+            : Collection::wrap($models)->modelKeys();
         return $this->whereKeyNot($keys);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -403,6 +403,7 @@ class Builder implements BuilderContract
         $keys = $models instanceof Model
             ? $models->getKey()
             : Collection::wrap($models)->modelKeys();
+
         return $this->whereKeyNot($keys);
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -311,6 +311,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Exclude the given models from the query results.
+     *
+     * @param  iterable|mixed  $models
+     * @return static
+     */
+    public function except($models)
+    {
+        return $this->whereKeyNot(
+            $models instanceof Model
+                ? $models->getKey()
+                : Collection::wrap($models)->modelKeys()
+        );
+    }
+
+    /**
      * Add a basic where clause to the query.
      *
      * @param  (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
@@ -390,21 +405,6 @@ class Builder implements BuilderContract
     public function orWhereNot($column, $operator = null, $value = null)
     {
         return $this->whereNot($column, $operator, $value, 'or');
-    }
-
-    /**
-     * Exclude the given models from the query results.
-     *
-     * @param  iterable|mixed  $models
-     * @return static
-     */
-    public function except($models): static
-    {
-        $keys = $models instanceof Model
-            ? $models->getKey()
-            : Collection::wrap($models)->modelKeys();
-
-        return $this->whereKeyNot($keys);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2316,7 +2316,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             new class extends Model
             {
                 protected $attributes = ['id' => 2];
-            }
+            },
         ]);
 
         $builder->except($models);
@@ -2340,7 +2340,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             new class extends Model
             {
                 protected $attributes = ['id' => 2];
-            }
+            },
         ];
 
         $builder->except($models);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2282,6 +2282,70 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
+    public function testExceptMethodWithModel()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', m::on(function ($argument) {
+            return $argument === '1';
+        }));
+
+        $builder->except(new class extends Model
+        {
+            protected $attributes = ['id' => 1];
+        });
+    }
+
+    public function testExceptMethodWithCollectionOfModel()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with($keyName, m::on(function ($argument) {
+            return $argument === [1, 2];
+        }));
+
+        $models = new Collection([
+            new class extends Model
+            {
+                protected $attributes = ['id' => 1];
+            },
+            new class extends Model
+            {
+                protected $attributes = ['id' => 2];
+            }
+        ]);
+
+        $builder->except($models);
+    }
+
+    public function testExceptMethodWithArrayOfModel()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $builder->getQuery()->shouldReceive('whereNotIn')->once()->with($keyName, m::on(function ($argument) {
+            return $argument === [1, 2];
+        }));
+
+        $models = [
+            new class extends Model
+            {
+                protected $attributes = ['id' => 1];
+            },
+            new class extends Model
+            {
+                protected $attributes = ['id' => 2];
+            }
+        ];
+
+        $builder->except($models);
+    }
+
     public function testWhereIn()
     {
         $model = new EloquentBuilderTestNestedStub;


### PR DESCRIPTION
The `except` method in `Illuminate\Database\Eloquent\Builder.php` is added to exclude an object of Model or collection of Model in builder query.
Internally, it make use of `whereKeyNot()` method after extracting the key/keys of object or collection respectively.

---

**Why not modified the `whereKeyNot` method?**
Modifying whereKeyNot() to handle this would complicate its current responsibilities and potentially introduce unexpected behavior for existing consumers. Instead, this PR:
- Keeps `whereKeyNot()` focused on keys/IDs
- Adds a new expressive method, `except()`, for working directly with model instances

---

### Usage

#### Before
```php
$videos = \App\Models\Video::query()
    ->whereIn('id', [2, 4])
    ->get();
$otherVideosUsingWhereKeyNot = \App\Models\Video::query()
    ->whereKeyNot($videos->pluck('id'))
    ->get();
```

#### After
```php
$videos = \App\Models\Video::query()
    ->whereIn('id', [2, 4])
    ->get();
$otherVideosUsingExcept = \App\Models\Video::query()
    ->except($videos)
    ->get();
```