### PR TITLE
[12.x] feat: add native return types to helper functions

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -13,7 +13,7 @@ if (! function_exists('collect')) {
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    function collect($value = [])
+    function collect($value = []): Collection
     {
         return new Collection($value);
     }

--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -9,9 +9,8 @@ if (! function_exists('Illuminate\Events\queueable')) {
      * Create a new queued Closure event listener.
      *
      * @param  \Closure  $closure
-     * @return \Illuminate\Events\QueuedClosure
      */
-    function queueable(Closure $closure)
+    function queueable(Closure $closure): QueuedClosure
     {
         return new QueuedClosure($closure);
     }

--- a/src/Illuminate/Filesystem/functions.php
+++ b/src/Illuminate/Filesystem/functions.php
@@ -8,9 +8,8 @@ if (! function_exists('Illuminate\Filesystem\join_paths')) {
      *
      * @param  string|null  $basePath
      * @param  string  ...$paths
-     * @return string
      */
-    function join_paths($basePath, ...$paths)
+    function join_paths($basePath, ...$paths): string
     {
         foreach ($paths as $index => $path) {
             if (empty($path) && $path !== '0') {

--- a/src/Illuminate/Log/functions.php
+++ b/src/Illuminate/Log/functions.php
@@ -10,7 +10,7 @@ if (! function_exists('Illuminate\Log\log')) {
      * @param  array  $context
      * @return ($message is null ? \Illuminate\Log\LogManager : null)
      */
-    function log($message = null, array $context = [])
+    function log($message = null, array $context = []): ?LogManager
     {
         return logger($message, $context);
     }

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -15,7 +15,7 @@ if (! function_exists('Illuminate\Support\defer')) {
      * @param  bool  $always
      * @return ($callback is null ? \Illuminate\Support\Defer\DeferredCallbackCollection : \Illuminate\Support\Defer\DeferredCallback)
      */
-    function defer(?callable $callback = null, ?string $name = null, bool $always = false)
+    function defer(?callable $callback = null, ?string $name = null, bool $always = false): DeferredCallback|DeferredCallbackCollection
     {
         if ($callback === null) {
             return app(DeferredCallbackCollection::class);
@@ -31,10 +31,8 @@ if (! function_exists('Illuminate\Support\defer')) {
 if (! function_exists('Illuminate\Support\php_binary')) {
     /**
      * Determine the PHP Binary.
-     *
-     * @return string
      */
-    function php_binary()
+    function php_binary(): string
     {
         return (new PhpExecutableFinder)->find(false) ?: 'php';
     }
@@ -43,10 +41,8 @@ if (! function_exists('Illuminate\Support\php_binary')) {
 if (! function_exists('Illuminate\Support\artisan_binary')) {
     /**
      * Determine the proper Artisan executable.
-     *
-     * @return string
      */
-    function artisan_binary()
+    function artisan_binary(): string
     {
         return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -19,9 +19,8 @@ if (! function_exists('append_config')) {
      * Assign high numeric IDs to a config item to force appending.
      *
      * @param  array  $array
-     * @return array
      */
-    function append_config(array $array)
+    function append_config(array $array): array
     {
         $start = 9999;
 
@@ -46,9 +45,8 @@ if (! function_exists('blank')) {
      * @phpstan-assert-if-true !=numeric|bool $value
      *
      * @param  mixed  $value
-     * @return bool
      */
-    function blank($value)
+    function blank($value): bool
     {
         if (is_null($value)) {
             return true;
@@ -83,9 +81,8 @@ if (! function_exists('class_basename')) {
      * Get the class "basename" of the given object / class.
      *
      * @param  string|object  $class
-     * @return string
      */
-    function class_basename($class)
+    function class_basename($class): string
     {
         $class = is_object($class) ? get_class($class) : $class;
 
@@ -98,9 +95,9 @@ if (! function_exists('class_uses_recursive')) {
      * Returns all traits used by a class, its parent classes and trait of their traits.
      *
      * @param  object|string  $class
-     * @return array
+     * @return array<string, string>
      */
-    function class_uses_recursive($class)
+    function class_uses_recursive($class): array
     {
         if (is_object($class)) {
             $class = get_class($class);
@@ -122,9 +119,8 @@ if (! function_exists('e')) {
      *
      * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|string|int|float|null  $value
      * @param  bool  $doubleEncode
-     * @return string
      */
-    function e($value, $doubleEncode = true)
+    function e($value, $doubleEncode = true): string
     {
         if ($value instanceof DeferringDisplayableValue) {
             $value = $value->resolveDisplayableValue();
@@ -165,9 +161,8 @@ if (! function_exists('filled')) {
      * @phpstan-assert-if-false !=numeric|bool $value
      *
      * @param  mixed  $value
-     * @return bool
      */
-    function filled($value)
+    function filled($value): bool
     {
         return ! blank($value);
     }
@@ -178,9 +173,8 @@ if (! function_exists('fluent')) {
      * Create a Fluent object from the given value.
      *
      * @param  object|array  $value
-     * @return \Illuminate\Support\Fluent
      */
-    function fluent($value)
+    function fluent($value): Fluent
     {
         return new Fluent($value);
     }
@@ -190,7 +184,7 @@ if (! function_exists('literal')) {
     /**
      * Return a new literal or anonymous object using named arguments.
      *
-     * @return \stdClass
+     * @return mixed
      */
     function literal(...$arguments)
     {
@@ -234,10 +228,8 @@ if (! function_exists('object_get')) {
 if (! function_exists('laravel_cloud')) {
     /**
      * Determine if the application is running on Laravel Cloud.
-     *
-     * @return bool
      */
-    function laravel_cloud()
+    function laravel_cloud(): bool
     {
         return ($_ENV['LARAVEL_CLOUD'] ?? false) === '1' ||
                ($_SERVER['LARAVEL_CLOUD'] ?? false) === '1';
@@ -292,9 +284,8 @@ if (! function_exists('preg_replace_array')) {
      * @param  string  $pattern
      * @param  array  $replacements
      * @param  string  $subject
-     * @return string
      */
-    function preg_replace_array($pattern, array $replacements, $subject)
+    function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
             foreach ($replacements as $value) {
@@ -457,9 +448,9 @@ if (! function_exists('trait_uses_recursive')) {
      * Returns all traits used by a trait and its traits.
      *
      * @param  object|string  $trait
-     * @return array
+     * @return array<string, string>
      */
-    function trait_uses_recursive($trait)
+    function trait_uses_recursive($trait): array
     {
         $traits = class_uses($trait) ?: [];
 
@@ -501,10 +492,8 @@ if (! function_exists('transform')) {
 if (! function_exists('windows_os')) {
     /**
      * Determine whether the current environment is Windows based.
-     *
-     * @return bool
      */
-    function windows_os()
+    function windows_os(): bool
     {
         return PHP_OS_FAMILY === 'Windows';
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -395,7 +395,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItReturnsSpecificErrorViewIfExists()
     {
-        $viewFactory = m::mock(stdClass::class);
+        $viewFactory = m::mock(ViewFactory::class);
         $viewFactory->shouldReceive('exists')->with('errors::502')->andReturn(true);
 
         $this->container->instance(ViewFactory::class, $viewFactory);
@@ -413,7 +413,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItReturnsFallbackErrorViewIfExists()
     {
-        $viewFactory = m::mock(stdClass::class);
+        $viewFactory = m::mock(ViewFactory::class);
         $viewFactory->shouldReceive('exists')->once()->with('errors::502')->andReturn(false);
         $viewFactory->shouldReceive('exists')->once()->with('errors::5xx')->andReturn(true);
 
@@ -432,7 +432,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     public function testItReturnsNullIfNoErrorViewExists()
     {
-        $viewFactory = m::mock(stdClass::class);
+        $viewFactory = m::mock(ViewFactory::class);
         $viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(false);
         $viewFactory->shouldReceive('exists')->once()->with('errors::4xx')->andReturn(false);
 


### PR DESCRIPTION
Hello!

This PR adds native return types to the helper functions (where the return type would not be `mixed`).

> [!NOTE]
> Functions cannot be extended so there *should not be any breaks*

### Motivation

I've been using [Rector](https://getrector.com) to automatically upgrade / refactor my codebase---it has the ability to automatically add types, narrow too wide types, etc. However, [in most cases it only uses native types](https://getrector.com/blog/new-in-rector-015-complete-safe-and-known-type-declarations#content-known-and-safe-types-first-only) to be completely safe during it's refactors---it skips over function calls like these that don't have native return types.

Adding actual return types like this will allow Rector (and other tools) to better understand the return type and be more safe.

Thanks!