### PR TITLE
opt: memo cache write operations override store values

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -134,7 +134,7 @@ class MemoizedStore implements LockProvider, Store
      */
     public function increment($key, $value = 1)
     {
-        return tap($this->repository->increment($key, $value), function ($result) use ($key, $value) {
+        return tap($this->repository->increment($key, $value), function ($result) use ($key) {
             if (false !== $result) {
                 $this->cache[$this->prefix($key)] = $result;
             }
@@ -150,7 +150,7 @@ class MemoizedStore implements LockProvider, Store
      */
     public function decrement($key, $value = 1)
     {
-        return tap($this->repository->decrement($key, $value), function ($result) use ($key, $value) {
+        return tap($this->repository->decrement($key, $value), function ($result) use ($key) {
             if (false !== $result) {
                 $this->cache[$this->prefix($key)] = $result;
             }

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -39,7 +39,7 @@ class MemoizedStore implements LockProvider, Store
         $prefixedKey = $this->prefix($key);
 
         if (array_key_exists($prefixedKey, $this->cache)) {
-            return $this->cache[$prefixedKey];
+            return !is_null($this->cache[$prefixedKey]) ? strval($this->cache[$prefixedKey]) : null;
         }
 
         return $this->cache[$prefixedKey] = $this->repository->get($key);
@@ -100,7 +100,7 @@ class MemoizedStore implements LockProvider, Store
      */
     public function put($key, $value, $seconds)
     {
-        unset($this->cache[$this->prefix($key)]);
+        $this->cache[$this->prefix($key)] = $value;
 
         return $this->repository->put($key, $value, $seconds);
     }
@@ -108,6 +108,7 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Store multiple items in the cache for a given number of seconds.
      *
+     * @param  array  $values
      * @param  int  $seconds
      * @return bool
      */
@@ -129,7 +130,10 @@ class MemoizedStore implements LockProvider, Store
      */
     public function increment($key, $value = 1)
     {
-        unset($this->cache[$this->prefix($key)]);
+        if (isset($this->cache[$this->prefix($key)]))
+        {
+            $this->cache[$this->prefix($key)] = $this->cache[$this->prefix($key)] + $value;
+        }
 
         return $this->repository->increment($key, $value);
     }
@@ -143,7 +147,10 @@ class MemoizedStore implements LockProvider, Store
      */
     public function decrement($key, $value = 1)
     {
-        unset($this->cache[$this->prefix($key)]);
+        if (isset($this->cache[$this->prefix($key)]))
+        {
+            $this->cache[$this->prefix($key)] = strval($this->cache[$this->prefix($key)] - $value);
+        }
 
         return $this->repository->decrement($key, $value);
     }

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -167,9 +167,9 @@ class MemoizedStore implements LockProvider, Store
     public function forever($key, $value)
     {
         return tap($this->repository->forever($key, $value), function ($result) use ($key, $value) {
-           if ($result){
-               $this->cache[$this->prefix($key)] = $value;
-           }
+            if ($result) {
+                $this->cache[$this->prefix($key)] = $value;
+            }
         });
     }
 

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -39,7 +39,7 @@ class MemoizedStore implements LockProvider, Store
         $prefixedKey = $this->prefix($key);
 
         if (array_key_exists($prefixedKey, $this->cache)) {
-            return !is_null($this->cache[$prefixedKey]) ? strval($this->cache[$prefixedKey]) : null;
+            return ! is_null($this->cache[$prefixedKey]) ? strval($this->cache[$prefixedKey]) : null;
         }
 
         return $this->cache[$prefixedKey] = $this->repository->get($key);
@@ -130,8 +130,7 @@ class MemoizedStore implements LockProvider, Store
      */
     public function increment($key, $value = 1)
     {
-        if (isset($this->cache[$this->prefix($key)]))
-        {
+        if (isset($this->cache[$this->prefix($key)])) {
             $this->cache[$this->prefix($key)] = $this->cache[$this->prefix($key)] + $value;
         }
 
@@ -147,8 +146,7 @@ class MemoizedStore implements LockProvider, Store
      */
     public function decrement($key, $value = 1)
     {
-        if (isset($this->cache[$this->prefix($key)]))
-        {
+        if (isset($this->cache[$this->prefix($key)])) {
             $this->cache[$this->prefix($key)] = strval($this->cache[$this->prefix($key)] - $value);
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -186,7 +186,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function increment($key, $value = 1)
     {
-        return $this->connection()->incrby($this->prefix.$key, $value);
+        return (string) $this->connection()->incrby($this->prefix.$key, $value);
     }
 
     /**
@@ -198,7 +198,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function decrement($key, $value = 1)
     {
-        return $this->connection()->decrby($this->prefix.$key, $value);
+        return (string) $this->connection()->decrby($this->prefix.$key, $value);
     }
 
     /**

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -596,4 +596,22 @@ class MemoizedStoreTest extends TestCase
             $this->assertSame($live, $memoized, "Failed for cache store: $name");
         }
     }
+
+    public function test_it_returns_consistent_types_for_increment_operations(){
+        foreach (['redis', 'database', 'memcached', 'array', 'file', 'null'] as $name) {
+            Cache::store($name)->put('count', 0);
+            Cache::memo($name)->increment('count');
+
+            $this->assertSame(Cache::store($name)->get('count'), Cache::memo($name)->get('count'), $name);
+        }
+    }
+
+    public function test_it_returns_consistent_types_for_decrement_operations(){
+        foreach (['redis', 'database', 'memcached', 'array', 'file', 'null'] as $name) {
+            Cache::store($name)->put('count', 10);
+            Cache::memo($name)->decrement('count');
+
+            $this->assertSame(Cache::store($name)->get('count'), Cache::memo($name)->get('count'), $name);
+        }
+    }
 }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -584,7 +584,8 @@ class MemoizedStoreTest extends TestCase
         $this->assertSame('value-2', $value);
     }
 
-    public function test_it_returns_consistent_types_between_memo_and_underlying_store() {
+    public function test_it_returns_consistent_types_between_memo_and_underlying_store()
+    {
         foreach (['redis', 'database', 'memcached'] as $name) {
             Cache::store($name)->put('count', 0);
             Cache::store($name)->increment('count');
@@ -592,7 +593,7 @@ class MemoizedStoreTest extends TestCase
             $memoized = Cache::memo($name)->get('count');
             $live = Cache::store($name)->get('count');
 
-            $this->assertSame($live, $memoized, "Failed for cache store: $name" );
+            $this->assertSame($live, $memoized, "Failed for cache store: $name");
         }
     }
 }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use BadMethodCallException;
 use Illuminate\Cache\Events\CacheEvent;
-use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\ForgettingKey;
 use Illuminate\Cache\Events\KeyForgotten;
@@ -12,8 +11,6 @@ use Illuminate\Cache\Events\KeyWritten;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Cache\Events\RetrievingManyKeys;
 use Illuminate\Cache\Events\WritingKey;
-use Illuminate\Cache\MemoizedStore;
-use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
@@ -164,11 +161,11 @@ class MemoizedStoreTest extends TestCase
 
         $reflection = new \ReflectionClass($memoStore);
 
-        $cacheProperty = tap($reflection->getProperty('cache'), function($reflectionProperty){
+        $cacheProperty = tap($reflection->getProperty('cache'), function ($reflectionProperty) {
             $reflectionProperty->setAccessible(true);
         });
 
-        $prefixedKey = tap($reflection->getMethod('prefix'), function($method) {
+        $prefixedKey = tap($reflection->getMethod('prefix'), function ($method) {
             $method->setAccessible(true);
         })->invoke($memoStore, 'name');
 
@@ -227,11 +224,11 @@ class MemoizedStoreTest extends TestCase
 
         $reflection = new \ReflectionClass($memoStore);
 
-        $cacheProperty = tap($reflection->getProperty('cache'), function($reflectionProperty){
+        $cacheProperty = tap($reflection->getProperty('cache'), function ($reflectionProperty) {
             $reflectionProperty->setAccessible(true);
         });
 
-        $prefixedKey = tap($reflection->getMethod('prefix'), function($method) {
+        $prefixedKey = tap($reflection->getMethod('prefix'), function ($method) {
             $method->setAccessible(true);
         })->invoke($memoStore, 'count');
 
@@ -272,11 +269,11 @@ class MemoizedStoreTest extends TestCase
 
         $reflection = new \ReflectionClass($memoStore);
 
-        $cacheProperty = tap($reflection->getProperty('cache'), function($reflectionProperty){
+        $cacheProperty = tap($reflection->getProperty('cache'), function ($reflectionProperty) {
             $reflectionProperty->setAccessible(true);
         });
 
-        $prefixedKey = tap($reflection->getMethod('prefix'), function($method){
+        $prefixedKey = tap($reflection->getMethod('prefix'), function ($method) {
             $method->setAccessible(true);
         })->invoke($memoStore, 'count');
 

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -597,7 +597,8 @@ class MemoizedStoreTest extends TestCase
         }
     }
 
-    public function test_it_returns_consistent_types_for_increment_operations(){
+    public function test_it_returns_consistent_types_for_increment_operations()
+    {
         foreach (['redis', 'database', 'memcached', 'array', 'file', 'null'] as $name) {
             Cache::store($name)->put('count', 0);
             Cache::memo($name)->increment('count');
@@ -606,7 +607,8 @@ class MemoizedStoreTest extends TestCase
         }
     }
 
-    public function test_it_returns_consistent_types_for_decrement_operations(){
+    public function test_it_returns_consistent_types_for_decrement_operations()
+    {
         foreach (['redis', 'database', 'memcached', 'array', 'file', 'null'] as $name) {
             Cache::store($name)->put('count', 10);
             Cache::memo($name)->decrement('count');


### PR DESCRIPTION
Hello,

I was just watching @taylorotwell's Keynote at Laracon, and saw him presenting an example about the new memo() cache features. It was this example, to be more precise:

## Current implementation
```php
 // roundtrip request #1, since 'name' is not in the memo store.
$name = Cache::memo()->get('name');

 // roundtrip request #2, updates the 'name' in the cache store.
Cache::memo()->put('name', 'Taylor', 10);

// roundtrip request #3, since 'name' was invalidated in the previous command
$name = Cache::memo()->get('name');
```
So this example got me wondering, why do we need to have 3 roundtrips to the cache store? Why is the `Cache::memo()->put()` method not memoizing the value?

## Unnecessary Cache Roundtrips
The issue I see is that this will make 3 roundtrips to the underlying cache store, because the put() command invalidates the existing memoized value. Instead of storing invalidating the cache, I think overriding the existing value would make more sense, and it could save an extra roundtrip request to the cache store.

## After the proposed solution
```php
 // roundtrip request #1, since 'name' is not in the memo store.
$name = Cache::memo()->get('name');

 // roundtrip request #2, updates the 'name' in the cache store AND stores it in the memo store.
Cache::memo()->put('name', 'Taylor', 10);

// no roundtrip request, since the value is already in the memo store.
$name = Cache::memo()->get('name');
```

### Disclaimer:
- This is a breaking change, so I am targeting the `master` branch.

### Note:
- This year's Laracon was one of the best one's I've seen! It's a good time to be a Laravel developer. Thanks to Taylor and the team 🔥🔥🔥