### PR TITLE
Add nullableTimestampsTz method to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1265,6 +1265,20 @@ class Blueprint
         return $this->timestamps($precision);
     }
 
+
+    /**
+     * Add nullable creation and update timestamps to the table.
+     *
+     * Alias for self::timestampsTz().
+     *
+     * @param  int|null  $precision
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Schema\ColumnDefinition>
+     */
+    public function nullableTimestampsTz($precision = null)
+    {
+        return $this->timestampsTz($precision);
+    }
+
     /**
      * Add creation and update timestampTz columns to the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1265,20 +1265,6 @@ class Blueprint
         return $this->timestamps($precision);
     }
 
-
-    /**
-     * Add nullable creation and update timestamps to the table.
-     *
-     * Alias for self::timestampsTz().
-     *
-     * @param  int|null  $precision
-     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Schema\ColumnDefinition>
-     */
-    public function nullableTimestampsTz($precision = null)
-    {
-        return $this->timestampsTz($precision);
-    }
-
     /**
      * Add creation and update timestampTz columns to the table.
      *
@@ -1291,6 +1277,19 @@ class Blueprint
             $this->timestampTz('created_at', $precision)->nullable(),
             $this->timestampTz('updated_at', $precision)->nullable(),
         ]);
+    }
+
+    /**
+     * Add nullable creation and update timestamps to the table.
+     *
+     * Alias for self::timestampsTz().
+     *
+     * @param  int|null  $precision
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Schema\ColumnDefinition>
+     */
+    public function nullableTimestampsTz($precision = null)
+    {
+        return $this->timestampsTz($precision);
     }
 
     /**


### PR DESCRIPTION
Added nullableTimestampsTz method as an alias for timestampsTz.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-po
This pull request adds a new convenience method to the `Blueprint` class for working with timestamp columns in database schemas.

Schema blueprint improvements:

* Added the `nullableTimestampsTz` method to `Blueprint`, which serves as an alias for `timestampsTz` and allows adding nullable timezone-aware creation and update timestamps to a table.licy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
