### PR TITLE
[12.x] Fix docblocks and all() method in ArrayStore for consistency

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -13,7 +13,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     /**
      * The array of stored values.
      *
-     * @var array<string, array{expiresAt: float, value: mixed}>
+     * @var array<string, array{value: mixed, expiresAt: float}>
      */
     protected $storage = [];
 
@@ -45,7 +45,7 @@ class ArrayStore extends TaggableStore implements LockProvider
      * Get all of the cached values and their expiration times.
      *
      * @param  bool  $unserialize
-     * @return array<string, array{expiresAt: float, value: mixed}>
+     * @return array<string, array{value: mixed, expiresAt: float}>
      */
     public function all($unserialize = true)
     {
@@ -57,8 +57,8 @@ class ArrayStore extends TaggableStore implements LockProvider
 
         foreach ($this->storage as $key => $data) {
             $storage[$key] = [
-                'expiresAt' => $data['expiresAt'],
                 'value' => unserialize($data['value']),
+                'expiresAt' => $data['expiresAt'],
             ];
         }
 


### PR DESCRIPTION
Description
---
This PR fixes an inconsistency between the **ArrayStore** docblocks and its actual runtime behavior.

Currently, the PHPDoc annotations and the `all()` method suggest that cached items are stored as:

```php
['expiresAt' => float, 'value' => mixed]
```

However, the `put()` method actually stores items as:

```php
['value' => mixed, 'expiresAt' => float]
```

This PR updates the docblocks and the `all()` method to reflect the correct array shape.

No behavior is changed; only the documentation and array construction order are corrected for consistency.

See
---
https://github.com/laravel/framework/blob/a7917a7f6447261873150f90201bccfa766352ac/src/Illuminate/Cache/ArrayStore.php#L101-L109