### PR TITLE
[12.x] Adds Model comparison assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Arr;
@@ -11,6 +12,8 @@ use Illuminate\Testing\Constraints\CountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
+use PHPUnit\Framework\Constraint\IsEqual;
+use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
 
 trait InteractsWithDatabase
@@ -182,6 +185,84 @@ trait InteractsWithDatabase
     protected function assertModelMissing($model)
     {
         return $this->assertDatabaseMissing($model);
+    }
+
+    /**
+     * Assert that a given models are equal to another.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $expected
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $result
+     * @return $this
+     */
+    public function assertModelIs($expected, $result)
+    {
+        $expected = Collection::wrap($expected)->sort()->map->getKey()->values()->all();
+        $result = Collection::wrap($result)->sort()->map->getKey()->values()->all();
+
+        $this->assertThat($expected, new IsEqual($result), 'Failed asserting that the models are equal.');
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given model is not equal to another.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $expected
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $result
+     * @return $this
+     */
+    public function assertModelIsNot($expected, $result)
+    {
+        $expected = Collection::wrap($expected)->sort()->map->getKey()->values()->all();
+        $result = Collection::wrap($result)->sort()->map->getKey()->values()->all();
+
+        $this->assertThat(
+            $expected, new ReverseConstraint(new IsEqual($result)), 'Failed asserting that the models are not equal.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given model is equal to another.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $expected
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $result
+     * @return $this
+     */
+    public function assertModelSame($expected, $result)
+    {
+        $normalize = fn ($model) => $model->withoutRelations()->getAttributes();
+
+        $expected = Collection::wrap($expected)->sort()->map($normalize)->values()->all();
+        $result = Collection::wrap($result)->sort()->map($normalize)->values()->all();
+
+        $this->assertThat($expected, new IsIdentical($result), 'Failed asserting that the models are the same.');
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given model is equal to another.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $expected
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Model[]  $result
+     * @return $this
+     */
+    public function assertModelNotSame($expected, $result)
+    {
+        $normalize = fn ($model) => $model->withoutRelations()->getAttributes();
+
+        $expected = Collection::wrap($expected)->sort()->map($normalize)->values()->all();
+        $result = Collection::wrap($result)->sort()->map($normalize)->values()->all();
+
+        $this->assertThat(
+            $expected,
+            new ReverseConstraint(new IsIdentical($result)),
+            'Failed asserting that the models are not the same.'
+        );
+
+        return $this;
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -372,6 +372,167 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertModelExists(new ProductStub($this->data));
     }
 
+    public function testAssertModelIsOnlyUsesId()
+    {
+        $this->assertModelIs(
+            new ProductStub(['id' => 3, 'name' => 'foo']),
+            new ProductStub(['id' => 3, 'name' => 'bar'])
+        );
+
+        $this->assertModelIs(
+            [new ProductStub(['id' => 2, 'name' => 'foo']), new ProductStub(['id' => 1, 'name' => 'bar'])],
+            [new ProductStub(['id' => 1, 'name' => 'baz']), new ProductStub(['id' => 2, 'name' => 'quz'])]
+        );
+    }
+
+    public function testAssertModelIsFailsWithDifferentSingleModel()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are equal.');
+
+        $this->assertModelIs(
+            new ProductStub(['id' => 3, 'name' => 'foo']),
+            new ProductStub(['id' => 2, 'name' => 'foo'])
+        );
+    }
+
+    public function testAssertModelIsFailsWithOneDifferentModelFromIterable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are equal.');
+
+        $this->assertModelIs(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'bar'])],
+            [new ProductStub(['id' => 1, 'name' => 'baz']), new ProductStub(['id' => 3, 'name' => 'quz'])]
+        );
+    }
+
+    public function testAssertModelIsFailsWithDifferentCount()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are equal.');
+
+        $this->assertModelIs(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'bar'])],
+            [new ProductStub(['id' => 1, 'name' => 'baz'])]
+        );
+    }
+
+    public function testAssertModelIsNotOnlyUsesId()
+    {
+        $this->assertModelIsNot(
+            new ProductStub(['id' => 3, 'name' => 'foo']),
+            new ProductStub(['id' => 2, 'name' => 'foo'])
+        );
+
+        $this->assertModelIsNot(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 3, 'name' => 'foo'])]
+        );
+
+        $this->assertModelIsNot(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 1, 'name' => 'foo'])]
+        );
+    }
+
+    public function testAssertModelIsNotFailsWithEqualSingleModel()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are not equal.');
+
+        $this->assertModelIsNot(
+            new ProductStub(['id' => 3, 'name' => 'foo']),
+            new ProductStub(['id' => 3, 'name' => 'foo'])
+        );
+    }
+
+    public function testAssertModelIsNotFailsWithAllEqualModelFromIterable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are not equal.');
+
+        $this->assertModelIsNot(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 2, 'name' => 'foo']), new ProductStub(['id' => 1, 'name' => 'foo'])]
+        );
+    }
+
+    public function testAssertModelSameWithSameAttributes()
+    {
+        $this->assertModelSame(
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+        );
+
+        $this->assertModelSame(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])]
+        );
+    }
+
+    public function testAssertModelSameFailsWithDifferentSingleModel()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are the same.');
+
+        $this->assertModelSame(
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+            new ProductStub(['id' => 1, 'name' => 'bar']),
+        );
+    }
+
+    public function testAssertModelSameFailsWithDifferentModelsFromIterable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are the same.');
+
+        $this->assertModelSame(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 1, 'name' => 'different'])]
+        );
+    }
+
+    public function testAssertModelNotSameUsesAttributes()
+    {
+        $this->assertModelNotSame(
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+            new ProductStub(['id' => 1, 'name' => 'different']),
+        );
+
+        $this->assertModelNotSame(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 2, 'name' => 'foo']), new ProductStub(['id' => 1, 'name' => 'different'])]
+        );
+
+        $this->assertModelNotSame(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 2, 'name' => 'foo'])]
+        );
+    }
+
+    public function testAssertModelNotSameFailsWithSameSingleModel()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are not the same.');
+
+        $this->assertModelNotSame(
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+            new ProductStub(['id' => 1, 'name' => 'foo']),
+        );
+    }
+
+    public function testAssertModelNotSameFailsWithDifferentModelsFromIterable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that the models are not the same.');
+
+        $this->assertModelNotSame(
+            [new ProductStub(['id' => 1, 'name' => 'foo']), new ProductStub(['id' => 2, 'name' => 'foo'])],
+            [new ProductStub(['id' => 2, 'name' => 'foo']), new ProductStub(['id' => 1, 'name' => 'foo'])],
+        );
+    }
+
     public function testGetTableNameFromModel()
     {
         $this->assertEquals($this->table, $this->getTable(ProductStub::class));


### PR DESCRIPTION
## What?

This PR expands some Model testing to check if two models (or Eloquent Collections) are the same or not. The idea is to compare two collections less verbosy than currently is.

- The `assertModelIs()` and `assertModelIsNot()` only checks using the models primary keys. It mimics the `is()` and `isNot()` methods of the Eloquent Model class. 
- The `assertModelSame` and `assertModelNotSame` takes into account all model attributes, so these must be 100% equal.

The main idea of these assertions are to compare collections, since the heavy lifting of normalizing both collections are done inside the test.

```php
use App\Models\User;
use App\User\Repository as UserRepository;

public function test_models_are_equal()
{
    $expected = User::query()->active()->get();
    
    // Before
    $this->assertTrue(
        $expected->sort()->map->withoutRelations()->map()->getAttributes()->values()->all(),
        UserRepository::get()->sort()->map->withoutRelations()->map()->getAttributes()->values()->all(),
    );
    
    // After
    $this->assertModelIs($expected, UserRepository::get());    
}
```