### PR TITLE
Add Unicode-support email validation helper to Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2119,4 +2119,15 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+    @param  string  $email
+     * @return bool
+     */
+    public static function isValidEmailUnicode($email)
+    {
+        return (bool) filter_var(
+            $email,
+            FILTER_VALIDATE_EMAIL,
+            FILTER_FLAG_EMAIL_UNICODE
+        );
+    }
 }


### PR DESCRIPTION
### What
This PR adds a new `isValidEmailUnicode` helper method to the `Illuminate\Support\Str` class.  
It validates email addresses with Unicode character support using PHP's `FILTER_VALIDATE_EMAIL` and `FILTER_FLAG_EMAIL_UNICODE`.

### Why
- Improves email validation accuracy for non-ASCII addresses.
- Provides better internationalization (i18n) support for Laravel applications.

### Impact
- No breaking changes.
- Backwards compatible.
- Developers can now use `Str::isValidEmailUnicode()` for Unicode-compliant email validation.

