### PR TITLE
[12.x] Make PendingBatch Macroable

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
 use Laravel\SerializableClosure\SerializableClosure;
 use RuntimeException;
 use Throwable;
@@ -17,7 +18,7 @@ use function Illuminate\Support\enum_value;
 
 class PendingBatch
 {
-    use Conditionable;
+    use Conditionable, Macroable;
 
     /**
      * The IoC container instance.

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -259,6 +259,15 @@ class BusPendingBatchTest extends TestCase
         );
         $this->expectNotToPerformAssertions();
     }
+
+    public function test_macroable(): void
+    {
+        PendingBatch::macro('onHighQueue', fn () => $this->onQueue('high'));
+
+        $pendingBatch = (new PendingBatch(new Container, new Collection))->onHighQueue();
+
+        $this->assertSame('high', $pendingBatch->queue());
+    }
 }
 
 class BatchableJob


### PR DESCRIPTION
Adds Macroable to the PendingBatch class.

This allows chaining custom methods on Bus::batch, one example (and our use case) being to add better ide visibility into the available queues;

```php
Bus::batch($jobs)->onHighQueue()->dispatch();

// instead of
Bus::batch($jobs)->onQueue('high')->dispatch();
```


---

See previous accepted PR's of adding Macroable to other places;

- https://github.com/laravel/framework/pull/54404
- https://github.com/laravel/framework/pull/55260
- https://github.com/laravel/framework/pull/54359
- https://github.com/laravel/framework/pull/51922
- https://github.com/laravel/framework/pull/51572