### PR TITLE
[12.x] Deferred Events

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -70,6 +70,20 @@ class Dispatcher implements DispatcherContract
     protected $transactionManagerResolver;
 
     /**
+     * The deferred events that should be dispatched later.
+     *
+     * @var array
+     */
+    protected $deferredEvents = [];
+
+    /**
+     * Indicates if events should be deferred.
+     *
+     * @var bool
+     */
+    protected $deferringEvents = false;
+
+    /**
      * Create a new event dispatcher instance.
      *
      * @param  \Illuminate\Contracts\Container\Container|null  $container
@@ -244,6 +258,13 @@ class Dispatcher implements DispatcherContract
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
+        // If events are being deferred, store them for later dispatch
+        if ($this->deferringEvents) {
+            $this->deferredEvents[] = func_get_args();
+
+            return null;
+        }
+
         // When the given "event" is actually an object we will assume it is an event
         // object and use the class as the event name and this event itself as the
         // payload to the handler, which makes object based events quite simple.
@@ -766,6 +787,37 @@ class Dispatcher implements DispatcherContract
         $this->transactionManagerResolver = $resolver;
 
         return $this;
+    }
+
+    /**
+     * Execute the given callback while deferring events, then dispatch all deferred events.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function defer(callable $callback)
+    {
+        $wasDeferring = $this->deferringEvents;
+        $previousDeferredEvents = $this->deferredEvents;
+
+        $this->deferringEvents = true;
+        $this->deferredEvents = [];
+
+        try {
+            $result = $callback();
+
+            // Dispatch all deferred events
+            $this->deferringEvents = false;
+
+            foreach ($this->deferredEvents as $args) {
+                $this->dispatch(...$args);
+            }
+
+            return $result;
+        } finally {
+            $this->deferringEvents = $wasDeferring;
+            $this->deferredEvents = $previousDeferredEvents;
+        }
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher implements DispatcherContract
     protected $transactionManagerResolver;
 
     /**
-     * The deferred events that should be dispatched later.
+     * The currently deferred events.
      *
      * @var array
      */
