### PR TITLE
[12.x] Add `WithoutModelTimestamps` trait for database seeders

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/WithoutModelTimestamps.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelTimestamps.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Console\Seeds;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait WithoutModelTimestamps
+{
+    /**
+     * Prevent model timestamps from being updated by the given callback.
+     */
+    public function withoutModelTimestamps(callable $callback): callable
+    {
+        return fn () => Model::withoutTimestamps($callback);
+    }
+}

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Console\Seeds\WithoutModelTimestamps;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -192,6 +193,10 @@ abstract class Seeder
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);
+        }
+
+        if (isset($uses[WithoutModelTimestamps::class])) {
+            $callback = $this->withoutModelTimestamps($callback);
         }
 
         return $callback();


### PR DESCRIPTION
Replaced by #56914 