### PR TITLE
[12.x] Indicate that `Context@scope()` may throw

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -541,6 +541,8 @@ class Repository
      * @param  array<string, mixed>  $data
      * @param  array<string, mixed>  $hidden
      * @return mixed
+     *
+     * @throws \Throwable
      */
     public function scope(callable $callback, array $data = [], array $hidden = [])
     {


### PR DESCRIPTION
This is similar to how `DB::transaction()` is hinted.