### PR TITLE
[12.x] Add deferred option to make:provider

### DIFF
--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -61,6 +61,10 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('deferred')) {
+            return $this->resolveStubPath('/stubs/provider.deferred.stub');
+        }
+
         return $this->resolveStubPath('/stubs/provider.stub');
     }
 
@@ -97,6 +101,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the provider already exists'],
+            ['deferred', null, InputOption::VALUE_NONE, 'Create a deferred service provider'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/provider.deferred.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider.deferred.stub
@@ -1,0 +1,37 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
+
+class {{ class }} extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return list<string>
+     */
+    public function provides(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/tests/Integration/Generators/ProviderMakeCommandTest.php
+++ b/tests/Integration/Generators/ProviderMakeCommandTest.php
@@ -6,6 +6,7 @@ class ProviderMakeCommandTest extends TestCase
 {
     protected $files = [
         'app/Providers/FooServiceProvider.php',
+        'app/Providers/DeferredServiceProvider.php',
     ];
 
     public function testItCanGenerateServiceProviderFile()
@@ -21,8 +22,24 @@ class ProviderMakeCommandTest extends TestCase
             'public function boot()',
         ], 'app/Providers/FooServiceProvider.php');
 
-        $this->assertEquals(require $this->app->getBootstrapProvidersPath(), [
-            'App\Providers\FooServiceProvider',
-        ]);
+        $this->assertContains('App\Providers\FooServiceProvider', require $this->app->getBootstrapProvidersPath());
+    }
+
+    public function testItCanGenerateDeferredServiceProviderFile()
+    {
+        $this->artisan('make:provider', ['name' => 'DeferredServiceProvider', '--deferred' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'namespace App\Providers;',
+            'use Illuminate\Contracts\Support\DeferrableProvider;',
+            'use Illuminate\Support\ServiceProvider;',
+            'class DeferredServiceProvider extends ServiceProvider implements DeferrableProvider',
+            'public function register()',
+            'public function boot()',
+            'public function provides()',
+        ], 'app/Providers/DeferredServiceProvider.php');
+
+        $this->assertContains('App\Providers\DeferredServiceProvider', require $this->app->getBootstrapProvidersPath());
     }
 }


### PR DESCRIPTION
Hello,

This PR adds a `--deferred` option to the `ProviderMakeCommand`, allowing generation of service providers implementing `DeferrableProvider`. Adds a new stub for deferred providers and corresponding test case.
