### PR TITLE
[12.x] Fix assertion in `testSendToOthersOnly` method

### DIFF
--- a/tests/Integration/Broadcasting/SendingBroadcastsViaAnonymousEventTest.php
+++ b/tests/Integration/Broadcasting/SendingBroadcastsViaAnonymousEventTest.php
@@ -118,7 +118,7 @@ class SendingBroadcastsViaAnonymousEventTest extends TestCase
             ->send();
 
         EventFacade::assertDispatched(AnonymousEvent::class, function ($event) {
-            return $event->socket = '12345';
+            return $event->socket === '12345';
         });
     }
 


### PR DESCRIPTION
Correct the socket ID comparison in the testSendToOthersOnly test method by replacing assignment (`=`) with strict equality check (`===`). 