### PR TITLE
[12.x] Add `Boot` and `Initialize` Model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Boot.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Boot.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Boot
+{
+    //
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/Initialize.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Initialize.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Initialize
+{
+    //
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -371,7 +371,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             if (! in_array($method->getName(), $booted) &&
                 $method->isStatic() &&
                 (in_array($method->getName(), $conventionalBootMethods) ||
-                 $method->getAttributes(Boot::class) !== [])) {
+                $method->getAttributes(Boot::class) !== [])) {
                 $method->invoke(null);
 
                 $booted[] = $method->getName();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -12,6 +12,8 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Attributes\Boot;
+use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Scope as LocalScope;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -30,6 +32,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use Stringable;
+use WeakMap;
 
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
 {
@@ -360,23 +363,32 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::$traitInitializers[$class] = [];
 
-        foreach (class_uses_recursive($class) as $trait) {
-            $method = 'boot'.class_basename($trait);
+        $uses = class_uses_recursive($class);
+        $conventionalBootMethods = array_map(static fn ($trait) => 'boot'.class_basename($trait), $uses);
+        $conventionalInitMethods = array_map(static fn ($trait) => 'initialize'.class_basename($trait), $uses);
 
-            if (method_exists($class, $method) && ! in_array($method, $booted)) {
-                forward_static_call([$class, $method]);
-
-                $booted[] = $method;
+        foreach ((new ReflectionClass($class))->getMethods() as $method) {
+            if (
+                ! in_array($method->getName(), $booted) &&
+                $method->isStatic() &&
+                (
+                    in_array($method->getName(), $conventionalBootMethods) ||
+                    $method->getAttributes(Boot::class) !== []
+                )
+            ) {
+                $method->invoke(null);
+                $booted[] = $method->getName();
             }
 
-            if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
-                static::$traitInitializers[$class][] = $method;
-
-                static::$traitInitializers[$class] = array_unique(
-                    static::$traitInitializers[$class]
-                );
+            if (
+                in_array($method->getName(), $conventionalInitMethods) ||
+                $method->getAttributes(Initialize::class) !== []
+            ) {
+                static::$traitInitializers[$class][] = $method->getName();
             }
         }
+
+        static::$traitInitializers[$class] = array_unique(static::$traitInitializers[$class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -32,7 +32,6 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use Stringable;
-use WeakMap;
 
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
 {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -363,26 +363,22 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         static::$traitInitializers[$class] = [];
 
         $uses = class_uses_recursive($class);
+
         $conventionalBootMethods = array_map(static fn ($trait) => 'boot'.class_basename($trait), $uses);
         $conventionalInitMethods = array_map(static fn ($trait) => 'initialize'.class_basename($trait), $uses);
 
         foreach ((new ReflectionClass($class))->getMethods() as $method) {
-            if (
-                ! in_array($method->getName(), $booted) &&
+            if (! in_array($method->getName(), $booted) &&
                 $method->isStatic() &&
-                (
-                    in_array($method->getName(), $conventionalBootMethods) ||
-                    $method->getAttributes(Boot::class) !== []
-                )
-            ) {
+                (in_array($method->getName(), $conventionalBootMethods) ||
+                 $method->getAttributes(Boot::class) !== [])) {
                 $method->invoke(null);
+
                 $booted[] = $method->getName();
             }
 
-            if (
-                in_array($method->getName(), $conventionalInitMethods) ||
-                $method->getAttributes(Initialize::class) !== []
-            ) {
+            if (in_array($method->getName(), $conventionalInitMethods) ||
+                $method->getAttributes(Initialize::class) !== []) {
                 static::$traitInitializers[$class][] = $method->getName();
             }
         }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Illuminate\Database\Eloquent\Attributes\Boot;
+use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -210,16 +212,26 @@ class ModelSerializationTest extends TestCase
         $model = new ModelBootTestWithTraitInitialization();
 
         $this->assertTrue($model->fooBar);
+        $this->assertTrue($model->initializedViaAttributeInClass);
+        $this->assertTrue($model->initializedViaAttributeInTrait);
         $this->assertTrue($model::hasGlobalScope('foo_bar'));
+        $this->assertTrue($model::hasGlobalScope('booted_attr_in_class'));
+        $this->assertTrue($model::hasGlobalScope('booted_attr_in_trait'));
 
         $model::clearBootedModels();
 
         $this->assertFalse($model::hasGlobalScope('foo_bar'));
+        $this->assertFalse($model::hasGlobalScope('booted_attr_in_class'));
+        $this->assertFalse($model::hasGlobalScope('booted_attr_in_trait'));
 
         $unSerializedModel = unserialize(serialize($model));
 
         $this->assertFalse($unSerializedModel->fooBar);
+        $this->assertFalse($unSerializedModel->initializedViaAttributeInClass);
+        $this->assertFalse($unSerializedModel->initializedViaAttributeInTrait);
         $this->assertTrue($model::hasGlobalScope('foo_bar'));
+        $this->assertTrue($model::hasGlobalScope('booted_attr_in_class'));
+        $this->assertTrue($model::hasGlobalScope('booted_attr_in_trait'));
     }
 
     /**
@@ -402,6 +414,8 @@ class ModelSerializationTest extends TestCase
 
 trait TraitBootsAndInitializersTest
 {
+    public bool $initializedViaAttributeInTrait = false;
+
     public $fooBar = false;
 
     public function initializeTraitBootsAndInitializersTest()
@@ -414,11 +428,39 @@ trait TraitBootsAndInitializersTest
         static::addGlobalScope('foo_bar', function () {
         });
     }
+
+    #[Boot]
+    public static function nonConventionalBootFunctionInTrait()
+    {
+        static::addGlobalScope('booted_attr_in_trait', function () {});
+    }
+
+    #[Initialize]
+    public function nonConventionalInitFunctionInTrait()
+    {
+        $this->initializedViaAttributeInTrait = ! $this->initializedViaAttributeInTrait;
+    }
 }
 
 class ModelBootTestWithTraitInitialization extends Model
 {
     use TraitBootsAndInitializersTest;
+
+    public static bool $bootedViaAttributeInClass = false;
+
+    public bool $initializedViaAttributeInClass = false;
+
+    #[Boot]
+    public static function nonConventionalBootFunctionInClass()
+    {
+        static::addGlobalScope('booted_attr_in_class', function () {});
+    }
+
+    #[Initialize]
+    public function nonConventionalInitFunctionInClass()
+    {
+        $this->initializedViaAttributeInClass = ! $this->initializedViaAttributeInClass;
+    }
 }
 
 class ModelSerializationTestUser extends Model


### PR DESCRIPTION
Right now, if you want to hook into Eloquent's boot or initialize phases, you need to use magically named methods. For example:

```php
trait Locatable {
  public static function bootLocatable() { ... }
  public function initializeLocatable() { ... }
}
```

If you ever rename the trait, you need to remember to also rename the methods. And if you misspell the method name, it can be hard to debug.

This introduces two new traits that add the same behavior:

```php
use Illuminate\Database\Eloquent\Attributes\Boot;
use Illuminate\Database\Eloquent\Attributes\Initialize;

trait Locatable {
  #[Boot]
  public static function namedWhatever() { ... }

  #[Initialize]
  public function alsoNamedWhatever() { ... }
}
```

A couple additional "features" that we get for free with this approach:

- You can now add `boot` and `initialize` hooks in the model directly if you want to
- You can add multiple hooks in the same trait if you need to for some reason