### PR TITLE
[12.x] Add `$key` parameter to `getChanges()` and `getPrevious()` methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2233,21 +2233,31 @@ trait HasAttributes
     /**
      * Get the attributes that were changed when the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @param  mixed  $default
+     *
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getChanges()
+    public function getChanges($key = null, $default = null)
     {
-        return $this->changes;
+        return (new static)->setRawAttributes(
+            $this->changes, $sync = true
+        )->getOriginalWithoutRewindingModel($key, $default);
     }
 
     /**
      * Get the attributes that were previously original before the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @param  mixed  $default
+     *
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
-    public function getPrevious()
+    public function getPrevious($key = null, $default = null)
     {
-        return $this->previous;
+        return (new static)->setRawAttributes(
+            $this->previous, $sync = true
+        )->getOriginalWithoutRewindingModel($key, $default);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2235,7 +2235,6 @@ trait HasAttributes
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     *
      * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function getChanges($key = null, $default = null)
@@ -2250,7 +2249,6 @@ trait HasAttributes
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     *
      * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function getPrevious($key = null, $default = null)

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -22,6 +22,12 @@ class EloquentModelTest extends DatabaseTestCase
             $table->string('name');
             $table->string('title');
         });
+
+        Schema::create('test_model3', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->json('data');
+        });
     }
 
     public function testUserCanUpdateNullableDate()
@@ -104,6 +110,76 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEmpty($user->getPrevious());
     }
 
+    public function testGetChangesWithKey()
+    {
+        $user = TestModel2::create([
+            'name' => $originalName = Str::random(),
+            'title' => $originalTitle = Str::random(),
+        ]);
+
+        $user->name = $newName = Str::random();
+        $user->title = $newTitle = Str::random();
+        $user->save();
+
+        $this->assertNull($user->getChanges('nonexistent'));
+        $this->assertSame($newName, $user->getChanges('name'));
+        $this->assertSame($newTitle, $user->getChanges('title'));
+        $this->assertSame('default', $user->getChanges('nonexistent', 'default'));
+        $this->assertEquals(['name' => $newName, 'title' => $newTitle], $user->getChanges());
+    }
+
+    public function testGetPreviousWithKey()
+    {
+        $user = TestModel2::create([
+            'name' => $originalName = Str::random(),
+            'title' => $originalTitle = Str::random(),
+        ]);
+
+        $user->name = $newName = Str::random();
+        $user->title = $newTitle = Str::random();
+        $user->save();
+
+        $this->assertNull($user->getPrevious('nonexistent'));
+        $this->assertSame($originalName, $user->getPrevious('name'));
+        $this->assertSame($originalTitle, $user->getPrevious('title'));
+        $this->assertSame('default', $user->getPrevious('nonexistent', 'default'));
+        $this->assertEquals(['name' => $originalName, 'title' => $originalTitle], $user->getPrevious());
+    }
+
+    public function testGetChangesAndPreviousWithCasts()
+    {
+        $user = TestModel3::create([
+            'name' => $originalName = Str::random(),
+            'data' => $originalData = ['key' => 'value'],
+        ]);
+
+        $user->name = $newName = Str::random();
+        $user->data = $newData = ['key' => 'new_value'];
+        $user->save();
+
+        $this->assertSame($newName, $user->getChanges('name'));
+        $this->assertEquals($newData, $user->getChanges('data'));
+        $this->assertSame($originalName, $user->getPrevious('name'));
+        $this->assertEquals($originalData, $user->getPrevious('data'));
+        $this->assertEquals(['name' => $newName, 'data' => $newData], $user->getChanges());
+        $this->assertEquals(['name' => $originalName, 'data' => $originalData], $user->getPrevious());
+    }
+
+    public function testGetChangesAndPreviousWithNoChanges()
+    {
+        $user = TestModel2::create([
+            'name' => $name = Str::random(),
+            'title' => $title = Str::random(),
+        ]);
+
+        $this->assertEmpty($user->getChanges());
+        $this->assertEmpty($user->getPrevious());
+        $this->assertNull($user->getChanges('name'));
+        $this->assertNull($user->getPrevious('name'));
+        $this->assertSame('default', $user->getChanges('name', 'default'));
+        $this->assertSame('default', $user->getPrevious('name', 'default'));
+    }
+
     public function testInsertRecordWithReservedWordFieldName()
     {
         Schema::create('actions', function (Blueprint $table) {
@@ -150,4 +226,12 @@ class TestModel2 extends Model
     public $table = 'test_model2';
     public $timestamps = false;
     protected $guarded = [];
+}
+
+class TestModel3 extends Model
+{
+    public $table = 'test_model3';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $casts = ['data' => 'array'];
 }


### PR DESCRIPTION
This PR adds optional `$key` and `$default` parameters to the `getChanges()` and `getPrevious()` methods in the `HasAttributes` trait, allowing developers to retrieve specific changed or previous attribute values directly:

**Before:**
```php
$changedName = $user->getChanges()['name'] ?? null;
$previousTitle = $user->getPrevious()['title'] ?? 'default';
```

**After:**

```php
$changedName = $user->getChanges('name');
$previousTitle = $user->getPrevious('title', 'default');
```

This aligns directly with the existing `getOriginal` method:

https://github.com/laravel/framework/blob/6d26643ad2b0ad13a7c5bc5b9b19084d6e6819af/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1986-L1998

This may be considered to be a breaking change, since developers who have overridden `getPrevious()/getChanges()` would have to support these new parameters. Otherwise they will receive this error:

```
Fatal error: Declaration of ...getPrevious() must be compatible with Illuminate\Database\Eloquent\Model::getPrevious($key = null, $default = null)
```

I can target Laravel 13 if you prefer -- let me know! Thanks for your time!