### PR TITLE
[12.x] Prevent redundant QueryExecuted listener

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -71,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled() && ! app()->has(ExceptionRenderer::class)) {
+        if ($this->app->hasDebugModeEnabled() && ! $this->app->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -71,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled() && !app()->has(ExceptionRenderer::class)) {
+        if ($this->app->hasDebugModeEnabled() && ! app()->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\ConnectionInterface;
@@ -70,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled()) {
+        if ($this->app->hasDebugModeEnabled() && !app()->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -2,7 +2,12 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Exceptions;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
+use Illuminate\Foundation\Exceptions\Renderer\Listener;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
+use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Mockery;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
@@ -36,5 +41,99 @@ class RendererTest extends TestCase
             ->assertInternalServerError()
             ->assertSee('RuntimeException')
             ->assertSee('Bad route!');
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItCanRenderExceptionPageWithRendererWhenDebugEnabled()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertSee('Custom Exception Renderer: Bad route!');
+    }
+
+    #[WithConfig('app.debug', false)]
+    public function testItDoesNotRenderExceptionPageWithRendererWhenDebugDisabled()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertDontSee('Custom Exception Renderer: Bad route!');
+    }
+
+    #[WithConfig('app.debug', false)]
+    public function testItDoesNotRegisterListenersWhenDebugDisabled()
+    {
+        $this->app->forgetInstance(ExceptionRenderer::class);
+        $this->assertFalse($this->app->bound(ExceptionRenderer::class));
+
+        $listener = \Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->never();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItDoesNotRegisterListenersWhenRendererBound()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $listener = \Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->never();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItRegistersListenersWhenRendererNotBound()
+    {
+        $this->app->forgetInstance(ExceptionRenderer::class);
+        $this->assertFalse($this->app->bound(ExceptionRenderer::class));
+
+        $listener = Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->once();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
     }
 }

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -47,10 +47,11 @@ class RendererTest extends TestCase
     public function testItCanRenderExceptionPageWithRendererWhenDebugEnabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });
@@ -66,10 +67,11 @@ class RendererTest extends TestCase
     public function testItDoesNotRenderExceptionPageWithRendererWhenDebugDisabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });
@@ -101,10 +103,11 @@ class RendererTest extends TestCase
     public function testItDoesNotRegisterListenersWhenRendererBound()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -89,11 +89,11 @@ class RendererTest extends TestCase
         $this->app->forgetInstance(ExceptionRenderer::class);
         $this->assertFalse($this->app->bound(ExceptionRenderer::class));
 
-        $listener = \Mockery::mock(Listener::class);
+        $listener = Mockery::mock(Listener::class);
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -114,11 +114,11 @@ class RendererTest extends TestCase
 
         $this->assertTrue($this->app->bound(ExceptionRenderer::class));
 
-        $listener = \Mockery::mock(Listener::class);
+        $listener = Mockery::mock(Listener::class);
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -134,7 +134,7 @@ class RendererTest extends TestCase
         $listener->shouldReceive('registerListeners')->once();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();


### PR DESCRIPTION
### Summary

This PR ensures that `Listener::registerListeners()` is only called when debug mode is enabled and the ExceptionRenderer has not already been bound in the container.

### Why

Without this condition, the Listener may be registered multiple times even if another ExceptionRenderer is present, causing duplicate handling of exception events and unnecessary population of the [$queries](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php#L21) variable.

### Tests

- Added a test to verify that listeners are not registered when ExceptionRenderer exists in the container.
- Added a test to verify that listeners are registered when ExceptionRenderer is not bound.
- Added tests to verify that exception pages are rendered correctly depending on whether the ExceptionRenderer is bound and whether debug mode is enabled or disabled.