### PR TITLE
[12.x] Fix pivot model generator to explicitly set incrementing property

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class {{ class }} extends Pivot
 {
-    //
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
 }


### PR DESCRIPTION
## Description

Currently, generating a pivot model using:

```bash
php artisan make:model Foo --pivot -m
```
produces a model that extends Pivot but does not explicitly set `$incrementing`. Pivot tables often do not have an auto-incrementing ID, which can cause confusion when using `updateOrCreate()`.

This PR updates the `model.pivot.stub` to explicitly set:
```php
public $incrementing = false;
```

Benefits
- Clarifies pivot model behavior.
- Prevents silent bugs with updateOrCreate() or other ID-dependent methods.
- Improves developer experience for new pivot models.

Related Issue
Fixes: [#56829](https://github.com/laravel/framework/issues/56829)

