### PR TITLE
Fix incorrect quote escaping in env writer. Closes #56480

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -256,12 +256,10 @@ class Env
         $containsDoubleQuotes = strpos($input, '"') !== false;
 
         if ($containsDoubleQuotes) {
-            $quoted = "'".self::addslashesExcept($input, ['"'])."'";
-        } else {
-            $quoted = '"'.self::addslashesExcept($input, ["'"]).'"';
-        }
-
-        return $quoted;
+           return "'".self::addslashesExcept($input, ['"'])."'";
+        } 
+    
+        return '"'.self::addslashesExcept($input, ["'"]).'"';
     }
 
     /**

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -245,43 +245,6 @@ class Env
     }
 
     /**
-     * Wrap a string in quotes, choosing double or single quotes
-     * depending on the presence of double quotes inside the string.
-     *
-     * @param  string  $input  The input string to be quoted.
-     * @return string The quoted string with appropriate escaping applied.
-     */
-    protected static function prepareQuotedValue(string $input): string
-    {
-        $containsDoubleQuotes = strpos($input, '"') !== false;
-
-        if ($containsDoubleQuotes) {
-            return "'".self::addslashesExcept($input, ['"'])."'";
-        }
-
-        return '"'.self::addslashesExcept($input, ["'"]).'"';
-    }
-
-    /**
-     * Escape a string using addslashes, excluding specified characters from being escaped.
-     *
-     * @param  string  $value  The input string to be escaped.
-     * @param  array  $except  Characters that should not be escaped.
-     * @return string The escaped string with exceptions applied.
-     */
-    protected static function addslashesExcept(string $value, array $except = []): string
-    {
-        $escaped = addslashes($value);
-
-        foreach ($except as $char) {
-            $escapedChar = '\\'.$char;
-            $escaped = str_replace($escapedChar, $char, $escaped);
-        }
-
-        return $escaped;
-    }
-
-    /**
      * Get the possible option for this environment variable.
      *
      * @param  string  $key
@@ -312,5 +275,36 @@ class Env
 
                 return $value;
             });
+    }
+
+    /**
+     * Wrap a string in quotes, choosing double or single quotes.
+     *
+     * @param  string  $input
+     * @return string
+     */
+    protected static function prepareQuotedValue(string $input)
+    {
+        return strpos($input, '"') !== false
+            ? "'".self::addSlashesExceptFor($input, ['"'])."'"
+            : '"'.self::addSlashesExceptFor($input, ["'"]).'"';
+    }
+
+    /**
+     * Escape a string using addslashes, excluding the specified characters from being escaped.
+     *
+     * @param  string  $value
+     * @param  array  $except
+     * @return string
+     */
+    protected static function addSlashesExceptFor(string $value, array $except = [])
+    {
+        $escaped = addslashes($value);
+
+        foreach ($except as $character) {
+            $escaped = str_replace('\\'.$character, $character, $escaped);
+        }
+
+        return $escaped;
     }
 }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -249,16 +249,16 @@ class Env
      * depending on the presence of double quotes inside the string.
      *
      * @param  string  $input  The input string to be quoted.
-     * @return string  The quoted string with appropriate escaping applied.
+     * @return string The quoted string with appropriate escaping applied.
      */
     protected static function prepareQuotedValue(string $input): string
     {
         $containsDoubleQuotes = strpos($input, '"') !== false;
 
         if ($containsDoubleQuotes) {
-            $quoted = "'" . self::addslashesExcept($input, ['"']) . "'";
+            $quoted = "'".self::addslashesExcept($input, ['"'])."'";
         } else {
-            $quoted = '"' . self::addslashesExcept($input, ["'"]) . '"';
+            $quoted = '"'.self::addslashesExcept($input, ["'"]).'"';
         }
 
         return $quoted;
@@ -269,14 +269,14 @@ class Env
      *
      * @param  string  $value  The input string to be escaped.
      * @param  array  $except  Characters that should not be escaped.
-     * @return string  The escaped string with exceptions applied.
+     * @return string The escaped string with exceptions applied.
      */
     protected static function addslashesExcept(string $value, array $except = []): string
     {
         $escaped = addslashes($value);
 
         foreach ($except as $char) {
-            $escapedChar = '\\' . $char;
+            $escapedChar = '\\'.$char;
             $escaped = str_replace($escapedChar, $char, $escaped);
         }
 

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -257,7 +257,7 @@ class Env
 
         if ($containsDoubleQuotes) {
             return "'".self::addslashesExcept($input, ['"'])."'";
-        } 
+        }
 
         return '"'.self::addslashesExcept($input, ["'"]).'"';
     }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -245,7 +245,7 @@ class Env
     }
 
     /**
-     * Wrap a string in quotes, choosing single or double quotes
+     * Wrap a string in quotes, choosing double or single quotes
      * depending on the presence of double quotes inside the string.
      *
      * @param  string  $input  The input string to be quoted.

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -256,9 +256,9 @@ class Env
         $containsDoubleQuotes = strpos($input, '"') !== false;
 
         if ($containsDoubleQuotes) {
-           return "'".self::addslashesExcept($input, ['"'])."'";
+            return "'".self::addslashesExcept($input, ['"'])."'";
         } 
-    
+
         return '"'.self::addslashesExcept($input, ["'"]).'"';
     }
 


### PR DESCRIPTION
Resolved an issue where the env writer incorrectly escaped single and double quotes, which caused the entire site to break with an HTTP 500 error.

Fixes https://github.com/laravel/framework/issues/56480
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
