### PR TITLE
[12.x] Add partial application

### DIFF
--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -56,15 +56,16 @@ if (! function_exists('Illuminate\Support\partial_application')) {
     /**
      * @template TReturn
      * @template TPartial of (callable(): TReturn)
+     *
      * @param  TPartial  $fn
      * @return TPartial|TReturn
      */
     function partial_application(callable $fn, array $params = [])
     {
         $paramCount = (new ReflectionFunction($fn))->getNumberOfParameters();
-    
+
         return fn (...$args) => (count($params) + count($args)) === $paramCount
             ? $fn(...[...$params, ...$args])
-            : partial_application($fn, [ ...$params, ...$args ]);
+            : partial_application($fn, [...$params, ...$args]);
     }
 }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -55,10 +55,9 @@ if (! function_exists('Illuminate\Support\artisan_binary')) {
 if (! function_exists('Illuminate\Support\partial_application')) {
     /**
      * @template TReturn
-     * @template TPartial of (callable(): TReturn)
      *
-     * @param  TPartial  $fn
-     * @return TPartial|TReturn
+     * @param  (callable(): TReturn)  $fn
+     * @return (callable(): TReturn)|TReturn
      */
     function partial_application(callable $fn, array $params = [])
     {

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -51,3 +51,20 @@ if (! function_exists('Illuminate\Support\artisan_binary')) {
         return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
     }
 }
+
+if (! function_exists('Illuminate\Support\partial_application')) {
+    /**
+     * @template TReturn
+     * @template TPartial of (callable(): TReturn)
+     * @param  TPartial  $fn
+     * @return TPartial|TReturn
+     */
+    function partial_application(callable $fn, array $params = [])
+    {
+        $paramCount = (new ReflectionFunction($fn))->getNumberOfParameters();
+    
+        return fn (...$args) => (count($params) + count($args)) === $paramCount
+            ? $fn(...[...$params, ...$args])
+            : partial_application($fn, [ ...$params, ...$args ]);
+    }
+}

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
+use ReflectionFunction;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 if (! function_exists('Illuminate\Support\defer')) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1527,7 +1527,7 @@ class SupportHelpersTest extends TestCase
             return $b ? $a : $c;
         };
 
-        $partiallyApplied = partial_applicatiopn($fn, $firstRun);
+        $partiallyApplied = \Illuminate\Support\partial_applicatiopn($fn, $firstRun);
         $partiallyApplied = $partiallyApplied(...$secondRun);
         $partiallyApplied = $partiallyApplied(...$thirdRun);
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -24,6 +24,7 @@ use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use Traversable;
+use function Illuminate\Support\partial_application;
 
 class SupportHelpersTest extends TestCase
 {
@@ -1505,6 +1506,33 @@ class SupportHelpersTest extends TestCase
             $expectedOutput,
             preg_replace_array($pattern, $replacements, $subject)
         );
+    }
+
+    public static function providesPartialApplicationData()
+    {
+        return [
+            [[], [], [], self::assertIsCallable(...)],
+            [[1], [], [], self::assertIsCallable(...)],
+            [[1, 'foo'], [], [], self::assertIsCallable(...)],
+            [[1, 'foo', true], [], [], self::assertIsInt(...)],
+            [[1, 'foo'], [true]], [], self::assertIsInt(...),
+            [[1], ['foo', true], [], self::assertIsInt(...)],
+            [[1], ['foo'], [true], self::assertIsInt(...)],
+        ];
+    }
+
+    #[DataProvider('providesPartialApplicationData')]
+    public function testPartialApplication(array $firstRun, array $secondRun, array $thirdRun, callable $assertion)
+    {
+        $fn = function (int $a, string $b, bool $c): string|int {
+            return $b ? $a : $c;
+        };
+
+        $partiallyApplied = partial_applicatiopn($fn, $firstRun);
+        $partiallyApplied = $partiallyApplied(...$secondRun);
+        $partiallyApplied = $partiallyApplied(...$thirdRun);
+
+        $assertion($partiallyApplied);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1514,7 +1514,7 @@ class SupportHelpersTest extends TestCase
             [[1], [], [], self::assertIsCallable(...)],
             [[1, 'foo'], [], [], self::assertIsCallable(...)],
             [[1, 'foo', true], [], [], self::assertIsInt(...)],
-            [[1, 'foo'], [true]], [], self::assertIsInt(...),
+            [[1, 'foo'], [true], [], self::assertIsInt(...)],
             [[1], ['foo', true], [], self::assertIsInt(...)],
             [[1], ['foo'], [true], self::assertIsInt(...)],
         ];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -24,6 +24,7 @@ use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use Traversable;
+use function Illuminate\Support\partial_application;
 
 class SupportHelpersTest extends TestCase
 {
@@ -1527,7 +1528,7 @@ class SupportHelpersTest extends TestCase
             return $b ? $a : $c;
         };
 
-        $partiallyApplied = \Illuminate\Support\partial_applicatiopn($fn, $firstRun);
+        $partiallyApplied = partial_application($fn, $firstRun);
         $partiallyApplied = $partiallyApplied(...$secondRun);
         $partiallyApplied = $partiallyApplied(...$thirdRun);
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -24,7 +24,6 @@ use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use Traversable;
-use function Illuminate\Support\partial_application;
 
 class SupportHelpersTest extends TestCase
 {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -24,6 +24,7 @@ use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use Traversable;
+
 use function Illuminate\Support\partial_application;
 
 class SupportHelpersTest extends TestCase

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1530,8 +1530,12 @@ class SupportHelpersTest extends TestCase
         };
 
         $partiallyApplied = partial_application($fn, $firstRun);
-        $partiallyApplied = $partiallyApplied(...$secondRun);
-        $partiallyApplied = $partiallyApplied(...$thirdRun);
+
+        $runs = [$secondRun, $thirdRun];
+        while (is_callable($partiallyApplied) && count($runs)) {
+            $run = array_shift($runs);
+            $partiallyApplied = $partiallyApplied(...$secondRun);
+        }
 
         $assertion($partiallyApplied);
     }


### PR DESCRIPTION
# Examples
## Currying
```php
/**
 * @return ($b ? $a : $c)
 */
$fn = function (int $a, string $b, bool $c): string|int {
    return $b ? $a : $c;
};
$partiallyApplied = partialApplication($fn);
var_dump(
    $partiallyApplied, // Closure
    $partiallyApplied(1), // Closure
    $partiallyApplied(1, 'foo'), // Closure
    $partiallyApplied(1, 'foo', true), // 1
    $partiallyApplied(1)('foo', true), // 1
    $partiallyApplied(1, 'foo')(true), // 1
    $partiallyApplied(1)('foo')(true), // 1
);
```

## Pre-configuring leading parameters of callbacks
```php
array_map(
    partial_application(implode(...), [', ']),
    [['lorem', 'ipsum'], ['dolor', 'sit']],
); // [ 'lorem, ipsum', 'dolor, sit' ]
```

# See also
* [Partial application](https://en.wikipedia.org/wiki/Partial_application) (Wikipedia)