### PR TITLE
Add actingAsGuest method for clearing actingAs calls

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -19,6 +19,21 @@ trait InteractsWithAuthentication
     }
 
     /**
+     * Clear the currently logged in user for the application.
+     *
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function actingAsGuest($guard = null)
+    {
+        $this->app['auth']->guard($guard)->forgetUser();
+
+        $this->app['auth']->shouldUse($guard);
+
+        return $this;
+    }
+
+    /**
      * Set the currently logged in user for the application.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -75,4 +75,29 @@ class InteractsWithAuthenticationTest extends TestCase
             ->assertSuccessful()
             ->assertSeeText('Hello taylorotwell');
     }
+
+    public function testActingAsGuestClearsTheUser()
+    {
+        Route::get('me', function (Request $request) {
+            return 'Hello '.$request->user()->username;
+        })->middleware(['auth']);
+        Route::get('login', function () {
+            return 'Login';
+        })->name('login');
+
+        $user = User::where('username', '=', 'taylorotwell')->first();
+
+        $this->actingAs($user);
+        $this->assertAuthenticated();
+
+        $this->get('/me')
+            ->assertSuccessful()
+            ->assertSeeText('Hello taylorotwell');
+
+        $this->actingAsGuest();
+        $this->assertGuest();
+
+        $this->get('/me')
+            ->assertRedirect(route('login'));
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an `actingAsGuest` method to be a complement to the `actingAs` method in tests. When called, it makes the default or specified guard forget the user that was set to it.

My particular use case was in a test that simulated a webhook call coming in after a user request. While the initial user request would be authenticated, I wanted to be sure the webhook request did not have any user associated with it, as it would not in reality.

```php
// Simulate initial user request
$this->actingAs($myUser)->post(route('buy-thing'));

// Simulate webhook
$this->actingAsGuest()->post(route('handle-webhook'), ['payload' => 'foo']);

// Simulating another step from the user's perspective
$this->actingAs($myUser)->get(route('after-purchase-redirect'));
```
