### PR TITLE
[12.x] Improve Collection type inference for keys() and all() methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -60,7 +60,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get all of the items in the collection.
      *
-     * @return array<TKey, TValue>
+     * @return (TKey is never ? list<TValue> : array<TKey, TValue>)
      */
     public function all()
     {
@@ -776,7 +776,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the keys of the collection items.
      *
-     * @return static<int, TKey>
+     * @return static<never, TKey>
      */
     public function keys()
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -99,7 +99,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get all items in the enumerable.
      *
-     * @return array<TKey, TValue>
+     * @return (TKey is never ? list<TValue> : array<TKey, TValue>)
      */
     public function all()
     {
@@ -744,7 +744,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static<int, TKey>
+     * @return static<never, TKey>
      */
     public function keys()
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -681,7 +681,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the keys of the collection items.
      *
-     * @return \Illuminate\Support\Collection<int, TKey>
+     * @return \Illuminate\Support\Collection<never, TKey>
      */
     public function keys()
     {

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -42,7 +42,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Get the keys present in the message bag.
      *
-     * @return array<string>
+     * @return list<string>
      */
     public function keys()
     {

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -76,7 +76,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get the keys for all of the input.
      *
-     * @return array
+     * @return list<mixed>
      */
     public function keys()
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -176,7 +176,8 @@ assertType('array<User>', $collection->getDictionary([new User]));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck('string'));
 assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck(['string']));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
+assertType('Illuminate\Support\Collection<never, int>', $collection->keys());
+assertType('list<int>', $collection->keys()->all());
 
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|User>>', $collection->zip([1]));
 assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string|User>>', $collection->zip(['string']));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -559,7 +559,8 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->intersect([n
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->intersectByKeys([new User]));
 
-assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
+assertType('Illuminate\Support\Collection<never, int>', $collection->keys());
+assertType('list<int>', $collection->keys()->all());
 
 assertType('User|null', $collection->last());
 assertType('User|null', $collection->last(function ($user, $int) {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -44,7 +44,7 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
     rescue(fn () => assertType('never', throw_if(true, Exception::class)));
-    assertType('false', throw_if(false, Exception::class));
+    assertType('false', throw_if(false, Exception::class)); /** @phpstan-ignore-line deadCode.unreachable */
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
     assertType('int', $foo);
@@ -63,7 +63,7 @@ function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
     rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
-    assertType('true', throw_unless(empty($foo)));
+    assertType('true', throw_unless(empty($foo)));  /** @phpstan-ignore-line deadCode.unreachable */
     throw_unless(is_int($foo));
     assertType('int', $foo);
     throw_unless($foo == false);

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -451,7 +451,8 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->intersec
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->intersectByKeys([new User]));
 
-assertType('Illuminate\Support\LazyCollection<int, int>', $collection->keys());
+assertType('Illuminate\Support\LazyCollection<never, int>', $collection->keys());
+assertType('list<int>', $collection->keys()->all());
 
 assertType('User|null', $collection->last());
 assertType('User|null', $collection->last(function ($user, $int) {


### PR DESCRIPTION
## Description

Improves static analysis type inference for Collection `keys()` and `all()` methods.

**Changes:**
- `keys()`: Return type from `Collection<int, TKey>` to `Collection<never, TKey>`
- `all()`: Return type to `list<TValue>` when `TKey` is `never`

**Before:**
```php
/** @var list<int> $list */ // Manual annotation required
$list = $collection->keys()->all();
array_is_list($list);
```

**After:**
```php
$list = $collection->keys()->all(); // Automatically inferred as list<int>
array_is_list($list);
```