### PR TITLE
[12.x] Allow retrieving single values from getChanges() and getPrevious()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2237,7 +2237,7 @@ trait HasAttributes
      * @param  mixed  $default
      * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getChanges(string|null $key = null, mixed $default = null)
+    public function getChanges($key = null, $default = null)
     {
         if ($key) {
             return $this->transformModelValue(
@@ -2255,7 +2255,7 @@ trait HasAttributes
      * @param  mixed  $default
      * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getPrevious(string|null $key = null, mixed $default = null)
+    public function getPrevious($key = null, $default = null)
     {
         if ($key) {
             return $this->transformModelValue(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2233,20 +2233,36 @@ trait HasAttributes
     /**
      * Get the attributes that were changed when the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getChanges()
+    public function getChanges(string|null $key = null, mixed $default = null)
     {
+        if ($key) {
+            return $this->transformModelValue(
+                $key, Arr::get($this->changes, $key, $default)
+            );
+        }
+
         return $this->changes;
     }
 
     /**
      * Get the attributes that were previously original before the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getPrevious()
+    public function getPrevious(string|null $key = null, mixed $default = null)
     {
+        if ($key) {
+            return $this->transformModelValue(
+                $key, Arr::get($this->previous, $key, $default)
+            );
+        }
+
         return $this->previous;
     }
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -34,9 +34,21 @@ class EloquentModelTest extends DatabaseTestCase
             'nullable_date' => $now = Carbon::now(),
         ]);
         $this->assertTrue($user->isDirty('nullable_date'));
+        $this->assertInstanceOf(Carbon::class, $user->nullable_date);
+        $this->assertEmpty($user->getChanges('nullable_date'));
+        $this->assertEmpty($user->getPrevious('nullable_date'));
 
         $user->save();
         $this->assertEquals($now->toDateString(), $user->nullable_date->toDateString());
+        $this->assertEquals($now->toDateString(), $user->getChanges('nullable_date')->toDateString());
+        $this->assertInstanceOf(Carbon::class, $user->getChanges('nullable_date'));
+        $this->assertEmpty($user->getPrevious('nullable_date'));
+
+        $user->update(['nullable_date' => null]);
+        $this->assertEquals(null, $user->nullable_date);
+        $this->assertEquals(null, $user->getChanges('nullable_date'));
+        $this->assertEquals($now->toDateString(), $user->getPrevious('nullable_date')->toDateString());
+        $this->assertInstanceOf(Carbon::class, $user->getPrevious('nullable_date'));
     }
 
     public function testAttributeChanges()
@@ -63,7 +75,9 @@ class EloquentModelTest extends DatabaseTestCase
 
         $this->assertEmpty($user->getDirty());
         $this->assertEquals(['name' => $overrideName], $user->getChanges());
+        $this->assertEquals($overrideName, $user->getChanges('name'));
         $this->assertEquals(['name' => $originalName], $user->getPrevious());
+        $this->assertEquals($originalName, $user->getPrevious('name'));
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -149,7 +149,9 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertSame('Dr.', $model->title);
         $this->assertSame('Dr.', $model->getOriginal('title'));
         $this->assertSame(['title' => 'Dr.'], $model->getChanges());
+        $this->assertSame('Dr.', $model->getChanges('title'));
         $this->assertSame(['title' => 'Ms.'], $model->getPrevious());
+        $this->assertSame('Ms.', $model->getPrevious('title'));
     }
 
     public function testSaveSyncsPrevious()
@@ -165,7 +167,9 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertSame('Dr.', $model->title);
         $this->assertSame('Dr.', $model->getOriginal('title'));
         $this->assertSame(['title' => 'Dr.'], $model->getChanges());
+        $this->assertSame('Dr.', $model->getChanges('title'));
         $this->assertSame(['title' => 'Ms.'], $model->getPrevious());
+        $this->assertSame('Ms.', $model->getPrevious('title'));
     }
 
     public function testIncrementSyncsPrevious()
@@ -178,7 +182,9 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         $this->assertEquals(1, $model->counter);
         $this->assertSame(['counter' => 1], $model->getChanges());
+        $this->assertSame(1, $model->getChanges('counter'));
         $this->assertSame(['counter' => 0], $model->getPrevious());
+        $this->assertSame(0, $model->getPrevious('counter'));
     }
 }
 


### PR DESCRIPTION
This PR enhances the developer experience by allowing the `getChanges()` and `getPrevious()` methods on Eloquent models to accept an optional $key and $default parameter. This change makes their API consistent with `getOriginal()`.

Previously, these methods only returned the entire array of changes or previous attributes. Now, developers can conveniently retrieve single attributes directly, with casting automatically applied according to the model's attribute casting definitions.

Example:
```PHP
$user = User::find(1);

$user->name; // John
$user->email; // john@example.com

$user->update([
    'name' => 'Jack',
    'email' => 'jack@example.com',
]);

$user->getChanges('name'); // Jack
$user->getChanges();

/*
    [
        'name' => 'Jack',
        'email' => 'jack@example.com',
    ]
*/

$user->getPrevious('name'); // John
$user->getPrevious();

/*
    [
        'name' => 'John',
        'email' => 'john@example.com',
    ]
*/
```

This example is derived and extended from the [Laravel documentation on examining attribute changes](https://laravel.com/docs/12.x/eloquent#examining-attribute-changes).
If this PR is accepted, I will open a follow-up PR to update the official documentation accordingly.