### PR TITLE
[12.x] Add Arr::isFlat()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -595,6 +595,20 @@ class Arr
     }
 
     /**
+     * Determines if an array is one-dimensional.
+     */
+    public static function isFlat($array): bool
+    {
+        foreach ($array as $entry) {
+            if (is_array($entry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Join all items using a string. The final items can use a separate glue string.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -784,6 +784,13 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isList(['foo' => 'bar', 'baz' => 'qux']));
     }
 
+    public function testIsFlat()
+    {
+        $this->assertTrue(Arr::isFlat([1, 'foo', 5 => 2.3, 'bar' => 'baz', new stdClass, true]);
+        $this->assertFalse(Arr::isFlat([1, 2, [3]));
+        $this->assertFalse(Arr::isFlat([[1]));
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -786,9 +786,9 @@ class SupportArrTest extends TestCase
 
     public function testIsFlat()
     {
-        $this->assertTrue(Arr::isFlat([1, 'foo', 5 => 2.3, 'bar' => 'baz', new stdClass, true]);
+        $this->assertTrue(Arr::isFlat([1, 'foo', 5 => 2.3, 'bar' => 'baz', new stdClass, true]));
         $this->assertFalse(Arr::isFlat([1, 2, [3]));
-        $this->assertFalse(Arr::isFlat([[1]));
+        $this->assertFalse(Arr::isFlat([[1]]));
     }
 
     public function testOnly()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -787,7 +787,7 @@ class SupportArrTest extends TestCase
     public function testIsFlat()
     {
         $this->assertTrue(Arr::isFlat([1, 'foo', 5 => 2.3, 'bar' => 'baz', new stdClass, true]));
-        $this->assertFalse(Arr::isFlat([1, 2, [3]));
+        $this->assertFalse(Arr::isFlat([1, 2, [3]]));
         $this->assertFalse(Arr::isFlat([[1]]));
     }
 


### PR DESCRIPTION
This function determines if no other arrays are nested in the given array.

# Examples
```php
Arr::isFlat([1, 'foo', 5 => 2.3, 'bar' => 'baz', new stdClass, true]); // true
Arr::isFlat([1, 2, [3]]); // false
Arr::isFlat([[1]]); // also false
```

# Notes
Currently, an array is only considered non-flat when it contains other arrays. Containing other non-scalars doesn't make them non-flat with the current implementation.