### PR TITLE
[12.x] Add ability to preserve keys when joining to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -741,7 +741,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if ($preserveKeys !== false) {
             $keyGlue = $preserveKeys === true ? ': ' : $preserveKeys;
-            $this->items = array_values($this->map(fn ($value, $key) => $key . $keyGlue . $value)->all());
+            $this->items = array_values($this->map(fn ($value, $key) => $key.$keyGlue.$value)->all());
         }
 
         if ($finalGlue === '') {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -737,8 +737,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  string  $finalGlue
      * @return string
      */
-    public function join($glue, $finalGlue = '')
+    public function join($glue, $finalGlue = '', bool|string $preserveKeys = false)
     {
+        if ($preserveKeys !== false) {
+            $keyGlue = $preserveKeys === true ? ': ' : $preserveKeys;
+            $this->items = array_values($this->map(fn ($value, $key) => $key . $keyGlue . $value)->all());
+        }
+
         if ($finalGlue === '') {
             return $this->implode($glue);
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5734,6 +5734,13 @@ class SupportCollectionTest extends TestCase
             [LazyCollection::class],
         ];
     }
+
+    public function testJoinPreservesKeys()
+    {
+        $collection = new Collection([['key' => 'a', 'value' => 1], ['key' => 'b', 'value' => 2]]));
+
+        $this->assertSame('a: 1,b: 2', $collection->pluck('value', 'key')->join(',', '', true));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5735,11 +5735,20 @@ class SupportCollectionTest extends TestCase
         ];
     }
 
-    public function testJoinPreservesKeys()
+    #[DataProvider('joinPreservesKeysProvider')]
+    public function testJoinPreservesKeys(string|bool $preserveKeys, string $expected)
     {
         $collection = new Collection([['key' => 'a', 'value' => 1], ['key' => 'b', 'value' => 2]]);
 
-        $this->assertSame('a: 1,b: 2', $collection->pluck('value', 'key')->join(',', '', true));
+        $this->assertSame($expected, $collection->pluck('value', 'key')->join(', ', '', $preserveKeys));
+    }
+
+    public static function joinPreservesKeysProvider()
+    {
+        return [
+            'with default key glue' => [true, 'a: 1, b: 2'],
+            'with custom key glue' => [' = ', 'a = 1, b = 2'],
+        ];
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5737,7 +5737,7 @@ class SupportCollectionTest extends TestCase
 
     public function testJoinPreservesKeys()
     {
-        $collection = new Collection([['key' => 'a', 'value' => 1], ['key' => 'b', 'value' => 2]]));
+        $collection = new Collection([['key' => 'a', 'value' => 1], ['key' => 'b', 'value' => 2]]);
 
         $this->assertSame('a: 1,b: 2', $collection->pluck('value', 'key')->join(',', '', true));
     }


### PR DESCRIPTION
Sometimes, especially when working with `pluck()` and providing the `key` parameter to it before using `join()`, you want your keys preserved, without having to manually call `map()` to join the keys with the values before joining the resulting values:
```php
$collection = collect([
    ['key' => 'a', 'value' => 1],
    ['key' => 'b', 'value' => 2],
]))

$collection
    ->pluck('value', 'key')
    ->join(', ', '', true); // a: 1, b: 2

// or with custom key glue
$collection
    ->pluck('value', 'key')
    ->join(', ', '', ' = '); // a = 1, b = 2
```
