### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -336,11 +336,7 @@ trait ReplacesAttributes
      */
     protected function replaceInArrayKeys($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -354,11 +350,7 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredArrayKeys($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -872,11 +864,7 @@ trait ReplacesAttributes
      */
     protected function replaceEndsWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -890,11 +878,7 @@ trait ReplacesAttributes
      */
     protected function replaceDoesntEndWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -908,11 +892,7 @@ trait ReplacesAttributes
      */
     protected function replaceStartsWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -926,11 +906,7 @@ trait ReplacesAttributes
      */
     protected function replaceDoesntStartWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -944,10 +920,6 @@ trait ReplacesAttributes
      */
     protected function replaceDoesntContain($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceIn($message, $attribute, $rule, $parameters);
     }
 }


### PR DESCRIPTION
Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceIn()
- replaceInArrayKeys()
- replaceRequiredArrayKeys()
- replaceEndsWith()
- replaceDoesntEndWith()
- replaceStartsWith()
- replaceDoesntStartWith()
- replaceDoesntContain()

Instead of duplicating the same code, these methods now delegate to the existing `replaceIn()` implementation.

This follows the same approach already used in `replaceNotIn()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L309-L312

This change reduces code duplication and makes the code easier to maintain.