### PR TITLE
[12.x] Support `null` parameter in `BusFake::chain()` method

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -733,10 +733,10 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Create a new chain of queueable jobs.
      *
-     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @param  \Illuminate\Support\Collection|array|null  $jobs
      * @return \Illuminate\Foundation\Bus\PendingChain
      */
-    public function chain($jobs)
+    public function chain($jobs = null)
     {
         $jobs = Collection::wrap($jobs);
         $jobs = ChainedBatch::prepareNestedBatches($jobs);


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/56536, I forgot to update the default value of the `$jobs` parameter of the `BusFake::chain()` method to match the `Dispatcher::chain()` method. Sorry! 😢 

https://github.com/laravel/framework/blob/568926f9008f223f000f7185bab96585754e2f9a/src/Illuminate/Bus/Dispatcher.php#L161-L167

https://github.com/laravel/framework/blob/568926f9008f223f000f7185bab96585754e2f9a/src/Illuminate/Support/Testing/Fakes/BusFake.php#L733-L739