### PR TITLE
fix: resolve PHPStan unreachable code errors in type assertions

### DIFF
--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -43,7 +43,7 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
-    assertType('never', throw_if(true, Exception::class));
+    rescue(fn () => assertType('never', throw_if(true, Exception::class)));
     assertType('false', throw_if(false, Exception::class));
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
@@ -62,7 +62,7 @@ function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
-    assertType('never', throw_unless(false, Exception::class));
+    rescue(fn() => assertType('never', throw_unless(false, Exception::class)));
     assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
     assertType('int', $foo);
@@ -72,8 +72,8 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
     assertType('DateTime', $bar);
 
     // Truthy/falsey argument
-    assertType('never', throw_unless(null, Exception::class));
-    assertType('never', throw_unless('', Exception::class));
+    rescue(fn() => assertType('never', throw_unless(null, Exception::class)));
+    rescue(fn() => assertType('never', throw_unless('', Exception::class)));
     assertType("'foo'", throw_unless('foo', Exception::class));
 }
 

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -62,7 +62,7 @@ function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
-    rescue(fn() => assertType('never', throw_unless(false, Exception::class)));
+    rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
     assertType('true', throw_unless(empty($foo)));
     throw_unless(is_int($foo));
     assertType('int', $foo);
@@ -72,8 +72,8 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
     assertType('DateTime', $bar);
 
     // Truthy/falsey argument
-    rescue(fn() => assertType('never', throw_unless(null, Exception::class)));
-    rescue(fn() => assertType('never', throw_unless('', Exception::class)));
+    rescue(fn () => assertType('never', throw_unless(null, Exception::class)));
+    rescue(fn () => assertType('never', throw_unless('', Exception::class)));
     assertType("'foo'", throw_unless('foo', Exception::class));
 }
 


### PR DESCRIPTION
This PR fixes PHPStan unreachable code errors in `Support/Helpers.php` type assertion tests.

## Problem
PHPStan was reporting "Unreachable statement - code above always terminates" errors on lines 47 and 66 because `throw_if(true, Exception::class)` and similar statements always throw an error when the first argument is truthy, causing PHPStan to detect that code following these statements is unreachable.

<img width="675" height="392" alt="image" src="https://github.com/user-attachments/assets/9afec21a-67e4-4d6d-83a4-3d59e49bb54f" />
