### PR TITLE
[12.x] Add `withScopedSingletons` to `ApplicationBuilder`

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -418,6 +418,25 @@ class ApplicationBuilder
     }
 
     /**
+     * Register an array of scoped singleton container bindings to be bound when the application is booting.
+     *
+     * @param  array  $scopedSingletons
+     * @return $this
+     */
+    public function withScopedSingletons(array $scopedSingletons)
+    {
+        return $this->registered(function ($app) use ($scopedSingletons) {
+            foreach ($scopedSingletons as $abstract => $concrete) {
+                if (is_string($abstract)) {
+                    $app->scoped($abstract, $concrete);
+                } else {
+                    $app->scoped($concrete);
+                }
+            }
+        });
+    }
+
+    /**
      * Register a callback to be invoked when the application's service providers are registered.
      *
      * @param  callable  $callback


### PR DESCRIPTION
I recently started to use Laravel octane as was surprised `withScopedSingletons` or `withScoped` method didn't already exist but one exists for `withSingletons`.

In this PR I took the same logic we have for `withSingletons` and created a new method.

If it fits into Laravel better I can rename `withScopedSingletons` to `withScoped`

If you need me to do any changes, I'd be more then happy