### PR TITLE
[12.x] Add ProhibitsDeletion Eloquent trait to block model deletion

### DIFF
--- a/src/Illuminate/Database/Eloquent/ProhibitsDeletion.php
+++ b/src/Illuminate/Database/Eloquent/ProhibitsDeletion.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Exception;
+
+/**
+ * Trait ProhibitsDeletion
+ *
+ * Prevents deletion of a model instance when enabled. This applies to both
+ * normal deletes and soft deletes (via SoftDeletes) because the `deleting`
+ * model event is intercepted and the `delete()` method is overridden.
+ *
+ * By default, deletion is prohibited. You can toggle the behavior at runtime
+ * via {@see shouldProhibitDeletion()}.
+ */
+trait ProhibitsDeletion
+{
+    /**
+     * Whether deletion is currently prohibited for this model class.
+     */
+    protected static bool $prohibitDeletion = true;
+
+    /**
+     * Boot the ProhibitsDeletion trait for a model.
+     *
+     * Attaches a listener to the `deleting` model event to prevent deletion
+     * when {@see shouldProhibitDeletion()} is true.
+     *
+     * @throws Exception If deletion is prohibited.
+     */
+    public static function bootProhibitsDeletion(): void
+    {
+        static::deleting(function (Model $model) {
+            if ($model->shouldProhibitDeletion()) {
+                $model->throwProhibited(false);
+            }
+        });
+    }
+
+    /**
+     * Delete the model from the database.
+     *
+     * This method is overridden to enforce deletion prohibition when
+     * {@see shouldProhibitDeletion()} is true.
+     *
+     * @return bool|null True if the model was deleted, false/null otherwise.
+     *
+     * @throws Exception If deletion is prohibited.
+     */
+    public function delete()
+    {
+        if ($this->shouldProhibitDeletion()) {
+            $this->throwProhibited(false);
+        }
+
+        return parent::delete();
+    }
+
+    /**
+     * Whether deletion should be prohibited for this model instance.
+     * Override this in your model for custom logic.
+     */
+    protected function shouldProhibitDeletion(): bool
+    {
+        return static::$prohibitDeletion;
+    }
+
+    /**
+     * Throw an exception indicating that deletion is prohibited.
+     *
+     * @throws Exception Always thrown to indicate deletion is prohibited.
+     */
+    protected function throwProhibited(bool $force): void
+    {
+        $class = static::class;
+        $prefix = $force ? 'Force deletion' : 'Deletion';
+
+        throw new Exception("$prefix of $class is prohibited.");
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a reusable Eloquent trait, **`ProhibitsDeletion`**, that prevents deleting model instances.
It blocks both **soft deletes** and **hard deletes** by default, with an opt-out toggle you can flip at runtime.

---

## Motivation
Some records should never be removed (system settings, reference data, audit logs, immutable history, etc.).
Today, developers either override `delete()` per model or wire up ad-hoc event listeners.

This trait provides a **small, consistent, and discoverable** core solution:
- Zero boilerplate beyond `use ProhibitsDeletion;`
- Safe by default (deletion prohibited)
- Clear exception message when a delete is attempted
- Compatible with `SoftDeletes` without method conflicts

---

## Why no `forceDelete()` override?
- Avoids a trait method conflict with `SoftDeletes`.
- In `SoftDeletes`, `forceDelete()` calls `delete()` internally, which triggers:
    - The overridden `delete()` method in `ProhibitsDeletion`
    - The `deleting` event listener

This means both soft and hard deletes are still blocked without extra conflict resolution.

---

## Usage
```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\ProhibitsDeletion;

class SystemSetting extends Model
{
  use ProhibitsDeletion;
}
```

---

## Attempting to delete:
```php
SystemSetting::first()->delete();
// throws: "Deletion of App\Models\SystemSetting is prohibited."
```

---

## Prohibiting deletion in production environment:
```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\ProhibitsDeletion;

class SystemSetting extends Model
{
  use ProhibitsDeletion;
  
  protected function shouldProhibitDeletion(): bool
  {
      return app()->isProduction();
  }
}
```
---

## Behavior & Compatibility Notes
- **Covers soft & hard deletes**
Works with or without `SoftDeletes`. No `insteadof` needed.
- **`deleteQuietly()`**
Skips events, but still calls `delete()` → prohibition still applies.
- **Bulk / query deletes**
`Model::where(...)->delete()` bypasses model instantiation/events → not intercepted.
- **Per-model class toggle**
`$prohibitDeletion` is static per model class.
- **Safe by default**
Defaults to `true` to reduce accidental production deletions.

---

## Tests (proposed)
- Prevents instance deletion via `delete()`
- Allows deletion when prohibition is toggled off
- Blocks deletion on models with `SoftDeletes` (both `delete()` and `forceDelete()`)
- Verifies `deleteQuietly()` still throws
- Confirms event listener behavior

---

## Why in Core?
- Eliminates repeated boilerplate for deletion protection
- Aligns with Eloquent’s trait-driven design
- Defaults to safe behavior, especially valuable in production
- Clear, explicit, opt-in mechanism
