### PR TITLE
[12.x] Improve Readability of resolve Method in Console Application

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -261,9 +261,8 @@ class Application extends SymfonyApplication implements ApplicationContract
         if (is_subclass_of($command, SymfonyCommand::class)) {
             $attribute = (new ReflectionClass($command))->getAttributes(AsCommand::class);
 
-            $commandName = ! empty($attribute) ? $attribute[0]->newInstance()->name : null;
-
-            if (! is_null($commandName)) {
+            if (! empty($attribute)) {
+                $commandName = $attribute[0]->newInstance()->name;
                 foreach (explode('|', $commandName) as $name) {
                     $this->commandMap[$name] = $command;
                 }


### PR DESCRIPTION
**What**

This pull request simplifies the resolve method in Illuminate\Console\Application by removing an unnecessary ternary operator and redundant is_null check.

**Why**

The original code used a ternary operator to assign the name attribute from the AsCommand attribute, followed by an is_null check to determine whether to proceed with mapping the command. This logic can be streamlined by directly checking if the attributes array is not empty, which improves code readability and reduces unnecessary conditional nesting, aligning with Laravel's emphasis on clean and expressive code.

**How**

The change replaces the following lines:
```php
$commandName = ! empty($attribute) ? $attribute[0]->newInstance()->name : null;

if (! is_null($commandName)) {

```
with:
```php
if (! empty($attribute)) {
    $commandName = $attribute[0]->newInstance()->name;
```
This maintains the same functionality while making the code more concise and easier to read. The behavior remains unchanged: if the attributes array is empty, the commandMap is not updated, and the method proceeds to the next conditions.

**Note**: Defining $commandName also can be ommited , so we can remove 1 line more, but the reason I keep $commandName is for clarity, the reader will understand thet the $attribute[0]->newInstance()->name  considered as command name.

**Impact**:

-Readability: The refactored code is more straightforward and aligns with PHP's modern coding practices.

-Performance: No measurable performance impact, as the change only removes a redundant condition.

-Behavior: The functional behavior is identical, ensuring backward compatibility.