### PR TITLE
[12.x] Add `allowedUrls` through `preventStrayRequests`

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -340,25 +340,20 @@ class Factory
     }
 
     /**
-     * Allow stray (unfaked) requests entirely, or (optionally) allow only specific URLs.
+     * Allow stray, unfaked requests entirely, or optionally allow only specific URLs.
      *
-     * Passing no argument keeps the current behavior and disables the guard.
-     * Passing a non-empty array keeps the guard enabled but allows matching URLs to pass through.
-     *
-     * @param  array<int, string>|null  $urls
+     * @param  array<int, string>|null  $only
      * @return $this
      */
-    public function allowStrayRequests(?array $urls = null)
+    public function allowStrayRequests(?array $only = null)
     {
-        if (is_null($urls)) {
-            // Backwards-compatible: fully allow stray requests.
-            $this->preventStrayRequests = false;
+        if (is_null($only)) {
+            $this->preventStrayRequests(false);
+
             $this->allowedStrayRequestUrls = [];
-
-            return $this;
+        } else {
+            $this->allowedStrayRequestUrls = array_values($only);
         }
-
-        $this->allowedStrayRequestUrls = array_values($urls);
 
         return $this;
     }
@@ -507,7 +502,10 @@ class Factory
     public function createPendingRequest()
     {
         return tap($this->newPendingRequest(), function ($request) {
-            $request->stub($this->stubCallbacks)->preventStrayRequests($this->preventStrayRequests)->allowStrayRequests($this->allowedStrayRequestUrls);
+            $request
+                ->stub($this->stubCallbacks)
+                ->preventStrayRequests($this->preventStrayRequests)
+                ->allowStrayRequests($this->allowedStrayRequestUrls);
         });
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -352,13 +352,12 @@ class Factory
     {
         if (is_null($urls)) {
             // Backwards-compatible: fully allow stray requests.
-            $this->preventingStrayRequests = false;
+            $this->preventStrayRequests = false;
             $this->allowedStrayRequestUrls = [];
 
             return $this;
         }
 
-        // Guard stays enabled, but whitelisted URLs are permitted.
         $this->allowedStrayRequestUrls = array_values($urls);
 
         return $this;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1511,7 +1511,7 @@ class PendingRequest
     /**
      * Allow stray, unfaked requests entirely, or optionally allow only specific URLs.
      *
-     * @param  array<int, string>  $urls
+     * @param  array<int, string>  $only
      * @return $this
      */
     public function allowStrayRequests(array $only)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -173,6 +173,13 @@ class PendingRequest
     protected $preventStrayRequests = false;
 
     /**
+     * A list of URL patterns that are allowed to bypass the stray request guard.
+     *
+     * @var array<int, string>
+     */
+    protected $allowedStrayRequestUrls = [];
+
+    /**
      * The middleware callables added by users that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -1376,7 +1383,7 @@ class PendingRequest
                     ->first();
 
                 if (is_null($response)) {
-                    if ($this->preventStrayRequests) {
+                    if (! $this->isAllowedRequestUrl((string) $request->getUri())) {
                         throw new StrayRequestException((string) $request->getUri());
                     }
 
@@ -1499,6 +1506,44 @@ class PendingRequest
         $this->preventStrayRequests = $prevent;
 
         return $this;
+    }
+
+    /**
+     * Allow stray (unfaked) requests entirely, or (optionally) allow only specific URLs.
+     *
+     * Passing no argument keeps the current behavior and disables the guard.
+     * Passing a non-empty array keeps the guard enabled but allows matching URLs to pass through.
+     *
+     * @param  array<int, string>  $urls
+     * @return $this
+     */
+    public function allowStrayRequests(array $urls)
+    {
+        // Guard stays enabled, but whitelisted URLs are permitted.
+        $this->allowedStrayRequestUrls = array_values($urls);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the given URL is whitelisted for stray requests.
+     *
+     * @param  string  $url
+     * @return bool
+     */
+    public function isAllowedRequestUrl($url)
+    {
+        if (! $this->preventStrayRequests) {
+            return true;
+        }
+
+        foreach ($this->allowedStrayRequestUrls as $pattern) {
+            if (Str::is($pattern, $url)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1509,24 +1509,20 @@ class PendingRequest
     }
 
     /**
-     * Allow stray (unfaked) requests entirely, or (optionally) allow only specific URLs.
-     *
-     * Passing no argument keeps the current behavior and disables the guard.
-     * Passing a non-empty array keeps the guard enabled but allows matching URLs to pass through.
+     * Allow stray, unfaked requests entirely, or optionally allow only specific URLs.
      *
      * @param  array<int, string>  $urls
      * @return $this
      */
-    public function allowStrayRequests(array $urls)
+    public function allowStrayRequests(array $only)
     {
-        // Guard stays enabled, but whitelisted URLs are permitted.
-        $this->allowedStrayRequestUrls = array_values($urls);
+        $this->allowedStrayRequestUrls = array_values($only);
 
         return $this;
     }
 
     /**
-     * Determine if the given URL is whitelisted for stray requests.
+     * Determine if the given URL is allowed as a stray request.
      *
      * @param  string  $url
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3464,6 +3464,21 @@ class HttpClientTest extends TestCase
         $this->assertTrue($this->factory->preventingStrayRequests());
     }
 
+    public function testAllowingStrayRequestUrls()
+    {
+        $this->assertFalse($this->factory->preventingStrayRequests());
+        $this->assertTrue($this->factory->isAllowedRequestUrl('127.0.0.1'));
+
+        $this->factory->preventStrayRequests();
+        $this->assertFalse($this->factory->isAllowedRequestUrl('127.0.0.1'));
+        $this->factory->allowStrayRequests([
+            '127.0.0.1',
+        ]);
+
+        $this->assertTrue($this->factory->preventingStrayRequests());
+        $this->assertTrue($this->factory->isAllowedRequestUrl('127.0.0.1'));
+    }
+
     public function testItCanAddAuthorizationHeaderIntoRequestUsingBeforeSendingCallback()
     {
         $this->factory->fake();

--- a/tests/Support/SupportFacadesHttpTest.php
+++ b/tests/Support/SupportFacadesHttpTest.php
@@ -56,6 +56,13 @@ class SupportFacadesHttpTest extends TestCase
         $this->assertSame($client, $this->app->make(Factory::class));
     }
 
+    public function testFacadeRootIsSharedWhenEnforcingFakingWithAllowedUrls(): void
+    {
+        $client = Http::preventStrayRequests()->allowStrayRequests(['127.0.0.1']);
+
+        $this->assertSame($client, $this->app->make(Factory::class));
+    }
+
     public function test_can_set_prevents_to_prevents_stray_requests(): void
     {
         Http::preventStrayRequests(true);


### PR DESCRIPTION
The purpose behind `Http::preventStrayRequests()` is great - it stops any stray requests from hitting endpoints.  
However, this also means that if you’re trying to use SSR to check the output from something like Inertia, those requests will be blocked and a `StrayRequestException` will be thrown.

This PR expands the existing `Http::allowStrayRequests()` method to accept an array of “allowed” URLs.  
For example:

```php
Http::allowStrayRequests([
    'http://127.0.0.1:13714/*',
]);
```

To keep things fully backward-compatible, calling `allowStrayRequests()` without arguments still turns `preventStrayRequests `off entirely, as it did before.

Both the `Http\Client\Factory` and `Http\Client\PendingResponse` classes have been adjusted to accept and pass the allowed list of URLs.

I’ve added a simple test to ensure the allow-list logic works.
I avoided adding a test that actually hits a real endpoint, since depending on when/how the tests are run, the result could vary - even for `127.0.0.1`.
