### PR TITLE
[12.x] Remove redundant isset check in csrf_token helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -402,11 +402,7 @@ if (! function_exists('csrf_token')) {
     {
         $session = app('session');
 
-        if (isset($session)) {
-            return $session->token();
-        }
-
-        throw new RuntimeException('Application session store not set.');
+        return $session->token();
     }
 }
 


### PR DESCRIPTION
## Summary
Removes the redundant `isset()` check from the `csrf_token()` helper function since the `$session` variable is guaranteed to be defined and non-null.

## Changes
- Eliminated unnecessary `isset($session)` conditional
- Simplified return logic to directly call `$session->token()`

## Reasoning
1. The `$session` variable is assigned via `app('session')`, which always returns a session instance in a properly configured Laravel application
2. The `isset()` check is redundant because:
   - `app()` always returns a binding (throws exception if missing)
   - The session is a core service that's always available
   - The variable assignment guarantees its existence
3. Aligns with Laravel's current code practices where session existence isn't checked in helpers
4. Resolves static analysis warnings about "variable always exists"