### PR TITLE
[12.x] `Bind` attribute accepts UnitEnum

### DIFF
--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -28,13 +28,13 @@ class Bind
      * Create a new attribute instance.
      *
      * @param  class-string  $concrete
-     * @param  non-empty-array<int, \BackedEnum|\UnitEnum|non-empty-string>|non-empty-string  $environments
+     * @param  non-empty-array<int, \BackedEnum|\UnitEnum|non-empty-string>|non-empty-string|\UnitEnum  $environments
      *
      * @throws \InvalidArgumentException
      */
     public function __construct(
         string $concrete,
-        string|array $environments = ['*'],
+        string|array|UnitEnum $environments = ['*'],
     ) {
         $environments = array_filter(is_array($environments) ? $environments : [$environments]);
 


### PR DESCRIPTION
We allow passing a string for the environments, so I think we should also allow passing an enum here.

## Is this a breaking change?
Yes, quite possibly. But I'm hoping that since this feature was released less than a week ago, the likelihood it has been extended in userland is pretty low.

It might make sense to just drop the typehints all together here to avoid breaking changes in the future.