### PR TITLE
feat: TestResponse::assertAborted assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -177,6 +177,36 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response is the result of an aborted request, matching the given status code, message, and headers.
+     *
+     * @param  int  $status
+     * @param  string|null  $message
+     * @param  array  $headers
+     * @return $this
+     */
+    public function assertAborted(int $status, ?string $message = null, array $headers = [])
+    {
+        $this->assertStatus($status);
+
+        $contentType = $this->baseResponse->headers->get('Content-Type', '');
+        $isJson = Str::of($contentType)->lower()->contains('application/json');
+
+        if ($message !== null) {
+            $isJson
+                ? $this->assertJson(['message' => $message])
+                : $this->assertSeeText($message);
+        } elseif ($isJson) {
+            $this->assertJsonStructure(['message']);
+        }
+
+        foreach ($headers as $header => $value) {
+            $this->assertHeader($header, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get an assertion message for a status assertion containing extra details when available.
      *
      * @param  string|int  $expected

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1212,6 +1212,44 @@ class TestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
+    public function testAssertAbortedWithJsonMessageAndHeaders()
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse(['message' => 'Forbidden'], 403, ['X-Foo' => 'Bar'])
+        );
+
+        $response->assertAborted(403, 'Forbidden', ['X-Foo' => 'Bar']);
+    }
+
+    public function testAssertAbortedWithJsonWithoutMessageAssertsStructure()
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse(['message' => 'Anything'], 400)
+        );
+
+        $response->assertAborted(400);
+    }
+
+    public function testAssertAbortedWithHtmlMessage()
+    {
+        $response = TestResponse::fromBaseResponse(
+            new Response('<h1>Forbidden</h1>', 403, ['Content-Type' => 'text/html; charset=UTF-8'])
+        );
+
+        $response->assertAborted(403, 'Forbidden');
+    }
+
+    public function testAssertAbortedFailsWhenJsonMessageDoesNotMatch()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse(['message' => 'Actual'], 422)
+        );
+
+        $response->assertAborted(422, 'Expected');
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This adds the `assertAborted` method to `TestReponse`.

The method simplifies testing responses created via the `abort()` helper by:

- Consolidating related assertions (status, message, headers) into one call
- Making test assertions mirror how the `abort()` helper is invoked