### PR TITLE
[12.x] Add defer method to PendingDispatch

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -88,6 +88,14 @@ trait Dispatchable
     }
 
     /**
+     * Defer dispatching a command to its appropriate handler.
+     */
+    public static function dispatchDefer(...$arguments)
+    {
+        return self::dispatch(...$arguments)->defer();
+    }
+
+    /**
      * Set the jobs that should run if this job is successful.
      *
      * @param  array  $chain

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -28,7 +28,7 @@ class PendingDispatch
     protected $afterResponse = false;
 
     /**
-     * Indicates if the job should be dispatched to the queue after the current request.
+     * Indicates if the job dispatch should be deferred.
      *
      * @var bool
      */
@@ -171,7 +171,7 @@ class PendingDispatch
     }
 
     /**
-     * Indicate that the job should be dispatched to the queue after the current request.
+     * Indicate that the job dispatch should be deferred.
      *
      * @return $this
      */

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -32,7 +32,7 @@ class PendingDispatch
      *
      * @var bool
      */
-    protected $defer = true;
+    protected $defer = false;
 
     /**
      * Create a new pending job dispatch.

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -28,6 +28,13 @@ class PendingDispatch
     protected $afterResponse = false;
 
     /**
+     * Indicates if the job should be dispatched to the queue after the current request.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
      * Create a new pending job dispatch.
      *
      * @param  mixed  $job
@@ -164,6 +171,18 @@ class PendingDispatch
     }
 
     /**
+     * Indicate that the job should be dispatched to the queue after the current request.
+     *
+     * @return $this
+     */
+    public function defer(): static
+    {
+        $this->defer = true;
+
+        return $this;
+    }
+
+    /**
      * Determine if the job should be dispatched.
      *
      * @return bool
@@ -217,6 +236,8 @@ class PendingDispatch
             return;
         } elseif ($this->afterResponse) {
             app(Dispatcher::class)->dispatchAfterResponse($this->job);
+        } elseif ($this->defer) {
+            defer(fn () => app(Dispatcher::class)->dispatch($this->job));
         } else {
             app(Dispatcher::class)->dispatch($this->job);
         }

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -103,6 +103,14 @@ class BusPendingDispatchTest extends TestCase
         );
     }
 
+    public function testDefer()
+    {
+        $this->pendingDispatch->defer();
+        $this->assertTrue(
+            (new ReflectionClass($this->pendingDispatch))->getProperty('defer')->getValue($this->pendingDispatch)
+        );
+    }
+
     public function testGetJob()
     {
         $this->assertSame($this->job, $this->pendingDispatch->getJob());

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -137,6 +138,17 @@ class JobDispatchingTest extends QueueTestCase
         UniqueJob::dispatchAfterResponse('test');
         $this->app->terminate();
         $this->assertFalse(UniqueJob::$ran);
+    }
+
+    public function testDispatchDeferDelaysDispatchingUntilDeferredCallbacksAreRun()
+    {
+        $this->assertFalse(Job::$ran);
+
+        Job::dispatchDefer('test');
+
+        $this->assertFalse(Job::$ran);
+        $this->app[DeferredCallbackCollection::class]->invoke();
+        $this->assertTrue(Job::$ran);
     }
 
     public function testQueueMayBeNullForJobQueueingAndJobQueuedEvent()

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -142,12 +142,14 @@ class JobDispatchingTest extends QueueTestCase
 
     public function testDispatchDeferDelaysDispatchingUntilDeferredCallbacksAreRun()
     {
-        $this->assertFalse(Job::$ran);
-
         Job::dispatchDefer('test');
 
         $this->assertFalse(Job::$ran);
-        $this->app[DeferredCallbackCollection::class]->invoke();
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+        $this->assertFalse(Job::$ran);
+
+        $this->app->get(DeferredCallbackCollection::class)->invoke();
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
         $this->assertTrue(Job::$ran);
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -144,12 +144,14 @@ class JobDispatchingTest extends QueueTestCase
     {
         Job::dispatchDefer('test');
 
+        $this->assertSame(1, $this->app[DeferredCallbackCollection::class]->count());
         $this->assertFalse(Job::$ran);
+
         $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
         $this->assertFalse(Job::$ran);
 
-        $this->app->get(DeferredCallbackCollection::class)->invoke();
-        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+        $this->app[DeferredCallbackCollection::class]->invoke();
+        $this->runQueueWorkerCommand(['--once' => true]);
         $this->assertTrue(Job::$ran);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for dispatching a job like:

```php
dispatch(new MyJob())->defer();
```

Which wouldn't put the job on the queue until after the request, command or job is finished.
Under the hood, Laravel's `defer()` function is used. We've had a `dispatch_defer` method in our codebase for a while now, and I think other people could benefit from this.

I've also written some tests for the dispatch logic.