### PR TITLE
[12.x] Normalize file path separators in `make:migration` command on Windows

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -170,7 +170,13 @@ class MigrationCreator
      */
     protected function getPath($name, $path)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        $path = $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+
+        if (windows_os()) {
+            $path = str_replace('/', '\\', $path);
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
This PR adds path normalization to the `make:migration` command by replacing forward slashes with backslashes on Windows.

## Why
Currently, the `make:migration` command in Laravel generates migration file paths using mixed directory separators on Windows systems.
This differs from other `make:` commands that extend the `src/Illuminate/Console/GeneratorCommand.php` class, which normalize paths by replacing forward slashes with backslashes on Windows:

https://github.com/laravel/framework/blob/12.x/src/Illuminate/Console/GeneratorCommand.php#L189

## Changes
Before:
```shell
INFO  Migration [C:\path\to\project\database\migrations/2025_08_08_083902_test.php] created successfully.  
```

After:
```shell
INFO  Migration [C:\path\to\project\database\migrations\2025_08_08_083902_test.php] created successfully.  
```
