### PR TITLE
[12.x] Introduce `AbstractCursorPaginator@withPersistentCursors()`

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -79,6 +79,20 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     protected $cursor;
 
     /**
+     * The memoized next cursor.
+     *
+     * @var \Illuminate\Pagination\Cursor|null|false
+     */
+    protected $nextCursor = false;
+
+    /**
+     * The memoized previous cursor.
+     *
+     * @var \Illuminate\Pagination\Cursor|null|false
+     */
+    protected $previousCursor = false;
+
+    /**
      * The paginator parameters for the cursor.
      *
      * @var array
@@ -157,6 +171,10 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function previousCursor()
     {
+        if ($this->previousCursor !== false) {
+            return $this->previousCursor;
+        }
+
         if (is_null($this->cursor) ||
             ($this->cursor->pointsToPreviousItems() && ! $this->hasMore)) {
             return null;
@@ -176,6 +194,10 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      */
     public function nextCursor()
     {
+        if ($this->nextCursor !== false) {
+            return $this->nextCursor;
+        }
+
         if ((is_null($this->cursor) && ! $this->hasMore) ||
             (! is_null($this->cursor) && $this->cursor->pointsToNextItems() && ! $this->hasMore)) {
             return null;
@@ -186,6 +208,19 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
         }
 
         return $this->getCursorForItem($this->items->last(), true);
+    }
+
+    /**
+     * Memoize the previous and next cursor values so you may manipulate the underlying items format.
+     *
+     * @return $this
+     */
+    public function withPersistCursors()
+    {
+        $this->nextCursor = $this->nextCursor();
+        $this->previousCursor = $this->previousCursor();
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -215,7 +215,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      *
      * @return $this
      */
-    public function withPersistCursors()
+    public function withPersistentCursors()
     {
         $this->nextCursor = $this->nextCursor();
         $this->previousCursor = $this->previousCursor();

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -283,7 +283,6 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $toInsert = [];
         for ($i = 1; $i <= 4; $i++) {
             $toInsert[] = [
-                'id' => $i,
                 'title' => 'Title '.$i,
             ];
         }
@@ -309,7 +308,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
     public function testNoNextResultsWithPersistentCursors()
     {
-        TestPost::create(['id' => 1, 'title' => 'A title']);
+        TestPost::create(['title' => 'A title']);
 
         $paginated = TestPost::query()
             ->cursorPaginate(1)

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -291,7 +291,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $paginated = TestPost::query()
             ->cursorPaginate(1)
-            ->withPersistCursors()
+            ->withPersistentCursors()
             ->through(static fn ($item) => ['other-id' => $item['id']]);
 
         $this->assertEquals(1, $paginated->items()[0]['other-id']);
@@ -312,7 +312,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
 
         $paginated = TestPost::query()
             ->cursorPaginate(1)
-            ->withPersistCursors()
+            ->withPersistentCursors()
             ->through(static fn ($item) => ['other-id' => $item['id']]);
 
         $this->assertEquals(1, $paginated->items()[0]['other-id']);

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -281,7 +281,7 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     public function testWithPersistentCursors()
     {
         $toInsert = [];
-        for($i = 1; $i <= 4; $i++) {
+        for ($i = 1; $i <= 4; $i++) {
             $toInsert[] = [
                 'id' => $i,
                 'title' => 'Title '.$i,

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -126,11 +126,7 @@ class CursorPaginatorTest extends TestCase
             'parameters' => ['id'],
         ]);
 
-        $throughFunc = static function ($item) {
-            return ['other-id' => $item['id']];
-        };
-
-        $paginator->withPersistCursors()->through($throughFunc);
+        $paginator->withPersistentCursors()->through(static fn ($item) => ['other-id' => $item['id']]);
         $this->assertSame(1, $paginator->previousCursor()->parameter('id'));
         $this->assertSame(2, $paginator->nextCursor()->parameter('id'));
         $this->assertEquals([

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -120,6 +120,25 @@ class CursorPaginatorTest extends TestCase
         ], $p->toArray());
     }
 
+    public function testWithPersistentCursorsAllowsManipulatingKeys()
+    {
+        $paginator = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], 2, new Cursor(['id' => 2], true), [
+            'parameters' => ['id'],
+        ]);
+
+        $throughFunc = static function ($item) {
+            return ['other-id' => $item['id']];
+        };
+
+        $paginator->withPersistCursors()->through($throughFunc);
+        $this->assertSame(1, $paginator->previousCursor()->parameter('id'));
+        $this->assertSame(2, $paginator->nextCursor()->parameter('id'));
+        $this->assertEquals([
+            ['other-id' => 1],
+            ['other-id' => 2],
+        ], $paginator->toArray()['data']);
+    }
+
     protected function getCursor($params, $isNext = true)
     {
         return (new Cursor($params, $isNext))->encode();


### PR DESCRIPTION
## Problem

If you attempt to manipulate cursor paginated data and remove (or rename) the primary key column, attempting to return JSON will fail. This is because the next/previous cursor is not generated until `toJson()` is called, and using `through` directly manipulates the items.

```php
Athlete::query()->cursorPaginate()
    ->through(fn (Athlete $athlete) => [
        'uuid' => $athlete->uuid,
        'name' => $athlete->name,
        'team' => $athlete->team,
    ])
    ->toArray(); // ❌ Undefined array key "id"
```

<img width="1011" height="435" alt="image" src="https://github.com/user-attachments/assets/e0a13ca4-3464-4a75-bcea-ed883df1ea86" />

This error is very confusing and unintuitive.

## Solution
Introduce `withPersistentCursors()` which memoizes the cursor values from the raw data. This **must be called before `through()`**.

```php
Athlete::query()->cursorPaginate()
    ->withPersistentCursors()
    ->through(fn (Athlete $athlete) => [
        'uuid' => $athlete->uuid,
        'name' => $athlete->name,
        'team' => $athlete->team,
    ])
    ->toArray(); // ✅ no problem, the cursor references `id` still.
```

## Improvements
This name is clunky. Another name might be `memoizeCursors()`.

I don't love that the order of function calling matters. It would be great if the cursor values were memoized by default (like automatically before calling `through()`) but I worry this may be a breaking change.