### PR TITLE
[12.x] Remove leftover `method_exists` checks

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -132,17 +132,11 @@ class AuthManager implements FactoryContract
         // When using the remember me functionality of the authentication services we
         // will need to be set the encryption instance of the guard, which allows
         // secure, encrypted cookie values to get generated for those cookies.
-        if (method_exists($guard, 'setCookieJar')) {
-            $guard->setCookieJar($this->app['cookie']);
-        }
+        $guard->setCookieJar($this->app['cookie']);
 
-        if (method_exists($guard, 'setDispatcher')) {
-            $guard->setDispatcher($this->app['events']);
-        }
+        $guard->setDispatcher($this->app['events']);
 
-        if (method_exists($guard, 'setRequest')) {
-            $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
-        }
+        $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
 
         if (isset($config['remember'])) {
             $guard->setRememberDuration($config['remember']);


### PR DESCRIPTION
Once upon a time, in the distant land of Laravel 5.1, the `Illuminate\Auth\AuthManager` class still extended the `Illuminate\Support\Manager` class and had a common entry point to create drivers:

https://github.com/laravel/framework/blob/7b586da6619b043fa79b6711c08a1c17cdca5a76/src/Illuminate/Auth/AuthManager.php#L16-L36

As a generic entry point for an arbitrary `Guard`, the `method_exists` checks were necessary to properly configure a guard instance.

Many refactorings came, and the `Illuminate\Auth\AuthManager` evolved to a thing of its own, but the `method_exists` checks remained as a leftover from that distant past and ended up on a different method `createSessionDriver()` that does not create a generic instance anymore.

As we now create a concrete class, we know by fact which methods it has and don't need to check for their existence anymore.

**This PR:**

- Removes unnecessary `method_exists()` checks from the `Illuminate\Auth\AuthManager@createSessionDriver()` method
