### PR TITLE
Support enum in Collection -> keyBy()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -576,6 +576,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         foreach ($this->items as $key => $item) {
             $resolvedKey = $keyBy($item, $key);
 
+            if ($resolvedKey instanceof \BackedEnum) {
+                $resolvedKey = $resolvedKey->value;
+            }
+
             if (is_object($resolvedKey)) {
                 $resolvedKey = (string) $resolvedKey;
             }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -12,8 +12,6 @@ use InvalidArgumentException;
 use stdClass;
 use Traversable;
 
-use function Illuminate\Support\enum_value;
-
 /**
  * @template TKey of array-key
  *

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -12,6 +12,8 @@ use InvalidArgumentException;
 use stdClass;
 use Traversable;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @template TKey of array-key
  *
@@ -576,8 +578,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         foreach ($this->items as $key => $item) {
             $resolvedKey = $keyBy($item, $key);
 
-            if ($resolvedKey instanceof \BackedEnum) {
-                $resolvedKey = $resolvedKey->value;
+            if ($resolvedKey instanceof \UnitEnum) {
+                $resolvedKey = enum_value($resolvedKey);
             }
 
             if (is_object($resolvedKey)) {


### PR DESCRIPTION
# Support `BackedEnum` in `Collection::keyBy()`

## Description

This PR extends Laravel’s `Collection::keyBy()` method to natively support PHP `BackedEnum`.  

Currently, when passing an enum instance as the key, the resulting associative array would contain the enum object itself as the array key, which is not practical in most use cases.  

With this change, if the resolved key is an instance of `\BackedEnum`, it will automatically use its **backed value** (string or int) instead of the enum object.

---

## Motivation

- PHP 8.1 introduced Enums, and they are now widely used as identifiers in Laravel applications (e.g. status, types, categories).  
- When working with collections, developers often need to group or key collections by enum values.  
- In PHP, array keys **must be `int` or `string`**. If an object is used, PHP will silently cast it to a string such as `"Object id #123"`, which is not meaningful or stable.  
- This fix ensures that when a `BackedEnum` is used as a key, its **backed value** (`string|int`) is used instead, providing predictable and useful keys.

---

## Example Usage

```php
enum Status: string {
    case ACTIVE = 'active';
    case INACTIVE = 'inactive';
}

$items = collect([
    ['id' => 1, 'status' => Status::ACTIVE],
    ['id' => 2, 'status' => Status::INACTIVE],
]);

$result = $items->keyBy('status');

//    Error Object of class App\Framework\Models\Enums\Status could not be converted to string
```