### PR TITLE
[12.x]: Add 'doesntContain' validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -537,6 +537,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute does not contain a list of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateDoesntContain($attribute, $value, $parameters)
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (in_array($parameter, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that the password of the currently authenticated user matches the given value.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -276,6 +276,21 @@ class Rule
     }
 
     /**
+     * Get a "does not contain" rule builder instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @return \Illuminate\Validation\Rules\DoesntContain
+     */
+    public static function doesntContain($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        return new Rules\DoesntContain(is_array($values) ? $values : func_get_args());
+    }
+
+    /**
      * Compile a set of rules for an attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rules/DoesntContain.php
+++ b/src/Illuminate/Validation/Rules/DoesntContain.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Stringable;
+
+use function Illuminate\Support\enum_value;
+
+class DoesntContain implements Stringable
+{
+    /**
+     * The values that should be contained in the attribute.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new doesntContain rule instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     */
+    public function __construct($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->values = is_array($values) ? $values : func_get_args();
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $values = array_map(function ($value) {
+            $value = enum_value($value);
+
+            return '"'.str_replace('"', '""', $value).'"';
+        }, $this->values);
+
+        return 'doesnt_contain:'.implode(',', $values);
+    }
+}

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+include_once 'Enums.php';
+
+class ValidationRuleDoesntContainTest extends TestCase {
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = Rule::doesntContain('Taylor');
+        $this->assertSame('doesnt_contain:"Taylor"', (string) $rule);
+
+        $rule = Rule::doesntContain('Taylor', 'Abigail');
+        $this->assertSame('doesnt_contain:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::doesntContain(['Taylor', 'Abigail']);
+        $this->assertSame('doesnt_contain:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::doesntContain(collect(['Taylor', 'Abigail']));
+        $this->assertSame('doesnt_contain:"Taylor","Abigail"', (string) $rule);
+
+        $rule = Rule::doesntContain([ArrayKeys::key_1, ArrayKeys::key_2]);
+        $this->assertSame('doesnt_contain:"key_1","key_2"', (string) $rule);
+
+        $rule = Rule::doesntContain([ArrayKeysBacked::key_1, ArrayKeysBacked::key_2]);
+        $this->assertSame('doesnt_contain:"key_1","key_2"', (string) $rule);
+
+        $rule = Rule::doesntContain(['Taylor', 'Taylor']);
+        $this->assertSame('doesnt_contain:"Taylor","Taylor"', (string) $rule);
+
+        $rule = Rule::doesntContain([1, 2, 3]);
+        $this->assertSame('doesnt_contain:"1","2","3"', (string) $rule);
+
+        $rule = Rule::doesntContain(['"foo"', '"bar"', '"baz"']);
+        $this->assertSame('doesnt_contain:"""foo""","""bar""","""baz"""', (string) $rule);
+    }
+
+    public function testDoesntContainValidation()
+    {
+        $trans = new Translator(new ArrayLoader, 'en');
+
+        // Test fails when value is string
+        $v = new Validator($trans, ['roles' => 'admin'], ['roles' => Rule::doesntContain('admin')]);
+        $this->assertTrue($v->fails());
+
+        // Test fails when array contains the value
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::doesntContain('admin')]);
+        $this->assertTrue($v->fails());
+
+        // Test fails when array contains all the values (using array argument)
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::doesntContain(['admin', 'editor'])]);
+        $this->assertTrue($v->fails());
+
+        // Test fails when array contains some of the values (using multiple arguments)
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::doesntContain('subscriber', 'admin')]);
+        $this->assertTrue($v->fails());
+
+        // Test passes when array does not contain any value
+        $v = new Validator($trans, ['roles' => ['subscriber', 'guest']], ['roles' => Rule::doesntContain(['admin', 'editor'])]);
+        $this->assertTrue($v->passes());
+
+        // Test fails when array includes a value (using string-like format)
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => 'doesnt_contain:admin']);
+        $this->assertTrue($v->fails());
+
+        // Test passes when array doesn't include a value (using string-like format)
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => 'doesnt_contain:editor']);
+        $this->assertTrue($v->passes());
+
+        // Test fails when array doesn't contain the value
+        $v = new Validator($trans, ['roles' => ['admin', 'user']], ['roles' => Rule::doesntContain('admin')]);
+        $this->assertTrue($v->fails());
+
+        // Test with empty array
+        $v = new Validator($trans, ['roles' => []], ['roles' => Rule::doesntContain('admin')]);
+        $this->assertTrue($v->passes());
+
+        // Test with nullable field
+        $v = new Validator($trans, ['roles' => null], ['roles' => ['nullable', Rule::doesntContain('admin')]]);
+        $this->assertTrue($v->passes());
+    }
+}

--- a/tests/Validation/ValidationRuleDoesntContainTest.php
+++ b/tests/Validation/ValidationRuleDoesntContainTest.php
@@ -10,7 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 include_once 'Enums.php';
 
-class ValidationRuleDoesntContainTest extends TestCase {
+class ValidationRuleDoesntContainTest extends TestCase
+{
     public function testItCorrectlyFormatsAStringVersionOfTheRule()
     {
         $rule = Rule::doesntContain('Taylor');


### PR DESCRIPTION
This PR introduces the `doesnt_contain` validation rule, which ensures an array does not contain **any** of the specified values. It complements the existing `contains` rule, which validates that an array includes all specified values. 

Like `contains`, `doesnt_contain` supports a string-like format (e.g., 'field' => 'doesnt_contain:spam') and is implemented in Illuminate\Validation\Validator with a corresponding `DoesntContain` rule class.

## How to use it
### Passing example
```php
use Illuminate\Support\Facades\Validator;

// ✅ passes
$validator = Validator::make(
    ['tags' => ['php', 'laravel', 'symfony']],
    ['tags' => 'required|array|doesnt_contain:javascript']
);
```

### Failing example
```php
use Illuminate\Support\Facades\Validator;

// ❌ fails
$validator = Validator::make(
    ['tags' => ['php', 'laravel', 'symfony']],
    ['tags' => 'required|array|doesnt_contain:php']
);
```

### Passing example using Rule class syntax:
```php
use Illuminate\Support\Facades\Validator;

// ✅ passes
$validator = Validator::make(
    ['tags' => ['php', 'laravel', 'symfony']],
    [
        'tags' => [
            'required',
            'array',
            Rule::doesntContain('javascript')
        ]
    ]
);
```