### PR TITLE
[12.x] Improving readability

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -792,11 +792,13 @@ trait HasAttributes
         foreach ($casts as $attribute => $cast) {
             $casts[$attribute] = match (true) {
                 is_object($cast) => value(function () use ($cast, $attribute) {
-                    return $cast instanceof Stringable
-                        ? (string) $cast
-                        : throw new InvalidArgumentException(
-                            "The cast object for the {$attribute} attribute must implement Stringable."
-                        );
+                    if ($cast instanceof Stringable) {
+                        return (string) $cast;
+                    }
+
+                    throw new InvalidArgumentException(
+                        "The cast object for the {$attribute} attribute must implement Stringable."
+                    );
                 }),
                 is_array($cast) => value(function () use ($cast) {
                     if (count($cast) === 1) {


### PR DESCRIPTION
Description
---
This PR replaces the inline ternary with a clearer if statement for better readability. The previous form was confusing and could be misread as returning an exception rather than throwing it.