### PR TITLE
[12.x] Enhancement: the beforeCommit method will now work even if using the ShouldQueueAfterCommit contract

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -382,7 +382,7 @@ abstract class Queue
     protected function shouldDispatchAfterCommit($job)
     {
         if ($job instanceof ShouldQueueAfterCommit) {
-            return true;
+            return ! (isset($job->afterCommit) && $job->afterCommit === false);
         }
 
         if (! $job instanceof Closure && is_object($job) && isset($job->afterCommit)) {

--- a/tests/Queue/BeforeCommitContractTest.php
+++ b/tests/Queue/BeforeCommitContractTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class BeforeCommitContractTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testJobWithoutContractRespectsBeforeCommit()
+    {
+        $job = new class
+        {
+            use Dispatchable, InteractsWithQueue, Queueable;
+
+            public function beforeCommit()
+            {
+                $this->afterCommit = false;
+
+                return $this;
+            }
+        };
+
+        $this->assertFalse($this->shouldDispatchAfterCommit($job));
+    }
+
+    public function testJobWithoutContractRespectsAfterCommit()
+    {
+        $job = new class
+        {
+            use Dispatchable, InteractsWithQueue, Queueable;
+
+            public function afterCommit()
+            {
+                $this->afterCommit = true;
+
+                return $this;
+            }
+        };
+
+        $job->afterCommit();
+
+        $this->assertTrue($this->shouldDispatchAfterCommit($job));
+    }
+
+    public function testJobWithContractDefaultsToAfterCommit()
+    {
+        $job = new class implements ShouldQueueAfterCommit
+        {
+            use Dispatchable, InteractsWithQueue, Queueable;
+        };
+
+        $this->assertTrue($this->shouldDispatchAfterCommit($job));
+    }
+
+    public function testJobWithContractAndAfterCommitFalseRespectsBeforeCommit()
+    {
+        $job = new class implements ShouldQueueAfterCommit
+        {
+            use Dispatchable, InteractsWithQueue, Queueable;
+
+            public function beforeCommit()
+            {
+                $this->afterCommit = false;
+
+                return $this;
+            }
+        };
+
+        $job->beforeCommit();
+
+        $this->assertFalse($this->shouldDispatchAfterCommit($job));
+    }
+
+    public function testJobWithContractAndExplicitAfterCommitTrueStillSchedulesAfterCommit()
+    {
+        $job = new class implements ShouldQueueAfterCommit
+        {
+            use Dispatchable, InteractsWithQueue, Queueable;
+
+            public function afterCommit()
+            {
+                $this->afterCommit = true;
+
+                return $this;
+            }
+        };
+
+        $job->afterCommit();
+
+        $this->assertTrue($this->shouldDispatchAfterCommit($job));
+    }
+
+    protected function shouldDispatchAfterCommit($job)
+    {
+        if ($job instanceof ShouldQueueAfterCommit) {
+            return ! (isset($job->afterCommit) && $job->afterCommit === false);
+        }
+
+        return isset($job->afterCommit) ? $job->afterCommit : false;
+    }
+}


### PR DESCRIPTION
This PR addresses the issue ([#56397](https://github.com/laravel/framework/issues/56397)). The issue is that when a job is using the `ShouldQueueAfterCommit` contract it always is dispatched after the commit even when the `beforeCommit` method is used when dispatching..

``` php
DB::transaction(function(){
    $someData = TestModel::create(...);

    JobWithShouldQueueAfterCommitContract::dispatch($someData)->beforeCommit(); // it still is dispatched after the db commit
});
```
<br>
But I guess the `beforeCommit` method should work even when the `ShouldQueueAfterCommit` contract is used, as the purpose of the `beforeCommit` method is to deliberately or especially specify that the **job must be dispatched before commit**.
<br>
So, that's why in the `shouldDispatchAfterCommit` method of `Queue.php`, I updated the logic a bit:

```php
if ($job instanceof ShouldQueueAfterCommit) {
    return ! (isset($job->afterCommit) && $job->afterCommit === false); // now it checks the afterCommit flag value
}
```

Hope, this will enhance the job dispatch behavior and make it better for DX. And yes, I added unit tests in `BeforeCommitContractTest.php` that checks the relevant cases mostly. 
<br>
Let me know if any more tests or explanations needed or if I need to modify anything. Thanks.