### PR TITLE
Refactor: Use Collection::isNotEmpty instead of count check

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -67,7 +67,7 @@ class StatusCommand extends BaseCommand
                     return (new Stringable($migration[1]))->contains('Pending');
                 }));
 
-            if (count($migrations) > 0) {
+            if ($migrations->isNotEmpty()) {
                 $this->newLine();
 
                 $this->components->twoColumnDetail('<fg=gray>Migration name</>', '<fg=gray>Batch / Status</>');


### PR DESCRIPTION
Replaced count($migrations) check with $migrations->isNotEmpty() for better readability and consistency with Collection usage.
