### PR TITLE
[12.x] Add prepend() and prependHidden() to context

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -371,6 +371,29 @@ class Repository
     }
 
     /**
+     * Prepend the given values to the beginning of the key's stack.
+     *
+     * @param  string  $key
+     * @param  mixed  ...$values
+     * @return $this
+     *
+     * @throws \RuntimeException
+     */
+    public function prepend($key, ...$values)
+    {
+        if (! $this->isStackable($key)) {
+            throw new RuntimeException("Unable to prepend value onto context stack for key [{$key}].");
+        }
+
+        $this->data[$key] = [
+            ...$values,
+            ...$this->data[$key] ?? [],
+        ];
+
+        return $this;
+    }
+
+    /**
      * Pop the latest value from the key's stack.
      *
      * @param  string  $key
@@ -405,6 +428,29 @@ class Repository
         $this->hidden[$key] = [
             ...$this->hidden[$key] ?? [],
             ...$values,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Prepend the given hidden values to the beginning of the key's stack.
+     *
+     * @param  string  $key
+     * @param  mixed  ...$values
+     * @return $this
+     *
+     * @throws \RuntimeException
+     */
+    public function prependHidden($key, ...$values)
+    {
+        if (! $this->isHiddenStackable($key)) {
+            throw new RuntimeException("Unable to prepend value onto hidden context stack for key [{$key}].");
+        }
+
+        $this->hidden[$key] = [
+            ...$values,
+            ...$this->hidden[$key] ?? [],
         ];
 
         return $this;

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -728,7 +728,6 @@ class ContextTest extends TestCase
         $this->assertSame(['a', 'b', 'c', 'd'], Context::get('foo'));
         $this->assertSame(['a', 'b', 'c', 'd'], Context::getHidden('bar'));
     }
-
 }
 
 enum Suit

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -698,6 +698,37 @@ class ContextTest extends TestCase
         Context::rememberHidden('foo', $closure);
         $this->assertSame(1, $closureRunCount);
     }
+
+    public function test_it_prepends_values_on_new_stack()
+    {
+        Context::prepend('foo', 'a');
+        Context::prepend('bar', 'b', 'c', 'a');
+
+        $this->assertSame(['a'], Context::get('foo'));
+        $this->assertSame(['b', 'c', 'a'], Context::get('bar'));
+    }
+
+    public function test_it_prepends_hidden_values_on_new_stack()
+    {
+        Context::prependHidden('foo', 'a');
+        Context::prependHidden('bar', 'b', 'c', 'a');
+
+        $this->assertSame(['a'], Context::getHidden('foo'));
+        $this->assertSame(['b', 'c', 'a'], Context::getHidden('bar'));
+    }
+
+    public function test_it_prepends_values_on_existing_stack()
+    {
+        Context::push('foo', 'b', 'c', 'd');
+        Context::prepend('foo', 'a');
+
+        Context::pushHidden('bar', 'b', 'c', 'd');
+        Context::prependHidden('bar', 'a');
+
+        $this->assertSame(['a', 'b', 'c', 'd'], Context::get('foo'));
+        $this->assertSame(['a', 'b', 'c', 'd'], Context::getHidden('bar'));
+    }
+
 }
 
 enum Suit


### PR DESCRIPTION
This pull request introduces two new methods, `prepend` and `prependHidden`, to the `Context` class. These methods provide enhanced flexibility for manipulating context data by allowing developers to add elements at the beginning of existing context collections.

### Use-Case:
```php
NavigationHelper::add(label: 'Home', url: '/dashboard');
// -> within that helper-function: context()->push('breadcrumb', ['label' => 'Home', 'url' => '/dashboard', 'icon' => null]);
NavigationHelper::add(label: 'Users', icon: 'user', url: '/users');
// -> within that helper-function: context()->push('breadcrumb', ['label' => 'Users', 'url' => '/users', 'icon' => 'user']);

// ... later; i.e. just prepending a Home-Icon without a label
NavigationHelper::prepend(icon: 'home', url: '/');
// -> within that helper-function - with this pull request -: 
// context()->prepend('breadcrumb', ['label' => null, 'url' => '/', 'icon' => 'home']);
```

Since we have a append (which is `push()`) we also should have a prepend().

### Notes:
- Includes relevant tests to ensure proper behavior of the new methods.
- No breaking changes introduced.