### PR TITLE
Add sortBy and sortByDesc as aliases for orderBy/orderByDesc on Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2742,7 +2742,6 @@ class Builder implements BuilderContract
         return $this->orderByDesc($column);
     }
 
-
     /**
      * Add an "order by" clause for a timestamp to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2728,7 +2728,7 @@ class Builder implements BuilderContract
     {
         return $this->orderBy($column, $direction);
     }
-    
+
     /**
      * Add a descending "order by" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2716,6 +2716,34 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "order by" clause to the query.
+     *
+     * Alias for orderBy.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $direction
+     * @return $this
+     */
+    public function sortBy($column, $direction = 'asc')
+    {
+        return $this->orderBy($column, $direction);
+    }
+    
+    /**
+     * Add a descending "order by" clause to the query.
+     *
+     * Alias for orderByDesc.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function sortByDesc($column)
+    {
+        return $this->orderByDesc($column);
+    }
+
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2076,6 +2076,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
+    
+    public function testSortBys()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->sortBy('email')->sortBy('age', 'desc')->sortByDesc('name');
+        $this->assertSame('select * from "users" order by "email" asc, "age" desc, "name" desc', $builder->toSql());
+    }
 
     public function testLatest()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2076,12 +2076,16 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
-    
+
     public function testSortBys()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->sortBy('email')->sortBy('age', 'desc')->sortByDesc('name');
         $this->assertSame('select * from "users" order by "email" asc, "age" desc, "name" desc', $builder->toSql());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->sortBy('age', SORT_NATURAL);
     }
 
     public function testLatest()


### PR DESCRIPTION
Currently, the Eloquent query builder uses orderBy and orderByDesc for sorting results at the database level, while sortBy and sortByDesc to do the same on Collections. This can be confusing.

### Proposal:
Add sortBy and sortByDesc as aliases for orderBy and orderByDesc on the Eloquent query builder. This would allow the following usage:

```
// Instead of:
User::orderBy('name')->get()
User::get()->map(...)->sortBy('newField');

// Allow:
User::sortBy('name')->get();
User::get()->map(...)->sortBy('newField');
```
### Benefits:
Make the API more consistent between query builders and collections.

### Cons:
When using more than one argument, the signatures are not compatible. Fortunately, `Builder::orderBy($column, $direction = 'asc')` raises an `InvalidArgumentException('Order direction must be "asc" or "desc".')` if the second argument is not compliant.

### Backward Compatibility:
Non-breaking change.

