### PR TITLE
[12.x] Add toPrettyJson method

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1270,6 +1270,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function toJson($options = 0);
 
     /**
+     * Get the collection of items as a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson();
+
+    /**
      * Get a CachingIterator instance.
      *
      * @param  int  $flags

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1270,7 +1270,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function toJson($options = 0);
 
     /**
-     * Get the collection of items as a pretty print formatted JSON.
+     * Get the collection of items as pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -985,7 +985,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Get the collection of items as a pretty print formatted JSON.
+     * Get the collection of items as pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -985,6 +985,16 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the collection of items as a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
+
+    /**
      * Get a CachingIterator instance.
      *
      * @param  int  $flags

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1801,7 +1801,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Convert the model instance to a pretty print formatted JSON.
+     * Convert the model instance to pretty print formatted JSON.
      *
      * @return string
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1801,6 +1801,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Convert the model instance to a pretty print formatted JSON.
+     *
+     * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\JsonEncodingException
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return mixed

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -154,7 +154,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Convert the resource to a pretty print formatted JSON.
+     * Convert the resource to pretty print formatted JSON.
      *
      * @return string
      *

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -135,7 +135,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Convert the model instance to JSON.
+     * Convert the resource to JSON.
      *
      * @param  int  $options
      * @return string
@@ -151,6 +151,18 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
         }
 
         return $json;
+    }
+
+    /**
+     * Convert the resource to a pretty print formatted JSON.
+     *
+     * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\JsonEncodingException
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
     }
 
     /**

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -182,7 +182,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     }
 
     /**
-     * Convert the object to a pretty print formatted JSON.
+     * Convert the object to pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -180,4 +180,14 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     {
         return json_encode($this->jsonSerialize(), $options);
     }
+
+    /**
+     * Convert the object to a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -244,7 +244,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
-     * Convert the object to a pretty print formatted JSON.
+     * Convert the object to pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -242,4 +242,14 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     {
         return json_encode($this->jsonSerialize(), $options);
     }
+
+    /**
+     * Convert the object to a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -185,4 +185,14 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     {
         return json_encode($this->jsonSerialize(), $options);
     }
+
+    /**
+     * Convert the object to a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -187,7 +187,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     }
 
     /**
-     * Convert the object to a pretty print formatted JSON.
+     * Convert the object to pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -204,6 +204,16 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     }
 
     /**
+     * Convert the fluent instance to a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
+
+    /**
      * Determine if the fluent instance is empty.
      *
      * @return bool

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -204,7 +204,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     }
 
     /**
-     * Convert the fluent instance to a pretty print formatted JSON.
+     * Convert the fluent instance to pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -432,7 +432,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     }
 
     /**
-     * Convert the object to a pretty print formatted JSON.
+     * Convert the object to pretty print formatted JSON.
      *
      * @return string
      */

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -432,6 +432,16 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     }
 
     /**
+     * Convert the object to a pretty print formatted JSON.
+     *
+     * @return string
+     */
+    public function toPrettyJson()
+    {
+        return $this->toJson(JSON_PRETTY_PRINT);
+    }
+
+    /**
      * Convert the message bag to its string representation.
      *
      * @return string

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3414,6 +3414,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
     }
 
+    public function testModelToPrettyJson(): void
+    {
+        $user = new EloquentModelStub(['name' => 'Mateus', 'active' => true]);
+        $results = $user->toPrettyJson();
+        $expected = $user->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
+
     public function testFillableWithMutators()
     {
         $model = new EloquentModelWithMutators;

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -46,4 +46,23 @@ class JsonResourceTest extends TestCase
 
         $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
     }
+
+    public function testJsonResourceToPrettyPrint(): void
+    {
+        $model = new class extends Model {
+        };
+
+        $resource = m::mock(JsonResource::class, ['resource' => $model])
+            ->makePartial()
+            ->shouldReceive('jsonSerialize')->once()->andReturn(['foo' => 'bar', 'bar' => 'foo'])
+            ->getMock();
+
+        $results = $resource->toPrettyJson();
+        $expected = $resource->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
 }

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -37,7 +37,7 @@ class JsonResourceTest extends TestCase
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])
             ->makePartial()
-            ->shouldReceive('jsonSerialize')->once()->andReturn(['foo' => 'bar'])
+            ->shouldReceive('jsonSerialize')->andReturn(['foo' => 'bar'])
             ->getMock();
 
         // Simulate a JSON error
@@ -54,7 +54,7 @@ class JsonResourceTest extends TestCase
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])
             ->makePartial()
-            ->shouldReceive('jsonSerialize')->once()->andReturn(['foo' => 'bar', 'bar' => 'foo'])
+            ->shouldReceive('jsonSerialize')->andReturn(['foo' => 'bar', 'bar' => 'foo'])
             ->getMock();
 
         $results = $resource->toPrettyJson();

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -120,6 +120,28 @@ class CursorPaginatorTest extends TestCase
         ], $p->toArray());
     }
 
+    public function testCursorPaginatorToJson()
+    {
+        $paginator = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], 2, null);
+        $results = $paginator->toJson();
+        $expected = json_encode($paginator->toArray());
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+    }
+
+    public function testCursorPaginatorToPrettyJson()
+    {
+        $paginator = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], 2, null);
+        $results = $paginator->toPrettyJson();
+        $expected = $paginator->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
+
     protected function getCursor($params, $isNext = true)
     {
         return (new Cursor($params, $isNext))->encode();

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -72,4 +72,26 @@ class PaginatorTest extends TestCase
         $this->assertInstanceOf(Paginator::class, $p);
         $this->assertSame(['1', '2', '3'], $p->items());
     }
+
+    public function testPaginatorToJson()
+    {
+        $p = new Paginator(['item1', 'item2', 'item3'], 3, 1);
+        $results = $p->toJson();
+        $expected = json_encode($p->toArray());
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+    }
+
+    public function testPaginatorToPrettyJson()
+    {
+        $p = new Paginator(['item1', 'item2', 'item3'], 3, 1);
+        $results = $p->toPrettyJson();
+        $expected = $p->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -663,7 +663,7 @@ class SupportCollectionTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expected, $results);
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
-        $this->assertStringContainsString("    ", $results);
+        $this->assertStringContainsString('    ', $results);
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -654,6 +654,19 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testToPrettyJsonEncodesTheJsonSerializeResult($collection)
+    {
+        $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();
+        $c->expects($this->once())->method('jsonSerialize')->willReturn(['foo' => 'bar', 'baz' => 'qux']);
+        $results = $c->toPrettyJson();
+        $expected = json_encode(['foo' => 'bar', 'baz' => 'qux'], JSON_PRETTY_PRINT);
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString("    ", $results);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCastingToStringJsonEncodesTheToArrayResult($collection)
     {
         $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -132,6 +132,19 @@ class SupportFluentTest extends TestCase
         $this->assertJsonStringEqualsJsonString(json_encode(['foo']), $results);
     }
 
+    public function testToPrettyJson()
+    {
+        $fluent = $this->getMockBuilder(Fluent::class)->onlyMethods(['toArray'])->getMock();
+        $fluent->expects($this->exactly(2))->method('toArray')->willReturn(['foo' => 'bar', 'bar' => 'foo']);
+        $results = $fluent->toPrettyJson();
+        $expected = $fluent->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
+
     public function testScope()
     {
         $fluent = new Fluent(['user' => ['name' => 'taylor']]);

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -255,6 +255,21 @@ class SupportMessageBagTest extends TestCase
         $this->assertSame('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
     }
 
+    public function testMessageBagReturnsExpectedPrettyJson()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo', 'bar');
+        $container->add('boom', 'baz');
+        $results = $container->toPrettyJson();
+        $expected = $container->toJson(JSON_PRETTY_PRINT);
+
+        $this->assertJsonStringEqualsJsonString($expected, $results);
+        $this->assertSame($expected, $results);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+    }
+
     public function testCountReturnsCorrectValue()
     {
         $container = new MessageBag;


### PR DESCRIPTION
This is basically a syntax sugar for:

```php
$collection = collect([1,2,3]);
$collection->toJson(JSON_PRETTY_PRINT);
```

To be called like this:

```php
$collection = collect([1,2,3]);
$collection->toPrettyJson();
```