### PR TITLE
[12.x] `Conditionable` trait added to `Router` class

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -472,10 +472,6 @@ class Router implements BindingRegistrar, RegistrarContract
     public function group(array $attributes, $routes)
     {
         foreach (Arr::wrap($routes) as $groupRoutes) {
-            if (array_key_exists('register', $attributes) && $attributes['register'] === false) {
-                continue;
-            }
-
             $this->updateGroupStack($attributes);
 
             // Once we have updated the group stack, we'll load the provided routes and

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
@@ -41,6 +42,7 @@ class Router implements BindingRegistrar, RegistrarContract
         __call as macroCall;
     }
     use Tappable;
+    use Conditionable;
 
     /**
      * The event dispatcher instance.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -472,6 +472,10 @@ class Router implements BindingRegistrar, RegistrarContract
     public function group(array $attributes, $routes)
     {
         foreach (Arr::wrap($routes) as $groupRoutes) {
+            if (array_key_exists('register', $attributes) && $attributes['register'] === false) {
+                continue;
+            }
+
             $this->updateGroupStack($attributes);
 
             // Once we have updated the group stack, we'll load the provided routes and

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -455,6 +455,20 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testRouteGroupWithRegisterAttributeSetToFalse()
+    {
+        $router = $this->getRouter();
+
+        $router->group(['register' => false], function (Registrar $router) {
+            $router->get('foo/bar', function () {
+                return 'hello';
+            });
+        });
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $router->dispatch(Request::create('foo/bar', 'GET'));
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -442,6 +442,19 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->bindingFieldFor('baz'));
     }
 
+    public function testRouteGroupWithRegisterAttributeSetToTrue()
+    {
+        $router = $this->getRouter();
+
+        $router->group(['register' => true], function (Registrar $router) {
+            $router->get('foo/bar', function () {
+                return 'hello';
+            });
+        });
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -442,6 +442,33 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->bindingFieldFor('baz'));
     }
 
+    public function testRouteWithConditionableTrue()
+    {
+        $router = $this->getRouter();
+
+        $router->when(true, function (Registrar $router) {
+            $router->get('foo/bar', function () {
+                return 'hello';
+            });
+        });
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
+    public function testRouteWithConditionableFalse()
+    {
+        $router = $this->getRouter();
+
+        $router->when(false, function (Registrar $router) {
+            $router->get('foo/bar', function () {
+                return 'hello';
+            });
+        });
+
+        $this->expectException(NotFoundHttpException::class);
+        $router->dispatch(Request::create('foo/bar', 'GET'));
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -442,33 +442,6 @@ class RoutingRouteTest extends TestCase
         $this->assertNull($route->bindingFieldFor('baz'));
     }
 
-    public function testRouteGroupWithRegisterAttributeSetToTrue()
-    {
-        $router = $this->getRouter();
-
-        $router->group(['register' => true], function (Registrar $router) {
-            $router->get('foo/bar', function () {
-                return 'hello';
-            });
-        });
-
-        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-    }
-
-    public function testRouteGroupWithRegisterAttributeSetToFalse()
-    {
-        $router = $this->getRouter();
-
-        $router->group(['register' => false], function (Registrar $router) {
-            $router->get('foo/bar', function () {
-                return 'hello';
-            });
-        });
-
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
-        $router->dispatch(Request::create('foo/bar', 'GET'));
-    }
-
     public function testMacro()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -453,6 +453,16 @@ class RoutingRouteTest extends TestCase
         });
 
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->when(true, function (Registrar $router) {
+            $router->group(['prefix' => 'group'], function (Registrar $router) {
+                $router->get('foo/bar', function () {
+                    return 'hello from group';
+                });
+            });
+        });
+
+        $this->assertSame('hello from group', $router->dispatch(Request::create('group/foo/bar', 'GET'))->getContent());
     }
 
     public function testRouteWithConditionableFalse()
@@ -467,6 +477,17 @@ class RoutingRouteTest extends TestCase
 
         $this->expectException(NotFoundHttpException::class);
         $router->dispatch(Request::create('foo/bar', 'GET'));
+
+        $router->when(false, function (Registrar $router) {
+            $router->group(['prefix' => 'group'], function (Registrar $router) {
+                $router->get('foo/bar', function () {
+                    return 'hello from group';
+                });
+            });
+        });
+
+        $this->expectException(NotFoundHttpException::class);
+        $router->dispatch(Request::create('group/foo/bar', 'GET'));
     }
 
     public function testMacro()


### PR DESCRIPTION
## Updated PR:

This PR adds the `Illuminate\Support\Traits\Conditionable` trait to the `Illuminate\Routing\Router` class, allowing developers to conditionally register routes using the fluent `when()` method.

### Usage

```php
Route::when(config('features.admin_routes'), function () {
    Route::group(['prefix' => 'admin'], function () {
        Route::get('/dashboard', fn () => 'admin dashboard');
    });
});
```

No breaking changes. The `Conditionable` trait simply adds the `when()` and `unless()` methods to the Router.

---

## Old PR: 

If the key doesn't exist, the route group is registered by default.
If defined, it behaves according to the defined boolean.

### Usage

```php
Route::group([
    'prefix' => 'home',
    'register' => false,
], function () {
    Route::get('/', function () {
        return view('welcome');
    });
});
```

This will skip registering the URLS within the 'home` prefix group.