### PR TITLE
[12.x] Add default scheduler output

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -102,6 +102,13 @@ class Schedule
     protected array $groupStack = [];
 
     /**
+     * The schedule default output.
+     *
+     * @var string|null
+     */
+    protected ?string $defaultOutput = null;
+
+    /**
      * Create a new schedule instance.
      *
      * @param  \DateTimeZone|string|null  $timezone
@@ -327,6 +334,8 @@ class Schedule
      */
     protected function mergePendingAttributes(Event $event)
     {
+        $this->mergeDefaultAttributes($event);
+
         if (isset($this->attributes)) {
             $this->attributes->mergeAttributes($event);
 
@@ -337,6 +346,13 @@ class Schedule
             $group = end($this->groupStack);
 
             $group->mergeAttributes($event);
+        }
+    }
+
+    protected function mergeDefaultAttributes(Event $event): void
+    {
+        if (! is_null($this->defaultOutput)) {
+            $event->appendOutputTo($this->defaultOutput);
         }
     }
 
@@ -460,6 +476,19 @@ class Schedule
         }
 
         return $this->dispatcher;
+    }
+
+    /**
+     * Specify the default output events should use from now on.
+     *
+     * @param  string|null  $output
+     * @return $this
+     */
+    public function setDefaultOutput(?string $output): Schedule
+    {
+        $this->defaultOutput = $output;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
# What

Allow setting the default output for scheduled work directly in the schedule instance

# Why

Despite having the option at a few levels, including the scheduled event itself (e.g., `$schedule->command('inspire')->appendOutputTo('/dev/stdout')`, the `schedule:work` command, to name a few, there is, as far as I know, no centralized output configuration for the scheduler. It can be beneficial for those running the scheduler in ephemeral and/or container-driven ecosystems (e.g., Kubernetes jobs), or in a space where the filesystem may not be the most suitable log storage system, to better control where the scheduler's output should be written.

This answers a few questions/threads/requests:
- https://github.com/laravel/framework/discussions/47448
- https://laracasts.com/discuss/channels/laravel/output-from-scheduler-to-stdout

_Important to note that, like for event-specific output, any **background task** using `/dev/stdout` or `/dev/stderr` will not appear in the final output, as it is redirected to `/dev/null`._