### PR TITLE
[12.x] Add attribute-based authorization for controller actions

### DIFF
--- a/src/Illuminate/Auth/Attributes/Authorize.php
+++ b/src/Illuminate/Auth/Attributes/Authorize.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Auth\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Authorize
+{
+    /**
+     * The ability to authorize.
+     *
+     * @var string
+     */
+    public string $ability;
+
+    /**
+     * The models to pass to the gate.
+     *
+     * @var array
+     */
+    public array $models;
+
+    /**
+     * Create a new authorize attribute instance.
+     *
+     * @param  string  $ability
+     * @param  string|array  ...$models
+     */
+    public function __construct(string $ability, string|array ...$models)
+    {
+        $this->ability = $ability;
+        $this->models = is_array($models[0] ?? null) ? $models[0] : $models;
+    }
+}

--- a/src/Illuminate/Auth/Attributes/Authorize.php
+++ b/src/Illuminate/Auth/Attributes/Authorize.php
@@ -4,7 +4,7 @@ namespace Illuminate\Auth\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_METHOD)]
 class Authorize
 {
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Auth\Attributes\Authorize;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\Collection;
+use ReflectionMethod;
 
 class ControllerDispatcher implements ControllerDispatcherContract
 {
@@ -39,11 +43,123 @@ class ControllerDispatcher implements ControllerDispatcherContract
     {
         $parameters = $this->resolveParameters($route, $controller, $method);
 
+        $this->handleAuthorizeAttribute($controller, $method, $parameters);
+
         if (method_exists($controller, 'callAction')) {
             return $controller->callAction($method, $parameters);
         }
 
         return $controller->{$method}(...array_values($parameters));
+    }
+
+    /**
+     * Handle authorization attribute if present on the method.
+     *
+     * @param  mixed  $controller
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    protected function handleAuthorizeAttribute($controller, $method, $parameters)
+    {
+        $reflection = new ReflectionMethod($controller, $method);
+        $attributes = $reflection->getAttributes(Authorize::class);
+
+        if (empty($attributes)) {
+            return;
+        }
+
+        /** @var \Illuminate\Auth\Attributes\Authorize $authorizeAttribute */
+        $authorizeAttribute = $attributes[0]->newInstance();
+
+        $gate = $this->container->make(Gate::class);
+
+        $gateArguments = $this->resolveGateArguments($authorizeAttribute, $reflection, $parameters);
+
+        $gate->authorize($authorizeAttribute->ability, $gateArguments);
+    }
+
+    /**
+     * Resolve the gate arguments from the authorize attribute and method parameters.
+     *
+     * @param  \Illuminate\Auth\Attributes\Authorize  $attribute
+     * @param  \ReflectionMethod  $method
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function resolveGateArguments($attribute, $method, $parameters)
+    {
+        if (empty($attribute->models)) {
+            return $this->autoResolveModelsFromParameters($method, $parameters);
+        }
+
+        $arguments = [];
+
+        foreach ($attribute->models as $model) {
+            if (is_string($model) && class_exists($model)) {
+                // If it's a class name, try to find a matching parameter
+                $arguments[] = $this->findParameterByType($method, $parameters, $model);
+            } else {
+                // If it's a parameter name, find it in the parameters
+                $arguments[] = $parameters[$model] ?? $model;
+            }
+        }
+
+        return array_filter($arguments, fn ($arg) => $arg !== null);
+    }
+
+    /**
+     * Auto-resolve model arguments from method parameters.
+     *
+     * @param  \ReflectionMethod  $method
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function autoResolveModelsFromParameters($method, $parameters)
+    {
+        $arguments = [];
+
+        foreach ($method->getParameters() as $param) {
+            $type = $param->getType();
+
+            if ($type && ! $type->isBuiltin() && class_exists($type->getName())) {
+                $typeName = $type->getName();
+
+                if (is_subclass_of($typeName, Model::class)) {
+                    $paramName = $param->getName();
+                    if (isset($parameters[$paramName])) {
+                        $arguments[] = $parameters[$paramName];
+                    }
+                }
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Find a parameter by its type.
+     *
+     * @param  \ReflectionMethod  $method
+     * @param  array  $parameters
+     * @param  string  $typeName
+     * @return mixed
+     */
+    protected function findParameterByType($method, $parameters, $typeName)
+    {
+        foreach ($method->getParameters() as $param) {
+            $type = $param->getType();
+
+            if ($type && $type->getName() === $typeName) {
+                $paramName = $param->getName();
+
+                return $parameters[$paramName] ?? null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Auth/AuthorizeAttributeTest.php
+++ b/tests/Auth/AuthorizeAttributeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Auth\Attributes\Authorize;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizeAttributeTest extends TestCase
+{
+    public function testAttributeCanBeInstantiatedWithAbilityOnly()
+    {
+        $attribute = new Authorize('update-post');
+
+        $this->assertEquals('update-post', $attribute->ability);
+        $this->assertEquals([], $attribute->models);
+    }
+
+    public function testAttributeCanBeInstantiatedWithAbilityAndModels()
+    {
+        $attribute = new Authorize('update-post', 'post', 'user');
+
+        $this->assertEquals('update-post', $attribute->ability);
+        $this->assertEquals(['post', 'user'], $attribute->models);
+    }
+
+    public function testAttributeCanBeInstantiatedWithAbilityAndModelArray()
+    {
+        $attribute = new Authorize('update-post', ['post', 'user']);
+
+        $this->assertEquals('update-post', $attribute->ability);
+        $this->assertEquals(['post', 'user'], $attribute->models);
+    }
+
+    public function testAttributeCanBeInstantiatedWithAbilityAndSingleModel()
+    {
+        $attribute = new Authorize('update-post', 'post');
+
+        $this->assertEquals('update-post', $attribute->ability);
+        $this->assertEquals(['post'], $attribute->models);
+    }
+}

--- a/tests/Routing/AuthorizeAttributeIntegrationTest.php
+++ b/tests/Routing/AuthorizeAttributeIntegrationTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Auth\Attributes\Authorize;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Route;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use stdClass;
+
+class AuthorizeAttributeIntegrationTest extends TestCase
+{
+    protected $container;
+    protected $user;
+    protected $gate;
+    protected $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new stdClass;
+        $this->user->id = 1;
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+
+        $this->gate = new Gate($this->container, function () {
+            return $this->user;
+        });
+
+        $this->container->instance(GateContract::class, $this->gate);
+        $this->dispatcher = new ControllerDispatcher($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        Container::setInstance(null);
+    }
+
+    public function testAttributeWorksWithClassBasedModelSpecification()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPostModel;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithClassBasedModels;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated with class', $result);
+    }
+
+    public function testAttributeHandlesNonModelParameters()
+    {
+        $this->gate->define('view-dashboard', function ($user) {
+            return $user->id === 1;
+        });
+
+        $route = $this->createRoute(['id' => 123, 'name' => 'test']);
+        $controller = new TestControllerWithNonModelParams;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'show');
+
+        $this->assertEquals('dashboard shown', $result);
+    }
+
+    public function testAttributeWorksWithEnumAbilities()
+    {
+        $this->gate->define('post.update', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPostModel;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithEnumAbility;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated with enum', $result);
+    }
+
+    public function testMultipleAuthorizeAttributesOnSameMethod()
+    {
+        $reflection = new ReflectionMethod(TestControllerWithMultipleAttributes::class, 'update');
+        $attributes = $reflection->getAttributes(Authorize::class);
+
+        // Should only process the first attribute
+        $this->assertCount(2, $attributes);
+
+        $this->gate->define('first-ability', function ($user) {
+            return true;
+        });
+
+        $this->gate->define('second-ability', function ($user) {
+            return false;
+        });
+
+        $route = $this->createRoute();
+        $controller = new TestControllerWithMultipleAttributes;
+
+        // Should pass because only the first attribute is processed
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated with multiple', $result);
+    }
+
+    public function testAttributeWithMissingModelParameter()
+    {
+        $this->gate->define('update-post', function ($user, $post = null) {
+            return $user->id === 1 && $post === null;
+        });
+
+        $route = $this->createRoute(); // No post parameter
+        $controller = new TestControllerWithMissingParam;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated without param', $result);
+    }
+
+    public function testAttributeFailsWhenGateThrowsException()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            throw new \Exception('Custom gate error');
+        });
+
+        $post = new TestPostModel;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithClassBasedModels;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Custom gate error');
+
+        $this->dispatcher->dispatch($route, $controller, 'update');
+    }
+
+    public function testAttributeWorksWithControllerMethodsWithoutParameters()
+    {
+        $this->gate->define('list-posts', function ($user) {
+            return $user->id === 1;
+        });
+
+        $route = $this->createRoute();
+        $controller = new TestControllerWithNoParams;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'index');
+
+        $this->assertEquals('listed', $result);
+    }
+
+    protected function createRoute($parameters = [])
+    {
+        $route = m::mock(Route::class);
+        $route->shouldReceive('parametersWithoutNulls')->andReturn($parameters);
+
+        return $route;
+    }
+}
+
+class TestPostModel extends Model
+{
+    public $id;
+    public $user_id;
+}
+
+class TestControllerWithClassBasedModels extends Controller
+{
+    #[Authorize('update-post', TestPostModel::class)]
+    public function update(TestPostModel $post)
+    {
+        return 'updated with class';
+    }
+}
+
+class TestControllerWithNonModelParams extends Controller
+{
+    #[Authorize('view-dashboard')]
+    public function show(int $id, string $name)
+    {
+        return 'dashboard shown';
+    }
+}
+
+class TestControllerWithEnumAbility extends Controller
+{
+    #[Authorize('post.update')]
+    public function update(TestPostModel $post)
+    {
+        return 'updated with enum';
+    }
+}
+
+class TestControllerWithMultipleAttributes extends Controller
+{
+    #[Authorize('first-ability')]
+    #[Authorize('second-ability')]
+    public function update()
+    {
+        return 'updated with multiple';
+    }
+}
+
+class TestControllerWithMissingParam extends Controller
+{
+    #[Authorize('update-post')]
+    public function update(?TestPostModel $post = null)
+    {
+        return 'updated without param';
+    }
+}
+
+class TestControllerWithNoParams extends Controller
+{
+    #[Authorize('list-posts')]
+    public function index()
+    {
+        return 'listed';
+    }
+}

