### PR TITLE
[12.x] Improve `InteractsWithContainer` return types

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -36,9 +36,11 @@ trait InteractsWithContainer
     /**
      * Register an instance of an object in the container.
      *
+     * @template TSwap of object
+     *
      * @param  string  $abstract
-     * @param  object  $instance
-     * @return object
+     * @param  TSwap  $instance
+     * @return TSwap
      */
     protected function swap($abstract, $instance)
     {
@@ -48,9 +50,11 @@ trait InteractsWithContainer
     /**
      * Register an instance of an object in the container.
      *
+     * @template TInstance of object
+     *
      * @param  string  $abstract
-     * @param  object  $instance
-     * @return object
+     * @param  TInstance  $instance
+     * @return TInstance
      */
     protected function instance($abstract, $instance)
     {


### PR DESCRIPTION
This PR allows tools like PHPStan and PHPStorm to infer the return type of `$this->instance(...)` and `$this->swap(...)` in tests