### PR TITLE
[12.x] Optimization: do not build a full list when not needed

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -885,7 +885,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($model);
 
-        if ($this->reject(fn ($model) => $model instanceof $class)->isNotEmpty()) {
+        if (!$this->every(fn ($model) => $model instanceof $class)) {
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 


### PR DESCRIPTION
This is purely a performance optimization. Rather than building a full list (which may loop over thousands of models), this version uses the early return of `->every()`.
