### PR TITLE
[12.x] Add method to retrieve the command on InvokedProcess

### DIFF
--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -80,6 +80,16 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Get the command line for the process.
+     *
+     * @return string
+     */
+    public function command()
+    {
+        return $this->command;
+    }
+
+    /**
      * Send a signal to the process.
      *
      * @param  int  $signal

--- a/src/Illuminate/Process/InvokedProcess.php
+++ b/src/Illuminate/Process/InvokedProcess.php
@@ -37,6 +37,16 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Get the command line for the process.
+     *
+     * @return string
+     */
+    public function command()
+    {
+        return $this->process->getCommandLine();
+    }
+
+    /**
      * Send a signal to the process.
      *
      * @param  int  $signal


### PR DESCRIPTION
Working on an artisan command that starts some concurrent processes and monitors them, I wanted to output the full command line of those processes for monitoring.

For example:

```php
$pool = Process::pool(function (Pool $pool) {
    // commands
})->start();

while ($pool->running()->isNotEmpty()) {
    $this->table(
        ['#', 'command'],
        $pool->running()->map(function (InvokedProcess $process) {
            $commandLine = (fn () => $this->process->getCommandLine())
                ->bindTo($process, $process);

            return [$process->id(), $commandLine()];
        })->all(),
    );

    Sleep::for(1)->second();
}

$pool->wait();
```

This would output a table with the current commands being run for each elapsed second.

As I couldn't retrieve the command line, I needed to use the `Closure` bind hack to access the `InvokedProcess`' protected `$process` property and grab the command line.

**This PR**

- Adds the `command()` method both to `InvokedProcess` and `FakeInvokedProcess` to retrieve a pooled process' command line.

If this PR is accepted, I will send a PR to the master branch to add this method to the `Illuminate\Contracts\Process\InvokedProcess` interface.