### PR TITLE
[12.x] Redirect intent in maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -134,7 +134,7 @@ class PreventRequestsDuringMaintenance
      */
     protected function bypassResponse(string $secret)
     {
-        return redirect()->intended()->withCookie(
+        return redirect()->intended('/')->withCookie(
             MaintenanceModeBypassCookie::create($secret)
         );
     }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -134,7 +134,7 @@ class PreventRequestsDuringMaintenance
      */
     protected function bypassResponse(string $secret)
     {
-        return redirect('/')->withCookie(
+        return redirect()->intended()->withCookie(
             MaintenanceModeBypassCookie::create($secret)
         );
     }


### PR DESCRIPTION
When the application is in maintenance mode and a secret is provided, successful validation always redirects to /.

This commit adds support for redirecting to the originally intended URL (similar to the login behavior). This can be useful, for example, when triggering maintenance mode from within the application and wanting to return to the same page afterward.