### PR TITLE
[12.X] Add connection information in the migration output.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -138,7 +138,10 @@ class MigrateCommand extends BaseCommand implements Isolatable
     protected function prepareDatabase()
     {
         if (! $this->repositoryExists()) {
-            $this->components->info('Preparing '.$this->migrator->resolveConnection($this->option('database'))->getDriverName().' database.');
+            $this->components->info(sprintf(
+                'Preparing %s database.',
+                $this->migrator->resolveConnection($this->option('database'))->getDriverName()
+            ));
 
             $this->components->task('Creating migration table', function () {
                 return $this->callSilent('migrate:install', array_filter([

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -138,7 +138,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
     protected function prepareDatabase()
     {
         if (! $this->repositoryExists()) {
-            $this->components->info('Preparing database.');
+            $this->components->info('Preparing '.$this->migrator->resolveConnection($this->option('database'))->getDriverName().' database.');
 
             $this->components->task('Creating migration table', function () {
                 return $this->callSilent('migrate:install', array_filter([

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Dba\Connection;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
@@ -69,12 +70,15 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
         $params = [$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)];
+        $connectionMock = m::mock(Connection::class);
+        $connectionMock->shouldReceive('getDriverName')->andReturn('mysql');
         $command = $this->getMockBuilder(MigrateCommand::class)->onlyMethods(['callSilent'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('resolveConnection')->andReturn($connectionMock);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Console\CommandMutex;
-use Illuminate\Database\Connection;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use Dba\Connection;
 use Illuminate\Console\CommandMutex;
+use Illuminate\Database\Connection;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Events\SchemaLoaded;


### PR DESCRIPTION
Output before:

``` bash
   INFO  Preparing database.  

  Creating migration table ....................................... 5.60ms DONE 
```

After this pr:

``` bash
   INFO  Preparing sqlite database.

  Creating migration table ....................................... 5.60ms DONE 
```

Reason:
Lost some time because my migrations were successfull on Cloud, but no data was in my remote database.
Because they ran on a `sqlite` db. Because the default value for `DB_CONNECTION` is set to that.

My first PR, please let me know if things should be done differently.