### PR TITLE
refactor: update cid param name

### DIFF
--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -89,7 +89,7 @@ class ResendTransport extends AbstractTransport
                 ];
 
                 if ($disposition === 'inline') {
-                    $item['inline_content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
+                    $item['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
                 }
 
                 $attachments[] = $item;
@@ -141,4 +141,6 @@ class ResendTransport extends AbstractTransport
     {
         return 'resend';
     }
+}
+   }
 }

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -141,6 +141,5 @@ class ResendTransport extends AbstractTransport
     {
         return 'resend';
     }
-}
    }
 }

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -141,5 +141,4 @@ class ResendTransport extends AbstractTransport
     {
         return 'resend';
     }
-   }
 }


### PR DESCRIPTION
Resend changed the param name to `content_id` in our API and SDK.
