### PR TITLE
[12.x] Use Str::snake delimiter when formatting attribute names

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -295,7 +295,7 @@ trait FormatsMessages
                 : $attribute;
         }
 
-        return str_replace('_', ' ', Str::snake($attribute));
+        return Str::snake($attribute, ' ');
     }
 
     /**


### PR DESCRIPTION
Simplifies `getDisplayableAttribute` by passing the space delimiter directly to `Str::snake` instead of applying a separate `str_replace`.