### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -35,11 +35,7 @@ trait ReplacesAttributes
      */
     protected function replaceDeclinedIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
-
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other', ':value'], $parameters, $message);
+        return $this->replaceAcceptedIf($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -213,11 +209,7 @@ trait ReplacesAttributes
      */
     protected function replaceMissingIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
-
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other', ':value'], $parameters, $message);
+        return $this->replaceAcceptedIf($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -400,10 +392,7 @@ trait ReplacesAttributes
      */
     protected function replacePresentIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other', ':value'], $parameters, $message);
+        return $this->replaceAcceptedIf($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -604,11 +593,7 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
-
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other', ':value'], $parameters, $message);
+        return $this->replaceAcceptedIf($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -676,11 +661,7 @@ trait ReplacesAttributes
      */
     protected function replaceProhibitedIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
-
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other', ':value'], $parameters, $message);
+        return $this->replaceAcceptedIf($message, $attribute, $rule, $parameters);
     }
 
     /**


### PR DESCRIPTION
Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceAcceptedIf()
- replaceDeclinedIf()
- replaceMissingIf()
- replacePresentIf()
- replaceRequiredIf()
- replaceProhibitedIf()

Instead of duplicating the same code, these methods now delegate to the existing `replaceAcceptedIf()` implementation.

This follows the same approach already used in `replacePresentWithAll()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L449-L452

This change reduces code duplication and makes the code easier to maintain.