### PR TITLE
[13.x] Make QueueBusy event consistent with other queue events

### DIFF
--- a/src/Illuminate/Queue/Events/QueueBusy.php
+++ b/src/Illuminate/Queue/Events/QueueBusy.php
@@ -7,12 +7,12 @@ class QueueBusy
     /**
      * Create a new event instance.
      *
-     * @param  string  $connection  The connection name.
+     * @param  string  $connectionName  The connection name.
      * @param  string  $queue  The queue name.
      * @param  int  $size  The size of the queue.
      */
     public function __construct(
-        public $connection,
+        public $connectionName,
         public $queue,
         public $size,
     ) {


### PR DESCRIPTION
Description
---
In the `QueueBusy` event, the `$connection` property currently holds the connection name. However, all other queue events like `JobProcessed`, `JobFailed`, etc. use `$connectionName` for this property.

This PR updates `QueueBusy` to use `$connectionName` for consistency with the rest of the queue events and to avoid confusion that `$connection` might be an actual connection instance.

Since this is a breaking change, it is being reintroduced for the next release where breaking changes are acceptable.