### PR TITLE
[12.x] Pass DateTimezone to Monolog

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -207,7 +207,7 @@ class LogManager implements LoggerInterface
         );
 
         return new Logger(
-            new Monolog('laravel', $this->prepareHandlers([$handler])),
+            new Monolog('laravel', $this->prepareHandlers([$handler]), [], $this->getTimezone()),
             $this->app['events']
         );
     }
@@ -298,7 +298,7 @@ class LogManager implements LoggerInterface
             $handlers = [new WhatFailureGroupHandler($handlers)];
         }
 
-        return new Monolog($this->parseChannel($config), $handlers, $processors);
+        return new Monolog($this->parseChannel($config), $handlers, $processors, $this->getTimezone());
     }
 
     /**
@@ -316,7 +316,7 @@ class LogManager implements LoggerInterface
                     $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
                 ), $config
             ),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
     }
 
     /**
@@ -332,7 +332,7 @@ class LogManager implements LoggerInterface
                 $config['path'], $config['days'] ?? 7, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
     }
 
     /**
@@ -356,7 +356,7 @@ class LogManager implements LoggerInterface
                 $config['bubble'] ?? true,
                 $config['exclude_fields'] ?? []
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
     }
 
     /**
@@ -372,7 +372,7 @@ class LogManager implements LoggerInterface
                 Str::snake($this->app['config']['app.name'], '-'),
                 $config['facility'] ?? LOG_USER, $this->level($config)
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
     }
 
     /**
@@ -387,7 +387,7 @@ class LogManager implements LoggerInterface
             $this->prepareHandler(new ErrorLogHandler(
                 $config['type'] ?? ErrorLogHandler::OPERATING_SYSTEM, $this->level($config)
             )),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
     }
 
     /**
@@ -435,6 +435,7 @@ class LogManager implements LoggerInterface
             $this->parseChannel($config),
             [$handler],
             $processors,
+            $this->getTimezone(),
         );
     }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -193,6 +193,16 @@ class LogManager implements LoggerInterface
     }
 
     /**
+     * The factory to create Monolog
+     *
+     * @see \Monolog\Logger::__construct()
+     */
+    protected function createMonolog(string $name, array $handlers, array $processors = []): Monolog
+    {
+        return new Monolog($name, $handlers, $processors, $this->getTimezone());
+    }
+
+    /**
      * Create an emergency log handler to avoid white screens of death.
      *
      * @return \Psr\Log\LoggerInterface

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Log;
 
 use Closure;
+use DateTimeZone;
 use Illuminate\Contracts\Log\ContextLogProcessor;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -68,7 +69,7 @@ class LogManager implements LoggerInterface
     /**
      * The timezone to pass to Monolog.
      *
-     * @var \DateTimeZone
+     * @var DateTimeZone
      */
     protected $timezone = null;
 
@@ -606,12 +607,12 @@ class LogManager implements LoggerInterface
     /**
      * Get the timezone to pass to Monolog.
      *
-     * @return \DateTimeZone
+     * @return DateTimeZone
      */
     public function getTimezone()
     {
         if (is_null($this->timezone)) {
-            $this->timezone = new \DateTimeZone($this->app['config']->get('logging.timezone', 'UTC'));
+            $this->timezone = new DateTimeZone($this->app['config']->get('logging.timezone', 'UTC'));
         }
 
         return $this->timezone;

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -217,7 +217,7 @@ class LogManager implements LoggerInterface
         );
 
         return new Logger(
-            new Monolog('laravel', $this->prepareHandlers([$handler])),
+            $this->createMonolog('laravel', $this->prepareHandlers([$handler])),
             $this->app['events']
         );
     }
@@ -308,7 +308,7 @@ class LogManager implements LoggerInterface
             $handlers = [new WhatFailureGroupHandler($handlers)];
         }
 
