### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -638,9 +638,7 @@ trait ReplacesAttributes
      */
     public function replaceRequiredIfDeclined($message, $attribute, $rule, $parameters)
     {
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other'], $parameters, $message);
+        return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -694,9 +692,7 @@ trait ReplacesAttributes
      */
     protected function replaceProhibitedIfAccepted($message, $attribute, $rule, $parameters)
     {
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other'], $parameters, $message);
+        return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -710,9 +706,7 @@ trait ReplacesAttributes
      */
     public function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
     {
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
-
-        return str_replace([':other'], $parameters, $message);
+        return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }
 
     /**


### PR DESCRIPTION
Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceRequiredIfAccepted()
- replaceRequiredIfDeclined()
- replaceProhibitedIfAccepted()
- replaceProhibitedIfDeclined()

Instead of duplicating the same code, these methods now delegate to the existing `replaceRequiredIfAccepted()` implementation.

This follows the same approach already used in `replacePresentWithAll()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L449-L452

This change reduces code duplication and makes the code easier to maintain.