### PR TITLE
[12.x] Str: Append & Prepend UUID&ULID

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2028,6 +2028,30 @@ class Str
     }
 
     /**
+     * Prepend a ULID to the given string.
+     *
+     * @param  string  $value
+     * @param  string  $separator
+     * @return string
+     */
+    public static function prependUlid($value, $separator = '')
+    {
+        return static::ulid().$separator.$value;
+    }
+
+    /**
+     * Append a ULID to the given string.
+     *
+     * @param  string  $value
+     * @param  string  $separator
+     * @return string
+     */
+    public static function appendUlid($value, $separator = '')
+    {
+        return $value.$separator.static::ulid();
+    }
+
+    /**
      * Generate a ULID.
      *
      * @param  \DateTimeInterface|null  $time

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2004,6 +2004,30 @@ class Str
     }
 
     /**
+     * Prepend a UUID to the given string.
+     *
+     * @param  string  $value
+     * @param  string  $separator
+     * @return string
+     */
+    public static function prependUuid($value, $separator = '')
+    {
+        return static::uuid7().$separator.$value;
+    }
+
+    /**
+     * Append a UUID to the given string.
+     *
+     * @param  string  $value
+     * @param  string  $separator
+     * @return string
+     */
+    public static function appendUuid($value, $separator = '')
+    {
+        return $value.$separator.static::uuid7();
+    }
+
+    /**
      * Generate a ULID.
      *
      * @param  \DateTimeInterface|null  $time

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -67,6 +67,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Append a UUID to the string.
+     *
+     * @param  string  $separator
+     * @return static
+     */
+    public function appendUuid($separator = '')
+    {
+        return new static(Str::appendUuid($this->value, $separator));
+    }
+
+    /**
      * Append a new line to the string.
      *
      * @param  int  $count
@@ -680,6 +691,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function prepend(...$values)
     {
         return new static(implode('', $values).$this->value);
+    }
+
+    /**
+     * Prepend a UUID to the string.
+     *
+     * @param  string  $separator
+     * @return static
+     */
+    public function prependUuid($separator = '')
+    {
+        return new static(Str::prependUuid($this->value, $separator));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -78,6 +78,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Append a ULID to the string.
+     *
+     * @param  string  $separator
+     * @return static
+     */
+    public function appendUlid($separator = '')
+    {
+        return new static(Str::appendUlid($this->value, $separator));
+    }
+
+    /**
      * Append a new line to the string.
      *
      * @param  int  $count
@@ -702,6 +713,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     public function prependUuid($separator = '')
     {
         return new static(Str::prependUuid($this->value, $separator));
+    }
+
+    /**
+     * Prepend a ULID to the string.
+     *
+     * @param  string  $separator
+     * @return static
+     */
+    public function prependUlid($separator = '')
+    {
+        return new static(Str::prependUlid($this->value, $separator));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1307,7 +1307,7 @@ class SupportStrTest extends TestCase
         $result = Str::prependUuid('test');
         $this->assertStringEndsWith('test', $result);
         $this->assertGreaterThan(4, strlen($result));
-        
+
         $resultWithSeparator = Str::prependUuid('test', '-');
         $this->assertStringEndsWith('-test', $resultWithSeparator);
         $this->assertStringContainsString('-', $resultWithSeparator);
@@ -1318,7 +1318,7 @@ class SupportStrTest extends TestCase
         $result = Str::appendUuid('test');
         $this->assertStringStartsWith('test', $result);
         $this->assertGreaterThan(4, strlen($result));
-        
+
         $resultWithSeparator = Str::appendUuid('test', '-');
         $this->assertStringStartsWith('test-', $resultWithSeparator);
         $this->assertStringContainsString('-', $resultWithSeparator);
@@ -1329,7 +1329,7 @@ class SupportStrTest extends TestCase
         $result = Str::prependUlid('test');
         $this->assertStringEndsWith('test', $result);
         $this->assertGreaterThan(4, strlen($result));
-        
+
         $resultWithSeparator = Str::prependUlid('test', '-');
         $this->assertStringEndsWith('-test', $resultWithSeparator);
         $this->assertStringContainsString('-', $resultWithSeparator);
@@ -1340,7 +1340,7 @@ class SupportStrTest extends TestCase
         $result = Str::appendUlid('test');
         $this->assertStringStartsWith('test', $result);
         $this->assertGreaterThan(4, strlen($result));
-        
+
         $resultWithSeparator = Str::appendUlid('test', '-');
         $this->assertStringStartsWith('test-', $resultWithSeparator);
         $this->assertStringContainsString('-', $resultWithSeparator);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1310,6 +1310,7 @@ class SupportStrTest extends TestCase
         
         $resultWithSeparator = Str::prependUuid('test', '-');
         $this->assertStringEndsWith('-test', $resultWithSeparator);
+        $this->assertStringContainsString('-', $resultWithSeparator);
     }
 
     public function testAppendUuid()
@@ -1320,7 +1321,29 @@ class SupportStrTest extends TestCase
         
         $resultWithSeparator = Str::appendUuid('test', '-');
         $this->assertStringStartsWith('test-', $resultWithSeparator);
-        $this->assertStringContains('-', $resultWithSeparator);
+        $this->assertStringContainsString('-', $resultWithSeparator);
+    }
+
+    public function testPrependUlid()
+    {
+        $result = Str::prependUlid('test');
+        $this->assertStringEndsWith('test', $result);
+        $this->assertGreaterThan(4, strlen($result));
+        
+        $resultWithSeparator = Str::prependUlid('test', '-');
+        $this->assertStringEndsWith('-test', $resultWithSeparator);
+        $this->assertStringContainsString('-', $resultWithSeparator);
+    }
+
+    public function testAppendUlid()
+    {
+        $result = Str::appendUlid('test');
+        $this->assertStringStartsWith('test', $result);
+        $this->assertGreaterThan(4, strlen($result));
+        
+        $resultWithSeparator = Str::appendUlid('test', '-');
+        $this->assertStringStartsWith('test-', $resultWithSeparator);
+        $this->assertStringContainsString('-', $resultWithSeparator);
     }
 
     public function testAsciiNull()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1302,6 +1302,27 @@ class SupportStrTest extends TestCase
         $this->assertInstanceOf(UuidInterface::class, Str::uuid7());
     }
 
