### PR TITLE
Fix RequestGuard::setRequest() to reset $this->user

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -80,6 +80,8 @@ class RequestGuard implements Guard
     public function setRequest(Request $request)
     {
         $this->request = $request;
+        // Reset the cached user since it might depend on the current request.
+        $this->user = null;
 
         return $this;
     }


### PR DESCRIPTION
Fixes #56809.

This same fix can also be applied/cherry-picked to any other versions, supported or not. The bug is present in all of them, as far as I can see.