### PR TITLE
[12.x] Add SSL/TLS support for MySQL and PostgreSQL connections

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -99,7 +99,7 @@ return [
             'search_path' => 'public',
             'sslmode' => env('PGSQL_SSL_MODE', 'prefer'),
             'sslcert' => env('PGSQL_SSL_CERT'),
-            'sslkey'  => env('PGSQL_SSL_KEY'),
+            'sslkey' => env('PGSQL_SSL_KEY'),
             'sslrootcert' => env('PGSQL_SSL_ROOT_CERT'),
         ],
 

--- a/config/database.php
+++ b/config/database.php
@@ -61,6 +61,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('MYSQL_ATTR_SSL_VERIFY', false),
             ]) : [],
         ],
 
@@ -96,7 +97,10 @@ return [
             'prefix' => '',
             'prefix_indexes' => true,
             'search_path' => 'public',
-            'sslmode' => 'prefer',
+            'sslmode' => env('PGSQL_SSL_MODE', 'prefer'),
+            'sslcert' => env('PGSQL_SSL_CERT'),
+            'sslkey'  => env('PGSQL_SSL_KEY'),
+            'sslrootcert' => env('PGSQL_SSL_ROOT_CERT'),
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
## Description

This PR adds optional SSL/TLS support for MySQL and PostgreSQL connections in `config/database.php`.

### MySQL
- Adds `PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` which can be configured via `.env` (`MYSQL_ATTR_SSL_VERIFY`).

### PostgreSQL
- Adds support for `sslmode`, `sslcert`, `sslkey`, and `sslrootcert` via `.env`.
- Allows developers to enable secure connections in production.

### Benefits
- Improves security for database connections.
- Makes configuration flexible and environment-driven.
