### PR TITLE
fix(cache): ensure Redis rate limiter keys always have TTL

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -177,6 +177,17 @@ class RateLimiter
             );
         }
 
+        // ensure TTL is always present for Redis keys
+        $store = $this->cache->getStore();
+        if ($store instanceof \Illuminate\Cache\RedisStore) {
+            $redis = $store->connection();
+            $ttl = $redis->ttl($key);
+
+            if ($ttl === -1) {
+                $redis->expire($key, $decaySeconds);
+            }
+        }
+
         return $hits;
     }
 

--- a/tests/Cache/RateLimiterRedisTtlFixTest.php
+++ b/tests/Cache/RateLimiterRedisTtlFixTest.php
@@ -39,7 +39,7 @@ class RateLimiterRedisTtlFixTest extends TestCase
 
         $store->shouldReceive('add')
             ->once()
-            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->with($key.':timer', Mockery::type('int'), $decay)
             ->andReturn(true);
         $store->shouldReceive('add')
             ->once()
@@ -79,7 +79,7 @@ class RateLimiterRedisTtlFixTest extends TestCase
 
         $store->shouldReceive('add')
             ->once()
-            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->with($key.':timer', Mockery::type('int'), $decay)
             ->andReturn(true);
         $store->shouldReceive('add')
             ->once()
@@ -122,7 +122,7 @@ class RateLimiterRedisTtlFixTest extends TestCase
 
         $store->shouldReceive('add')
             ->once()
-            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->with($key.':timer', Mockery::type('int'), $decay)
             ->andReturn(true);
         $store->shouldReceive('add')
             ->once()

--- a/tests/Cache/RateLimiterRedisTtlFixTest.php
+++ b/tests/Cache/RateLimiterRedisTtlFixTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RedisStore;
+use Illuminate\Cache\Repository;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class RateLimiterRedisTtlFixTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testRestoresRedisTtlWhenTtlIsMinusOne(): void
+    {
+        $key = 'test-key';
+        $decay = 60;
+        $amount = 1;
+
+        $redisConnection = Mockery::mock('stdClass');
+        $redisConnection->shouldReceive('ttl')
+            ->once()
+            ->with($key)
+            ->andReturn(-1);
+        $redisConnection->shouldReceive('expire')
+            ->once()
+            ->with($key, $decay)
+            ->andReturn(true);
+
+        $store = Mockery::mock(RedisStore::class);
+
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->andReturn(true);
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key, 0, $decay)
+            ->andReturn(true);
+        $store->shouldReceive('increment')
+            ->once()
+            ->with($key, $amount)
+            ->andReturn($amount);
+        $store->shouldReceive('put')->never();
+
+        // ✅ allow multiple calls
+        $store->shouldReceive('connection')
+            ->atLeast()->once()
+            ->andReturn($redisConnection);
+
+        $limiter = new RateLimiter(new Repository($store));
+
+        $hits = $limiter->increment($key, $decay, $amount);
+
+        $this->assertSame(1, $hits);
+    }
+
+    public function testDoesNotCallExpireWhenTtlIsNonNegative(): void
+    {
+        $key = 'test-key';
+        $decay = 60;
+
+        $redisConnection = Mockery::mock('stdClass');
+        $redisConnection->shouldReceive('ttl')
+            ->once()
+            ->with($key)
+            ->andReturn(30);
+        $redisConnection->shouldReceive('expire')->never();
+
+        $store = Mockery::mock(RedisStore::class);
+
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->andReturn(true);
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key, 0, $decay)
+            ->andReturn(true);
+        $store->shouldReceive('increment')
+            ->once()
+            ->with($key, 1)
+            ->andReturn(1);
+        $store->shouldReceive('put')->never();
+
+        // ✅ allow multiple calls
+        $store->shouldReceive('connection')
+            ->atLeast()->once()
+            ->andReturn($redisConnection);
+
+        $limiter = new RateLimiter(new Repository($store));
+
+        $hits = $limiter->increment($key, $decay, 1);
+
+        $this->assertSame(1, $hits);
+    }
+
+    public function testHandlesEdgeCaseWhenKeyExistedButHitsBecomesOneAgain(): void
+    {
+        $key = 'test-key';
+        $decay = 60;
+
+        $redisConnection = Mockery::mock('stdClass');
+        $redisConnection->shouldReceive('ttl')
+            ->once()
+            ->with($key)
+            ->andReturn(-1);
+        $redisConnection->shouldReceive('expire')
+            ->once()
+            ->with($key, $decay)
+            ->andReturn(true);
+
+        $store = Mockery::mock(RedisStore::class);
+
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key . ':timer', Mockery::type('int'), $decay)
+            ->andReturn(true);
+        $store->shouldReceive('add')
+            ->once()
+            ->with($key, 0, $decay)
+            ->andReturn(false);
+        $store->shouldReceive('increment')
+            ->once()
+            ->with($key, 1)
+            ->andReturn(1);
+        $store->shouldReceive('put')
+            ->once()
+            ->with($key, 1, $decay)
+            ->andReturn(true);
+
+        // ✅ allow multiple calls
+        $store->shouldReceive('connection')
+            ->atLeast()->once()
+            ->andReturn($redisConnection);
+
+        $limiter = new RateLimiter(new Repository($store));
+
+        $hits = $limiter->increment($key, $decay, 1);
+
+        $this->assertSame(1, $hits);
+    }
+
+    public function testRemainsNoopForNonRedisStoreAndStillReturnsHits(): void
+    {
+        $store = new ArrayStore;
+        $limiter = new RateLimiter(new Repository($store));
+
+        $key = 'test-key';
+        $hits = $limiter->increment($key, 2, 1);
+
+        $this->assertSame(1, $hits);
+        $this->assertFalse($limiter->tooManyAttempts($key, 2));
+    }
+}


### PR DESCRIPTION
After pull request #56656 was drafted, I went and thought more about the problem and realized that a change had to be made to the increment method so that problem #55459 wouldn't happen again.
Tests

Added comprehensive tests to cover:

TTL = -1 → Ensures expire() is called to restore TTL.

TTL ≥ 0 → Confirms no redundant expire() is issued.

Edge case (!$added && $hits == 1) → Still correctly puts the value with TTL while also restoring expiration if missing.

Non-Redis stores → Behavior remains unchanged