### PR TITLE
[12.x] Add ability to define Arguments and Options for Artisan Commands with Attributes

### DIFF
--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -21,5 +21,6 @@ abstract class Argument
         public string $description = '',
         public array|bool|float|int|string|null $default = null,
         public array|Closure $suggestedValues = [],
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Closure;
+
+abstract class Argument
+{
+    /**
+     * @param  string  $name
+     * @param  bool  $required
+     * @param  bool  $array
+     * @param  string  $description
+     * @param  array|bool|float|int|string|null  $default
+     * @param  array|Closure  $suggestedValues
+     */
+    public function __construct(
+        public string $name,
+        public bool $required = true,
+        public bool $array = false,
+        public string $description = '',
+        public array|bool|float|int|string|null $default = null,
+        public array|Closure $suggestedValues = [],
+    ) {}
+}

--- a/src/Illuminate/Console/Attributes/FlagOption.php
+++ b/src/Illuminate/Console/Attributes/FlagOption.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use Symfony\Component\Console\Input\InputOption;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class FlagOption extends Option
+{
+    /**
+     * @param  string  $name
+     * @param  array|string|null  $shortcut
+     * @param  string  $description
+     * @param  bool  $negatable
+     */
+    public function __construct(
+        public string $name,
+        public array|string|null $shortcut = null,
+        public string $description = '',
+        public bool $negatable = false,
+    ) {
+        parent::__construct(
+            name: $name,
+            shortcut: $shortcut,
+            mode: $negatable ? InputOption::VALUE_NEGATABLE | InputOption::VALUE_NONE : InputOption::VALUE_NONE,
+            description: $description,
+        );
+    }
+}

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -22,5 +22,6 @@ abstract class Option
         public string $description = '',
         public array|bool|float|int|string|null $default = null,
         public array|Closure $suggestedValues = [],
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Closure;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class Option
+{
+    /**
+     * @param  string  $name
+     * @param  array|string|null  $shortcut
+     * @param  int  $mode
+     * @param  string  $description
+     * @param  array|bool|float|int|string|null  $default
+     * @param  array|Closure  $suggestedValues
+     */
+    public function __construct(
+        public string $name,
+        public array|string|null $shortcut = null,
+        public int $mode = InputOption::VALUE_NONE,
+        public string $description = '',
+        public array|bool|float|int|string|null $default = null,
+        public array|Closure $suggestedValues = [],
+    ) {}
+}

--- a/src/Illuminate/Console/Attributes/OptionalArgument.php
+++ b/src/Illuminate/Console/Attributes/OptionalArgument.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use Closure;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class OptionalArgument extends Argument
+{
+    /**
+     * @param  string  $name
+     * @param  bool  $array
+     * @param  string  $description
+     * @param  array|bool|float|int|string|null  $default
+     * @param  array|Closure  $suggestedValues
+     */
+    public function __construct(
+        public string $name,
+        public bool $array = false,
+        public string $description = '',
+        public array|bool|float|int|string|null $default = null,
+        public array|Closure $suggestedValues = [],
+    ) {
+        parent::__construct(
+            name: $name,
+            required: false,
+            array: $array,
+            description: $description,
+            default: $default,
+            suggestedValues: $suggestedValues,
+        );
+    }
+}

--- a/src/Illuminate/Console/Attributes/RequiredArgument.php
+++ b/src/Illuminate/Console/Attributes/RequiredArgument.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use Closure;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class RequiredArgument extends Argument
+{
+    /**
+     * @param  string  $name
+     * @param  bool  $array
+     * @param  string  $description
+     * @param  array|Closure  $suggestedValues
+     */
+    public function __construct(
+        public string $name,
+        public bool $array = false,
+        public string $description = '',
+        public array|Closure $suggestedValues = [],
+    ) {
+        parent::__construct(
+            name: $name,
+            array: $array,
+            description: $description,
+            suggestedValues: $suggestedValues,
+        );
+    }
+}

