### PR TITLE
[12.x] Add `forget()` method to `Fluent` class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -98,6 +98,19 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     }
 
     /**
+     * Remove one or many items from the attributes.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function forget($keys)
+    {
+        Arr::forget($this->attributes, $keys);
+
+        return $this;
+    }
+
+    /**
      * Get an attribute from the fluent instance.
      *
      * @param  string  $key

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -433,6 +433,23 @@ class SupportFluentTest extends TestCase
         ], $fluent->getAttributes());
     }
 
+    public function testForget()
+    {
+        $fluent = new Fluent([
+            'name' => 'Taylor',
+            'email' => 'taylor@example.com',
+            'role' => 'admin',
+        ]);
+
+        $fluent->forget('email');
+        $this->assertNull($fluent->get('email'));
+        $this->assertSame('Taylor', $fluent->get('name'));
+        $this->assertSame('admin', $fluent->get('role'));
+
+        $fluent->forget(['name', 'role']);
+        $this->assertEmpty($fluent->toArray());
+    }
+
     public function testMacroable()
     {
         Fluent::macro('foo', function () {


### PR DESCRIPTION
Right now, you have to use unset() or magic methods to remove attributes. This method makes it easier and cleaner to remove keys, supports nested keys, and allows method chaining.