### PR TITLE
[12.x] Add `removeVariables()` method to Env helper

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -179,7 +179,6 @@ class Env
      *
      * @param  array  $variables
      * @param  string  $pathToFile
-     *
      * @return void
      *
      * @throws RuntimeException

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -175,6 +175,36 @@ class Env
     }
 
     /**
+     * Remove an array of keys from the environment file.
+     *
+     * @param  array  $variables
+     * @param  string  $pathToFile
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     * @throws FileNotFoundException
+     */
+    public static function removeVariables(array $variables, string $pathToFile): void
+    {
+        $filesystem = new Filesystem;
+
+        if ($filesystem->missing($pathToFile)) {
+            throw new RuntimeException("The file [{$pathToFile}] does not exist.");
+        }
+
+        $envContent = $filesystem->get($pathToFile);
+
+        $lines = explode(PHP_EOL, $envContent);
+
+        foreach ($variables as $variable) {
+            $lines = array_filter($lines, fn ($line) => ! str_starts_with($line, $variable.'='));
+        }
+
+        $filesystem->put($pathToFile, implode(PHP_EOL, $lines));
+    }
+
+    /**
      * Add a variable to the environment file contents.
      *
      * @param  string  $key

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1442,6 +1442,39 @@ class SupportHelpersTest extends TestCase
         );
     }
 
+    public function testRemoveVariablesFromFile()
+    {
+        $filesystem = new Filesystem;
+        $path = __DIR__.'/tmp/env-test-file';
+        $filesystem->put($path, implode(PHP_EOL, [
+            'APP_NAME=Laravel',
+            'APP_ENV=local',
+            'APP_KEY=base64:randomkey',
+            'APP_DEBUG=true',
+            'APP_URL=http://localhost',
+            '',
+            'DB_CONNECTION=mysql',
+            'DB_HOST=',
+        ]));
+
+        Env::removeVariables([
+            'APP_DEBUG',
+            'APP_URL',
+            'DB_HOST',
+        ], $path);
+
+        $this->assertSame(
+            implode(PHP_EOL, [
+                'APP_NAME=Laravel',
+                'APP_ENV=local',
+                'APP_KEY=base64:randomkey',
+                '',
+                'DB_CONNECTION=mysql',
+            ]),
+            $filesystem->get($path)
+        );
+    }
+
     public function testWillThrowAnExceptionIfFileIsMissingWhenTryingToWriteVariables(): void
     {
         $this->expectExceptionObject(new RuntimeException('The file [missing-file] does not exist.'));


### PR DESCRIPTION
I liked the idea introduced in https://github.com/laravel/framework/pull/56474.
Since we already have both `writeVariable()` and `writeVariables()`, I’ve added a corresponding `removeVariables()` method to support removing multiple environment variables in a similar way.
