### PR TITLE
fix: base class guard in return types is breaking custom guards

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cookie\Factory as CookieFactory;
@@ -169,9 +170,9 @@ if (! function_exists('auth')) {
      * Get the available auth instance.
      *
      * @param  string|null  $guard
-     * @return ($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)
+     * @return ($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\Guard)
      */
-    function auth($guard = null): AuthFactory|StatefulGuard
+    function auth($guard = null): AuthFactory|Guard
     {
         if (is_null($guard)) {
             return app(AuthFactory::class);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -6,7 +6,6 @@ use Illuminate\Broadcasting\PendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
-use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -9,7 +9,7 @@ assertType('mixed', app('foo'));
 assertType('Illuminate\Config\Repository', app(Repository::class));
 
 assertType('Illuminate\Contracts\Auth\Factory', auth());
-assertType('Illuminate\Contracts\Auth\StatefulGuard', auth('foo'));
+assertType('Illuminate\Contracts\Auth\Guard', auth('foo'));
 
 assertType('Illuminate\Cache\CacheManager', cache());
 assertType('bool', cache(['foo' => 'bar'], 42));


### PR DESCRIPTION
The newly added strict [types](https://github.com/laravel/framework/pull/56684) are causing issues with popular packages like [jwt-auth](https://github.com/tymondesigns/jwt-auth) since the custom Guard implements the Guard contract (parent). 

I feel the return type is too strict. I don't think the return type should be `mixed` but shouldn't it at least be Guard and not StatefulGuard. This way custom guard implementations are not breaking. 

With 11.5k ⭐ on `jwt-auth`, I'm surprised no one got this issue today.

<img width="1864" height="112" alt="image" src="https://github.com/user-attachments/assets/588d04ba-1d41-4332-b221-51381a2b7933" />
