### PR TITLE
[12.x] Fix prevent group attribute pollution in schedule

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -312,7 +312,7 @@ class Schedule
             throw new RuntimeException('Invoke an attribute method such as Schedule::daily() before defining a schedule group.');
         }
 
-        $this->groupStack[] = $this->attributes;
+        $this->groupStack[] = clone $this->attributes;
 
         $events($this);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixed: #56497 

# scheduling logic
``` php
Carbon::setTestNow(Carbon::create(2024, 1, 1, 8, 05, 0));
dump('Current time: '.Carbon::now()->toDateTimeString());
Schedule::days([1, 2, 3, 4, 5, 6])->group(function () {
    Schedule::between('07:00', '08:00')->group(function () {
        Schedule::call(Task1::class)->everyMinute();
        Schedule::call(Task2::class)->everyFiveMinutes();
    });

    Schedule::call(Task3::class)->at('08:05');
});
```

# before
``` bash
root@PeopleSea-PC:/laravel-bug-report# php artisan schedule:run
"Current time: 2024-01-01 08:05:00" // routes/console.php:12

   INFO  No scheduled commands are ready to run.  
```

# after
``` bash
root@PeopleSea-PC:/laravel-bug-report# php artisan schedule:run
"Current time: 2024-01-01 08:05:00" // routes/console.php:12

  2024-01-01 08:05:00 Running [App\Jobs\Task3] .......................................32.63ms DONE
```


# Solution approach:
 It is correct that attributes are inherited when group is nestedly called.  However, if filters are declared in the child group, it will directly change the top-level group.  Therefore, clone should be used to prevent filters from causing contamination.