--- a/src/Illuminate/Console/Attributes/ValueOption.php
+++ b/src/Illuminate/Console/Attributes/ValueOption.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use Closure;
+use Symfony\Component\Console\Input\InputOption;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ValueOption extends Option
+{
+    /**
+     * @param  string  $name
+     * @param  bool  $array
+     * @param  array|string|null  $shortcut
+     * @param  string  $description
+     * @param  array|bool|float|int|string|null $default
+     * @param  array|Closure $suggestedValues
+     */
+    public function __construct(
+        public string $name,
+        public bool $array = false,
+        public array|string|null $shortcut = null,
+        public string $description = '',
+        public array|bool|float|int|string|null $default = null,
+        public array|Closure $suggestedValues = [],
+    ) {
+        parent::__construct(
+            name: $name,
+            shortcut: $shortcut,
+            mode: $array ? InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL : InputOption::VALUE_OPTIONAL,
+            description: $description,
+            default: $default,
+            suggestedValues: $suggestedValues,
+        );
+    }
+}

--- a/src/Illuminate/Console/Attributes/ValueOption.php
+++ b/src/Illuminate/Console/Attributes/ValueOption.php
@@ -14,16 +14,16 @@ class ValueOption extends Option
      * @param  bool  $array
      * @param  array|string|null  $shortcut
      * @param  string  $description
-     * @param  array|bool|float|int|string|null $default
-     * @param  array|Closure $suggestedValues
+     * @param  array|bool|float|int|string|null  $default
+     * @param  array|Closure  $suggestedValues
      */
     public function __construct(
         public string $name,
         public bool $array = false,
         public array|string|null $shortcut = null,
         public string $description = '',
-        public array|bool|float|int|string|null  $default = null,
-        public array|Closure  $suggestedValues = [],
+        public array|bool|float|int|string|null $default = null,
+        public array|Closure $suggestedValues = [],
     ) {
         parent::__construct(
             name: $name,

--- a/src/Illuminate/Console/Attributes/ValueOption.php
+++ b/src/Illuminate/Console/Attributes/ValueOption.php
@@ -22,8 +22,8 @@ class ValueOption extends Option
         public bool $array = false,
         public array|string|null $shortcut = null,
         public string $description = '',
-        public array|bool|float|int|string|null $default = null,
-        public array|Closure $suggestedValues = [],
+        public array|bool|float|int|string|null  $default = null,
+        public array|Closure  $suggestedValues = [],
     ) {
         parent::__construct(
             name: $name,

--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -57,7 +57,6 @@ trait HasParameters
             return [];
         }
 
-        $arguments = [];
         $generalArguments = $this->buildArgumentsList($attributes, Argument::class);
 
         $requiredArguments = $this->buildArgumentsList($attributes, RequiredArgument::class)
@@ -72,19 +71,11 @@ trait HasParameters
                 fn (array $argument) => $argument['mode'] === InputArgument::OPTIONAL || $argument['mode'] === InputArgument::IS_ARRAY)
             );
 
-        foreach ($nonArrayArguments as $argument) {
-            $arguments[] = $argument;
-        }
-
-        foreach ($optionalArguments as $argument) {
-            $arguments[] = $argument;
-        }
-
-        foreach ($arrayArguments as $argument) {
-            $arguments[] = $argument;
-        }
-
-        return $arguments;
+        return [
+            ...$nonArrayArguments,
+            ...$optionalArguments,
+            ...$arrayArguments,
+        ];
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -92,19 +92,13 @@ trait HasParameters
             return [];
         }
 
-        $options = [];
         $valueOptions = $this->buildOptionsList($attributes, ValueOption::class);
         $flagOptions = $this->buildOptionsList($attributes, FlagOption::class);
 
