### PR TITLE
[12.x] Use array_first and array_last polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "symfony/mime": "^7.2.0",
         "symfony/polyfill-php83": "^1.31",
         "symfony/polyfill-php84": "^1.31",
-        "symfony/polyfill-php85": "^1.31",
+        "symfony/polyfill-php85": "^1.33",
         "symfony/process": "^7.2.0",
         "symfony/routing": "^7.2.0",
         "symfony/uid": "^7.2.0",

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -256,11 +256,7 @@ class Arr
                 return value($default);
             }
 
-            foreach ($array as $item) {
-                return $item;
-            }
-
-            return value($default);
+            return array_first($array);
         }
 
         $key = array_find_key($array, $callback);
@@ -283,7 +279,7 @@ class Arr
     public static function last($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
-            return empty($array) ? value($default) : end($array);
+            return empty($array) ? value($default) : array_last($array);
         }
 
         return static::first(array_reverse($array, true), $callback, $default);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -256,7 +256,15 @@ class Arr
                 return value($default);
             }
 
-            return array_first($array);
+            if (is_array($array)) {
+                return array_first($array);
+            }
+
+            foreach ($array as $item) {
+                return $item;
+            }
+
+            return value($default);
         }
 
         $key = array_find_key($array, $callback);

--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -34,6 +34,7 @@ class HasInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array<string, mixed>  $data
+     * @return void
      */
     public function __construct(Connection $database, array $data)
     {
@@ -81,7 +82,7 @@ class HasInDatabase extends Constraint
 
         $similarResults = $query->where(
             array_key_first($this->data),
-            $this->data[array_key_first($this->data)]
+            array_first($this->data),
         )->select(array_keys($this->data))->limit($this->show)->get();
 
         if ($similarResults->isNotEmpty()) {


### PR DESCRIPTION
There is a new release of symfony/polyfill-php85 that includes both the array_first and array_last methods. This PR implements those methods into the appropriate Arr helper methods, and at src/Illuminate/Testing/Constraints/HasInDatabase.php.

(Fixes the tests from #56702)