### PR TITLE
[12.x] Remove extra space before line number in exception trace

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
@@ -8,7 +8,7 @@
                 <div class="mb-2">
                     @if (config('app.editor'))
                         <a href="{{ $frame->editorHref() }}" class="text-blue-500 hover:underline">
-                            <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span><span class="font-mono text-xs">:{{ $frame->line() }}</span>
+                            <span class="wrap">{{ $frame->file() }}</span><span class="font-mono text-xs">:{{ $frame->line() }}</span>
                         </a>
                     @else
                         <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span><span class="font-mono text-xs">:{{ $frame->line() }}</span>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/editor.blade.php
@@ -6,16 +6,13 @@
         <div class="mb-3">
             <div class="text-md text-gray-500 dark:text-gray-400">
                 <div class="mb-2">
-
                     @if (config('app.editor'))
                         <a href="{{ $frame->editorHref() }}" class="text-blue-500 hover:underline">
-                            <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span>
+                            <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span><span class="font-mono text-xs">:{{ $frame->line() }}</span>
                         </a>
                     @else
-                        <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span>
+                        <span class="wrap text-gray-900 dark:text-gray-300">{{ $frame->file() }}</span><span class="font-mono text-xs">:{{ $frame->line() }}</span>
                     @endif
-
-                    <span class="font-mono text-xs">:{{ $frame->line() }}</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**This pull request improves the exception renderer UI by refining how file and line references are displayed.**

* The file name and line number are now rendered together as part of the clickable link (or plain text). This ensures that when copying the reference, IDEs like PhpStorm can correctly open the file at the specified line. Previously, an extra space prevented this behavior.
* The link color was being overridden by an inner `<span>` style, making it appear as plain text. This has been corrected so clickable links are visually distinct.

### Example

#### Before

Copied text:

```
routes/web.php :7
```

<img width="2204" height="1392" alt="Screenshot before" src="https://github.com/user-attachments/assets/ee8d75ce-c425-4c10-b4a8-bd76243cdc8d" />

#### After

Copied text:

```
routes/web.php:7
```

<img width="2204" height="1392" alt="Screenshot after" src="https://github.com/user-attachments/assets/55533b36-a04d-44ed-b981-23e007eda04c" />