### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -531,11 +531,7 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
-        }
-
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return $this->replaceGt($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -549,11 +545,7 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
-        }
-
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return $this->replaceGt($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -567,11 +559,7 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
-        }
-
-        return str_replace(':value', $this->getSize($attribute, $value), $message);
+        return $this->replaceGt($message, $attribute, $rule, $parameters);
     }
 
     /**


### PR DESCRIPTION
Continuation of: #56792

---

Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceGt()
- replaceLt()
- replaceGte()
- replaceLte()

Instead of duplicating the same code, these methods now delegate to the existing `replaceGt()` implementation.

This follows the same approach already used in `replaceNotIn()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L309-L312

This change reduces code duplication and makes the code easier to maintain.