### PR TITLE
[12.x] Add fluent method to config

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
@@ -188,6 +189,18 @@ class Repository implements ArrayAccess, ConfigContract
     public function collection(string $key, $default = null): Collection
     {
         return new Collection($this->array($key, $default));
+    }
+
+    /**
+     * Get the specified array configuration value as a Fluent instance.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return Fluent
+     */
+    public function fluent(string $key, $default = null): Fluent
+    {
+        return new Fluent($this->array($key, $default));
     }
 
     /**

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -371,5 +372,21 @@ class RepositoryTest extends TestCase
         $this->expectExceptionMessageMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
 
         $this->repository->float('a.b');
+    }
+
+    public function testItGetsAsFluent(): void
+    {
+        $config = $this->repository->fluent('associate');
+
+        $this->assertInstanceOf(Fluent::class, $config);
+        $this->assertSame($this->repository->array('associate'), $config->toArray());
+    }
+
+    public function testItTrhowsAnExceptionWhenTryingToGetNonArrayValueAsFluent(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an array, (.*) given.#');
+
+        $this->repository->fluent('a.b');
     }
 }


### PR DESCRIPTION
## Overview

Introduces a way to fetch an array configuration value as an `Illuminate\Support\Fluent` instance. This mirrors the existing `collection()` helper and provides a way to access nested configuration data with property access and helper methods from `Fluent`.

## Example

```php
// config/services.php
return [
    // ...
    'ses' => [
            'key' => env('AWS_ACCESS_KEY_ID'),
            'secret' => env('AWS_SECRET_ACCESS_KEY'),
            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
        ],
];
```

```php
$ses = config()->fluent('services.ses');
$ses->key;
$ses->isEmpty(); // false
```