### PR TITLE
Add support for multiple Actions in Mail Notifications

### DIFF
--- a/src/Illuminate/Notifications/Line.php
+++ b/src/Illuminate/Notifications/Line.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+class Line
+{
+    /**
+     * The line content.
+     *
+     * @var string
+     */
+    public string $content;
+
+    /**
+     * Create a new line.
+     *
+     * @param  string  $content
+     */
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+}

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -265,7 +265,8 @@ class SimpleMessage
     {
         $this->content[] = $action;
         $this->actions[] = ['text' => $action->text, 'url' => $action->url];
-        
+
+        // Backwards compatibility
         $this->actionText = $action->text;
         $this->actionUrl = $action->url;
 

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -54,6 +54,7 @@ class SimpleMessage
      * The text / label for the action.
      *
      * @var string
+     *
      * @deprecated Use the $actions array
      */
     public $actionText;
@@ -62,6 +63,7 @@ class SimpleMessage
      * The action URL.
      *
      * @var string
+     *
      * @deprecated Use the $actions array
      */
     public $actionUrl;
@@ -245,13 +247,13 @@ class SimpleMessage
     protected function pushLine($line)
     {
         $formatted = $this->formatLine($line);
-        
+
         $this->content[] = new Line($formatted);
-        
+
         $this->actions
             ? $this->outroLines[] = $formatted
             : $this->introLines[] = $formatted;
-            
+
         return $this;
     }
 

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -10,29 +10,22 @@
 @endif
 @endif
 
-{{-- Intro Lines --}}
-@foreach ($introLines as $line)
-{{ $line }}
+{{-- Content --}}
+@foreach ($content as $item)
+@if ($item instanceof \Illuminate\Notifications\Line)
+{{ $item->content }}
 
-@endforeach
-
-{{-- Action Button --}}
-@isset($actionText)
-<?php
+@elseif ($item instanceof \Illuminate\Notifications\Action)
+@php
     $color = match ($level) {
         'success', 'error' => $level,
         default => 'primary',
     };
-?>
-<x-mail::button :url="$actionUrl" :color="$color">
-{{ $actionText }}
+@endphp
+<x-mail::button :url="$item->url" :color="$color">
+{{ $item->text }}
 </x-mail::button>
-@endisset
-
-{{-- Outro Lines --}}
-@foreach ($outroLines as $line)
-{{ $line }}
-
+@endif
 @endforeach
 
 {{-- Salutation --}}
@@ -44,15 +37,26 @@
 @endif
 
 {{-- Subcopy --}}
-@isset($actionText)
+@if (count($actions) > 0)
 <x-slot:subcopy>
+@if (count($actions) === 1)
 @lang(
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
     'into your web browser:',
     [
-        'actionText' => $actionText,
+        'actionText' => $actions[0]['text'],
     ]
-) <span class="break-all">[{{ $displayableActionUrl }}]({{ $actionUrl }})</span>
+) <span class="break-all">[{{ str_replace(['mailto:', 'tel:'], '', $actions[0]['url']) }}]({{ $actions[0]['url'] }})</span>
+@else
+@lang("If you're having trouble with the buttons above, copy and paste the URLs below into your web browser:")
+
+@foreach ($actions as $action)
+**{{ $action['text'] }}:** <span class="break-all">[{{ str_replace(['mailto:', 'tel:'], '', $action['url']) }}]({{ $action['url'] }})</span>
+@unless ($loop->last)
+
+@endunless
+@endforeach
+@endif
 </x-slot:subcopy>
-@endisset
+@endif
 </x-mail::message>

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -389,4 +389,152 @@ class NotificationMailMessageTest extends TestCase
             ],
         ], $mailMessage->attachments);
     }
