### PR TITLE
[12.x] Fix multi-line embedded image replacement in mail views

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -267,7 +267,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function replaceEmbeddedAttachments(string $renderedView, array $attachments)
     {
-        if (preg_match_all('/<img\b[^>]*src=[\'"]cid:([^\'"]+)[\'"][^>]*>/is', $renderedView, $matches)) {
+        if (preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/is', $renderedView, $matches)) {
             foreach (array_unique($matches[1]) as $image) {
                 foreach ($attachments as $attachment) {
                     if ($attachment->getFilename() === $image) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -267,7 +267,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function replaceEmbeddedAttachments(string $renderedView, array $attachments)
     {
-        if (preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/i', $renderedView, $matches)) {
+        if (preg_match_all('/<img\b[^>]*src=[\'"]cid:([^\'"]+)[\'"][^>]*>/is', $renderedView, $matches)) {
             foreach (array_unique($matches[1]) as $image) {
                 foreach ($attachments as $attachment) {
                     if ($attachment->getFilename() === $image) {

--- a/tests/Integration/Mail/Fixtures/embed-multiline.blade.php
+++ b/tests/Integration/Mail/Fixtures/embed-multiline.blade.php
@@ -1,0 +1,4 @@
+Embed multiline content: <img
+    src="{{ $message->embedData('foo', 'foo.jpg', 'image/png') }}"
+    alt="multiline image"
+>

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -79,6 +79,18 @@ class SendingMarkdownMailTest extends TestCase
         EOT, $email);
     }
 
+    public function testEmbedMultilineImage()
+    {
+        Mail::to('test@mail.com')->send($mailable = new EmbedMultilineMailable());
+
+        $html = html_entity_decode($mailable->render());
+
+        $this->assertStringContainsString('Embed multiline content: <img', $html);
+        $this->assertStringContainsString('alt="multiline image"', $html);
+        $this->assertStringContainsString('data:image/png;base64', $html);
+        $this->assertStringNotContainsString('cid:foo.jpg', $html);
+    }
+
     public function testMessageAsPublicPropertyMayBeDefinedAsViewData()
     {
         Mail::to('test@mail.com')->send($mailable = new MessageAsPublicPropertyMailable());
@@ -186,6 +198,23 @@ class EmbedMailable extends Mailable
     {
         return new Content(
             markdown: 'embed',
+        );
+    }
+}
+
+class EmbedMultilineMailable extends Mailable
+{
+    public function envelope()
+    {
+        return new Envelope(
+            subject: 'My basic title',
+        );
+    }
+
+    public function content()
+    {
+        return new Content(
+            markdown: 'embed-multiline',
         );
     }
 }


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/56808

### Problem:
This PR resolves an issue where embedded images in email views with multi-line **\<img\>** tags were not correctly replaced with inline data URIs.

### Fix:
- The fix updates the **replaceEmbeddedAttachments** logic to handle multi-line tags, ensuring images are properly rendered in the final HTML.
- Added a new test case was added to verify that multi-line embedded images are correctly processed and replaced with **data:image/png;base64,...** URIs, and that no **cid:** references remain in the output.

### Impact:
- No breaking changes.
- Regex is now safer and more robust for multi-line tags.