### PR TITLE
[13.x] Generate plural morph pivot table name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Support\Str;
 
 trait AsPivot
@@ -166,13 +167,13 @@ trait AsPivot
      */
     public function getTable()
     {
-        if (! isset($this->table)) {
+        if (! isset($this->table) && (! $this instanceof MorphPivot)) {
             $this->setTable(str_replace(
                 '\\', '', Str::snake(Str::singular(class_basename($this)))
             ));
         }
 
-        return $this->table;
+        return parent::getTable();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2834,8 +2834,12 @@ class EloquentTestPost extends Eloquent
 
     public function tags()
     {
-        return $this->morphToMany(EloquentTestTag::class, 'taggable', null, null, 'tag_id')->withPivot('taxonomy');
+        return $this->morphToMany(EloquentTestTag::class, 'taggable', Taggable::class, null, 'tag_id')->withPivot('taxonomy');
     }
+}
+
+class Taggable extends MorphPivot
+{
 }
 
 class EloquentTestTag extends Eloquent


### PR DESCRIPTION
This is another attempt to fix #43800. In [the documentation](https://laravel.com/docs/12.x/eloquent-relationships#many-to-many-polymorphic-relations), polymorphic relationships use pivot tables with plural names. However, the `Pivot` model class does not take that into account when automatically generating the table name since standard (non-polymorphic) pivot tables use singular names and the `MorphPivot` class extends from it.

The tests never properly covered this case since all usages of the `MorphPivot` class set the table name explicitly since it does not match the class names.

This is a breaking change because existing code could be depending on the morph pivot table name being singular in order to work around the bug.