### PR TITLE
[12.x]: implement mergeIfMissing collection helper method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -882,6 +882,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Merge the collection with the given items, appending only the missing items.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeIfMissing($items)
+    {
+        return new static(array_merge($this->getArrayableItems($items), $this->items));
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -876,6 +876,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Merge the collection with the given items, appending only the missing items.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeIfMissing($items)
+    {
+        return $this->passthru('mergeIfMissing', func_get_args());
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1263,6 +1263,19 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testMergeIfMissingCollection($collection)
+    {
+        $a = new $collection(['name' => 'Hello']);
+        $b = new $collection(['surname' => 'World']);
+
+        $c = new $collection(['name' => 'Hello', 'surname' => 'World']);
+        $d = new $collection(['surname' => 'Laravel']);
+
+        $this->assertEquals(['name' => 'Hello', 'surname' => 'World'], $a->mergeIfMissing($b)->all());
+        $this->assertEquals(['name' => 'Hello', 'surname' => 'World'], $c->mergeIfMissing($d)->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testMergeRecursiveNull($collection)
     {
         $c = new $collection(['name' => 'Hello']);


### PR DESCRIPTION
# Add mergeIfMissing method to Collection

Adds a `mergeIfMissing()` method that merges items into a collection while preserving existing keys. Only keys that don't already exist in the original collection are added.

_This feature was inspired by Laravel's `$request->mergeIfMissing()` method._

## Current merge() method behaviour

The existing `merge()` method overwrites values for matching keys:

```php
$collection = collect(['name' => 'John', 'age' => 30, 'city' => 'Boston']);
$merged = $collection->merge(['age' => 25, 'city' => 'NYC', 'country' => 'USA']);

// Result: ['name' => 'John', 'age' => 25, 'city' => 'NYC', 'country' => 'USA']
// ❌ Original age (30) and city (Boston) were overwritten
```

## Solution with mergeIfMissing()

The new `mergeIfMissing()` method preserves existing values:

```php
$collection = collect(['name' => 'John', 'age' => 30, 'city' => 'Boston']);
$merged = $collection->mergeIfMissing(['age' => 25, 'city' => 'NYC', 'country' => 'USA']);

// Result: ['name' => 'John', 'age' => 30, 'city' => 'Boston', 'country' => 'USA']
// ✅ Original age (30) and city (Boston) preserved, only country added
```