### PR TITLE
Enhance Slug Generation for camelCase and PascalCase Strings in `Str::slug`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1510,6 +1510,18 @@ class Str
     {
         $title = $language ? static::ascii($title, $language) : $title;
 
+        // Handle camel, studly, and pascal case
+        if (static::isMatch('/(?<!\s)[A-Z]/', substr($title, 1))) {
+            // Convert abbreviations to lowercase for proper snake-casing
+            $title = preg_replace_callback(
+                '/\b[A-Z]{2,}\b/u',
+                fn ($matches) => static::lower($matches[0]),
+                $title
+            );
+
+            $title = static::snake($title);
+        }
+
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -516,6 +516,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('500-dollar-bill', Str::slug('500$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('500-dollar-bill', Str::slug('500-$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('أحمد-في-المدرسة', Str::slug('أحمد@المدرسة', '-', null, ['@' => 'في']));
+        $this->assertSame('there-is-faq-module-here', Str::slug('There is FAQ module here'));
+        $this->assertSame('method-name-in-camel-case', Str::slug('methodNameInCamelCase'));
+        $this->assertSame('class-name-in-pascal-case', Str::slug('ClassNameInPascalCase'));
     }
 
     public function testStrStart()


### PR DESCRIPTION
This pull request enhances the `Str::slug` method to better handle camelCase, StudlyCase, and PascalCase strings, ensuring that such cases are converted to properly formatted slugs. Additionally, new tests have been added to verify this improved functionality.

**Slug generation improvements:**

* Updated the `Str::slug` method to detect camelCase, StudlyCase, and PascalCase strings and convert them to snake_case before generating the slug. This includes handling abbreviations by converting them to lowercase for consistent slug formatting.

**Testing enhancements:**

* Added new test cases in `SupportStrTest.php` to verify slug generation for camelCase, StudlyCase, PascalCase, and strings containing abbreviations, ensuring the changes work as expected.