### PR TITLE
[12.x] Simplify MariaDB connection by extending MySQL config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -64,25 +64,9 @@ return [
             ]) : [],
         ],
 
-        'mariadb' => [
+        'mariadb' => array_merge(config('database.connections.mysql'), [
             'driver' => 'mariadb',
-            'url' => env('DB_URL'),
-            'host' => env('DB_HOST', '127.0.0.1'),
-            'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'laravel'),
-            'username' => env('DB_USERNAME', 'root'),
-            'password' => env('DB_PASSWORD', ''),
-            'unix_socket' => env('DB_SOCKET', ''),
-            'charset' => env('DB_CHARSET', 'utf8mb4'),
-            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
-            'prefix' => '',
-            'prefix_indexes' => true,
-            'strict' => true,
-            'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
-        ],
+        ]),
 
         'pgsql' => [
             'driver' => 'pgsql',


### PR DESCRIPTION
## Description

This PR refactors the MariaDB connection in `config/database.php` to extend the existing MySQL configuration instead of duplicating it. This keeps the code DRY and easier to maintain, while preserving all MariaDB-specific settings.

### Before
- `mariadb` config was almost a copy-paste of `mysql`.

### After
- `mariadb` config now merges with `mysql` and only overrides the driver.
