### PR TITLE
[12.x] Feat: Add withSuccess, withError, withWarning, and withInfo redirect helpers

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -146,6 +146,62 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
+     * Flash a success message to the session.
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function withSuccess($message)
+    {
+        return $this->with([
+            'type'=> 'success',
+            'message'=> $message
+        ]);
+    }
+
+    /**
+     * Flash a error message to the session.
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function withError($message)
+    {
+        return $this->with([
+            'type'=> 'error',
+            'message'=> $message
+        ]);
+    }
+
+    /**
+     * Flash a warning message to the session.
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function withWarning($message)
+    {
+        return $this->with([
+            'type' => 'warning',
+            'message' => $message,
+        ]);
+    }
+
+    /**
+     * Flash an info message to the session.
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function withInfo($message)
+    {
+        return $this->with([
+            'type' => 'info',
+            'message' => $message,
+        ]);
+    }
+
+    /**
      * Parse the given errors into an appropriate value.
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -151,6 +151,54 @@ class HttpRedirectResponseTest extends TestCase
         $response->withFoo('bar');
     }
 
+    public function testWithSuccessOnRedirect()
+    {
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET'));
+        $response->setSession($session = m::mock(Store::class));
+
+        $session->shouldReceive('flash')->once()->with('type', 'success');
+        $session->shouldReceive('flash')->once()->with('message', 'Saved');
+
+        $response->withSuccess('Saved');
+    }
+
+    public function testWithErrorOnRedirect()
+    {
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET'));
+        $response->setSession($session = m::mock(Store::class));
+
+        $session->shouldReceive('flash')->once()->with('type', 'error');
+        $session->shouldReceive('flash')->once()->with('message', 'Failed');
+
+        $response->withError('Failed');
+    }
+
+    public function testWithWarningOnRedirect()
+    {
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET'));
+        $response->setSession($session = m::mock(Store::class));
+
+        $session->shouldReceive('flash')->once()->with('type', 'warning');
+        $session->shouldReceive('flash')->once()->with('message', 'Be careful');
+
+        $response->withWarning('Be careful');
+    }
+
+    public function testWithInfoOnRedirect()
+    {
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET'));
+        $response->setSession($session = m::mock(Store::class));
+
+        $session->shouldReceive('flash')->once()->with('type', 'info');
+        $session->shouldReceive('flash')->once()->with('message', 'Heads up');
+
+        $response->withInfo('Heads up');
+    }
+
     public function testMagicCallException()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
### **Overview:**
This PR introduces four convenience methods to `Illuminate\Http\RedirectResponse`:

- `withSuccess($message)`
- `withError($message)`
- `withWarning($message)`
- `withInfo($message)`

### **Example:**
Currently you will need to write something like:

```php
return redirect()->back()->with(['type' => 'success', 'message' => 'Saved']);
```

Now you can do something like this:
```php
return redirect()->back()->withSuccess('Saved');
return redirect()->back()->withError('Failed');
return redirect()->back()->withWarning('Be careful');
return redirect()->back()->withInfo('Heads up');
```
They also work with route helpers:
```php
public function store(Request $request)
{
    // ...
    return redirect()->route('posts.index')->withSuccess('Post created');
}

return to_route('posts.index')->withSuccess('Post created');
```

### **Why:**
- Flashing a simple success, error, warning, or info message after redirects is very common.
- Easy to consume on the frontend (e.g. via Inertia flash props).
- `withError()` is singular and distinct from `withErrors()`, so no conflict exists.