### PR TITLE
[12.x] Add `whereRowIn()` Eloquent Stipulation

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -399,8 +399,8 @@ class Grammar extends BaseGrammar
     {
         if (! empty($where['valueTuples'])) {
             $parsedColumns = implode(', ', array_map([$this, 'wrap'], $where['columns']));
-            $parsedValues = implode(', ', array_map(function($row) {
-                return '(' . $this->parameterize($row) . ')';
+            $parsedValues = implode(', ', array_map(function ($row) {
+                return '('.$this->parameterize($row).')';
             }, $where['valueTuples']));
 
             return '('.$parsedColumns.') in ('.$parsedValues.')';
@@ -413,8 +413,8 @@ class Grammar extends BaseGrammar
     {
         if (! empty($where['valueTuples'])) {
             $parsedColumns = implode(', ', array_map([$this, 'wrap'], $where['columns']));
-            $parsedValues = implode(', ', array_map(function($row) {
-                return '(' . $this->parameterize($row) . ')';
+            $parsedValues = implode(', ', array_map(function ($row) {
+                return '('.$this->parameterize($row).')';
             }, $where['valueTuples']));
 
             return '('.$parsedColumns.') not in ('.$parsedValues.')';

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -395,6 +395,34 @@ class Grammar extends BaseGrammar
         return '0 = 1';
     }
 
+    protected function whereRowIn(Builder $query, $where)
+    {
+        if (! empty($where['valueTuples'])) {
+            $parsedColumns = implode(', ', array_map([$this, 'wrap'], $where['columns']));
+            $parsedValues = implode(', ', array_map(function($row) {
+                return '(' . $this->parameterize($row) . ')';
+            }, $where['valueTuples']));
+
+            return '('.$parsedColumns.') in ('.$parsedValues.')';
+        }
+
+        return '0 = 1';
+    }
+
+    protected function whereRowNotIn(Builder $query, $where)
+    {
+        if (! empty($where['valueTuples'])) {
+            $parsedColumns = implode(', ', array_map([$this, 'wrap'], $where['columns']));
+            $parsedValues = implode(', ', array_map(function($row) {
+                return '(' . $this->parameterize($row) . ')';
+            }, $where['valueTuples']));
+
+            return '('.$parsedColumns.') not in ('.$parsedValues.')';
+        }
+
+        return '0 = 1';
+    }
+
     /**
      * Compile a "where null" clause.
      *


### PR DESCRIPTION
# Motivation

This pull request introduces the `whereRowIn()`, `orWhereRowIn()`, `whereRowNotIn()`, and `orWhereRowNotIn()` methods to Laravel’s Eloquent and Query Builder, enabling efficient row value (tuple) comparisons using the standard syntax WHERE (column1, column2) IN ((value1, value2), ...). This feature is supported by MySQL 5.6+, PostgreSQL, SQLite (3.15.0+), and SQL Server (2008+), but is currently unavailable in Eloquent's fluent API.

Currently, developers must use nested where and orWhere clauses to achieve the same result, which is verbose and less efficient. For example:

```php
User::where(function ($query) {
    $query->where('id', 1)->where('name', 'Aiyana Gaylord');
})->orWhere(function ($query) {
    $query->where('id', 2)->where('name', 'Jerome Borer');
})->get();
```

This generates:

```sql
SELECT * FROM users WHERE (id = 1 AND name = 'Aiyana Gaylord') OR (id = 2 AND name = 'Jerome Borer');
```

The whereRowIn method simplifies this to:

```
User::whereRowIn([
    ['id' => 1, 'name' => 'Aiyana Gaylord'],
    ['id' => 2, 'name' => 'Jerome Borer'],
])->get();
```

This produces:

```sql
SELECT * FROM users WHERE (id, name) IN ((1, 'Aiyana Gaylord'), (2, 'Jerome Borer'));
```

The new method improves readability, reduces boilerplate, and leverages native database optimizations for tuple comparisons, making it ideal for filtering rows based on composite keys or paired values.

This is my first PR to the framework, so please let me know if you're interested in this or if I should move functionality, testing, etc., somewhere else!