### PR TITLE
[12.x] Allow mass assignment for value object casting.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -216,7 +216,7 @@ trait GuardsAttributes
      */
     protected function isGuardableColumn($key)
     {
-        if ($this->hasSetMutator($key) || $this->hasAttributeSetMutator($key)) {
+        if ($this->hasSetMutator($key) || $this->hasAttributeSetMutator($key) || $this->isClassCastable($key)) {
             return true;
         }
 

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\ComparesCastableAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
@@ -58,6 +59,12 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->schema()->create('documents', function (Blueprint $table) {
             $table->increments('id');
             $table->json('document');
+        });
+
+        $this->schema()->create('people', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('address_line_one');
+            $table->string('address_line_two');
         });
     }
 
@@ -183,7 +190,7 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertEquals('3.00', $model->amount->value);
     }
 
-    public function test_model_with_custom_casts_compare_function()
+    public function testModelWithCustomCastsCompareFunction()
     {
         // Set raw attribute, this is an example of how we would receive JSON string from the database.
         // Note the spaces after the colon.
@@ -200,6 +207,25 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertFalse($model->isDirty('document'));
         $document->title = 'hello world 2';
         $this->assertTrue($model->isDirty('document'));
+    }
+
+    public function testModelWithCustomCastsUnguardedCanBeMassAssigned()
+    {
+        Person::preventSilentlyDiscardingAttributes();
+
+        $model = Person::create(['address' => new AddressDto('123 Main St.', 'Anytown, USA')]);
+        $this->assertSame('123 Main St.', $model->address->lineOne);
+        $this->assertSame('Anytown, USA', $model->address->lineTwo);
+    }
+
+    public function testModelWithCustomCastsCanBeGuardedAgainstMassAssigned()
+    {
+        Person::preventSilentlyDiscardingAttributes();
+        $this->expectException(MassAssignmentException::class);
+
+        $model = new Person();
+        $model->guard(['address']);
+        $model->create(['id' => 1, 'address' => new AddressDto('123 Main St.', 'Anytown, USA')]);
     }
 
     /**
@@ -446,6 +472,15 @@ class Document extends Model
     ];
 }
 
+class Person extends Model
+{
+    protected $guarded = ['id'];
+    public $timestamps = false;
+    protected $casts = [
+        'address' => AsAddress::class,
+    ];
+}
+
 class StructuredDocumentCaster implements CastsAttributes, ComparesCastableAttributes
 {
     public function get($model, $key, $value, $attributes)
@@ -461,5 +496,26 @@ class StructuredDocumentCaster implements CastsAttributes, ComparesCastableAttri
     public function compare($model, $key, $value1, $value2)
     {
         return json_decode($value1) == json_decode($value2);
+    }
+}
+
+class AddressDto
+{
+    public function __construct(public string $lineOne, public string $lineTwo)
+    {
+        //
+    }
+}
+
+class AsAddress implements CastsAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return new AddressDto($attributes['address_line_one'], $attributes['address_line_two']);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return ['address_line_one' => $value->lineOne, 'address_line_two' => $value->lineTwo];
     }
 }


### PR DESCRIPTION
Hey Taylor,

I ran into an issue this morning when trying to mass assign an attribute that's a cast that wasn't being guarded. 

Given a model that uses a value cast object, that's not explicitly guarded:
```PHP
class Person extends Model
{
    protected $guarded = ['id'];
    public $timestamps = false;
    protected $casts = [
        'address' => AsAddress::class,
    ];
}
```

I would expect to be able to mass assign the attribute:
```PHP
Person::create(['address' => new AddressDto('123 Main St.', 'Anytown, USA')]);
```

However, this was throwing: `Illuminate\Database\Eloquent\MassAssignmentException: Add [address] to fillable property to allow mass assignment on [Illuminate\Tests\Database\Person].`

I tried to use the `Model::handleDiscardedAttributeViolationUsing(...)` method added in #44664 to handle that within my app, but wasn't able to since the value that was trying to be set wasn't being passed into the closure. That's probably another update needed to make that hook more useful. 

After digging into how we determine if an attribute is `isFillable()` or not, I see that we're already checking if the attribute `hasSetMutator` or `hasAttributeSetMutator` so it felt natural to also check if the attribute `isClassCastable`.  