### PR TITLE
[12.x] Reduce unnecessary conditional check

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1545,7 +1545,7 @@ class Blueprint
             ->after($after);
 
         $this->unsignedBigInteger("{$name}_id")
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1566,7 +1566,7 @@ class Blueprint
 
         $this->unsignedBigInteger("{$name}_id")
             ->nullable()
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1585,7 +1585,7 @@ class Blueprint
             ->after($after);
 
         $this->uuid("{$name}_id")
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1606,7 +1606,7 @@ class Blueprint
 
         $this->uuid("{$name}_id")
             ->nullable()
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1625,7 +1625,7 @@ class Blueprint
             ->after($after);
 
         $this->ulid("{$name}_id")
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1646,7 +1646,7 @@ class Blueprint
 
         $this->ulid("{$name}_id")
             ->nullable()
-            ->after(! is_null($after) ? "{$name}_type" : null);
+            ->after("{$name}_type");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }


### PR DESCRIPTION
Description
---
The `*_id` column is always placed after the `*_type` column, regardless of whether `$after` is provided. This PR simplifies the implementation, ensure consistent ordering, and remove the need for a conditional check.

Continuation of: #56613