### PR TITLE
[12.x] Add default testing database connection using SQLite memory

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -114,6 +114,11 @@ return [
             // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
 
+        'testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
     ],
 
     /*


### PR DESCRIPTION
## Description

This PR adds a default `testing` database connection using SQLite in-memory.

### Why?
Currently, running `php artisan test` on a fresh clone fails unless a database is configured.  
With this change, tests work out of the box. So, no setup required.

### Benefits
- Zero-configuration testing
- Faster test execution with SQLite memory
- Improved developer experience
