### PR TITLE
Added "after" support for morphs and nullableMorphs Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1569,7 +1569,7 @@ class Blueprint
     public function uuidMorphs($name, $indexName = null, $after = null)
     {
         $this->string("{$name}_type")
-            ->after($after);   $this->after($after);
+            ->after($after);
 
         $this->uuid("{$name}_id")
             ->after(!is_null($after) ? "{$name}_type" : null);

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1483,9 +1483,9 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function morphs($name, $indexName = null, $after = null)
@@ -1502,9 +1502,9 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function nullableMorphs($name, $indexName = null, $after = null)
@@ -1521,9 +1521,9 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table using numeric IDs (incremental).
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function numericMorphs($name, $indexName = null, $after = null)
@@ -1532,7 +1532,7 @@ class Blueprint
             ->after($after);
 
         $this->unsignedBigInteger("{$name}_id")
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1540,9 +1540,9 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using numeric IDs (incremental).
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function nullableNumericMorphs($name, $indexName = null, $after = null)
@@ -1553,7 +1553,7 @@ class Blueprint
 
         $this->unsignedBigInteger("{$name}_id")
             ->nullable()
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1561,9 +1561,9 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table using UUIDs.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function uuidMorphs($name, $indexName = null, $after = null)
@@ -1572,7 +1572,7 @@ class Blueprint
             ->after($after);
 
         $this->uuid("{$name}_id")
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1580,9 +1580,9 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using UUIDs.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function nullableUuidMorphs($name, $indexName = null, $after = null)
@@ -1593,7 +1593,7 @@ class Blueprint
 
         $this->uuid("{$name}_id")
             ->nullable()
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1601,9 +1601,9 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table using ULIDs.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function ulidMorphs($name, $indexName = null, $after = null)
@@ -1612,7 +1612,7 @@ class Blueprint
             ->after($after);
 
         $this->ulid("{$name}_id")
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1620,9 +1620,9 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using ULIDs.
      *
-     * @param string $name
-     * @param string|null $indexName
-     * @param string|null $after
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @param  string|null  $after
      * @return void
      */
     public function nullableUlidMorphs($name, $indexName = null, $after = null)
@@ -1633,7 +1633,7 @@ class Blueprint
 
         $this->ulid("{$name}_id")
             ->nullable()
-            ->after(!is_null($after) ? "{$name}_type" : null);
+            ->after(! is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1483,51 +1483,53 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function morphs($name, $indexName = null)
+    public function morphs($name, $indexName = null, $after = null)
     {
         if (Builder::$defaultMorphKeyType === 'uuid') {
-            $this->uuidMorphs($name, $indexName);
+            $this->uuidMorphs($name, $indexName, $after);
         } elseif (Builder::$defaultMorphKeyType === 'ulid') {
-            $this->ulidMorphs($name, $indexName);
+            $this->ulidMorphs($name, $indexName, $after);
         } else {
-            $this->numericMorphs($name, $indexName);
+            $this->numericMorphs($name, $indexName, $after);
         }
     }
 
     /**
      * Add nullable columns for a polymorphic table.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function nullableMorphs($name, $indexName = null)
+    public function nullableMorphs($name, $indexName = null, $after = null)
     {
         if (Builder::$defaultMorphKeyType === 'uuid') {
-            $this->nullableUuidMorphs($name, $indexName);
+            $this->nullableUuidMorphs($name, $indexName, $after);
         } elseif (Builder::$defaultMorphKeyType === 'ulid') {
-            $this->nullableUlidMorphs($name, $indexName);
+            $this->nullableUlidMorphs($name, $indexName, $after);
         } else {
-            $this->nullableNumericMorphs($name, $indexName);
+            $this->nullableNumericMorphs($name, $indexName, $after);
         }
     }
 
     /**
      * Add the proper columns for a polymorphic table using numeric IDs (incremental).
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function numericMorphs($name, $indexName = null)
+    public function numericMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type");
+        $this->string("{$name}_type")
+            ->after($after);
 
-        $this->unsignedBigInteger("{$name}_id");
+        $this->unsignedBigInteger("{$name}_id")
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1535,15 +1537,19 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using numeric IDs (incremental).
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function nullableNumericMorphs($name, $indexName = null)
+    public function nullableNumericMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type")->nullable();
+        $this->string("{$name}_type")
+            ->nullable()
+            ->after($after);
 
-        $this->unsignedBigInteger("{$name}_id")->nullable();
+        $this->unsignedBigInteger("{$name}_id")
+            ->nullable()
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1551,15 +1557,17 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table using UUIDs.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function uuidMorphs($name, $indexName = null)
+    public function uuidMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type");
+        $this->string("{$name}_type")
+            ->after($after);   $this->after($after);
 
-        $this->uuid("{$name}_id");
+        $this->uuid("{$name}_id")
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1567,15 +1575,19 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using UUIDs.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function nullableUuidMorphs($name, $indexName = null)
+    public function nullableUuidMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type")->nullable();
+        $this->string("{$name}_type")
+            ->nullable()
+            ->after($after);
 
-        $this->uuid("{$name}_id")->nullable();
+        $this->uuid("{$name}_id")
+            ->nullable()
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1583,15 +1595,17 @@ class Blueprint
     /**
      * Add the proper columns for a polymorphic table using ULIDs.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function ulidMorphs($name, $indexName = null)
+    public function ulidMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type");
+        $this->string("{$name}_type")
+            ->after($after);
 
-        $this->ulid("{$name}_id");
+        $this->ulid("{$name}_id")
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1599,15 +1613,19 @@ class Blueprint
     /**
      * Add nullable columns for a polymorphic table using ULIDs.
      *
-     * @param  string  $name
-     * @param  string|null  $indexName
+     * @param string $name
+     * @param string|null $indexName
      * @return void
      */
-    public function nullableUlidMorphs($name, $indexName = null)
+    public function nullableUlidMorphs($name, $indexName = null, $after = null)
     {
-        $this->string("{$name}_type")->nullable();
+        $this->string("{$name}_type")
+            ->nullable()
+            ->after($after);
 
-        $this->ulid("{$name}_id")->nullable();
+        $this->ulid("{$name}_id")
+            ->nullable()
+            ->after($after ?? "{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1532,7 +1532,7 @@ class Blueprint
             ->after($after);
 
         $this->unsignedBigInteger("{$name}_id")
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1553,7 +1553,7 @@ class Blueprint
 
         $this->unsignedBigInteger("{$name}_id")
             ->nullable()
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1572,7 +1572,7 @@ class Blueprint
             ->after($after);   $this->after($after);
 
         $this->uuid("{$name}_id")
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1593,7 +1593,7 @@ class Blueprint
 
         $this->uuid("{$name}_id")
             ->nullable()
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1612,7 +1612,7 @@ class Blueprint
             ->after($after);
 
         $this->ulid("{$name}_id")
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1633,7 +1633,7 @@ class Blueprint
 
         $this->ulid("{$name}_id")
             ->nullable()
-            ->after($after ?? "{$name}_type");
+            ->after(!is_null($after) ? "{$name}_type" : null);
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1485,6 +1485,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function morphs($name, $indexName = null, $after = null)
@@ -1503,6 +1504,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function nullableMorphs($name, $indexName = null, $after = null)
@@ -1521,6 +1523,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function numericMorphs($name, $indexName = null, $after = null)
@@ -1539,6 +1542,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function nullableNumericMorphs($name, $indexName = null, $after = null)
@@ -1559,6 +1563,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function uuidMorphs($name, $indexName = null, $after = null)
@@ -1577,6 +1582,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function nullableUuidMorphs($name, $indexName = null, $after = null)
@@ -1597,6 +1603,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function ulidMorphs($name, $indexName = null, $after = null)
@@ -1615,6 +1622,7 @@ class Blueprint
      *
      * @param string $name
      * @param string|null $indexName
+     * @param string|null $after
      * @return void
      */
     public function nullableUlidMorphs($name, $indexName = null, $after = null)


### PR DESCRIPTION
Added support for the **after** option to the **morphs** and **nullableMorphs** Blueprint methods.

Benefit: This allows you to add polymorphic relationships to an existing database table and precisely control the placement of the new columns (**morphable_id** and **morphable_type**). This eliminates the need for manual SQL commands to position the columns correctly after they're added.