### PR TITLE
[12.x] Clarify auth once doesn't trigger login event

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -253,7 +253,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Log a user into the application without sessions or cookies.
+     * Log a user into the application without sessions or cookies and without firing the Login event.
      *
      * @param  array  $credentials
      * @return bool
@@ -276,7 +276,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Log the given user ID into the application without sessions or cookies.
+     * Log the given user ID into the application without sessions or cookies and without firing the Login event.
      *
      * @param  mixed  $id
      * @return \Illuminate\Contracts\Auth\Authenticatable|false

--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -14,7 +14,7 @@ interface StatefulGuard extends Guard
     public function attempt(array $credentials = [], $remember = false);
 
     /**
-     * Log a user into the application without sessions or cookies.
+     * Log a user into the application without sessions or cookies and without firing the Login event.
      *
      * @param  array  $credentials
      * @return bool
@@ -40,7 +40,7 @@ interface StatefulGuard extends Guard
     public function loginUsingId($id, $remember = false);
 
     /**
-     * Log the given user ID into the application without sessions or cookies.
+     * Log the given user ID into the application without sessions or cookies and without firing the Login event.
      *
      * @param  mixed  $id
      * @return \Illuminate\Contracts\Auth\Authenticatable|false

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -578,7 +578,7 @@ class AuthGuardTest extends TestCase
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
-        
+
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldNotReceive('dispatch')->with(m::type(Login::class));
 
@@ -623,7 +623,7 @@ class AuthGuardTest extends TestCase
         $timebox->shouldReceive('call')->once()->andReturnUsing(function ($callback) use ($timebox) {
             return $callback($timebox->shouldReceive('returnEarly')->once()->getMock());
         });
-        
+
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));


### PR DESCRIPTION
## Description

This PR clarifies the documentation for the once() and onceUsingId() authentication methods to explicitly mention that they don't fire the `Login` event, in addition to not using sessions or cookies.

We wanted to perform a temporary login without trigger the `Login` event and found the `once()` to do what we needed. However, the fact that the `Login` event is not dispatched doesn't seem to be documented.

## Tests
Only the docblocks have changed in the code, but I also added tests to verify that the `Login` event is indeed not dispatched when using the `once()` methods.

## Laravel docs
If this is merged, I can make sure to make the same adjustments to https://github.com/laravel/docs