### PR TITLE
[12.x] Add the ability to preview commands to run in `optimize` && `optimize:clear`

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -44,6 +44,14 @@ class OptimizeClearCommand extends Command
             ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
+        if ($this->option('pretend')) {
+            foreach ($tasks as $description => $command) {
+                $this->components->twoColumnDetail($description, $command);
+            }
+
+            return;
+        }
+
         foreach ($tasks as $description => $command) {
             $this->components->task($description, fn () => $this->callSilently($command) == 0);
         }
@@ -78,6 +86,7 @@ class OptimizeClearCommand extends Command
     {
         return [
             ['except', 'e', InputOption::VALUE_OPTIONAL, 'The commands to skip'],
+            ['pretend', null, InputOption::VALUE_NONE, 'Display commands that run during optimize:clear without executing them'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -44,6 +44,14 @@ class OptimizeCommand extends Command
             ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
+        if ($this->option('list')) {
+            foreach($tasks as $description => $command) {
+                $this->components->twoColumnDetail($description, $command);
+            }
+
+            return;
+        }
+
         foreach ($tasks as $description => $command) {
             $this->components->task($description, fn () => $this->callSilently($command) == 0);
         }
@@ -76,6 +84,7 @@ class OptimizeCommand extends Command
     {
         return [
             ['except', 'e', InputOption::VALUE_OPTIONAL, 'Do not run the commands matching the key or name'],
+            ['list', 'l', InputOption::VALUE_NONE, 'List all optimizations to run'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -44,7 +44,7 @@ class OptimizeCommand extends Command
             ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
             ->toArray();
 
-        if ($this->option('list')) {
+        if ($this->option('pretend')) {
             foreach($tasks as $description => $command) {
                 $this->components->twoColumnDetail($description, $command);
             }
@@ -84,7 +84,7 @@ class OptimizeCommand extends Command
     {
         return [
             ['except', 'e', InputOption::VALUE_OPTIONAL, 'Do not run the commands matching the key or name'],
-            ['list', 'l', InputOption::VALUE_NONE, 'List all optimizations to run'],
+            ['pretend', null, InputOption::VALUE_NONE, 'Display commands that run during optimize without executing them'],
         ];
     }
 }


### PR DESCRIPTION
Realized it's not super convenient to see what runs when I call `php artisan optimize`. Here we have a nice clean way to be able to preview what commands will be run

<img width="1211" height="210" alt="image" src="https://github.com/user-attachments/assets/6e2a5b8b-5dd5-4d27-85be-e0ec48a585de" />
