### PR TITLE
Update auth function return type to accept non-stateful Guard

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -6,7 +6,7 @@ use Illuminate\Broadcasting\PendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
-use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cookie\Factory as CookieFactory;
@@ -169,9 +169,9 @@ if (! function_exists('auth')) {
      * Get the available auth instance.
      *
      * @param  string|null  $guard
-     * @return ($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)
+     * @return ($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\Guard)
      */
-    function auth($guard = null): AuthFactory|StatefulGuard
+    function auth($guard = null): AuthFactory|Guard
     {
         if (is_null($guard)) {
             return app(AuthFactory::class);

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -9,7 +9,7 @@ assertType('mixed', app('foo'));
 assertType('Illuminate\Config\Repository', app(Repository::class));
 
 assertType('Illuminate\Contracts\Auth\Factory', auth());
-assertType('Illuminate\Contracts\Auth\StatefulGuard', auth('foo'));
+assertType('Illuminate\Contracts\Auth\Guard', auth('foo'));
 
 assertType('Illuminate\Cache\CacheManager', cache());
 assertType('bool', cache(['foo' => 'bar'], 42));


### PR DESCRIPTION
After the addition of:
https://github.com/laravel/framework/commit/6d5dfad051e6b7f1c51fb113189b52be3fd36170#diff-6a2323fa8736e9d453a642748f40d503d69e17a5b9ea944a57e45b271870be75R174

Calls to the `auth()` function would fail if the requested guard is not a StatefulGuard, while it is certainly possible to want non-stateful auth. Such as `\Illuminate\Auth\TokenGuard`

After this change StatefulGuards may be returned, as well as non-stateful guards.

---

The current workaround is to implement the StatefulGuard in a custom Auth guard and throwing an exception whenever an unsupported function is called from the StatefulGuard.