### PR TITLE
[12.x] Normalize file path separators for commands on Windows

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -63,8 +63,14 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function writeView()
     {
+        $separator = '/';
+
+        if (windows_os()) {
+            $separator = '\\';
+        }
+
         $path = $this->viewPath(
-            str_replace('.', '/', $this->getView()).'.blade.php'
+            str_replace('.', $separator, $this->getView()).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -67,8 +67,14 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
+        $separator = '/';
+
+        if (windows_os()) {
+            $separator = '\\';
+        }
+
         $path = $this->viewPath(
-            str_replace('.', '/', $this->getView()).'.blade.php'
+            str_replace('.', $separator, $this->getView()).'.blade.php'
         );
 
         if ($this->files->exists($path)) {
@@ -89,8 +95,14 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeView()
     {
+        $separator = '/';
+
+        if (windows_os()) {
+            $separator = '\\';
+        }
+
         $path = $this->viewPath(
-            str_replace('.', '/', $this->getView()).'.blade.php'
+            str_replace('.', $separator, $this->getView()).'.blade.php'
         );
 
         if ($this->files->exists($path)) {

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -63,8 +63,14 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
+        $separator = '/';
+
+        if (windows_os()) {
+            $separator = '\\';
+        }
+
         $path = $this->viewPath(
-            str_replace('.', '/', $this->option('markdown')).'.blade.php'
+            str_replace('.', $separator, $this->option('markdown')).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {


### PR DESCRIPTION
Description
---
This PR adds path normalization for the following commands by replacing forward slashes with backslashes on Windows.

- make:mail
- make:component
- make:notification

Why?
---
Currently, these commands uses mixed directory separators on Windows systems.

---

Continuation of: #56591