### PR TITLE
Blueprint mysql/mariadb table attributes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1653,7 +1653,7 @@ class Blueprint
     {
         return $this->addCommand('tableAttribute', [
             'attribute' => $attributeName,
-            'value' => $attributeValue
+            'value' => $attributeValue,
         ]);
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1646,6 +1646,18 @@ class Blueprint
     }
 
     /**
+     * Set an attribute of the table.
+     * This only works with the mysql or mariadb storage engines.
+     */
+    public function tableAttribute(string $attributeName, string $attributeValue): Fluent
+    {
+        return $this->addCommand('tableAttribute', [
+            'attribute' => $attributeName,
+            'value' => $attributeValue
+        ]);
+    }
+
+    /**
      * Create a new index command on the blueprint.
      *
      * @param  string  $type

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -693,6 +693,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a command that modifies a table attribute.
+     */
+    public function compileTableAttribute(Blueprint $blueprint, Fluent $command): string
+    {
+        return "alter table {$this->wrapTable($blueprint)} {$command->attribute} = {$command->value}";
+    }
+
+    /**
      * Quote-escape the given tables, views, or types.
      *
      * @param  array<string>  $names

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -655,6 +655,25 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `posts` add `note` tinytext not null default \'this\'\'ll work too\''], $getSql('MySql'));
     }
 
+    public function testTableAttribute()
+    {
+        // Test setting the innoDB row_format attribute
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->tableAttribute('ROW_FORMAT', 'COMPACT');
+            })->toSql();
+        };
+        $this->assertEquals(['alter table `posts` ROW_FORMAT = COMPACT'], $getSql('MySql'));
+
+        // Test setting the innoDB page compression attribute
+        $getSql = function ($grammar) {
+            return $this->getBlueprint($grammar, 'posts', function ($table) {
+                $table->tableAttribute('COMPRESSION', '"zlib"');
+            })->toSql();
+        };
+        $this->assertEquals(['alter table `posts` COMPRESSION = "zlib"'], $getSql('MySql'));
+    }
+
     protected function getConnection(?string $grammar = null, string $prefix = '')
     {
         $connection = m::mock(Connection::class)


### PR DESCRIPTION
This is a fairly minimal addition to the schema Blueprint class and mysql grammar that adds the ability to specify special table attributes for mysql/mariadb. This is useful for specifying the usage of some of the more advanced (but often underrated) features of the database engine as makes sense for a given project or workload. A fairly good example of useful attributes to control are the InnoDB page compression attributes supported on MySQL [(Docs)](https://dev.mysql.com/doc/refman/8.4/en/innodb-page-compression.html) and MariaDB [(Docs)](https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-page-compression), which can significantly reduce database storage footprints for many workloads at a fairly insignificant performance cost.

This does not break any existing features or applications as it is entirely additive, existing applications would need to explicitly utilize this new blueprint method to have any changes in functionality. Therefore, I think this minor feature should be fine to include an update to 12.x.