### PR TITLE
[12.x] Support enum values in `Collection` `countBy` method

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -319,7 +319,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Count the number of items in the collection by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|string|null  $countBy
+     * @param  (callable(TValue, TKey): array-key|\UnitEnum)|string|null  $countBy
      * @return static<array-key, int>
      */
     public function countBy($countBy = null)
@@ -332,7 +332,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $counts = [];
 
             foreach ($this as $key => $value) {
-                $group = $countBy($value, $key);
+                $group = enum_value($countBy($value, $key));
 
                 if (empty($counts[$group])) {
                     $counts[$group] = 0;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -805,6 +805,9 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([1, 5, 1, 5, 5, 1]);
         $this->assertEquals([1 => 3, 5 => 3], $c->countBy()->all());
+
+        $c = new $collection([StaffEnum::James, StaffEnum::Joe, StaffEnum::Taylor]);
+        $this->assertEquals(['James' => 1, 'Joe' => 1, 'Taylor' => 1], $c->countBy()->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -815,6 +818,12 @@ class SupportCollectionTest extends TestCase
             ['key' => 'b'], ['key' => 'b'], ['key' => 'b'],
         ]);
         $this->assertEquals(['a' => 4, 'b' => 3], $c->countBy('key')->all());
+
+        $c = new $collection([
+            ['key' => TestBackedEnum::A],
+            ['key' => TestBackedEnum::B], ['key' => TestBackedEnum::B],
+        ]);
+        $this->assertEquals([1 => 1, 2 => 2], $c->countBy('key')->all());
     }
 
     #[DataProvider('collectionClassProvider')]
@@ -829,6 +838,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([true => 2, false => 3], $c->countBy(function ($i) {
             return $i % 2 === 0;
         })->all());
+
+        $c = new $collection(['A', 'A', 'B', 'A']);
+        $this->assertEquals(['A' => 3, 'B' => 1], $c->countBy(static fn ($i) => TestStringBackedEnum::from($i))->all());
     }
 
     public function testAdd()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to allow usage of enums in the `countBy` method on `Collection` classes, by appropriately converting them to strings or ints which can be used as array keys. It also adds some corresponding tests for different method usecases and different enum types.