### PR TITLE
[12.x] Add DatabaseStore::setConnection(), fix docblock for setLockConnection()

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -446,6 +446,16 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Get the connection used to manage locks.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    public function getLockConnection()
+    {
+        return $this->lockConnection;
+    }
+
+    /**
      * Set the underlying database connection.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -446,16 +446,6 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
-     * Get the connection used to manage locks.
-     *
-     * @return \Illuminate\Database\ConnectionInterface
-     */
-    public function getLockConnection()
-    {
-        return $this->lockConnection;
-    }
-
-    /**
      * Set the underlying database connection.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -466,6 +456,16 @@ class DatabaseStore implements LockProvider, Store
         $this->connection = $connection;
 
         return $this;
+    }
+
+    /**
+     * Get the connection used to manage locks.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    public function getLockConnection()
+    {
+        return $this->lockConnection;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -446,7 +446,20 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
-     * Specify the name of the connection that should be used to manage locks.
+     * Set the underlying database connection.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return $this
+     */
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Specify the connection that should be used to manage locks.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @return $this


### PR DESCRIPTION
This adds `setConnection()` (`getConnection()` and `setLockConnection()` already exist). Need this for supporting multi-DB cache stores in Tenancy.

Also corrects docblock for `setLockConnection()` — it receives the connection instance, not the name.

Second commit also adds `getLockConnection()` for consistency, since `setLockConnection()` already existed. I don't need this and can revert if you'd object to this addition. It just seems logical to have getters for things that already have a setter.