### PR TITLE
feat: a simple "repeat" helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -815,14 +815,16 @@ if (! function_exists('repeat')) {
     /**
      * Execute the given closure a given number of times.
      *
-     * @param  callable(): void $callback
+     * @param  callable(): bool|void $callback
      * @param  int  $iterations
      * @return null
      */
     function repeat(callable $callback, $iterations)
     {
         while ($iterations > 0) {
-            $callback();
+            if ($callback() === true) {
+                break;
+            }
             $iterations--;
         }
     }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -822,7 +822,7 @@ if (! function_exists('repeat')) {
     function repeat(callable $callback, $iterations)
     {
         while ($iterations > 0) {
-            if ($callback() === true) {
+            if ($callback() === false) {
                 break;
             }
             $iterations--;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -811,6 +811,23 @@ if (! function_exists('rescue')) {
     }
 }
 
+if (! function_exists('repeat')) {
+    /**
+     * Execute the given closure a given number of times.
+     *
+     * @param  callable(): void $callback
+     * @param  int  $iterations
+     * @return null
+     */
+    function repeat(callable $callback, $iterations)
+    {
+        while ($iterations > 0) {
+            $callback();
+            $iterations--;
+        }
+    }
+}
+
 if (! function_exists('resolve')) {
     /**
      * Resolve a service from the container.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -821,11 +821,10 @@ if (! function_exists('repeat')) {
      */
     function repeat(callable $callback, $iterations)
     {
-        while ($iterations > 0) {
-            if ($callback() === false) {
+        for ($i = 1; $i <= $iterations; $i++) {
+            if ($callback($i) === false) {
                 break;
             }
-            $iterations--;
         }
     }
 }

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -52,6 +52,21 @@ class FoundationHelpersTest extends TestCase
         );
     }
 
+     public function testRepeat()
+    {
+        $value = 0;
+
+        repeat(function () use (&$value) {
+                $value++;
+        }, 5);
+
+        $this->assertEquals(
+            5,
+            $value
+        );
+
+    }
+
     public function testMixReportsExceptionWhenAssetIsMissingFromManifest()
     {
         $handler = new FakeHandler;

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -65,6 +65,23 @@ class FoundationHelpersTest extends TestCase
             $value
         );
 
+
+        // Test returning true stops the loop.
+
+        $valueTwo = 0;
+
+        repeat(function () use (&$valueTwo) {
+                if ($valueTwo >= 3) {
+                    return true;
+                }
+                $valueTwo++;
+        }, 5);
+
+        $this->assertEquals(
+            3,
+            $valueTwo
+        );
+
     }
 
     public function testMixReportsExceptionWhenAssetIsMissingFromManifest()

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -55,14 +55,25 @@ class FoundationHelpersTest extends TestCase
      public function testRepeat()
     {
         $value = 0;
+        $greatestIteration = null;
+        repeat(function ($iteration) use (&$value, &$greatestIteration) {
 
-        repeat(function () use (&$value) {
-                $value++;
+            $value++;
+             $this->assertEquals(
+            $value,
+            $iteration
+            );
+             $greatestIteration = $iteration;
         }, 5);
 
         $this->assertEquals(
             5,
             $value
+        );
+
+        $this->assertEquals(
+            5,
+            $greatestIteration
         );
 
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -66,13 +66,14 @@ class FoundationHelpersTest extends TestCase
         );
 
 
-        // Test returning true stops the loop.
+        // Test returning anything stops the loop
+
 
         $valueTwo = 0;
 
         repeat(function () use (&$valueTwo) {
                 if ($valueTwo >= 3) {
-                    return true;
+                    return false;
                 }
                 $valueTwo++;
         }, 5);


### PR DESCRIPTION
Adds in a simple `repeat` helper that I found myself wanting recently.

Current argument pattern is `(callback, numberOfIterations)`, but i'm open to reversing that if it aligns a bit more with other examples or reads better.

It just uses a simple `while` loop behind the scenes.

```php
// Repeat a function 5 times.
repeat(fn() => $this->myFunction(), 5);
```

Returns from the closure are discarded.

Returning `false` will stop the loop, though i'm open to removing that if people would rather that program flow was managed purely by throwing exceptions inside userland code.
