### PR TITLE
[12.x] add Collection fromCsv method 

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -203,7 +203,7 @@ trait EnumeratesValues
     {
         $body = str($body)->replace(["\r\n", "\r"], "\n")->value();
 
-        $lines = tap(collect(explode(PHP_EOL, $body)), fn ($collection) => $collection->filter())->all();
+        $lines = tap(collect(explode("\n", $body)), fn ($collection) => $collection->filter())->all();
 
         if (empty($lines)) {
             return new static();

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -201,9 +201,7 @@ trait EnumeratesValues
      */
     public static function fromCsv($body, $hasHeader = false, $separator = ',', $enclosure = '"', $escape = '\\')
     {
-        $body = str($body)->replace(["\r\n", "\r"], "\n")->value();
-
-        $lines = tap(collect(explode("\n", $body)), fn ($collection) => $collection->filter())->all();
+        $lines = tap(collect(explode(PHP_EOL, $body)), fn ($collection) => $collection->filter())->all();
 
         if (empty($lines)) {
             return new static();

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -201,6 +201,8 @@ trait EnumeratesValues
      */
     public static function fromCsv($body, $hasHeader = false, $separator = ',', $enclosure = '"', $escape = '\\')
     {
+        $body = str($body)->replace(["\r\n", "\r"], "\n")->value();
+
         $lines = tap(collect(explode(PHP_EOL, $body)), fn ($collection) => $collection->filter())->all();
 
         if (empty($lines)) {
@@ -210,7 +212,7 @@ trait EnumeratesValues
         $header = $hasHeader ? collect(str_getcsv(array_shift($lines), $separator, $enclosure, $escape)) : false;
 
         return collect($lines)->map(fn ($row) => str_getcsv($row, $separator))
-            ->when($hasHeader, function(Collection $collection) use ($header) {
+            ->when($hasHeader, function (Collection $collection) use ($header) {
                 return $collection->map(fn ($row) => $header->combine($row)->all());
             });
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -211,7 +211,7 @@ trait EnumeratesValues
 
         $header = $hasHeader ? collect(str_getcsv(array_shift($lines), $separator, $enclosure, $escape)) : false;
 
-        return collect($lines)->map(fn ($row) => str_getcsv($row, $separator))
+        return collect($lines)->map(fn ($row) => str_getcsv($row, $separator, $enclosure, $escape))
             ->when($hasHeader, function (Collection $collection) use ($header) {
                 return $collection->map(fn ($row) => $header->combine($row)->all());
             });

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -199,9 +199,9 @@ trait EnumeratesValues
      * @param  string  $escape
      * @return static<TKey, TValue>
      */
-    public static function fromCsv($body, $hasHeader = false, $separator = ',', $enclosure = '"', $escape = "\\")
+    public static function fromCsv($body, $hasHeader = false, $separator = ',', $enclosure = '"', $escape = '\\')
     {
-        $lines = tap(collect(explode(PHP_EOL, $body)), fn($collection) => $collection->filter())->all();
+        $lines = tap(collect(explode(PHP_EOL, $body)), fn ($collection) => $collection->filter())->all();
 
         if (empty($lines)) {
             return new static();
@@ -209,7 +209,7 @@ trait EnumeratesValues
 
         $header = $hasHeader ? collect(str_getcsv(array_shift($lines), $separator, $enclosure, $escape)) : false;
 
-        return collect($lines)->map(fn($row) => str_getcsv($row, $separator))
+        return collect($lines)->map(fn ($row) => str_getcsv($row, $separator))
             ->when($hasHeader, function(Collection $collection) use ($header) {
                 return $collection->map(fn($row) => $header->combine($row)->all());
             });

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -211,7 +211,7 @@ trait EnumeratesValues
 
         return collect($lines)->map(fn ($row) => str_getcsv($row, $separator))
             ->when($hasHeader, function(Collection $collection) use ($header) {
-                return $collection->map(fn($row) => $header->combine($row)->all());
+                return $collection->map(fn ($row) => $header->combine($row)->all());
             });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2436,8 +2436,8 @@ class SupportCollectionTest extends TestCase
 
     public function testFromCsv()
     {
-        $csvWithoutHeaders = "John;30" . PHP_EOL . "Jane;25";
-        $csvWithHeaders = "Name;Age" . PHP_EOL . "John;30";
+        $csvWithoutHeaders = 'John;30'.PHP_EOL.'Jane;25';
+        $csvWithHeaders = 'Name;Age'.PHP_EOL.'John;30';
 
         $collectionWithoutHeaders = Collection::fromCsv(body: $csvWithoutHeaders, separator: ';');
         $collectionWithHeaders = Collection::fromCsv(body: $csvWithHeaders, hasHeader: true, separator: ';');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2434,6 +2434,18 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    public function testFromCsv()
+    {
+        $csvWithoutHeaders = "John;30\nJane;25";
+        $csvWithHeaders = "Name;Age\nJohn;30";
+
+        $collectionWithoutHeaders = Collection::fromCsv(body: $csvWithoutHeaders, separator: ';');
+        $collectionWithHeaders = Collection::fromCsv(body: $csvWithHeaders, hasHeader: true, separator: ';');
+
+        $this->assertSame([['Name' => 'John', 'Age' => '30']], $collectionWithHeaders->all());
+        $this->assertSame([['John', '30'], ['Jane', '25']], $collectionWithoutHeaders->all());
+    }
+
     public function testGetOrPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2436,8 +2436,8 @@ class SupportCollectionTest extends TestCase
 
     public function testFromCsv()
     {
-        $csvWithoutHeaders = "John;30\nJane;25";
-        $csvWithHeaders = "Name;Age\nJohn;30";
+        $csvWithoutHeaders = "John;30" . PHP_EOL . "Jane;25";
+        $csvWithHeaders = "Name;Age" . PHP_EOL . "John;30";
 
         $collectionWithoutHeaders = Collection::fromCsv(body: $csvWithoutHeaders, separator: ';');
         $collectionWithHeaders = Collection::fromCsv(body: $csvWithHeaders, hasHeader: true, separator: ';');


### PR DESCRIPTION
# Add `fromCsv` Method to `Collection` Class

## Introduction
This PR introduces a new `fromCsv` static method to the `Illuminate\Support\Collection` class, enabling the creation of a collection by parsing a CSV string. Similar to the existing `fromJson` method, `fromCsv` provides a convenient way to handle CSV data, with support for headers, custom delimiters, enclosures, and escape characters. 

## How to Use It
```php
// With headers
$csv = "name,age\nJohn,30\nJane,25";
$collection = Collection::fromCsv($csv, true);
$collection->all();
// [['name' => 'John', 'age' => '30'], ['name' => 'Jane', 'age' => '25']]

// Without headers
$csv = "John,30\nJane,25";
$collection = Collection::fromCsv($csv, false);
$collection->all();
// [['John', '30'], ['Jane', '25']]

// Custom separator and quoted values
$csv = "name;description\nJohn;\"Software, Engineer\"\nJane;\"Data, Scientist\"";
$collection = Collection::fromCsv($csv, true, ';');
$collection->all();
// [['name' => 'John', 'description' => 'Software, Engineer'], ['name' => 'Jane', 'description' => 'Data, Scientist']]
```
