### PR TITLE
[12.x] Ensures casts objects can be transformed into strings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -802,7 +802,7 @@ trait HasAttributes
                     }
 
                     throw new InvalidArgumentException(
-                        "The $attribute cast object must implement Stringable or CastAttributes."
+                        "The cast object for $attribute attribute must implement Stringable or CastAttributes."
                     );
                 }),
                 is_array($cast) => value(function () use ($cast) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -796,7 +796,7 @@ trait HasAttributes
                     return $cast instanceof Stringable
                         ? (string) $cast
                         : throw new InvalidArgumentException(
-                            "The cast object for the $attribute attribute must implement Stringable or be declared as string."
+                            "The cast object for the {$attribute} attribute must implement Stringable."
                         );
                 }),
                 is_array($cast) => value(function () use ($cast) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -793,17 +793,11 @@ trait HasAttributes
         foreach ($casts as $attribute => $cast) {
             $casts[$attribute] = match (true) {
                 is_object($cast) => value(function () use ($cast, $attribute) {
-                    if ($cast instanceof Stringable) {
-                        return (string) $cast;
-                    }
-
-                    if ($cast instanceof CastsAttributes) {
-                        return $cast::class.':'.implode(',', get_object_vars($cast));
-                    }
-
-                    throw new InvalidArgumentException(
-                        "The cast object for $attribute attribute must implement Stringable or CastAttributes."
-                    );
+                    return $cast instanceof Stringable
+                        ? (string) $cast
+                        : throw new InvalidArgumentException(
+                            "The cast object for the $attribute attribute must implement Stringable or be declared as string."
+                        );
                 }),
                 is_array($cast) => value(function () use ($cast) {
                     if (count($cast) === 1) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -798,7 +798,7 @@ trait HasAttributes
                     }
 
                     if ($cast instanceof CastsAttributes) {
-                        return $cast::class .':'. implode(',', get_object_vars($cast));
+                        return $cast::class.':'.implode(',', get_object_vars($cast));
                     }
 
                     throw new InvalidArgumentException(

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3359,7 +3359,7 @@ class DatabaseEloquentModelTest extends TestCase
         $casts = $model->getCasts();
 
         $this->assertSame('int', $casts['castStringableObject']);
-        $this->assertSame(CastsAttributesInstance::class . ':foo,bar', $casts['castCastAttributesObject']);
+        $this->assertSame(CastsAttributesInstance::class.':foo,bar', $casts['castCastAttributesObject']);
     }
 
     public function testUsingPlainObjectAsCastThrowsException()
@@ -3370,7 +3370,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->expectExceptionMessage('The cast object for something attribute must implement Stringable or CastAttributes.');
 
         $model->mergeCasts([
-            'something' => (object) []
+            'something' => (object) [],
         ]);
     }
 
@@ -4416,11 +4416,11 @@ class CastsAttributesInstance implements CastsAttributes
 
     public function get(Model $model, string $key, mixed $value, array $attributes)
     {
-
+        //
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes)
     {
-
+        //
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3376,7 +3376,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelCastingStub;
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The cast object for the something attribute must implement Stringable or be declared as string.');
+        $this->expectExceptionMessage('The cast object for the something attribute must implement Stringable.');
 
         $model->mergeCasts([
             'something' => (object) [],

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3376,7 +3376,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelCastingStub;
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The cast object for something attribute must implement Stringable or be declared as string.');
+        $this->expectExceptionMessage('The cast object for the something attribute must implement Stringable or be declared as string.');
 
         $model->mergeCasts([
             'something' => (object) [],


### PR DESCRIPTION
# What?

This adds the ability for a Model to cast an attribute using a Stringable object rather than a string. This allows for **expressive casting** instead of static methods trying to shove in all arguments possible without hints (and no warranties over consistent argument names between versions).

The idea is to let these complex Casters to call an auxiliary class or methods that handles the configuration, a _Castable builder_ of sorts. It can even be the cast class itself.

```php
// Before
public function casts()
{
    return [
        // true? null? why? time to read the source code?
        'cart' => AsCart::fromColumns('items', true, null),
    ];
}

// After
public function casts()
{
    return [
        // Oh... now I understand!
        'cart' => AsCart::from('items')->withDiscounts()->withoutExpiration(),
    ]
}
```

The way it works is relatively simple: if we're passing an object that implements `Stringable`, we will use its string representation as a cast, which most of the time will be manually done by the developer.

```php
use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
use Closure;

class AsCart implements CastsAttributes, Stringable
{
    public function __construct(public $column, public $discounts, public $expires)
    {
    
    }

    public function withDiscounts()
    {
        $this->discounts = true;
        
        return $this;
    }
    
    public function withoutExpiration()
    {
        $this->expires = null;
        
        return $this;
    }
    
    public function __toString(): string
    {
        return static::class . ':' . implode(',', get_class_vars($this));
    }
    
    public static function from(string $column = 'items')
    {
        return new static($column);
    }
}


public function casts()
{
    return [
        'cart' => AsCart::from('items')->withDiscounts()->withoutExpiration()
        // It will be set as "\App\Casts\AsCart:items,1,"
    ]
}
```

The magic behind all of this new match arm in `ensureCastsAreStringValues()`, that works when the `cast()` method of the Model is called. It detects if the cast is an object and proceeds as previously explained. In a nutshell:

```php
is_object($cast) => value(function () use ($cast) {
    // If the object is a Stringable, then let the developer configure the cast.
    if ($cast instanceof Stringable) {
        return (string) $cast;
    }

    // It's just an object? Warn the developer.
    throw new InvalidArgumentException(
        "The cast object for the $attribute attribute must implement Stringable or be declared as string."
    );
})
```