### PR TITLE
Use Collection isNotEmpty() Instead of count() for Migration Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Release Notes for 11.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v11.45.1...11.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v11.45.2...11.x)
+
+## [v11.45.2](https://github.com/laravel/framework/compare/v11.45.1...v11.45.2) - 2025-08-13
+
+* [11.x] Fix validation to not throw incompatible validation exception by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/55963
+* [11.x] Fix `symfony/console:7.4` compatibility by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/56015
+* [11.x] Pass the limiter to the when & report callbacks by [@jimmypuckett](https://github.com/jimmypuckett) in https://github.com/laravel/framework/pull/56129
+* [11.x] Backport test fixes by [@GrahamCampbell](https://github.com/GrahamCampbell) in https://github.com/laravel/framework/pull/56183
+* Revert "[11.x] Pass the limiter to the when & report callbacks" by [@GrahamCampbell](https://github.com/GrahamCampbell) in https://github.com/laravel/framework/pull/56184
+* [11.x] Correct how base options for missing config files are preloaded by [@u01jmg3](https://github.com/u01jmg3) in https://github.com/laravel/framework/pull/56216
+* [11.x] backport #56235 by [@calebdw](https://github.com/calebdw) in https://github.com/laravel/framework/pull/56236
+* [11.x] Consistent use of `mb_split()` to split strings into words by [@GrahamCampbell](https://github.com/GrahamCampbell) in https://github.com/laravel/framework/pull/56617
+* [11.x] `CacheSchedulingMutex` should use lock connection by [@GrahamCampbell](https://github.com/GrahamCampbell) in https://github.com/laravel/framework/pull/56614
+* [11.x] Test Improvements by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/56630
+* [11.x] Update `orchestra/testbench-core` deps by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/56636
 
 ## [v11.45.1](https://github.com/laravel/framework/compare/v11.45.0...v11.45.1) - 2025-06-03
 

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "league/flysystem-read-only": "^3.25.1",
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
-        "orchestra/testbench-core": "^9.13.2",
+        "orchestra/testbench-core": "9.x-dev#78a641cf",
         "pda/pheanstalk": "^5.0.6",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "league/flysystem-read-only": "^3.25.1",
         "league/flysystem-sftp-v3": "^3.25.1",
         "mockery/mockery": "^1.6.10",
-        "orchestra/testbench-core": "9.x-dev#78a641cf",
+        "orchestra/testbench-core": "^9.16.0",
         "pda/pheanstalk": "^5.0.6",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -45,16 +45,16 @@ class Command extends SymfonyCommand
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * The console command help text.
      *
      * @var string
      */
-    protected $help;
+    protected $help = '';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.
@@ -103,13 +103,13 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        if (! isset($this->description)) {
-            $this->setDescription((string) static::getDefaultDescription());
-        } else {
-            $this->setDescription((string) $this->description);
+        if (! empty($this->description)) {
+            $this->setDescription($this->description);
         }
 
-        $this->setHelp((string) $this->help);
+        if (! empty($this->help)) {
+            $this->setHelp($this->help);
+        }
 
         $this->setHidden($this->isHidden());
 

--- a/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
+++ b/src/Illuminate/Console/Scheduling/CacheSchedulingMutex.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Console\Scheduling;
 
 use DateTimeInterface;
+use Illuminate\Cache\DynamoDbStore;
 use Illuminate\Contracts\Cache\Factory as Cache;
+use Illuminate\Contracts\Cache\LockProvider;
 
 class CacheSchedulingMutex implements SchedulingMutex, CacheAware
 {
@@ -41,8 +43,16 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      */
     public function create(Event $event, DateTimeInterface $time)
     {
+        $mutexName = $event->mutexName().$time->format('Hi');
+
+        if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
+            return $this->cache->store($this->store)->getStore()
+                ->lock($mutexName, 3600)
+                ->acquire();
+        }
+
         return $this->cache->store($this->store)->add(
-            $event->mutexName().$time->format('Hi'), true, 3600
+            $mutexName, true, 3600
         );
     }
 
@@ -55,9 +65,26 @@ class CacheSchedulingMutex implements SchedulingMutex, CacheAware
      */
     public function exists(Event $event, DateTimeInterface $time)
     {
-        return $this->cache->store($this->store)->has(
-            $event->mutexName().$time->format('Hi')
-        );
+        $mutexName = $event->mutexName().$time->format('Hi');
+
+        if ($this->shouldUseLocks($this->cache->store($this->store)->getStore())) {
+            return ! $this->cache->store($this->store)->getStore()
+                ->lock($mutexName, 3600)
+                ->get(fn () => true);
+        }
+
+        return $this->cache->store($this->store)->has($mutexName);
+    }
+
+    /**
+     * Determine if the given store should use locks for cache event mutexes.
+     *
+     * @param  \Illuminate\Contracts\Cache\Store  $store
+     * @return bool
+     */
+    protected function shouldUseLocks($store)
+    {
+        return $store instanceof LockProvider && ! $store instanceof DynamoDbStore;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -68,7 +68,7 @@ class StatusCommand extends BaseCommand
                     return (new Stringable($migration[1]))->contains('Pending');
                 }));
 
-            if (count($migrations) > 0) {
+            if ($migrations->isNotEmpty()) {
                 $this->newLine();
 
                 $this->components->twoColumnDetail('<fg=gray>Migration name</>', '<fg=gray>Batch / Status</>');

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '11.45.1';
+    const VERSION = '11.45.2';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -9,7 +9,9 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\LogManager;
 use Illuminate\Support\Env;
 use Monolog\Handler\NullHandler;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\ErrorHandler;
+use PHPUnit\Runner\Version;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Throwable;
@@ -304,15 +306,16 @@ class HandleExceptions
     /**
      * Flush the bootstrapper's global state.
      *
+     * @param  \PHPUnit\Framework\TestCase|null  $testCase
      * @return void
      */
-    public static function flushState()
+    public static function flushState(?TestCase $testCase = null)
     {
         if (is_null(static::$app)) {
             return;
         }
 
-        static::flushHandlersState();
+        static::flushHandlersState($testCase);
 
         static::$app = null;
 
@@ -322,9 +325,10 @@ class HandleExceptions
     /**
      * Flush the bootstrapper's global handlers state.
      *
+     * @param  \PHPUnit\Framework\TestCase|null  $testCase
      * @return void
      */
-    public static function flushHandlersState()
+    public static function flushHandlersState(?TestCase $testCase = null)
     {
         while (true) {
             $previousHandler = set_exception_handler(static fn () => null);
@@ -355,7 +359,12 @@ class HandleExceptions
 
             if ((fn () => $this->enabled ?? false)->call($instance)) {
                 $instance->disable();
-                $instance->enable();
+
+                if (version_compare(Version::id(), '12.3.4', '>=')) {
+                    $instance->enable($testCase);
+                } else {
+                    $instance->enable();
+                }
             }
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Bootstrap;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Collection;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
@@ -69,7 +70,7 @@ class LoadConfiguration
             ? $this->getBaseConfiguration()
             : [];
 
-        foreach (array_diff(array_keys($base), array_keys($files)) as $name => $config) {
+        foreach ((new Collection($base))->diffKeys($files) as $name => $config) {
             $repository->set($name, $config);
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
@@ -67,7 +67,7 @@ class Listener
             'connectionName' => $event->connectionName,
             'time' => $event->time,
             'sql' => $event->sql,
-            'bindings' => $event->bindings,
+            'bindings' => $event->connection->prepareBindings($event->bindings),
         ];
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -105,6 +105,10 @@ trait InteractsWithRedis
      */
     public function tearDownRedis()
     {
+        if (static::$connectionFailedOnceWithDefaultsSkip === true) {
+            return;
+        }
+
         if (isset($this->redis['phpredis'])) {
             $this->redis['phpredis']->connection()->flushdb();
         }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -175,7 +175,7 @@ trait InteractsWithTestCaseLifecycle
         Factory::flushState();
         EncodedHtmlString::flushState();
         EncryptCookies::flushState();
-        HandleExceptions::flushState();
+        HandleExceptions::flushState($this);
         Markdown::flushState();
         Migrator::withoutMigrations([]);
         Once::flush();

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -69,7 +69,9 @@ class TrustProxies
         $trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
 
         if (is_null($trustedIps) &&
-            (laravel_cloud() || str_ends_with($request->host(), '.on-forge.com'))) {
+            (laravel_cloud() ||
+             str_ends_with($request->host(), '.on-forge.com') ||
+             str_ends_with($request->host(), '.on-vapor.com'))) {
             $trustedIps = '*';
         }
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -68,7 +68,8 @@ class TrustProxies
     {
         $trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
 
-        if (is_null($trustedIps) && laravel_cloud()) {
+        if (is_null($trustedIps) &&
+            (laravel_cloud() || str_ends_with($request->host(), '.on-forge.com'))) {
             $trustedIps = '*';
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1402,7 +1402,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = explode(' ', $value);
+        $parts = mb_split('\s+', $value);
 
         $parts = count($parts) > 1
             ? array_map([static::class, 'title'], $parts)
@@ -1435,7 +1435,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = preg_split('/\s+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        $words = mb_split('\s+', $value);
 
         for ($i = 0; $i < count($words); $i++) {
             $lowercaseWord = mb_strtolower($words[$i]);
@@ -1638,7 +1638,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = explode(' ', static::replace(['-', '_'], ' ', $value));
+        $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UsePusherChannelsNamesTest extends TestCase
 {
     #[DataProvider('channelsProvider')]
-    public function testChannelNameNormalization($requestChannelName, $normalizedName)
+    public function testChannelNameNormalization($requestChannelName, $normalizedName, $guarded)
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 
@@ -44,7 +44,7 @@ class UsePusherChannelsNamesTest extends TestCase
     }
 
     #[DataProvider('channelsProvider')]
-    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
+    public function testIsGuardedChannel($requestChannelName, $normalizedName, $guarded)
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -38,7 +38,7 @@ class HandleExceptionsTest extends TestCase
     protected function tearDown(): void
     {
         Application::setInstance(null);
-        HandleExceptions::flushState();
+        HandleExceptions::flushState($this);
 
         m::close();
     }

--- a/tests/Foundation/Bootstrap/LoadConfigurationTest.php
+++ b/tests/Foundation/Bootstrap/LoadConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Bootstrap;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use PHPUnit\Framework\TestCase;
@@ -12,7 +13,7 @@ class LoadConfigurationTest extends TestCase
     {
         $app = new Application();
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertSame('Laravel', $app['config']['app.name']);
     }
@@ -22,7 +23,7 @@ class LoadConfigurationTest extends TestCase
         $app = new Application();
         $app->dontMergeFrameworkConfiguration();
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertNull($app['config']['app.name']);
     }
@@ -32,9 +33,28 @@ class LoadConfigurationTest extends TestCase
         $app = new Application(__DIR__.'/../fixtures');
         $app->useConfigPath(__DIR__.'/../fixtures/config');
 
-        (new LoadConfiguration())->bootstrap($app);
+        (new LoadConfiguration)->bootstrap($app);
 
         $this->assertNull($app['config']['bar.foo']);
         $this->assertSame('bar', $app['config']['custom.foo']);
+    }
+
+    public function testConfigurationArrayKeysMatchLoadedFilenames()
+    {
+        $baseConfigPath = __DIR__.'/../../../config';
+        $customConfigPath = __DIR__.'/../fixtures/config';
+
+        $app = new Application();
+        $app->useConfigPath($customConfigPath);
+
+        (new LoadConfiguration)->bootstrap($app);
+
+        $this->assertEqualsCanonicalizing(
+            array_keys($app['config']->all()),
+            collect((new Filesystem)->files([
+                $baseConfigPath,
+                $customConfigPath,
+            ]))->map(fn ($file) => $file->getBaseName('.php'))->unique()->values()->toArray()
+        );
     }
 }

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -45,7 +45,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
     {
         $this->deprecationsFound = false;
 
-        HandleExceptions::flushHandlersState();
+        HandleExceptions::flushHandlersState($this);
 
         parent::tearDown();
     }

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -43,8 +43,8 @@ assertType('Illuminate\Support\HigherOrderTapProxy', tap(new User()));
 
 function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 {
-    assertType('never', throw_if(true, Exception::class));
-    assertType('false', throw_if(false, Exception::class));
+    rescue(fn () => assertType('never', throw_if(true, Exception::class)));
+    assertType('false', throw_if(false, Exception::class)); // @phpstan-ignore deadCode.unreachable
     assertType('false', throw_if(empty($foo)));
     throw_if(is_float($foo));
     assertType('int', $foo);
@@ -62,8 +62,8 @@ function testThrowIf(float|int $foo, ?DateTime $bar = null): void
 function testThrowUnless(float|int $foo, ?DateTime $bar = null): void
 {
     assertType('true', throw_unless(true, Exception::class));
-    assertType('never', throw_unless(false, Exception::class));
-    assertType('true', throw_unless(empty($foo)));
+    rescue(fn () => assertType('never', throw_unless(false, Exception::class)));
+    assertType('true', throw_unless(empty($foo))); // @phpstan-ignore deadCode.unreachable
     throw_unless(is_int($foo));
     assertType('int', $foo);
     throw_unless($foo == false);


### PR DESCRIPTION
This PR replaces plain PHP array checks with Laravel collection methods for better readability and consistency.

- Replaced `count($migrations) > 0` with `$migrations->isNotEmpty()`
- Improves code clarity and leverages Laravel's collection capabilitie