--- a/tests/Routing/AuthorizeAttributePolicyTest.php
+++ b/tests/Routing/AuthorizeAttributePolicyTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Auth\Attributes\Authorize;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Route;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class AuthorizeAttributePolicyTest extends TestCase
+{
+    protected $container;
+    protected $user;
+    protected $gate;
+    protected $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new stdClass;
+        $this->user->id = 1;
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+
+        $this->gate = new Gate($this->container, function () {
+            return $this->user;
+        });
+
+        $this->container->instance(GateContract::class, $this->gate);
+        $this->dispatcher = new ControllerDispatcher($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        Container::setInstance(null);
+    }
+
+    public function testAuthorizeAttributeWorksWithPolicies()
+    {
+        $this->gate->policy(TestPostWithPolicies::class, TestPostPolicy::class);
+
+        $post = new TestPostWithPolicies;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithPolicy;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated via policy', $result);
+    }
+
+    public function testAuthorizeAttributeWithPolicyDeniesAccess()
+    {
+        $this->gate->policy(TestPostWithPolicies::class, TestPostPolicy::class);
+
+        $post = new TestPostWithPolicies;
+        $post->user_id = 2;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithPolicy;
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->dispatcher->dispatch($route, $controller, 'update');
+    }
+
+    public function testAuthorizeAttributeWorksWithPolicyAndMultipleModels()
+    {
+        $this->gate->policy(TestPostWithPolicies::class, TestPostPolicy::class);
+        $this->gate->policy(TestCommentWithPolicies::class, TestCommentPolicy::class);
+
+        $post = new TestPostWithPolicies;
+        $post->id = 1;
+        $post->user_id = 1;
+
+        $comment = new TestCommentWithPolicies;
+        $comment->id = 1;
+        $comment->post_id = 1;
+        $comment->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post, 'comment' => $comment]);
+        $controller = new TestControllerWithMultiplePolicyModels;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'updateComment');
+
+        $this->assertEquals('comment updated via policy', $result);
+    }
+
+    public function testAuthorizeAttributeWithCustomPolicyMethod()
+    {
+        $this->gate->policy(TestPostWithPolicies::class, TestPostPolicy::class);
+
+        $post = new TestPostWithPolicies;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithCustomPolicyMethod;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'publish');
+
+        $this->assertEquals('published via policy', $result);
+    }
+
+    protected function createRoute($parameters = [])
+    {
+        $route = m::mock(Route::class);
+        $route->shouldReceive('parametersWithoutNulls')->andReturn($parameters);
+
+        return $route;
+    }
+}
+
+// Test Models
+class TestPostWithPolicies extends Model
+{
+    public $id;
+    public $user_id;
+}
+
+class TestCommentWithPolicies extends Model
+{
+    public $id;
+    public $post_id;
+    public $user_id;
+}
+
+class TestPostPolicy
+{
+    public function update($user, $post)
+    {
+        return $user->id === $post->user_id;
+    }
+
+    public function publish($user, $post)
+    {
+        return $user->id === $post->user_id;
+    }
+}
+
+class TestCommentPolicy
+{
+    public function updateComment($user, $comment, $post)
+    {
+        return $user->id === $post->user_id && $comment->post_id === $post->id;
+    }
+}
+
+class TestControllerWithPolicy extends Controller
+{
+    #[Authorize('update')]
+    public function update(TestPostWithPolicies $post)
+    {
+        return 'updated via policy';
+    }
+}
+
+class TestControllerWithMultiplePolicyModels extends Controller
+{
+    #[Authorize('updateComment', 'comment', 'post')]
+    public function updateComment(TestPostWithPolicies $post, TestCommentWithPolicies $comment)
+    {
+        return 'comment updated via policy';
+    }
+}
+
+class TestControllerWithCustomPolicyMethod extends Controller
+{
+    #[Authorize('publish')]
+    public function publish(TestPostWithPolicies $post)
+    {
+        return 'published via policy';
+    }
+}