+
+    public function testActionsAreIncludedInToArray()
+    {
+        $message = new MailMessage;
+        $message->action('Accept', 'https://example.com/accept')
+                ->action('Reject', 'https://example.com/reject');
+
+        $array = $message->toArray();
+
+        $this->assertArrayHasKey('actions', $array);
+        $this->assertSame([
+            ['text' => 'Accept', 'url' => 'https://example.com/accept'],
+            ['text' => 'Reject', 'url' => 'https://example.com/reject'],
+        ], $array['actions']);
+
+        $this->assertSame('Reject', $array['actionText']);
+        $this->assertSame('https://example.com/reject', $array['actionUrl']);
+    }
+
+    public function testBackwardCompatibilityWithSingleAction()
+    {
+        $message = new MailMessage;
+        $message->action('Single Action', 'https://example.com');
+
+        $array = $message->toArray();
+
+        $this->assertSame('Single Action', $array['actionText']);
+        $this->assertSame('https://example.com', $array['actionUrl']);
+        $this->assertCount(1, $array['actions']);
+        $this->assertSame('Single Action', $array['actions'][0]['text']);
+        $this->assertSame('https://example.com', $array['actions'][0]['url']);
+    }
+
+    public function testEmptyActionsArray()
+    {
+        $message = new MailMessage;
+
+        $this->assertSame([], $message->actions);
+
+        $array = $message->toArray();
+        $this->assertSame([], $array['actions']);
+        $this->assertNull($array['actionText']);
+        $this->assertNull($array['actionUrl']);
+    }
+
+    public function testSingleActionIsProvidedToTemplate()
+    {
+        $message = new MailMessage;
+        $message->subject('Test Subject')
+                ->action('Single Action', 'https://example.com/single');
+
+        $data = $message->data();
+
+        $this->assertArrayHasKey('actions', $data);
+        $this->assertCount(1, $data['actions']);
+        $this->assertSame('Single Action', $data['actions'][0]['text']);
+        $this->assertSame('https://example.com/single', $data['actions'][0]['url']);
+
+        $this->assertSame('Single Action', $data['actionText']);
+        $this->assertSame('https://example.com/single', $data['actionUrl']);
+    }
+
+    public function testMultipleActionsAreProvidedToTemplate()
+    {
+        $message = new MailMessage;
+        $message->subject('Test Subject')
+                ->action('Accept', 'https://example.com/accept')
+                ->action('Reject', 'https://example.com/reject')
+                ->action('Review', 'https://example.com/review');
+
+        $data = $message->data();
+
+        $this->assertArrayHasKey('actions', $data);
+        $this->assertCount(3, $data['actions']);
+        
+        $this->assertSame('Accept', $data['actions'][0]['text']);
+        $this->assertSame('https://example.com/accept', $data['actions'][0]['url']);
+        
+        $this->assertSame('Reject', $data['actions'][1]['text']);
+        $this->assertSame('https://example.com/reject', $data['actions'][1]['url']);
+        
+        $this->assertSame('Review', $data['actions'][2]['text']);
+        $this->assertSame('https://example.com/review', $data['actions'][2]['url']);
+
+        $this->assertTrue(!empty($data['actions']));
+        $this->assertFalse(empty($data['actions']));
+    }
+
+    public function testLineMethodPlacementWithActions()
+    {
+        $message = new MailMessage;
+        $message->line('Intro line 1')
+                ->line('Intro line 2')
+                ->action('Accept', 'https://example.com/accept')
+                ->line('Outro line 1')
+                ->action('Reject', 'https://example.com/reject')
+                ->line('Outro line 2');
+
+        $data = $message->data();
+
+        $this->assertCount(2, $data['introLines']);
+        $this->assertSame('Intro line 1', $data['introLines'][0]);
+        $this->assertSame('Intro line 2', $data['introLines'][1]);
+
+        $this->assertCount(2, $data['outroLines']);
+        $this->assertSame('Outro line 1', $data['outroLines'][0]);
+        $this->assertSame('Outro line 2', $data['outroLines'][1]);
+
+        $this->assertCount(2, $data['actions']);
+        $this->assertSame('Accept', $data['actions'][0]['text']);
+        $this->assertSame('Reject', $data['actions'][1]['text']);
+    }
+
+    public function testInterleavedContentOrder()
+    {
+        $message = new MailMessage;
+        $message->line('Intro line 1')
+                ->line('Intro line 2')
+                ->action('Accept', 'https://example.com/accept')
+                ->line('Outro line 1')
+                ->action('Reject', 'https://example.com/reject')
+                ->line('Outro line 2');
+
+        $data = $message->data();
+
+        $this->assertArrayHasKey('content', $data);
+        $this->assertCount(6, $data['content']);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Line::class, $data['content'][0]);
+        $this->assertSame('Intro line 1', $data['content'][0]->content);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Line::class, $data['content'][1]);
+        $this->assertSame('Intro line 2', $data['content'][1]->content);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Action::class, $data['content'][2]);
+        $this->assertSame('Accept', $data['content'][2]->text);
+        $this->assertSame('https://example.com/accept', $data['content'][2]->url);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Line::class, $data['content'][3]);
+        $this->assertSame('Outro line 1', $data['content'][3]->content);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Action::class, $data['content'][4]);
+        $this->assertSame('Reject', $data['content'][4]->text);
+        $this->assertSame('https://example.com/reject', $data['content'][4]->url);
+
+        $this->assertInstanceOf(\Illuminate\Notifications\Line::class, $data['content'][5]);
+        $this->assertSame('Outro line 2', $data['content'][5]->content);
+    }
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -463,17 +463,17 @@ class NotificationMailMessageTest extends TestCase
 
         $this->assertArrayHasKey('actions', $data);
         $this->assertCount(3, $data['actions']);
-        
+
         $this->assertSame('Accept', $data['actions'][0]['text']);
         $this->assertSame('https://example.com/accept', $data['actions'][0]['url']);
-        
+
         $this->assertSame('Reject', $data['actions'][1]['text']);
         $this->assertSame('https://example.com/reject', $data['actions'][1]['url']);
-        
+
         $this->assertSame('Review', $data['actions'][2]['text']);
         $this->assertSame('https://example.com/review', $data['actions'][2]['url']);
 
-        $this->assertTrue(!empty($data['actions']));
+        $this->assertTrue(! empty($data['actions']));
         $this->assertFalse(empty($data['actions']));
     }
 


### PR DESCRIPTION
This PR adds support for multiple action method calls in mail notifications.

Currently, calling `->action()` more than once would only render the last button, without any exception or warning.

For example, given the following mail message:

```php
return (new MailMessage)
    ->line('You have been invited to join a team!')
    ->action('Accept', 'https://example.com/accept')
    ->action('Reject', 'https://example.com/reject');
```

It currently renders with only the last action on the chain:

<img width="686" height="582" alt="image" src="https://github.com/user-attachments/assets/936ba350-ba02-46f5-a318-347b3e0591f8" />


With this PR, it allows multiple `action` methods to render:


<img width="680" height="722" alt="image" src="https://github.com/user-attachments/assets/66afae85-90f9-4a5f-9b14-1d1e6143982e" />

Secondly, it enables mixing `line` and `action` calls in any order.

```php
return (new MailMessage)
    ->line('Intro line 1')
    ->line('Intro line 2')
    ->action('Accept', 'https://example.com/accept')
    ->line('Outro line 1')
    ->action('Reject', 'https://example.com/reject')
    ->line('Outro line 2');
```

<img width="682" height="840" alt="image" src="https://github.com/user-attachments/assets/dd975e49-0fae-4424-a074-e8c0858e727f" />

This supports backwards compatibility with no breaking changes.