### PR TITLE
[12.x] Remove @throws phpDocs in the TransformToResource trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -13,8 +13,6 @@ trait TransformsToResource
      *
      * @param  class-string<\Illuminate\Http\Resources\Json\JsonResource>|null  $resourceClass
      * @return \Illuminate\Http\Resources\Json\JsonResource
-     *
-     * @throws \Throwable
      */
     public function toResource(?string $resourceClass = null): JsonResource
     {
@@ -29,8 +27,6 @@ trait TransformsToResource
      * Guess the resource class for the model.
      *
      * @return \Illuminate\Http\Resources\Json\JsonResource
-     *
-     * @throws \Throwable
      */
     protected function guessResource(): JsonResource
     {


### PR DESCRIPTION
The trait methods throw only LogicException, which should never be in the "catch()" section. 

PhpDoc in LogicException:
`Exception that represents error in the program logic. This kind of exception should lead directly to a fix in your code.`

So, these methods shouldn't contain any `@throws` phpDoc