### PR TITLE
[12.x] Add "Copy as Markdown" button to error page

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -89,8 +89,15 @@ class Renderer
             $this->htmlErrorRenderer->render($throwable),
         );
 
+        $exception = new Exception($flattenException, $request, $this->listener, $this->basePath);
+
+        $exceptionAsMarkdown = $this->viewFactory->make('laravel-exceptions-renderer::markdown', [
+            'exception' => $exception,
+        ])->render();
+
         return $this->viewFactory->make('laravel-exceptions-renderer::show', [
-            'exception' => new Exception($flattenException, $request, $this->listener, $this->basePath),
+            'exception' => $exception,
+            'exceptionAsMarkdown' => $exceptionAsMarkdown,
         ])->render();
     }
 

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/copy-button.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/copy-button.blade.php
@@ -1,0 +1,25 @@
+<script>
+    let exceptionAsMarkdown = {{ Illuminate\Support\Js::from($markdown) }}
+</script>
+<div
+    class="relative inline-block text-sm rounded-full bg-white px-3 py-2 dark:bg-gray-800 sm:col-span-1 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer transition-colors duration-200 ease-in-out"
+    x-data="{
+        copied: false,
+        copy() {
+            const textarea = document.createElement('textarea');
+            textarea.value = exceptionAsMarkdown;
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+
+            this.copied = true;
+            setTimeout(() => this.copied = false, 1000);
+        }
+    }"
+    @click="copy"
+>
+    <span x-text="copied ? 'Copied to clipboard' : 'Copy as Markdown'"></span>
+</div>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/navigation.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/navigation.blade.php
@@ -21,8 +21,8 @@
             </div>
 
             <div class="flex items-center gap-3 sm:gap-6">
-                <x-laravel-exceptions-renderer::theme-switcher />
                 <x-laravel-exceptions-renderer::copy-button :markdown="$exceptionAsMarkdown" />
+                <x-laravel-exceptions-renderer::theme-switcher />
             </div>
         </div>
     </div>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/navigation.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/navigation.blade.php
@@ -22,6 +22,7 @@
 
             <div class="flex items-center gap-3 sm:gap-6">
                 <x-laravel-exceptions-renderer::theme-switcher />
+                <x-laravel-exceptions-renderer::copy-button :markdown="$exceptionAsMarkdown" />
             </div>
         </div>
     </div>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -1,0 +1,39 @@
+# {{ $exception->class() }} - {!! $exception->title() !!}
+{!! $exception->message() !!}
+
+## Stack trace:
+@foreach($exception->frames() as $index => $frame)
+{{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
+@endforeach
+
+## Request:
+{{ $exception->request()->method() }} {{ Str::start($exception->request()->path(), '/') }}
+
+## Headers
+
+@forelse ($exception->requestHeaders() as $key => $value)
+* **{{ $key }}**: {!! $value !!}
+@empty
+No headers data
+@endforelse
+
+## Route Context:
+@forelse($exception->applicationRouteContext() as $name => $value)
+{{ $name }}: {!! $value !!}
+@empty
+No routing data
+@endforelse
+
+@if ($routeParametersContext = $exception->applicationRouteParametersContext())
+## Routing Parameters:
+
+{!! $routeParametersContext !!}
+@endif
+
+## Database Queries:
+
+@forelse ($exception->applicationQueries() as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time])
+* {{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
+@empty
+No database queries
+@endforelse

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -1,6 +1,10 @@
 # {{ $exception->class() }} - {!! $exception->title() !!}
 {!! $exception->message() !!}
 
+PHP {{ PHP_VERSION }}
+Laravel {{ app()->version() }}
+{{ $exception->request()->httpHost() }}
+
 ## Stack trace:
 @foreach($exception->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -5,12 +5,14 @@ PHP {{ PHP_VERSION }}
 Laravel {{ app()->version() }}
 {{ $exception->request()->httpHost() }}
 
-## Stack trace:
+## Stack Trace
+
 @foreach($exception->frames() as $index => $frame)
 {{ $index }} - {{ $frame->file() }}:{{ $frame->line() }}
 @endforeach
 
-## Request:
+## Request
+
 {{ $exception->request()->method() }} {{ Str::start($exception->request()->path(), '/') }}
 
 ## Headers
@@ -18,14 +20,15 @@ Laravel {{ app()->version() }}
 @forelse ($exception->requestHeaders() as $key => $value)
 * **{{ $key }}**: {!! $value !!}
 @empty
-No headers data
+No header data available.
 @endforelse
 
-## Route Context:
+## Route Context
+
 @forelse($exception->applicationRouteContext() as $name => $value)
 {{ $name }}: {!! $value !!}
 @empty
-No routing data
+No routing data available.
 @endforelse
 
 @if ($routeParametersContext = $exception->applicationRouteParametersContext())
@@ -34,10 +37,10 @@ No routing data
 {!! $routeParametersContext !!}
 @endif
 
-## Database Queries:
+## Database Queries
 
 @forelse ($exception->applicationQueries() as ['connectionName' => $connectionName, 'sql' => $sql, 'time' => $time])
 * {{ $connectionName }} - {!! $sql !!} ({{ $time }} ms)
 @empty
-No database queries
+No database queries detected.
 @endforelse

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
@@ -1,6 +1,6 @@
 <x-laravel-exceptions-renderer::layout :$exception>
     <div class="renderer container mx-auto lg:px-8">
-        <x-laravel-exceptions-renderer::navigation :$exception />
+        <x-laravel-exceptions-renderer::navigation :$exception :$exceptionAsMarkdown />
 
         <main class="px-6 pb-12 pt-6">
             <div class="container mx-auto">


### PR DESCRIPTION
With Laravel Boost now being released, I thought it would be cool to also give the Laravel exception page a "boost".
This PR introduces a new "Copy as Markdown" button on the default exception view.

<img width="2490" height="882" alt="CleanShot 2025-08-14 at 12 21 04@2x" src="https://github.com/user-attachments/assets/ae525173-018f-4dda-a2f4-7b585fc2c1b7" />

When clicking this button, we copy a markdown representation of the exception to the users clipboard, which can then be used for AI agents/LLMs.

The markdown contains all the information that is also visible on the page:

Exception title, class, message
PHP and Laravel Version
Request and route context
Application context

As these exceptions also happen in non-secure (`http://`) environments, like within Herd, I used the "old-school" way of copying the content to the clipboard, as `navigator.clipboard` requires HTTPS and would therefore fail locally.