### PR TITLE
[12.x] Cache Singleton/Scoped attribute checks

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1769,6 +1769,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->abstractAliases = [];
         $this->scopedInstances = [];
         $this->checkedForAttributeBindings = [];
+        $this->checkedForContainerBindings = [];
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -326,6 +326,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         $type = null;
+
         if (! empty($reflection->getAttributes(Singleton::class))) {
             $type = 'singleton';
         } elseif (! empty($reflection->getAttributes(Scoped::class))) {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -135,7 +135,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @var array<class-string, "scoped"|"singleton"|null>
      */
-    protected $checkedForSingleOrScopedAttributes = [];
+    protected $checkedForSingletonOrScopedAttributes = [];
 
     /**
      * All of the registered rebound callbacks.
@@ -313,8 +313,8 @@ class Container implements ArrayAccess, ContainerContract
             ? $reflection->getName()
             : $reflection;
 
-        if (array_key_exists($className, $this->checkedForSingleOrScopedAttributes)) {
-            return $this->checkedForSingleOrScopedAttributes[$className];
+        if (array_key_exists($className, $this->checkedForSingletonOrScopedAttributes)) {
+            return $this->checkedForSingletonOrScopedAttributes[$className];
         }
 
         try {
@@ -322,7 +322,7 @@ class Container implements ArrayAccess, ContainerContract
                 ? $reflection
                 : new ReflectionClass($reflection);
         } catch (ReflectionException) {
-            return $this->checkedForSingleOrScopedAttributes[$className] = null;
+            return $this->checkedForSingletonOrScopedAttributes[$className] = null;
         }
 
         $type = null;
@@ -332,7 +332,7 @@ class Container implements ArrayAccess, ContainerContract
             $type = 'scoped';
         }
 
-        return $this->checkedForSingleOrScopedAttributes[$className] = $type;
+        return $this->checkedForSingletonOrScopedAttributes[$className] = $type;
     }
 
     /**
@@ -1775,7 +1775,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->abstractAliases = [];
         $this->scopedInstances = [];
         $this->checkedForAttributeBindings = [];
-        $this->checkedForSingleOrScopedAttributes = [];
+        $this->checkedForSingletonOrScopedAttributes = [];
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -311,13 +311,17 @@ class Container implements ArrayAccess, ContainerContract
             ? $reflection->getName()
             : $reflection;
 
-        if (($cached = ($this->checkedForContainerBindings[$className] ?? false)) !== false) {
-            return $cached;
+        if (array_key_exists($className, $this->checkedForContainerBindings)) {
+            return $this->checkedForContainerBindings[$className];
         }
 
-        $reflection = $reflection instanceof ReflectionClass
-            ? $reflection
-            : new ReflectionClass($reflection);
+        try {
+            $reflection = $reflection instanceof ReflectionClass
+                ? $reflection
+                : new ReflectionClass($reflection);
+        } catch (ReflectionException) {
+            return $this->checkedForContainerBindings[$className] = null;
+        }
 
         $type = null;
         if (! empty($reflection->getAttributes(Singleton::class))) {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -131,9 +131,11 @@ class Container implements ArrayAccess, ContainerContract
     protected $checkedForAttributeBindings = [];
 
     /**
+     * Whether a class has already been checked for Singleton or Scoped attributes.
+     *
      * @var array<class-string, "scoped"|"singleton"|null>
      */
-    protected $checkedForContainerBindings = [];
+    protected $checkedForSingleOrScopedAttributes = [];
 
     /**
      * All of the registered rebound callbacks.
@@ -311,8 +313,8 @@ class Container implements ArrayAccess, ContainerContract
             ? $reflection->getName()
             : $reflection;
 
-        if (array_key_exists($className, $this->checkedForContainerBindings)) {
-            return $this->checkedForContainerBindings[$className];
+        if (array_key_exists($className, $this->checkedForSingleOrScopedAttributes)) {
+            return $this->checkedForSingleOrScopedAttributes[$className];
         }
 
         try {
@@ -320,7 +322,7 @@ class Container implements ArrayAccess, ContainerContract
                 ? $reflection
                 : new ReflectionClass($reflection);
         } catch (ReflectionException) {
-            return $this->checkedForContainerBindings[$className] = null;
+            return $this->checkedForSingleOrScopedAttributes[$className] = null;
         }
 
         $type = null;
@@ -330,7 +332,7 @@ class Container implements ArrayAccess, ContainerContract
             $type = 'scoped';
         }
 
-        return $this->checkedForContainerBindings[$className] = $type;
+        return $this->checkedForSingleOrScopedAttributes[$className] = $type;
     }
 
     /**
@@ -1773,7 +1775,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->abstractAliases = [];
         $this->scopedInstances = [];
         $this->checkedForAttributeBindings = [];
-        $this->checkedForContainerBindings = [];
+        $this->checkedForSingleOrScopedAttributes = [];
     }
 
     /**


### PR DESCRIPTION
Currently, when the container is building a class, we perform reflection to check if the class has `#[Scoped]` or `#[Singleton]` attributes. This is unnecessary to check more than once on a particular class.

This keeps a memo of the class-string to the outcome of the `Container@getScopedTyped()` call. This is similar to how we keep a cache of classes we have checked for `#[Bind]` attributes.

---

I would normally reach for an enum here but did not because they aren't particularly common in the framework. 🤷 