### PR TITLE
[12.x]  add 'dry-run' option for `schedule:run`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -139,7 +139,7 @@ class ScheduleRunCommand extends Command
                 $this->newLine();
             }
 
-            if ($this->dryRun){
+            if ($this->dryRun) {
                 $summary = $event->getSummaryForDisplay();
 
                 $command = $event instanceof CallbackEvent
@@ -151,7 +151,7 @@ class ScheduleRunCommand extends Command
                     Carbon::now()->format('Y-m-d H:i:s'),
                     $command
                 ));
-            } else if ($event->onOneServer) {
+            } elseif ($event->onOneServer) {
                 $this->runSingleServerEvent($event);
             } else {
                 $this->runEvent($event);
@@ -289,7 +289,7 @@ class ScheduleRunCommand extends Command
                         Carbon::now()->format('Y-m-d H:i:s'),
                         $command
                     ));
-                } else if ($event->onOneServer) {
+                } elseif ($event->onOneServer) {
                     $this->runSingleServerEvent($event);
                 } else {
                     $this->runEvent($event);

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -59,7 +59,7 @@ class ScheduleRunCommand extends Command
     protected $eventsRan = false;
 
     /**
-     * Printw commands without executing them.
+     * Print commands without executing them.
      *
      * @var bool
      */

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -139,7 +139,7 @@ class ScheduleRunCommand extends Command
                 $this->newLine();
             }
 
-            if ( $this->dryRun ){
+            if ($this->dryRun){
                 $summary = $event->getSummaryForDisplay();
 
                 $command = $event instanceof CallbackEvent
@@ -277,7 +277,7 @@ class ScheduleRunCommand extends Command
                     continue;
                 }
 
-                if ( $this->dryRun ) {
+                if ($this->dryRun) {
                     $summary = $event->getSummaryForDisplay();
 
                     $command = $event instanceof CallbackEvent

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -140,17 +140,7 @@ class ScheduleRunCommand extends Command
             }
 
             if ($this->dryRun) {
-                $summary = $event->getSummaryForDisplay();
-
-                $command = $event instanceof CallbackEvent
-                    ? $summary
-                    : trim(str_replace($this->phpBinary, '', $event->command));
-
-                $this->components->info(sprintf(
-                    '<fg=gray>%s</> Skipping [%s], because the scheduler is started with the dry-run option.',
-                    Carbon::now()->format('Y-m-d H:i:s'),
-                    $command
-                ));
+                $this->outputDryRunMessage($event);
             } elseif ($event->onOneServer) {
                 $this->runSingleServerEvent($event);
             } else {
@@ -278,17 +268,7 @@ class ScheduleRunCommand extends Command
                 }
 
                 if ($this->dryRun) {
-                    $summary = $event->getSummaryForDisplay();
-
-                    $command = $event instanceof CallbackEvent
-                        ? $summary
-                        : trim(str_replace($this->phpBinary, '', $event->command));
-
-                    $this->components->info(sprintf(
-                        '<fg=gray>%s</> Skipping [%s], because the scheduler is started with the dry-run option.',
-                        Carbon::now()->format('Y-m-d H:i:s'),
-                        $command
-                    ));
+                    $this->outputDryRunMessage($event);
                 } elseif ($event->onOneServer) {
                     $this->runSingleServerEvent($event);
                 } else {
@@ -320,5 +300,26 @@ class ScheduleRunCommand extends Command
     protected function clearInterruptSignal()
     {
         $this->cache->forget('illuminate:schedule:interrupt');
+    }
+
+    /**
+     * Output a formatted message indicating a scheduled task is skipped in dry-run mode.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return void
+     */
+    private function outputDryRunMessage(Event $event)
+    {
+        $summary = $event->getSummaryForDisplay();
+
+        $command = $event instanceof CallbackEvent
+            ? $summary
+            : trim(str_replace($this->phpBinary, '', $event->command));
+
+        $this->components->info(sprintf(
+            '<fg=gray>%s</> Skipping [%s], because the scheduler is started with the dry-run option.',
+            Carbon::now()->format('Y-m-d H:i:s'),
+            $command
+        ));
     }
 }


### PR DESCRIPTION
# Add `--dry-run` Option to `schedule:run` Command

## Description
This pull request introduces a `--dry-run` option to the `php artisan schedule:run` command, allowing developers to preview scheduled tasks that would run without executing them. This enhances the developer experience by providing a safe way to test and verify scheduled tasks.

## Example
```php
 php artisan schedule:run --dry-run                                                              

INFO  2025-08-03 21:47:17 Skipping ['example command'], because the scheduler is started with the dry-run option.  
INFO  2025-08-03 21:47:22 Skipping ['example command'], because the scheduler is started with the dry-run option.  
INFO  2025-08-03 21:47:27 Skipping ['example command'], because the scheduler is started with the dry-run option.  

```