### PR TITLE
[12.x] Remove @return tags from constructors

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -34,7 +34,6 @@ class HasInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array<string, mixed>  $data
-     * @return void
      */
     public function __construct(Connection $database, array $data)
     {


### PR DESCRIPTION
Description
---
PR #55076 removes `@return` tags from constructors, but this one was newly introduced in #56703.