-        foreach ($valueOptions as $option) {
-            $options[] = $option;
-        }
-
-        foreach ($flagOptions as $option) {
-            $options[] = $option;
-        }
-
-        return $options;
+        return [
+            ...$valueOptions,
+            ...$flagOptions,
+        ];
     }
 
     private function buildArgumentsList(Collection $attributes, string $attributeClass): Collection

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -19,11 +19,9 @@ class CommandAttributesTest extends TestCase
         $command = resolve(TestCommand::class);
         $definition = $command->getDefinition();
         $arguments = Collection::make($definition->getArguments())
-            ->keyBy(fn (InputArgument $argument) => $argument->getName()
-        );
+            ->keyBy(fn (InputArgument $argument) => $argument->getName());
         $options = Collection::make($definition->getOptions())
-            ->keyBy(fn (InputOption $option) => $option->getName()
-        );
+            ->keyBy(fn (InputOption $option) => $option->getName());
 
         $this->assertCount(2, $arguments);
         $this->assertTrue($arguments->get('name')->isRequired());

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Attributes\FlagOption;
+use Illuminate\Console\Attributes\OptionalArgument;
+use Illuminate\Console\Attributes\RequiredArgument;
+use Illuminate\Console\Attributes\ValueOption;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class CommandAttributesTest extends TestCase
+{
+    public function testCommandAttributesForArgumentsAndOptions()
+    {
+        $command = resolve(TestCommand::class);
+        $definition = $command->getDefinition();
+        $arguments = Collection::make($definition->getArguments())
+            ->keyBy(fn (InputArgument $argument) => $argument->getName()
+        );
+        $options = Collection::make($definition->getOptions())
+            ->keyBy(fn (InputOption $option) => $option->getName()
+        );
+
+        $this->assertCount(2, $arguments);
+        $this->assertTrue($arguments->get('name')->isRequired());
+        $this->assertFalse($arguments->get('age')->isRequired());
+        $this->assertEquals(18, $arguments->get('age')->getDefault());
+
+        $this->assertCount(3, $options);
+        $this->assertEquals('m', $options->get('negative')->getShortcut());
+        $this->assertTrue($options->get('negative')->isNegatable());
+        $this->assertEquals('The year', $options->get('year')->getDescription());
+        $this->assertTrue($options->get('scores')->isArray());
+        $this->assertEquals([1, 2, 3], $options->get('scores')->getDefault());
+    }
+}
+
+#[RequiredArgument(name: 'name')]
+#[OptionalArgument(name: 'age', default: 18)]
+#[FlagOption(name: 'negative', shortcut: 'm', negatable: true)]
+#[ValueOption(name: 'year', description: 'The year')]
+#[ValueOption(name: 'scores', array: true, default: [1, 2, 3])]
+class TestCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'app:test';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Overview

Since Laravel is using PHP Attributes to enhance the features in the Framework, I thought of adding the ability to define Arguments and Options in Artisan Commands with them. Currently we can use the signature of a command for doing it:

```php
protected $signature = 'mail:send {user} {--queue}';
```

## Changes

With this PR, I introduce four different attributes:

* `RequiredArgument` - for arguments that are required
* `OptionalArgument` - for arguments that are optional
* `FlagOption` - for options that behave like flags
* `ValueOption` - for options that can have values

## Examples

For the example shared above, this would be how it would look like with the Attributes.

```php
#[RequiredArgument(name: 'user')]
#[FlagOption(name: 'queue')]
class SendMail extends command
{
    protected $name = 'mail:send';
}
```

This is an example with all the Attributes, with more configurations so you can have an idea how it would look like:

```php
#[RequiredArgument(name: 'name')]
#[OptionalArgument(name: 'age', default: 18)]
#[FlagOption(name: 'negative', shortcut: 'm', negatable: true)]
#[ValueOption(name: 'year', description: 'The year')]
#[ValueOption(name: 'scores', array: true, default: [1, 2, 3])]
class TestCommand extends Command
{
    protected $name = 'app:test';
}
```