### PR TITLE
[12.x] Improve `countBy` docblock in `Collection` to allow for enum callback

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1852,7 +1852,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Count the number of items in the collection by a field or using a callback.
      *
-     * @param  (callable(TValue, TKey): array-key)|string|null  $countBy
+     * @param  (callable(TValue, TKey): array-key|\UnitEnum)|string|null  $countBy
      * @return static<array-key, int>
      */
     public function countBy($countBy = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
As a follow-up to #56830 this PR ensures the docblock of the `Collection` class is adequately updated as well.

Notes:
- I've intentionally still skipped over updating the `Enumerable` interface docblock here, given that updating its signature (even though only 'softly' in a docblock) should probably be considered a breaking change. I'm willing to follow-up with doing this while targetting the `master` branch.
- (\cc @calebdw) I figured there might be more method docblocks for collections that currently are incomplete in not denoting their "enum support status". For example, I was looking at the `groupBy` docblock, which includes `callable(TValue, TKey): TGroupKey` but probably should be changed to say `callable(TValue, TKey): TGroupKey|\BackedEnum|\Stringable` given the implementation. However, when trying such things I quickly ran into errors of the sort 
```
Unable to resolve the template type TGroupKey in call to method Illuminate\Support\Collection<X,Y>::groupBy()
```
so maybe this requires some additional care.