### PR TITLE
[12.x] Fix usage of `Scoped` and `Singleton` on interfaces

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1017,7 +1017,7 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
-        $bindAttributes = $reflected->getAttributes(Bind::class) ?? [];
+        $bindAttributes = $reflected->getAttributes(Bind::class);
         if ($bindAttributes === []) {
             return $abstract;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1018,6 +1018,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         $bindAttributes = $reflected->getAttributes(Bind::class);
+
         if ($bindAttributes === []) {
             return $abstract;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -998,7 +998,6 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
-
         return $this->getConcreteBindingFromAttributes($abstract, $reflected);
     }
 
@@ -1049,7 +1048,7 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
-        match($this->getScopedTyped($reflected)) {
+        match ($this->getScopedTyped($reflected)) {
             'scoped' => $this->scoped($abstract, $concrete),
             'singleton' => $this->singleton($abstract, $concrete),
             null => $this->bind($abstract, $concrete),

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -998,7 +998,7 @@ class Container implements ArrayAccess, ContainerContract
             return $abstract;
         }
 
-        return $this->getConcreteBindingFromAttributes($abstract, $reflected);
+        return $this->getConcreteBindingFromAttributes($abstract);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -267,7 +267,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @return bool
      */
-    public function isShared($abstract)
+        public function isShared($abstract)
     {
         if (isset($this->instances[$abstract])) {
             return true;
@@ -281,22 +281,38 @@ class Container implements ArrayAccess, ContainerContract
             return false;
         }
 
-        $reflection = new ReflectionClass($abstract);
-
-        if (! empty($reflection->getAttributes(Singleton::class))) {
-            return true;
+        if ($scopedType = $this->getScopedTyped(new ReflectionClass($abstract)) === null) {
+            return false;
         }
 
-        if (! empty($reflection->getAttributes(Scoped::class))) {
+        if ($scopedType === 'scoped') {
             if (! in_array($abstract, $this->scopedInstances, true)) {
                 $this->scopedInstances[] = $abstract;
             }
-
-            return true;
         }
 
-        return false;
+        return true;
     }
+
+    /**
+     * Determine if a ReflectionClass has scoping attributes applied.
+     *
+     * @param  ReflectionClass<object>  $reflection
+     * @return "singleton"|"scoped"|null
+     */
+    protected function getScopedTyped(ReflectionClass $reflection): ?string
+    {
+        if (! empty($reflection->getAttributes(Singleton::class))) {
+            return 'singleton';
+        }
+
+        if (! empty($reflection->getAttributes(Scoped::class))) {
+            return 'scoped';
+        }
+
+        return null;
+    }
+
 
     /**
      * Determine if a given string is an alias.

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -875,6 +875,17 @@ class ContainerTest extends TestCase
         $container->make(ProdEnvOnlyInterface::class);
     }
 
+    public function testScopedSingletonWithBind()
+    {
+        $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($environments) => true);
+
+        $original = $container->make(HasScope::class);
+        $new = $container->make(HasScope::class);
+
+        $this->assertSame($original, $new);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -1129,5 +1140,16 @@ class OriginalConcrete implements OverrideInterface
 }
 
 class AltConcrete implements OverrideInterface
+{
+}
+
+
+#[Bind(HasScopeConcrete::class)]
+#[Scoped]
+interface HasScope
+{
+}
+
+class HasScopeConcrete implements HasScope
 {
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1156,7 +1156,6 @@ class AltConcrete implements OverrideInterface
 {
 }
 
-
 #[Bind(IsScopedConcrete::class)]
 #[Scoped]
 interface IsScoped

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -880,8 +880,21 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->resolveEnvironmentUsing(fn ($environments) => true);
 
-        $original = $container->make(HasScope::class);
-        $new = $container->make(HasScope::class);
+        $original = $container->make(IsScoped::class);
+        $new = $container->make(IsScoped::class);
+
+        $this->assertSame($original, $new);
+        $container->forgetScopedInstances();
+        $this->assertNotSame($original, $container->make(IsScoped::class));
+    }
+
+    public function testSingletonWithBind()
+    {
+        $container = new Container;
+        $container->resolveEnvironmentUsing(fn ($environments) => true);
+
+        $original = $container->make(IsSingleton::class);
+        $new = $container->make(IsSingleton::class);
 
         $this->assertSame($original, $new);
     }
@@ -1144,12 +1157,18 @@ class AltConcrete implements OverrideInterface
 }
 
 
-#[Bind(HasScopeConcrete::class)]
+#[Bind(IsScopedConcrete::class)]
 #[Scoped]
-interface HasScope
+interface IsScoped
 {
 }
 
-class HasScopeConcrete implements HasScope
+class IsScopedConcrete implements IsScoped
+{
+}
+
+#[Bind(IsScopedConcrete::class)]
+#[Singleton]
+interface IsSingleton
 {
 }


### PR DESCRIPTION
Noticed earlier that this doesn't work as described in the docs 😰 

---
The methodology is that we only check for the Scoped/Singleton on classes (interfaces, abstract classes) that also have Bind.

This raises a few questions:

1. Should we be caching classes that we have already checked for Scoped/Singleton?
2. Do we care about parent-child hierarchies? If we have InterfaceB which extends InterfaceA, and InterfaceA is marked as a singleton, when we call `resolve(InterfaceB::class)`, should it be marking it as a singleton?