### PR TITLE
Add new `mergeVisible`, `mergeHidden` and `mergeAppends` methods.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2386,6 +2386,19 @@ trait HasAttributes
     }
 
     /**
+     * Merge new appended attributes with existing appended attributes on the model.
+     *
+     * @param  array<string>  $visible
+     * @return $this
+     */
+    public function mergeAppends(array $appends)
+    {
+        $this->appends = array_values(array_unique(array_merge($this->appends, $appends)));
+
+        return $this;
+    }
+
+    /**
      * Return whether the accessor attribute has been appended.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2388,7 +2388,7 @@ trait HasAttributes
     /**
      * Merge new appended attributes with existing appended attributes on the model.
      *
-     * @param  array<string>  $visible
+     * @param  array<string>  $appends
      * @return $this
      */
     public function mergeAppends(array $appends)

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -42,6 +42,19 @@ trait HidesAttributes
     }
 
     /**
+     * Merge new hidden attributes with existing hidden attributes on the model.
+     *
+     * @param  array<string>  $hidden
+     * @return $this
+     */
+    public function mergeHidden(array $hidden)
+    {
+        $this->hidden = array_values(array_unique(array_merge($this->hidden, $hidden)));
+
+        return $this;
+    }
+
+    /**
      * Get the visible attributes for the model.
      *
      * @return array<string>
@@ -60,6 +73,19 @@ trait HidesAttributes
     public function setVisible(array $visible)
     {
         $this->visible = $visible;
+
+        return $this;
+    }
+
+    /**
+     * Merge new visible attributes with existing visible attributes on the model.
+     *
+     * @param  array<string>  $visible
+     * @return $this
+     */
+    public function mergeVisible(array $visible)
+    {
+        $this->visible = array_values(array_unique(array_merge($this->visible, $visible)));
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3953,7 +3953,6 @@ class EloquentModelHiddenStub extends Model
     protected $hidden = ['foo'];
 }
 
-
 class EloquentModelDynamicVisibleStub extends Model
 {
     protected $table = 'stub';

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1495,6 +1495,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
+    public function testMergeHiddenMergesHidden()
+    {
+        $model = new EloquentModelHiddenStub;
+
+        $hiddenCount = count($model->getHidden());
+        $this->assertContains('foo', $model->getHidden());
+
+        $model->mergeHidden(['bar']);
+        $this->assertCount($hiddenCount + 1, $model->getHidden());
+        $this->assertContains('bar', $model->getHidden());
+    }
+
     public function testVisible()
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
@@ -1502,6 +1514,18 @@ class DatabaseEloquentModelTest extends TestCase
         $array = $model->toArray();
         $this->assertArrayHasKey('name', $array);
         $this->assertArrayNotHasKey('age', $array);
+    }
+
+    public function testMergeVisibleMergesVisible()
+    {
+        $model = new EloquentModelVisibleStub;
+
+        $visibleCount = count($model->getVisible());
+        $this->assertContains('foo', $model->getVisible());
+
+        $model->mergeVisible(['bar']);
+        $this->assertCount($visibleCount + 1, $model->getVisible());
+        $this->assertContains('bar', $model->getVisible());
     }
 
     public function testDynamicHidden()
@@ -2419,6 +2443,18 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->setVisible([]);
         $this->assertEquals([], $model->toArray());
+    }
+
+    public function testMergeAppendsMergesAppends()
+    {
+        $model = new EloquentModelAppendsStub;
+
+        $appendsCount = count($model->getAppends());
+        $this->assertEquals(['is_admin', 'camelCased', 'StudlyCased'], $model->getAppends());
+
+        $model->mergeAppends(['bar']);
+        $this->assertCount($appendsCount + 1, $model->getAppends());
+        $this->assertContains('bar', $model->getAppends());
     }
 
     public function testGetMutatedAttributes()
@@ -3904,6 +3940,19 @@ class EloquentModelDynamicHiddenStub extends Model
         return ['age', 'id'];
     }
 }
+
+class EloquentModelVisibleStub extends Model
+{
+    protected $table = 'stub';
+    protected $visible = ['foo'];
+}
+
+class EloquentModelHiddenStub extends Model
+{
+    protected $table = 'stub';
+    protected $hidden = ['foo'];
+}
+
 
 class EloquentModelDynamicVisibleStub extends Model
 {


### PR DESCRIPTION
This PR adds additional attribute helper methods to Eloquent models for merging visibility-related arrays, bringing them in line with existing helpers like `mergeCasts`, `mergeFillable`, and `mergeGuarded`.

These new methods simplify scenarios where traits need to augment a model’s configuration without overwriting existing values.

#### Example

Today, when adding 2FA support via a trait, you might write:

Trait: `HasTwoFactorAuthentication.php`

```php
protected function initializeTwoFactorAuthentication(): void
{
    $this->setHidden(array_merge($this->getHidden(), [
        'app_authentication_secret',
        'app_authentication_recovery_codes',
    ]));

    $this->mergeCasts([
        'app_authentication_secret' => 'encrypted',
        'app_authentication_recovery_codes' => 'encrypted:array',
    ]);
}
```

With this PR, the hidden attributes can be merged just as cleanly as casts:

```php
protected function initializeTwoFactorAuthentication(): void
{
    $this->mergeHidden([
        'app_authentication_secret',
        'app_authentication_recovery_codes',
    ]);

    $this->mergeCasts([
        'app_authentication_secret' => 'encrypted',
        'app_authentication_recovery_codes' => 'encrypted:array',
    ]);
}
```

#### Existing Methods

* `$model->mergeCasts()`
* `$model->mergeFillable()`
* `$model->mergeGuarded()`

#### New Methods Added

* `$model->mergeVisible()`
* `$model->mergeHidden()`
* `$model->mergeAppends()`
