### PR TITLE
[12.x] Fix: Add `$forceWrap` property to JsonResource for consistent API response #56724

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,11 +50,11 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static $wrap = 'data';
 
     /**
-     * Whether to force wrapping even if $wrap key exists in resource data.
+     * Whether to force wrapping even if the $wrap key exists in underlying resource data.
      *
      * @var bool
      */
-    public static bool $forceWrap = false;
+    public static bool $forceWrapping = false;
 
     /**
      * Create a new resource instance.

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -50,6 +50,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public static $wrap = 'data';
 
     /**
+     * Whether to force wrapping even if $wrap key exists in resource data.
+     *
+     * @var bool
+     */
+    public static bool $forceWrap = false;
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  $resource

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -75,7 +75,7 @@ class ResourceResponse implements Responsable
     /**
      * Determine if we have a default wrapper and the given data is unwrapped.
      *
-     * @param array $data
+     * @param  array  $data
      * @return bool
      */
     protected function haveDefaultWrapperAndDataIsUnwrapped(array $data): bool

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -75,11 +75,15 @@ class ResourceResponse implements Responsable
     /**
      * Determine if we have a default wrapper and the given data is unwrapped.
      *
-     * @param  array  $data
+     * @param array $data
      * @return bool
      */
-    protected function haveDefaultWrapperAndDataIsUnwrapped($data)
+    protected function haveDefaultWrapperAndDataIsUnwrapped(array $data): bool
     {
+        if ($this->resource instanceof JsonResource && $this->resource::$forceWrap) {
+            return $this->wrapper() !== null;
+        }
+
         return $this->wrapper() && ! array_key_exists($this->wrapper(), $data);
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -78,7 +78,7 @@ class ResourceResponse implements Responsable
      * @param  array  $data
      * @return bool
      */
-    protected function haveDefaultWrapperAndDataIsUnwrapped(array $data): bool
+    protected function haveDefaultWrapperAndDataIsUnwrapped($data)
     {
         if ($this->resource instanceof JsonResource && $this->resource::$forceWrap) {
             return $this->wrapper() !== null;

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -80,7 +80,7 @@ class ResourceResponse implements Responsable
      */
     protected function haveDefaultWrapperAndDataIsUnwrapped($data)
     {
-        if ($this->resource instanceof JsonResource && $this->resource::$forceWrap) {
+        if ($this->resource instanceof JsonResource && $this->resource::$forceWrapping) {
             return $this->wrapper() !== null;
         }
 

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1855,7 +1855,8 @@ class ResourceTest extends TestCase
 
     public function testResourceSkipsWrappingWhenDataKeyExists()
     {
-        $resource = new class(['id' => 5, 'title' => 'Test', 'data' => 'some data']) extends JsonResource {
+        $resource = new class(['id' => 5, 'title' => 'Test', 'data' => 'some data']) extends JsonResource
+        {
             public static $wrap = 'data';
         };
 
@@ -1871,7 +1872,8 @@ class ResourceTest extends TestCase
 
     public function testResourceWrapsWhenDataKeyDoesNotExist()
     {
-        $resource = new class(['id' => 5, 'title' => 'Test']) extends JsonResource {
+        $resource = new class(['id' => 5, 'title' => 'Test']) extends JsonResource
+        {
             public static $wrap = 'data';
         };
 
@@ -1882,13 +1884,14 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'title' => 'Test',
-            ]
+            ],
         ], $content);
     }
 
     public function testResourceForceWrapOverridesDataKeyCheck()
     {
-        $resource = new class(['id' => 5, 'title' => 'Test', 'data' => 'some data']) extends JsonResource {
+        $resource = new class(['id' => 5, 'title' => 'Test', 'data' => 'some data']) extends JsonResource
+        {
             public static $wrap = 'data';
             public static bool $forceWrap = true;
         };
@@ -1901,7 +1904,7 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'title' => 'Test',
                 'data' => 'some data',
-            ]
+            ],
         ], $content);
     }
 

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1893,7 +1893,7 @@ class ResourceTest extends TestCase
         $resource = new class(['id' => 5, 'title' => 'Test', 'data' => 'some data']) extends JsonResource
         {
             public static $wrap = 'data';
-            public static bool $forceWrap = true;
+            public static bool $forceWrapping = true;
         };
 
         $response = $resource->toResponse(request());


### PR DESCRIPTION
# Fix: Add `$forceWrap` property to JsonResource for consistent API response wrapping

## Problem

check #56724 

Laravel JsonResource wrapping behavior is inconsistent when the resource data contains a key that matches the `$wrap` property (usually `'data'`). This causes unpredictable API responses depending on the internal structure of the model.

### Current Behavior (Bug)
```php
// Model WITHOUT 'data' column
$task = Task::find(1); // Task model with id=1, title="Task 1"
return new TaskResource($task);
// Response: {"data": {"id": 1, "title": "Task 1"}}

// Model WITH 'data' column  
$task = Task::find(1); // Task model with id=1, title="Task 1", data="some value"
return new TaskResource($task);
// Response: {"id": 1, "title": "Task 1", "data": "some value"} // ❌ No wrapping!
```

### Root Cause
In `ResourceResponse::haveDefaultWrapperAndDataIsUnwrapped()`, wrapping is skipped if the resource array already contains a top-level key equal to `$wrap`:

```php
protected function haveDefaultWrapperAndDataIsUnwrapped($data) 
{
    return $this->wrapper() && ! array_key_exists($this->wrapper(), $data);
}
```

## Solution

Added an opt-in `$forceWrap` static property to `JsonResource` that forces wrapping even when the wrapper key exists in the resource data.

### Changes Made

#### 1. Add `$forceWrap` property to JsonResource
```php
// src/Illuminate/Http/Resources/Json/JsonResource.php

/**
 * Whether to force wrapping even if $wrap key exists in resource data.
 *
 * @var bool
 */
public static $forceWrap = false;
```

#### 2. Update ResourceResponse to check `$forceWrap`
```php
// src/Illuminate/Http/Resources/Json/ResourceResponse.php

protected function haveDefaultWrapperAndDataIsUnwrapped($data)
{
    if ($this->resource instanceof JsonResource && $this->resource::$forceWrap) {
        return $this->wrapper() !== null;
    }

    return $this->wrapper() && ! array_key_exists($this->wrapper(), $data);
}
```

## Usage

```php
class TaskResource extends JsonResource
{
    public static $wrap = 'data';
    public static $forceWrap = true; // ← Forces consistent wrapping

    public function toArray(Request $request): array
    {
        return [
            'id' => $this->id,
            'title' => $this->title,
            'data' => $this->data, // Won't break wrapping anymore
        ];
    }
}
```

### Results
```php
// Model WITH 'data' column + forceWrap = true
$task = Task::find(1); // Task model with id=1, title="Task 1", data="some value"
return new TaskResource($task);
// Response: {"data": {"id": 1, "title": "Task 1", "data": "some value"}} ✅ Consistent!
```

## Benefits

✅ **Predictable API Responses** - Response shape is no longer dependent on model field names  
✅ **Backward Compatible** - Default behavior unchanged, purely opt-in  
✅ **Explicit Developer Intent** - Clear declaration of wrapping behavior  
✅ **Supports Modern API Patterns** - Enables JSON:API, GraphQL-style APIs with reserved keys

## Test Coverage

Added simple, direct tests:
- `testResourceSkipsWrappingWhenDataKeyExists` - Demonstrates the original bug
- `testResourceWrapsWhenDataKeyDoesNotExist` - Verifies normal behavior 
- `testResourceForceWrapOverridesDataKeyCheck` - Verifies the fix works

Tests directly call `$resource->toResponse()` and verify JSON output - no complex route setup needed.

All existing tests pass (76/76), confirming no breaking changes.

## Impact

This fixes a long-standing inconsistency in Laravel resource responses that has confused developers and created brittle API contracts. The solution follows Laravel's design philosophy of being explicit over implicit while maintaining full backward compatibility.