### PR TITLE
[12.x] Add ability to deduplicate multiple characters with a single Str::deduplicate call

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -371,10 +371,10 @@ class Str
      * Replace consecutive instances of a given character with a single character in the given string.
      *
      * @param  string  $string
-     * @param  string|array<string>  $characters
+     * @param  array<string>|string  $characters
      * @return string
      */
-    public static function deduplicate(string $string, string|array $characters = ' '): string
+    public static function deduplicate(string $string, array|string $characters = ' ')
     {
         if (is_string($characters)) {
             return preg_replace('/'.preg_quote($characters, '/').'+/u', $characters, $string);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -371,7 +371,7 @@ class Str
      * Replace consecutive instances of a given character with a single character in the given string.
      *
      * @param  string  $string
-     * @param  string  $character
+     * @param  string|array<string>  $characters
      * @return string
      */
     public static function deduplicate(string $string, string|array $characters = ' '): string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -380,12 +380,11 @@ class Str
             return preg_replace('/'.preg_quote($characters, '/').'+/u', $characters, $string);
         }
 
-        $result = $string;
-        foreach ($characters as $character) {
-            $result = preg_replace('/'.preg_quote($character, '/').'+/u', $character, $result);
-        }
-
-        return $result;
+        return array_reduce(
+            $characters,
+            fn ($carry, $character) => preg_replace('/'.preg_quote($character, '/').'+/u', $character, $carry),
+            $string
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -374,9 +374,18 @@ class Str
      * @param  string  $character
      * @return string
      */
-    public static function deduplicate(string $string, string $character = ' ')
+    public static function deduplicate(string $string, string|array $characters = ' '): string
     {
-        return preg_replace('/'.preg_quote($character, '/').'+/u', $character, $string);
+        if (is_string($characters)) {
+            return preg_replace('/'.preg_quote($characters, '/').'+/u', $characters, $string);
+        }
+
+        $result = $string;
+        foreach ($characters as $character) {
+            $result = preg_replace('/'.preg_quote($character, '/').'+/u', $character, $result);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -482,6 +482,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('what', Str::deduplicate('whaaat', 'a'));
         $this->assertSame('/some/odd/path/', Str::deduplicate('/some//odd//path/', '/'));
         $this->assertSame('ムだム', Str::deduplicate('ムだだム', 'だ'));
+        $this->assertSame(' laravel forever ', Str::deduplicate(' laravell    foreverrr  ', [' ', 'l', 'r']));
     }
 
     public function testParseCallback()


### PR DESCRIPTION
Currently, if we want to deduplicate multiple characters at once from a string, we need to call the `Str::deduplicate` method multiple times.

```php
$string = 'Laravelll    4ever';
$result = Str::deduplicate(Str::deduplicate($string, 'l')); // Laravel 4ever
```

With this change, we can do it in a single call, making it cleaner and easier to get the expected result:

```php
$string = 'Laravelll    4ever';
$result = Str::deduplicate($string, [' ', 'l']); // Laravel 4ever
```