### PR TITLE
[12.x] Make `Pipeline` macroable

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -6,12 +6,14 @@ use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use Throwable;
 
 class Pipeline implements PipelineContract
 {
     use Conditionable;
+    use Macroable;
 
     /**
      * The container implementation.

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^12.0",
+        "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0"
     },
     "autoload": {


### PR DESCRIPTION
This is just a simple pull request to make `Pipeline` macroable so that we can add convenience methods to it in userland without needing to extend or decorate the class.