### PR TITLE
[12.x] fix: add polyfill requirement to illuminate packages

### DIFF
--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -18,7 +18,8 @@
         "illuminate/conditionable": "^12.0",
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
-        "symfony/polyfill-php84": "^1.31"
+        "symfony/polyfill-php84": "^1.31",
+        "symfony/polyfill-php85": "^1.33"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -23,7 +23,8 @@
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0",
-        "laravel/serializable-closure": "^1.3|^2.0"
+        "laravel/serializable-closure": "^1.3|^2.0",
+        "symfony/polyfill-php85": "^1.33"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -25,6 +25,7 @@
         "illuminate/macroable": "^12.0",
         "nesbot/carbon": "^3.8.4",
         "symfony/polyfill-php83": "^1.31",
+        "symfony/polyfill-php85": "^1.33"
         "voku/portable-ascii": "^2.0.2"
     },
     "conflict": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -25,7 +25,7 @@
         "illuminate/macroable": "^12.0",
         "nesbot/carbon": "^3.8.4",
         "symfony/polyfill-php83": "^1.31",
-        "symfony/polyfill-php85": "^1.33"
+        "symfony/polyfill-php85": "^1.33",
         "voku/portable-ascii": "^2.0.2"
     },
     "conflict": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

After the introduction of https://github.com/laravel/framework/pull/56706, we need to make the individual `illuminate/*` packages also have the requirement for `symfony/polyfill-php85`.

This prevents the following error from happening if you only use separate `illuminate/support` package:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Illuminate\Support\array_first() in /home/runner/.composer/vendor/illuminate/collections/Arr.php:260
Stack trace:
#0 /home/runner/.composer/vendor/illuminate/collections/Collection.php(432): Illuminate\Support\Arr::first()
#1 /home/runner/.composer/vendor/erikgaal/cx/src/Tasks/Renderer/StaticRenderer.php(26): Illuminate\Support\Collection->first()
#2 /home/runner/.composer/vendor/erikgaal/cx/src/Tasks/TaskRunner.php(33): Cx\Tasks\Renderer\StaticRenderer->started()
#3 /home/runner/.composer/vendor/erikgaal/cx/src/Commands/RunManyCommand.php(53): Cx\Tasks\TaskRunner->run()
#4 /home/runner/.composer/vendor/symfony/console/Command/Command.php(318): Cx\Commands\RunManyCommand->execute()
#5 /home/runner/.composer/vendor/symfony/console/Application.php(1074): Symfony\Component\Console\Command\Command->run()
#6 /home/runner/.composer/vendor/symfony/console/Application.php(341): Symfony\Component\Console\Application->doRunCommand()
#7 /home/runner/.composer/vendor/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRun()
#8 /home/runner/.composer/vendor/erikgaal/cx/cx(36): Symfony\Component\Console\Application->run()
#9 /home/runner/.composer/vendor/bin/cx(119): include('...')
```