### PR TITLE
[12.x] Use PHP 8.4 array helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "symfony/mailer": "^7.2.0",
         "symfony/mime": "^7.2.0",
         "symfony/polyfill-php83": "^1.31",
+        "symfony/polyfill-php84": "^1.31",
         "symfony/process": "^7.2.0",
         "symfony/routing": "^7.2.0",
         "symfony/uid": "^7.2.0",

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -263,13 +263,9 @@ class Arr
             return value($default);
         }
 
-        foreach ($array as $key => $value) {
-            if ($callback($value, $key)) {
-                return $value;
-            }
-        }
+        $key = array_find_key($array, $callback);
 
-        return value($default);
+        return $key !== null ? $array[$key] : value($default);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -184,9 +184,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (func_num_args() === 1) {
             if ($this->useAsCallable($key)) {
-                $placeholder = new stdClass;
-
-                return $this->first($key, $placeholder) !== $placeholder;
+                return array_any($this->items, $key);
             }
 
             return in_array($key, $this->items);
@@ -598,13 +596,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $value) {
-            if (! array_key_exists($value, $this->items)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn ($key) => array_key_exists($key, $this->items));
     }
 
     /**
@@ -621,13 +613,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $keys = is_array($key) ? $key : func_get_args();
 
-        foreach ($keys as $value) {
-            if (array_key_exists($value, $this->items)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($keys, fn ($key) => array_key_exists($key, $this->items));
     }
 
     /**
@@ -1188,13 +1174,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return array_search($value, $this->items, $strict);
         }
 
-        foreach ($this->items as $key => $item) {
-            if ($value($item, $key)) {
-                return $key;
-            }
-        }
-
-        return false;
+        return array_find_key($this->items, $value) ?? false;
     }
 
     /**

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -17,7 +17,8 @@
         "php": "^8.2",
         "illuminate/conditionable": "^12.0",
         "illuminate/contracts": "^12.0",
-        "illuminate/macroable": "^12.0"
+        "illuminate/macroable": "^12.0",
+        "symfony/polyfill-php84": "^1.31"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PHP 8.4 introduces new array search functions for finding items matching criteria or determining if any/all of them pass. See also https://php.watch/versions/8.4/array_find-array_find_key-array_any-array_all.

This PR introduces these helpers in the `Arr` and `Collection` classes to use modern and simplified logic. By requiring the Symfony polyfills for lower PHP versions, this should be backwards compatible. 

This is effectively #53426 re-opened, but with polyfills to allow for actual code simplification. These polyfills can also be easily recognized and removed upon requiring a higher PHP minimal version in the future.
