### PR TITLE
Fix parameters order in PHPUnit assertion

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -159,7 +159,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $actual = count($this->files($path, $recursive));
 
         PHPUnit::assertEquals(
-            $actual, $count, "Expected [{$count}] files at [{$path}], but found [{$actual}]."
+            $count, $actual, "Expected [{$count}] files at [{$path}], but found [{$actual}]."
         );
 
         return $this;


### PR DESCRIPTION
This would pass or fail the test as expected, but the error message would have the "expected" and "actual" values swapped