### PR TITLE
[13.x] Resolve Symfony Console `add()` method deprecation

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -206,6 +206,18 @@ class Application extends SymfonyApplication implements ApplicationContract
     }
 
     /**
+     * Alias for addCommand() since Symfony's add() method was deprecated.
+     *
+     * @param  \Symfony\Component\Console\Command\Command  $command
+     * @return \Symfony\Component\Console\Command\Command|null
+     */
+    #[\Override]
+    public function add(SymfonyCommand $command): ?SymfonyCommand
+    {
+        return $this->addCommand($command);
+    }
+
+    /**
      * Add a command to the console.
      *
      * @param  \Symfony\Component\Console\Command\Command|callable  $command


### PR DESCRIPTION
## Summary
Resolves Symfony Console deprecation warnings by simply overriding the deprecated `add()` method to delegate to `addCommand()`.

## Problem
Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()" method is deprecated and will be removed in Symfony 8.0, use "Symfony\Component\Console\Application::addCommand()" instead.

Actual error from the tests:
```php
ErrorException: Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()" method is deprecated and will be removed in Symfony 8.0, use "Symfony\Component\Console\Application::addCommand()" instead.
/Users/x/framework/vendor/symfony/deprecation-contracts/function.php:25
/Users/x/framework/vendor/symfony/console/Application.php:537
/Users/x/framework/vendor/symfony/console/Application.php:1345
/Users/x/framework/vendor/symfony/console/Application.php:619
/Users/x/framework/src/Illuminate/Console/Application.php:161
/Users/x/framework/src/Illuminate/Foundation/Console/Kernel.php:426
/Users/x/framework/src/Illuminate/Testing/PendingCommand.php:330
/Users/x/framework/src/Illuminate/Testing/PendingCommand.php:533
/Users/x/framework/tests/Testing/Console/RouteListCommandTest.php:121
```


## Solution
- Override the `add()` method in `Illuminate\Console\Application` 
- Delegate to `addCommand()` to maintain Laravel's command registration logic
- Preserve backward compatibility while eliminating deprecation warnings