### PR TITLE
[12.x] fix: csrf_token can return null

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -397,7 +397,7 @@ if (! function_exists('csrf_token')) {
      *
      * @throws \RuntimeException
      */
-    function csrf_token(): string
+    function csrf_token(): ?string
     {
         $session = app('session');
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/pull/56684#issuecomment-3224511023

cc: @chris-ware 