### PR TITLE
Fix: Prevent unnecessary query logging on exceptions with a custom renderer

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -71,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled() && ! app()->has(ExceptionRenderer::class)) {
+        if ($this->app->hasDebugModeEnabled() && ! $this->app->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -71,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled() && !app()->has(ExceptionRenderer::class)) {
+        if ($this->app->hasDebugModeEnabled() && ! app()->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\ConnectionInterface;
@@ -70,7 +71,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
             ], 'laravel-errors');
         }
 
-        if ($this->app->hasDebugModeEnabled()) {
+        if ($this->app->hasDebugModeEnabled() && !app()->has(ExceptionRenderer::class)) {
             $this->app->make(Listener::class)->registerListeners(
                 $this->app->make(Dispatcher::class)
             );

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -2,7 +2,12 @@
 
 namespace Illuminate\Tests\Integration\Foundation\Exceptions;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\ExceptionRenderer;
+use Illuminate\Foundation\Exceptions\Renderer\Listener;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
+use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Mockery;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 use RuntimeException;
@@ -36,5 +41,99 @@ class RendererTest extends TestCase
             ->assertInternalServerError()
             ->assertSee('RuntimeException')
             ->assertSee('Bad route!');
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItCanRenderExceptionPageWithRendererWhenDebugEnabled()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertSee('Custom Exception Renderer: Bad route!');
+    }
+
+    #[WithConfig('app.debug', false)]
+    public function testItDoesNotRenderExceptionPageWithRendererWhenDebugDisabled()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertDontSee('Custom Exception Renderer: Bad route!');
+    }
+
+    #[WithConfig('app.debug', false)]
+    public function testItDoesNotRegisterListenersWhenDebugDisabled()
+    {
+        $this->app->forgetInstance(ExceptionRenderer::class);
+        $this->assertFalse($this->app->bound(ExceptionRenderer::class));
+
+        $listener = \Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->never();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItDoesNotRegisterListenersWhenRendererBound()
+    {
+        $this->app->singleton(ExceptionRenderer::class, function () {
+            return new class() implements ExceptionRenderer {
+                public function render($throwable)
+                {
+                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                }
+            };
+        });
+
+        $this->assertTrue($this->app->bound(ExceptionRenderer::class));
+
+        $listener = \Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->never();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
+    }
+
+    #[WithConfig('app.debug', true)]
+    public function testItRegistersListenersWhenRendererNotBound()
+    {
+        $this->app->forgetInstance(ExceptionRenderer::class);
+        $this->assertFalse($this->app->bound(ExceptionRenderer::class));
+
+        $listener = Mockery::mock(Listener::class);
+        $listener->shouldReceive('registerListeners')->once();
+
+        $this->app->instance(Listener::class, $listener);
+        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+
+        $provider = $this->app->getProvider(FoundationServiceProvider::class);
+        $provider->boot();
     }
 }

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -47,10 +47,11 @@ class RendererTest extends TestCase
     public function testItCanRenderExceptionPageWithRendererWhenDebugEnabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });
@@ -66,10 +67,11 @@ class RendererTest extends TestCase
     public function testItDoesNotRenderExceptionPageWithRendererWhenDebugDisabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });
@@ -101,10 +103,11 @@ class RendererTest extends TestCase
     public function testItDoesNotRegisterListenersWhenRendererBound()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer {
+            return new class() implements ExceptionRenderer
+            {
                 public function render($throwable)
                 {
-                    return response('Custom Exception Renderer: ' . $throwable->getMessage(), 500);
+                    return response('Custom Exception Renderer: '.$throwable->getMessage(), 500);
                 }
             };
         });

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -89,11 +89,11 @@ class RendererTest extends TestCase
         $this->app->forgetInstance(ExceptionRenderer::class);
         $this->assertFalse($this->app->bound(ExceptionRenderer::class));
 
-        $listener = \Mockery::mock(Listener::class);
+        $listener = Mockery::mock(Listener::class);
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -114,11 +114,11 @@ class RendererTest extends TestCase
 
         $this->assertTrue($this->app->bound(ExceptionRenderer::class));
 
-        $listener = \Mockery::mock(Listener::class);
+        $listener = Mockery::mock(Listener::class);
         $listener->shouldReceive('registerListeners')->never();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
@@ -134,7 +134,7 @@ class RendererTest extends TestCase
         $listener->shouldReceive('registerListeners')->once();
 
         $this->app->instance(Listener::class, $listener);
-        $this->app->instance(Dispatcher::class, \Mockery::mock(Dispatcher::class));
+        $this->app->instance(Dispatcher::class, Mockery::mock(Dispatcher::class));
 
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();


### PR DESCRIPTION
Reopen: https://github.com/laravel/framework/pull/56865

### **The Problem**

When a package like `spatie/laravel-ignition` is installed, it provides its own `ExceptionRenderer`. However, the framework's default exception listener is still registered alongside it. This causes every exception to be handled twice, resulting in redundant work and unnecessary memory usage (e.g., populating `$queries` when it is not needed).

### **Simple Recreation**

1.  **Install `spatie/laravel-ignition`** in a fresh Laravel project.
    ```bash
    composer require spatie/laravel-ignition
    ```
2.  **Create a route that throws an exception:**
    ```php
    // routes/web.php
    Route::get('/test-exception', fn() => throw new Exception('test'));
    ```
3.  **Temporarily add a `dd()`** to the framework's default listener to see it run:
    ```php
    // In vendor/laravel/framework/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php:73
    // Inside the Listener class, method onQueryExecuted()
    public function onQueryExecuted(QueryExecuted $event)
    {
        if (count($this->queries) === 100) {
            return;
        }

        $this->queries[] = [
            'connectionName' => $event->connectionName,
            'time' => $event->time,
            'sql' => $event->sql,
            'bindings' => $event->bindings,
        ];

        dd($this->queries); 
    }
    ```
4.  Access `/test-exception` in the browser. You will see the `dd()` message, proving the default listener ran when it shouldn't have.

#### **The Solution**

This PR adds a check (`! $this->app->bound(ExceptionRenderer::class)`) to ensure the default listener is only registered if no other `ExceptionRenderer` has already been bound to the container. This cleanly prevents the duplication.

#### **Tests**

  * Added test to ensure listeners are **not** registered if `ExceptionRenderer` exists.
  * Added test to ensure listeners **are** registered if `ExceptionRenderer` does not exist.
