### PR TITLE
[12.x] Raising JobAttempted event in Sync Queue

### DIFF
--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
@@ -131,7 +132,11 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
+            $exceptionOccurred = true;
+
             $this->handleException($queueJob, $e);
+        } finally {
+            $this->raiseJobAttemptedEvent($queueJob, $exceptionOccurred ?? false);
         }
 
         return 0;
@@ -172,6 +177,20 @@ class SyncQueue extends Queue implements QueueContract
     {
         if ($this->container->bound('events')) {
             $this->container['events']->dispatch(new JobProcessed($this->connectionName, $job));
+        }
+    }
+
+    /**
+     * Raise job attempted event.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  bool  $exceptionOccurred  Indicates if an exception occurred while processing the job.
+     * @return void
+     */
+    protected function raiseJobAttemptedEvent(Job $job, $exceptionOccurred = false)
+    {
+        if ($this->container->bound('events')) {
+            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exceptionOccurred));
         }
     }
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -47,7 +47,7 @@ class QueueSyncQueueTest extends TestCase
         $container = new Container;
         Container::setInstance($container);
         $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->times(3);
+        $events->shouldReceive('dispatch')->times(4);
         $container->instance('events', $events);
         $container->instance(Dispatcher::class, $events);
         $sync->setContainer($container);


### PR DESCRIPTION
Currently Worker raises JobAttempted event (added in https://github.com/laravel/framework/pull/52710/files#diff-d1e6684c51f2038f97ba12fee146a8f77b1bca1c747b29951ff5746446165a91R448, [src/Illuminate/Queue/Worker.php:448](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Queue/Worker.php#L452))

Sync Queue raises mostly same events as Worker, but is missing this event. This PR adds this event to SyncQueue
