### PR TITLE
[12.x] Add shared property to #[Bind] attribute for singleton service binding

### DIFF
--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -25,6 +25,11 @@ class Bind
     public array $environments = [];
 
     /**
+     * Should the class binding be shared in the container.
+     */
+    public bool $shared;
+
+    /**
      * Create a new attribute instance.
      *
      * @param  class-string  $concrete
@@ -35,6 +40,7 @@ class Bind
     public function __construct(
         string $concrete,
         string|array $environments = ['*'],
+        bool $shared = false,
     ) {
         $environments = array_filter(is_array($environments) ? $environments : [$environments]);
 
@@ -49,5 +55,7 @@ class Bind
             $environment instanceof UnitEnum => $environment->name,
             default => $environment,
         }, $environments);
+
+        $this->shared = $shared;
     }
 }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1008,10 +1008,11 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getConcreteBindingFromAttributes($abstract, $reflectedAttributes)
     {
-        $concrete = $maybeConcrete = null;
+        $concrete = $maybeConcrete = $shared = null;
 
         foreach ($reflectedAttributes as $reflectedAttribute) {
             $instance = $reflectedAttribute->newInstance();
+            $shared = $instance->shared;
 
             if ($instance->environments === ['*']) {
                 $maybeConcrete = $instance->concrete;
@@ -1034,7 +1035,7 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
-        $this->bind($abstract, $concrete);
+        $this->bind($abstract, $concrete, $shared ?? false);
 
         return $this->bindings[$abstract]['concrete'];
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -777,6 +777,26 @@ class ContainerTest extends TestCase
         $this->assertSame($firstInstantiation, $secondInstantiation);
     }
 
+    public function testBindInterfaceToNonSingletonAndMakeSharedViaBinding()
+    {
+        $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($arr) => true);
+        $firstInstantiation = $container->get(ContainerBindNonSingletonButSharedTestInterface::class);
+        $secondInstantiation = $container->get(ContainerBindNonSingletonButSharedTestInterface::class);
+
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+    }
+
+    public function testBindInterfaceToNonSingletonAndMakeNotSharedViaBinding()
+    {
+        $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($arr) => true);
+        $firstInstantiation = $container->get(ContainerBindNonSingletonAndNotSharedTestInterface::class);
+        $secondInstantiation = $container->get(ContainerBindNonSingletonAndNotSharedTestInterface::class);
+
+        $this->assertNotSame($firstInstantiation, $secondInstantiation);
+    }
+
     public function testBindInterfaceToScoped()
     {
         $container = new Container;
@@ -1040,6 +1060,10 @@ class ContainerSingletonAttribute
 {
 }
 
+class ContainerNonSingletonAttribute
+{
+}
+
 #[Scoped]
 class ContainerScopedAttribute
 {
@@ -1047,6 +1071,16 @@ class ContainerScopedAttribute
 
 #[Bind(ContainerSingletonAttribute::class, environments: ['foo', ContainerTestEnvironments::Bar])]
 interface ContainerBindSingletonTestInterface
+{
+}
+
+#[Bind(ContainerNonSingletonAttribute::class, shared: true)]
+interface ContainerBindNonSingletonButSharedTestInterface
+{
+}
+
+#[Bind(ContainerNonSingletonAttribute::class, shared: false)]
+interface ContainerBindNonSingletonAndNotSharedTestInterface
 {
 }
 


### PR DESCRIPTION
This PR extends the `#[Bind]` attribute by introducing a 'new' `shared` argument to control whether the bound service should be registered as a singleton (shared) in the service container.

**Example:**

```php
#[Bind(ChatService::class, shared: true)]
interface ChatServiceInterface
{
    public function send(string $message): void;
}
```

<br>

**Why?**

Because our current AppServiceProvider looks like this and I would love to move everything to the interface instead and not use an extra `#[Singleton]` on the service class:

```php
$this->app->bind(Interfaces\Services\ExampleServiceInterface::class, Services\ExampleService::class, true);
```