### PR TITLE
[12.x] Add Arr::reduce to reduce arrays to a single value

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,7 +828,7 @@ class Arr
     }
 
     /**
-     * Reduce the items to a single value.
+     * Reduce the array to a single value (single accumulated result).
      *
      * @template TKey
      * @template TValue
@@ -849,7 +849,6 @@ class Arr
 
         return $carry;
     }
-
 
     /**
      * Push an item onto the beginning of an array.

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,6 +828,30 @@ class Arr
     }
 
     /**
+     * Reduce the items to a single value.
+     *
+     * @template TKey
+     * @template TValue
+     * @template TCarry
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  callable(TCarry, TValue, TKey): TCarry  $callback
+     * @param  TCarry  $initial
+     * @return TCarry
+     */
+    public static function reduce(array $array, callable $callback, mixed $initial = null)
+    {
+        $carry = $initial;
+
+        foreach ($array as $key => $value) {
+            $carry = $callback($carry, $value, $key);
+        }
+
+        return $carry;
+    }
+
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1039,7 +1039,7 @@ class SupportArrTest extends TestCase
     public function testReduce()
     {
         $array = [1, 2, 3, 4];
-        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item, 0);
+        $result = Arr::reduce($array, fn ($carry, $item) => $carry + $item, 0);
         $this->assertEquals(10, $result);
 
         $array = ['apple', 'banana', 'apple'];
@@ -1050,7 +1050,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['apple' => 2, 'banana' => 1], $result);
 
         $array = ['a', 'b', 'c'];
-        $result = Arr::reduce($array, fn($carry, $item) => $carry . $item, '');
+        $result = Arr::reduce($array, fn ($carry, $item) => $carry.$item, '');
         $this->assertEquals('abc', $result);
 
         $array = ['a' => 10, 'b' => 20];
@@ -1061,11 +1061,11 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['a' => 20, 'b' => 40], $result);
 
         $array = [];
-        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item, 5);
+        $result = Arr::reduce($array, fn ($carry, $item) => $carry + $item, 5);
         $this->assertEquals(5, $result);
         
         $array = [];
-        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item);
+        $result = Arr::reduce($array, fn ($carry, $item) => $carry + $item);
         $this->assertNull($result);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1036,6 +1036,39 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
+    public function testReduce()
+    {
+        $array = [1, 2, 3, 4];
+        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item, 0);
+        $this->assertEquals(10, $result);
+
+        $array = ['apple', 'banana', 'apple'];
+        $result = Arr::reduce($array, function ($carry, $item) {
+            $carry[$item] = ($carry[$item] ?? 0) + 1;
+            return $carry;
+        }, []);
+        $this->assertEquals(['apple' => 2, 'banana' => 1], $result);
+
+        $array = ['a', 'b', 'c'];
+        $result = Arr::reduce($array, fn($carry, $item) => $carry . $item, '');
+        $this->assertEquals('abc', $result);
+
+        $array = ['a' => 10, 'b' => 20];
+        $result = Arr::reduce($array, function ($carry, $item, $key) {
+            $carry[$key] = $item * 2;
+            return $carry;
+        }, []);
+        $this->assertEquals(['a' => 20, 'b' => 40], $result);
+
+        $array = [];
+        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item, 5);
+        $this->assertEquals(5, $result);
+        
+        $array = [];
+        $result = Arr::reduce($array, fn($carry, $item) => $carry + $item);
+        $this->assertNull($result);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1065,7 +1065,7 @@ class SupportArrTest extends TestCase
         $array = [];
         $result = Arr::reduce($array, fn ($carry, $item) => $carry + $item, 5);
         $this->assertEquals(5, $result);
-        
+
         $array = [];
         $result = Arr::reduce($array, fn ($carry, $item) => $carry + $item);
         $this->assertNull($result);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1045,6 +1045,7 @@ class SupportArrTest extends TestCase
         $array = ['apple', 'banana', 'apple'];
         $result = Arr::reduce($array, function ($carry, $item) {
             $carry[$item] = ($carry[$item] ?? 0) + 1;
+
             return $carry;
         }, []);
         $this->assertEquals(['apple' => 2, 'banana' => 1], $result);
@@ -1056,6 +1057,7 @@ class SupportArrTest extends TestCase
         $array = ['a' => 10, 'b' => 20];
         $result = Arr::reduce($array, function ($carry, $item, $key) {
             $carry[$key] = $item * 2;
+
             return $carry;
         }, []);
         $this->assertEquals(['a' => 20, 'b' => 40], $result);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds `Arr::reduce(array $array, callable $callback, mixed $initial = null)` a small, non-breaking helper that iteratively reduces an array to a single value (**single accumulated result**).

Sample usages:
```php
// Count occurrences
$fruits = ['apple','banana','apple'];
$counts = Arr::reduce($fruits, function ($carry, $item) {
    $carry[$item] = ($carry[$item] ?? 0) + 1;
    return $carry;
}, []); 
// ['apple' => 2, 'banana' => 1]

// Preserve and transform keys
$items = ['x' => 10, 'y' => 20];
$double = Arr::reduce($items, fn($carry, $value, $key) => ($carry[$key] = $value * 2) && $carry, []); 
// ['x'=>20,'y'=>40]

// Sum
$total = Arr::reduce([1,2,3,4], fn($carry, $v) => $carry + $v, 0);
// 10
```

