### PR TITLE
[12.x] Add native bitwise operator support to Query Builder and Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -408,6 +408,76 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a bitwise scope to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBitwise($column, $value, $boolean = 'and')
+    {
+        $this->query->whereBitwise($column, $value, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add a bitwise exact match scope to the query.
+     *
+     * @param  string  $column
+     * @param  int  $mask
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBitwiseExact($column, $mask, $value, $boolean = 'and')
+    {
+        $this->query->whereBitwiseExact($column, $mask, $value, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where bitwise" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @return $this
+     */
+    public function orWhereBitwise($column, $value)
+    {
+        return $this->whereBitwise($column, $value, 'or');
+    }
+
+    /**
+     * Add a "where not bitwise" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotBitwise($column, $value, $boolean = 'and')
+    {
+        $this->query->whereNotBitwise($column, $value, $boolean);
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where not bitwise" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @return $this
+     */
+    public function orWhereNotBitwise($column, $value)
+    {
+        return $this->whereNotBitwise($column, $value, 'or');
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2432,6 +2432,70 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a bitwise "AND" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBitwise($column, $value, $boolean = 'and')
+    {
+        return $this->whereRaw("{$column} & ? > 0", [$value], $boolean);
+    }
+
+    /**
+     * Add a bitwise "AND" clause with exact match to the query.
+     *
+     * @param  string  $column
+     * @param  int  $mask
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBitwiseExact($column, $mask, $value, $boolean = 'and')
+    {
+        return $this->whereRaw("({$column} & ?) = ?", [$mask, $value], $boolean);
+    }
+
+    /**
+     * Add a bitwise "OR" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @return $this
+     */
+    public function orWhereBitwise($column, $value)
+    {
+        return $this->whereBitwise($column, $value, 'or');
+    }
+
+    /**
+     * Add a bitwise "NOT" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotBitwise($column, $value, $boolean = 'and')
+    {
+        return $this->whereRaw("{$column} & ? = 0", [$value], $boolean);
+    }
+
+    /**
+     * Add a bitwise "OR NOT" clause to the query.
+     *
+     * @param  string  $column
+     * @param  int  $value
+     * @return $this
+     */
+    public function orWhereNotBitwise($column, $value)
+    {
+        return $this->whereNotBitwise($column, $value, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6893,6 +6893,40 @@ SQL;
         $this->assertEquals([1], $builder->getBindings());
     }
 
+    public function testWhereBitwise()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBitwise('permissions', 4);
+        $this->assertSame('select * from "users" where permissions & ? > 0', $builder->toSql());
+        $this->assertEquals([4], $builder->getBindings());
+    }
+
+    public function testWhereBitwiseExact()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBitwiseExact('permissions', 15, 15);
+        $this->assertSame('select * from "users" where (permissions & ?) = ?', $builder->toSql());
+        $this->assertEquals([15, 15], $builder->getBindings());
+    }
+
+    public function testOrWhereBitwise()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->whereBitwise('permissions', 1)
+            ->orWhereBitwise('permissions', 2);
+        $this->assertSame('select * from "users" where permissions & ? > 0 or permissions & ? > 0', $builder->toSql());
+        $this->assertEquals([1, 2], $builder->getBindings());
+    }
+
+    public function testWhereNotBitwise()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotBitwise('permissions', 4);
+        $this->assertSame('select * from "users" where permissions & ? = 0', $builder->toSql());
+        $this->assertEquals([4], $builder->getBindings());
+    }
+
     public function testFrom()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
### Summary
This PR introduces native support for bitwise operations in Laravel's Query Builder and Eloquent ORM. Currently, developers need to use `whereRaw()` for bitwise operations, which reduces code readability and type safety.

### What does this PR do?

1. **Adds new Query Builder methods:**
   - `whereBitwise()` / `orWhereBitwise()` - Check if bits are set
   - `whereNotBitwise()` / `orWhereNotBitwise()` - Check if bits are not set
   - `whereBitwiseExact()` - Check for exact bit pattern match

2. **Adds Eloquent Builder support:**
   - All Query Builder bitwise methods available in Eloquent
   - Maintains consistency with existing Eloquent patterns

### Breaking Changes
None. This PR only adds new functionality without modifying existing behavior.

## Usage Examples

### Basic Usage:
```php
// Check if user has read permission (bit 4)
User::whereBitwise('permissions', 4)->get();

// Check multiple permissions with OR
User::whereBitwise('permissions', 4)
    ->orWhereBitwise('permissions', 2)
    ->get();

// Check users without delete permission
User::whereNotBitwise('permissions', 8)->get();

// Check exact permission set (all CRUD = 15)
User::whereBitwiseExact('permissions', 15, 15)->get();
```
### Complex Queries:
```php
User::where(function ($query) {
    $query->whereBitwise('permissions', 4)
          ->orWhereBitwise('permissions', 2);
})->whereNotBitwise('permissions', 8)->get();
```