### PR TITLE
[12.x] Online (concurrently) index creation for PostgreSQL and SqlServer

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -341,6 +341,7 @@ class PostgresGrammar extends Grammar
                 $command->algorithm ? ' using '.$command->algorithm : '',
                 $this->columnize($command->columns)
             );
+
             $sql = sprintf('alter table %s add constraint %s unique using index %s',
                 $this->wrapTable($blueprint),
                 $this->wrap($command->index),

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -323,7 +323,7 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @return string
+     * @return string[]
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
@@ -333,12 +333,28 @@ class PostgresGrammar extends Grammar
             $uniqueStatement .= ' nulls '.($command->nullsNotDistinct ? 'not distinct' : 'distinct');
         }
 
-        $sql = sprintf('alter table %s add constraint %s %s (%s)',
-            $this->wrapTable($blueprint),
-            $this->wrap($command->index),
-            $uniqueStatement,
-            $this->columnize($command->columns)
-        );
+        if ($command->online || $command->algorithm) {
+            $createIndexSql = sprintf('create unique index %s%s on %s%s (%s)',
+                $command->online ? 'concurrently ' : '',
+                $this->wrap($command->index),
+                $this->wrapTable($blueprint),
+                $command->algorithm ? ' using '.$command->algorithm : '',
+                $this->columnize($command->columns)
+            );
+            $sql = sprintf('alter table %s add constraint %s unique using index %s',
+                $this->wrapTable($blueprint),
+                $this->wrap($command->index),
+                $this->wrap($command->index)
+            );
+        } else {
+            $sql = sprintf(
+                'alter table %s add constraint %s %s (%s)',
+                $this->wrapTable($blueprint),
+                $this->wrap($command->index),
+                $uniqueStatement,
+                $this->columnize($command->columns)
+            );
+        }
 
         if (! is_null($command->deferrable)) {
             $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
@@ -348,7 +364,7 @@ class PostgresGrammar extends Grammar
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
         }
 
-        return $sql;
+        return isset($createIndexSql) ? [$createIndexSql, $sql] : [$sql];
     }
 
     /**
@@ -360,7 +376,8 @@ class PostgresGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s on %s%s (%s)',
+        return sprintf('create index %s%s on %s%s (%s)',
+            $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
@@ -385,7 +402,8 @@ class PostgresGrammar extends Grammar
             return "to_tsvector({$this->quoteString($language)}, {$this->wrap($column)})";
         }, $command->columns);
 
-        return sprintf('create index %s on %s using gin ((%s))',
+        return sprintf('create index %s%s on %s using gin ((%s))',
+            $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             implode(' || ', $columns)
@@ -421,7 +439,8 @@ class PostgresGrammar extends Grammar
     {
         $columns = $this->columnizeWithOperatorClass($command->columns, $command->operatorClass);
 
-        return sprintf('create index %s on %s%s (%s)',
+        return sprintf('create index %s%s on %s%s (%s)',
+            $command->online ? 'concurrently ' : '',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -272,10 +272,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create unique index %s on %s (%s)',
+        return sprintf('create unique index %s on %s (%s)%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $command->online ? ' with (online = on)' : ''
         );
     }
 
@@ -288,10 +289,11 @@ class SqlServerGrammar extends Grammar
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('create index %s on %s (%s)',
+        return sprintf('create index %s on %s (%s)%s',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->columnize($command->columns)
+            $this->columnize($command->columns),
+            $command->online ? ' with (online = on)' : ''
         );
     }
 

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Fluent;
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
+ * @method $this online(bool $value = true) Specify that index creation should not lock table (PostgreSQL/SqlServer)
  */
 class IndexDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Fluent;
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
- * @method $this online(bool $value = true) Specify that index creation should not lock table (PostgreSQL/SqlServer)
+ * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -307,6 +307,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "bar" unique nulls distinct ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('create unique index concurrently "users_foo_unique" on "users" ("foo")', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_foo_unique" unique using index "users_foo_unique"', $statements[1]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -325,6 +336,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('foo', 'baz')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index concurrently "baz" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingFulltextIndex()
@@ -357,6 +378,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'spanish\', "body")))', $statements[0]);
     }
 
+    public function testAddingFulltextIndexOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fulltext('body')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index concurrently "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[0]);
+    }
+
     public function testAddingFulltextIndexWithFluency()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -375,6 +406,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
+    }
+
+    public function testAddingSpatialIndexOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
+        $blueprint->spatialIndex('coordinates')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index concurrently "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
@@ -407,6 +448,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index "my_index" on "geo" using gist ("coordinates" point_ops, "location" point_ops)', $statements[0]);
     }
 
+    public function testAddingSpatialIndexWithOperatorClassOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'geo');
+        $blueprint->spatialIndex('coordinates', 'my_index', 'point_ops')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index concurrently "my_index" on "geo" using gist ("coordinates" point_ops)', $statements[0]);
+    }
+
     public function testAddingRawIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -415,6 +466,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
+    public function testAddingRawIndexOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->rawIndex('(function(column))', 'raw_index')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index concurrently "raw_index" on "users" ((function(column)))', $statements[0]);
     }
 
     public function testAddingIncrementingID()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -283,6 +283,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
+    public function testAddingUniqueKeyOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('foo', 'bar')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create unique index "bar" on "users" ("foo") with (online = on)', $statements[0]);
+    }
+
     public function testAddingIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -291,6 +301,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+    }
+
+    public function testAddingIndexOnline()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index(['foo', 'bar'], 'baz')->online();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar") with (online = on)', $statements[0]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -73,4 +73,22 @@ class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
         $userColumns = Schema::getColumns('users');
         $this->assertNull($userColumns[1]['generation']);
     }
+
+    public function testCreateIndexesOnline()
+    {
+        Schema::create('table', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('title', 200);
+
+            $table->unique('title')->online();
+            $table->index(['created_at'])->online();
+        });
+
+        $indexes = Schema::getIndexes('table');
+        $indexNames = collect($indexes)->pluck('name');
+
+        $this->assertContains('table_title_unique', $indexNames);
+        $this->assertContains('table_created_at_index', $indexNames);
+    }
 }


### PR DESCRIPTION
By default Postgresql and SqlServer create index using write lock (exclusive lock) on table. This makes application unusable durng migration, if index creation is long (big table), leading to downtime wich is not suitable in production.

* Postgresql offers "Concurently" option for index creation without application downtime.
* SqlServer offers "Online" option for such case.
* Latest versions of MySql and MariaDB have ALGORITHM and LOCK options, but according to documentation default option gives maximum posible concurrency (https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-online-ddl/innodb-online-ddl-overview#default-locking-strategy). So Changes for MySQL/MariaDB are not needed.

Currentrly creating indexex concurrently is possible only with DB::statement method. This PR adds ability to use it online() method in index definition.

Tried different names for IndexDefinition method (withoutLock, noLock, concurrently). Selected "online", as it's most widely used terminology. See https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-online-ddl/innodb-online-ddl-overview , https://learn.microsoft.com/en-us/sql/relational-databases/indexes/perform-index-operations-online?view=sql-server-ver16 .

Currently postgresql uses add constraint command for unique indexes, which does not support Concurently option. For such case two commands are used (create index and add constraint), as described in https://www.postgresql.org/docs/17/sql-altertable.html#SQL-ALTERTABLE-DESC-ADD-TABLE-CONSTRAINT-USING-INDEX 