### PR TITLE
fix: Helper function secure_url not always returning a string

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -893,7 +893,7 @@ if (! function_exists('secure_url')) {
      */
     function secure_url($path, $parameters = []): string
     {
-        return url($path, $parameters, true);
+        return url()->secure($path, $parameters);
     }
 }
 

--- a/tests/Illuminate/Tests/Foundation/HelpersTest.php
+++ b/tests/Illuminate/Tests/Foundation/HelpersTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Illuminate\Tests\Foundation;
 
 use Orchestra\Testbench\TestCase;

--- a/tests/Illuminate/Tests/Foundation/HelpersTest.php
+++ b/tests/Illuminate/Tests/Foundation/HelpersTest.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Illuminate\Tests\Foundation;
+
+use Orchestra\Testbench\TestCase;
+
+class HelpersTest extends TestCase
+{
+    public function test_secure_url_can_return_string(): void
+    {
+        $this->assertIsString(secure_url('/'));
+        $this->assertIsString(secure_url(null));
+    }
+}


### PR DESCRIPTION
Resolves issue https://github.com/laravel/framework/issues/56806

Also added a test for both scenarios. Rollback my change on 896 and watch it fail.

Main issue is we allow anything in the path, yet declare a return type of string despite if a null path is passed in, a URLGenerator is returned.

This ensures that a string is always returned.

This does have the implication PRE https://github.com/laravel/framework/pull/56684 whereby users might have been handling a URLGenerator being returned before a string was declared as the return type. Although I expect most users will have been handling strings anyway and if a URL generator was returned doing what I'm doing!

Plus the secure method feels better to utilize here?

cheers