### PR TITLE
Fix return type docblock for resetAttempts method in RateLimiter

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -210,7 +210,7 @@ class RateLimiter
      * Reset the number of attempts for the given key.
      *
      * @param  string  $key
-     * @return mixed
+     * @return bool
      */
     public function resetAttempts($key)
     {

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -11,7 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static int increment(string $key, \DateTimeInterface|\DateInterval|int $decaySeconds = 60, int $amount = 1)
  * @method static int decrement(string $key, \DateTimeInterface|\DateInterval|int $decaySeconds = 60, int $amount = 1)
  * @method static mixed attempts(string $key)
- * @method static mixed resetAttempts(string $key)
+ * @method static bool resetAttempts(string $key)
  * @method static int remaining(string $key, int $maxAttempts)
  * @method static int retriesLeft(string $key, int $maxAttempts)
  * @method static void clear(string $key)


### PR DESCRIPTION
This PR fixes the return type docblock from `mixed` to `bool` in the `resetAttempts` method in RateLimiter.