### PR TITLE
[11.x] Chore: Decouple Str::random() from Validator

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Once;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
 use Illuminate\View\Component;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
@@ -186,6 +187,7 @@ trait InteractsWithTestCaseLifecycle
         TrimStrings::flushState();
         TrustProxies::flushState();
         TrustHosts::flushState();
+        Validator::flushState();
         ValidateCsrfToken::flushState();
         WorkCommand::flushState();
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -187,8 +187,8 @@ trait InteractsWithTestCaseLifecycle
         TrimStrings::flushState();
         TrustProxies::flushState();
         TrustHosts::flushState();
-        Validator::flushState();
         ValidateCsrfToken::flushState();
+        Validator::flushState();
         WorkCommand::flushState();
 
         if ($this->callbackException) {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -358,6 +358,16 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Flush the validator's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$placeholderHash = null;
+    }
+
+    /**
      * Parse the data array, converting dots and asterisks.
      *
      * @param  array  $data

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -358,16 +358,6 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Flush the validator's global state.
-     *
-     * @return void
-     */
-    public static function flushState()
-    {
-        static::$placeholderHash = null;
-    }
-
-    /**
      * Parse the data array, converting dots and asterisks.
      *
      * @param  array  $data
@@ -1665,6 +1655,16 @@ class Validator implements ValidatorContract
         [$class, $method] = Str::parseCallback($callback, 'validate');
 
         return $this->container->make($class)->{$method}(...array_values($parameters));
+    }
+
+    /**
+     * Flush the validator's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$placeholderHash = null;
     }
 
     /**


### PR DESCRIPTION
The use of `Str::random()` within the `Validator` can lead to non-deterministic test outcomes when using random string mocking such as `Str::createRandomStringsUsing()` or `Str::createRandomStringsUsingSequence()`.

For example, with a test file that contains a set of tests as follows:

```php
test('the thing is authorised', function () {
    postJson(...)->assertForbidden();
});

test('the thing was successful', function () {
    Str::createRandomStringsUsingSequence([
        'dot_placeholder', // Account for the form request being resolved via ValidatesWhenResolved
        'some_random_string',
        'another_random_string',
    ]);

    postJson(...)
        ->assertCreated()
        ->assertStreamedContent()
        ->assertJson(fn ($json) => $json
            ->where('data.0.id', 'some_random_string') // True in isolation, dot_placeholder otherwise
            ->where('data.1.id', 'another_random_string') // True in isolation, some_random_string otherwise
            ->etc()
        );
});
```

When accounting for the call to `Str::random()` within the `Validator` class' constructor, the test will pass in isolation i.e. filtering to only run `the thing was successful`.

If, however, the test file or the full test is run, `the thing was successful` fails making assertions against the matching random strings due to the `Validator::$placeholderHash` already being set in a preceding test.

As the `$placeholderHash` is a static property, the state persists through a single test process, which is why it impacts file, folder, and suite, but not a single test.

This PR adds a `flushState` method to the `Validator` class and calls it from the [`InteractsWithTestCaseLifecycpe`](https://github.com/laravel/framework/blob/c1b1628f6bdd9104cf68af0add3a356c93b027ee/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php) trait, inline with similar behaviour elsewhere in the framework, per @timacdonald's [suggestion](https://github.com/laravel/framework/pull/56852#issuecomment-3240735332).