### PR TITLE
[12.x] Add prepend option for Str::plural()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -988,7 +988,7 @@ class Str
      */
     public static function plural($value, $count = 2, $prepend = false)
     {
-        return ($prepend ? number_format($count) . ' ' : '') . Pluralizer::plural($value, $count);
+        return ($prepend ? number_format($count).' ' : '').Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -988,7 +988,7 @@ class Str
      */
     public static function plural($value, $count = 2, $prepend = false)
     {
-        return ($prepend ? number_format($count).' ' : '').Pluralizer::plural($value, $count);
+        return ($prepend ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -983,11 +983,12 @@ class Str
      *
      * @param  string  $value
      * @param  int|array|\Countable  $count
+     * @param  bool  $prepend
      * @return string
      */
-    public static function plural($value, $count = 2)
+    public static function plural($value, $count = 2, $prepend = false)
     {
-        return Pluralizer::plural($value, $count);
+        return ($prepend ? number_format($count) . ' ' : '') . Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -983,12 +983,12 @@ class Str
      *
      * @param  string  $value
      * @param  int|array|\Countable  $count
-     * @param  bool  $prepend
+     * @param  bool  $prependCount
      * @return string
      */
-    public static function plural($value, $count = 2, $prepend = false)
+    public static function plural($value, $count = 2, $prependCount = false)
     {
-        return ($prepend ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
+        return ($prependCount ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -629,11 +629,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Get the plural form of an English word.
      *
      * @param  int|array|\Countable  $count
+     * @param  bool  $prependCount
      * @return static
      */
-    public function plural($count = 2)
+    public function plural($count = 2, $prependCount = false)
     {
-        return new static(Str::plural($this->value, $count));
+        return new static(Str::plural($this->value, $count, $prependCount));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1860,6 +1860,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo baZ baz bar', $result);
     }
 
+    public function testPlural(): void
+    {
+        $this->assertSame('Laracon', Str::plural('Laracon', 1));
+        $this->assertSame('Laracons', Str::plural('Laracon', 3));
+        $this->assertSame('1,000 Laracons', Str::plural('Laracon', 1000, prepend: true));
+    }
+
     public function testPluralPascal(): void
     {
         // Test basic functionality with default count

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1864,7 +1864,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('Laracon', Str::plural('Laracon', 1));
         $this->assertSame('Laracons', Str::plural('Laracon', 3));
-        $this->assertSame('1,000 Laracons', Str::plural('Laracon', 1000, prepend: true));
+        $this->assertSame('1,000 Laracons', Str::plural('Laracon', 1000, prependCount: true));
     }
 
     public function testPluralPascal(): void


### PR DESCRIPTION
When we reach for the `Str::plural()` helper, we frequently want to prepend the pluralized string with the `$count` itself. That typically looks something like this:

```blade
We had {{ number_format($attendees->count()) . ' ' . Str::plural('attendee', $attendees->count()) }} at Laracon 2025.
```

This PR cleans up the repetition a bit, by adding an optional `prependCount` parameter to the `Str::plural()` method. Here's what the above looks like, when using that option:

```blade
We had {{ Str::plural('attendee', $attendees->count(), prependCount: true) }} at Laracon 2025.
```

The parameter defaults to `false`, so a non-breaking change. Tests included, and added a couple of extras that I think are mostly covered by the Pluralizer...but thought it might be helpful to ensure we don't get any unexpected `$count` prepending when this new param is _not_ in use, since the Pluralizer isn't aware of that piece. Let me know if there's anything I can change or help with, here! Happy to update docs as well, if this gets merged.

_Edit: updated to reflect Taylor's formatting changes on parameter name_