### PR TITLE
[12.x] Allow `true` and `false` as string in boolean validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -491,7 +491,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value, $parameters)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'true', 'false'];
 
         if (($parameters[0] ?? null) === 'strict') {
             $acceptable = [true, false];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3089,10 +3089,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -3164,10 +3164,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
**Fix boolean type handling in GET request**

In the GET API, when boolean values are passed from the React component (e.g. true, false), they are sent as strings ("true", "false"). This causes validation errors like “The :attribute field must be a valid boolean.”

This PR updates the validation or parsing logic to correctly interpret stringified booleans as valid boolean values.