### PR TITLE
Add missing parameters to isUrl and isUuid

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -382,21 +382,23 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Determine if a given value is a valid URL.
      *
+     * @param  array  $protocols
      * @return bool
      */
-    public function isUrl()
+    public function isUrl(array $protocols = [])
     {
-        return Str::isUrl($this->value);
+        return Str::isUrl($this->value, $protocols);
     }
 
     /**
      * Determine if a given string is a valid UUID.
      *
+     * @param  int<0, 8>|'max'|null  $version
      * @return bool
      */
-    public function isUuid()
+    public function isUuid($version = null)
     {
-        return Str::isUuid($this->value);
+        return Str::isUuid($this->value, $version);
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -43,13 +43,19 @@ class SupportStringableTest extends TestCase
     public function testIsUrl()
     {
         $this->assertTrue($this->stringable('https://laravel.com')->isUrl());
+        $this->assertTrue($this->stringable('https://laravel.com')->isUrl(['https']));
+
         $this->assertFalse($this->stringable('invalid url')->isUrl());
+        $this->assertFalse($this->stringable('https://laravel.com')->isUrl(['http']));
     }
 
     public function testIsUuid()
     {
         $this->assertTrue($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid());
+        $this->assertTrue($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid(4));
+
         $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->isUuid());
+        $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid(7));
     }
 
     public function testIsUlid()


### PR DESCRIPTION
This pull request fixes missing parameters in the isUrl and isUuid methods of the Stringable class and adds corresponding tests.

Currently, these calls are valid but should not be, because the methods do not respect the provided parameters:

```php
Str::of('https://laravel.com')->isUrl(['http']); // should return false, but returns true
Str::of('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid(7); // should return false, but returns true
```