-        return new Monolog($this->parseChannel($config), $handlers, $processors);
+        return $this->createMonolog($this->parseChannel($config), $handlers, $processors);
     }
 
     /**
@@ -319,7 +319,7 @@ class LogManager implements LoggerInterface
      */
     protected function createSingleDriver(array $config)
     {
-        return new Monolog($this->parseChannel($config), [
+        return $this->createMonolog($this->parseChannel($config), [
             $this->prepareHandler(
                 new StreamHandler(
                     $config['path'], $this->level($config),
@@ -337,7 +337,7 @@ class LogManager implements LoggerInterface
      */
     protected function createDailyDriver(array $config)
     {
-        return new Monolog($this->parseChannel($config), [
+        return $this->createMonolog($this->parseChannel($config), [
             $this->prepareHandler(new RotatingFileHandler(
                 $config['path'], $config['days'] ?? 7, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
@@ -353,7 +353,7 @@ class LogManager implements LoggerInterface
      */
     protected function createSlackDriver(array $config)
     {
-        return new Monolog($this->parseChannel($config), [
+        return $this->createMonolog($this->parseChannel($config), [
             $this->prepareHandler(new SlackWebhookHandler(
                 $config['url'],
                 $config['channel'] ?? null,
@@ -377,7 +377,7 @@ class LogManager implements LoggerInterface
      */
     protected function createSyslogDriver(array $config)
     {
-        return new Monolog($this->parseChannel($config), [
+        return $this->createMonolog($this->parseChannel($config), [
             $this->prepareHandler(new SyslogHandler(
                 Str::snake($this->app['config']['app.name'], '-'),
                 $config['facility'] ?? LOG_USER, $this->level($config)
@@ -393,7 +393,7 @@ class LogManager implements LoggerInterface
      */
     protected function createErrorlogDriver(array $config)
     {
-        return new Monolog($this->parseChannel($config), [
+        return $this->createMonolog($this->parseChannel($config), [
             $this->prepareHandler(new ErrorLogHandler(
                 $config['type'] ?? ErrorLogHandler::OPERATING_SYSTEM, $this->level($config)
             )),
@@ -441,7 +441,7 @@ class LogManager implements LoggerInterface
             ->map(fn ($processor) => $this->app->make($processor['processor'] ?? $processor, $processor['with'] ?? []))
             ->toArray();
 
-        return new Monolog(
+        return $this->createMonolog(
             $this->parseChannel($config),
             [$handler],
             $processors,

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -612,7 +612,7 @@ class LogManager implements LoggerInterface
     public function getTimezone()
     {
         if (is_null($this->timezone)) {
-            $this->timezone = new DateTimeZone($this->app['config']->get('logging.timezone', 'UTC'));
+            $this->timezone = new DateTimeZone($this->app['config']->get('logging.timezone', date_default_timezone_get()));
         }
 
         return $this->timezone;

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -66,6 +66,13 @@ class LogManager implements LoggerInterface
     protected $dateFormat = 'Y-m-d H:i:s';
 
     /**
+     * The timezone to pass to Monolog.
+     *
+     * @var \DateTimeZone
+     */
+    protected $timezone = null;
+
+    /**
      * Create a new Log manager instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -584,6 +591,20 @@ class LogManager implements LoggerInterface
     public function setDefaultDriver($name)
     {
         $this->app['config']['logging.default'] = $name;
+    }
+
+    /**
+     * Get the timezone to pass to Monolog.
+     *
+     * @return \DateTimeZone
+     */
+    public function getTimezone()
+    {
+        if (is_null($this->timezone)) {
+            $this->timezone = new \DateTimeZone($this->app['config']['logging.timezone']);
+        }
+
+        return $this->timezone;
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -194,7 +194,7 @@ class LogManager implements LoggerInterface
     }
 
     /**
-     * The factory to create Monolog
+     * The factory to create Monolog.
      *
      * @see \Monolog\Logger::__construct()
      */

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -207,7 +207,7 @@ class LogManager implements LoggerInterface
         );
 
         return new Logger(
-            new Monolog('laravel', $this->prepareHandlers([$handler]), [], $this->getTimezone()),
+            new Monolog('laravel', $this->prepareHandlers([$handler])),
             $this->app['events']
         );
     }
@@ -298,7 +298,7 @@ class LogManager implements LoggerInterface
             $handlers = [new WhatFailureGroupHandler($handlers)];
         }
 
-        return new Monolog($this->parseChannel($config), $handlers, $processors, $this->getTimezone());
+        return new Monolog($this->parseChannel($config), $handlers, $processors);
     }
 
     /**
@@ -316,7 +316,7 @@ class LogManager implements LoggerInterface
                     $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
                 ), $config
             ),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -332,7 +332,7 @@ class LogManager implements LoggerInterface
                 $config['path'], $config['days'] ?? 7, $this->level($config),
                 $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -356,7 +356,7 @@ class LogManager implements LoggerInterface
                 $config['bubble'] ?? true,
                 $config['exclude_fields'] ?? []
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -372,7 +372,7 @@ class LogManager implements LoggerInterface
                 Str::snake($this->app['config']['app.name'], '-'),
                 $config['facility'] ?? LOG_USER, $this->level($config)
             ), $config),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -387,7 +387,7 @@ class LogManager implements LoggerInterface
             $this->prepareHandler(new ErrorLogHandler(
                 $config['type'] ?? ErrorLogHandler::OPERATING_SYSTEM, $this->level($config)
             )),
-        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : [], $this->getTimezone());
+        ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }
 
     /**
@@ -435,7 +435,6 @@ class LogManager implements LoggerInterface
             $this->parseChannel($config),
             [$handler],
             $processors,
-            $this->getTimezone(),
         );
     }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -611,7 +611,7 @@ class LogManager implements LoggerInterface
     public function getTimezone()
     {
         if (is_null($this->timezone)) {
-            $this->timezone = new \DateTimeZone($this->app['config']['logging.timezone']);
+            $this->timezone = new \DateTimeZone($this->app['config']->get('logging.timezone', 'UTC'));
         }
 
         return $this->timezone;

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -61,7 +61,7 @@ class LogManagerTest extends TestCase
 
         // createMonolog is protected. so use ReflectionMethod
         $monolog = (new \ReflectionMethod($manager, 'createMonolog'))
-            ->invoke($manager, 'nameToPassToMonolog');
+            ->invoke($manager, 'nameToPassToMonolog', []);
 
         $this->assertEquals('PRC', $monolog->getTimezone()->getName());
     }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -50,6 +50,22 @@ class LogManagerTest extends TestCase
         $this->assertEquals('single', $manager->getDefaultDriver());
     }
 
+    public function testTimezone()
+    {
+        $config = $this->app['config'];
+
+        $config->set('logging.timezone', 'PRC');
+
+        $manager = new LogManager($this->app);
+        $this->assertEquals('PRC', $manager->getTimezone()->getName());
+
+        // createMonolog is protected. so use ReflectionMethod
+        $monolog = (new \ReflectionMethod($manager, 'createMonolog'))
+            ->invoke($manager, 'nameToPassToMonolog');
+
+        $this->assertEquals('PRC', $monolog->getTimezone()->getName());
+    }
+
     public function testStackChannel()
     {
         $config = $this->app['config'];


### PR DESCRIPTION
Monolog 构造器期望输入一个时区，当传递这个时区参数后，输出的日志就能正确显示当地用户的本地时区。
当我们查看日志时，其实总是期望看到本地的时区，而不是UTC时区，方便快速根据时间查找日志条目。

<img width="2980" height="2018" alt="wechat_2025-07-28_171853_687" src="https://github.com/user-attachments/assets/a2b2969e-34ae-4641-951a-dbc42d60e83a" />
