### PR TITLE
[12.x] Allow passing command class instances directly to `Schedule::command()` and `Artisan::call()`

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -179,7 +179,9 @@ class Application extends SymfonyApplication implements ApplicationContract
         if (is_subclass_of($command, SymfonyCommand::class)) {
             $callingClass = true;
 
-            $command = get_class($command);
+            if(is_object($command)) {
+                $command = get_class($command);
+            }
 
             $command = $this->laravel->make($command)->getName();
         }

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -179,7 +179,7 @@ class Application extends SymfonyApplication implements ApplicationContract
         if (is_subclass_of($command, SymfonyCommand::class)) {
             $callingClass = true;
 
-            if(is_object($command)) {
+            if (is_object($command)) {
                 $command = get_class($command);
             }
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -147,7 +147,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Run an Artisan console command by name.
      *
-     * @param  string  $command
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $parameters
      * @param  \Symfony\Component\Console\Output\OutputInterface|null  $outputBuffer
      * @return int
@@ -170,7 +170,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Parse the incoming Artisan command and its input.
      *
-     * @param  string  $command
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $parameters
      * @return array
      */
@@ -178,6 +178,8 @@ class Application extends SymfonyApplication implements ApplicationContract
     {
         if (is_subclass_of($command, SymfonyCommand::class)) {
             $callingClass = true;
+
+            $command = get_class($command);
 
             $command = $this->laravel->make($command)->getName();
         }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -17,6 +17,7 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use RuntimeException;
 
 use function Illuminate\Support\enum_value;
@@ -149,12 +150,22 @@ class Schedule
     /**
      * Add a new Artisan command event to the schedule.
      *
-     * @param  string  $command
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $parameters
      * @return \Illuminate\Console\Scheduling\Event
      */
     public function command($command, array $parameters = [])
     {
+        if ($command instanceof SymfonyCommand) {
+            $command = get_class($command);
+
+            $command = Container::getInstance()->make($command);
+
+            return $this->exec(
+                Application::formatCommandString($command->getName()), $parameters,
+            )->description($command->getDescription());
+        }
+
         if (class_exists($command)) {
             $command = Container::getInstance()->make($command);
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -17,8 +17,8 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
-use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use RuntimeException;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 use function Illuminate\Support\enum_value;
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -408,7 +408,7 @@ class Kernel implements KernelContract
     /**
      * Run an Artisan console command by name.
      *
-     * @param  string  $command
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $parameters
      * @param  \Symfony\Component\Console\Output\OutputInterface|null  $outputBuffer
      * @return int

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
  * @method static \Illuminate\Console\Scheduling\Schedule resolveConsoleSchedule()
  * @method static \Illuminate\Foundation\Console\ClosureCommand command(string $signature, \Closure $callback)
  * @method static void registerCommand(\Symfony\Component\Console\Command\Command $command)
- * @method static int call(string $command, array $parameters = [], \Symfony\Component\Console\Output\OutputInterface|null $outputBuffer = null)
+ * @method static int call(\Symfony\Component\Console\Command\Command|string $command, array $parameters = [], \Symfony\Component\Console\Output\OutputInterface|null $outputBuffer = null)
  * @method static \Illuminate\Foundation\Bus\PendingDispatch queue(string $command, array $parameters = [])
  * @method static array all()
  * @method static string output()

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
 
 /**
  * @method static \Illuminate\Console\Scheduling\CallbackEvent call(string|callable $callback, array $parameters = [])
- * @method static \Illuminate\Console\Scheduling\Event command(string $command, array $parameters = [])
+ * @method static \Illuminate\Console\Scheduling\Event command(\Symfony\Component\Console\Command\Command|string $command, array $parameters = [])
  * @method static \Illuminate\Console\Scheduling\CallbackEvent job(object|string $job, \UnitEnum|string|null $queue = null, \UnitEnum|string|null $connection = null)
  * @method static \Illuminate\Console\Scheduling\Event exec(string $command, array $parameters = [])
  * @method static void group(\Closure $events)

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -222,6 +222,25 @@ class ConsoleApplicationTest extends TestCase
         $this->assertSame(0, $statusCode);
     }
 
+    public function testCallMethodCanCallArtisanCommandUsingCommandClassObject()
+    {
+        $app = new Application(
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $app->addCommands([$command = new FakeCommandWithInputPrompting()]);
+
+        $command->setLaravel($laravel);
+
+        $statusCode = $app->call($command);
+
+        $this->assertTrue($command->prompted);
+        $this->assertSame('foo', $command->argument('name'));
+        $this->assertSame(0, $statusCode);
+    }
+
     protected function getMockConsole(array $methods)
     {
         $app = m::mock(ApplicationContract::class, ['version' => '6.0']);

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -117,6 +117,26 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals($phpBinary.' '.$artisanBinary.' foo:bar --force', $events[0]->command);
     }
 
+    public function testCreateNewArtisanCommandUsingCommandClassObject()
+    {
+        $command = new class extends Command
+        {
+            protected $signature = 'foo:bar';
+
+            public function handle()
+            {
+            }
+        };
+
+        $schedule = $this->schedule;
+        $schedule->command($command, ['--force']);
+
+        $events = $schedule->events();
+        $phpBinary = Application::phpBinary();
+        $artisanBinary = Application::artisanBinary();
+        $this->assertEquals($phpBinary.' '.$artisanBinary.' foo:bar --force', $events[0]->command);
+    }
+
     public function testItUsesCommandDescriptionAsEventDescription()
     {
         $schedule = $this->schedule;


### PR DESCRIPTION
This PR adds support for passing instantiated command objects (extending `Symfony\Component\Console\Command\Command`) directly to:

```php
Schedule::command(...)
Artisan::call(...)
```

## Why?
Currently, when working with Artisan commands, developers must pass either the command signature (a string) or the class name (e.g., `TestCommand::class`), which Laravel resolves from the container.

 - A similar pattern exists in `Schedule::job()` method, which accepts either a job class instance or a job class name. If a class name is provided, Laravel resolves it from the container:
 
 https://github.com/laravel/framework/blob/12.x/src/Illuminate/Console/Scheduling/Schedule.php#L179

 - Laravel already supports working with actual command instances internally. For example, the `call()` method from the `src/Illuminate/Console/Concerns/CallsCommands.php` trait (used in the `Illuminate\Console\Command` class) allows this:

```php
class TestCommand extends Command
{
  public function handle()
  {
      $this->call(new AnotherTestCommand);
  }
}
```

https://github.com/laravel/framework/blob/12.x/src/Illuminate/Console/Concerns/CallsCommands.php#L27

 - Additionally, this behavior is supported in the `parseCommand()` method in `src/Illuminate/Console/Application.php`, which checks if the argument is a subclass of `SymfonyCommand`. However, this logic was not accessible through higher-level APIs like `Artisan::call()`:

https://github.com/laravel/framework/blob/12.x/src/Illuminate/Console/Application.php#L177

## Changes

Before:
```php
Schedule::command(TestCommand::class);
Artisan::call(AnotherTestCommand::class);
```

Now also supported:
```php
Schedule::command(new TestCommand);
Artisan::call(new AnotherTestCommand);
```
