### PR TITLE
[12.x] provide a default slot name when compiling

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -560,14 +560,14 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name'] ?: $matches['boundName']);
+            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name'] ?: $matches['boundName'] ?: 'slot');
 
             if (Str::contains($name, '-') && ! empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 
             // If the name was given as a simple string, we will wrap it in quotes as if it was bound for convenience...
-            if (! empty($matches['inlineName']) || ! empty($matches['name'])) {
+            if (empty($matches['boundName'])) {
                 $name = "'{$name}'";
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -560,14 +560,14 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name'] ?: $matches['boundName'] ?: 'slot');
+            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name'] ?: $matches['boundName']) ?: "'slot'";
 
             if (Str::contains($name, '-') && ! empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 
             // If the name was given as a simple string, we will wrap it in quotes as if it was bound for convenience...
-            if (empty($matches['boundName'])) {
+            if (! empty($matches['inlineName']) || ! empty($matches['name'])) {
                 $name = "'{$name}'";
             }
 

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -207,6 +207,13 @@ class BladeTest extends TestCase
 </div>', trim($content));
     }
 
+    public function test_no_name_passed_to_slot_uses_default_name()
+    {
+        $content = Blade::render('<x-link href="#"><x-slot>default slot</x-slot></x-link>');
+
+        $this->assertSame('<a href="#">default slot</a>', trim($content));
+    }
+
     public function testViewCacheCommandHandlesConfiguredBladeExtensions()
     {
         View::addExtension('sh', 'blade');


### PR DESCRIPTION
currently it is required that a name be passed to a slot for a component via 1 of 3 methods:

```blade
<x-slot:name></x-slot>

<x-slot name="name"></x-slot>

<x-slot :name="$name"></x-slot>
```

If you omit all of these options you currently get a syntax error due to an incorrectly compiled slot.

```php
<?php $__env->slot(, null, []); ?> slot <?php $__env->endSlot(); ?>
```

This commit adds a default slot name of "slot" if no others are given. This allows the user to omit designating a name if they wish to use the slot as the default, which is available in the component as `$slot`.

```blade
<x-slot></x-slot>
````

compiles to:

```php
<?php $__env->slot('slot', null, []); ?> slot <?php $__env->endSlot(); ?>
```

This simple string of "slot" joins the "inline name" and "attribute name" in needing to be wrapped in single quotes, unlike the "bound name". In order to accomplish this I reversed the logic of the conditional change so instead of looking for either not empty "inline name" or not empty "attribute name", it looks for empty "bound name". the inversion of logic should behave the same, and gives a very small performance improvement.

---

I could see someone making the argument this should be sent to master. Even though it was never documented, I'm considering it more as a bug fix, as using it this way in the past would have resulted in an error. Happy to resubmit though.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
