### PR TITLE
[12.x] Partially reverts 56703

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -256,10 +256,6 @@ class Arr
                 return value($default);
             }
 
-            if (is_array($array)) {
-                return array_first($array);
-            }
-
             foreach ($array as $item) {
                 return $item;
             }


### PR DESCRIPTION
Description
---
The `is_array` check (newly introduced in #56703) is redundant since the existing `foreach` already works with both `arrays` and other `iterables`. So, we don’t need the special case.