### PR TITLE
[12.x] Normalize comments for timestampsTz() and nullableTimestampsTz()

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1266,7 +1266,7 @@ class Blueprint
     }
 
     /**
-     * Add creation and update timestampTz columns to the table.
+     * Add nullable creation and update timestampTz columns to the table.
      *
      * @param  int|null  $precision
      * @return \Illuminate\Support\Collection<int, \Illuminate\Database\Schema\ColumnDefinition>
@@ -1280,7 +1280,7 @@ class Blueprint
     }
 
     /**
-     * Add nullable creation and update timestamps to the table.
+     * Add nullable creation and update timestampTz columns to the table.
      *
      * Alias for self::timestampsTz().
      *


### PR DESCRIPTION
Description
---
The docblocks for `timestampsTz()` and `nullableTimestampsTz()` currently use different wording, while the `timestamps()` and `nullableTimestamps()` methods share the same comment. This PR updates the `timestampsTz()` and `nullableTimestampsTz()` comments for consistency and clarity.

Note
---
It seems that PR #56720 copied the comment from the `nullableTimestamps()` method.