### PR TITLE
[12.x] `ArrayStore::all()`

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -13,7 +13,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     /**
      * The array of stored values.
      *
-     * @var array<int, array{expiresAt: float, value: mixed}>
+     * @var array<string, array{expiresAt: float, value: mixed}>
      */
     protected $storage = [];
 
@@ -219,10 +219,23 @@ class ArrayStore extends TaggableStore implements LockProvider
     /**
      * Get the underlying cache storage.
      *
-     * @return array<int, array{expiresAt: float, value: mixed}>
+     * @param  bool  $unserializeIfSerialized
+     * @return array<string, array{expiresAt: float, value: mixed}>
      */
-    public function getStorage()
+    public function getStorage($unserializeIfSerialized = true)
     {
-        return $this->storage;
+        if ($unserializeIfSerialized === false || $this->serializesValues === false) {
+            return $this->storage;
+        }
+
+        $storageToReturn = [];
+        foreach($this->storage as $key => $data) {
+            $storageToReturn[$key] = [
+                'expiresAt' => $data['expiresAt'],
+                'value' => unserialize($data['value'])
+            ];
+        }
+        
+        return $storage;
     }
 }

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -13,7 +13,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     /**
      * The array of stored values.
      *
-     * @var array
+     * @var array<int, array{expiresAt: float, value: mixed}>
      */
     protected $storage = [];
 
@@ -214,5 +214,15 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function restoreLock($name, $owner)
     {
         return $this->lock($name, 0, $owner);
+    }
+
+    /**
+     * Get the underlying cache storage.
+     *
+     * @return array<int, array{expiresAt: float, value: mixed}>
+     */
+    public function getStorage()
+    {
+        return $this->storage;
     }
 }

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -228,9 +228,9 @@ class ArrayStore extends TaggableStore implements LockProvider
             return $this->storage;
         }
 
-        $storageToReturn = [];
+        $storage = [];
         foreach($this->storage as $key => $data) {
-            $storageToReturn[$key] = [
+            $storage[$key] = [
                 'expiresAt' => $data['expiresAt'],
                 'value' => unserialize($data['value'])
             ];

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -42,6 +42,30 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Get all of the cached values and their expiration times.
+     *
+     * @param  bool  $unserialize
+     * @return array<string, array{expiresAt: float, value: mixed}>
+     */
+    public function all($unserialize = true)
+    {
+        if ($unserialize === false || $this->serializesValues === false) {
+            return $this->storage;
+        }
+
+        $storage = [];
+
+        foreach ($this->storage as $key => $data) {
+            $storage[$key] = [
+                'expiresAt' => $data['expiresAt'],
+                'value' => unserialize($data['value']),
+            ];
+        }
+
+        return $storage;
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
@@ -214,28 +238,5 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function restoreLock($name, $owner)
     {
         return $this->lock($name, 0, $owner);
-    }
-
-    /**
-     * Get the underlying cache storage.
-     *
-     * @param  bool  $unserializeIfSerialized
-     * @return array<string, array{expiresAt: float, value: mixed}>
-     */
-    public function getStorage($unserializeIfSerialized = true)
-    {
-        if ($unserializeIfSerialized === false || $this->serializesValues === false) {
-            return $this->storage;
-        }
-
-        $storage = [];
-        foreach ($this->storage as $key => $data) {
-            $storage[$key] = [
-                'expiresAt' => $data['expiresAt'],
-                'value' => unserialize($data['value']),
-            ];
-        }
-
-        return $storage;
     }
 }

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -229,13 +229,13 @@ class ArrayStore extends TaggableStore implements LockProvider
         }
 
         $storage = [];
-        foreach($this->storage as $key => $data) {
+        foreach ($this->storage as $key => $data) {
             $storage[$key] = [
                 'expiresAt' => $data['expiresAt'],
-                'value' => unserialize($data['value'])
+                'value' => unserialize($data['value']),
             ];
         }
-        
+
         return $storage;
     }
 }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -326,7 +326,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($firstLock->isOwnedByCurrentProcess());
     }
 
-    public function testCanGetStorage()
+    public function testCanGetAll()
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -335,10 +335,10 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertEquals([
             'foo' => ['value' => 'bar', 'expiresAt' => Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000],
-        ], $store->getStorage());
+        ], $store->all());
     }
 
-    public function testCanGetStorageWhenSerialized()
+    public function testCanGetAllWhenSerialized()
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -346,7 +346,7 @@ class CacheArrayStoreTest extends TestCase
         $store->put('foo', 'bar', 10);
         $this->assertEquals([
             'foo' => ['value' => 'bar', 'expiresAt' => $expiresAt = (Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000)],
-        ], $store->getStorage());
+        ], $store->all());
 
         // Now let's put a serializable value in there
         $store->forget('foo');
@@ -357,11 +357,11 @@ class CacheArrayStoreTest extends TestCase
                 'value' => Carbon::now(),
                 'expiresAt' => $expiresAt,
             ],
-        ], $store->getStorage());
+        ], $store->all());
 
         $this->assertEquals(
             serialize(Carbon::now()),
-            $store->getStorage(false)['foo']['value']
+            $store->all(false)['foo']['value']
         );
     }
 }


### PR DESCRIPTION
I needed a way to extract the data from the ArrayStore inside of a test. While I could get the value of many records and adjust the Carbon timestamp to see when they expire, this doesn't seem particularly developer-friendly.