### PR TITLE
Overwrite Routes Cache File, without deleting (route:cache)

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1320,11 +1320,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
         return $this->normalizeCachePath('APP_CONFIG_CACHE', 'cache/config.php');
     }
 
-    /**
-    public function routesAreCached()
-    {
-        return $this['files']->exists($this->getCachedRoutesPath()) && !$this->routesCachedMustBeIgnored;
-    }
 
     /**
      * Determine if the application routes are cached.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -209,6 +209,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $absoluteCachePathPrefixes = ['/', '\\'];
 
     /**
+     * Prevent cached routes to be loaded
+     * @var bool
+     */
+    protected $routesCachedMustBeIgnored = false;
+
+    /**
      * Create a new Illuminate application instance.
      *
      * @param  string|null  $basePath
@@ -1315,13 +1321,19 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+    public function routesAreCached()
+    {
+        return $this['files']->exists($this->getCachedRoutesPath()) && !$this->routesCachedMustBeIgnored;
+    }
+
+    /**
      * Determine if the application routes are cached.
      *
      * @return bool
      */
     public function routesAreCached()
     {
-        return $this['files']->exists($this->getCachedRoutesPath());
+        return $this['files']->exists($this->getCachedRoutesPath()) && !$this->routesCachedMustBeIgnored;
     }
 
     /**
@@ -1332,6 +1344,15 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function getCachedRoutesPath()
     {
         return $this->normalizeCachePath('APP_ROUTES_CACHE', 'cache/routes-v7.php');
+    }
+
+    /**
+     * Prevent routes cached from being loaded
+     * @return void
+     */
+    public function routesCachedMustBeIgnored()
+    {
+        $this->routesCachedMustBeIgnored = true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -51,7 +51,6 @@ class RouteCacheCommand extends Command
      */
     public function handle()
     {
-        $this->callSilent('route:clear');
 
         $routes = $this->getFreshApplicationRoutes();
 
@@ -91,6 +90,7 @@ class RouteCacheCommand extends Command
     protected function getFreshApplication()
     {
         return tap(require $this->laravel->bootstrapPath('app.php'), function ($app) {
+            $app->routesCachedMustBeIgnored();
             $app->make(ConsoleKernelContract::class)->bootstrap();
         });
     }


### PR DESCRIPTION
When you issue a route:cache command, the current behavior aims
to delete the routes-cache-file (bootstrap/cache/routes-v7.php) if exists, boot the framework again,  to get a clear route instance, then serialize and write to cache-file again.

Sometimes during deployment,  if the time to compute/create the new cache-route  file take long,
A user may hit 500 error, or even the artisan boot   can hit a exception, by the time he checks 
if the route-cache-file exists, and when he actually load then.

With this change, we generate the new route-files, without deleting the current one, and then overwrite after.


Another proposal ( we can switch to ), is, if try to load from cache, and then, if there is a exception, switch to non-cached.

<img width="1800" height="672" alt="Screenshot 2025-08-22 at 11 00 51" src="https://github.com/user-attachments/assets/cdbcbbbf-e476-4116-ae99-6db357d491f1" />
