### PR TITLE
[12.x] Parse Redis "friendly" algorithm names into integers

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -260,7 +260,7 @@ class PhpRedisConnector implements Connector
             'constant' => Redis::BACKOFF_ALGORITHM_CONSTANT,
         ];
 
-        if (is_int($algorithm) && in_array($algorithm, $algorithms)) {
+        if (is_int($algorithm)) {
             return $algorithm;
         }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -248,26 +248,23 @@ class PhpRedisConnector implements Connector
      *
      * @param  mixed  $algorithm
      * @return int
+     *
+     * @throws \InvalidArgumentException
      */
     protected function parseBackoffAlgorithm(mixed $algorithm)
     {
-        $algorithms = [
+        if (is_int($algorithm)) {
+            return $algorithm;
+        }
+
+        return match ($algorithm) {
             'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
             'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
             'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
             'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
             'uniform' => Redis::BACKOFF_ALGORITHM_UNIFORM,
             'constant' => Redis::BACKOFF_ALGORITHM_CONSTANT,
-        ];
-
-        if (is_int($algorithm)) {
-            return $algorithm;
-        }
-
-        if (array_key_exists($algorithm, $algorithms)) {
-            return $algorithms[$algorithm];
-        }
-
-        throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid PhpRedis backoff algorithm.");
+            default => throw new InvalidArgumentException("Algorithm [{$algorithm}] is not a valid PhpRedis backoff algorithm.")
+        };
     }
 }

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -136,13 +136,13 @@ class RedisCacheIntegrationTest extends TestCase
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);
 
-        new RedisManager($this->app ?? new Application(), 'phpredis', [
+        (new RedisManager($this->app ?? new Application(), 'phpredis', [
             'default' => [
                 'host' => $host,
                 'port' => $port,
                 'backoff_algorithm' => 'foo',
             ],
-        ])->connection();
+        ]))->connection();
     }
 
     public static function phpRedisBackoffAlgorithmsProvider()

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -128,6 +128,25 @@ class RedisCacheIntegrationTest extends TestCase
         );
     }
 
+    public function testAnInvalidPhpRedisBackoffAlgorithmIsConvertedToDefault()
+    {
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
+
+        $manager = new RedisManager(new Application(), 'phpredis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'backoff_algorithm' => 7,
+            ],
+        ]);
+
+        $this->assertEquals(
+            Redis::BACKOFF_ALGORITHM_DEFAULT,
+            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
+        );
+    }
+
     public function testItFailsWithAnInvalidPhpRedisAlgorithm()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -94,7 +94,7 @@ class RedisCacheIntegrationTest extends TestCase
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);
 
-        $manager = new RedisManager($this->app ?? new Application(), 'phpredis', [
+        $manager = new RedisManager(new Application(), 'phpredis', [
             'default' => [
                 'host' => $host,
                 'port' => $port,
@@ -114,7 +114,7 @@ class RedisCacheIntegrationTest extends TestCase
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);
 
-        $manager = new RedisManager($this->app ?? new Application(), 'phpredis', [
+        $manager = new RedisManager(new Application(), 'phpredis', [
             'default' => [
                 'host' => $host,
                 'port' => $port,
@@ -136,7 +136,7 @@ class RedisCacheIntegrationTest extends TestCase
         $host = Env::get('REDIS_HOST', '127.0.0.1');
         $port = Env::get('REDIS_PORT', 6379);
 
-        (new RedisManager($this->app ?? new Application(), 'phpredis', [
+        (new RedisManager(new Application(), 'phpredis', [
             'default' => [
                 'host' => $host,
                 'port' => $port,


### PR DESCRIPTION
`PhpRedis` expects integers (backed by constants) for its options — if we can parse strings into the proper ints, we can avoid the `match` here: https://github.com/laravel/laravel/pull/6666