### PR TITLE
[12.x] Add prefix check for dynamic validation methods

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1672,10 +1672,12 @@ class Validator implements ValidatorContract
      */
     public function __call($method, $parameters)
     {
-        $rule = Str::snake(substr($method, 8));
+        if (str_starts_with($method, 'validate')) {
+            $rule = Str::snake(substr($method, 8));
 
-        if (isset($this->extensions[$rule])) {
-            return $this->callExtension($rule, $parameters);
+            if (isset($this->extensions[$rule])) {
+                return $this->callExtension($rule, $parameters);
+            }
         }
 
         throw new BadMethodCallException(sprintf(


### PR DESCRIPTION
Update `__call` to only handle methods starting with `validate`. This prevents unrelated method calls from being processed and aligns with patterns used elsewhere in the framework.
