### PR TITLE
[Docblock] Add return type to defer() helper

### DIFF
--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -13,7 +13,7 @@ if (! function_exists('Illuminate\Support\defer')) {
      * @param  callable|null  $callback
      * @param  string|null  $name
      * @param  bool  $always
-     * @return \Illuminate\Support\Defer\DeferredCallback|\Illuminate\Support\Defer\DeferredCallbackCollection
+     * @return ($callback is null ? \Illuminate\Support\Defer\DeferredCallbackCollection : \Illuminate\Support\Defer\DeferredCallback)
      */
     function defer(?callable $callback = null, ?string $name = null, bool $always = false)
     {

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -13,7 +13,7 @@ if (! function_exists('Illuminate\Support\defer')) {
      * @param  callable|null  $callback
      * @param  string|null  $name
      * @param  bool  $always
-     * @return \Illuminate\Support\Defer\DeferredCallback
+     * @return \Illuminate\Support\Defer\DeferredCallback|\Illuminate\Support\Defer\DeferredCallbackCollection
      */
     function defer(?callable $callback = null, ?string $name = null, bool $always = false)
     {


### PR DESCRIPTION
### Summary

This pull request adds a missing `@return` docblock to the `defer()` global helper defined in `Illuminate\Support\functions.php`.

The helper returns either a `DeferredCallback` or a `DeferredCallbackCollection`, depending on whether a callable is passed. Currently, the docblock does not specify the return type when `$callback` is `null`, which can negatively impact IDE autocompletion and static analysis.

### Benefits

- Improves IDE support (e.g., PhpStorm, VS Code)
- Enhances compatibility with static analysis tools (e.g., PHPStan, Psalm)
- Clarifies the actual behavior of the helper for future maintainers and contributors
- Does not introduce any functional changes or side effects

### Why This Is Safe

- This is a **docblock-only** change; it does not alter runtime behavior.
- No existing code depends on the absence of the return type in the docblock.

### Related

This helper is part of the newer `Illuminate\Support\defer()` system introduced for deferring callbacks, and this docblock ensures full developer insight into the return behavior of the helper.
