### PR TITLE
[12.x] Add `to_action` helper method

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -950,6 +950,22 @@ if (! function_exists('storage_path')) {
     }
 }
 
+if (! function_exists('to_action')) {
+    /**
+     * Create a new redirect response to a controller action.
+     *
+     * @param  string|array  $action
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+    */
+    function to_action($action, $parameters = [], $status = 302, $headers = [])
+    {
+        return redirect()->action($action, $parameters, $status, $headers);
+    }
+}
+
 if (! function_exists('to_route')) {
     /**
      * Create a new redirect response to a named route.

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -49,6 +49,29 @@ class RouteRedirectTest extends TestCase
         $response->assertRedirect('users/999/overview');
     }
 
+    public function testToActionHelper()
+    {
+        Route::get('to', [ApiResourceTestController::class, 'index']);
+
+        Route::get('from-301', function () {
+            return to_action([ApiResourceTestController::class, 'index'], [], 301);
+        });
+
+        Route::get('from-302', function () {
+            return to_action([ApiResourceTestController::class, 'index']);
+        });
+
+        $this->get('from-301')
+            ->assertRedirect('to')
+            ->assertStatus(301)
+            ->assertSee('Redirecting to');
+
+        $this->get('from-302')
+            ->assertRedirect('to')
+            ->assertStatus(302)
+            ->assertSee('Redirecting to');
+    }
+
     public function testToRouteHelper()
     {
         Route::get('to', function () {


### PR DESCRIPTION
This PR introduces a new `to_action` helper function similar to the `to_route` helper, this will simplify redirecting to actions without the need for calling the url/route.