### PR TITLE
[12.x] Use FQCN for @mixin annotation for consistency

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -3,13 +3,12 @@
 namespace Illuminate\Database\Concerns;
 
 use Closure;
-use Illuminate\Database\Connection;
 use Illuminate\Database\DeadlockException;
 use RuntimeException;
 use Throwable;
 
 /**
- * @mixin Connection
+ * @mixin \Illuminate\Database\Connection
  */
 trait ManagesTransactions
 {


### PR DESCRIPTION
Description
---
This PR updates the @mixin annotation introduced in #56681 to use the **Fully Qualified Class Name** for consistency with how @mixin annotation is used throughout the framework.

See
---
https://github.com/laravel/framework/blob/262168af41da0049b52ec9e302a8fa78a9980a34/src/Illuminate/Process/Pool.php#L8-L11

https://github.com/laravel/framework/blob/262168af41da0049b52ec9e302a8fa78a9980a34/src/Illuminate/Queue/Capsule/Manager.php#L10-L13

https://github.com/laravel/framework/blob/262168af41da0049b52ec9e302a8fa78a9980a34/src/Illuminate/Mail/TextMessage.php#L7-L9