### PR TITLE
[12.x] - add `dispatchedOnce` methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -141,20 +141,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function assertDispatchedOnce($command)
     {
-        $callback = null;
-
-        if ($command instanceof Closure) {
-            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
-        }
-
-        $count = $this->dispatched($command, $callback)->count() +
-                 $this->dispatchedAfterResponse($command, $callback)->count() +
-                 $this->dispatchedSync($command, $callback)->count();
-
-        PHPUnit::assertSame(
-            1, $count,
-            "The expected [{$command}] job was pushed {$count} times instead of once."
-        );
+        $this->assertDispatchedTimes($command, 1);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -133,6 +133,31 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
+     * Assert if a job was pushed exactly once.
+     *
+     * @param  string|\Closure  $command
+     * @param  int  $times
+     * @return void
+     */
+    public function assertDispatchedOnce($command)
+    {
+        $callback = null;
+
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        }
+
+        $count = $this->dispatched($command, $callback)->count() +
+                 $this->dispatchedAfterResponse($command, $callback)->count() +
+                 $this->dispatchedSync($command, $callback)->count();
+
+        PHPUnit::assertSame(
+            1, $count,
+            "The expected [{$command}] job was pushed {$count} times instead of once."
+        );
+    }
+
+    /**
      * Assert if a job was pushed a number of times.
      *
      * @param  string|\Closure  $command

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -156,12 +156,7 @@ class EventFake implements Dispatcher, Fake
      */
     public function assertDispatchedOnce($event)
     {
-        $count = $this->dispatched($event)->count();
-
-        PHPUnit::assertSame(
-            1, $count,
-            "The expected [{$event}] event was dispatched {$count} times instead of once."
-        );
+        $this->assertDispatchedTimes($event, 1);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -148,6 +148,23 @@ class EventFake implements Dispatcher, Fake
     }
 
     /**
+     * Assert if an event was dispatched exactly once.
+     *
+     * @param  string  $event
+     * @param  int  $times
+     * @return void
+     */
+    public function assertDispatchedOnce($event)
+    {
+        $count = $this->dispatched($event)->count();
+
+        PHPUnit::assertSame(
+            1, $count,
+            "The expected [{$event}] event was dispatched {$count} times instead of once."
+        );
+    }
+
+    /**
      * Assert if an event was dispatched a number of times.
      *
      * @param  string  $event

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -284,7 +284,7 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fake->assertDispatchedOnce(BusJobStub::class);
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of once.', $e->getMessage());
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of 1 times.', $e->getMessage());
         }
 
         $this->fake->assertDispatchedTimes(BusJobStub::class, 2);

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -275,6 +275,21 @@ class SupportTestingBusFakeTest extends TestCase
         });
     }
 
+    public function testAssertDispatchedOnce()
+    {
+        $this->fake->dispatch(new BusJobStub);
+        $this->fake->dispatchNow(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedOnce(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of once.', $e->getMessage());
+        }
+
+        $this->fake->assertDispatchedTimes(BusJobStub::class, 2);
+    }
+
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(new BusJobStub);

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -76,6 +76,21 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class, 2);
     }
 
+    public function testAssertDispatchedOnce()
+    {
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->dispatch(EventStub::class);
+
+        try {
+            $this->fake->assertDispatchedOnce(EventStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of once.', $e->getMessage());
+        }
+
+        $this->fake->assertDispatchedTimes(EventStub::class, 2);
+    }
+
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(EventStub::class);

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -85,7 +85,7 @@ class SupportTestingEventFakeTest extends TestCase
             $this->fake->assertDispatchedOnce(EventStub::class);
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of once.', $e->getMessage());
+            $this->assertStringContainsString('The expected [Illuminate\Tests\Support\EventStub] event was dispatched 2 times instead of 1 times.', $e->getMessage());
         }
 
         $this->fake->assertDispatchedTimes(EventStub::class, 2);


### PR DESCRIPTION
When using the `assertDispatchedTimes` method, it can be confusing because the default parameter is 1.

Sometimes we want to know that something was dispatched exactly once and be able to easily read this at a glance.

Currently you could just do:
```php
Event::assertDispatchTimes($myEvent, 1);
```
However some tools remove the `1` as it is "dead code" due to `1` being the default argument. So it becomes:
```php
Event::assertDispatchTimes($myEvent);
```
 This reads like an unfinished sentence.

This PR adds:
```php
Event::assertDispatchedOnce(...)
```
This is very explicit and easy to read.