### PR TITLE
Add ability to specify a transaction mode for SQLite connection

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -41,6 +41,7 @@ return [
             'busy_timeout' => null,
             'journal_mode' => null,
             'synchronous' => null,
+            'transaction_mode' => 'DEFERRED',
         ],
 
         'mysql' => [

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Database\Concerns;
 
 use Closure;
+use Illuminate\Database\Connection;
 use Illuminate\Database\DeadlockException;
 use RuntimeException;
 use Throwable;
 
+/**
+ * @mixin Connection
+ */
 trait ManagesTransactions
 {
     /**
@@ -148,7 +152,7 @@ trait ManagesTransactions
             $this->reconnectIfMissingConnection();
 
             try {
-                $this->getPdo()->beginTransaction();
+                $this->executeBeginTransactionStatement();
             } catch (Throwable $e) {
                 $this->handleBeginTransactionException($e);
             }
@@ -184,7 +188,7 @@ trait ManagesTransactions
         if ($this->causedByLostConnection($e)) {
             $this->reconnect();
 
-            $this->getPdo()->beginTransaction();
+            $this->executeBeginTransactionStatement();
         } else {
             throw $e;
         }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1471,6 +1471,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run the statement to start a new transaction.
+     *
+     * @return void
+     */
+    protected function executeBeginTransactionStatement()
+    {
+        $this->getPdo()->beginTransaction();
+    }
+
+    /**
      * Set the transaction manager instance on the connection.
      *
      * @param  \Illuminate\Database\DatabaseTransactionsManager  $manager
@@ -1491,16 +1501,6 @@ class Connection implements ConnectionInterface
     public function unsetTransactionManager()
     {
         $this->transactionsManager = null;
-    }
-
-    /**
-     * Run the statement to start a new transaction.
-     *
-     * @return void
-     */
-    public function executeBeginTransactionStatement()
-    {
-        $this->getPdo()->beginTransaction();
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1494,6 +1494,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run the statement to start a new transaction.
+     *
+     * @return void
+     */
+    public function executeBeginTransactionStatement()
+    {
+        $this->getPdo()->beginTransaction();
+    }
+
+    /**
      * Determine if the connection is in a "dry run".
      *
      * @return bool

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -21,6 +21,24 @@ class SQLiteConnection extends Connection
     }
 
     /**
+     * Run the statement to start a new transaction.
+     *
+     * @return void
+     */
+    protected function executeBeginTransactionStatement()
+    {
+        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
+            $mode = $this->getConfig('transaction_mode') ?? 'DEFERRED';
+
+            $this->getPdo()->exec("BEGIN {$mode} TRANSACTION");
+
+            return;
+        }
+
+        $this->getPdo()->beginTransaction();
+    }
+
+    /**
      * Escape a binary value for safe SQL embedding.
      *
      * @param  string  $value
@@ -99,18 +117,5 @@ class SQLiteConnection extends Connection
     protected function getDefaultPostProcessor()
     {
         return new SQLiteProcessor;
-    }
-
-    public function executeBeginTransactionStatement()
-    {
-        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
-            $mode = $this->getConfig('transaction_mode') ?? 'DEFERRED';
-
-            $this->getPdo()->exec("BEGIN $mode TRANSACTION");
-
-            return;
-        }
-
-        $this->getPdo()->beginTransaction();
     }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -100,4 +100,17 @@ class SQLiteConnection extends Connection
     {
         return new SQLiteProcessor;
     }
+
+    public function executeBeginTransactionStatement()
+    {
+        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
+            $mode = $this->getConfig('transaction_mode') ?? 'DEFERRED';
+
+            $this->getPdo()->exec("BEGIN $mode TRANSACTION");
+
+            return;
+        }
+
+        $this->getPdo()->beginTransaction();
+    }
 }


### PR DESCRIPTION
This PR adds the ability to specify which mode SQLite should use for running transactions. This is done via an additional config option in `database.php`.

I've opted for the current implementation because PDO currently lacks the ability specify a transaction mode when running `$pdo->beginTransaction()`. We have to work around this by manually running a `BEGIN $MODE TRANSACTION` statement.

Justification:
By default, SQLite transactions run in DEFERRED mode, which causes problems (namely, a bunch of SQLITE_BUSY errors) when running in WAL mode. The recommended production setup for SQLite is WAL mode paired with IMMEDIATE transactions. [This article](https://stancl.substack.com/p/using-sqlite-in-production-with-laravel) has a good breakdown of the problem specifically with Laravel. In short, currently running an SQLite database in production with database driven queues and cache will result in many logged `Database is locked` errors in your logs and some failed jobs. One could reproduce this by, e.g. starting a few queue workers in multiple terminals and dispatching 100 jobs to the queue.

I wanted to include tests as well, but I'm not sure how to test which statement runs when beginning transactions. Initially I planned to use the built in query logging, but discovered that transaction statements are not included in the query log, which makes sense.