### PR TITLE
[12.x] Use `getContainer()` to avoid fatal error in `Pipeline` with transactions

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -131,7 +131,7 @@ class Pipeline implements PipelineContract
 
         try {
             return $this->withinTransactions
-                ? $this->container->make('db')->transaction(fn () => $pipeline($this->passable))
+                ? $this->getContainer()->make('db')->transaction(fn () => $pipeline($this->passable))
                 : $pipeline($this->passable);
         } finally {
             if ($this->finally) {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -255,6 +255,19 @@ class PipelineTest extends TestCase
             });
     }
 
+    public function testPipelineThrowsExceptionWhenUsingTransactionsWithoutContainer()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A container instance has not been passed to the Pipeline.');
+
+        (new Pipeline)->send('data')
+            ->through(PipelineTestPipeOne::class)
+            ->withinTransactions()
+            ->then(function ($piped) {
+                return $piped;
+            });
+    }
+
     public function testPipelineThenReturnMethodRunsPipelineThenReturnsPassable()
     {
         $result = (new Pipeline(new Container))


### PR DESCRIPTION
Currently, the `Pipeline` class directly accesses `$this->container` when running the pipeline within a database transaction:

```php
$this->container->make('db')->transaction(fn () => $pipeline($this->passable));
```

If the container is not set, this causes a fatal error:

> `Call to a member function make() on null`

This error is unhelpful and makes debugging difficult.

This PR improves the robustness of the `Pipeline` by replacing the direct container access with the existing `getContainer()` method, which throws a clear and descriptive `RuntimeException` if the container is missing:

```php
$this->getContainer()->make('db')->transaction(fn () => $pipeline($this->passable));
```

This ensures that users get a meaningful error message:

> `A container instance has not been passed to the Pipeline.`

Additionally, a test was added to verify this behavior when transactions are enabled but no container is set.
