### PR TITLE
[12.x] Adding indefinite article string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -97,95 +97,95 @@ class Str
 
         // Any number starting with an '8' uses 'an'
         if (preg_match("/^[8](\d+)?/", $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         // Numbers starting with a '1' are trickier, only use 'an' if there are
         // 3, 6, 9, … digits after the 11 or 18
         if (preg_match("/^[1][1](\d+)?/", $string) || (preg_match("/^[1][8](\d+)?/", $string))) {
             if (strlen(preg_replace(["/\s/", '/,/', "/\.(\d+)?/"], '', $string)) % 3 == 2) {
-                return $an;
+                return $an.' '.$string;
             }
         }
 
         // Ordinal forms
         if (preg_match('/^([bcdgjkpqtuvwyz]-?th)/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         if (preg_match('/^([aefhilmnorsx]-?th)/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         // Special cases
         if (preg_match('/^(euler|hour(?!i)|heir|honest|hono)/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         if (preg_match('/^[aefhilmnorsx]$/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         if (preg_match('/^[bcdgjkpqtuvwyz]$/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         // Abbreviations
         if (preg_match('/^((?! FJO | [HLMNS]Y.  | RY[EO] | SQU | ( F[LR]? | [HL] | MN? | N | RH? | S[CHKLMNPTVW]? | X(YL)?) [AEIOU]) [FHLMNRSX][A-Z])/x', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         if (preg_match('/^[aefhilmnorsx][.-]/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         if (preg_match('/^[a-z][.-]/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         // Consonants
         if (preg_match('/^[^aeiouy]/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         // Special vowel forms
         if (preg_match('/^e[uw]/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         if (preg_match("/^onc?e\b/i", $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         if (preg_match('/^uni([^nmd]|mo)/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         if (preg_match('/^ut[th]/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         if (preg_match('/^u[bcfhjkqrst][aeiou]/i', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         // Special capitals
         if (preg_match('/^U[NK][AIEO]?/', $string)) {
-            return $a;
+            return $a.' '.$string;
         }
 
         // Vowels
         if (preg_match('/^[aeiou]/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         // Before certain consonants, y implies an "i" sound
         if (preg_match('/^(y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt))/i', $string)) {
-            return $an;
+            return $an.' '.$string;
         }
 
         // Not sure, so guess 'a'
-        return $a;
+        return $a.' '.$string;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -85,6 +85,110 @@ class Str
     }
 
     /**
+     * Determine appropriate indefinite article.
+     *
+     * @param  string  $string  A word or phrase
+     * @return string
+     */
+    public static function a($string)
+    {
+        $a = 'a';
+        $an = 'an';
+
+        // Any number starting with an '8' uses 'an'
+        if (preg_match("/^[8](\d+)?/", $string)) {
+            return $an;
+        }
+
+        // Numbers starting with a '1' are trickier, only use 'an' if there are
+        // 3, 6, 9, … digits after the 11 or 18
+        if (preg_match("/^[1][1](\d+)?/", $string) || (preg_match("/^[1][8](\d+)?/", $string))) {
+            if (strlen(preg_replace(["/\s/", '/,/', "/\.(\d+)?/"], '', $string)) % 3 == 2) {
+                return $an;
+            }
+        }
+
+        // Ordinal forms
+        if (preg_match('/^([bcdgjkpqtuvwyz]-?th)/i', $string)) {
+            return $a;
+        }
+
+        if (preg_match('/^([aefhilmnorsx]-?th)/i', $string)) {
+            return $an;
+        }
+
+        // Special cases
+        if (preg_match('/^(euler|hour(?!i)|heir|honest|hono)/i', $string)) {
+            return $an;
+        }
+
+        if (preg_match('/^[aefhilmnorsx]$/i', $string)) {
+            return $an;
+        }
+
+        if (preg_match('/^[bcdgjkpqtuvwyz]$/i', $string)) {
+            return $a;
+        }
+
+        // Abbreviations
+        if (preg_match('/^((?! FJO | [HLMNS]Y.  | RY[EO] | SQU | ( F[LR]? | [HL] | MN? | N | RH? | S[CHKLMNPTVW]? | X(YL)?) [AEIOU]) [FHLMNRSX][A-Z])/x', $string)) {
+            return $an;
+        }
+
+        if (preg_match('/^[aefhilmnorsx][.-]/i', $string)) {
+            return $an;
+        }
+
+        if (preg_match('/^[a-z][.-]/i', $string)) {
+            return $a;
+        }
+
+        // Consonants
+        if (preg_match('/^[^aeiouy]/i', $string)) {
+            return $a;
+        }
+
+        // Special vowel forms
+        if (preg_match('/^e[uw]/i', $string)) {
+            return $a;
+        }
+
+        if (preg_match("/^onc?e\b/i", $string)) {
+            return $a;
+        }
+
+        if (preg_match('/^uni([^nmd]|mo)/i', $string)) {
+            return $a;
+        }
+
+        if (preg_match('/^ut[th]/i', $string)) {
+            return $an;
+        }
+
+        if (preg_match('/^u[bcfhjkqrst][aeiou]/i', $string)) {
+            return $a;
+        }
+
+        // Special capitals
+        if (preg_match('/^U[NK][AIEO]?/', $string)) {
+            return $a;
+        }
+
+        // Vowels
+        if (preg_match('/^[aeiou]/i', $string)) {
+            return $an;
+        }
+
+        // Before certain consonants, y implies an "i" sound
+        if (preg_match('/^(y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt))/i', $string)) {
+            return $an;
+        }
+
+        // Not sure, so guess 'a'
+        return $a;
+    }
+
+    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $subject

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -46,7 +46,7 @@ class SupportStrTest extends TestCase
         foreach ($assertions as $assertion) {
             foreach ($assertion as $case => $expected) {
                 // ensure that the expected prefix is added to the original case
-                $this->assertEquals($expected, Str::a($case));
+                $this->assertEquals($expected.' '.$case, Str::a($case));
             }
         }
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -12,6 +12,46 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
+
+    public function testStringIndefiniteArticles() {
+        $assertions = [];
+
+        // Numbers
+        $assertions[] = [0 => 'a', 1 => 'a', 8 => 'an', 88 => 'an', 800 => 'an', 11 => 'an', 100 => 'a', 18 => 'an', 28 => 'a', 110 => 'a', 111 => 'a', 1111 => 'a', 1100 => 'a', 18000 => 'an', 11000000 => 'an', '-1' => 'a', '-18' => 'a'];
+
+        // Ordinal forms
+        $assertions[] = ['eleventh' => 'an', 'eighth' => 'an', 'ninth' => 'a', 'one hundredth' => 'a', 'eighteenth' => 'an', 'millionth' => 'a', 'elevenhundredth' => 'an', 'hundredth' => 'a'];
+
+        // Special cases
+        $assertions[] = ['euler number' => 'an', 's' => 'an', 'x' => 'an', 'hour' => 'an', 'heir' => 'an', 'honest' => 'an', 'honorary' => 'an', 'b' => 'a', 'z' => 'a'];
+
+        // Abbreviations
+        $assertions[] = ['mr.' => 'a', 'mrs.' => 'a', 'dr.' => 'a', 'st.' => 'a', 'x-ray' => 'an'];
+
+        // Consonants
+        $assertions[] = ['dog' => 'a', 'horse' => 'a', 'zealot' => 'a', 'doctor' => 'a', 'dancer' => 'a', 'car' => 'a', 'laser' => 'a', 'beer' => 'a'];
+
+        // Special vowel forms
+        $assertions[] = ['european' => 'a', 'once' => 'a', 'one' => 'a', 'university' => 'a', 'universal' => 'a', 'utter' => 'an', 'useful' => 'a'];
+
+        // Special capitals
+        $assertions[] = ['Ukranian' => 'an', 'Uzbekistani' => 'an', 'UNO' => 'a', 'American' => 'an'];
+
+        // Vowels
+        $assertions[] = ['apple' => 'an', 'elephant' => 'an', 'ugly duck' => 'an', 'unit' => 'a', 'itchy sweater' => 'an', 'engineer' => 'an', 'orange' => 'an'];
+
+        // Y
+        $assertions[] = ['year' => 'a', 'yellow' => 'a', 'yclad' => 'an'];
+
+        foreach ($assertions as $assertion) {
+            foreach ($assertion as $case => $expected) {
+                // ensure that the expected prefix is added to the original case
+                $this->assertEquals($expected, Str::a($case));
+            }
+        }
+    }
+
+
     public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));


### PR DESCRIPTION
This PR adds a new helper method `a` which can be used to determine the correct indefinite article to use for any particular input string.

This code is largely based on https://github.com/zachflower/php-indefinite-article but it seemed better to lift the relevant bits of code rather than add another dependency. The project license seems compatible but let me know if you think otherwise.

Since this is an English specific language structure I have not added any translation support here.

# Usage

```php
Str::a('elephant'); // an elephant
Str::a('hour');     // an hour
Str::a('project');  // a project
Str::a('asset');    // an asset
Str::a('commit');   // a commit
```

