### PR TITLE
[12.x] Switch back to ternaries in `DatabaseManager` to allow for empty named connections

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -92,7 +92,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        [$database, $type] = $this->parseConnectionName($name = enum_value($name) ?? $this->getDefaultConnection());
+        [$database, $type] = $this->parseConnectionName($name = enum_value($name) ?: $this->getDefaultConnection());
 
         // If we haven't created this connection, we'll create it based on the config
         // provided in the application. Once we've created the connections we will
@@ -298,7 +298,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function purge($name = null)
     {
-        $this->disconnect($name = enum_value($name) ?? $this->getDefaultConnection());
+        $this->disconnect($name = enum_value($name) ?: $this->getDefaultConnection());
 
         unset($this->connections[$name]);
     }
@@ -311,7 +311,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function disconnect($name = null)
     {
-        if (isset($this->connections[$name = enum_value($name) ?? $this->getDefaultConnection()])) {
+        if (isset($this->connections[$name = enum_value($name) ?: $this->getDefaultConnection()])) {
             $this->connections[$name]->disconnect();
         }
     }
@@ -324,7 +324,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function reconnect($name = null)
     {
-        $this->disconnect($name = enum_value($name) ?? $this->getDefaultConnection());
+        $this->disconnect($name = enum_value($name) ?: $this->getDefaultConnection());
 
         if (! isset($this->connections[$name])) {
             return $this->connection($name);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Within the scope of #56878 some ternaries were replaced with null-coalescing operators in the logic of `DatabaseManager`. This is a behavioral change w.r.t. explicitly empty string being used for connection names. These would previously fall back to being treated as the default connection (due to being falsey), but no longer are. An example of such usage can be found at https://github.com/Flynsarmy/laravel-csv-seeder/blob/master/src/CsvSeeder.php#L37.

Whether or not such cases should be considered valid or not, especially in the long run, is up for debate (given they should probably use an explicit `null` instead of empty string). However, to prevent further disruption for now, this PR reverts back to using ternaries. If wanted, this may be reverted in a future (major) version.

Should close #56888 and fix #56892.