### PR TITLE
[12.x] Use `array_first` and `array_last`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -637,7 +637,7 @@ class Arr
         }
 
         if (count($array) === 1) {
-            return end($array);
+            return array_last($array);
         }
 
         $finalItem = array_pop($array);

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -203,7 +203,7 @@ if (! function_exists('head')) {
      */
     function head($array)
     {
-        return reset($array);
+        return array_first($array);
     }
 }
 
@@ -216,7 +216,7 @@ if (! function_exists('last')) {
      */
     function last($array)
     {
-        return end($array);
+        return array_last($array);
     }
 }
 

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -203,7 +203,7 @@ if (! function_exists('head')) {
      */
     function head($array)
     {
-        return array_first($array);
+        return empty($array) ? false : array_first($array);
     }
 }
 
@@ -216,7 +216,7 @@ if (! function_exists('last')) {
      */
     function last($array)
     {
-        return array_last($array);
+        return empty($array) ? false : array_last($array);
     }
 }
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -334,7 +334,7 @@ class Schedule
         }
 
         if (! empty($this->groupStack)) {
-            $group = end($this->groupStack);
+            $group = array_last($this->groupStack);
 
             $group->mergeAttributes($event);
         }
@@ -476,7 +476,7 @@ class Schedule
         }
 
         if (method_exists(PendingEventAttributes::class, $method)) {
-            $this->attributes ??= end($this->groupStack) ?: new PendingEventAttributes($this);
+            $this->attributes ??= array_last($this->groupStack) ?: new PendingEventAttributes($this);
 
             return $this->attributes->$method(...$parameters);
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1286,7 +1286,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getLastParameterOverride()
     {
-        return count($this->with) ? end($this->with) : [];
+        return count($this->with) ? array_last($this->with) : [];
     }
 
     /**
@@ -1646,7 +1646,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function currentlyResolving()
     {
-        return end($this->buildStack) ?: null;
+        return array_last($this->buildStack) ?: null;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -369,7 +369,7 @@ class Connection implements ConnectionInterface
             throw new MultipleColumnsSelectedException;
         }
 
-        return reset($record);
+        return array_last($record);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -507,7 +507,7 @@ class Builder implements BuilderContract
             return [];
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         }
 
@@ -1265,12 +1265,12 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         }
 
         if (is_null($update)) {
-            $update = array_keys(reset($values));
+            $update = array_keys(array_last($values));
         }
 
         return $this->toBase()->upsert(
@@ -1366,7 +1366,7 @@ class Builder implements BuilderContract
 
         $segments = preg_split('/\s+as\s+/i', $this->query->from);
 
-        $qualifiedColumn = end($segments).'.'.$column;
+        $qualifiedColumn = array_last($segments).'.'.$column;
 
         $values[$qualifiedColumn] = Arr::get($values, $qualifiedColumn, $values[$column]);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -507,7 +507,7 @@ class Builder implements BuilderContract
             return [];
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_first($values))) {
             $values = [$values];
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -507,7 +507,7 @@ class Builder implements BuilderContract
             return [];
         }
 
-        if (! is_array(array_last($values))) {
+        if (! is_array(reset($values))) {
             $values = [$values];
         }
 
@@ -1265,12 +1265,12 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(array_last($values))) {
+        if (! is_array(reset($values))) {
             $values = [$values];
         }
 
         if (is_null($update)) {
-            $update = array_keys(array_last($values));
+            $update = array_keys(reset($values));
         }
 
         return $this->toBase()->upsert(

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1265,12 +1265,12 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_first($values))) {
             $values = [$values];
         }
 
         if (is_null($update)) {
-            $update = array_keys(reset($values));
+            $update = array_keys(array_first($values));
         }
 
         return $this->toBase()->upsert(

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -240,7 +240,7 @@ class Collection extends BaseCollection implements QueueableCollection
             }
 
             if (is_callable($value)) {
-                $path[count($segments) - 1][end($segments)] = $value;
+                $path[count($segments) - 1][array_last($segments)] = $value;
             }
 
             $this->loadMissingRelation($this, $path);

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -291,7 +291,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
-        if (! empty($values) && ! is_array(reset($values))) {
+        if (! empty($values) && ! is_array(array_last($values))) {
             $values = [$values];
         }
 
@@ -581,7 +581,7 @@ abstract class HasOneOrMany extends Relation
     {
         $segments = explode('.', $this->getQualifiedForeignKeyName());
 
-        return end($segments);
+        return array_last($segments);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -291,7 +291,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
-        if (! empty($values) && ! is_array(reset($values))) {
+        if (! empty($values) && ! is_array(array_first($values))) {
             $values = [$values];
         }
 
@@ -581,7 +581,7 @@ abstract class HasOneOrMany extends Relation
     {
         $segments = explode('.', $this->getQualifiedForeignKeyName());
 
-        return end($segments);
+        return array_last($segments);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -291,7 +291,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
-        if (! empty($values) && ! is_array(array_last($values))) {
+        if (! empty($values) && ! is_array(reset($values))) {
             $values = [$values];
         }
 
@@ -581,7 +581,7 @@ abstract class HasOneOrMany extends Relation
     {
         $segments = explode('.', $this->getQualifiedForeignKeyName());
 
-        return array_last($segments);
+        return end($segments);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -116,7 +116,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
      */
     public function upsert(array $values, $uniqueBy, $update = null)
     {
-        if (! empty($values) && ! is_array(reset($values))) {
+        if (! empty($values) && ! is_array(array_last($values))) {
             $values = [$values];
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3158,7 +3158,7 @@ class Builder implements BuilderContract
     {
         $result = (array) $this->sole([$column]);
 
-        return reset($result);
+        return array_last($result);
     }
 
     /**
@@ -3781,7 +3781,7 @@ class Builder implements BuilderContract
             return true;
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         }
 
@@ -3818,7 +3818,7 @@ class Builder implements BuilderContract
             return 0;
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
@@ -3976,7 +3976,7 @@ class Builder implements BuilderContract
             return (int) $this->insert($values);
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
@@ -3987,7 +3987,7 @@ class Builder implements BuilderContract
         }
 
         if (is_null($update)) {
-            $update = array_keys(reset($values));
+            $update = array_keys(array_last($values));
         }
 
         $this->applyBeforeQueryCallbacks();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3130,7 +3130,7 @@ class Builder implements BuilderContract
     {
         $result = (array) $this->first([$column]);
 
-        return count($result) > 0 ? reset($result) : null;
+        return count($result) > 0 ? array_first($result) : null;
     }
 
     /**
@@ -3142,7 +3142,7 @@ class Builder implements BuilderContract
     {
         $result = (array) $this->selectRaw($expression, $bindings)->first();
 
-        return count($result) > 0 ? reset($result) : null;
+        return count($result) > 0 ? array_first($result) : null;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -430,9 +430,9 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+        $min = $this->parameter(is_array($where['values']) ? array_first($where['values']) : $where['values'][0]);
 
-        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+        $max = $this->parameter(is_array($where['values']) ? array_last($where['values']) : $where['values'][1]);
 
         return $this->wrap($where['column']).' '.$between.' '.$min.' and '.$max;
     }
@@ -448,9 +448,9 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        $min = $this->wrap(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+        $min = $this->wrap(is_array($where['values']) ? array_first($where['values']) : $where['values'][0]);
 
-        $max = $this->wrap(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+        $max = $this->wrap(is_array($where['values']) ? array_last($where['values']) : $where['values'][1]);
 
         return $this->wrap($where['column']).' '.$between.' '.$min.' and '.$max;
     }
@@ -466,9 +466,9 @@ class Grammar extends BaseGrammar
     {
         $between = $where['not'] ? 'not between' : 'between';
 
-        $min = $this->wrap(is_array($where['columns']) ? reset($where['columns']) : $where['columns'][0]);
+        $min = $this->wrap(is_array($where['columns']) ? array_first($where['columns']) : $where['columns'][0]);
 
-        $max = $this->wrap(is_array($where['columns']) ? end($where['columns']) : $where['columns'][1]);
+        $max = $this->wrap(is_array($where['columns']) ? array_last($where['columns']) : $where['columns'][1]);
 
         return $this->parameter($where['value']).' '.$between.' '.$min.' and '.$max;
     }
@@ -1186,11 +1186,11 @@ class Grammar extends BaseGrammar
             return "insert into {$table} default values";
         }
 
-        if (! is_array(reset($values))) {
+        if (! is_array(array_last($values))) {
             $values = [$values];
         }
 
-        $columns = $this->columnize(array_keys(reset($values)));
+        $columns = $this->columnize(array_keys(array_last($values)));
 
         // We need to build a list of parameter place-holders of values that are bound
         // to the query. Each insert should have the exact same number of parameter

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -415,7 +415,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
-        $columns = $this->columnize(array_keys(reset($values)));
+        $columns = $this->columnize(array_keys(array_last($values)));
 
         $sql = 'merge '.$this->wrapTable($query->from).' ';
 

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -387,7 +387,7 @@ abstract class Grammar extends BaseGrammar
         $commands = $this->getCommandsByName($blueprint, $name);
 
         if (count($commands) > 0) {
-            return reset($commands);
+            return array_last($commands);
         }
     }
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -341,7 +341,7 @@ class BroadcastingInstallCommand extends Command
             file_put_contents($filePath, $newContents);
         } else {
             // Add Echo configuration after the last import...
-            $lastImport = end($matches[0]);
+            $lastImport = array_last($matches[0]);
 
             $positionOfLastImport = strrpos($contents, $lastImport);
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -294,7 +294,7 @@ if (! function_exists('cache')) {
             );
         }
 
-        return app('cache')->put(key($key), reset($key), ttl: $default);
+        return app('cache')->put(key($key), array_first($key), ttl: $default);
     }
 }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -509,7 +509,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function mergeWithLastGroup($new, $prependExistingPrefix = true)
     {
-        return RouteGroup::merge($new, end($this->groupStack), $prependExistingPrefix);
+        return RouteGroup::merge($new, array_last($this->groupStack), $prependExistingPrefix);
     }
 
     /**
@@ -535,7 +535,7 @@ class Router implements BindingRegistrar, RegistrarContract
     public function getLastGroupPrefix()
     {
         if ($this->hasGroupStack()) {
-            $last = end($this->groupStack);
+            $last = array_last($this->groupStack);
 
             return $last['prefix'] ?? '';
         }
@@ -640,7 +640,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function prependGroupNamespace($class)
     {
-        $group = end($this->groupStack);
+        $group = array_last($this->groupStack);
 
         return isset($group['namespace']) && ! str_starts_with($class, '\\') && ! str_starts_with($class, $group['namespace'])
             ? $group['namespace'].'\\'.$class
@@ -655,7 +655,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function prependGroupController($class)
     {
-        $group = end($this->groupStack);
+        $group = array_last($this->groupStack);
 
         if (! isset($group['controller'])) {
             return $class;

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -301,7 +301,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
             return $this->macroCall($method, $parameters);
         }
 
-        $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true;
+        $this->attributes[$method] = count($parameters) > 0 ? array_last($parameters) : true;
 
         return $this;
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -94,7 +94,7 @@ class Reflector
             ));
         } while ($includeParents && false !== $reflectionClass = $reflectionClass->getParentClass());
 
-        return $includeParents ? new Collection($attributes) : reset($attributes);
+        return $includeParents ? new Collection($attributes) : array_first($attributes);
     }
 
     /**


### PR DESCRIPTION
This PR complements #56703. It replaces all of the `end` and `reset` function calls with the new `array_first` and `array_last` functions from PHP 8.5 (used through Polyfil).