### PR TITLE
[8.4] Use PHP 8.4 array helpers in Arr utils

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -557,13 +557,7 @@ class Arr
      */
     public static function every($array, callable $callback)
     {
-        foreach ($array as $key => $value) {
-            if (! $callback($value, $key)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($array, $callback);
     }
 
     /**
@@ -575,13 +569,7 @@ class Arr
      */
     public static function some($array, callable $callback)
     {
-        foreach ($array as $key => $value) {
-            if ($callback($value, $key)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($array, $callback);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Per suggestion https://github.com/laravel/framework/pull/56619#issuecomment-3175196482, this PR continues on #56619 by using PHP 8.4 helpers for the functions introduced in #56526.