### PR TITLE
Url-safe base64 encode/decode

### DIFF
--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -4,6 +4,7 @@ namespace Illuminate\Pagination;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use UnexpectedValueException;
 
 /** @implements Arrayable<array-key, mixed> */
@@ -104,7 +105,7 @@ class Cursor implements Arrayable
      */
     public function encode()
     {
-        return str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(json_encode($this->toArray())));
+        return Str::toUrlSafeBase64(json_encode($this->toArray()));
     }
 
     /**
@@ -119,7 +120,7 @@ class Cursor implements Arrayable
             return null;
         }
 
-        $parameters = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $encodedString)), true);
+        $parameters = json_decode(Str::fromUrlSafeBase64($encodedString), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             return null;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1832,7 +1832,7 @@ class Str
      */
     public static function toUrlSafeBase64($string): string
     {
-        return str_replace(["+", "/", "="], ["-", "_", ""], base64_encode($string));
+        return str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($string));
     }
 
     /**
@@ -1844,7 +1844,7 @@ class Str
      */
     public static function fromUrlSafeBase64($string, $strict = false)
     {
-        return base64_decode(str_replace(["-", "_"], ["+", "/"], $string), $strict);
+        return base64_decode(str_replace(['-', '_'], ['+', '/'], $string), $strict);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1825,6 +1825,29 @@ class Str
     }
 
     /**
+     * Convert the given string to url safe Base64 encoding.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function toUrlSafeBase64($string): string
+    {
+        return str_replace(["+", "/", "="], ["-", "_", ""], base64_encode($string));
+    }
+
+    /**
+     * Decode the given url safe Base64 encoded string.
+     *
+     * @param  string  $string
+     * @param  bool  $strict
+     * @return string|false
+     */
+    public static function fromUrlSafeBase64($string, $strict = false)
+    {
+        return base64_decode(str_replace(["-", "_"], ["+", "/"], $string), $strict);
+    }
+
+    /**
      * Make a string's first character lowercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1386,6 +1386,27 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Convert the string to Base64 encoding.
+     *
+     * @return static
+     */
+    public function toUrlSafeBase64()
+    {
+        return new static(Str::toUrlSafeBase64($this->value));
+    }
+
+    /**
+     * Decode the Base64 encoded string.
+     *
+     * @param  bool  $strict
+     * @return static
+     */
+    public function fromUrlSafeBase64($strict = false)
+    {
+        return new static(Str::fromUrlSafeBase64($this->value, $strict));
+    }
+
+    /**
      * Hash the string using the given algorithm.
      *
      * @param  string  $algorithm

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1788,6 +1788,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('foobar', Str::fromBase64(base64_encode('foobar'), true));
     }
 
+    public function testToUrlSafeBase64()
+    {
+        $this->assertSame('Zm9v', Str::toUrlSafeBase64('foo')); // 'foo' is 'Zm9v' in base64
+        $this->assertSame('Zg', Str::toUrlSafeBase64('f')); // 'f' is 'Zg==' in base64
+        $this->assertSame('-g', Str::toUrlSafeBase64("\xfa")); // '\xfa' is '+g==' in base64
+        $this->assertSame('_w', Str::toUrlSafeBase64("\xff")); // '\xff' is '/w==' in base64
+    }
+
+    public function testFromUrlSafeBase64()
+    {
+        $this->assertSame('foo', Str::fromUrlSafeBase64('Zm9v')); // 'foo' is 'Zm9v' in base64
+        $this->assertSame('f', Str::fromUrlSafeBase64('Zg')); // 'f' is 'Zg==' in base64
+        $this->assertSame("\xfa", Str::fromUrlSafeBase64('-g')); // '\xfa' is '+g==' in base64
+        $this->assertSame("\xff", Str::fromUrlSafeBase64('_w')); // '\xff' is '/w==' in base64
+    }
+
     public function testChopStart()
     {
         foreach ([

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1550,6 +1550,22 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foobarbaz', (string) $this->stringable(base64_encode('foobarbaz'))->fromBase64());
     }
 
+    public function testToUrlSafeBase64()
+    {
+        $this->assertSame('Zm9v', (string) $this->stringable('foo')->toUrlSafeBase64()); // 'foo' is 'Zm9v' in base64
+        $this->assertSame('Zg', (string) $this->stringable('f')->toUrlSafeBase64()); // 'f' is 'Zg==' in base64
+        $this->assertSame('-g', (string) $this->stringable("\xfa")->toUrlSafeBase64()); // '\xfa' is '+g==' in base64
+        $this->assertSame('_w', (string) $this->stringable("\xff")->toUrlSafeBase64()); // '\xff' is '/w==' in base64
+    }
+
+    public function testFromUrlSafeBase64()
+    {
+        $this->assertSame('foo', (string) $this->stringable('Zm9v')->fromUrlSafeBase64()); // 'foo' is 'Zm9v' in base64
+        $this->assertSame('f', (string) $this->stringable('Zg')->fromUrlSafeBase64()); // 'f' is 'Zg==' in base64
+        $this->assertSame("\xfa", (string) $this->stringable('-g')->fromUrlSafeBase64()); // '\xfa' is '+g==' in base64
+        $this->assertSame("\xff", (string) $this->stringable('_w')->fromUrlSafeBase64()); // '\xff' is '/w==' in base64
+    }
+
     public function testHash()
     {
         $this->assertSame(hash('xxh3', 'foo'), (string) $this->stringable('foo')->hash('xxh3'));


### PR DESCRIPTION
This pull request exposes two new handy string helpers `toUrlSafeBase64` and `fromUrlSafeBase64`, the helper methods have also been used to replace the current base64 parsing logic in place in the pagination Cursor class. 