### PR TITLE
Fix test failures in PHPUnit 12.3.2

### DIFF
--- a/tests/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Queue/FailOnExceptionMiddlewareTest.php
@@ -28,7 +28,7 @@ class FailOnExceptionMiddlewareTest extends TestCase
     /**
      * @return array<string, array{class-string<\Throwable>, FailOnException, bool}>
      */
-    public static function testMiddlewareDataProvider(): array
+    public static function middlewareDataProvider(): array
     {
         return [
             'exception is in list' => [
@@ -44,7 +44,7 @@ class FailOnExceptionMiddlewareTest extends TestCase
         ];
     }
 
-    #[DataProvider('testMiddlewareDataProvider')]
+    #[DataProvider('middlewareDataProvider')]
     public function test_middleware(
         string $thrown,
         FailOnException $middleware,


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request fixes [a test failure](https://github.com/laravel/framework/actions/runs/16868057809) in [PHPUnit 12.3.2](https://github.com/sebastianbergmann/phpunit/releases/tag/12.3.2).

The latest version of PHPUnit now issues a warning if the data provider name starts with `test`:
https://github.com/sebastianbergmann/phpunit/issues/6300#issuecomment-3170434097

I've removed the `test` name in one instance.
