### PR TITLE
Update fluent() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -170,10 +170,10 @@ if (! function_exists('filled')) {
 
 if (! function_exists('fluent')) {
     /**
-    * Create a Fluent object from the given value.
-    *
-    * @param  null|object|iterable  $value
-    */
+     * Create a Fluent object from the given value.
+     *
+     * @param  null|object|iterable  $value
+     */
     function fluent($value = null): Fluent
     {
       return new Fluent($value ?? []);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -170,13 +170,13 @@ if (! function_exists('filled')) {
 
 if (! function_exists('fluent')) {
     /**
-     * Create a Fluent object from the given value.
-     *
-     * @param  object|array  $value
-     */
-    function fluent($value): Fluent
+    * Create a Fluent object from the given value.
+    *
+    * @param  null|object|iterable  $value
+    */
+    function fluent($value = null): Fluent
     {
-        return new Fluent($value);
+      return new Fluent($value ?? []);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -172,11 +172,11 @@ if (! function_exists('fluent')) {
     /**
      * Create a Fluent object from the given value.
      *
-     * @param  null|object|iterable  $value
+     * @param  iterable|object|null  $value
      */
     function fluent($value = null): Fluent
     {
-      return new Fluent($value ?? []);
+        return new Fluent($value ?? []);
     }
 }
 


### PR DESCRIPTION
### Add null support and flexibility to fluent() helper

  **Changes**:
  - Add `null` to accepted parameter types with default value
  - Add `iterable` type support for Collections and other iterable objects
  - Enable `fluent()` calls without arguments (returns empty Fluent instance)

  **Benefits**:
  - Prevents errors when passing potentially null values like `fluent($array['key'])`
  - Supports common usage patterns like fluent() for empty instances
  - Better static analysis with expanded type hints
  - Full backward compatibility - all existing code continues to work unchanged

  Simple enhancement that makes the helper more resilient and developer-friendly by gracefully handling null inputs instead of causing runtime errors.
