### PR TITLE
[12.x] Handle null as a falsy condition

### DIFF
--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -18,10 +18,14 @@ class RequiredIf implements Stringable
     /**
      * Create a new required validation rule based on a condition.
      *
-     * @param  (\Closure(): bool)|bool  $condition
+     * @param  (\Closure(): bool)|bool|null  $condition
      */
     public function __construct($condition)
     {
+        if (is_null($condition)) {
+            $condition = false;
+        }
+
         if ($condition instanceof Closure || is_bool($condition)) {
             $this->condition = $condition;
         } else {

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -77,5 +77,10 @@ class ValidationRequiredIfTest extends TestCase
 
         $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
         $this->assertTrue($v->passes());
+
+        $rule = new RequiredIf(null);
+
+        $v = new Validator($trans, ['x' => 'foo'], ['x' => ['string', $rule]]);
+        $this->assertTrue($v->passes());
     }
 }


### PR DESCRIPTION
### What
Handle `null` as a falsy condition.

### Why

The `requiredIf` constructor was type-improved in [this commit](https://github.com/negoziator/framework/commit/7ce337e48fb32b53df844af0c7390d87b5c4e47c), which no longer resolves `null` as a falsy value.

There's  scenarios where it makes sense to handle `null` as a falsy value e.g

```php
//  Some FormRequest rules
 ...
 'some_admin_key' => [new RequiredIf(user()?->isAdmin()), 'string'], // user() is null.
 ```