### PR TITLE
[12.x] Add support for drop patterns to the `make:migration` command's `TableGuesser`.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -86,7 +86,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         }
 
         // Next, we will attempt to guess the table name if this the migration has
-        // "create" or "drop" in the name. This will allow us to provide a convenient way
+        // "create" in the name. This will allow us to provide a convenient way
         // of creating migrations that create new tables for the application.
         if (! $table) {
             [$table, $create] = TableGuesser::guess($name);

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -86,7 +86,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         }
 
         // Next, we will attempt to guess the table name if this the migration has
-        // "create" in the name. This will allow us to provide a convenient way
+        // "create" or "drop" in the name. This will allow us to provide a convenient way
         // of creating migrations that create new tables for the application.
         if (! $table) {
             [$table, $create] = TableGuesser::guess($name);

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -14,6 +14,11 @@ class TableGuesser
         '/.+_(to|from|in)_(\w+)$/',
     ];
 
+    const DROP_PATTERNS = [
+        '/^drop_(\w+)_table$/',
+        '/^drop_(\w+)$/',
+    ];
+
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
      *
@@ -31,6 +36,12 @@ class TableGuesser
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
                 return [$matches[2], $create = false];
+            }
+        }
+
+        foreach (self::DROP_PATTERNS as $pattern) {
+            if (preg_match($pattern, $migration, $matches)) {
+                return [$matches[1], $create = false];
             }
         }
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,6 +28,10 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('drop_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
@@ -49,6 +53,10 @@ class TableGuesserTest extends TestCase
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('drop_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
     }


### PR DESCRIPTION
This PR adds support for detecting migrations that drop tables in the `TableGuesser` class.

Currently, TableGuesser can detect `create` and `change` patterns, but not `drop` migrations.

With this change, migrations like:

```shell
php artisan make:migration drop_users_table
php artisan make:migration drop_users
```
will now be correctly guessed.
