### PR TITLE
Widen `CastsAttributes::set()` phpdoc to `TGet|TSet|null`

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -5,6 +5,10 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * Recommendation:
+ * Prefer symmetric casts (TGet == TSet) so "$a = $a = $b"
+ * remain safe and unsurprising.
+ * 
  * @template TGet
  * @template TSet
  */
@@ -24,10 +28,12 @@ interface CastsAttributes
     /**
      * Transform the attribute to its underlying model values.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @param  string  $key
-     * @param  TSet|null  $value
-     * @param  array<string, mixed>  $attributes
+     * Important:
+     * Implementations must tolerate receiving the runtime cast value (TGet) here.
+     * As with object caching, `set()` may receive the value returned by `get()` (TGet).
+     * Implementations should therefore accept both TGet and TSet.
+     *
+     * @param  TGet|TSet|null  $value
      * @return mixed
      */
     public function set(Model $model, string $key, mixed $value, array $attributes);

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Recommendation: (TGet == TSet) so "$a = $a = $b"
+ * Recommendation: (TGet == TSet) so "$a = $a = $b".
  * 
  * @template TGet
  * @template TSet
@@ -27,6 +27,7 @@ interface CastsAttributes
      * Transform the attribute to its underlying model values.
      *
      * Note: set() may receive the value returned by get().
+     * 
      * @param  TGet|TSet|null  $value
      * @return mixed
      */

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * Recommendation: (TGet == TSet) so "$a = $a = $b".
- * 
+ *
  * @template TGet
  * @template TSet
  */
@@ -27,7 +27,7 @@ interface CastsAttributes
      * Transform the attribute to its underlying model values.
      *
      * Note: set() may receive the value returned by get().
-     * 
+     *
      * @param  TGet|TSet|null  $value
      * @return mixed
      */

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -5,9 +5,7 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Recommendation:
- * Prefer symmetric casts (TGet == TSet) so "$a = $a = $b"
- * remain safe and unsurprising.
+ * Recommendation: (TGet == TSet) so "$a = $a = $b"
  * 
  * @template TGet
  * @template TSet
@@ -28,11 +26,7 @@ interface CastsAttributes
     /**
      * Transform the attribute to its underlying model values.
      *
-     * Important:
-     * Implementations must tolerate receiving the runtime cast value (TGet) here.
-     * As with object caching, `set()` may receive the value returned by `get()` (TGet).
-     * Implementations should therefore accept both TGet and TSet.
-     *
+     * Note: set() may receive the value returned by get().
      * @param  TGet|TSet|null  $value
      * @return mixed
      */


### PR DESCRIPTION
**What**
Widen the phpdoc of `CastsAttributes::set()` to `TGet|TSet|null`. No runtime changes.

**Why**
With Eloquent’s cast object caching (`classCastCache` / `mergeAttributesFromClassCasts`), a common flow (read → reassign → save) calls `set()` with the **runtime value** returned by `get()` (TGet). If `set()` only accepts TSet, this breaks with the cache (TypeErrors or forced `withoutObjectCaching = true`, losing the cache’s benefit).

**Minimal repro**
```php
$vo = $model->attr;   // get(): returns VO (runtime), may be cached
$model->attr = $vo;   // reassign same VO
$model->save();       // set() receives VO => must accept TGet
```

**Result**
Clarifies contract and keeps cached casts working as intended. Encourages symmetric casts (TGet == TSet). Doc-only change.
