### PR TITLE
[12.x] Update the db:seed command to accept multiple seeders separated by commas

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -96,11 +96,12 @@ class SeedCommand extends Command
     }
 
     /**
-     * Get a seeder from a class.
+     * Get a seeder instance from a class.
      *
+     * @param string $class
      * @return \Illuminate\Database\Seeder
      */
-    protected function getSeeder(string $class)
+    protected function getSeeder($class)
     {
         if (! str_contains($class, '\\')) {
             $class = 'Database\\Seeders\\'.$class;

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -98,7 +98,7 @@ class SeedCommand extends Command
     /**
      * Get a seeder instance from a class.
      *
-     * @param string $class
+     * @param  string  $class
      * @return \Illuminate\Database\Seeder
      */
     protected function getSeeder($class)
@@ -165,7 +165,7 @@ class SeedCommand extends Command
     protected function getOptions()
     {
         return [
-            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'The class names of a number of seeders', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];


### PR DESCRIPTION
In our large projects, I sometimes don't want to run all seeders, a single seeder, but just a sub set of seeders.

```php
// Before
php artisan db:seed --class=GenresSeeder
php artisan db:seed --class=DirectorsSeeder
php artisan db:seed --class=MoviesSeeder

// After
php artisan db:seed --class=GenresSeeder,DirectorsSeeder,MoviesSeeder
```

Of course I can create another seeder and group the above together using the `call` function. But it would be kinda hard and clunky to name and remember that aggregating seeder. This change will make things straightforward and easier.