### PR TITLE
[12.x] Add `Request::find()` and `Request::findOrFail()` helpers

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -372,6 +372,36 @@ trait InteractsWithData
     }
 
     /**
+     * Retrieve data from the instance as a model.
+     * 
+     * @template T of \Illuminate\Database\Eloquent\Model
+     * @param  string  $key
+     * @param  class-string<T>  $modelClass
+     * @return T|\Illuminate\Database\Eloquent\Collection<int, T>|null
+     */
+    public function find($key, $modelClass)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        return $modelClass::find($this->data($key));
+    }
+
+    /**
+     * Retrieve data from the instance as a model or fail.
+     * 
+     * @template T of \Illuminate\Database\Eloquent\Model
+     * @param  string  $key
+     * @param  class-string<T>  $modelClass
+     * @return T|\Illuminate\Database\Eloquent\Collection<int, T>
+     */
+    public function findOrFail($key, $modelClass)
+    {
+        return $modelClass::findOrFail($this->data($key));
+    }
+
+    /**
      * Retrieve data from the instance as a collection.
      *
      * @param  array|string|null  $key


### PR DESCRIPTION
The `Request` class now has a bunch of helpers for retrieving data in specific formats (`string`, `int`, `enum`, etc).

Something that still feels a bit "icky" is finding models using request data. The current syntax looks something like this:

```php
Organization::find($request->input('organization_id'))
Organization::findOrFail($request->input('organization_id'))
```

This PR adds two new helper methods: `find()` and `findOrFail()`.

These just defer to the provided model class.

```php
$request->find('organization_id', Organization::class);
$request->findOrFail('organization_id', Organization::class);
```

The methods are also templated so static analyzers will understand that they either return an instance of the specified model or a collection of those models.


