### PR TITLE
[12.x] added `redirect($url)->movedPermanently()` method

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -93,19 +93,6 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Set the status to 302 (Found).
-     * This is the default status code.
-     *
-     * @return $this
-     */
-    public function found()
-    {
-        $this->setStatusCode(Response::HTTP_FOUND);
-
-        return $this;
-    }
-
-    /**
      * Remove all uploaded files form the given input array.
      *
      * @param  array  $input

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -85,7 +85,7 @@ class RedirectResponse extends BaseRedirectResponse
      *
      * @return $this
      */
-    public function permanent()
+    public function movedPermanently()
     {
         $this->setStatusCode(Response::HTTP_MOVED_PERMANENTLY);
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -81,6 +81,31 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
+     * Set the status to 301 (Moved Permanently).
+     *
+     * @return $this
+     */
+    public function permanent()
+    {
+        $this->setStatusCode(Response::HTTP_MOVED_PERMANENTLY);
+
+        return $this;
+    }
+
+    /**
+     * Set the status to 302 (Found).
+     * This is the default status code.
+     *
+     * @return $this
+     */
+    public function found()
+    {
+        $this->setStatusCode(Response::HTTP_FOUND);
+
+        return $this;
+    }
+
+    /**
      * Remove all uploaded files form the given input array.
      *
      * @param  array  $input


### PR DESCRIPTION
I needed to set up many 301 redirects, which I used `redirect($url, 301)` for, which isn't terrible, but I was surprised to see there wasn't a helper for this, as it seems it would be a common option when redirecting.

This PR adds a simple `movedPermanently` method on the `Illuminate\Http\RedirectResponse` class.

### Usage
```php
 // before
redirect($url, 301);
redirect($url, Response::HTTP_MOVED_PERMANENTLY);

 // after (adds the option below)
redirect($url)->movedPermanently();
```

I thought of adding methods for the [other 3xx statuses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#redirection_messages), but for 99% of use cases, you'd be either using 301 (moved permanently) or 302 (found), so I didn't worry about them.
