### PR TITLE
Fix: ensure failed_jobs.uuid always has a value, add DB default and P…

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -13,7 +14,7 @@ return new class extends Migration
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->id();
-            $table->string('uuid')->unique();
+            $table->string('uuid')->unique()->default(DB::raw('(UUID())'));;
             $table->text('connection');
             $table->text('queue');
             $table->longText('payload');

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -58,8 +58,10 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
 
         $exception = (string) mb_convert_encoding($exception, 'UTF-8');
 
+        $uuid = (string) \Illuminate\Support\Str::uuid();
+
         return $this->getTable()->insertGetId(compact(
-            'connection', 'queue', 'payload', 'exception', 'failed_at'
+            'uuid', 'connection', 'queue', 'payload', 'exception', 'failed_at'
         ));
     }
 


### PR DESCRIPTION
When inserting large volumes of failed jobs under heavy load,
some environments encounter "uuid doesn't have a default value" errors
from MySQL. This PR adds two safeguards:

1. Database-level default UUID() for the uuid column in failed_jobs migration stub.
2. Additional PHP fallback in DatabaseFailedJobProvider to guarantee a UUID string.

This ensures failed job logging is resilient even under extreme queue loads.
