### PR TITLE
[12.x] Improve output grammar in `ScheduleRunCommand`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -162,7 +162,7 @@ class ScheduleRunCommand extends Command
             $this->runEvent($event);
         } else {
             $this->components->info(sprintf(
-                'Skipping [%s], as command already run on another server.', $event->getSummaryForDisplay()
+                'Skipping [%s], as command already ran on another server.', $event->getSummaryForDisplay()
             ));
         }
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -162,7 +162,7 @@ class ScheduleRunCommand extends Command
             $this->runEvent($event);
         } else {
             $this->components->info(sprintf(
-                'Skipping [%s], as command already ran on another server.', $event->getSummaryForDisplay()
+                'Skipping [%s] because the command already ran on another server.', $event->getSummaryForDisplay()
             ));
         }
     }


### PR DESCRIPTION
I think the message reads better this way.

<img width="1024" height="512" alt="image" src="https://github.com/user-attachments/assets/e43d8cb0-2a89-42fc-8416-ee470ba908e6" />

PS: Since this is probably the easiest way to guarantee you see this: the `max-processes` functionality is in the docs, but a new version of `pint` hasn't been tagged yet.