### PR TITLE
Add NTLM authentication support to Http Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -472,6 +472,20 @@ class PendingRequest
     }
 
     /**
+     * Specify the digest authentication username and password for the request.
+     *
+     * @param  string  $username
+     * @param  string  $password
+     * @return $this
+     */
+    public function withNtlmAuth($username, $password)
+    {
+        return tap($this, function () use ($username, $password) {
+            $this->options['auth'] = [$username, $password, 'ntlm'];
+        });
+    }
+
+    /**
      * Specify an authorization token for the request.
      *
      * @param  string  $token

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -472,7 +472,7 @@ class PendingRequest
     }
 
     /**
-     * Specify the digest authentication username and password for the request.
+     * Specify the NTLM authentication username and password for the request.
      *
      * @param  string  $username
      * @param  string  $password

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -49,6 +49,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest replaceHeaders(array $headers)
  * @method static \Illuminate\Http\Client\PendingRequest withBasicAuth(string $username, string $password)
  * @method static \Illuminate\Http\Client\PendingRequest withDigestAuth(string $username, string $password)
+ * @method static \Illuminate\Http\Client\PendingRequest withNtlmAuth(string $username, string $password)
  * @method static \Illuminate\Http\Client\PendingRequest withToken(string $token, string $type = 'Bearer')
  * @method static \Illuminate\Http\Client\PendingRequest withUserAgent(string|bool $userAgent)
  * @method static \Illuminate\Http\Client\PendingRequest withUrlParameters(array $parameters = [])


### PR DESCRIPTION
This pull request introduces NTLM authentication support for the Laravel HTTP Client, extending its capabilities for integrations with services that require this authentication method (e.g., certain Microsoft services or legacy APIs).

The implementation leverages Guzzle’s built‑in NTLM option: https://docs.guzzlephp.org/en/stable/request-options.html?highlight=ntlm

Example usage:

```php
$response = HTTP::withNtlmAuth($username, $password)->post(/* ... */);
```
