### PR TITLE
[12.x] Add Arr::some() and Arr::every()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -553,6 +553,42 @@ class Arr
     }
 
     /**
+     * Determine if all items pass the given truth test.
+     *
+     * @param  iterable  $array
+     * @param  (callable(mixed, array-key): bool)  $callback
+     * @return bool
+     */
+    public static function every($array, callable $callback)
+    {
+        foreach ($array as $key => $value) {
+            if (! $callback($value, $key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if some items pass the given truth test.
+     *
+     * @param  iterable  $array
+     * @param  (callable(mixed, array-key): bool)  $callback
+     * @return bool
+     */
+    public static function some($array, callable $callback)
+    {
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get an integer item from an array using "dot" notation.
      */
     public static function integer(ArrayAccess|array $array, string|int|null $key, ?int $default = null): int

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -749,16 +749,16 @@ class SupportArrTest extends TestCase
 
     public function testEvery()
     {
-        $this->assertFalse(Arr::every([1, 2], is_string(...)));
-        $this->assertFalse(Arr::every(['foo', 2], is_string(...)));
-        $this->assertTrue(Arr::every(['foo', 'bar'], is_string(...)));
+        $this->assertFalse(Arr::every([1, 2], fn ($value, $key) => is_string($value)));
+        $this->assertFalse(Arr::every(['foo', 2], fn ($value, $key) => is_string($value)));
+        $this->assertTrue(Arr::every(['foo', 'bar'], fn ($value, $key) => is_string($value)));
     }
 
     public function testSome()
     {
-        $this->assertFalse(Arr::some([1, 2], is_string(...)));
-        $this->assertTrue(Arr::some(['foo', 2], is_string(...)));
-        $this->assertTrue(Arr::some(['foo', 'bar'], is_string(...)));
+        $this->assertFalse(Arr::some([1, 2], fn ($value, $key) => is_string($value)));
+        $this->assertTrue(Arr::some(['foo', 2], fn ($value, $key) => is_string($value)));
+        $this->assertTrue(Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)));
     }
 
     public function testIsAssoc()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -747,6 +747,20 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::hasAny($array, ['foo.bax', 'foo.baz']));
     }
 
+    public function testEvery()
+    {
+        $this->assertFalse(Arr::every([1, 2], is_string(...)));
+        $this->assertFalse(Arr::every(['foo', 2], is_string(...)));
+        $this->assertTrue(Arr::every(['foo', 'bar'], is_string(...)));
+    }
+
+    public function testSome()
+    {
+        $this->assertFalse(Arr::some([1, 2], is_string(...)));
+        $this->assertTrue(Arr::some(['foo', 2], is_string(...)));
+        $this->assertTrue(Arr::some(['foo', 'bar'], is_string(...)));
+    }
+
     public function testIsAssoc()
     {
         $this->assertTrue(Arr::isAssoc(['a' => 'a', 0 => 'b']));


### PR DESCRIPTION
Retry of #32158

# Examples
```php
Arr::every([1, 2], fn ($value, $key) => is_string($value)); // false
Arr::every(['foo', 2], fn ($value, $key) => is_string($value)); // false
Arr::every(['foo', 'bar'], fn ($value, $key) => is_string($value)); // true

Arr::some([1, 2], fn ($value, $key) => is_string($value)); // false
Arr::some(['foo', 2], fn ($value, $key) => is_string($value)); // true
Arr::some(['foo', 'bar'], fn ($value, $key) => is_string($value)); // true
```