+    public function testPrependUuid()
+    {
+        $result = Str::prependUuid('test');
+        $this->assertStringEndsWith('test', $result);
+        $this->assertGreaterThan(4, strlen($result));
+        
+        $resultWithSeparator = Str::prependUuid('test', '-');
+        $this->assertStringEndsWith('-test', $resultWithSeparator);
+    }
+
+    public function testAppendUuid()
+    {
+        $result = Str::appendUuid('test');
+        $this->assertStringStartsWith('test', $result);
+        $this->assertGreaterThan(4, strlen($result));
+        
+        $resultWithSeparator = Str::appendUuid('test', '-');
+        $this->assertStringStartsWith('test-', $resultWithSeparator);
+        $this->assertStringContains('-', $resultWithSeparator);
+    }
+
     public function testAsciiNull()
     {
         $this->assertSame('', Str::ascii(null));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -58,6 +58,26 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid(7));
     }
 
+    public function testPrependUuid()
+    {
+        $result = $this->stringable('test')->prependUuid();
+        $this->assertStringEndsWith('test', (string) $result);
+        $this->assertGreaterThan(4, strlen((string) $result));
+
+        $resultWithSeparator = $this->stringable('test')->prependUuid('-');
+        $this->assertStringEndsWith('-test', (string) $resultWithSeparator);
+    }
+
+    public function testAppendUuid()
+    {
+        $result = $this->stringable('test')->appendUuid();
+        $this->assertStringStartsWith('test', (string) $result);
+        $this->assertGreaterThan(4, strlen((string) $result));
+        
+        $resultWithSeparator = $this->stringable('test')->appendUuid('-');
+        $this->assertStringStartsWith('test-', (string) $resultWithSeparator);
+    }
+
     public function testIsUlid()
     {
         $this->assertTrue($this->stringable('01GJSNW9MAF792C0XYY8RX6QFT')->isUlid());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -63,9 +63,10 @@ class SupportStringableTest extends TestCase
         $result = $this->stringable('test')->prependUuid();
         $this->assertStringEndsWith('test', (string) $result);
         $this->assertGreaterThan(4, strlen((string) $result));
-
+        
         $resultWithSeparator = $this->stringable('test')->prependUuid('-');
         $this->assertStringEndsWith('-test', (string) $resultWithSeparator);
+        $this->assertStringContainsString('-', (string) $resultWithSeparator);
     }
 
     public function testAppendUuid()
@@ -76,6 +77,29 @@ class SupportStringableTest extends TestCase
         
         $resultWithSeparator = $this->stringable('test')->appendUuid('-');
         $this->assertStringStartsWith('test-', (string) $resultWithSeparator);
