### PR TITLE
github action make checkout option persist-credentials explicit

### DIFF
--- a/.github/workflows/databases-nightly.yml
+++ b/.github/workflows/databases-nightly.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -72,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -123,6 +127,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -170,6 +176,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -219,6 +227,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -266,6 +276,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -314,6 +326,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -353,6 +367,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -102,6 +106,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -140,6 +146,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -192,6 +200,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Download & Extract beanstalkd
         run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -133,7 +135,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -133,6 +135,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: "false"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -135,8 +133,7 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: "false"
+
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-
+        with:
+          persist-credentials: "false"
+          
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: "false"
-          
+
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
Hello,

The goal of this PR is to make the use of the `persist-credentials` option in the `actions/checkout` action explicit.

By default, `actions/checkout` persists a credential in the checked-out repo’s `.git/config`, allowing subsequent Git operations to be authenticated.
However, this behavior can be problematic:

* Subsequent steps may unintentionally expose `.git/config` publicly, e.g. by uploading it as part of an artifact via `actions/upload-artifact`.
* Even without that risk, persisting credentials in `.git/config` is not ideal unless explicitly required.

Unless Git operations are needed in later steps, `actions/checkout` should be used with:

```yaml
steps:
  - uses: actions/checkout@v4
    with:
      persist-credentials: false
```

### Impact

This change only affects the CI/CD workflows and has no impact on end users.

### Testing

To validate this change, the CI pipeline must pass across all impacted workflows.
If preferred, I can split this into multiple PRs for easier review and merging.

I can also begin applying this change to other Laravel repositories before proposing it directly to the framework.

Best,
