### PR TITLE
[12.x] Fix `spliceIntoPosition` docblock to allow `string|int` values

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -655,7 +655,7 @@ trait ManagesFrequencies
      * Splice the given value into the given position of the expression.
      *
      * @param  int  $position
-     * @param  string  $value
+     * @param  string|int  $value
      * @return $this
      */
     protected function spliceIntoPosition($position, $value)


### PR DESCRIPTION
The `spliceIntoPosition` method in `src/Illuminate/Console/Scheduling/ManagesFrequencies.php` can accept both strings and integers as value.

Example:
https://github.com/laravel/framework/blob/ce4faf187fb8a181b21cf95cbb2a5e72e1643ad1/src/Illuminate/Console/Scheduling/ManagesFrequencies.php#L576-L582
