### PR TITLE
[12.x] Ensure consistent results for first() method across databases

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\RecordNotFoundException;
@@ -363,6 +364,15 @@ trait BuildsQueries
      */
     public function first($columns = ['*'])
     {
+        if (method_exists($this, 'getModel') && $this->getModel()) {
+            $query = $this->getQuery();
+            $model = $this->getModel();
+
+            if (empty($query->orders) && empty($query->joins) && $model->getKeyName() && ! $model instanceof Pivot) {
+                $this->orderBy($model->getQualifiedKeyName());
+            }
+        }
+
         return $this->limit(1)->get($columns)->first();
     }
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -368,7 +368,12 @@ trait BuildsQueries
             $query = $this->getQuery();
             $model = $this->getModel();
 
-            if (empty($query->orders) && empty($query->joins) && $model->getKeyName() && ! $model instanceof Pivot) {
+
+            if (empty($query->orders) &&
+                empty($query->joins) &&
+                empty($query->wheres) &&
+                $model->getKeyName() &&
+                ! $model instanceof Pivot) {
                 $this->orderBy($model->getQualifiedKeyName());
             }
         }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -368,7 +368,6 @@ trait BuildsQueries
             $query = $this->getQuery();
             $model = $this->getModel();
 
-
             if (empty($query->orders) &&
                 empty($query->joins) &&
                 empty($query->wheres) &&

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -315,7 +315,6 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $queryBuilder = $this->getMockQueryBuilder();
         $queryBuilder->orders = [['column' => 'name', 'direction' => 'asc']];
-        
         $builder = m::mock(Builder::class.'[orderBy,limit,get]', [$queryBuilder]);
         $model = $this->getMockModel();
         $builder->setModel($model);
@@ -332,7 +331,6 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $queryBuilder = $this->getMockQueryBuilder();
         $queryBuilder->joins = [['table' => 'other_table']];
-        
         $builder = m::mock(Builder::class.'[orderBy,limit,get]', [$queryBuilder]);
         $model = $this->getMockModel();
         $builder->setModel($model);
@@ -349,7 +347,6 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $queryBuilder = $this->getMockQueryBuilder();
         $queryBuilder->wheres = [['type' => 'Basic', 'column' => 'name', 'operator' => '=', 'value' => 'John']];
-        
         $builder = m::mock(Builder::class.'[orderBy,limit,get]', [$queryBuilder]);
         $model = $this->getMockModel();
         $builder->setModel($model);


### PR DESCRIPTION
This addresses inconsistent behavior of the first() method between PostgreSQL and MySQL/MariaDB when no explicit ordering is provided.

PostgreSQL returns non-deterministic results for LIMIT queries without ORDER BY, while MySQL/MariaDB returns predictable results. This change automatically adds ordering by the model's qualified primary key when conditions are met.

Ordering is added when:
- Using an Eloquent model
- No explicit ORDER BY exists
- No joins are present
- Model has a primary key
- Model is not a Pivot

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
