### PR TITLE
[12.x] Add fromJson() to Arr helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1242,7 +1242,7 @@ class Arr
         $array = json_decode($json, $associative, $depth, $flags);
 
         if (! is_array($array)) {
-            throw new InvalidArgumentException('The given JSON cannot be parsed into an array.');
+            throw new InvalidArgumentException('The given JSON cannot be parsed into an array: ' . get_debug_type($array) . ' given instead.');
         }
 
         return $array;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1223,4 +1223,28 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Tries to parse the given JSON into an array.
+     *
+     * @param  string  $json
+     * @param  bool|null  $associative
+     * @param  int  $depth
+     * @param  int-mask-of<JSON_BIGINT_AS_STRING|JSON_INVALID_UTF8_IGNORE|JSON_INVALID_UTF8_SUBSTITUTE|JSON_OBJECT_AS_ARRAY|JSON_THROW_ON_ERROR>  $flags
+     */
+    public static function fromJson(string $json, ?bool $associative = true, int $depth = 512, int $flags = 0): array
+    {
+        if (! json_validate($json)) {
+            $errorMessage = json_last_error_msg();
+            throw new InvalidArgumentException('Please provide a valid JSON: ' . $errorMessage);
+        }
+
+        $array = json_decode($json, $associative, $depth, $flags);
+
+        if (! is_array($array)) {
+            throw new InvalidArgumentException('The given JSON cannot be parsed into an array.');
+        }
+
+        return $array;
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1234,7 +1234,7 @@ class Arr
      */
     public static function fromJson(string $json, ?bool $associative = true, int $depth = 512, int $flags = 0): array
     {
-        if (! json_validate($json, $depth, $flags)) {
+        if (! json_validate($json, $depth, JSON_INVALID_UTF8_IGNORE & $flags == JSON_INVALID_UTF8_IGNORE ? JSON_INVALID_UTF8_IGNORE : 0)) {
             $errorMessage = json_last_error_msg();
             throw new InvalidArgumentException('Please provide a valid JSON: '.$errorMessage);
         }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1236,13 +1236,13 @@ class Arr
     {
         if (! json_validate($json)) {
             $errorMessage = json_last_error_msg();
-            throw new InvalidArgumentException('Please provide a valid JSON: ' . $errorMessage);
+            throw new InvalidArgumentException('Please provide a valid JSON: '.$errorMessage);
         }
 
         $array = json_decode($json, $associative, $depth, $flags);
 
         if (! is_array($array)) {
-            throw new InvalidArgumentException('The given JSON cannot be parsed into an array: ' . get_debug_type($array) . ' given instead.');
+            throw new InvalidArgumentException('The given JSON cannot be parsed into an array: '.get_debug_type($array).' given instead.');
         }
 
         return $array;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1234,7 +1234,7 @@ class Arr
      */
     public static function fromJson(string $json, ?bool $associative = true, int $depth = 512, int $flags = 0): array
     {
-        if (! json_validate($json)) {
+        if (! json_validate($json, $depth, $flags)) {
             $errorMessage = json_last_error_msg();
             throw new InvalidArgumentException('Please provide a valid JSON: '.$errorMessage);
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1829,7 +1829,7 @@ class SupportArrTest extends TestCase
         ];
     }
 
-    #[DataProvider('provideFromJsonInvalid')
+    #[DataProvider('provideFromJsonInvalid')]
     public function testFromJsonFails(string $json, ?bool $associative, int $depth, int $flags, string $exceptionMessage)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1848,7 +1848,7 @@ class SupportArrTest extends TestCase
         ];
     }
 
-    #[DataProvider('provideFromJsonValid')
+    #[DataProvider('provideFromJsonValid')]
     public function testFromJsonSuccessful(string $json, ?bool $associative, int $depth, int $flags, array $expected)
     {
         $this->assertEquals($expected, Arr::fromJson($json, $associative, $depth, $flags));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1843,8 +1843,8 @@ class SupportArrTest extends TestCase
             'list strict' => ['[1, 2, 3]', false, 512, 0, [1, 2, 3]],
             'list loose with array flag' => ['[1, 2, 3]', null, 512, JSON_OBJECT_AS_ARRAY, [1, 2, 3]],
             'list loose with assoc arg' => ['[1, 2, 3]', true, 512, 0, [1, 2, 3]],
-            'hashmap loose with array flag' => ['{"foo": "bar"}', null, 512, JSON_OBJECT_AS_ARRAY, ["foo" => "bar"]],
-            'hashmap loose with assoc arg' => ['{"foo": "bar"}', true, 512, 0, ["foo" => "bar"]],
+            'hashmap loose with array flag' => ['{"foo": "bar"}', null, 512, JSON_OBJECT_AS_ARRAY, ['foo' => 'bar']],
+            'hashmap loose with assoc arg' => ['{"foo": "bar"}', true, 512, 0, ['foo' => 'bar']],
         ];
     }
 


### PR DESCRIPTION
Counterpart of #56697, so to speak

# Examples
```php
Arr::fromJson('}', false, 512, 0); // ❌ Throws 'Please provide a valid JSON: Syntax error'
Arr::fromJson("[\"\u{D800}\"]", false, 512, 0); // ❌ Throws 'Please provide a valid JSON: Malformed UTF-8 characters, possibly incorrectly encoded'
Arr::fromJson('[[[[]]]]', false, 2, 0); // ❌ Throws 'Please provide a valid JSON: Maximum stack depth exceeded'
Arr::fromJson('null', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: null given instead'
Arr::fromJson('42', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: int given instead'
Arr::fromJson('42.1', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: float given instead'
Arr::fromJson('"foo"', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: string given instead'
Arr::fromJson('true', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: bool given instead'
Arr::fromJson('{"foo": "bar"}', false, 512, 0); // ❌ Throws 'The given JSON cannot be parsed into an array: stdClass given instead'

Arr::fromJson('[1, 2, 3]', false, 512, 0); // ✔️ [1, 2, 3]
Arr::fromJson('[1, 2, 3]', null, 512, JSON_OBJECT_AS_ARRAY); // ✔️ [1, 2, 3]
Arr::fromJson('[1, 2, 3]', true, 512, 0); // ✔️ [1, 2, 3]
Arr::fromJson('{"foo": "bar"}', null, 512, JSON_OBJECT_AS_ARRAY); // ✔️ ["foo" => "bar"]
Arr::fromJson('{"foo": "bar"}', true, 512, 0); // ✔️ ["foo" => "bar"]
```