### PR TITLE
[12.x] Improve `make:migration` command tests coverage

### DIFF
--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -50,6 +50,22 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsForUpdateMigration()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_bar', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'bar', false)
+            ->andReturn(__DIR__.'/migrations/2025_08_26_110457_remove_foo_from_bar.php');
+
+        $this->runCommand($command, ['name' => 'remove_foo_from_bar']);
+    }
+
     public function testBasicCreateGivesCreatorProperArgumentsWhenNameIsStudlyCase()
     {
         $command = new MigrateMakeCommand(
@@ -64,6 +80,22 @@ class DatabaseMigrationMakeCommandTest extends TestCase
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
+    }
+
+    public function testBasicCreateGivesCreatorProperArgumentsForUpdateMigrationWhenNameIsStudlyCase()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_bar', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'bar', false)
+            ->andReturn(__DIR__.'/migrations/2025_08_26_110457_remove_foo_from_bar.php');
+
+        $this->runCommand($command, ['name' => 'RemoveFooFromBar']);
     }
 
     public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
@@ -82,6 +114,22 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsForUpdateMigrationWhenTableIsSet()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_bar', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'baz', false)
+            ->andReturn(__DIR__.'/migrations/2025_08_26_110457_remove_foo_from_bar.php');
+
+        $this->runCommand($command, ['name' => 'remove_foo_from_bar', '--table' => 'baz']);
+    }
+
     public function testBasicCreateGivesCreatorProperArgumentsWhenCreateTablePatternIsFound()
     {
         $command = new MigrateMakeCommand(
@@ -98,6 +146,22 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'create_users_table']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsWhenUpdateTablePatternIsFound()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_baz', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'baz', false)
+            ->andReturn(__DIR__.'/migrations/2025_08_26_110457_remove_foo_from_baz.php');
+
+        $this->runCommand($command, ['name' => 'remove_foo_from_baz']);
+    }
+
     public function testCanSpecifyPathToCreateMigrationsIn()
     {
         $command = new MigrateMakeCommand(
@@ -111,6 +175,36 @@ class DatabaseMigrationMakeCommandTest extends TestCase
             ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
             ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
+    public function testCanSpecifyPathForUpdateMigrationToCreateMigrationsIn()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $command->setLaravel($app);
+        $app->setBasePath('/home/laravel');
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_bar', '/home/laravel/vendor/laravel-package/migrations', 'bar', false)
+            ->andReturn('/home/laravel/vendor/laravel-package/migrations/2025_08_26_110457_remove_foo_from_bar.php');
+        $this->runCommand($command, ['name' => 'remove_foo_from_bar', '--path' => 'vendor/laravel-package/migrations']);
+    }
+
+    public function testCanSpecifyPathForUpdateMigrationToCreateMigrationsInWhenTableIsSet()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $command->setLaravel($app);
+        $app->setBasePath('/home/laravel');
+        $creator->shouldReceive('create')->once()
+            ->with('remove_foo_from_bar', '/home/laravel/vendor/laravel-package/migrations', 'baz', false)
+            ->andReturn('/home/laravel/vendor/laravel-package/migrations/2025_08_26_110457_remove_foo_from_bar.php');
+        $this->runCommand($command, ['name' => 'remove_foo_from_bar', '--path' => 'vendor/laravel-package/migrations', '--table' => 'baz']);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
This PR introduces a set of new tests focusing on update migrations in the `DatabaseMigrationMakeCommandTest`. Previously, coverage focused on create migrations, but update migrations also need tests.

## Added Tests:

- `testBasicCreateGivesCreatorProperArgumentsForUpdateMigration`
Ensures that a standard update migration name generates the correct table name and `$create = false`.

- `testBasicCreateGivesCreatorProperArgumentsForUpdateMigrationWhenNameIsStudlyCase`
Verifies that StudlyCase migration names are normalized and processed correctly and `$create = false`.

- `testBasicCreateGivesCreatorProperArgumentsForUpdateMigrationWhenTableIsSet`
Confirms that the `--table` option overrides the inferred table name for update migrations and `$create = false`.

- `testBasicCreateGivesCreatorProperArgumentsWhenUpdateTablePatternIsFound`
Covers the case when the correct update migration naming pattern is detected and `$create = false`.

- `testCanSpecifyPathForUpdateMigrationToCreateMigrationsIn`
Validates that the `--path` option works correctly with update migrations and `$create = false`.

- `testCanSpecifyPathForUpdateMigrationToCreateMigrationsInWhenTableIsSet`
Ensures `--path` and `--table` can be combined for update migrations and `$create = false`.