### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -678,15 +678,7 @@ trait ReplacesAttributes
      */
     protected function replaceProhibitedUnless($message, $attribute, $rule, $parameters)
     {
-        $other = $this->getDisplayableAttribute($parameters[0]);
-
-        $values = [];
-
-        foreach (array_slice($parameters, 1) as $value) {
-            $values[] = $this->getDisplayableValue($parameters[0], $value);
-        }
-
-        return str_replace([':other', ':values'], [$other, implode(', ', $values)], $message);
+        return $this->replaceRequiredUnless($message, $attribute, $rule, $parameters);
     }
 
     /**


### PR DESCRIPTION
Continuation of: #56795

---

Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceRequiredUnless()
- replaceProhibitedUnless()

Instead of duplicating the same code, these methods now delegate to the existing `replaceRequiredUnless()` implementation.

This follows the same approach already used in `replaceNotIn()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L309-L312

This change reduces code duplication and makes the code easier to maintain.