### PR TITLE
Add 'page' field to paginator links

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -121,16 +121,19 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
                 return [
                     'url' => $url,
                     'label' => (string) $page,
+                    'page' => $page,
                     'active' => $this->currentPage() === $page,
                 ];
             });
         })->prepend([
             'url' => $this->previousPageUrl(),
             'label' => function_exists('__') ? __('pagination.previous') : 'Previous',
+            'page' => $this->currentPage() > 1 ? $this->currentPage() - 1 : null,
             'active' => false,
         ])->push([
             'url' => $this->nextPageUrl(),
             'label' => function_exists('__') ? __('pagination.next') : 'Next',
+            'page' => $this->hasMorePages() ? $this->currentPage() + 1 : null,
             'active' => false,
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -901,7 +901,7 @@ class ResourceTest extends TestCase
         );
 
         $this->assertEquals(
-            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
+            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","page":null,"active":false},{"url":"\/?page=1","label":"1","page":1,"active":true},{"url":null,"label":"Next &raquo;","page":null,"active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
             $response->baseResponse->content()
         );
     }


### PR DESCRIPTION
**Problem description**

When building a Vue.js (or any SPA) client consuming a Laravel API, the `LengthAwarePaginator::linkCollection()` method returns an array of links containing:

```php
[
    'url' => string|null,
    'label' => string,
    'active' => bool,
]
```

In many frontend use-cases, we don’t actually need the `url` — we only care about the **page number** so we can make an API call like:

```javascript
fetch(`/api/entity?page=${page}`)
```

Currently, the page number has to be extracted from the `url` on the client side, which:

* Adds unnecessary parsing logic,
* Makes the code less readable,
* Can break if the URL format changes,
* Is inconvenient when API calls are wrapped in multiple layers of abstraction (TypeScript clients, base URLs, interceptors, etc.).

**Proposed solution**

Include an additional `page` key in each link returned by `LengthAwarePaginator::linkCollection()`, e.g.:

```php
[
    'url' => null,
    'label' => '« Previous',
    'page' => null,
    'active' => false,
],
[
    'url' => 'https://example.com?page=1',
    'label' => '1',
    'page' => 1,
    'active' => true,
],
[
    'url' => 'https://example.com?page=2',
    'label' => '2',
    'page' => 2,
    'active' => false,
],
[
    'url' => 'https://example.com?page=2',
    'label' => 'Next »',
    'page' => 2,
    'active' => false,
],
```

Where:

* `page` is an integer for navigable links,
* `null` for disabled links (e.g., `...`, previous when on the first page, next when on the last page).

This provides the frontend with a ready-to-use page number, avoids URL parsing, and doesn’t break backward compatibility — all existing keys remain unchanged.
