### PR TITLE
[12.x] Fixed an issue when calling `hasNested` with a first relationship of type `morphTo`.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -100,7 +100,7 @@ trait QueriesRelationships
         $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback, $initialRelations) {
             // checking if the same closure is called multiple time.
             // if so, we need to "reset" the relation array to loop through them again.
-            if($count === 1 && empty($relations)) {
+            if ($count === 1 && empty($relations)) {
                 $relations = [...$initialRelations];
                 array_shift($relations);
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -88,6 +88,7 @@ trait QueriesRelationships
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
     {
         $relations = explode('.', $relations);
+        $initialRelations = [...$relations];
 
         $doesntHave = $operator === '<' && $count === 1;
 
@@ -96,7 +97,14 @@ trait QueriesRelationships
             $count = 1;
         }
 
-        $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
+        $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback, $initialRelations) {
+            // checking if the same closure is called multiple time.
+            // if so, we need to "reset" the relation array to loop through them again.
+            if($count === 1 && empty($relations)) {
+                $relations = [...$initialRelations];
+                array_shift($relations);
+            }
+
             // In order to nest "has", we need to add count relation constraints on the
             // callback Closure. We'll do this by simply passing the Closure its own
             // reference to itself so it calls itself recursively on each segment.

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -88,6 +88,7 @@ trait QueriesRelationships
     protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
     {
         $relations = explode('.', $relations);
+
         $initialRelations = [...$relations];
 
         $doesntHave = $operator === '<' && $count === 1;
@@ -98,10 +99,10 @@ trait QueriesRelationships
         }
 
         $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback, $initialRelations) {
-            // checking if the same closure is called multiple time.
-            // if so, we need to "reset" the relation array to loop through them again.
+            // If the same closure is called multiple times, reset the relation array to loop through them again...
             if ($count === 1 && empty($relations)) {
                 $relations = [...$initialRelations];
+
                 array_shift($relations);
             }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1765,7 +1765,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $connection->shouldReceive('select')->once()->andReturn([
             [$morphToKey => EloquentBuilderTestModelFarRelatedStub::class],
-            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class]
+            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class],
         ]);
 
         $builder = $model->orWhereHasMorph('morph', [EloquentBuilderTestModelFarRelatedStub::class], function ($q) {
@@ -2931,7 +2931,6 @@ class EloquentBuilderTestModelOtherFarRelatedStub extends Model
             'self_id',
         );
     }
-
 
     public function baz()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1727,6 +1727,64 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder->toSql(), $result);
     }
 
+    public function testHasNestedWithMorphTo()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $connection = $this->mockConnectionForModel($model, '');
+
+        $morphToKey = $model->morph()->getMorphType();
+
+        $connection->shouldReceive('select')->once()->andReturn([
+            [$morphToKey => EloquentBuilderTestModelFarRelatedStub::class],
+            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class]
+        ]);
+
+        $builder = $model->orWhereHasMorph('morph', [EloquentBuilderTestModelFarRelatedStub::class], function ($q) {
+            $q->has('baz');
+        })->orWhereHasMorph('morph', [EloquentBuilderTestModelOtherFarRelatedStub::class], function ($q) {
+            $q->has('baz');
+        });
+
+        $results = $model->has('morph.baz')->toSql();
+
+        // we need to adjust the expected builder because some parathesis are added,
+        // which doesn't impact the behavior of the test.
+
+        $builderSql = $builder->toSql();
+        $builderSql = str_replace(')))) or ((', '))) or (', $builderSql);
+
+        $this->assertSame($builderSql, $results);
+    }
+
+    public function testHasNestedWithMorphToAndMultipleSubRelations()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $connection = $this->mockConnectionForModel($model, '');
+
+        $morphToKey = $model->morph()->getMorphType();
+
+        $connection->shouldReceive('select')->once()->andReturn([
+            [$morphToKey => EloquentBuilderTestModelFarRelatedStub::class],
+            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class]
+        ]);
+
+        $builder = $model->orWhereHasMorph('morph', [EloquentBuilderTestModelFarRelatedStub::class], function ($q) {
+            $q->has('baz.bam');
+        })->orWhereHasMorph('morph', [EloquentBuilderTestModelOtherFarRelatedStub::class], function ($q) {
+            $q->has('baz.bam');
+        });
+
+        $results = $model->has('morph.baz.bam')->toSql();
+
+        // we need to adjust the expected builder because some parathesis are added,
+        // which doesn't impact the behavior of the test.
+
+        $builderSql = $builder->toSql();
+        $builderSql = str_replace(')))) or ((', '))) or (', $builderSql);
+
+        $this->assertSame($builderSql, $results);
+    }
+
     public function testOrHasNested()
     {
         $model = new EloquentBuilderTestModelParentStub;
@@ -2683,6 +2741,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);
+
+        return $connection;
     }
 
     protected function getBuilder()
@@ -2835,6 +2895,11 @@ class EloquentBuilderTestModelCloseRelatedStub extends Model
     {
         return $this->hasMany(EloquentBuilderTestModelFarRelatedStub::class);
     }
+
+    public function bam()
+    {
+        return $this->hasMany(EloquentBuilderTestModelOtherFarRelatedStub::class);
+    }
 }
 
 class EloquentBuilderTestModelFarRelatedStub extends Model
@@ -2847,6 +2912,30 @@ class EloquentBuilderTestModelFarRelatedStub extends Model
             'related_id',
             'self_id',
         );
+    }
+
+    public function baz()
+    {
+        return $this->belongsTo(EloquentBuilderTestModelCloseRelatedStub::class);
+    }
+}
+
+class EloquentBuilderTestModelOtherFarRelatedStub extends Model
+{
+    public function roles()
+    {
+        return $this->belongsToMany(
+            EloquentBuilderTestModelParentStub::class,
+            'user_role',
+            'related_id',
+            'self_id',
+        );
+    }
+
+
+    public function baz()
+    {
+        return $this->belongsTo(EloquentBuilderTestModelCloseRelatedStub::class);
     }
 }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1736,7 +1736,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $connection->shouldReceive('select')->once()->andReturn([
             [$morphToKey => EloquentBuilderTestModelFarRelatedStub::class],
-            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class]
+            [$morphToKey => EloquentBuilderTestModelOtherFarRelatedStub::class],
         ]);
 
         $builder = $model->orWhereHasMorph('morph', [EloquentBuilderTestModelFarRelatedStub::class], function ($q) {


### PR DESCRIPTION
When calling the `hasNested` function with a string of relationship of which the first one was a morphTo, we had a `Error: Call to a member function getRelationExistenceQuery() on null`. 

This is because the `$relations` array, in the `hasNested` function is passed by reference, but not reset between morph types. 

The proposed solution is not perfect, but it works fine. I'm open to suggestion as I'm sure it can be a little bit more elegant.  

Fixes #56490