### PR TITLE
[12.x] Simpler and consistent `Arr::collapse()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -105,15 +105,13 @@ class Arr
 
         foreach ($array as $values) {
             if ($values instanceof Collection) {
-                $values = $values->all();
-            } elseif (! is_array($values)) {
-                continue;
+                array_push($results, ...$values->all());
+            } elseif (is_array($values)) {
+                array_push($results, ...$values);
             }
-
-            $results[] = $values;
         }
 
-        return array_merge([], ...$results);
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -105,13 +105,13 @@ class Arr
 
         foreach ($array as $values) {
             if ($values instanceof Collection) {
-                array_push($results, ...$values->all());
+                $results[] = $values->all();
             } elseif (is_array($values)) {
-                array_push($results, ...$values);
+                $results[] = $values;
             }
         }
 
-        return $results;
+        return array_merge([], ...$results);
     }
 
     /**


### PR DESCRIPTION
Removed the negation and `continue` as felt easier to read, plus removed reuse of `$values` variable in the loop.
