### PR TITLE
[12.x] Align trait usage for consistency

### DIFF
--- a/tests/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Queue/FailOnExceptionMiddlewareTest.php
@@ -98,9 +98,7 @@ class FailOnExceptionMiddlewareTest extends TestCase
 
 class FailOnExceptionMiddlewareTestJob implements ShouldQueue
 {
-    use InteractsWithQueue;
-    use Queueable;
-    use Dispatchable;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public static array $_middleware = [];
 


### PR DESCRIPTION
Description
---
This PR updates the `FailOnExceptionMiddlewareTestJob` class to follow the same trait import order used in other queue-related classes, such as `CallQueuedClosure`.

See
---
https://github.com/laravel/framework/blob/b8e2aa2527fb5601698e8021b3b205632ef2e4ba/src/Illuminate/Queue/CallQueuedClosure.php#L16