### PR TITLE
Prevent contextual bindings from following stale aliases

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -690,6 +690,8 @@ class Container implements ArrayAccess, ContainerContract
             throw new LogicException("[{$abstract}] is aliased to itself.");
         }
 
+        $this->removeAbstractAlias($alias);
+
         $this->aliases[$alias] = $abstract;
 
         $this->abstractAliases[$abstract][] = $alias;

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -123,6 +123,23 @@ class ContextualBindingTest extends TestCase
         );
     }
 
+    public function testContextualBindingDoesNotFollowStaleAliases()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectOne::class)->needs('stale')->give(ContainerContextImplementationStub::class);
+        $container->when(ContainerTestContextInjectOne::class)->needs('live')->give(ContainerContextImplementationStubTwo::class);
+
+        $container->alias(IContainerContextContractStub::class, 'stale');
+        $container->alias('unrelated', 'stale');
+        $container->alias(IContainerContextContractStub::class, 'live');
+
+        $this->assertInstanceOf(
+            ContainerContextImplementationStubTwo::class,
+            $container->make(ContainerTestContextInjectOne::class)->impl
+        );
+    }
+
     public function testContextualBindingWorksForMultipleClasses()
     {
         $container = new Container;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When resolving contextual bindings, the container does a reverse lookup on aliases: it checks to see if there is a contextual binding on an alias of the interface it needs an instance of. `$container->abstractAliases` is a reverse mapping of interfaces to their aliases that supports this lookup. Because `$container->alias()` does not remove old entries from `abstractAliases`, the container ends up checking whether there _ever has been_ an alias to the current interface, not whether there _currently is_ such an alias.

This PR adds a test for the correct behaviour and a fix that makes the test pass.

There are some unrelated failing tests.