### PR TITLE
[13.x] Remove deprecated forgetApp from HandleExceptions

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -292,18 +292,6 @@ class HandleExceptions
     }
 
     /**
-     * Clear the local application instance from memory.
-     *
-     * @return void
-     *
-     * @deprecated This method will be removed in a future Laravel version.
-     */
-    public static function forgetApp()
-    {
-        static::$app = null;
-    }
-
-    /**
      * Flush the bootstrapper's global state.
      *
      * @param  \PHPUnit\Framework\TestCase|null  $testCase

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -377,23 +377,6 @@ class HandleExceptionsTest extends TestCase
         );
     }
 
-    public function testForgetApp()
-    {
-        $instance = $this->handleExceptions();
-
-        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
-            $property = $reflection->getProperty('app');
-
-            return $property->getValue($instance);
-        });
-
-        $this->assertNotNull($appResolver());
-
-        HandleExceptions::forgetApp();
-
-        $this->assertNull($appResolver());
-    }
-
     public function testHandlerForgetsPreviousApp()
     {
         $instance = $this->handleExceptions();


### PR DESCRIPTION
Description
---
Since PR #49622, Laravel introduced `flushState()` and `flushHandlersState()` as the replacement.

Question
---
Should the `testForgetApp()` test be removed entirely, or should we rename it to `testFlushState()` and update the call from `HandleExceptions::forgetApp();` to `HandleExceptions::flushState();`?

Backward Compatibility
---
Since this (maybe) a breaking change, it is being reintroduced for the next release where breaking changes are acceptable.