### PR TITLE
Fix: Add consistent ordering to first() method for database compatibi…

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -363,6 +363,18 @@ trait BuildsQueries
      */
     public function first($columns = ['*'])
     {
+        // Ensure consistent results across databases by adding default ordering
+        // when no explicit ordering is provided. This addresses inconsistencies
+        // between PostgreSQL and MySQL/MariaDB when using LIMIT without ORDER BY.
+        $query = method_exists($this, 'getQuery') ? $this->getQuery() : $this;
+        
+        if (empty($query->orders)) {
+            // For Eloquent queries, use the model's primary key
+            if (method_exists($this, 'getModel') && $this->getModel()) {
+                $this->orderBy($this->getModel()->getKeyName());
+            }
+        }
+
         return $this->limit(1)->get($columns)->first();
     }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\RecordNotFoundException;
@@ -363,15 +364,12 @@ trait BuildsQueries
      */
     public function first($columns = ['*'])
     {
-        // Ensure consistent results across databases by adding default ordering
-        // when no explicit ordering is provided. This addresses inconsistencies
-        // between PostgreSQL and MySQL/MariaDB when using LIMIT without ORDER BY.
-        $query = method_exists($this, 'getQuery') ? $this->getQuery() : $this;
-        
-        if (empty($query->orders)) {
-            // For Eloquent queries, use the model's primary key
-            if (method_exists($this, 'getModel') && $this->getModel()) {
-                $this->orderBy($this->getModel()->getKeyName());
+        if (method_exists($this, 'getModel') && $this->getModel()) {
+            $query = $this->getQuery();
+            $model = $this->getModel();
+
+            if (empty($query->orders) && empty($query->joins) && $model->getKeyName() && ! $model instanceof Pivot) {
+                $this->orderBy($model->getQualifiedKeyName());
             }
         }
 


### PR DESCRIPTION
Fix: Add consistent ordering to first() method for database compatibility

This commit addresses inconsistent behavior of the first() method between PostgreSQL and MySQL/MariaDB databases when no explicit ordering is provided.

**Problem:**
- PostgreSQL returns non-deterministic results for `SELECT * FROM table LIMIT 1` without ORDER BY, as it may return different rows on different executions
- MySQL/MariaDB tends to return rows in a more predictable order (often by insertion order or storage order), making the behavior appear consistent
- This inconsistency caused the same Laravel code to behave differently across database systems

**Solution:**
- Modified first() method in BuildsQueries trait to automatically add ordering by the model's primary key when no explicit ordering is present
- Only applies to Eloquent queries where a model is available
- Maintains backward compatibility while ensuring consistent results
- Added comprehensive tests to verify the new behavior

**Changes:**
- Enhanced first() method to check for existing ordering before adding default
- For Eloquent models, uses getKeyName() to determine the primary key
- Only adds ordering when no existing ORDER BY clause is present
- Added two new test cases to verify ordering behavior

**Benefits:**
- Consistent behavior across PostgreSQL, MySQL, and MariaDB
- No breaking changes to existing code
- Improved reliability for applications using multiple database systems
- Better predictability for testing and development

Fixes database consistency issues when using first() without explicit ordering.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
