### PR TITLE
[12.x] Add `withHeartbeat` method to `LazyCollection`

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -4,6 +4,8 @@ namespace Illuminate\Support;
 
 use ArrayIterator;
 use Closure;
+use DateInterval;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
@@ -1748,6 +1750,42 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 yield $item;
             }
         });
+    }
+
+    /**
+     * Run the given callback every time the interval has passed.
+     *
+     * @return static<TKey, TValue>
+     */
+    public function withHeartbeat(DateInterval|int $interval, callable $callback)
+    {
+        $seconds = is_int($interval) ? $interval : $this->intervalSeconds($interval);
+
+        return new static(function () use ($seconds, $callback) {
+            $start = $this->now();
+
+            foreach ($this as $key => $value) {
+                $now = $this->now();
+
+                if (($now - $start) >= $seconds) {
+                    $callback();
+
+                    $start = $now;
+                }
+
+                yield $key => $value;
+            }
+        });
+    }
+
+    /**
+     * Get the total seconds from the given interval.
+     */
+    protected function intervalSeconds(DateInterval $interval): int
+    {
+        $start = new DateTimeImmutable();
+
+        return $start->add($interval)->getTimestamp() - $start->getTimestamp();
     }
 
     /**

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1706,6 +1706,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testWithHeartbeatIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->withHeartbeat(1, function () {
+                // Heartbeat callback
+            });
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->withHeartbeat(1, function () {
+                // Heartbeat callback
+            })->all();
+        });
+    }
+
     public function testWrapIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
Adds a new `withHeartbeat` method to `LazyCollection`, which allows you to run a callback at regular time intervals while the collection is being lazily enumerated:

```php
$collection
    ->withHeartbeat(CarbonInterval::minutes(5), function () {
        // ...
    })
    ->each(function ($item) {
        // ...
    });
```

### Main use case

In long-running tasks such as batch processing reports, you may need to hold a lock to prevent concurrent execution. However, if the code unexpectedly fails to release the lock, you don't want it to persist indefinitely. A common strategy is to acquire a short-lived lock, and then periodically extend it while the task is still running.

Here's an example where we acquire a lock for 5 minutes, then reacquire it every 4 minutes (assuming a report never takes a full minute to generate):

```php
$lock = Cache::lock('generate-reports', CarbonInterval::minutes(5));

$lock->acquire();

Reports::where('status', 'pending')
    ->lazy()
    ->withHeartbeat(CarbonInterval::minutes(4), $lock->reacquire(...))
    ->each($this->generateReport(...));

$lock->release();
```

**Note**: the locking logic above is simplified for clarity. It's essentially pseudo-code.