### PR TITLE
[12.x] Fix: Allow validateIn rule for Enum types

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -30,6 +30,8 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use ValueError;
 
+use function Illuminate\Support\enum_value;
+
 trait ValidatesAttributes
 {
     /**
@@ -1473,7 +1475,10 @@ trait ValidatesAttributes
             return count(array_diff($value, $parameters)) === 0;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array(
+            $value instanceof \UnitEnum ? enum_value($value) : (string) $value,
+            $parameters
+        );
     }
 
     /**

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -88,5 +88,17 @@ class ValidationInRuleTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'foo'], ['x' => ['required', Rule::in('foo', 'bar')]]);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => StringStatus::pending], ['x' => Rule::in(StringStatus::pending)]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => StringStatus::pending], ['x' => Rule::in(StringStatus::done)]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => PureEnum::one], ['x' => Rule::in(PureEnum::one)]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => PureEnum::one], ['x' => Rule::in(PureEnum::two)]);
+        $this->assertFalse($v->passes());
     }
 }


### PR DESCRIPTION
Fix: Allow using Enums as input data when using `Rule::in`, without having to first convert them to string.
https://github.com/filamentphp/filament/issues/16890#issuecomment-3132166199
