### PR TITLE
[12.x] Add isRegex stringable helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -591,6 +591,25 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid regex.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isRegex($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        if ($value === '') {
+            return false;
+        }
+
+        return @preg_match($value, '') !== false;
+    }
+
+    /**
      * Determine if a given value is a valid URL.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -380,6 +380,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string is valid Regex.
+     *
+     * @return bool
+     */
+    public function isRegex()
+    {
+        return Str::isRegex($this->value);
+    }
+
+    /**
      * Determine if a given value is a valid URL.
      *
      * @param  array  $protocols

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -81,6 +81,43 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable(null)->isJson());
     }
 
+    public function testIsRegex()
+    {
+        // Test valid regex patterns
+        $this->assertTrue($this->stringable('/hello/')->isRegex());
+        $this->assertTrue($this->stringable('/hello/i')->isRegex());
+        $this->assertTrue($this->stringable('/^[a-z]+$/')->isRegex());
+        $this->assertTrue($this->stringable('/\d+/')->isRegex());
+        $this->assertTrue($this->stringable('~hello world~')->isRegex());
+        $this->assertTrue($this->stringable('@hello@i')->isRegex());
+        $this->assertTrue($this->stringable('#[a-zA-Z0-9]#')->isRegex());
+        $this->assertTrue($this->stringable('![a-z]+!u')->isRegex());
+        $this->assertTrue($this->stringable('%\s+%m')->isRegex());
+
+        // Test complex valid patterns
+        $this->assertTrue($this->stringable('/(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})/')->isRegex());
+        $this->assertTrue($this->stringable('/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/')->isRegex());
+        $this->assertTrue($this->stringable('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/')->isRegex());
+
+        // Test invalid regex patterns
+        $this->assertFalse($this->stringable('/hello')->isRegex()); // Missing closing delimiter
+        $this->assertFalse($this->stringable('hello/')->isRegex()); // Missing opening delimiter
+        $this->assertFalse($this->stringable('/[a-z+/')->isRegex()); // Unclosed bracket
+        $this->assertFalse($this->stringable('/(/')->isRegex()); // Unclosed parenthesis
+        $this->assertFalse($this->stringable('/(?P<name>test/')->isRegex()); // Unclosed named group
+        $this->assertFalse($this->stringable()->isRegex()); // Empty string
+
+        // Test plain strings (not regex patterns)
+        $this->assertFalse($this->stringable('hello world')->isRegex());
+        $this->assertFalse($this->stringable('123')->isRegex());
+        $this->assertFalse($this->stringable('simple text')->isRegex());
+
+        // Test edge cases
+        $this->assertTrue($this->stringable('/./')->isRegex()); // Dot pattern
+        $this->assertTrue($this->stringable('/$/')->isRegex()); // End anchor
+        $this->assertTrue($this->stringable('/^$/')->isRegex()); // Empty line pattern
+    }
+
     public function testIsMatch()
     {
         $this->assertTrue($this->stringable('Hello, Laravel!')->isMatch('/.*,.*!/'));


### PR DESCRIPTION
## Overview

This PR adds an `isRegex` helper method that we can use to check if a string is a valid regex pattern.

## Examples

```php
$result = Str::of('/hello/')->isRegex(); // true
$result = Str::of('/hello/i')->isRegex(); // true
$result = Str::of('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/')->isRegex(); // true

$result = Str::of('')->isRegex(); // false
$result = Str::of('hello')->isRegex(); // false
$result = Str::of('/[a-z+/')->isRegex(); // false
```