### PR TITLE
fix: resolve schedule:work path outside project root

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -41,8 +41,8 @@ class ScheduleWorkCommand extends Command
 
         [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
-         $command = Application::phpBinary().' '.ProcessUtils::escapeArgument($this->laravel->basePath('artisan')).' schedule:run';
-    $command = Application::phpBinary().' '.ProcessUtils::escapeArgument($this->laravel->basePath('artisan')).' schedule:run';
+        $command = Application::phpBinary().' '.ProcessUtils::escapeArgument($this->laravel->basePath('artisan')).' schedule:run';
+
         if ($this->option('run-output-file')) {
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -41,15 +41,14 @@ class ScheduleWorkCommand extends Command
 
         [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
-        $command = Application::formatCommandString('schedule:run');
-
+         $command = Application::phpBinary().' '.ProcessUtils::escapeArgument($this->laravel->basePath('artisan')).' schedule:run';
+    $command = Application::phpBinary().' '.ProcessUtils::escapeArgument($this->laravel->basePath('artisan')).' schedule:run';
         if ($this->option('run-output-file')) {
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';
         }
 
         while (true) {
             usleep(100 * 1000);
-
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
                 $executions[] = $execution = Process::fromShellCommandline($command);


### PR DESCRIPTION
Construct command using php binary and the artisan path relative to the Laravel application, ensuring that schedule:run works from any working directory. Fixes laravel/framework#56390.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