@@ -258,7 +258,6 @@ class Dispatcher implements DispatcherContract
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
-        // If events are being deferred, store them for later dispatch
         if ($this->deferringEvents) {
             $this->deferredEvents[] = func_get_args();
 
@@ -806,7 +805,6 @@ class Dispatcher implements DispatcherContract
         try {
             $result = $callback();
 
-            // Dispatch all deferred events
             $this->deferringEvents = false;
 
             foreach ($this->deferredEvents as $args) {

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static \Illuminate\Events\Dispatcher setQueueResolver(callable $resolver)
  * @method static \Illuminate\Events\Dispatcher setTransactionManagerResolver(callable $resolver)
  * @method static array getRawListeners()
+ * @method static mixed defer(callable $callback)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -37,6 +37,66 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('barbar', $_SERVER['__event.test']);
     }
 
+    public function testDeferEventExecution()
+    {
+        unset($_SERVER['__event.test']);
+        $d = new Dispatcher;
+        $d->listen('foo', function ($foo) {
+            $_SERVER['__event.test'] = $foo;
+        });
+
+        $result = $d->defer(function () use ($d) {
+            $d->dispatch('foo', ['bar']);
+            $this->assertArrayNotHasKey('__event.test', $_SERVER);
+            return 'callback_result';
+        });
+
+        $this->assertEquals('callback_result', $result);
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
+    public function testDeferMultipleEvents()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+        $d->listen('foo', function ($value) {
+            $_SERVER['__event.test'][] = $value;
+        });
+        $d->listen('bar', function ($value) {
+            $_SERVER['__event.test'][] = $value;
+        });
+        $d->defer(function () use ($d) {
+            $d->dispatch('foo', ['foo']);
+            $d->dispatch('bar', ['bar']);
+            $this->assertSame([], $_SERVER['__event.test']);
+        });
+
+        $this->assertSame(['foo', 'bar'], $_SERVER['__event.test']);
+    }
+
+    public function testDeferNestedEvents()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+        $d->listen('foo', function ($foo) {
+            $_SERVER['__event.test'][] = $foo;
+        });
+
+        $d->defer(function () use ($d) {
+            $d->dispatch('foo', ['outer1']);
+
+            $d->defer(function () use ($d) {
+                $d->dispatch('foo', ['inner']);
+                $this->assertSame([], $_SERVER['__event.test']);
+            });
+
+            $this->assertSame(['inner'], $_SERVER['__event.test']);
+            $d->dispatch('foo', ['outer2']);
+        });
+
+        $this->assertSame(['inner', 'outer1', 'outer2'], $_SERVER['__event.test']);
+    }
+
     public function testHaltingEventExecution()
     {
         unset($_SERVER['__event.test']);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -48,6 +48,7 @@ class EventsDispatcherTest extends TestCase
         $result = $d->defer(function () use ($d) {
             $d->dispatch('foo', ['bar']);
             $this->assertArrayNotHasKey('__event.test', $_SERVER);
+
             return 'callback_result';
         });
 

--- a/tests/Integration/Events/DeferEventsTest.php
+++ b/tests/Integration/Events/DeferEventsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class DeferEventsTest extends TestCase
+{
+    public function testDeferEvents()
+    {
+        unset($_SERVER['__event.test']);
+
+        Event::listen('foo', function ($foo) {
+            $_SERVER['__event.test'] = $foo;
+        });
+
+        $response = Event::defer(function () {
+            Event::dispatch('foo', ['bar']);
+
+            $this->assertArrayNotHasKey('__event.test', $_SERVER);
+
+            return 'callback_result';
+        });
+
+        $this->assertEquals('callback_result', $response);
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
+    public function testDeferModelEvents()
+    {
+        $_SERVER['__model_event.test'] = [];
+
+        TestModel::saved(function () {
+            $_SERVER['__model_event.test'][] = 'saved';
+        });
+
+        $response = Event::defer(function () {
+            $model = new TestModel();
+            $model->fireModelEvent('saved', false);
+
+            $this->assertSame([], $_SERVER['__model_event.test']);
+
+            return 'model_event_response';
+        });
+
+        $this->assertEquals('model_event_response', $response);
+        $this->assertContains('saved', $_SERVER['__model_event.test']);
+    }
+
+    public function testDeferMultipleModelEvents()
+    {
+        $_SERVER['__model_events'] = [];
+
+        TestModel::saved(function () {
+            $_SERVER['__model_events'][] = 'saved:TestModel';
+        });
+
+        AnotherTestModel::created(function () {
+            $_SERVER['__model_events'][] = 'created:AnotherTestModel';
+        });
+
+        $response = Event::defer(function () {
+            $model1 = new TestModel();
+            $model1->fireModelEvent('saved');
+
+            $model2 = new AnotherTestModel();
+            $model2->fireModelEvent('created');
+
+            // Events should not have fired yet
+            $this->assertSame([], $_SERVER['__model_events']);
+
+            return 'multiple_models_response';
+        });
+
+        $this->assertEquals('multiple_models_response', $response);
+        $this->assertSame(['saved:TestModel', 'created:AnotherTestModel'], $_SERVER['__model_events']);
+    }
+}
+
+class TestModel extends Model
+{
+    public function fireModelEvent($event, $halt = true)
+    {
+        return parent::fireModelEvent($event, $halt);
+    }
+}
+
+class AnotherTestModel extends Model
+{
+    public function fireModelEvent($event, $halt = true)
+    {
+        return parent::fireModelEvent($event, $halt);
+    }
+}


### PR DESCRIPTION
This introduces a new concept: **Deferred Events**.

### Use Cases

When we need to listen do a model event that creates child records, let's think of the following scenario:

```php
$parent = Parent::create();
$parent->children()->create();

Parent::created(function ($model) {
    $parent->children()->count(); // 0
});
```

Currently if you listen for `Parent::created`, the child will not be available yet, we would need to dispatch a event after the child is created, or dispatch a job and have after commit enabled.

With the new idea:

```php
Event::defer(function () {
    $parent = Parent::create();
    $parent->children()->create();
});

Parent::created(function ($model) {
    $parent->children()->count(); // 1
});
```

This allows us to defer the execution of the events to after the callback is executed, ensuring that all related records are available.

This also might open a lot of other possibilities.

Thoughts?