### PR TITLE
[12.x] Adding support for specific events to Event::defer()

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void forgetPushed()
  * @method static \Illuminate\Events\Dispatcher setQueueResolver(callable $resolver)
  * @method static \Illuminate\Events\Dispatcher setTransactionManagerResolver(callable $resolver)
- * @method static mixed defer(callable $callback)
+ * @method static mixed defer(callable $callback, ?array $events = null)
  * @method static array getRawListeners()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -98,6 +98,84 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame(['inner', 'outer1', 'outer2'], $_SERVER['__event.test']);
     }
 
+    public function testDeferSpecificEvents()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+
+        $d->listen('foo', function ($foo) {
+            $_SERVER['__event.test'][] = $foo;
+        });
+
+        $d->listen('bar', function ($bar) {
+            $_SERVER['__event.test'][] = $bar;
+        });
+
+        $d->defer(function () use ($d) {
+            $d->dispatch('foo', ['deferred']);
+            $d->dispatch('bar', ['immediate']);
+
+            $this->assertSame(['immediate'], $_SERVER['__event.test']);
+        }, ['foo']);
+
+        $this->assertSame(['immediate', 'deferred'], $_SERVER['__event.test']);
+    }
+
+    public function testDeferSpecificNestedEvents()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+
+        $d->listen('foo', function ($foo) {
+            $_SERVER['__event.test'][] = $foo;
+        });
+
+        $d->listen('bar', function ($bar) {
+            $_SERVER['__event.test'][] = $bar;
+        });
+
+        $d->defer(function () use ($d) {
+            $d->dispatch('foo', ['outer-deferred']);
+            $d->dispatch('bar', ['outer-immediate']);
+
+            $this->assertSame(['outer-immediate'], $_SERVER['__event.test']);
+
+            $d->defer(function () use ($d) {
+                $d->dispatch('foo', ['inner-deferred']);
+                $d->dispatch('bar', ['inner-immediate']);
+
+                $this->assertSame(['outer-immediate', 'inner-immediate'], $_SERVER['__event.test']);
+            }, ['foo']);
+
+            $this->assertSame(['outer-immediate', 'inner-immediate', 'inner-deferred'], $_SERVER['__event.test']);
+        }, ['foo']);
+
+        $this->assertSame(['outer-immediate', 'inner-immediate', 'inner-deferred', 'outer-deferred'], $_SERVER['__event.test']);
+    }
+
+    public function testDeferSpecificObjectEvents()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+
+        $d->listen(DeferTestEvent::class, function () {
+            $_SERVER['__event.test'][] = 'DeferTestEvent';
+        });
+
+        $d->listen(ImmediateTestEvent::class, function () {
+            $_SERVER['__event.test'][] = 'ImmediateTestEvent';
+        });
+
+        $d->defer(function () use ($d) {
+            $d->dispatch(new DeferTestEvent());
+            $d->dispatch(new ImmediateTestEvent());
+
+            $this->assertSame(['ImmediateTestEvent'], $_SERVER['__event.test']);
+        }, [DeferTestEvent::class]);
+
+        $this->assertSame(['ImmediateTestEvent', 'DeferTestEvent'], $_SERVER['__event.test']);
+    }
+
     public function testHaltingEventExecution()
     {
         unset($_SERVER['__event.test']);
@@ -786,4 +864,12 @@ class TestListener3
     {
         $_SERVER['__event.test'][] = 'handle-3';
     }
+}
+
+class DeferTestEvent
+{
+}
+
+class ImmediateTestEvent
+{
 }


### PR DESCRIPTION
As a continuation of https://github.com/laravel/framework/pull/56556, a good point was raised: https://github.com/laravel/framework/pull/56556#issuecomment-3160831448

Which on second though the idea to being able to set specific events to defer, so now:

```php
Event::defer(function () {
    $parent = Parent::create();
    $parent->children()->create();
}, ['eloquent.created: '.Parent::class]);

Parent::created(function ($model) {
    $parent->children()->count(); // 1
});
```

That way, other events like `creating` will still be triggered, being able to have more control and avoid unexpected behavior. 