### PR TITLE
[12.x] Improve `queue:prune-failed` tests coverage

### DIFF
--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -82,6 +82,20 @@ class DatabaseFailedJobProviderTest extends TestCase
         $this->assertSame(0, $this->failedJobsTable()->count());
     }
 
+    public function testCanPruneFailedJobsWithRelativeHoursAndMinutes()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 8, 24, 12, 0, 0));
+
+        $this->createFailedJobsRecord(['failed_at' => Carbon::create(2025, 8, 24, 11, 45, 0)]);
+        $this->createFailedJobsRecord(['failed_at' => Carbon::create(2025, 8, 24, 13, 0, 0)]);
+
+        $this->provider->prune(Carbon::create(2025, 8, 24, 11, 45, 0));
+        $this->assertSame(2, $this->failedJobsTable()->count());
+
+        $this->provider->prune(Carbon::create(2025, 8, 24, 14, 0, 0));
+        $this->assertSame(0, $this->failedJobsTable()->count());
+    }
+
     public function testCanFlushFailedJobs()
     {
         Date::setTestNow(Date::now());

--- a/tests/Queue/DatabaseUuidFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseUuidFailedJobProviderTest.php
@@ -102,6 +102,24 @@ class DatabaseUuidFailedJobProviderTest extends TestCase
         $this->assertEmpty($provider->all());
     }
 
+    public function testPruningFailedJobsWithRelativeHoursAndMinutes()
+    {
+        $provider = $this->getFailedJobProvider();
+
+        Carbon::setTestNow(Carbon::create(2025, 8, 24, 12, 30, 0));
+
+        $provider->log('connection-1', 'queue-1', json_encode(['uuid' => 'uuid-1']), new RuntimeException());
+        $provider->log('connection-2', 'queue-2', json_encode(['uuid' => 'uuid-2']), new RuntimeException());
+
+        $provider->prune(Carbon::create(2025, 8, 24, 12, 30, 0));
+
+        $this->assertCount(2, $provider->all());
+
+        $provider->prune(Carbon::create(2025, 8, 24, 13, 0, 0));
+
+        $this->assertEmpty($provider->all());
+    }
+
     public function testJobsCanBeCounted()
     {
         $provider = $this->getFailedJobProvider();

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -133,6 +133,23 @@ class FileFailedJobProviderTest extends TestCase
         $this->assertCount(2, $failedJobs);
     }
 
+    public function testCanPruneFailedJobsWithRelativeHours()
+    {
+        $this->logFailedJob();
+        $this->logFailedJob();
+
+        $this->provider->prune(now()->addHour(1));
+        $failedJobs = $this->provider->all();
+        $this->assertEmpty($failedJobs);
+
+        $this->logFailedJob();
+        $this->logFailedJob();
+
+        $this->provider->prune(now()->subHour(1));
+        $failedJobs = $this->provider->all();
+        $this->assertCount(2, $failedJobs);
+    }
+
     public function testEmptyFailedJobsByDefault()
     {
         $failedJobs = $this->provider->all();


### PR DESCRIPTION
This PR enhances the test coverage for the `queue:prune-failed` command, focusing specifically on scenarios involving the `--hours` option. Previously, tests only verified pruning at the date level. The new tests ensure precise pruning at the hour level, covering important edge cases.

## Benefits:

- ***Edge case handling***: The prune logic uses a strict `less than` comparison. For example, if a job failed at `11:00` and pruning is performed at `11:00`, only jobs that failed before `11:00` are deleted. These tests verify that behavior.

- ***Coverage***: Tests verify pruning behavior for all `PrunableFailedJobProvider` implementations supported by this command:

    `src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php`
    `src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php`
    `src/Illuminate/Queue/Failed/FileFailedJobProvider.php`



