### PR TITLE
[12.x] Make built-in functions be callable with collection callbacks whose parameter count doesn't fit

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -432,7 +432,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function first(?callable $callback = null, $default = null)
     {
-        return Arr::first($this->items, fn ($value, $key) => $this->callPotentialBuiltinCallback($callback, $value, $key), $default);
+        if ($callback) {
+            return Arr::first($this->items, fn ($value, $key) => $this->callPotentialBuiltinCallback($callback, $value, $key), $default);
+        }
+
+        return Arr::first($this->items, default: $default);
     }
 
     /**
@@ -795,7 +799,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function last(?callable $callback = null, $default = null)
     {
-        return Arr::last($this->items, fn ($value, $key) => $this->callPotentialBuiltinCallback($callback, $value, $key), $default);
+        if ($callback) {
+            return Arr::last($this->items, fn ($value, $key) => $this->callPotentialBuiltinCallback($callback, $value, $key), $default);
+        }
+
+        return Arr::last($this->items, default: $default);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Closure;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\TransformsToResourceCollection;
@@ -1966,12 +1967,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TReturn
      *
-     * @param  (callable(): TReturn)  $fn
+     * @param  (callable(): TReturn)|string|array{object|class-string, string}  $fn
      * @return TReturn
      */
-    private function callPotentialBuiltinCallback(callable $fn, ...$arguments): mixed
+    private function callPotentialBuiltinCallback(callable|string|array $fn, ...$arguments): mixed
     {
-        $reflectionFunction = new ReflectionFunction($fn);
+        $reflectionFunction = new ReflectionFunction(Closure::fromCallable($fn));
         if ($reflectionFunction->isInternal() && ($paramCount = $reflectionFunction->getNumberOfParameters()) < count($arguments)) {
             return call_user_func($fn, ...array_slice($arguments, 0, $paramCount));
         }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1954,14 +1954,15 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Built-in or internal functions, unlike userland functions, must be called with the proper
      * number of arguments. Userland functions can discard additional arguments on their own
      * To align built-in function behavior with their userland counterparts, callback function calls
-     * with callables have to be wrapped in this function
+     * with callables have to be wrapped in this function.
      *
      * @template TReturn
+     *
      * @param  (callable(): TReturn)  $fn
      * @return TReturn
      */
     private function callPotentialBuiltinCallback(callable $fn, ...$arguments): mixed
-    {   
+    {
         $reflectionFunction = new ReflectionFunction($fn);
         if ($reflectionFunction->isInternal() && ($paramCount = $reflectionFunction->getNumberOfParameters()) < count($arguments)) {
             return call_user_func($fn, ...array_slice($arguments, 0, $paramCount));

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1951,7 +1951,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Built-in or interal functions, unlike userland functions, must be called with the proper
+     * Built-in or internal functions, unlike userland functions, must be called with the proper
      * number of arguments. Userland functions can discard additional arguments on their own
      * To align built-in function behavior with their userland counterparts, callback function calls
      * with callables have to be wrapped in this function

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -876,6 +876,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3], $c->filter()->all());
     }
 
+    public function testCallPotentialBuiltinCallback()
+    {
+        $this->assertEquals(['foo'], collect(['a' => 1, 'b' => 'foo'])->filter(is_string(...))->all());
+        $this->assertEquals(['Foo', 'Bar'], collect(['a' => 'foo', 'b' => 'bar'])->map(ucfirst(...))->all());
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testHigherOrderKeyBy($collection)
     {


### PR DESCRIPTION
# Problem
Built-in or internal functions, unlike userland functions, must be called with the proper number of arguments. Userland functions can discard additional arguments on their own.

```php
(new Collection([1, 'foo']))->filter('is_string')); // TypeError: is_string() expects exactly 1 argument, 2 given
```

# Solution
This PR introduces the internal wrapper utility for certain methods to align built-in function behavior with their userland counterparts, callback function calls with callables have to be wrapped in this function to not throw an exception.

```php
(new Collection([1, 'foo']))->filter('is_string')); // ['foo']
```
