### PR TITLE
[12.x]: New Builder Variables

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1055,7 +1055,7 @@ class Blueprint
      * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function float($column, $precision = 53)
+    public function float($column, $precision = null)
     {
         $precision ??= Builder::$defaultFloatPrecision;
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -810,7 +810,7 @@ class Blueprint
      */
     public function char($column, $length = null)
     {
-        $length = ! is_null($length) ? $length : Builder::$defaultStringLength;
+        $length ??= Builder::$defaultStringLength;
 
         return $this->addColumn('char', $column, compact('length'));
     }
@@ -824,7 +824,7 @@ class Blueprint
      */
     public function string($column, $length = null)
     {
-        $length = $length ?: Builder::$defaultStringLength;
+        $length ??= Builder::$defaultStringLength;
 
         return $this->addColumn('string', $column, compact('length'));
     }
@@ -1052,11 +1052,13 @@ class Blueprint
      * Create a new float column on the table.
      *
      * @param  string  $column
-     * @param  int  $precision
+     * @param  int|null  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function float($column, $precision = 53)
     {
+        $precision ??= Builder::$defaultFloatPrecision;
+
         return $this->addColumn('float', $column, compact('precision'));
     }
 
@@ -1075,12 +1077,15 @@ class Blueprint
      * Create a new decimal column on the table.
      *
      * @param  string  $column
-     * @param  int  $total
-     * @param  int  $places
+     * @param  int|null  $total
+     * @param  int|null  $places
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function decimal($column, $total = 8, $places = 2)
+    public function decimal($column, $total = null, $places = null)
     {
+        $total ??= Builder::$defaultDecimalTotal;
+        $places ??= Builder::$defaultDecimalPlaces;
+
         return $this->addColumn('decimal', $column, compact('total', 'places'));
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -54,6 +54,21 @@ class Builder
     public static $defaultMorphKeyType = 'int';
 
     /**
+     * The default decimal total for migrations.
+     */
+    public static ?int $defaultDecimalTotal = 8;
+
+    /**
+     * The default decimal places for migrations.
+     */
+    public static ?int $defaultDecimalPlaces = 2;
+
+    /**
+     * The default float precision for migrations.
+     */
+    public static ?int $defaultFloatPrecision = 53;
+
+    /**
      * Create a new database Schema manager.
      *
      * @param  \Illuminate\Database\Connection  $connection

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -56,17 +56,17 @@ class Builder
     /**
      * The default decimal total for migrations.
      */
-    public static ?int $defaultDecimalTotal = 8;
+    public static int $defaultDecimalTotal = 8;
 
     /**
      * The default decimal places for migrations.
      */
-    public static ?int $defaultDecimalPlaces = 2;
+    public static int $defaultDecimalPlaces = 2;
 
     /**
      * The default float precision for migrations.
      */
-    public static ?int $defaultFloatPrecision = 53;
+    public static int $defaultFloatPrecision = 53;
 
     /**
      * Create a new database Schema manager.

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -744,6 +744,19 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" float(5) not null', $statements[0]);
+
+        Builder::$defaultFloatPrecision = 10;
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->float('foo');
+        $statements = $blueprint->toSql();
+
+        try {
+            $this->assertCount(1, $statements);
+            $this->assertSame('alter table "users" add column "foo" float(10) not null', $statements[0]);
+        } finally {
+            Builder::$defaultFloatPrecision = 53;
+        }
     }
 
     public function testAddingDouble()
@@ -764,6 +777,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
+
+        Builder::$defaultDecimalTotal = 19;
+        Builder::$defaultDecimalPlaces = 4;
+
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->decimal('foo');
+        $statements = $blueprint->toSql();
+
+        try {
+            $this->assertCount(1, $statements);
+            $this->assertSame('alter table "users" add column "foo" decimal(19, 4) not null', $statements[0]);
+        } finally {
+            Builder::$defaultDecimalTotal = 8;
+            Builder::$defaultDecimalPlaces = 2;
+        }
     }
 
     public function testAddingBoolean()


### PR DESCRIPTION
Add default precision settings for `DECIMAL` and `FLOAT` columns in migrations.

This PR introduces three new static variables to define default precision for numeric columns in migrations:

- `public static int $defaultDecimalTotal = 8;` – Default total digits for `DECIMAL` columns.
- `public static int $defaultDecimalPlaces = 2;` – Default decimal places for `DECIMAL` columns.
- `public static int $defaultFloatPrecision = 53;` – Default precision for `FLOAT` columns.

These defaults make it easier to keep numeric column definitions consistent across projects.
