### PR TITLE
[12.x] Add `InteractsWithData` trait to `ComponentAttributeBag`

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use JsonSerializable;
@@ -19,7 +20,7 @@ use Traversable;
 
 class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializable, Htmlable, Stringable
 {
-    use Conditionable, Macroable;
+    use Conditionable, InteractsWithData, Macroable;
 
     /**
      * The raw array of attributes.
@@ -41,11 +42,16 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
     /**
      * Get all the attribute values.
      *
+     * @param  array|mixed|null  $keys
      * @return array
      */
-    public function all()
+    public function all($keys = null)
     {
-        return $this->attributes;
+        if (is_null($keys)) {
+            return $this->attributes;
+        }
+
+        return $this->only($keys)->toArray();
     }
 
     /**
@@ -72,56 +78,19 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Determine if a given attribute exists in the attribute array.
+     * Retrieve data from the instance.
      *
-     * @param  array|string  $key
-     * @return bool
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
      */
-    public function has($key)
+    protected function data($key = null, $default = null)
     {
-        $keys = is_array($key) ? $key : func_get_args();
-
-        foreach ($keys as $value) {
-            if (! array_key_exists($value, $this->attributes)) {
-                return false;
-            }
+        if (is_null($key)) {
+            return $this->attributes;
         }
 
-        return true;
-    }
-
-    /**
-     * Determine if any of the keys exist in the attribute array.
-     *
-     * @param  array|string  $key
-     * @return bool
-     */
-    public function hasAny($key)
-    {
-        if (! count($this->attributes)) {
-            return false;
-        }
-
-        $keys = is_array($key) ? $key : func_get_args();
-
-        foreach ($keys as $value) {
-            if ($this->has($value)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if a given attribute is missing from the attribute array.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function missing($key)
-    {
-        return ! $this->has($key);
+        return $this->get($key, $default);
     }
 
     /**

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -118,6 +118,32 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('class="font-bold" id="my-id"', (string) $bag->except(['name', 'missing']));
     }
 
+    public function testAttributeRetrievalUsingDotNotation()
+    {
+        $bag = new ComponentAttributeBag([
+            'data.config' => 'value1',
+            'x-on:click.prevent' => 'handler',
+            'wire:model.lazy' => 'username',
+            '@submit.prevent' => 'submitForm',
+            'wire:model.debounce.500ms' => 'search',
+        ]);
+
+        $this->assertFalse($bag->has('data'));
+        $this->assertFalse($bag->has('wire:model.debounce'));
+
+        $this->assertTrue($bag->has('data.config'));
+        $this->assertTrue($bag->has('x-on:click.prevent'));
+        $this->assertTrue($bag->has('wire:model.lazy'));
+        $this->assertTrue($bag->has('@submit.prevent'));
+        $this->assertTrue($bag->has('wire:model.debounce.500ms'));
+
+        $this->assertSame('value1', $bag->get('data.config'));
+        $this->assertSame('handler', $bag->get('x-on:click.prevent'));
+        $this->assertSame('username', $bag->get('wire:model.lazy'));
+        $this->assertSame('submitForm', $bag->get('@submit.prevent'));
+        $this->assertSame('search', $bag->get('wire:model.debounce.500ms'));
+    }
+
     public function testItMakesAnExceptionForAlpineXdata()
     {
         $bag = new ComponentAttributeBag([

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -101,6 +101,21 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-extract-1',
             'test-extract-2' => 'defaultValue',
         ]));
+
+        // Test only() method
+        $bag = new ComponentAttributeBag(['class' => 'font-bold', 'name' => 'test', 'id' => 'my-id']);
+        $this->assertInstanceOf(ComponentAttributeBag::class, $bag->only('class'));
+        $this->assertSame('class="font-bold"', (string) $bag->only('class'));
+        $this->assertSame('class="font-bold" name="test"', (string) $bag->only(['class', 'name']));
+        $this->assertSame('', (string) $bag->only('missing'));
+        $this->assertSame('name="test"', (string) $bag->only(['name', 'missing']));
+
+        // Test except() method
+        $this->assertInstanceOf(ComponentAttributeBag::class, $bag->except('class'));
+        $this->assertSame('name="test" id="my-id"', (string) $bag->except('class'));
+        $this->assertSame('id="my-id"', (string) $bag->except(['class', 'name']));
+        $this->assertSame('class="font-bold" name="test" id="my-id"', (string) $bag->except('missing'));
+        $this->assertSame('class="font-bold" id="my-id"', (string) $bag->except(['name', 'missing']));
     }
 
     public function testItMakesAnExceptionForAlpineXdata()
@@ -126,18 +141,20 @@ class ViewComponentAttributeBagTest extends TestCase
 
     public function testAttributeExistence()
     {
-        $bag = new ComponentAttributeBag(['name' => 'test']);
+        $bag = new ComponentAttributeBag(['name' => 'test', 'href' => '', 'src' => null]);
 
-        $this->assertTrue((bool) $bag->has('name'));
-        $this->assertTrue((bool) $bag->has(['name']));
-        $this->assertTrue((bool) $bag->hasAny(['class', 'name']));
-        $this->assertTrue((bool) $bag->hasAny('class', 'name'));
-        $this->assertFalse((bool) $bag->missing('name'));
-        $this->assertFalse((bool) $bag->has('class'));
-        $this->assertFalse((bool) $bag->has(['class']));
-        $this->assertFalse((bool) $bag->has(['name', 'class']));
-        $this->assertFalse((bool) $bag->has('name', 'class'));
-        $this->assertTrue((bool) $bag->missing('class'));
+        $this->assertTrue($bag->has('src'));
+        $this->assertTrue($bag->has('href'));
+        $this->assertTrue($bag->has('name'));
+        $this->assertTrue($bag->has(['name']));
+        $this->assertTrue($bag->hasAny(['class', 'name']));
+        $this->assertTrue($bag->hasAny('class', 'name'));
+        $this->assertFalse($bag->missing('name'));
+        $this->assertFalse($bag->has('class'));
+        $this->assertFalse($bag->has(['class']));
+        $this->assertFalse($bag->has(['name', 'class']));
+        $this->assertFalse($bag->has('name', 'class'));
+        $this->assertTrue($bag->missing('class'));
     }
 
     public function testAttributeIsEmpty()
@@ -163,5 +180,213 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertIsArray($bag->toArray());
         $this->assertEquals(['name' => 'test', 'class' => 'font-bold'], $bag->toArray());
+    }
+
+    public function testFilled()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'class' => 'font-bold',
+            'empty' => '',
+            'whitespace' => '   ',
+            'zero' => '0',
+            'false' => false,
+            'null' => null,
+        ]);
+
+        $this->assertTrue($bag->filled('name'));
+        $this->assertTrue($bag->filled('class'));
+        $this->assertTrue($bag->filled('zero'));
+        $this->assertTrue($bag->filled('false'));
+        $this->assertFalse($bag->filled('null'));
+        $this->assertFalse($bag->filled('empty'));
+        $this->assertFalse($bag->filled('whitespace'));
+        $this->assertFalse($bag->filled('nonexistent'));
+
+        // Multiple keys
+        $this->assertTrue($bag->filled(['name', 'class']));
+        $this->assertFalse($bag->filled(['name', 'empty']));
+        $this->assertTrue($bag->filled('name', 'class'));
+        $this->assertFalse($bag->filled('name', 'empty'));
+    }
+
+    public function testIsNotFilled()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'empty' => '',
+            'whitespace' => '   ',
+        ]);
+
+        $this->assertFalse($bag->isNotFilled('name'));
+        $this->assertTrue($bag->isNotFilled('empty'));
+        $this->assertTrue($bag->isNotFilled('whitespace'));
+        $this->assertTrue($bag->isNotFilled('nonexistent'));
+
+        // Multiple keys - all must be empty
+        $this->assertTrue($bag->isNotFilled(['empty', 'whitespace']));
+        $this->assertFalse($bag->isNotFilled(['name', 'empty']));
+    }
+
+    public function testAnyFilled()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'empty' => '',
+            'whitespace' => '   ',
+        ]);
+
+        $this->assertTrue($bag->anyFilled(['name', 'empty']));
+        $this->assertTrue($bag->anyFilled(['empty', 'name']));
+        $this->assertFalse($bag->anyFilled(['empty', 'whitespace']));
+        $this->assertTrue($bag->anyFilled('name', 'empty'));
+        $this->assertFalse($bag->anyFilled('empty', 'whitespace'));
+    }
+
+    public function testWhenFilled()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'empty' => '',
+        ]);
+
+        $result = $bag->whenFilled('name', function ($value) {
+            return 'callback-'.$value;
+        });
+        $this->assertEquals('callback-test', $result);
+
+        $result = $bag->whenFilled('empty', function ($value) {
+            return 'callback-'.$value;
+        });
+        $this->assertSame($bag, $result);
+
+        $result = $bag->whenFilled('empty', function ($value) {
+            return 'callback-'.$value;
+        }, function () {
+            return 'default-callback';
+        });
+        $this->assertEquals('default-callback', $result);
+    }
+
+    public function testWhenHas()
+    {
+        $bag = new ComponentAttributeBag(['name' => 'test']);
+
+        $result = $bag->whenHas('name', function ($value) {
+            return 'callback-'.$value;
+        });
+        $this->assertEquals('callback-test', $result);
+
+        $result = $bag->whenHas('missing', function ($value) {
+            return 'callback-'.$value;
+        });
+        $this->assertSame($bag, $result);
+
+        $result = $bag->whenHas('missing', function ($value) {
+            return 'callback-'.$value;
+        }, function () {
+            return 'default-callback';
+        });
+        $this->assertEquals('default-callback', $result);
+    }
+
+    public function testWhenMissing()
+    {
+        $bag = new ComponentAttributeBag(['name' => 'test']);
+
+        $result = $bag->whenMissing('name', function () {
+            return 'callback';
+        });
+        $this->assertSame($bag, $result);
+
+        $result = $bag->whenMissing('missing', function () {
+            return 'callback';
+        });
+        $this->assertEquals('callback', $result);
+
+        $result = $bag->whenMissing('name', function () {
+            return 'callback';
+        }, function () {
+            return 'default-callback';
+        });
+        $this->assertEquals('default-callback', $result);
+    }
+
+    public function testString()
+    {
+        $bag = new ComponentAttributeBag([
+            'name' => 'test',
+            'empty' => '',
+            'number' => 123,
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Support\Stringable::class, $bag->string('name'));
+        $this->assertEquals('test', (string) $bag->string('name'));
+        $this->assertEquals('', (string) $bag->string('empty'));
+        $this->assertEquals('123', (string) $bag->string('number'));
+        $this->assertEquals('default', (string) $bag->string('missing', 'default'));
+    }
+
+    public function testBoolean()
+    {
+        $bag = new ComponentAttributeBag([
+            'true_string' => 'true',
+            'false_string' => 'false',
+            'one' => '1',
+            'zero' => '0',
+            'yes' => 'yes',
+            'no' => 'no',
+            'on' => 'on',
+            'off' => 'off',
+        ]);
+
+        $this->assertTrue($bag->boolean('true_string'));
+        $this->assertFalse($bag->boolean('false_string'));
+        $this->assertTrue($bag->boolean('one'));
+        $this->assertFalse($bag->boolean('zero'));
+        $this->assertTrue($bag->boolean('yes'));
+        $this->assertFalse($bag->boolean('no'));
+        $this->assertTrue($bag->boolean('on'));
+        $this->assertFalse($bag->boolean('off'));
+        $this->assertTrue($bag->boolean('missing', true));
+        $this->assertFalse($bag->boolean('missing', false));
+    }
+
+    public function testInteger()
+    {
+        $bag = new ComponentAttributeBag([
+            'number' => '123',
+            'float' => '123.45',
+            'string' => 'abc',
+        ]);
+
+        $this->assertSame(123, $bag->integer('number'));
+        $this->assertSame(123, $bag->integer('float'));
+        $this->assertSame(0, $bag->integer('string'));
+        $this->assertSame(42, $bag->integer('missing', 42));
+    }
+
+    public function testFloat()
+    {
+        $bag = new ComponentAttributeBag([
+            'number' => '123',
+            'float' => '123.45',
+            'string' => 'abc',
+        ]);
+
+        $this->assertSame(123.0, $bag->float('number'));
+        $this->assertSame(123.45, $bag->float('float'));
+        $this->assertSame(0.0, $bag->float('string'));
+        $this->assertSame(42.5, $bag->float('missing', 42.5));
+    }
+
+    public function testExists()
+    {
+        $bag = new ComponentAttributeBag(['name' => 'test']);
+
+        $this->assertTrue($bag->exists('name'));
+        $this->assertFalse($bag->exists('missing'));
+        $this->assertTrue($bag->exists(['name']));
+        $this->assertFalse($bag->exists(['missing']));
     }
 }


### PR DESCRIPTION
This PR adds the `InteractsWithData` trait to `ComponentAttributeBag`, giving developers cleaner ways to work with Blade component attributes.

## Why this change?

Working with component attributes currently requires a lot of boilerplate:

```php
// Checking if attribute has a value
if (($attributes->get('data-progress') ?? '') !== '') {
    // ...
}

// Converting to boolean
$isExpanded = in_array($attributes->get('data-expanded'), ['true', '1', 'on', 'yes'], true); // Or using filter_var()

// Getting integers with defaults
$maxItems = is_numeric($attributes->get('data-max-items')) ? (int) $attributes->get('data-max-items') : 5;
```

## What's new?

By reusing `InteractsWithData`, we gain many powerful methods.

### ✅ Simple validation methods

```blade
{{-- Check if attribute has a value --}}
@if ($attributes->filled('data-tooltip'))
    <span data-tooltip="{{ $attributes->get('data-tooltip') }}">
@endif

{{-- Check multiple attributes at once --}}
@if ($attributes->anyFilled(['data-image-src', 'data-video-url']))
    <div class="media-container">...</div>
@endif
```

### 🎯 Type casting that just works

```blade
{{-- Boolean conversion --}}
<dialog @if($attributes->boolean('data-modal-open')) open @endif>

{{-- Integer with default --}}
<div data-carousel-slides="{{ $attributes->integer('data-slides-count', 3) }}">

{{-- String as Stringable --}}
<h1 data-heading-level="{{ $attributes->string('data-level')->lower() }}">

{{-- Even enums! --}}
<div data-theme="{{ $attributes->enum('data-color-scheme', ThemeEnum::class)?->value }}">
```

### 🌟 Card component with dynamic link

```blade
{{-- Before: Messy conditional logic --}}
@if (($attributes->get('href') ?? '') !== '')
    <a href="{{ $attributes->get('href') }}" class="card-wrapper">
        <div class="card-content">{{ $slot }}</div>
    </a>
@else
    <div class="card-wrapper">
        <div class="card-content">{{ $slot }}</div>
    </div>
@endif

{{-- After: Clean and readable --}}
@if ($attributes->filled('href'))
    <a {{ $attributes->only(['href', 'target', 'rel'])->class('card-wrapper') }}>
        <div class="card-content">{{ $slot }}</div>
    </a>
@else
    <div {{ $attributes->except(['href', 'target', 'rel'])->class('card-wrapper') }}>
        <div class="card-content">{{ $slot }}</div>
    </div>
@endif
```
