### PR TITLE
[12.x] Add `Arr::keys()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -238,6 +238,17 @@ class Arr
     }
 
     /**
+     * Determine if the given key exists in the provided array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function keys($array)
+    {
+        return array_keys($array);
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @template TKey

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -238,7 +238,7 @@ class Arr
     }
 
     /**
-     * Returns all keys from an array
+     * Returns all keys from an array.
      *
      * @param  array  $array
      * @return array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -238,7 +238,7 @@ class Arr
     }
 
     /**
-     * Determine if the given key exists in the provided array.
+     * Returns all keys from an array
      *
      * @param  array  $array
      * @return array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1773,4 +1773,13 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testKeys()
+    {
+        $array = ['name' => 'Taylor', 'country' => 'USA'];
+
+        $result = Arr::keys($array);
+
+        $this->assertEquals(['name', 'country'], $result);
+    }
 }


### PR DESCRIPTION
This PR introduces a new `Arr::keys()` helper method that returns all keys from an array.

## Benefits:
- Maintains consistency with existing Arr helper methods
- Works with both numeric and associative arrays
- Reduces the need to use native PHP functions directly in Laravel applications

## Examples

```php
$numericArray = ['Taylor', 'USA'];
$associativeArray = ['name' => 'Taylor', 'country' => 'USA']; 

$numericResult = Arr::keys($numericArray); // returns [0, 1]
$associativeResult = Arr::keys($associativeArray); // returns ['name', 'country']
```