### PR TITLE
[12.x] revert changes to `old()` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -630,8 +630,9 @@ if (! function_exists('old')) {
      *
      * @param  string|null  $key
      * @param  \Illuminate\Database\Eloquent\Model|string|array|null  $default
+     * @return string|array|null
      */
-    function old($key = null, $default = null): string|array|null
+    function old($key = null, $default = null)
     {
         return app('request')->old($key, $default);
     }


### PR DESCRIPTION
this is a breaking change, as previously users could pass any type of value to `$default`. with this change it forces all `$default`s to be `string|array|null`.

this is a reversion of part of #56684

for the following code:

```php
dump(new \Illuminate\Support\Collection(['foo', 'bar']));
dd(old('tags', new \Illuminate\Support\Collection(['foo', 'bar'])))
```

prior to change:

<img width="701" height="165" alt="Screenshot 2025-08-26 at 10 22 37 AM" src="https://github.com/user-attachments/assets/2d346e3d-70ab-442c-a6a0-1c0c480c3fd7" />

after changes:

<img width="694" height="118" alt="Screenshot 2025-08-26 at 10 22 23 AM" src="https://github.com/user-attachments/assets/e029355f-c5ba-4511-8e5f-02b4e086f18d" />


