### PR TITLE
[12.x] Fix path to Str in exception markdown

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/markdown.blade.php
@@ -13,7 +13,7 @@ Laravel {{ app()->version() }}
 
 ## Request
 
-{{ $exception->request()->method() }} {{ Str::start($exception->request()->path(), '/') }}
+{{ $exception->request()->method() }} {{ \Illuminate\Support\Str::start($exception->request()->path(), '/') }}
 
 ## Headers
 


### PR DESCRIPTION
Otherwise showing an exception will fail with an exception, if the facade could not be found.

This error might have been introduced in v12.25.0