### PR TITLE
[12.x] Add `unless_between` and `digits_unless_between` validation rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -482,6 +482,24 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the size of an attribute is not between a set of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateUnlessBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'unless_between');
+
+        return with(
+            BigNumber::of($this->getSize($attribute, $value)),
+            fn ($size) => $size->isLessThanOrEqualTo($this->trim($parameters[0])) || $size->isGreaterThanOrEqualTo($this->trim($parameters[1]))
+        );
+    }
+
+    /**
      * Validate that an attribute is a boolean.
      *
      * @param  string  $attribute
@@ -742,6 +760,24 @@ trait ValidatesAttributes
 
         return ! preg_match('/[^0-9]/', $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
+    }
+
+    /**
+     * Validate that an attribute is not between a given number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateDigitsUnlessBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'digits_unless_between');
+
+        $length = strlen((string) $value);
+
+        return ! preg_match('/[^0-9]/', $value)
+            && ($length <= $parameters[0] || $length >= $parameters[1]);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -495,7 +495,7 @@ trait ValidatesAttributes
 
         return with(
             BigNumber::of($this->getSize($attribute, $value)),
-            fn ($size) => $size->isLessThanOrEqualTo($this->trim($parameters[0])) || $size->isGreaterThanOrEqualTo($this->trim($parameters[1]))
+            fn ($size) => $size->isLessThan($this->trim($parameters[0])) || $size->isGreaterThan($this->trim($parameters[1]))
         );
     }
 
@@ -777,7 +777,7 @@ trait ValidatesAttributes
         $length = strlen((string) $value);
 
         return ! preg_match('/[^0-9]/', $value)
-            && ($length <= $parameters[0] || $length >= $parameters[1]);
+            && ($length < $parameters[0] || $length > $parameters[1]);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Numeric.php
+++ b/src/Illuminate/Validation/Rules/Numeric.php
@@ -28,6 +28,18 @@ class Numeric implements Stringable
     }
 
     /**
+     * The field under validation must not have a size between the given min and max (inclusive).
+     *
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @return $this
+     */
+    public function unlessBetween(int|float $min, int|float $max): Numeric
+    {
+        return $this->addRule('unless_between:'.$min.','.$max);
+    }
+
+    /**
      * The field under validation must contain the specified number of decimal places.
      *
      * @param  int  $min
@@ -77,6 +89,18 @@ class Numeric implements Stringable
     public function digitsBetween(int $min, int $max): Numeric
     {
         return $this->integer()->addRule('digits_between:'.$min.','.$max);
+    }
+
+    /**
+     * The integer under validation must not between the given min and max number of digits.
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return $this
+     */
+    public function digitsUnlessBetween(int $min, int $max): Numeric
+    {
+        return $this->integer()->addRule('digits_unless_between:'.$min.','.$max);
     }
 
     /**

--- a/tests/Validation/ValidationNumericRuleTest.php
+++ b/tests/Validation/ValidationNumericRuleTest.php
@@ -29,6 +29,15 @@ class ValidationNumericRuleTest extends TestCase
         $this->assertEquals('numeric|between:1.5,10.5', (string) $rule);
     }
 
+    public function testUnlessBetweenRule()
+    {
+        $rule = Rule::numeric()->unlessBetween(1, 10);
+        $this->assertEquals('numeric|unless_between:1,10', (string) $rule);
+
+        $rule = Rule::numeric()->unlessBetween(1.5, 10.5);
+        $this->assertEquals('numeric|unless_between:1.5,10.5', (string) $rule);
+    }
+
     public function testDecimalRule()
     {
         $rule = Rule::numeric()->decimal(2, 4);
@@ -54,6 +63,12 @@ class ValidationNumericRuleTest extends TestCase
     {
         $rule = Rule::numeric()->digitsBetween(2, 10);
         $this->assertEquals('numeric|integer|digits_between:2,10', (string) $rule);
+    }
+
+    public function testDigitsUnlessBetweenRule()
+    {
+        $rule = Rule::numeric()->digitsUnlessBetween(2, 10);
+        $this->assertEquals('numeric|integer|digits_unless_between:2,10', (string) $rule);
     }
 
     public function testGreaterThanRule()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3542,10 +3542,23 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_unless_between:6,8']);
         $this->assertTrue($v->passes());
 
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_unless_between:2,4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_unless_between:2,5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_unless_between:1,3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_unless_between:3,6']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'digits_unless_between:1,10']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'digits_unless_between:2,5']);
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'digits_unless_between:4,6']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_unless_between:1,6']);
@@ -3684,6 +3697,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:4,6']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:5,7']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:3,5']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => 'asdadad'], ['foo' => 'Unless_Between:4,6']);
         $this->assertTrue($v->passes());
 
@@ -3691,6 +3710,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,150']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:123,150']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,123']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:150,200']);
@@ -3703,6 +3728,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.04']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.03,0.05']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.03']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.02']);
         $this->assertTrue($v->passes());
 
@@ -3710,6 +3741,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:1,5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:4,6']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:2,4']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Unless_Between:4,6']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3694,75 +3694,75 @@ class ValidationValidatorTest extends TestCase
     public function testValidateUnlessBetween()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:4,6']);
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'unless_between:4,6']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:5,7']);
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'unless_between:5,7']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:3,5']);
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'unless_between:3,5']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'asdadad'], ['foo' => 'Unless_Between:4,6']);
+        $v = new Validator($trans, ['foo' => 'asdadad'], ['foo' => 'unless_between:4,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'asd'], ['foo' => 'Unless_Between:4,6']);
+        $v = new Validator($trans, ['foo' => 'asd'], ['foo' => 'unless_between:4,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,150']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|unless_between:100,150']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:123,150']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|unless_between:123,150']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,123']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|unless_between:100,123']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:150,200']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|unless_between:150,200']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,120']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|unless_between:100,120']);
         $this->assertTrue($v->passes());
 
         // can work with float
-        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.04']);
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|unless_between:0.01,0.04']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.03,0.05']);
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|unless_between:0.03,0.05']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.03']);
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|unless_between:0.01,0.03']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.02']);
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|unless_between:0.01,0.02']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '0.04'], ['foo' => 'Numeric|Unless_Between:0.05,0.07']);
+        $v = new Validator($trans, ['foo' => '0.04'], ['foo' => 'Numeric|unless_between:0.05,0.07']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:1,5']);
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|unless_between:1,5']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:4,6']);
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|unless_between:4,6']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:2,4']);
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|unless_between:2,4']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Unless_Between:4,6']);
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|unless_between:4,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3, 4, 5, 6]], ['foo' => 'Array|Unless_Between:2,5']);
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4, 5, 6]], ['foo' => 'Array|unless_between:2,5']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);
-        $v = new Validator($trans, ['photo' => $file], ['photo' => 'Unless_Between:1,2']);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'unless_between:1,2']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
-        $v = new Validator($trans, ['photo' => $file], ['photo' => 'Unless_Between:2,4']);
+        $v = new Validator($trans, ['photo' => $file], ['photo' => 'unless_between:2,4']);
         $this->assertFalse($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3386,13 +3386,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|Between:1.88888888888888888886,1.88888888888888888888']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|Unless_Between:1.88888888888888888886,1.88888888888888888888']);
+        $v = new Validator($trans, ['foo' => '1.88888888888888888887'], ['foo' => 'Decimal:20|unless_between:1.88888888888888888886,1.88888888888888888888']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.88888888888888888885'], ['foo' => 'Decimal:20|Unless_Between:1.88888888888888888886,1.88888888888888888888']);
+        $v = new Validator($trans, ['foo' => '1.88888888888888888885'], ['foo' => 'Decimal:20|unless_between:1.88888888888888888886,1.88888888888888888888']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|Unless_Between:1.88888888888888888886,1.88888888888888888888']);
+        $v = new Validator($trans, ['foo' => '1.88888888888888888889'], ['foo' => 'Decimal:20|unless_between:1.88888888888888888886,1.88888888888888888888']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1.88888888888888888888'], ['foo' => 'Decimal:20|Gt:1.88888888888888888888']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3684,41 +3684,39 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Unless_Between:4,6']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'anc'], ['foo' => 'Unless_Between:3,5']);
+        $v = new Validator($trans, ['foo' => 'asdadad'], ['foo' => 'Unless_Between:4,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => 'ancf'], ['foo' => 'Unless_Between:1,4']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['foo' => 'ancfs'], ['foo' => 'Unless_Between:2,4']);
+        $v = new Validator($trans, ['foo' => 'asd'], ['foo' => 'Unless_Between:4,6']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,150']);
         $this->assertFalse($v->passes());
 
-        // inclusive on min
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:123,200']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:150,200']);
         $this->assertTrue($v->passes());
 
-        // inclusive on max
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:0,123']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Unless_Between:100,120']);
         $this->assertTrue($v->passes());
 
         // can work with float
-        $v = new Validator($trans, ['foo' => '0.02'], ['foo' => 'Numeric|Unless_Between:0.01,0.02']);
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.04']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.03'], ['foo' => 'Numeric|Unless_Between:0.01,0.02']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '0.02'], ['foo' => 'Numeric|Unless_Between:0.02,0.04']);
+        $v = new Validator($trans, ['foo' => '0.04'], ['foo' => 'Numeric|Unless_Between:0.05,0.07']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '3'], ['foo' => 'Numeric|Unless_Between:4,6']);
-        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'Array|Unless_Between:1,5']);
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Unless_Between:4,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Unless_Between:2,5']);
-        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4, 5, 6]], ['foo' => 'Array|Unless_Between:2,5']);
+        $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);


### PR DESCRIPTION
This PR introduces two new validation rules:

`unless_between`
`digits_unless_between`

These rules are the inverse of their existing counterparts, `between` and `digits_between`.

## Description
`unless_between:min,max`:
Fails validation if the value is between min and max, inclusive.
Passes if the value is outside of that range.

`digits_unless_between:min,max`:
Fails validation if the number of digits is between min and max, inclusive.
Passes if the number of digits is outside that range.

## Examples
`unless_between` example:

```php
Validator::make(['score' => 10], [
    'score' => 'numeric|unless_between:20,30' //✅ Passes
]);

Validator::make(['score' => 10], [
    'score' => 'numeric|unless_between:5,15' //❌ Fails
]);

Validator::make(['score' => 10], [
    'score' => 'numeric|unless_between:10,20' //❌ Fails
]);
```

`digits_unless_between` example:

```php
Validator::make(['code' => '12345'], [
    'code' => 'digits_unless_between:2,4' //✅ Passes
]);

Validator::make(['code' => '123'], [
    'code' => 'digits_unless_between:2,4' //❌ Fails
]);

Validator::make(['code' => '123'], [
    'code' => 'digits_unless_between:3,5' //❌ Fails
]);
```

Using `Rule` class syntax:

```php
$validator = Validator::make(
    ['score' => 10],
    [
        'score' => [
            'required',
            Rule::numeric()->unlessBetween(15, 20), //✅ Passes
        ],
    ]
);
```

```php
$validator = Validator::make(
    ['code' => '1234'],
    [
        'code' => [
            'required',
            Rule::numeric()->digitsUnlessBetween(1, 3), //✅ Passes
        ],
    ]
);
```
## Follow-up
I will submit a follow-up PR to the Laravel documentation once it is approved.