### PR TITLE
[12.x] Remove unnecessary return in ddBody for consistency

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1757,15 +1757,18 @@ class TestResponse implements ArrayAccess
     {
         $content = $this->content();
 
-        return json_validate($content)
-            ? $this->ddJson($key)
-            : dd($content);
+        if (json_validate($content)) {
+            $this->ddJson($key);
+        }
+
+        dd($content);
     }
 
     /**
      * Dump the JSON payload from the response and end the script.
      *
      * @param  string|null  $key
+     * @return never
      */
     public function ddJson($key = null)
     {


### PR DESCRIPTION
Description
---
In PR #56621, the implementation was updated to use a `return` with a ternary:

```php
return json_validate($content)
    ? $this->ddJson($key)
    : dd($content);
```

Since both `dd()` and `ddJson()` terminate the script, the return here is **effectively unreachable**. This makes the code look like it returns a value, when in reality it never does.

A clearer approach, and one that aligns with the original implementation’s style (just without the `function_exists` guard), would be:

```php
if (json_validate($content)) {
    $this->ddJson($key);
}

dd($content);
```

This keeps the semantics consistent with the `@return never` contract and with other `dd*` helpers in the framework.