### PR TITLE
[12.x] Add ability to `prepend()` and `append()` to `PendingChain`

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -161,10 +161,10 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Create a new chain of queueable jobs.
      *
-     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @param  \Illuminate\Support\Collection|array|null  $jobs
      * @return \Illuminate\Foundation\Bus\PendingChain
      */
-    public function chain($jobs)
+    public function chain($jobs = null)
     {
         $jobs = Collection::wrap($jobs);
         $jobs = ChainedBatch::prepareNestedBatches($jobs);

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -97,19 +97,6 @@ class PendingChain
     }
 
     /**
-     * Set the desired delay in seconds for the chain.
-     *
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
-     * @return $this
-     */
-    public function delay($delay)
-    {
-        $this->delay = $delay;
-
-        return $this;
-    }
-
-    /**
      * Prepend a job to the chain.
      *
      * @param  mixed  $job
@@ -149,6 +136,19 @@ class PendingChain
         }
 
         array_push($this->chain, ...$jobs->toArray());
+
+        return $this;
+    }
+
+    /**
+     * Set the desired delay in seconds for the chain.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @return $this
+     */
+    public function delay($delay)
+    {
+        $this->delay = $delay;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Foundation\Bus;
 
 use Closure;
+use Illuminate\Bus\ChainedBatch;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Conditionable;
 use Laravel\SerializableClosure\SerializableClosure;
 
@@ -103,6 +105,50 @@ class PendingChain
     public function delay($delay)
     {
         $this->delay = $delay;
+
+        return $this;
+    }
+
+    /**
+     * Prepend a job to the chain.
+     *
+     * @param  mixed  $job
+     * @return $this
+     */
+    public function prepend($job)
+    {
+        $jobs = ChainedBatch::prepareNestedBatches(
+            Collection::wrap($job)
+        );
+
+        if ($this->job) {
+            array_unshift($this->chain, $this->job);
+        }
+
+        $this->job = $jobs->shift();
+
+        array_unshift($this->chain, ...$jobs->toArray());
+
+        return $this;
+    }
+
+    /**
+     * Append a job to the chain.
+     *
+     * @param  mixed  $job
+     * @return $this
+     */
+    public function append($job)
+    {
+        $jobs = ChainedBatch::prepareNestedBatches(
+            Collection::wrap($job)
+        );
+
+        if (! $this->job) {
+            $this->job = $jobs->shift();
+        }
+
+        array_push($this->chain, ...$jobs->toArray());
 
         return $this;
     }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static mixed dispatchNow(mixed $command, mixed $handler = null)
  * @method static \Illuminate\Bus\Batch|null findBatch(string $batchId)
  * @method static \Illuminate\Bus\PendingBatch batch(\Illuminate\Support\Collection|mixed $jobs)
- * @method static \Illuminate\Foundation\Bus\PendingChain chain(\Illuminate\Support\Collection|array $jobs)
+ * @method static \Illuminate\Foundation\Bus\PendingChain chain(\Illuminate\Support\Collection|array $jobs = null)
  * @method static bool hasCommandHandler(mixed $command)
  * @method static mixed getCommandHandler(mixed $command)
  * @method static mixed dispatchToQueue(mixed $command)

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -322,6 +322,61 @@ class JobChainingTest extends QueueTestCase
         $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
     }
 
+    public function testChainCanBeAppended()
+    {
+        $chain = Bus::chain();
+
+        $chain->append($firstJob = new JobChainingNamedTestJob('j1'));
+        $chain->append($secondJob = new JobChainingNamedTestJob('j2'));
+        $chain->append($thirdJob = new JobChainingNamedTestJob('j3'));
+
+        $this->assertEquals($firstJob, $chain->job);
+        $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
+    }
+
+    public function testChainCanBeAppendedWithInitialJob()
+    {
+        $chain = Bus::chain([
+            $firstJob = new JobChainingNamedTestJob('j1'),
+        ]);
+
+        $chain->append([
+            $secondJob = new JobChainingNamedTestJob('j2'),
+            $thirdJob = new JobChainingNamedTestJob('j3'),
+        ]);
+
+        $this->assertEquals($firstJob, $chain->job);
+        $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
+    }
+
+    public function testChainCanBePrepended()
+    {
+        $chain = Bus::chain();
+
+        $chain->prepend($firstJob = new JobChainingNamedTestJob('j1'));
+        $chain->prepend($secondJob = new JobChainingNamedTestJob('j2'));
+        $chain->prepend($thirdJob = new JobChainingNamedTestJob('j3'));
+
+        $this->assertEquals($thirdJob, $chain->job);
+        $this->assertEquals([$secondJob, $firstJob], $chain->chain);
+    }
+
+    public function testChainCanBePrependedWithInitialJob()
+    {
+        $chain = Bus::chain([
+            $firstJob = new JobChainingNamedTestJob('j4'),
+        ]);
+
+        $chain->prepend([
+            $secondJob = new JobChainingNamedTestJob('j1'),
+            $thirdJob = new JobChainingNamedTestJob('j2'),
+            $fourthJob = new JobChainingNamedTestJob('j3'),
+        ]);
+
+        $this->assertEquals($secondJob, $chain->job);
+        $this->assertEquals([$thirdJob, $fourthJob, $firstJob], $chain->chain);
+    }
+
     public function testBatchCanBeAddedToChain()
     {
         Bus::chain([


### PR DESCRIPTION
**Description**:

This PR adds the ability to prepend and append jobs on a Bus `PendingChain`, giving developers the ability to conditionally transform the chain before its dispatched.

**Example**:

```php
$recording = Media::first();

$chain = Bus::chain([
    new TranscribeRecording($recording)
]);

if ($this->hasAudioNormalizationEnabled()) {
    $chain->prepend(new NormalizeAudio($recording));
}

if ($this->hasTranscriptionRedactionEnabled()) {
    $chain->append(new RedactTranscription($recording));
}

$chain->dispatch();
```

In the example above:

- If audio normalization is enabled, the `NormalizeAudio` job will be moved to the first position of the chain and the `TranscribeRecording` job will be moved to the second
- If transcription redaction is enabled, it will be pushed onto the back of the chain ensuring it is always the last job to run regardless of whichever ones preceded it 

Let me know your thoughts! Thanks for your time 🙏 