### PR TITLE
[12.x] Use new error and exception handler getters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "symfony/mailer": "^7.2.0",
         "symfony/mime": "^7.2.0",
         "symfony/polyfill-php83": "^1.31",
+        "symfony/polyfill-php85": "^1.31",
         "symfony/process": "^7.2.0",
         "symfony/routing": "^7.2.0",
         "symfony/uid": "^7.2.0",

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -326,27 +326,11 @@ class HandleExceptions
      */
     public static function flushHandlersState()
     {
-        while (true) {
-            $previousHandler = set_exception_handler(static fn () => null);
-
-            restore_exception_handler();
-
-            if ($previousHandler === null) {
-                break;
-            }
-
+        while (get_exception_handler() !== null) {
             restore_exception_handler();
         }
 
-        while (true) {
-            $previousHandler = set_error_handler(static fn () => null);
-
-            restore_error_handler();
-
-            if ($previousHandler === null) {
-                break;
-            }
-
+        while (get_error_handler() !== null) {
             restore_error_handler();
         }
 

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -26,6 +26,7 @@
         "symfony/http-foundation": "^7.2.0",
         "symfony/http-kernel": "^7.2.0",
         "symfony/polyfill-php83": "^1.31",
+        "symfony/polyfill-php85": "^1.31",
         "symfony/mime": "^7.2.0"
     },
     "autoload": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In PHP 8.5, new `get_exception_handler` and `get_error_handler` functions are introduced, see also https://wiki.php.net/rfc/get-error-exception-handler.

This PR employs these new functions for simplified code, leveraging the Symfony PHP polyfill for backwards compatibility.
