### PR TITLE
[12.x] Fix typehint for `VerifyEmail::toMailUsing()`

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -21,7 +21,7 @@ class VerifyEmail extends Notification
     /**
      * The callback that should be used to build the mail message.
      *
-     * @var \Closure|null
+     * @var (\Closure(mixed, string): \Illuminate\Notifications\Messages\MailMessage|\Illuminate\Contracts\Mail\Mailable)|null
      */
     public static $toMailCallback;
 
@@ -104,7 +104,7 @@ class VerifyEmail extends Notification
     /**
      * Set a callback that should be used when building the notification mail message.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(mixed, string): (\Illuminate\Notifications\Messages\MailMessage|\Illuminate\Contracts\Mail\Mailable)  $callback
      * @return void
      */
     public static function toMailUsing($callback)


### PR DESCRIPTION
Currently, the toMailUsing method in the VerifyEmail notification only documents the $callback parameter as a generic \Closure without specifying the expected input parameters or return type.
This PR improves the docblock by adding a return type declaration to the callback, specifying that it should return either an instance of MailMessage or a Mailable.
This detailed typehint helps IDEs and static analysis tools (like PHPStan or Psalm) better understand the expected usage, improving developer experience and code quality.