### PR TITLE
[12.x] Add support for drop patterns to the `make:migration` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -89,13 +89,13 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // "create" in the name. This will allow us to provide a convenient way
         // of creating migrations that create new tables for the application.
         if (! $table) {
-            [$table, $create] = TableGuesser::guess($name);
+            [$table, $create, $drop] = TableGuesser::guess($name);
         }
 
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $table, $create, $drop ?? false);
     }
 
     /**
@@ -104,12 +104,13 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * @param  string  $name
      * @param  string  $table
      * @param  bool  $create
+     * @param  bool  $drop
      * @return void
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $table, $create, $drop)
     {
         $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $drop
         );
 
         if (windows_os()) {

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -14,6 +14,11 @@ class TableGuesser
         '/.+_(to|from|in)_(\w+)$/',
     ];
 
+    const DROP_PATTERNS = [
+        '/^drop_(\w+)_table$/',
+        '/^drop_(\w+)$/',
+    ];
+
     /**
      * Attempt to guess the table name and "creation" status of the given migration.
      *
@@ -31,6 +36,12 @@ class TableGuesser
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
                 return [$matches[2], $create = false];
+            }
+        }
+
+        foreach (self::DROP_PATTERNS as $pattern) {
+            if (preg_match($pattern, $migration, $matches)) {
+                return [$matches[1], $create = false];
             }
         }
     }

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -29,19 +29,19 @@ class TableGuesser
     {
         foreach (self::CREATE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[1], $create = true];
+                return [$matches[1], $create = true, $drop = false];
             }
         }
 
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
+                return [$matches[2], $create = false, $drop = false];
             }
         }
 
         foreach (self::DROP_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[1], $create = false];
+                return [$matches[1], $create = false, $drop = true];
             }
         }
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -49,18 +49,19 @@ class MigrationCreator
      * @param  string  $path
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $drop
      * @return string
      *
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $drop = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($table, $create, $drop);
 
         $path = $this->getPath($name, $path);
 
@@ -107,9 +108,10 @@ class MigrationCreator
      *
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $drop
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($table, $create, $drop)
     {
         if (is_null($table)) {
             $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
@@ -119,6 +121,10 @@ class MigrationCreator
             $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create.stub')
                 ? $customPath
                 : $this->stubPath().'/migration.create.stub';
+        } elseif ($drop) {
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.drop.stub')
+                ? $customPath
+                : $this->stubPath().'/migration.drop.stub';
         } else {
             $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update.stub')
                 ? $customPath

--- a/src/Illuminate/Database/Migrations/stubs/migration.drop.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.drop.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::dropIfExists('{{ table }}');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -71,6 +71,20 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz');
     }
 
+    public function testTableDropMigrationStoresMigrationFile()
+    {
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.drop.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.drop.stub')->andReturn('return new class DummyTable');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $creator->create('create_bar', 'foo', 'baz', drop: true);
+    }
+
     public function testTableCreationMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -44,7 +44,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -60,7 +60,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
@@ -76,7 +76,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
@@ -92,7 +92,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
@@ -108,7 +108,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, false)
             ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
     }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -9,55 +9,67 @@ class TableGuesserTest extends TestCase
 {
     public function testMigrationIsProperlyParsed()
     {
-        [$table, $create] = TableGuesser::guess('create_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('create_users_table');
         $this->assertSame('users', $table);
         $this->assertTrue($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('add_status_column_to_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('add_status_column_to_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('add_is_sent_to_crm_column_to_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('add_is_sent_to_crm_column_to_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('change_status_column_in_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('change_status_column_in_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('drop_users_table');
+        [$table, $create, $drop] = TableGuesser::guess('drop_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertTrue($drop);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
     {
-        [$table, $create] = TableGuesser::guess('create_users');
+        [$table, $create, $drop] = TableGuesser::guess('create_users');
         $this->assertSame('users', $table);
         $this->assertTrue($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('add_status_column_to_users');
+        [$table, $create, $drop] = TableGuesser::guess('add_status_column_to_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('add_is_sent_to_crm_column_column_to_users');
+        [$table, $create, $drop] = TableGuesser::guess('add_is_sent_to_crm_column_column_to_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('change_status_column_in_users');
+        [$table, $create, $drop] = TableGuesser::guess('change_status_column_in_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        [$table, $create, $drop] = TableGuesser::guess('drop_status_column_from_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertFalse($drop);
 
-        [$table, $create] = TableGuesser::guess('drop_users');
+        [$table, $create, $drop] = TableGuesser::guess('drop_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+        $this->assertTrue($drop);
     }
 }

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -28,6 +28,10 @@ class TableGuesserTest extends TestCase
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('drop_users_table');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
@@ -49,6 +53,10 @@ class TableGuesserTest extends TestCase
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
+        $this->assertSame('users', $table);
+        $this->assertFalse($create);
+
+        [$table, $create] = TableGuesser::guess('drop_users');
         $this->assertSame('users', $table);
         $this->assertFalse($create);
     }


### PR DESCRIPTION
This was introduced in #56608

While the `TableGuesser` correctly identifies table names, it does not currently provide a dedicated stub for `drop` migrations. Since `TableGuesser` only distinguishes between two states - `create` and `change` (via a boolean `$create` flag) - `drop` migrations are not properly recognized and default to the `change` stub.

## Changes

- Add a `$drop` flag that correctly identifies drop migrations.
- Update `getStub()` to use this new flag and return a drop stub.

