### PR TITLE
[12.x] Always cast something as fluent if column is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
@@ -20,7 +20,7 @@ class AsFluent implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return new Fluent($value ? Json::decode($value) : []);
+                return new Fluent(Json::decode($value ?? '[]'));
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
@@ -20,7 +20,7 @@ class AsFluent implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($value) ? new Fluent(Json::decode($value)) : null;
+                return new Fluent($value ? Json::decode($value) : []);
             }
 
             public function set($model, $key, $value, $attributes)


### PR DESCRIPTION
This PR attempts to address a problem when an entire column is null.

## Problem
The current `AsFluent` implementation returns `null` when the database column is null, causing runtime errors when developers try to use Fluent methods:

```php
// This crashes if preferences is null in database
$user->preferences->get('theme'); // Call to a member function get() on null
```

## Rationale

By always returning a fluent, we can prevent errors when calling `->get()` blindly. Since you can't set a default value for `json` columns in MySQL, it becomes particularly tricky to add this AsFluent cast to existing datasets.

This may be a "breaking" change if anyone is dependent on checking for `null` to determine if the column was set - but realistically, most developers want to work with an empty Fluent object rather than handle null checks.