+        $this->assertStringContainsString('-', (string) $resultWithSeparator);
+    }
+
+    public function testPrependUlid()
+    {
+        $result = $this->stringable('test')->prependUlid();
+        $this->assertStringEndsWith('test', (string) $result);
+        $this->assertGreaterThan(4, strlen((string) $result));
+        
+        $resultWithSeparator = $this->stringable('test')->prependUlid('-');
+        $this->assertStringEndsWith('-test', (string) $resultWithSeparator);
+        $this->assertStringContainsString('-', (string) $resultWithSeparator);
+    }
+
+    public function testAppendUlid()
+    {
+        $result = $this->stringable('test')->appendUlid();
+        $this->assertStringStartsWith('test', (string) $result);
+        $this->assertGreaterThan(4, strlen((string) $result));
+        
+        $resultWithSeparator = $this->stringable('test')->appendUlid('-');
+        $this->assertStringStartsWith('test-', (string) $resultWithSeparator);
+        $this->assertStringContainsString('-', (string) $resultWithSeparator);
     }
 
     public function testIsUlid()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -63,7 +63,7 @@ class SupportStringableTest extends TestCase
         $result = $this->stringable('test')->prependUuid();
         $this->assertStringEndsWith('test', (string) $result);
         $this->assertGreaterThan(4, strlen((string) $result));
-        
+
         $resultWithSeparator = $this->stringable('test')->prependUuid('-');
         $this->assertStringEndsWith('-test', (string) $resultWithSeparator);
         $this->assertStringContainsString('-', (string) $resultWithSeparator);
@@ -74,7 +74,7 @@ class SupportStringableTest extends TestCase
         $result = $this->stringable('test')->appendUuid();
         $this->assertStringStartsWith('test', (string) $result);
         $this->assertGreaterThan(4, strlen((string) $result));
-        
+
         $resultWithSeparator = $this->stringable('test')->appendUuid('-');
         $this->assertStringStartsWith('test-', (string) $resultWithSeparator);
         $this->assertStringContainsString('-', (string) $resultWithSeparator);
@@ -85,7 +85,7 @@ class SupportStringableTest extends TestCase
         $result = $this->stringable('test')->prependUlid();
         $this->assertStringEndsWith('test', (string) $result);
         $this->assertGreaterThan(4, strlen((string) $result));
-        
+
         $resultWithSeparator = $this->stringable('test')->prependUlid('-');
         $this->assertStringEndsWith('-test', (string) $resultWithSeparator);
         $this->assertStringContainsString('-', (string) $resultWithSeparator);
@@ -96,7 +96,7 @@ class SupportStringableTest extends TestCase
         $result = $this->stringable('test')->appendUlid();
         $this->assertStringStartsWith('test', (string) $result);
         $this->assertGreaterThan(4, strlen((string) $result));
-        
+
         $resultWithSeparator = $this->stringable('test')->appendUlid('-');
         $this->assertStringStartsWith('test-', (string) $resultWithSeparator);
         $this->assertStringContainsString('-', (string) $resultWithSeparator);


### PR DESCRIPTION
This PR adds 4 new methods to the `Str` helper that helps append and prepend uuid/ulid to strings.

UUID and ULID are often being used when manipulating strings, for example when a user uploading a file and a unique file name is needed to be created and we want to fluently manipulate it we can reach for `appendUuid` & `prependUuid` or `appendUlid` & `prependUlid`.

## Usage Examples

```php
// UUID methods
Str::prependUuid('user');           // "01234567-89ab-cdef-0123-456789abcdefuser"
Str::prependUuid('user', '-');      // "01234567-89ab-cdef-0123-456789abcdef-user"
Str::appendUuid('user');            // "user01234567-89ab-cdef-0123-456789abcdef"
Str::appendUuid('user', '-');       // "user-01234567-89ab-cdef-0123-456789abcdef"

// ULID methods
Str::prependUlid('user');           // "01GJSNW9MAF792C0XYY8RX6QFTuser"
Str::prependUlid('user', '-');      // "01GJSNW9MAF792C0XYY8RX6QFT-user"
Str::appendUlid('user');            // "user01GJSNW9MAF792C0XYY8RX6QFT"
Str::appendUlid('user', '-');       // "user-01GJSNW9MAF792C0XYY8RX6QFT"

// Stringable usage - File upload example
str($originalName)->before('.')->appendUuid('_')
    ->append(".{$uploadedFile->getClientOriginalExtension()}");

