### PR TITLE
[12.x]: add `isEmail` str helper method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
 use JsonException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -688,13 +689,11 @@ class Str
      * @param  mixed  $value
      * @return bool
      */
-    public static function isEmail($value)
+    public static function isEmail($value, array $parameters = ['filter'])
     {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+       return (new class {
+            use ValidatesAttributes;
+        })->validateEmail('email', $value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -683,6 +683,21 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid email address.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isEmail($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -691,7 +691,8 @@ class Str
      */
     public static function isEmail($value, array $parameters = ['filter'])
     {
-       return (new class {
+        return (new class
+        {
             use ValidatesAttributes;
         })->validateEmail('email', $value, $parameters);
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -426,9 +426,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      *
      * @return bool
      */
-    public function isEmail()
+    public function isEmail(array $parameters = ['filter'])
     {
-        return Str::isEmail($this->value);
+        return Str::isEmail($this->value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -422,6 +422,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the given string is empty.
+     *
+     * @return bool
+     */
+    public function isEmail()
+    {
+        return Str::isEmail($this->value);
+    }
+
+    /**
      * Determine if the given string is not empty.
      *
      * @return bool

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1568,4 +1568,19 @@ class SupportStringableTest extends TestCase
         $this->assertNotSame('foo', $encrypted->value());
         $this->assertSame('foo', $encrypted->decrypt()->value());
     }
+
+    public function testIsEmail()
+    {
+        $this->assertTrue($this->stringable('taylor@laravel.com')->isEmail());
+        $this->assertTrue($this->stringable('taylor123@laravel.com')->isEmail());
+        $this->assertTrue($this->stringable('taylor.otwell.with.dots@sub.laravel.com')->isEmail());
+        $this->assertTrue($this->stringable('taylor_otwell@laravel.com')->isEmail());
+        $this->assertTrue($this->stringable('TAYLOR@LARAVEL.COM')->isEmail());
+
+        $this->assertFalse($this->stringable('taylor')->isEmail());
+        $this->assertFalse($this->stringable('taylor@')->isEmail());
+        $this->assertFalse($this->stringable('@laravel.com')->isEmail());
+        $this->assertFalse($this->stringable('taylor..otwell@laravel.com')->isEmail());
+        $this->assertFalse($this->stringable('taylor@otwell')->isEmail());
+    }
 }


### PR DESCRIPTION
This PR adds a new isEmail() method to the Stringable class for quick email format validation. The method provides a convenient way to check if a string is a valid email address.

### Example
Current approach requires breaking the fluent chain:
```php
class UpdateBackupEmailAction
{
   public function execute(User $user, array $data): bool
   {
       if (isset($data['backup_email']) && !Str::isEmail($data['backup_email'])) {
           throw new InvalidArgumentException('Invalid backup email format');
       }
       
       return $user->update(['backup_email' => $data['backup_email']]);
   }
}
```
