### PR TITLE
[12.x] Add support for horizontal table layout in the Artisan console `table()` method

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -226,9 +226,10 @@ trait InteractsWithIO
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  \Symfony\Component\Console\Helper\TableStyle|string  $tableStyle
      * @param  array  $columnStyles
+     * @param  bool  $horizontal
      * @return void
      */
-    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [], $horizontal = false)
     {
         $table = new Table($this->output);
 
@@ -241,6 +242,8 @@ trait InteractsWithIO
         foreach ($columnStyles as $columnIndex => $columnStyle) {
             $table->setColumnStyle($columnIndex, $columnStyle);
         }
+
+        $table->setHorizontal($horizontal);
 
         $table->render();
     }


### PR DESCRIPTION
This PR enhances the Artisan console `table()` method by introducing support for horizontal layout rendering.

## Why?
Symfony's Console component supports a horizontal layout mode for tables, which transposes the rows and columns. This can be especially helpful when displaying datasets with a small number of fields but many entries, making the output more readable.

## Before

```php
$this->table(
    ['ID', 'Name', 'Email'],
    [
        [1, 'Alice', 'alice@example.com'],
        [2, 'Bob', 'bob@example.com'],
        [3, 'Charlie', 'charlie@example.com'],
    ],
);
```

<img width="335" height="174" alt="image" src="https://github.com/user-attachments/assets/709f1b1d-3f09-4697-963c-4b69f892c5db" />

## After

```php
$this->table(
    ['ID', 'Name', 'Email'],
    [
        [1, 'Alice', 'alice@example.com'],
        [2, 'Bob', 'bob@example.com'],
        [3, 'Charlie', 'charlie@example.com'],
    ],
    horizontal: true
);
```

<img width="569" height="124" alt="image" src="https://github.com/user-attachments/assets/e0f51e2a-22e4-447a-a08b-3cd52ea0eb0b" />

## Follow-up
A follow-up PR will be submitted to the Laravel documentation upon approval.