### PR TITLE
Enhance Slug Generation for camelCase and PascalCase Strings in `Str::slug`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1510,6 +1510,18 @@ class Str
     {
         $title = $language ? static::ascii($title, $language) : $title;
 
+        // Handle camel, studly, and pascal case
+        if (static::isMatch('/(?<!\s)[A-Z]/', substr($title, 1))) {
+            // Convert abbreviations to lowercase for proper snake-casing
+            $title = preg_replace_callback(
+                '/\b[A-Z]{2,}\b/u',
+                fn ($matches) => static::lower($matches[0]),
+                $title
+            );
+
+            $title = static::snake($title);
+        }
+
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1879,7 +1879,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', []));   // plural (empty array count is 0)
 
         // Test with Countable
-        $countable = new class () implements \Countable {
+        $countable = new class() implements \Countable {
             public function count(): int
             {
                 return 3;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -516,6 +516,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('500-dollar-bill', Str::slug('500$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('500-dollar-bill', Str::slug('500-$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('أحمد-في-المدرسة', Str::slug('أحمد@المدرسة', '-', null, ['@' => 'في']));
+        $this->assertSame('method-name-in-camel-case', Str::slug('methodNameInCamelCase'));
+        $this->assertSame('class-name-is-long', Str::slug('ClassNameIsLong'));
+        $this->assertSame('there-is-faq-module-here', Str::slug('There is FAQ module here'));
     }
 
     public function testStrStart()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -308,9 +308,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
         $this->assertSame(
             'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
-            Str::excerpt('This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+            Str::excerpt(
+                'This is the ultimate supercalifragilisticexpialidocious very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?',
+                'very',
                 ['omission' => '[...]'],
-            ));
+            )
+        );
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
         $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));
@@ -516,9 +519,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('500-dollar-bill', Str::slug('500$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('500-dollar-bill', Str::slug('500-$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('أحمد-في-المدرسة', Str::slug('أحمد@المدرسة', '-', null, ['@' => 'في']));
-        $this->assertSame('method-name-in-camel-case', Str::slug('methodNameInCamelCase'));
-        $this->assertSame('class-name-is-long', Str::slug('ClassNameIsLong'));
         $this->assertSame('there-is-faq-module-here', Str::slug('There is FAQ module here'));
+        $this->assertSame('method-name-in-camel-case', Str::slug('methodNameInCamelCase'));
+        $this->assertSame('class-name-in-pascal-case', Str::slug('ClassNameInPascalCase'));
     }
 
     public function testStrStart()
@@ -1876,8 +1879,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', []));   // plural (empty array count is 0)
 
         // Test with Countable
-        $countable = new class implements \Countable
-        {
+        $countable = new class () implements \Countable {
             public function count(): int
             {
                 return 3;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1879,7 +1879,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', []));   // plural (empty array count is 0)
 
         // Test with Countable
-        $countable = new class() implements \Countable {
+        $countable = new class() implements \Countable
+        {
             public function count(): int
             {
                 return 3;


### PR DESCRIPTION
This pull request enhances the `Str::slug` method to better handle camelCase, StudlyCase, and PascalCase strings, ensuring that such cases are converted to properly formatted slugs. Additionally, new tests have been added to verify this improved functionality.

**Slug generation improvements:**

* Updated the `Str::slug` method to detect camelCase, StudlyCase, and PascalCase strings and convert them to snake_case before generating the slug. This includes handling abbreviations by converting them to lowercase for consistent slug formatting.

**Testing enhancements:**

* Added new test cases in `SupportStrTest.php` to verify slug generation for camelCase, StudlyCase, PascalCase, and strings containing abbreviations, ensuring the changes work as expected.