### PR TITLE
[12.x] Prevent unintended sleep on early failure of assertSequence

### DIFF
--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -428,29 +428,37 @@ class Sleep
      */
     public static function assertSequence($sequence)
     {
-        static::assertSleptTimes(count($sequence));
+        try {
+            static::assertSleptTimes(count($sequence));
 
-        (new Collection($sequence))
-            ->zip(static::$sequence)
-            ->eachSpread(function (?Sleep $expected, CarbonInterval $actual) {
-                if ($expected === null) {
-                    return;
+            (new Collection($sequence))
+                ->zip(static::$sequence)
+                ->eachSpread(function (?Sleep $expected, CarbonInterval $actual) {
+                    if ($expected === null) {
+                        return;
+                    }
+
+                    PHPUnit::assertTrue(
+                        $expected->shouldNotSleep()->duration->equalTo($actual),
+                        vsprintf('Expected sleep duration of [%s] but actually slept for [%s].', [
+                            $expected->duration->cascade()->forHumans([
+                                'options' => 0,
+                                'minimumUnit' => 'microsecond',
+                            ]),
+                            $actual->cascade()->forHumans([
+                                'options' => 0,
+                                'minimumUnit' => 'microsecond',
+                            ]),
+                        ])
+                    );
+                });
+        } finally {
+            foreach ($sequence as $expected) {
+                if ($expected instanceof self) {
+                    $expected->shouldNotSleep();
                 }
-
-                PHPUnit::assertTrue(
-                    $expected->shouldNotSleep()->duration->equalTo($actual),
-                    vsprintf('Expected sleep duration of [%s] but actually slept for [%s].', [
-                        $expected->duration->cascade()->forHumans([
-                            'options' => 0,
-                            'minimumUnit' => 'microsecond',
-                        ]),
-                        $actual->cascade()->forHumans([
-                            'options' => 0,
-                            'minimumUnit' => 'microsecond',
-                        ]),
-                    ])
-                );
-            });
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When `Sleep::assertSequence` is given `Sleep` instances as "expected" values and

1. the count assertion fails or
2. one of the duration checks fail (since we are going one by one via `each`)

the remaining `Sleep` objects can execute their destructors before they’ve been marked as "do not sleep".

This makes the tests run for a longer time than expected because the remaining `Sleep` objects will actually sleep, even though this is unintended.

Reproduction:

```php
/**
 * Expected runtime: instant
 * Actual runtime: 3 seconds
 * Reason: in the `each` call, the first instance will fail the test, therefore
 * the second instance won't be marked as "do not sleep" - it will sleep
 */
it('will fail the first iteration', function () {
    Sleep::fake();

    Sleep::sleep(3);
    Sleep::sleep(3);

    Sleep::assertSequence([
        Sleep::sleep(3.1),
        Sleep::sleep(3),
    ]);
});

/**
 * Expected runtime: instant
 * Actual runtime: 3 seconds
 * Reason: the count assertion fails, no instance will be marked as "do not sleep" - they will sleep
 */
it('will fail the count assertion', function () {
    Sleep::fake();

    Sleep::sleep(3);
    Sleep::sleep(3);

    Sleep::assertSequence([
        Sleep::sleep(3),
    ]);
});
```