### PR TITLE
[12.x] Prefer Symfony PHP polyfills over `function_exists` calls

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
-use JsonException;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
@@ -577,17 +576,7 @@ class Str
             return false;
         }
 
-        if (function_exists('json_validate')) {
-            return json_validate($value, 512);
-        }
-
-        try {
-            json_decode($value, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return false;
-        }
-
-        return true;
+        return json_validate($value, 512);
     }
 
     /**
@@ -937,17 +926,7 @@ class Str
      */
     public static function padBoth($value, $length, $pad = ' ')
     {
-        if (function_exists('mb_str_pad')) {
-            return mb_str_pad($value, $length, $pad, STR_PAD_BOTH);
-        }
-
-        $short = max(0, $length - mb_strlen($value));
-        $shortLeft = floor($short / 2);
-        $shortRight = ceil($short / 2);
-
-        return mb_substr(str_repeat($pad, $shortLeft), 0, $shortLeft).
-               $value.
-               mb_substr(str_repeat($pad, $shortRight), 0, $shortRight);
+        return mb_str_pad($value, $length, $pad, STR_PAD_BOTH);
     }
 
     /**
@@ -960,13 +939,7 @@ class Str
      */
     public static function padLeft($value, $length, $pad = ' ')
     {
-        if (function_exists('mb_str_pad')) {
-            return mb_str_pad($value, $length, $pad, STR_PAD_LEFT);
-        }
-
-        $short = max(0, $length - mb_strlen($value));
-
-        return mb_substr(str_repeat($pad, $short), 0, $short).$value;
+        return mb_str_pad($value, $length, $pad, STR_PAD_LEFT);
     }
 
     /**
@@ -979,13 +952,7 @@ class Str
      */
     public static function padRight($value, $length, $pad = ' ')
     {
-        if (function_exists('mb_str_pad')) {
-            return mb_str_pad($value, $length, $pad, STR_PAD_RIGHT);
-        }
-
-        $short = max(0, $length - mb_strlen($value));
-
-        return $value.mb_substr(str_repeat($pad, $short), 0, $short);
+        return mb_str_pad($value, $length, $pad, STR_PAD_RIGHT);
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -24,6 +24,7 @@
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
         "nesbot/carbon": "^3.8.4",
+        "symfony/polyfill-php83": "^1.31",
         "voku/portable-ascii": "^2.0.2"
     },
     "conflict": {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1757,11 +1757,9 @@ class TestResponse implements ArrayAccess
     {
         $content = $this->content();
 
-        if (function_exists('json_validate') && json_validate($content)) {
-            $this->ddJson($key);
-        }
-
-        dd($content);
+        return json_validate($content)
+            ? $this->ddJson($key)
+            : dd($content);
     }
 
     /**

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -19,7 +19,8 @@
         "illuminate/collections": "^12.0",
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
-        "illuminate/support": "^12.0"
+        "illuminate/support": "^12.0",
+        "symfony/polyfill-php83": "^1.31"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1631,13 +1631,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if (function_exists('json_validate')) {
-            return json_validate($value);
-        }
-
-        json_decode($value);
-
-        return json_last_error() === JSON_ERROR_NONE;
+        return json_validate($value);
     }
 
     /**

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -26,7 +26,8 @@
         "illuminate/support": "^12.0",
         "illuminate/translation": "^12.0",
         "symfony/http-foundation": "^7.2",
-        "symfony/mime": "^7.2"
+        "symfony/mime": "^7.2",
+        "symfony/polyfill-php83": "^1.31"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In various places of the codebase, `function_exists` calls are employed to allow usage of functions introduced in recent PHP versions without breaking backwards compatibility. This has two major downsides namely:
- having more complicated code at current, as two implementations need to be maintained
- these might be harder to spot and replace in the future, when a higher PHP version is enforced and thus these checks become obsolete.

Therefore this PR proposes to use the [Symfony polyfills](https://github.com/symfony/polyfill) instead. This will ensure the functions are available on all supported PHP versions, thus retaining backwards compatibility, without requiring any code modifications. Moreover, given these are easily findable in the corresponding `composer.json` files, they can be easily removed in the future when the PHP version is raised, without further checking which functions correspond to which PHP version.
