### PR TITLE
[12.x] Add Vitess-specific safe to retry errors

### DIFF
--- a/src/Illuminate/Database/LostConnectionDetector.php
+++ b/src/Illuminate/Database/LostConnectionDetector.php
@@ -83,6 +83,12 @@ class LostConnectionDetector implements LostConnectionDetectorContract
             'Connection lost',
             'Broken pipe',
             'SQLSTATE[25006]: Read only sql transaction: 7',
+            'vtgate connection error: no healthy endpoints',
+            'primary is not serving, there may be a reparent operation in progress',
+            'current keyspace is being resharded',
+            'no healthy tablet available',
+            'transaction pool connection limit exceeded',
+            'SSL operation failed with code 5',
         ]);
     }
 }


### PR DESCRIPTION
Vitess is a popular MySQL proxy used by GitHub, HubSpot and PlanetScale.