### PR TITLE
[12.x] Alias Benchmark class

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Benchmark;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Js;
 use Illuminate\Support\Number;
@@ -276,6 +277,7 @@ abstract class Facade
             'Arr' => Arr::class,
             'Artisan' => Artisan::class,
             'Auth' => Auth::class,
+            'Benchmark' => Benchmark::class,
             'Blade' => Blade::class,
             'Broadcast' => Broadcast::class,
             'Bus' => Bus::class,


### PR DESCRIPTION
I end up using Benchmark a lot, mainly in Tinker.  It would be nice to have an alias: 

Before
```
Psy Shell v0.12.10 (PHP 8.4.6 — cli) by Justin Hileman
> Benchmark::measure(fn() => 1+1);

   Error  Class "Benchmark" not found.
   
  // Need the full path ^...
```

After
```
> Benchmark::measure(fn() => 1+1);
= 0.001667
```