### PR TITLE
fix: align ResponseFactory::eventStream signature with interface

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Contracts\Routing;
 
+use Closure;
+use Illuminate\Http\StreamedEvent;
+
 interface ResponseFactory
 {
     /**
@@ -65,7 +68,7 @@ interface ResponseFactory
      * @param  \Illuminate\Http\StreamedEvent|string|null  $endStreamWith
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function eventStream($callback, array $headers = [], $endStreamWith = '</stream>');
+    public function eventStream(Closure $callback, array $headers = [], StreamedEvent|string|null $endStreamWith = '</stream>');
 
     /**
      * Create a new streamed response instance.


### PR DESCRIPTION
# Fix: Align ResponseFactory::eventStream signature with interface

## Summary

This PR fixes a method signature mismatch in `Illuminate\Routing\ResponseFactory::eventStream` that was causing fatal errors in tests.

## Problem

PR #56306 added the `eventStream` method signature to the `Illuminate\Contracts\Routing\ResponseFactory` interface to improve type support and static analysis. However, the existing concrete implementation in `Illuminate\Routing\ResponseFactory` uses type hints that don't match the interface declaration, creating a fatal error:
<img width="1175" height="554" alt="image" src="https://github.com/user-attachments/assets/d41a467f-c4a4-4161-a34c-4f1299601911" />