### PR TITLE
[12.x] Add support for inline attachments in Resend transport

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -73,7 +73,7 @@ class ResendTransport extends AbstractTransport
             foreach ($email->getAttachments() as $attachment) {
                 $attachmentHeaders = $attachment->getPreparedHeaders();
                 $contentType = $attachmentHeaders->get('Content-Type')->getBody();
-
+                $disposition = $attachmentHeaders->getHeaderBody('Content-Disposition');
                 $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
 
                 if ($contentType == 'text/calendar') {
@@ -87,6 +87,10 @@ class ResendTransport extends AbstractTransport
                     'content' => $content,
                     'filename' => $filename,
                 ];
+
+                if ($disposition === 'inline') {
+                    $item['inline_content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
+                }
 
                 $attachments[] = $item;
             }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for inline attachments in the Resend mailer. Support for inline attachments was recently added by the Resend team in https://github.com/resend/resend-laravel/pull/87 and this PR simply adds the same support to the framework.
