### PR TITLE
[12.x] Let `toPrettyJson()` accepts options

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1272,9 +1272,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the collection of items as pretty print formatted JSON.
      *
+     *
+     * @param  int  $options
      * @return string
      */
-    public function toPrettyJson();
+    public function toPrettyJson(int $options = 0);
 
     /**
      * Get a CachingIterator instance.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -987,11 +987,12 @@ trait EnumeratesValues
     /**
      * Get the collection of items as pretty print formatted JSON.
      *
+     * @param  int  $options
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1803,13 +1803,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Convert the model instance to pretty print formatted JSON.
      *
+     * @param  int  $options
      * @return string
      *
      * @throws \Illuminate\Database\Eloquent\JsonEncodingException
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -163,13 +163,14 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Convert the resource to pretty print formatted JSON.
      *
+     * @param  int  $options
      * @return string
      *
      * @throws \Illuminate\Database\Eloquent\JsonEncodingException
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 
     /**

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -184,10 +184,12 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     /**
      * Convert the object to pretty print formatted JSON.
      *
+     * @params int $options
+     *
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -246,10 +246,12 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Convert the object to pretty print formatted JSON.
      *
+     * @params int $options
+     *
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -189,10 +189,12 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Convert the object to pretty print formatted JSON.
      *
+     * @params int $options
+     *
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 }

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -206,11 +206,13 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Convert the fluent instance to pretty print formatted JSON.
      *
+     * @params int $options
+     *
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 
     /**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -434,11 +434,13 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Convert the object to pretty print formatted JSON.
      *
+     * @params int $options
+     *
      * @return string
      */
-    public function toPrettyJson()
+    public function toPrettyJson(int $options = 0)
     {
-        return $this->toJson(JSON_PRETTY_PRINT);
+        return $this->toJson(JSON_PRETTY_PRINT | $options);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3448,7 +3448,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testModelToPrettyJson(): void
     {
-        $user = new EloquentModelStub(['name' => 'Mateus', 'active' => true]);
+        $user = new EloquentModelStub(['name' => 'Mateus', 'active' => true, 'number' => '123']);
         $results = $user->toPrettyJson();
         $expected = $user->toJson(JSON_PRETTY_PRINT);
 
@@ -3456,6 +3456,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
+
+        $results = $user->toPrettyJson(JSON_NUMERIC_CHECK);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('"number": 123', $results);
     }
 
     public function testFillableWithMutators()

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -54,7 +54,7 @@ class JsonResourceTest extends TestCase
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])
             ->makePartial()
-            ->shouldReceive('jsonSerialize')->andReturn(['foo' => 'bar', 'bar' => 'foo'])
+            ->shouldReceive('jsonSerialize')->andReturn(['foo' => 'bar', 'bar' => 'foo', 'number' => 123])
             ->getMock();
 
         $results = $resource->toPrettyJson();
@@ -64,5 +64,10 @@ class JsonResourceTest extends TestCase
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
+
+        $results = $resource->toPrettyJson(JSON_NUMERIC_CHECK);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('"number": 123', $results);
     }
 }

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -132,7 +132,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testCursorPaginatorToPrettyJson()
     {
-        $paginator = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], 2, null);
+        $paginator = new CursorPaginator([['id' => '1'], ['id' => '2'], ['id' => '3'], ['id' => '4']], 2, null);
         $results = $paginator->toPrettyJson();
         $expected = $paginator->toJson(JSON_PRETTY_PRINT);
 
@@ -140,6 +140,11 @@ class CursorPaginatorTest extends TestCase
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
+
+        $results = $paginator->toPrettyJson(JSON_NUMERIC_CHECK);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('"id": 1', $results);
     }
 
     protected function getCursor($params, $isNext = true)

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -85,7 +85,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorToPrettyJson()
     {
-        $p = new Paginator(['item1', 'item2', 'item3'], 3, 1);
+        $p = new Paginator(['item/1', 'item/2', 'item/3'], 3, 1);
         $results = $p->toPrettyJson();
         $expected = $p->toJson(JSON_PRETTY_PRINT);
 
@@ -93,5 +93,11 @@ class PaginatorTest extends TestCase
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('item\/1', $results);
+
+        $results = $p->toPrettyJson(JSON_UNESCAPED_SLASHES);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('item/1', $results);
     }
 }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -261,6 +261,7 @@ class SupportMessageBagTest extends TestCase
         $container->setFormat(':message');
         $container->add('foo', 'bar');
         $container->add('boom', 'baz');
+        $container->add('baz', '123');
         $results = $container->toPrettyJson();
         $expected = $container->toJson(JSON_PRETTY_PRINT);
 
@@ -268,6 +269,13 @@ class SupportMessageBagTest extends TestCase
         $this->assertSame($expected, $results);
         $this->assertStringContainsString("\n", $results);
         $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('"123"', $results);
+
+        $results = $container->toPrettyJson(JSON_NUMERIC_CHECK);
+        $this->assertStringContainsString("\n", $results);
+        $this->assertStringContainsString('    ', $results);
+        $this->assertStringContainsString('123', $results);
+        $this->assertStringNotContainsString('"123"', $results);
     }
 
     public function testCountReturnsCorrectValue()


### PR DESCRIPTION
### Description

This PR enhances the `prettyJson` helper by introducing support for **JSON options**, giving developers more control over JSON encoding beyond the default `JSON_PRETTY_PRINT`, see https://github.com/laravel/framework/pull/56697.

### Motivation

Currently, `prettyJson` always forces `JSON_PRETTY_PRINT`, without a way to adjust encoding flags. This limits use cases such as:

* Encoding Unicode characters without escaping (`JSON_UNESCAPED_UNICODE`)
* Preserving slashes (`JSON_UNESCAPED_SLASHES`)
* Adding other `json_encode` options when needed

By making `options` configurable, developers can fine-tune the output according to their requirements.

### Changes

* Adds an `$options` parameter (default: `none`) to `prettyJson`.
* Maintains backward compatibility with existing calls.
* Extends test coverage to validate behavior with additional flags.

### Example Usage

```php
prettyJson(['foo' => 'bar'], JSON_UNESCAPED_UNICODE);
```

### Testing

* ✅ Added unit tests for custom options
* ✅ Verified backward compatibility (no breaking changes)

### Related

N/A
