### PR TITLE
[12.x] Add roundToHalf method to Number helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -437,4 +437,59 @@ class Number
             throw new RuntimeException('The "intl" PHP extension is required to use the ['.$method.'] method.');
         }
     }
+
+    /**
+     * Round the given number to the nearest half increment (.0 or .5).
+     *
+     * @param  int|float  $number
+     * @param  bool  $up  Whether to round up (true) or down (false) when between increments
+     * @return float
+     */
+    public static function roundToHalf(int|float $number, bool $up = true): float
+    {
+        $integer = floor($number);
+        $decimal = $number - $integer;
+
+        if ($up) {
+            // Round up logic
+            if ($decimal <= 0.0) {
+                return (float) $integer;
+            } elseif ($decimal <= 0.5) {
+                return $integer + 0.5;
+            } else {
+                return (float) ($integer + 1);
+            }
+        } else {
+            // Round down logic
+            if ($decimal < 0.5) {
+                return (float) $integer;
+            } elseif ($decimal < 1.0) {
+                return $integer + 0.5;
+            } else {
+                return (float) ($integer + 1);
+            }
+        }
+    }
+
+    /**
+     * Round the given number up to the nearest half increment (.0 or .5).
+     *
+     * @param  int|float  $number
+     * @return float
+     */
+    public static function ceilToHalf(int|float $number): float
+    {
+        return static::roundToHalf($number, true);
+    }
+
+    /**
+     * Round the given number down to the nearest half increment (.0 or .5).
+     *
+     * @param  int|float  $number
+     * @return float
+     */
+    public static function floorToHalf(int|float $number): float
+    {
+        return static::roundToHalf($number, false);
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -370,4 +370,76 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
+
+     public function testRoundToHalfUp()
+     {
+        // Test cases for rounding up (max flag)
+        $this->assertEquals(100.0, Number::roundToHalf(100.0, true));
+        $this->assertEquals(100.5, Number::roundToHalf(100.1, true));
+        $this->assertEquals(100.5, Number::roundToHalf(100.22, true));
+        $this->assertEquals(100.5, Number::roundToHalf(100.5, true));
+        $this->assertEquals(101.0, Number::roundToHalf(100.6, true));
+        $this->assertEquals(101.0, Number::roundToHalf(100.77, true));
+        $this->assertEquals(101.0, Number::roundToHalf(100.99, true));
+    }
+
+    public function testRoundToHalfDown()
+    {
+        // Test cases for rounding down (min flag)
+        $this->assertEquals(100.0, Number::roundToHalf(100.0, false));
+        $this->assertEquals(100.0, Number::roundToHalf(100.1, false));
+        $this->assertEquals(100.0, Number::roundToHalf(100.22, false));
+        $this->assertEquals(100.0, Number::roundToHalf(100.49, false));
+        $this->assertEquals(100.5, Number::roundToHalf(100.5, false));
+        $this->assertEquals(100.5, Number::roundToHalf(100.6, false));
+        $this->assertEquals(100.5, Number::roundToHalf(100.77, false));
+        $this->assertEquals(100.5, Number::roundToHalf(100.99, false));
+    }
+
+    public function testCeilToHalf()
+    {
+        $this->assertEquals(100.0, Number::ceilToHalf(100.0));
+        $this->assertEquals(100.5, Number::ceilToHalf(100.1));
+        $this->assertEquals(100.5, Number::ceilToHalf(100.22));
+        $this->assertEquals(101.0, Number::ceilToHalf(100.77));
+    }
+
+    public function testFloorToHalf()
+    {
+        $this->assertEquals(100.0, Number::floorToHalf(100.0));
+        $this->assertEquals(100.0, Number::floorToHalf(100.22));
+        $this->assertEquals(100.5, Number::floorToHalf(100.77));
+        $this->assertEquals(100.5, Number::floorToHalf(100.99));
+    }
+
+    public function testNegativeNumbers()
+    {
+        // Test negative numbers
+        $this->assertEquals(-100.0, Number::roundToHalf(-100.22, true));
+        $this->assertEquals(-100.5, Number::roundToHalf(-100.77, true));
+
+        $this->assertEquals(-100.5, Number::roundToHalf(-100.22, false));
+        $this->assertEquals(-101.0, Number::roundToHalf(-100.77, false));
+    }
+
+    public function testIntegerInputs()
+    {
+        $this->assertEquals(5.0, Number::roundToHalf(5, true));
+        $this->assertEquals(5.0, Number::roundToHalf(5, false));
+    }
+
+    public function testEdgeCases()
+    {
+        // Test exact half values
+        $this->assertEquals(0.5, Number::roundToHalf(0.5, true));
+        $this->assertEquals(0.5, Number::roundToHalf(0.5, false));
+
+        // Test zero
+        $this->assertEquals(0.0, Number::roundToHalf(0.0, true));
+        $this->assertEquals(0.0, Number::roundToHalf(0.0, false));
+
+        // Test very small decimals
+        $this->assertEquals(0.5, Number::roundToHalf(0.01, true));
+        $this->assertEquals(0.0, Number::roundToHalf(0.01, false));
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -371,8 +371,8 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
 
-     public function testRoundToHalfUp()
-     {
+    public function testRoundToHalfUp()
+    {
         // Test cases for rounding up (max flag)
         $this->assertEquals(100.0, Number::roundToHalf(100.0, true));
         $this->assertEquals(100.5, Number::roundToHalf(100.1, true));


### PR DESCRIPTION
# Add roundToHalf method to Number helper

## Description

This PR adds a new `roundToHalf()` method to the `Illuminate\Support\Number` helper class that rounds numbers to the nearest half increment (`.0` or `.5`). This is useful for scenarios like:

- Rating systems (1.0, 1.5, 2.0, 2.5, etc.)
- Price adjustments to quarter/half dollar amounts
- UI elements that need consistent half-step increments

## Changes Made

### New Methods Added

1. **`Number::roundToHalf(int|float $number, bool $up = true): float`**
   - Main method that rounds numbers to nearest `.0` or `.5`
   - `$up` parameter controls rounding direction when between increments

2. **`Number::ceilToHalf(int|float $number): float`**
   - Convenience method that always rounds up to nearest half

3. **`Number::floorToHalf(int|float $number): float`**
   - Convenience method that always rounds down to nearest half

### Examples

```php
// Round UP (when $up = true, default behavior)
Number::roundToHalf(100.22, true);  // 100.5
Number::roundToHalf(100.77, true);  // 101.0
Number::ceilToHalf(100.22);         // 100.5

// Round DOWN (when $up = false)
Number::roundToHalf(100.22, false); // 100.0
Number::roundToHalf(100.77, false); // 100.5
Number::floorToHalf(100.77);        // 100.5
```

### Logic Explanation

**Round Up Mode (`$up = true`):**
- `0.0 < decimal ≤ 0.5` → round to `.5`
- `0.5 < decimal < 1.0` → round to next integer

**Round Down Mode (`$up = false`):**
- `0.0 ≤ decimal < 0.5` → round to `.0`
- `0.5 ≤ decimal < 1.0` → round to `.5`

## Tests

Comprehensive test coverage includes:
- Basic rounding scenarios (your examples)
- Edge cases (exact halves, zeros, integers)
- Negative numbers
- Both convenience methods
- All boundary conditions

---

**Files Modified:**
- `src/Illuminate/Support/Number.php` - Added new methods
- `tests/Support/NumberTest.php` - Added comprehensive test coverage
