### PR TITLE
actions checkout disable persist-credentials

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -72,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Hello, 
the goal of this PR is to disable persisting credentials on the checkout actions
﻿

cf : https://docs.zizmor.sh/audits/#artipacked

If you are open to it , im willing to update all the actions to explicitly disable or allow those credentials