### PR TITLE
[12.x] Add asset validation to `withoutVite()` and `withoutMix()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -225,7 +225,7 @@ trait InteractsWithContainer
     protected function withoutViteStrict()
     {
         return $this->withoutVite(function ($asset) {
-            $path = resource_path($asset);
+            $path = base_path($asset);
 
             if (! file_exists($path)) {
                 throw new \InvalidArgumentException("Vite asset does not exist: {$asset} (resolved to: {$path})");

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -103,11 +103,11 @@ class InteractsWithContainerTest extends TestCase
     public function testWithoutViteStrictThrowsForMissingAsset()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Vite asset does not exist: non-existent-file.js');
+        $this->expectExceptionMessage('Vite asset does not exist: resources/non-existent-file.js');
 
         $this->withoutViteStrict();
 
-        app(Vite::class)(['non-existent-file.js']);
+        app(Vite::class)(['resources/non-existent-file.js']);
     }
 
     public function testWithoutViteStrictValidatesExistingAssets()
@@ -120,7 +120,7 @@ class InteractsWithContainerTest extends TestCase
             $this->withoutViteStrict();
 
             // Should not throw for existing file
-            $result = app(Vite::class)(['temp-test-asset.js']);
+            $result = app(Vite::class)(['resources/temp-test-asset.js']);
             $this->assertSame('', $result->toHtml());
         } finally {
             if (file_exists($assetPath)) {


### PR DESCRIPTION
## Problem
 When testing views that use `@vite()` and `mix()` directives, developers often use `withoutVite()` and `withoutMix()` to skip a pricey assets compilation step. However, there's no way to validate that the referenced asset files actually exist, leading to broken asset references going undetected in tests.

  ```php
  // This test passes even if app.js doesn't exist
  $this->withoutVite()
       ->get('/dashboard')
       ->assertOk();
```

##  Solution

  Add optional callback support to withoutVite() and withoutMix() with convenient strict validation helpers:
```php
  // Validate assets exist during tests
  $this->withoutViteStrict()
       ->get('/dashboard')
       ->assertOk(); // Throws if resources/js/app.js missing

  // Custom validation logic  
  $this->withoutVite(function ($asset, $buildDirectory) {
      Log::info("Asset loaded: {$asset}");
      // Custom validation logic here
  });
```

###  Key Features

  - Backward compatible - existing `withoutVite()`/`withoutMix()` calls unchanged
  - Flexible callbacks - execute custom logic on asset method calls
  - Strict helpers - `withoutViteStrict()` and `withoutMixStrict()` for common validation
  - A room for further improvements: it's possible e.g. to return data from such a callback (instead of returning `new HtmlString('')`

##  Usage
```php
  class FeatureTest extends TestCase
  {
      public function test_dashboard_loads()
      {
          // Ensures all @vite() assets exist
          $this->withoutViteStrict()
               ->get('/dashboard')
               ->assertOk();
      }
  }
```

  This catches missing asset references early in the development cycle, preventing broken builds and improving developer confidence.

## Alternatives

To simplify things, we can use a boolean parameter for `withoutVite(bool $string = false)` instead of this callback, it will simplify things.

  Benefits:
  - Simpler API surface
  - Could become default behavior in Laravel 13.x
  - Less flexibility but covers 90% of use cases

