### PR TITLE
[11.x] `CacheSchedulingMutex` should use lock connection

### DIFF
--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use DateTimeInterface;
+use Illuminate\Cache\DynamoDbStore;
 use Illuminate\Contracts\Cache\Factory as Cache;
+use Illuminate\Contracts\Cache\LockProvider;
 
 class CacheSchedulingMutex implements SchedulingMutex, CacheAware
 {
@@ -41,8 +43,16 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      */
     public function create(Event $event, DateTimeInterface $time)
     {
+        $mutexName = $event->mutexName().$time->format('Hi');
+
+        if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
+            return $this->cache->store($this->store)->getStore()
+                ->lock($mutexName, 3600)
+                ->acquire();
+        }
+
         return $this->cache->store($this->store)->add(
-            $event->mutexName().$time->format('Hi'), true, 3600
+            $mutexName, true, 3600
         );
     }
 
@@ -55,9 +65,26 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      */
     public function exists(Event $event, DateTimeInterface $time)
     {
-        return $this->cache->store($this->store)->has(
-            $event->mutexName().$time->format('Hi')
-        );
+        $mutexName = $event->mutexName().$time->format('Hi');
+
+        if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
+            return ! $this->cache->store($this->store)->getStore()
+                ->lock($mutexName, 3600)
+                ->get(fn () => true);
+        }
+
+        return $this->cache->store($this->store)->has($mutexName);
+    }
+
+    /**
+     * Determine if the given store should use locks for cache event mutexes.
+     *
+     * @param  \Illuminate\Contracts\Cache\Store  $store
+     * @return bool
+     */
+    protected function shouldUseLocks($store)
+    {
+        return $store instanceof LockProvider && ! $store instanceof DynamoDbStore;
     }
 
     /**


### PR DESCRIPTION
Backport of #56472 for 11.x.