### PR TITLE
[12.x] New #[ShouldQueue] attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/ShouldQueue.php
+++ b/src/Illuminate/Container/Attributes/ShouldQueue.php
@@ -5,6 +5,6 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-class ShouldQueue extends Database
+final class ShouldQueue
 {
 }

--- a/src/Illuminate/Container/Attributes/ShouldQueue.php
+++ b/src/Illuminate/Container/Attributes/ShouldQueue.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class ShouldQueue extends Database
+{
+}

--- a/src/Illuminate/Container/Attributes/ShouldQueue.php
+++ b/src/Illuminate/Container/Attributes/ShouldQueue.php
@@ -4,7 +4,7 @@ namespace Illuminate\Container\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_CLASS)]
 class ShouldQueue extends Database
 {
 }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -556,9 +556,14 @@ class Dispatcher implements DispatcherContract
     protected function handlerShouldBeQueued($class)
     {
         try {
-            return (new ReflectionClass($class))->implementsInterface(
-                ShouldQueue::class
-            );
+            $reflectionClass = new ReflectionClass($class);
+
+            $shouldQueueAttributes = $reflectionClass->getAttributes(\Illuminate\Container\Attributes\ShouldQueue::class);
+
+            $hasShouldQueueAttribute = !empty($shouldQueueAttributes);
+            $implementsShouldQueueInterface = $reflectionClass->implementsInterface(ShouldQueue::class);
+
+            return $hasShouldQueueAttribute || $implementsShouldQueueInterface;
         } catch (Exception) {
             return false;
         }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -560,7 +560,7 @@ class Dispatcher implements DispatcherContract
 
             $shouldQueueAttributes = $reflectionClass->getAttributes(\Illuminate\Container\Attributes\ShouldQueue::class);
 
-            $hasShouldQueueAttribute = !empty($shouldQueueAttributes);
+            $hasShouldQueueAttribute = ! empty($shouldQueueAttributes);
             $implementsShouldQueueInterface = $reflectionClass->implementsInterface(ShouldQueue::class);
 
             return $hasShouldQueueAttribute || $implementsShouldQueueInterface;

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -36,6 +36,23 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
     }
 
+    public function testQueuedEventHandlersAreQueuedWithAttribute()
+    {
+        $d = new Dispatcher;
+        $queue = m::mock(Queue::class);
+
+        $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
+
+        $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
+
+        $d->setQueueResolver(function () use ($queue) {
+            return $queue;
+        });
+
+        $d->listen('some.event', TestDispatcherQueuedHandlerWithAttribute::class.'@someMethod');
+        $d->dispatch('some.event', ['foo', 'bar']);
+    }
+
     public function testCustomizedQueuedEventHandlersAreQueued()
     {
         $d = new Dispatcher;
@@ -219,6 +236,15 @@ class QueuedEventsTest extends TestCase
 }
 
 class TestDispatcherQueuedHandler implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+}
+
+#[\Illuminate\Container\Attributes\ShouldQueue]
+class TestDispatcherQueuedHandlerWithAttribute
 {
     public function handle()
     {


### PR DESCRIPTION
This PR adds a new `#[ShouldQueue]` attribute as an alternative to `ShouldQueue` interface for event listeners that should be queued.

It always felt a little tricky to me the need to implement an interface that doesn't actually have any method signature to implement, in order to indicate that a listener needed to be queued. Now that we have attributes in PHP, I think this approach feels much more elegant.

This
```
namespace App\Listeners;

use Illuminate\Contracts\Queue\ShouldQueue;

class DoSomething implements ShouldQueue
{
    public function handle()
    {
    }
}
```

Could now be written as
```
namespace App\Listeners;

use Illuminate\Container\Attributes\ShouldQueue;

#[ShouldQueue]
class DoSomething
{
    public function handle()
    {
    }
}
```
