### PR TITLE
[12.x] Fixed version increment

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '12.21.0';
+    const VERSION = '12.22.0';
 
     /**
      * The base path for the Laravel installation.


### PR DESCRIPTION
The version of the latest release is still `12.21.0`, should be `12.22.0`.
This will require retagging or patch version increment to `12.22.1`.