### PR TITLE
Feature: detect running database seeder

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -93,6 +93,22 @@ interface Application extends Container
     public function runningInConsole();
 
     /**
+     * Determine if the application is running database seeder(s).
+     *
+     * @return bool
+     */
+    public function runningDatabaseSeeder();
+
+
+    /**
+     * Set the database seeding state.
+     *
+     * @param  bool  $seeding
+     * @return $this
+     */
+    public function setDatabaseSeeding($seeding);
+
+    /**
      * Determine if the application is running unit tests.
      *
      * @return bool

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -99,7 +99,6 @@ interface Application extends Container
      */
     public function runningDatabaseSeeder();
 
-
     /**
      * Set the database seeding state.
      *

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -67,9 +67,17 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
-        });
+        // Set the seeding state before running seeders
+        $this->laravel->setDatabaseSeeding(true);
+
+        try {
+            Model::unguarded(function () {
+                $this->getSeeder()->__invoke();
+            });
+        } finally {
+            // Always reset the seeding state, even if an exception occurs
+            $this->laravel->setDatabaseSeeding(false);
+        }
 
         if ($previousConnection) {
             $this->resolver->setDefaultConnection($previousConnection);

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -44,6 +44,12 @@ abstract class Seeder
     {
         $classes = Arr::wrap($class);
 
+        // Ensure seeding state is maintained for nested seeders
+        // This is set once before processing all classes
+        if ($this->container->bound('app')) {
+            $this->container->make('app')->setDatabaseSeeding(true);
+        }
+
         foreach ($classes as $class) {
             $seeder = $this->resolve($class);
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -188,6 +188,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $isRunningInConsole;
 
     /**
+     * Indicates if the application is running database seeder(s).
+     *
+     * @var bool
+     */
+    protected $isDatabaseSeeding = false;
+
+    /**
      * The application namespace.
      *
      * @var string
@@ -821,6 +828,29 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $_SERVER['argv'][1] ?? null,
             is_array($commands[0]) ? $commands[0] : $commands
         );
+    }
+
+    /**
+     * Determine if the application is running database seeder(s).
+     *
+     * @return bool
+     */
+    public function runningDatabaseSeeder()
+    {
+        return $this->isDatabaseSeeding;
+    }
+
+    /**
+     * Set the database seeding state.
+     *
+     * @param  bool  $seeding
+     * @return $this
+     */
+    public function setDatabaseSeeding($seeding)
+    {
+        $this->isDatabaseSeeding = $seeding;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -42,6 +42,8 @@ namespace Illuminate\Support\Facades;
  * @method static string detectEnvironment(\Closure $callback)
  * @method static bool runningInConsole()
  * @method static bool runningConsoleCommand(string|array ...$commands)
+ * @method static bool runningDatabaseSeeder()
+ * @method static \Illuminate\Foundation\Application setDatabaseSeeding(bool $seeding)
  * @method static bool runningUnitTests()
  * @method static bool hasDebugModeEnabled()
  * @method static void registered(callable $callback)
@@ -145,7 +147,6 @@ namespace Illuminate\Support\Facades;
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
- *
  * @see \Illuminate\Foundation\Application
  */
 class App extends Facade

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -609,6 +609,42 @@ class FoundationApplicationTest extends TestCase
             $this->assertSame(['X-FOO' => 'BAR'], $exception->getHeaders());
         }
     }
+
+    public function testRunningDatabaseSeederReturnsFalseByDefault()
+    {
+        $app = new Application();
+        $this->assertFalse($app->runningDatabaseSeeder());
+    }
+
+    public function testCanSetDatabaseSeedingState()
+    {
+        $app = new Application();
+        $app->setDatabaseSeeding(true);
+        $this->assertTrue($app->runningDatabaseSeeder());
+
+        $app->setDatabaseSeeding(false);
+        $this->assertFalse($app->runningDatabaseSeeder());
+    }
+
+    public function testSetDatabaseSeedingReturnsApplicationInstance()
+    {
+        $app = new Application();
+        $result = $app->setDatabaseSeeding(true);
+
+        $this->assertInstanceOf(Application::class, $result);
+        $this->assertSame($app, $result);
+    }
+
+    public function testCanChainDatabaseSeedingMethods()
+    {
+        $app = new Application();
+        $result = $app
+            ->setDatabaseSeeding(true)
+            ->setDatabaseSeeding(false);
+
+        $this->assertInstanceOf(Application::class, $result);
+        $this->assertFalse($app->runningDatabaseSeeder());
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider


### PR DESCRIPTION
## Description
This PR adds `runningDatabaseSeeder()` method to detect when the application is executing database seeders, following the same pattern as `runningInConsole()` and `runningUnitTests()`.

## Motivation
Model events and observers are commonly used in Laravel to trigger external actions (API calls, notifications, webhooks) when models are created or updated. Currently, developers resort to workarounds like environment variables or static flags to prevent these side effects during database seeding, where creating thousands of models would trigger thousands of unwanted external requests.

This standardized approach provides a clean Laravel way to:
- Prevent external API calls
- Disable notifications and emails
- Skip audit logging
- Avoid cache invalidation
- Bypass search indexing

## Implementation
- Follows existing Laravel patterns
- Properly implements Application contract
- Handles nested seeders correctly
- Includes exception safety with try/finally
- Zero breaking changes

## Example: User Model Observer with External CRM Integration
```php
<?php

namespace App\Observers;

use App\Models\User;
use Illuminate\Support\Facades\Http;

class UserObserver
{
    /**
     * Handle the User "created" event.
     */
    public function created(User $user): void
    {
        // Skip external API calls during database seeding
        if (app()->runningDatabaseSeeder()) {
            return;
        }

        // Sync user to external CRM system (HubSpot, Salesforce, etc.)
        Http::post('https://api.hubspot.com/contacts/v1/contact', [
            'properties' => [
                ['property' => 'email', 'value' => $user->email],
                ['property' => 'firstname', 'value' => $user->first_name],
                ['property' => 'lastname', 'value' => $user->last_name],
                ['property' => 'lifecyclestage', 'value' => 'customer'],
            ]
        ]);
    }
}
```

## The Problem Without This Feature
```php

// Database seeder
User::factory()->count(1000)->create();

```

When seeding 1,000 test users:
- Without `runningDatabaseSeeder()`: Makes 1,000 API calls to HubSpot with fake data
- With `runningDatabaseSeeder()`: No API calls during seeding

## More Use Cases
This feature is essential for preventing unwanted side effects during database seeding:

### Common Scenarios

- External API Calls: Skip syncing to CRM systems (HubSpot, Salesforce), payment processors (Stripe), or analytics platforms during seeding
- Notifications: Prevent sending thousands of notifications when seeding user data
- Webhook Dispatching: Avoid triggering webhooks to customer endpoints during seeding
- Search Indexing: Skip indexing in Elasticsearch/Algolia when creating seed data
- Cache Invalidation: Prevent unnecessary cache flushes during seeding operations
- Audit Logging: Exclude seed data from audit logs and activity tracking
- File Generation: Skip generating PDFs, invoices, or reports for seeded records
- Real-time Broadcasting: Prevent broadcasting events through Pusher/Ably during seeding
- Third-party Integrations: Avoid syncing with external inventory, shipping, or accounting systems

