### PR TITLE
[12.x] Fix concurrency closure invocation: use base64 encoding

### DIFF
--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -45,7 +45,9 @@ class InvokeSerializedClosureCommand extends Command
                 'successful' => true,
                 'result' => serialize($this->laravel->call(match (true) {
                     ! is_null($this->argument('code')) => unserialize($this->argument('code')),
-                    isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize($_SERVER['LARAVEL_INVOKABLE_CLOSURE']),
+                    isset($_SERVER['LARAVEL_INVOKABLE_CLOSURE']) => unserialize(
+                        base64_decode($_SERVER['LARAVEL_INVOKABLE_CLOSURE'])
+                    ),
                     default => fn () => null,
                 })),
             ]));

--- a/src/Illuminate/Concurrency/ProcessDriver.php
+++ b/src/Illuminate/Concurrency/ProcessDriver.php
@@ -34,7 +34,9 @@ class ProcessDriver implements Driver
         $results = $this->processFactory->pool(function (Pool $pool) use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $key => $task) {
                 $pool->as($key)->path(base_path())->env([
-                    'LARAVEL_INVOKABLE_CLOSURE' => serialize(new SerializableClosure($task)),
+                    'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
+                        serialize(new SerializableClosure($task))
+                    ),
                 ])->command($command);
             }
         })->start()->wait();
@@ -68,7 +70,9 @@ class ProcessDriver implements Driver
         return defer(function () use ($tasks, $command) {
             foreach (Arr::wrap($tasks) as $task) {
                 $this->processFactory->path(base_path())->env([
-                    'LARAVEL_INVOKABLE_CLOSURE' => serialize(new SerializableClosure($task)),
+                    'LARAVEL_INVOKABLE_CLOSURE' => base64_encode(
+                        serialize(new SerializableClosure($task))
+                    ),
                 ])->run($command.' 2>&1 &');
             }
         });

--- a/tests/Integration/Concurrency/Console/InvokeSerializedClosureCommandTest.php
+++ b/tests/Integration/Concurrency/Console/InvokeSerializedClosureCommandTest.php
@@ -57,8 +57,10 @@ class InvokeSerializedClosureCommandTest extends TestCase
         $closure = fn () => 'From Environment';
         $serialized = serialize(new SerializableClosure($closure));
 
+        $encoded = base64_encode($serialized);
+
         // Set the environment variable
-        $_SERVER['LARAVEL_INVOKABLE_CLOSURE'] = $serialized;
+        $_SERVER['LARAVEL_INVOKABLE_CLOSURE'] = $encoded;
 
         // Create a new output buffer
         $output = new BufferedOutput;


### PR DESCRIPTION
Fix concurrency closure invocation to use base64 encoding for environment variable:

- Updated `ProcessDriver` to base64 encode serialized closures in the `LARAVEL_INVOKABLE_CLOSURE` environment variable.
- Modified `InvokeSerializedClosureCommand` to decode base64 before unserializing closures from the environment.
- Adjusted related test to set the environment variable using base64 encoding.

These changes will fix the issue, when default serializing add some kind of non-binary safe characters:
- `\x00*\x00propertyName → protected property`
- `\x00ClassName\x00propertyName → private property of a specific class`