--- a/tests/Routing/ControllerDispatcherAuthorizeAttributeTest.php
+++ b/tests/Routing/ControllerDispatcherAuthorizeAttributeTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Auth\Attributes\Authorize;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Route;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ControllerDispatcherAuthorizeAttributeTest extends TestCase
+{
+    protected $container;
+    protected $user;
+    protected $gate;
+    protected $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = new stdClass;
+        $this->user->id = 1;
+
+        $this->container = new Container;
+        Container::setInstance($this->container);
+
+        $this->gate = new Gate($this->container, function () {
+            return $this->user;
+        });
+
+        $this->container->instance(GateContract::class, $this->gate);
+        $this->dispatcher = new ControllerDispatcher($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        Container::setInstance(null);
+    }
+
+    public function testAuthorizeAttributeWithParamsIsHandledForControllers()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPost;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithAttribute;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated', $result);
+    }
+
+    public function testAuthorizeAttributeWithoutParamsIsHandledForController()
+    {
+        $this->gate->define('create-post', function ($user) {
+            return $user->id === 1;
+        });
+
+        $route = $this->createRoute();
+        $controller = new TestControllerWithAttribute;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'create');
+
+        $this->assertEquals('created', $result);
+    }
+
+    public function testAuthorizeAttributeThrowsAuthorizationExceptionWhenUnauthorized()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPost;
+        $post->user_id = 2;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithAttribute;
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->dispatcher->dispatch($route, $controller, 'update');
+    }
+
+    public function testAuthorizeAttributeAutoResolvesModelsFromMethodParameters()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPost;
+        $post->user_id = 1;
+
+        $route = $this->createRoute(['post' => $post]);
+        $controller = new TestControllerWithAutoResolve;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated', $result);
+    }
+
+    public function testAuthorizeAttributeWorksWithMultipleModels()
+    {
+        $this->gate->define('edit-post-comment', function ($user, $post, $comment) {
+            return $user->id === $post->user_id && $comment->post_id === $post->id;
+        });
+
+        $post = new TestPost;
+        $post->id = 1;
+        $post->user_id = 1;
+
+        $comment = new TestComment;
+        $comment->post_id = 1;
+
+        $route = $this->createRoute(['post' => $post, 'comment' => $comment]);
+        $controller = new TestControllerWithMultipleModels;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'updateComment');
+
+        $this->assertEquals('comment updated', $result);
+    }
+
+    public function testAuthorizeAttributeWorksWithSpecificModelParameters()
+    {
+        $this->gate->define('update-post', function ($user, $post) {
+            return $user->id === $post->user_id;
+        });
+
+        $post = new TestPost;
+        $post->user_id = 1;
+
+        $user = new TestUser;
+        $user->id = 2;
+
+        $route = $this->createRoute(['post' => $post, 'user' => $user]);
+        $controller = new TestControllerWithSpecificModels;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'update');
+
+        $this->assertEquals('updated', $result);
+    }
+
+    public function testControllerMethodWithoutAuthorizeAttributeIsNotAffected()
+    {
+        $route = $this->createRoute();
+        $controller = new TestControllerWithAttribute;
+
+        $result = $this->dispatcher->dispatch($route, $controller, 'index');
+
+        $this->assertEquals('index', $result);
+    }
+
+    protected function createRoute($parameters = [])
+    {
+        $route = m::mock(Route::class);
+        $route->shouldReceive('parametersWithoutNulls')->andReturn($parameters);
+
+        return $route;
+    }
+}
+
+class TestPost extends Model
+{
+    public $id;
+    public $user_id;
+}
+
+class TestComment extends Model
+{
+    public $post_id;
+}
+
+class TestUser extends Model
+{
+    public $id;
+}
+
+class TestControllerWithAttribute extends Controller
+{
+    #[Authorize('create-post')]
+    public function create()
+    {
+        return 'created';
+    }
+
+    #[Authorize('update-post', 'post')]
+    public function update(TestPost $post)
+    {
+        return 'updated';
+    }
+
+    public function index()
+    {
+        return 'index';
+    }
+}
+
+class TestControllerWithAutoResolve extends Controller
+{
+    #[Authorize('update-post')]
+    public function update(TestPost $post)
+    {
+        return 'updated';
+    }
+}
+
+class TestControllerWithMultipleModels extends Controller
+{
+    #[Authorize('edit-post-comment')]
+    public function updateComment(TestPost $post, TestComment $comment)
+    {
+        return 'comment updated';
+    }
+}
+
+class TestControllerWithSpecificModels extends Controller
+{
+    #[Authorize('update-post', 'post')]
+    public function update(TestPost $post, TestUser $user)
+    {
+        return 'updated';
+    }
+}


### PR DESCRIPTION
This PR adds a new `#[Authorize]` attribute that allows you to authorize controller actions instead of manually calling authorization inside the method.

Examples:

```php
// simple authorization without parameters
#[Authorize('create-post')] 
public function store()
{
    // replaces Gate::authorize('create-post')
}

// with explicit model parameters
#[Authorize('update-post', 'post')]
public function updatePost(Post $post)
{
    // replaces Gate::authorize('update-post', $post)
}

// auto-resolve parameters from method signature
#[Authorize('update-post')]
public function updatePost(Post $post)
{
    // Automatically passes $post to gate based on type hint
}
```