### PR TITLE
[12.x] add back return type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -498,6 +498,7 @@ if (! function_exists('event')) {
      * @param  string|object  $event
      * @param  mixed  $payload
      * @param  bool  $halt
+     * @return array|null
      */
     function event(...$args)
     {


### PR DESCRIPTION
this fully reverts the change from #56684 that was partially reverted in #56773 by adding back the `@return` docblock.

clearly this docblock isn't the whole story, but I think it's good to have it back until we fully figure out what the accurate answer is here.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
