### PR TITLE
[12.x] Fix escaping of quotes compatibility in ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -495,7 +495,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            $string .= ' '.$key.'="'.str_replace('"', '&quot;', trim($value)).'"';
         }
 
         return trim($string);


### PR DESCRIPTION
This PR will fix how ComponentAttributeBag escapes quotes when casting to HTML

using `&quot;` instead of `\\"` increases compatibility when passing js code in `wire:*` attribute

see https://github.com/driesvints/blade-icons/blob/805e15827a89d17a5a04e1690e8fad335f0e086d/src/Factory.php#L234 for reference
