### PR TITLE
[12.x] Add `Arr::blank` and `Arr::filled`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -463,6 +463,28 @@ class Arr
     }
 
     /**
+     * Determine if the values in the array are "filled".
+     */
+    public static function filled($value)
+    {
+        return ! static::blank($value);
+    }
+
+    /**
+     * Determine if the values in the array are "blank".
+     */
+    public static function blank($value)
+    {
+        foreach (static::wrap($value) as $item) {
+            if (! blank($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Check if an item or items exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -463,7 +463,10 @@ class Arr
     }
 
     /**
-     * Determine if the values in the array are "filled".
+     * Determine if any of the array values are "filled".
+     *
+     * @param  array  $array
+     * @return bool
      */
     public static function filled($value)
     {
@@ -471,7 +474,10 @@ class Arr
     }
 
     /**
-     * Determine if the values in the array are "blank".
+     * Determine if all the array values are "blank".
+     *
+     * @param  array  $array
+     * @return bool
      */
     public static function blank($value)
     {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -664,6 +664,38 @@ class SupportArrTest extends TestCase
         Arr::array($test_array, 'string');
     }
 
+    public function testBlank()
+    {
+        $this->assertTrue(Arr::blank(null));
+        $this->assertTrue(Arr::blank([null, '']));
+        $this->assertTrue(Arr::blank([]));
+        $this->assertTrue(Arr::blank([[]]));
+        $this->assertTrue(Arr::blank(['foo' => null]));
+        $this->assertTrue(Arr::blank(''));
+        $this->assertTrue(Arr::blank('  '));
+
+        $this->assertFalse(Arr::blank('foo'));
+        $this->assertFalse(Arr::blank(['foo', null]));
+        $this->assertFalse(Arr::blank(['foo' => 'bar']));
+        $this->assertFalse(Arr::blank(['foo' => 'bar', 'baz' => null]));
+    }
+
+    public function testFilled()
+    {
+        $this->assertTrue(Arr::filled('foo'));
+        $this->assertTrue(Arr::filled(['foo', null]));
+        $this->assertTrue(Arr::filled(['foo' => 'bar']));
+        $this->assertTrue(Arr::filled(['foo' => 'bar', 'baz' => null]));
+
+        $this->assertFalse(Arr::filled(null));
+        $this->assertFalse(Arr::filled([null, '']));
+        $this->assertFalse(Arr::filled([]));
+        $this->assertFalse(Arr::filled([[]]));
+        $this->assertFalse(Arr::filled(['foo' => null]));
+        $this->assertFalse(Arr::filled(''));
+        $this->assertFalse(Arr::filled('  '));
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -676,6 +676,7 @@ class SupportArrTest extends TestCase
 
         $this->assertFalse(Arr::blank('foo'));
         $this->assertFalse(Arr::blank(['foo', null]));
+        $this->assertFalse(Arr::blank([null, 'foo']));
         $this->assertFalse(Arr::blank(['foo' => 'bar']));
         $this->assertFalse(Arr::blank(['foo' => 'bar', 'baz' => null]));
     }
@@ -684,6 +685,7 @@ class SupportArrTest extends TestCase
     {
         $this->assertTrue(Arr::filled('foo'));
         $this->assertTrue(Arr::filled(['foo', null]));
+        $this->assertTrue(Arr::filled([null, 'foo']));
         $this->assertTrue(Arr::filled(['foo' => 'bar']));
         $this->assertTrue(Arr::filled(['foo' => 'bar', 'baz' => null]));
 


### PR DESCRIPTION
### Description

This PR adds two utility functions to the `Arr` class -- `blank` and `filled`.

`Arr::blank` allows you to determine whether _all the values_ in an array are blank.

`Arr::filled` allows you to determine whether _at least one value_ in the array is _not_ blank.

### Usage

```php
$data = [
    'name' => '',
    'email' => null,
    'phone_number' => '  ',
];

if (Arr::blank($data)) {
    throw new Exception("At least one value is required.");
}
```

```php
$filters = [
    'price' => $request->input('price'),
    'location' => $request->input('location'),
    'category' => $request->input('category'),
];

if (Arr::filled($filters)) {
    $query->apply($filters);
}
```

Let me know your thoughts!