### PR TITLE
[12.x] Adds per-user Policies Group

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -90,7 +90,7 @@ class Gate implements GateContract
      *
      * @var bool
      */
-    protected $usesPoliciesGroup;
+    protected $shouldGroupPoliciesByUser;
 
     /**
      * Create a new gate instance.
@@ -755,9 +755,9 @@ class Gate implements GateContract
      * @param  bool $use
      * @return $this
      */
-    public function usePoliciesGroup($use = true)
+    public function groupPoliciesByUser($use = true)
     {
-        $this->usesPoliciesGroup = $use;
+        $this->shouldGroupPoliciesByUser = $use;
 
         return $this;
     }
@@ -770,8 +770,8 @@ class Gate implements GateContract
      */
     protected function getPoliciesGroup($class)
     {
-        if ($this->usesPoliciesGroup && $user = $this->resolveUser()) {
-            return method_exists($user, 'policiesGroup') ? $user->policiesGroup($class) : class_basename($user);
+        if ($this->shouldGroupPoliciesByUser && $user = $this->resolveUser()) {
+            return method_exists($user, 'groupPoliciesBy') ? $user->groupPoliciesBy($class) : class_basename($user);
         }
 
         return false;

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -738,9 +738,9 @@ class Gate implements GateContract
         })->when(str_contains($classDirname, '\\Models\\'), function ($collection) use ($class, $classDirname) {
             return $collection->concat([str_replace('\\Models\\', '\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy'])
                 ->concat([str_replace('\\Models\\', '\\Models\\Policies\\', $classDirname).'\\'.class_basename($class).'Policy']);
-        })->when($this->getPoliciesGroup($class), function ($collection, $group) use ($classDirname) {
+        })->when($this->getPoliciesGroup($class), function ($collection, $group) {
             return $collection->concat(
-                $collection->map(function ($policy) use ($classDirname, $group) {
+                $collection->map(function ($policy) use ($group) {
                     return str_replace('\\Policies\\', '\\Policies\\' . $group . '\\', $policy);
                 })
             );

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -752,7 +752,7 @@ class Gate implements GateContract
     /**
      * Groups guessed policies by an additional namespace based on the authenticatable user.
      *
-     * @param  bool $use
+     * @param  bool  $use
      * @return $this
      */
     public function groupPoliciesByUser($use = true)

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -23,7 +23,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static mixed raw(string $ability, array|mixed $arguments = [])
  * @method static mixed getPolicyFor(object|string $class)
  * @method static \Illuminate\Auth\Access\Gate guessPolicyNamesUsing(callable $callback)
- * @method static \Illuminate\Auth\Access\Gate usePoliciesGroup(bool $use = true)
+ * @method static \Illuminate\Auth\Access\Gate groupPoliciesByUser(bool $use = true)
  * @method static mixed resolvePolicy(object|string $class)
  * @method static \Illuminate\Auth\Access\Gate forUser(\Illuminate\Contracts\Auth\Authenticatable|mixed $user)
  * @method static array abilities()

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -23,6 +23,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static mixed raw(string $ability, array|mixed $arguments = [])
  * @method static mixed getPolicyFor(object|string $class)
  * @method static \Illuminate\Auth\Access\Gate guessPolicyNamesUsing(callable $callback)
+ * @method static \Illuminate\Auth\Access\Gate usePoliciesGroup(bool $use = true)
  * @method static mixed resolvePolicy(object|string $class)
  * @method static \Illuminate\Auth\Access\Gate forUser(\Illuminate\Contracts\Auth\Authenticatable|mixed $user)
  * @method static array abilities()

--- a/tests/Integration/Auth/Fixtures/AuthenticationTestUserWithPoliciesGroup.php
+++ b/tests/Integration/Auth/Fixtures/AuthenticationTestUserWithPoliciesGroup.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Integration\Auth\Fixtures;
 
 class AuthenticationTestUserWithPoliciesGroup extends AuthenticationTestUser
 {
-    public function policiesGroup()
+    public function groupPoliciesBy()
     {
         return 'AuthenticationTestUser';
     }

--- a/tests/Integration/Auth/Fixtures/AuthenticationTestUserWithPoliciesGroup.php
+++ b/tests/Integration/Auth/Fixtures/AuthenticationTestUserWithPoliciesGroup.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures;
+
+class AuthenticationTestUserWithPoliciesGroup extends AuthenticationTestUser
+{
+    public function policiesGroup()
+    {
+        return 'AuthenticationTestUser';
+    }
+}

--- a/tests/Integration/Auth/Fixtures/Models/Policies/SubTestUser/Nested/SubTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Models/Policies/SubTestUser/Nested/SubTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Models\Policies\SubTestUser\Nested;
+
+class SubTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/Fixtures/Models/Policies/SubTestUser/SubTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Models/Policies/SubTestUser/SubTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Models\Policies\SubTestUser;
+
+class SubTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/Fixtures/Policies/AuthenticationTestUser/AuthenticationTestUserPolicy.php
+++ b/tests/Integration/Auth/Fixtures/Policies/AuthenticationTestUser/AuthenticationTestUserPolicy.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Auth\Fixtures\Policies\AuthenticationTestUser;
+
+class AuthenticationTestUserPolicy
+{
+    //
+}

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -87,7 +87,7 @@ class GatePolicyResolutionTest extends TestCase
     {
         $this->be(new AuthenticationTestUser());
 
-        Gate::usePoliciesGroup();
+        Gate::groupPoliciesByUser();
 
         $this->assertInstanceOf(
             Fixtures\Policies\AuthenticationTestUser\AuthenticationTestUserPolicy::class,
@@ -95,14 +95,14 @@ class GatePolicyResolutionTest extends TestCase
         );
     }
 
-    public function testPolicyCanBueGuessedUsingGroupNamespaceInsideModelsNamespace()
+    public function testNestedPolicyCanBueGuessedUsingGroupNamespaceInsideModelsNamespace()
     {
         $this->be(new SubTestUser());
 
-        Gate::usePoliciesGroup();
+        Gate::groupPoliciesByUser();
 
         $this->assertInstanceOf(
-            Fixtures\Models\Policies\SubTestUser\SubTestUserPolicy::class,
+            Fixtures\Models\Policies\SubTestUser\Nested\SubTestUserPolicy::class,
             Gate::getPolicyFor(SubTestUser::class)
         );
     }
@@ -111,7 +111,7 @@ class GatePolicyResolutionTest extends TestCase
     {
         $this->be(new SubTestUser());
 
-        Gate::usePoliciesGroup();
+        Gate::groupPoliciesByUser();
 
         $this->assertInstanceOf(
             TopTestUserPolicy::class,
@@ -128,7 +128,7 @@ class GatePolicyResolutionTest extends TestCase
     {
         $this->actingAsGuest();
 
-        Gate::usePoliciesGroup();
+        Gate::groupPoliciesByUser();
 
         $this->assertInstanceOf(
             AuthenticationTestUserPolicy::class,
@@ -138,7 +138,7 @@ class GatePolicyResolutionTest extends TestCase
 
     public function testPolicyCallbackOverridesPoliciesGroup()
     {
-        Gate::usePoliciesGroup()->guessPolicyNamesUsing(function () {
+        Gate::groupPoliciesByUser()->guessPolicyNamesUsing(function () {
             return [
                 'App\\Policies\\TestUserPolicy',
                 AuthenticationTestUserPolicy::class,
@@ -155,7 +155,7 @@ class GatePolicyResolutionTest extends TestCase
     {
         $this->be(new AuthenticationTestUserWithPoliciesGroup());
 
-        Gate::usePoliciesGroup();
+        Gate::groupPoliciesByUser();
 
         $this->assertInstanceOf(
             Fixtures\Policies\AuthenticationTestUser\AuthenticationTestUserPolicy::class,


### PR DESCRIPTION
# What

Adds a namespace to Policy guessing to effectively separate Policies by the user class that is authenticated, which solves the problem of using more than one guard:

- Using a policy resolver callback to pick the policy for each Auth Guard
- Having a single Policy growing to Cthulhu levels for each Auth Guard
- Having a Policy router for all models.

Instead of bastardizing the authorization, the `groupPoliciesByUser()` solves that problem automatically.

```php
use Illuminate\Support\Facades\Auth;use Illuminate\Support\Facades\Gate;

// Before...
Gate::guessPolicyNamesUsing(static function (string $modelClass): string {
        $policy = class_basename($modelClass) . 'Policy';

        $policies = [
            "App\Models\Policies\\$policy",
            "App\Policies\\$policy",
        ];

        if ($user = class_basename(app('auth')->user())) {
            $policies = [
                "App\Models\Policies\\$user\\$policy",
                "App\Policies\\$user\\$policy",
                ...$policies
            ];
        }

        return array_find($policies, 'class_exists');
});

// After...
Gate::groupPoliciesByUser();
```

For example, if the guard uses the `App\Models\Admin` model, a policy for the `App\Models\Post` will be found at `App\Models\Policies\Admin\PostPolicy`.

## How

It works by checking if the Policies Grouping is activated through `groupPoliciesByUser()` and if there is a user authenticated. If it's not, or there is a custom callback to resolve policy names, everything will be resolved as usual.

When it's activated, it will add the class basename (like `Admin` for the class `App\Models\Admin`) to the policies namespace, prioritising the most particular policy over the most general:

1. `App\Models\Policies\Admin\PostPolicy`
2. `App\Policies\Admin\PostPolicy`
3. `App\Models\Policies\PostPolicy`
4. `App\Policies\PostPolicy`

What makes this a better approach than a custom resolving callback is that if the most particular policy doesn't exist, it will automatically fallback to the broader policy. Since it's opt-in, apps using the resolving callback will be unaffected.

The resolution also supports having a custom namespace if necessary, per user. If the user has the `groupPoliciesBy` method, it will be called to resolve the namespace instead of using the class basename. Since it's a method call, it allows the dev to change the policy group namespace at runtime:

```php
use Illuminate\Foundation\Auth\User as Authenticatable;

class Admin extends Authenticatable
{
    // ...
    
    /**
     * Set an additional namespace to discover grouped policies. 
     * 
     * @param  class-string  $class
     * @return string
     */
    public function groupPoliciesBy(string $class): string
    {
        return 'Administrator';
    }
}
```

Alternatively, a particular model can return an empty string or `null` to disable grouping policies. For example, this can be used to make all policies for the `User` model be at `App\Model\Policies\*`, while the `Admin` to be explicitly at `App\Models\Policies\Admin\*`.