### PR TITLE
[12.x] Add Modelable interface

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -6,6 +6,8 @@ use CachingIterator;
 use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Modelable;
+use Illuminate\Database\Eloquent\Model;
 use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
@@ -18,7 +20,7 @@ use Traversable;
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>
  */
-interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
+interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable, Modelable
 {
     /**
      * Create a new collection instance if the value isn't one already.
@@ -1253,6 +1255,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return array<TKey, mixed>
      */
     public function toArray();
+
+    /**
+     * Convert the object to an Eloquent Model instance.
+     *
+     * @param  class-string $class
+     * @return Model
+     */
+    public function toModel(string $class): Model;
 
     /**
      * Convert the object into something JSON serializable.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1259,7 +1259,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string $class
+     * @param  class-string  $class
      * @return Model
      */
     public function toModel(string $class): Model;

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1259,7 +1259,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string  $class
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $class
      * @return Model
      */
     public function toModel(string $class): Model;

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -957,7 +957,7 @@ trait EnumeratesValues
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string $class
+     * @param  class-string  $class
      * @return Model
      */
     public function toModel(string $class): Model

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -957,7 +957,9 @@ trait EnumeratesValues
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string  $class
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $class
      * @return Model
      */
     public function toModel(string $class): Model

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -8,6 +8,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -951,6 +952,17 @@ trait EnumeratesValues
     public function toArray()
     {
         return $this->map(fn ($value) => $value instanceof Arrayable ? $value->toArray() : $value)->all();
+    }
+
+    /**
+     * Convert the object to an Eloquent Model instance.
+     *
+     * @param  class-string $class
+     * @return Model
+     */
+    public function toModel(string $class): Model
+    {
+        return new $class($this->toArray());
     }
 
     /**

--- a/src/Illuminate/Contracts/Support/Modelable.php
+++ b/src/Illuminate/Contracts/Support/Modelable.php
@@ -9,7 +9,7 @@ interface Modelable
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string $class
+     * @param  class-string  $class
      * @return Model
      */
     public function toModel(string $class): Model;

--- a/src/Illuminate/Contracts/Support/Modelable.php
+++ b/src/Illuminate/Contracts/Support/Modelable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface Modelable
+{
+    /**
+     * Convert the object to an Eloquent Model instance.
+     *
+     * @param  class-string $class
+     * @return Model
+     */
+    public function toModel(string $class): Model;
+}

--- a/src/Illuminate/Contracts/Support/Modelable.php
+++ b/src/Illuminate/Contracts/Support/Modelable.php
@@ -9,7 +9,9 @@ interface Modelable
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string  $class
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $class
      * @return Model
      */
     public function toModel(string $class): Model;

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -6,6 +6,8 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Modelable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
@@ -20,7 +22,7 @@ use Traversable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
+class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable, Modelable
 {
     use Conditionable, InteractsWithData, Macroable {
         __call as macroCall;
@@ -180,6 +182,17 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     public function toArray()
     {
         return $this->attributes;
+    }
+
+    /**
+     * Convert the object to an Eloquent Model instance.
+     *
+     * @param  class-string $class
+     * @return Model
+     */
+    public function toModel(string $class): Model
+    {
+        return new $class($this->toArray());
     }
 
     /**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -187,7 +187,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string $class
+     * @param  class-string  $class
      * @return Model
      */
     public function toModel(string $class): Model

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -187,7 +187,9 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Convert the object to an Eloquent Model instance.
      *
-     * @param  class-string  $class
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $class
      * @return Model
      */
     public function toModel(string $class): Model

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -645,6 +645,18 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testToModelReturnsModel($collection)
+    {
+        $c = new $collection(['name' => 'Taylor', 'active' => true, 'not_valid' => 'foo']);
+        $results = $c->toModel(StubCollectionModel::class);
+
+        $this->assertInstanceOf(StubCollectionModel::class, $results);
+        $this->assertSame('Taylor', $results->name);
+        $this->assertTrue($results->active);
+        $this->assertNull($results->not_valid);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testToJsonEncodesTheJsonSerializeResult($collection)
     {
         $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();
@@ -5924,4 +5936,9 @@ enum StaffEnum
     case Taylor;
     case Joe;
     case James;
+}
+
+class StubCollectionModel extends Model
+{
+    protected $fillable = ['name', 'active'];
 }

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayIterator;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
@@ -130,6 +131,17 @@ class SupportFluentTest extends TestCase
         $results = $fluent->toJson();
 
         $this->assertJsonStringEqualsJsonString(json_encode(['foo']), $results);
+    }
+
+    public function testToModelReturnsModel()
+    {
+        $fluent = new Fluent(['name' => 'Taylor', 'active' => true, 'not_valid' => 'foo']);
+        $results = $fluent->toModel(StubFluentModel::class);
+
+        $this->assertInstanceOf(StubFluentModel::class, $results);
+        $this->assertSame('Taylor', $results->name);
+        $this->assertTrue($results->active);
+        $this->assertNull($results->not_valid);
     }
 
     public function testScope()
@@ -490,6 +502,11 @@ class SupportFluentTest extends TestCase
         $this->assertTrue($fluent->isNotEmpty());
         $this->assertFalse($fluent->isEmpty());
     }
+}
+
+class StubFluentModel extends Model
+{
+    protected $fillable = ['name', 'active'];
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
## Overview

This PR introduces a new `Modelable` interface, providing a standardized way to convert data structures into Eloquent Model instances. The interface has been implemented for both the `Enumberable` and the `Fluent` classes.

This provides a unified interface for converting different data structures to Eloquent models and the method signature ensures type-safe conversion with proper IDE support.

This can benefit package creators who need to implement transformations of any class instances into Eloquent Models, or checking if a class has this support.

## Examples

```php
// Converting a Collection to a Model
$collection = collect(['name' => 'Taylor', 'email' => 'taylor@laravel.com']);
$user = $collection->toModel(User::class);

// Converting a Fluent instance to a Model
$fluent = new Fluent(['name' => 'Taylor', 'email' => 'taylor@laravel.com']);
$user = $fluent->toModel(User::class);
```