### PR TITLE
[12.x] Add `--days` option to `queue:prune-failed` command

### DIFF
--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -16,7 +16,8 @@ class PruneFailedJobsCommand extends Command
      * @var string
      */
     protected $signature = 'queue:prune-failed
-                {--hours=24 : The number of hours to retain failed jobs data}';
+                {--hours=24 : The number of hours to retain failed jobs data}
+                {--days= : The number of days to retain failed jobs data}';
 
     /**
      * The console command description.
@@ -35,7 +36,12 @@ class PruneFailedJobsCommand extends Command
         $failer = $this->laravel['queue.failer'];
 
         if ($failer instanceof PrunableFailedJobProvider) {
-            $count = $failer->prune(Carbon::now()->subHours($this->option('hours')));
+
+            $before = ($this->option('days')) ?
+                Carbon::now()->subDays($this->option('days')) :
+                Carbon::now()->subHours($this->option('hours'));
+
+            $count = $failer->prune($before);
         } else {
             $this->components->error('The ['.class_basename($failer).'] failed job storage driver does not support pruning.');
 

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -36,7 +36,6 @@ class PruneFailedJobsCommand extends Command
         $failer = $this->laravel['queue.failer'];
 
         if ($failer instanceof PrunableFailedJobProvider) {
-
             $before = ($this->option('days')) ?
                 Carbon::now()->subDays($this->option('days')) :
                 Carbon::now()->subHours($this->option('hours'));


### PR DESCRIPTION
## Description

This PR adds a `--days` option to the `queue:prune-failed` Artisan command, making it easier for developers to prune failed jobs older than a specific number of days. 

## Key points

- Simplifies usage: Developers who want to remove jobs older than, for example, 15 days, no longer need to calculate the equivalent in hours `(15 * 24)`. They can now simply run:

```shell
php artisan queue:prune-failed --days=15
```

- When the `--days` option is specified, it takes priority over the default `--hours` option.

## Tests

The existing prune method already has tests covering the underlying logic. This change only adds a convenient wrapper for date calculation, so no additional tests are necessary:

https://github.com/laravel/framework/blob/b8e2aa2527fb5601698e8021b3b205632ef2e4ba/tests/Queue/DatabaseFailedJobProviderTest.php#L68-L83

https://github.com/laravel/framework/blob/b8e2aa2527fb5601698e8021b3b205632ef2e4ba/tests/Queue/DatabaseUuidFailedJobProviderTest.php#L87-L103

https://github.com/laravel/framework/blob/b8e2aa2527fb5601698e8021b3b205632ef2e4ba/tests/Queue/FileFailedJobProviderTest.php#L119-L134