### PR TITLE
[12.x] Allow creating additional components when model already exists

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -54,8 +54,7 @@ class ModelMakeCommand extends GeneratorCommand
 
             if (! confirm("Do you want to generate additional components for the model?")) {
                 return false;
-            }
-            else {
+            } else {
                 $this->afterPromptingForMissingArguments($this->input, $this->output);
             }
         }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\confirm;
 
 #[AsCommand(name: 'make:model')]
 class ModelMakeCommand extends GeneratorCommand
@@ -47,7 +48,17 @@ class ModelMakeCommand extends GeneratorCommand
     public function handle()
     {
         if (parent::handle() === false && ! $this->option('force')) {
-            return false;
+
+            if(!$this->alreadyExists($this->getNameInput())) {
+                return false;
+            }
+
+            if(!confirm("Do you want to generate additional components for Model {$this->getNameInput()}?")) {
+                return false;
+            }
+            else {
+                $this->afterPromptingForMissingArguments($this->input, $this->output);
+            }
         }
 
         if ($this->option('all')) {

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -48,12 +48,11 @@ class ModelMakeCommand extends GeneratorCommand
     public function handle()
     {
         if (parent::handle() === false && ! $this->option('force')) {
-
-            if(!$this->alreadyExists($this->getNameInput())) {
+            if (! $this->alreadyExists($this->getNameInput())) {
                 return false;
             }
 
-            if(!confirm("Do you want to generate additional components for Model {$this->getNameInput()}?")) {
+            if (! confirm("Do you want to generate additional components for the model?")) {
                 return false;
             }
             else {

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -247,4 +247,15 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('database/seeders/FooSeeder.php');
         $this->assertFilenameExists('tests/Feature/Models/FooTest.php');
     }
+
+    public function testItAsksForAdditionalComponentsForExistingModel()
+    {
+        $this->artisan('make:model', ['name' => 'Foo'])
+            ->assertExitCode(0);
+
+       $this->artisan('make:model', ['name' => 'Foo'])
+           ->assertExitCode(0)
+           ->expectsConfirmation('Do you want to generate additional components for Model Foo?', 'yes')
+           ->expectsQuestion('Would you like any of the following?', []);
+    }
 }

--- a/tests/Integration/Generators/ModelMakeCommandTest.php
+++ b/tests/Integration/Generators/ModelMakeCommandTest.php
@@ -255,7 +255,7 @@ class ModelMakeCommandTest extends TestCase
 
        $this->artisan('make:model', ['name' => 'Foo'])
            ->assertExitCode(0)
-           ->expectsConfirmation('Do you want to generate additional components for Model Foo?', 'yes')
+           ->expectsConfirmation('Do you want to generate additional components for the model?', 'yes')
            ->expectsQuestion('Would you like any of the following?', []);
     }
 }


### PR DESCRIPTION
When running `make:model Conference` and forgetting flags like `-mf`, the command fails if the model already exists. This forces developers to either manually create missing components manually or use the `--force` flag which will delete existing implementations inside the model (or delete the model and start over).

## Suggestion
Instead of failing, prompt the user to create additional components using the same interactive multiselect interface available when running `make:model` without parameters.

## Example

### Before

```
✨ php artisan make:model Conference

   ERROR  Model already exists.
```

### After

```
✨ php artisan make:model Conference

   ERROR  Model already exists.

 ┌ Do you want to generate additional components for Model Conference? ┐
 │ Yes                                                                 │
 └─────────────────────────────────────────────────────────────────────┘

 ┌ Would you like any of the following? ────────────────────────┐
 │ › ◻ Database Seeder                                        ┃ │
 │   ◻ Factory                                                │ │
 │   ◻ Form Requests                                          │ │
 │   ◻ Migration                                              │ │
 │   ◻ Policy                                                 │ │
 └──────────────────────────────────────────────────────────────┘

```


I've also added a test to the best of my knowledge.
I think this improves the DX by allowing to add forgotten components without starting over. (I run into this on a regular basis. 😅)