### PR TITLE
Clarify `CastsAttributes::set()` phpdoc to accept TGet; recommend symmetric casts

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -5,6 +5,10 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * Recommendation:
+ * Prefer symmetric casts (TGet == TSet) so "$a = $a = $b"
+ * remain safe and unsurprising.
+ * 
  * @template TGet
  * @template TSet
  */
@@ -24,10 +28,12 @@ interface CastsAttributes
     /**
      * Transform the attribute to its underlying model values.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  string  $key
-     * @param  TSet|null  $value
-     * @param  array<string, mixed>  $attributes
+     * Important:
+     * Implementations must tolerate receiving the runtime cast value (TGet) here.
+     * As with object caching, `set()` may receive the value returned by `get()` (TGet).
+     * Implementations should therefore accept both TGet and TSet.
+     *
+     * @param  TGet|TSet|null  $value
      * @return mixed
      */
     public function set(Model $model, string $key, mixed $value, array $attributes);


### PR DESCRIPTION
## Summary
`CastsAttributes::set()` can receive the **runtime cast value (TGet)**, not only an “assignment” type (TSet). This happens in common read → reassign → save flows and should be reflected in the contract’s phpdoc to preserve **assignment symmetry** (developers reasonably expect `$a = $a = $b` to be safe).

## What this PR changes
- Update the phpdoc of `Illuminate\Contracts\Database\Eloquent\CastsAttributes::set()` to accept `TGet|TSet|null`.
- Add a short note recommending **symmetric casts (TGet == TSet)** to avoid surprises when re-assigning values returned by `get()`.

## Example
```php
$a = $model->attr;   // get(): returns VO (runtime)
$model->attr = $a;   // reassign same VO
$model->save();      // set() may receive VO → must be tolerated
```

## Rationale / Benefits
- Matches real call paths where `set()` can receive the value produced by `get()`.
- Prevents surprising TypeErrors in userland casts after read→reassign→save cycles.
- Improves static analysis hints and sets clear expectations for custom casts.

## Backward compatibility
- **No runtime behavior changes.** Phpdoc clarification only.

## Target branch
- `12.x` (supported branch per Laravel’s support policy)