### PR TITLE
[12.x] Add attributes for marking setUp and tearDown lifecycle hooks in traits

### DIFF
--- a/src/Illuminate/Foundation/Testing/Attributes/SetUp.php
+++ b/src/Illuminate/Foundation/Testing/Attributes/SetUp.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Testing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class SetUp
+{
+    //
+}

--- a/src/Illuminate/Foundation/Testing/Attributes/TearDown.php
+++ b/src/Illuminate/Foundation/Testing/Attributes/TearDown.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Testing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class TearDown
+{
+    //
+}

--- a/src/Illuminate/Foundation/Testing/WithConsoleEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithConsoleEvents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Testing\Attributes\SetUp;
 
 trait WithConsoleEvents
 {
@@ -11,6 +12,7 @@ trait WithConsoleEvents
      *
      * @return void
      */
+    #[SetUp]
     protected function setUpWithConsoleEvents()
     {
         $this->app[ConsoleKernel::class]->rerouteSymfonyCommandEvents();

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -3,23 +3,40 @@
 namespace Illuminate\Tests\Foundation\Testing;
 
 use Illuminate\Foundation\Testing\TestCase as FoundationTestCase;
+use Illuminate\Testing\Attributes\SetUp;
+use Illuminate\Testing\Attributes\TearDown;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
 trait TestTrait
 {
-    public $setUp = false;
-    public $tearDown = false;
+    // Integers to ensure methods are called exactly once
+    public int $setUp = 0;
+    public int $setUpWithAttribute = 0;
+    public int $tearDown = 0;
+    public int $tearDownWithAttribute = 0;
 
     public function setUpTestTrait()
     {
-        $this->setUp = true;
+        $this->setUp++;
+    }
+
+    #[SetUp]
+    protected function setUpTestTraitWithAttribute()
+    {
+        $this->setUpWithAttribute++;
     }
 
     public function tearDownTestTrait()
     {
-        $this->tearDown = true;
+        $this->tearDown++;
+    }
+
+    #[TearDown]
+    public function tearDownTestTraitWithAttribute()
+    {
+        $this->tearDownWithAttribute++;
     }
 }
 
@@ -38,11 +55,13 @@ class BootTraitsTest extends TestCase
         $method = new ReflectionMethod($testCase, 'setUpTraits');
         $method->invoke($testCase);
 
-        $this->assertTrue($testCase->setUp);
+        $this->assertSame(1, $testCase->setUp);
+        $this->assertSame(1, $testCase->setUpWithAttribute);
 
         $method = new ReflectionMethod($testCase, 'callBeforeApplicationDestroyedCallbacks');
         $method->invoke($testCase);
 
-        $this->assertTrue($testCase->tearDown);
+        $this->assertSame(1, $testCase->tearDown);
+        $this->assertSame(1, $testCase->tearDownWithAttribute);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Inspired by #56518, this PR aims to introduce `SetUp` and `TearDown` attributes for (trait) methods, that allow executing them during the respective hook calls in a test lifecycle. This allows for more flexibility on these kind of methods, e.g. no longer requiring exact name matching.

To illustrate the usage, it has also been added to the `WithConsoleEvents` trait. 

Implementation choices:
- the naming of attributes can be changed to liking; this seemed the simplest to me
- I've altered the respective test to use a call-count mechanism to ensure methods are only called once; one can also verify that adding the attribute to the method with correct name indeed only results in a single call
- after digging a bit further, the `Before` and `After` PHPUnit attributes (see also https://docs.phpunit.de/en/12.3/attributes.html#before) already introduce very similar possibilities, so it's also an option to prefer those 


Potential follow-ups:
- applying this to more internal traits to simplify the list of other trait setup calls inside `setUpTraits`; this would likely require some additional mechanism to enforce correct order of executing hooks
- applying to the `WithRedis` trait, although its setUp and tearDown hooks are seemingly called in two different ways (right away vs. hooked to test application lifetime)
