### PR TITLE
[12.x] Revert #56608

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -14,11 +14,6 @@ class TableGuesser
         '/.+_(to|from|in)_(\w+)$/',
     ];
 
-    const DROP_PATTERNS = [
-        '/^drop_(\w+)_table$/',
-        '/^drop_(\w+)$/',
-    ];
-
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
      *
@@ -36,12 +31,6 @@ class TableGuesser
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
                 return [$matches[2], $create = false];
-            }
-        }
-
-        foreach (self::DROP_PATTERNS as $pattern) {
-            if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[1], $create = false];
             }
         }
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,10 +28,6 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
-
-        [$table, $create] = TableGuesser::guess('drop_users_table');
-        $this->assertSame('users', $table);
-        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
@@ -53,10 +49,6 @@ class TableGuesserTest extends TestCase
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
-        $this->assertSame('users', $table);
-        $this->assertFalse($create);
-
-        [$table, $create] = TableGuesser::guess('drop_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
     }


### PR DESCRIPTION
This reverts #56608

The reason is that while `TableGuesser` correctly identifies the table name, it uses the same stub as `change` migration when generating a `drop` migration.


