### PR TITLE
[12.x] Do not dispatch `MessageLogged` twice

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -245,9 +245,9 @@ class Logger implements LoggerInterface
      */
     protected function fireLogEvent($level, $message, array $context = [])
     {
-        // Avoid dispatching the event multiple times if our logger instance is the
-        // LogManager. The child LogManager will handle dispatching the event.
-        if ($this->logger instanceof LogManager && $this->logger->getEventDispatcher() !== null) {
+        // Avoid dispatching the event multiple times if our logger instance is the LogManager...
+        if ($this->logger instanceof LogManager && 
+            $this->logger->getEventDispatcher() !== null) {
             return;
         }
 

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -245,6 +245,12 @@ class Logger implements LoggerInterface
      */
     protected function fireLogEvent($level, $message, array $context = [])
     {
+        // Avoid dispatching the event multiple times if our logger instance is the
+        // LogManager. The child LogManager will handle dispatching the event.
+        if ($this->logger instanceof LogManager && $this->logger->getEventDispatcher() !== null) {
+            return;
+        }
+
         // If the event dispatcher is set, we will pass along the parameters to the
         // log listeners. These are useful for building profilers or other tools
         // that aggregate all of the log messages for a given "request" cycle.

--- a/tests/Integration/Log/LoggingIntegrationTest.php
+++ b/tests/Integration/Log/LoggingIntegrationTest.php
@@ -17,7 +17,7 @@ class LoggingIntegrationTest extends TestCase
         Log::info('Hello World');
     }
 
-    public function testCallingLogDirectlyDispatchesTwoEvents()
+    public function testCallingLoggerDirectlyDispatchesOneEvent()
     {
         Event::fake([MessageLogged::class]);
 

--- a/tests/Integration/Log/LoggingIntegrationTest.php
+++ b/tests/Integration/Log/LoggingIntegrationTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Log;
 
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Log\Logger;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Orchestra\Testbench\TestCase;
 
@@ -12,5 +15,14 @@ class LoggingIntegrationTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         Log::info('Hello World');
+    }
+
+    public function testCallingLogDirectlyDispatchesTwoEvents()
+    {
+        Event::fake([MessageLogged::class]);
+
+        $this->app->make(Logger::class)->debug('my debug message');
+
+        Event::assertDispatchedTimes(MessageLogged::class, 1);
     }
 }


### PR DESCRIPTION
This is related to https://github.com/laravel/pail/issues/52

If you call `app(\Illuminate\Log\Logger::class)->debug("Totwells - Taylor Otwell's Arkansas style tater tots")` using Pail (and I would bet Telescope too), it will record two separate log entries, because they react to the MessageLogged event.

Instantiating Logger sets the `$logger` instance to LogManager. Therefore, the `Logger` class and its `$logger` both dispatch the event.