### PR TITLE
[12.x] Add `Countable` support to `Fluent` class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayIterator;
+use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Traits\Conditionable;
@@ -20,7 +21,7 @@ use Traversable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
+class Fluent implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
     use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;
@@ -221,6 +222,16 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     public function isNotEmpty(): bool
     {
         return ! $this->isEmpty();
+    }
+
+    /**
+     * Get the number of attributes set on the fluent instance.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->attributes);
     }
 
     /**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -490,6 +490,22 @@ class SupportFluentTest extends TestCase
         $this->assertTrue($fluent->isNotEmpty());
         $this->assertFalse($fluent->isEmpty());
     }
+
+    public function testCountable()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'role' => 'admin',
+        ]);
+
+        $this->assertCount(2, $fluent);
+
+        $fluent->set('company', 'Laravel');
+        $this->assertCount(3, $fluent);
+
+        $fluent->offsetUnset('role');
+        $this->assertCount(2, $fluent);
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
This PR adds the `Countable` interface to the `Fluent` class and implements the `count()` method.

Now you can use `count()` directly on `Fluent` instances, making it easier to check how many attributes they contain.