### PR TITLE
[12.x] Allow passing enum to `Database` attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Database.php
+++ b/src/Illuminate/Container/Attributes/Database.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Database implements ContextualAttribute
@@ -12,7 +13,7 @@ class Database implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public ?string $connection = null)
+    public function __construct(public UnitEnum|string|null $connection = null)
     {
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Per #56271 it is allowed to pass an enum value to the database `connection` call. It therefore makes sense to allow this on the (corresponding) `Database` attribute as well.