### PR TITLE
[12.x]: collection get method works with dot notation

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -482,7 +482,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function get($key, $default = null)
     {
-        if ($this->usesDotNotation($key)){
+        if ($this->usesDotNotation($key)) {
             return Arr::get($this->items, $key, $default);
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -482,6 +482,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function get($key, $default = null)
     {
+        if ($this->usesDotNotation($key)){
+            return Arr::get($this->items, $key, $default);
+        }
+
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
@@ -1120,6 +1124,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $this->offsetSet($key, $value);
 
         return $this;
+    }
+
+    /**
+     * Determine if the key contains the dot notation syntax.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    protected function usesDotNotation($key)
+    {
+        return is_string($key) && strpos($key, '.');
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2434,6 +2434,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    public function testGetWithDotSyntax()
+    {
+        $data = new Collection(['author' => ['name' => 'taylor', 'email' => 'foo']]);
+
+        $this->assertSame('taylor', $data->get('author.name'));
+    }
+
     public function testGetOrPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);


### PR DESCRIPTION
# Add dot notation support to Collection get() method

Enhances the `get()` method to support dot notation for setting nested array values, making it easier to work with nested data structures.

*This PR is complementary to #56573*

## Problem with current put() method

The existing `get()` method only works with top-level keys, making nested data fetching complicated:

```php
$collection = collect(['author' => ['name' => 'Hello']]);
$collection->get('author.name');

// It will return `null`
```

## Solution with dot notation support

```php
$collection = collect(['author' => ['name' => 'Hello']]);
$collection->get('author.name');

// It will return `Hello`
```

## Why this is a good feature IMO:
- No breaking changes
- Follows dot notation patterns used throughout the framework
- Method chaining preserved