### PR TITLE
[12.x] Add filled_any and blank_any helpers with tests and types

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -76,6 +76,24 @@ if (! function_exists('blank')) {
     }
 }
 
+if (! function_exists('blank_any')) {
+    /**
+     * Determine if at least one of the given values is "blank".
+     *
+     * @param  mixed  ...$values
+     */
+    function blank_any(...$values): bool
+    {
+        foreach ($values as $value) {
+            if (blank($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if (! function_exists('class_basename')) {
     /**
      * Get the class "basename" of the given object / class.
@@ -165,6 +183,24 @@ if (! function_exists('filled')) {
     function filled($value): bool
     {
         return ! blank($value);
+    }
+}
+
+if (! function_exists('filled_any')) {
+    /**
+     * Determine if at least one of the given values is "filled".
+     *
+     * @param  mixed  ...$values
+     */
+    function filled_any(...$values): bool
+    {
+        foreach ($values as $value) {
+            if (filled($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -84,13 +84,7 @@ if (! function_exists('blank_any')) {
      */
     function blank_any(...$values): bool
     {
-        foreach ($values as $value) {
-            if (blank($value)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($values, blank(...));
     }
 }
 
@@ -194,13 +188,7 @@ if (! function_exists('filled_any')) {
      */
     function filled_any(...$values): bool
     {
-        foreach ($values as $value) {
-            if (filled($value)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($values, filled(...));
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -101,6 +101,13 @@ class SupportHelpersTest extends TestCase
         $this->assertFalse(blank($model));
     }
 
+    public function testBlankAny()
+    {
+        $this->assertTrue(blank_any('', 'bar'));
+        $this->assertFalse(blank_any('foo', 'bar'));
+        $this->assertTrue(blank_any(new \Illuminate\Support\Stringable('')));
+    }
+
     public function testClassBasename()
     {
         $this->assertSame('Baz', class_basename('Foo\Bar\Baz'));
@@ -166,6 +173,13 @@ class SupportHelpersTest extends TestCase
 
         $object = new SupportTestCountable();
         $this->assertFalse(filled($object));
+    }
+
+    public function testFilledAny()
+    {
+        $this->assertTrue(filled_any('foo', null));
+        $this->assertFalse(filled_any(null, ''));
+        $this->assertTrue(filled_any(0, false));
     }
 
     public function testValue()

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -15,6 +15,19 @@ if (blank($value)) {
     assertType('bool|float|int|non-empty-string', $value);
 }
 
+/** @var array<bool|float|int|string|null> $values */
+if (filled_any(...$values)) {
+    assertType('array<bool|float|int|string|null>', $values);
+} else {
+    assertType('array<string|null>', $values);
+}
+
+if (blank_any(...$values)) {
+    assertType('array<bool|float|int|string|null>', $values);
+} else {
+    assertType('array<bool|float|int|non-empty-string>', $values);
+}
+
 assertType('User', object_get(new User(), null));
 assertType('User', object_get(new User(), ''));
 assertType('mixed', object_get(new User(), 'name'));

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -16,17 +16,8 @@ if (blank($value)) {
 }
 
 /** @var array<bool|float|int|string|null> $values */
-if (filled_any(...$values)) {
-    assertType('array<bool|float|int|string|null>', $values);
-} else {
-    assertType('array<string|null>', $values);
-}
-
-if (blank_any(...$values)) {
-    assertType('array<bool|float|int|string|null>', $values);
-} else {
-    assertType('array<bool|float|int|non-empty-string>', $values);
-}
+assertType('bool', filled_any(...$values));
+assertType('bool', blank_any(...$values));
 
 assertType('User', object_get(new User(), null));
 assertType('User', object_get(new User(), ''));


### PR DESCRIPTION
# Add filled_any and blank_any helpers with tests and types

## Motivation
Laravel already provides the `filled()` and `blank()` helpers to check whether a single value is "filled" or "blank".  
In practice, developers often need to check *multiple values* at once (for example, when at least one of several form fields must be provided).  
Currently this requires verbose `||` or `&&` checks.

## Implementation
This PR introduces two new helpers in `Illuminate/Support/helpers.php`:

- `filled_any(...$values)` → returns `true` if **at least one** of the given values is filled.  
- `blank_any(...$values)` → returns `true` if **at least one** of the given values is blank.  

In addition:
- Tests were added in `SupportHelpersTest.php` to cover the new helpers.  
- PHPStan type assertions were added in `types/Support/Helpers.php` to refine type inference.  

## Examples
```php
// Before
if (filled($request->name) || filled($request->email)) {
    // ...
}

// After
if (filled_any($request->name, $request->email)) {
    // ...
}

if (blank_any($request->password, $request->password_confirmation)) {
    // ...
}
```

## Backward Compatibility
This change is fully backward compatible.  
It only introduces two new global helpers without altering the behavior of existing ones.