### PR TITLE
[12.x] Add `Arr::push()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -976,7 +976,7 @@ class Arr
     /**
      * Push an item into an array using "dot" notation.
      *
-     * @param  ArrayAccess|array  $array
+     * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key
      * @param  mixed  $values
      * @return array
@@ -984,6 +984,7 @@ class Arr
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {
         $target = static::array($array, $key, []);
+
         array_push($target, ...$values);
 
         return static::set($array, $key, $target);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -974,6 +974,22 @@ class Arr
     }
 
     /**
+     * Push an item into an array using "dot" notation.
+     *
+     * @param  ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed $value): array
+    {
+        $target = static::array($array, $key, []);
+        $target[] = $value;
+
+        return static::set($array, $key, $target);
+    }
+
+    /**
      * Shuffle the given array and return the result.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -978,13 +978,13 @@ class Arr
      *
      * @param  ArrayAccess|array  $array
      * @param  string|int|null  $key
-     * @param  mixed  $value
+     * @param  mixed  $values
      * @return array
      */
-    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed $value): array
+    public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {
         $target = static::array($array, $key, []);
-        $target[] = $value;
+        array_push($target, ...$values);
 
         return static::set($array, $key, $target);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -77,19 +77,16 @@ class SupportArrTest extends TestCase
         Arr::push($array, 'office.furniture', 'Desk');
         $this->assertEquals(['Desk'], $array['office']['furniture']);
 
-        Arr::push($array, 'office.furniture', 'Chair');
-        $this->assertEquals(['Desk', 'Chair'], $array['office']['furniture']);
-
-        Arr::push($array, 'office.furniture', 'Lamp');
+        Arr::push($array, 'office.furniture', 'Chair', 'Lamp');
         $this->assertEquals(['Desk', 'Chair', 'Lamp'], $array['office']['furniture']);
 
         $array = [];
 
-        Arr::push($array, null, 'Chris');
-        $this->assertEquals(['Chris'], $array);
-
-        Arr::push($array, null, 'Nuno');
+        Arr::push($array, null, 'Chris', 'Nuno');
         $this->assertEquals(['Chris', 'Nuno'], $array);
+
+        Arr::push($array, null, 'Taylor');
+        $this->assertEquals(['Chris', 'Nuno', 'Taylor'], $array);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -70,6 +70,34 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['category' => ['type' => 'Table']], Arr::add(['category' => ['type' => 'Table']], 'category.type', 'Chair'));
     }
 
+    public function testPush()
+    {
+        $array = [];
+
+        Arr::push($array, 'office.furniture', 'Desk');
+        $this->assertEquals(['Desk'], $array['office']['furniture']);
+
+        Arr::push($array, 'office.furniture', 'Chair');
+        $this->assertEquals(['Desk', 'Chair'], $array['office']['furniture']);
+
+        Arr::push($array, 'office.furniture', 'Lamp');
+        $this->assertEquals(['Desk', 'Chair', 'Lamp'], $array['office']['furniture']);
+
+        $array = [];
+
+        Arr::push($array, null, 'Chris');
+        $this->assertEquals(['Chris'], $array);
+
+        Arr::push($array, null, 'Nuno');
+        $this->assertEquals(['Chris', 'Nuno'], $array);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Array value for key [foo.bar] must be an array, boolean found.');
+
+        $array = ['foo' => ['bar' => false]];
+        Arr::push($array, 'foo.bar', 'baz');
+    }
+
     public function testCollapse()
     {
         // Normal case: a two-dimensional array with different elements


### PR DESCRIPTION
Often times I find myself wanting to push something to an array (if the array exists), or initialize it to an empty array and then push it (if the array doesn't exist yet). For example:

```php
if ($this->hasChanges($data)) {
  Arr::push($result, 'pending.changes', $data);
}
```

In this case, if `$result['pending']['changes']` does not yet exist, it's created as an empty array, then `$data` is pushed to it (and if it's already an array, `$data` is pushed to the existing one).

**Why not a macro?** This isn't something you can implement simply using `Arr::macro` because macros don't pass values by reference.

(This is a function that I reach for every month or so, and each time manage to surprise myself when I can't find it on the `Arr` helper 😂)