### PR TITLE
[12.x] file generated event

### DIFF
--- a/src/Illuminate/Console/Events/FileGenerated.php
+++ b/src/Illuminate/Console/Events/FileGenerated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+class FileGenerated
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $path  The full path of the generated file.
+     * @param  string  $type  The type of file (e.g., Controller, Migration, etc.).
+     */
+    public function __construct(
+        public string $path,
+        public string $type,
+    ) {
+    }
+}

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -142,9 +142,9 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     abstract protected function getStub();
 
     /**
-     * Execute the console command.
+     * Execute the console command and fire FileGenerated event.
      *
-     * @return bool|null
+     * @return bool|null False if the file exists or name is reserved.
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Finder\Finder;
@@ -191,6 +192,8 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         $this->components->info(sprintf('%s [%s] created successfully.', $info, $path));
+
+        Event::dispatch(new Events\FileGenerated($path, $info));
     }
 
     /**


### PR DESCRIPTION
This PR adds an automatic event trigger in the GeneratorCommand class. Whenever a file is generated (e.g., a controller, model), the event is fired. This allows other parts of the application to react to file creation, such as logging, additional processing, or notifications