### PR TITLE
[12.x]: collection put method works with dot notation

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1122,6 +1122,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         $this->offsetSet($key, $value);
+
         return $this;
     }
 
@@ -1146,6 +1147,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     protected function putWithDotNotation($key, $value)
     {
         Arr::set($this->items, $key, $value);
+
         return $this;
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1117,8 +1117,35 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function put($key, $value)
     {
-        $this->offsetSet($key, $value);
+        if ($this->usesDotNotation($key)) {
+            return $this->putWithDotNotation($key, $value);
+        }
 
+        $this->offsetSet($key, $value);
+        return $this;
+    }
+
+    /**
+     * Determine if the key contains the dot notation syntax.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    protected function usesDotNotation($key)
+    {
+        return is_string($key) && strpos($key, '.');
+    }
+
+    /**
+     * Put an item using dot notation.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    protected function putWithDotNotation($key, $value)
+    {
+        Arr::set($this->items, $key, $value);
         return $this;
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2472,6 +2472,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'dayle', 'email' => 'foo'], $data->all());
     }
 
+    public function testPutWithDotNotation()
+    {
+        $data = new Collection(['author' => ['name' => 'taylor']]);
+        $data = $data->put('author.lastname', 'otwell');
+        $this->assertEquals(['author' => ['name' => 'taylor', 'lastname' => 'otwell']], $data->all());
+    }
+
     public function testPutWithNoKey()
     {
         $data = new Collection(['taylor', 'shawn']);


### PR DESCRIPTION
# Add dot notation support to Collection put() method

Enhances the `put()` method to support dot notation for setting nested array values, making it easier to work with nested data structures.

*This PR is also inspired by another Laravel existing feature, which is the `Arr::set()` helper*

## Problem with current put() method

The existing `put()` method only works with top-level keys, making nested data manipulation cumbersome:

```php
$collection = collect(['author' => ['name' => 'Hello']]);
$collection->put('author.name', 'Laravel');

// Current result
[
    "author" => ["name" => "Hello"],
    "author.name" => "Laravel"  // ❌ Unwanted literal key
]

// How you can workaround this currently:
$author = $collection->get('author');
$author['name'] = 'Laravel';
$collection->put('author', $author);
```

## Solution with dot notation support

The enhanced `put()` method automatically detects dot notation and upserts nested structures:

```php
$collection = collect(['author' => ['name' => 'Hello']]);
$collection->put('author.name', 'Laravel');

// Properly updates nested values
[
    "author" => ["name" => "Laravel"]  // ✅ Nested value updated
]

// Properly ads new nested values
$collection->put('author.surname', 'World');
[
    "author" => [
        "name" => "Laravel",
        "surname" => "World"  // ✅ New nested value added
    ]
]
```

## Why this is a good feature IMO:
- No breaking changes
- Follows dot notation patterns used throughout the framework
- Method chaining preserved