### PR TITLE
[12.x] Add consistent read option to DynamoDB cache store

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -84,6 +84,7 @@ return [
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
             'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
             'endpoint' => env('DYNAMODB_ENDPOINT'),
+            'consistent_read' => (bool) env('DYNAMODB_CACHE_CONSISTENT_READ', false),
         ],
 
         'octane' => [

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -278,7 +278,8 @@ class CacheManager implements FactoryContract
                 $config['attributes']['key'] ?? 'key',
                 $config['attributes']['value'] ?? 'value',
                 $config['attributes']['expiration'] ?? 'expires_at',
-                $this->getPrefix($config)
+                $this->getPrefix($config),
+                $config['consistent_read'] ?? false
             ),
             $config
         );

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -73,6 +73,8 @@ class DynamoDbStoreTest extends TestCase
 
         $app['config']->set('cache.default', 'dynamodb');
 
+        $app['config']->set('cache.stores.dynamodb.consistent_read', true);
+
         $config = $app['config']->get('cache.stores.dynamodb');
 
         /** @var \Aws\DynamoDb\DynamoDbClient $client */


### PR DESCRIPTION
This PR adds a `consistent_read` configuration option to the DynamoDB cache store,
allowing users to enable consistent reads when needed.

By default, DynamoDB uses eventually consistent reads for better performance and costs. 
However, there are cases where strongly consistent reads are necessary to ensure the most up-to-date data is retrieved. 
This change makes it possible to configure consistent reads.