### PR TITLE
[12.x] Allows `APP_BASE_PATH` from `$_SERVER`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -254,6 +254,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         return match (true) {
             isset($_ENV['APP_BASE_PATH']) => $_ENV['APP_BASE_PATH'],
+            isset($_SERVER['APP_BASE_PATH']) => $_SERVER['APP_BASE_PATH'],
             default => dirname(array_values(array_filter(
                 array_keys(ClassLoader::getRegisteredLoaders()),
                 fn ($path) => ! str_starts_with($path, 'phar://'),


### PR DESCRIPTION
This would be useful in Github Actions environment where using `steps.*.env` would populate `$_SERVER` instead of `$_ENV`:

```yaml
      - name: Execute tests
        run: php vendor/bin/pest
        env:
          APP_BASE_PATH: ${{ github.workspace }}/vendor/laravel/vue-starter-kit
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
