### PR TITLE
[12.x] Add `WithoutModelTimestamps` trait for database seeders

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/WithoutModelTimestamps.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelTimestamps.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Console\Seeds;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait WithoutModelTimestamps
+{
+    /**
+     * Prevent model timestamps from being updated by the given callback.
+     */
+    public function withoutModelTimestamps(callable $callback): callable
+    {
+        return fn () => Model::withoutTimestamps($callback);
+    }
+}

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Console\Seeds\WithoutModelTimestamps;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -192,6 +193,10 @@ abstract class Seeder
 
         if (isset($uses[WithoutModelEvents::class])) {
             $callback = $this->withoutModelEvents($callback);
+        }
+
+        if (isset($uses[WithoutModelTimestamps::class])) {
+            $callback = $this->withoutModelTimestamps($callback);
         }
 
         return $callback();


### PR DESCRIPTION
This pull request introduces a new trait for database seeders, `WithoutModelTimestamps` — which prevents model timestamps from being touched while running seeds.

## Why ?

When running seeders, developers may need to update records for testing, bootstrapping, or populating new columns without altering timestamp fields. The `WithoutModelTimestamps` trait ensures these operations leave timestamps untouched, preserving the integrity of historical and reference data.

```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Seeder;
use Illuminate\Database\Console\Seeds\WithoutModelTimestamps;

class DatabaseSeeder extends Seeder
{
    use WithoutModelTimestamps;

    /**
     * Run the database seeders without modifying timestamp columns,
     * even for factories or seeders executed via the call() method.
     */
    public function run()
    {
        User::factory(10)->create();

        $this->call([
            UserSeeder::class,
            UserWithoutModelTimestampsSeeder::class,
        ]);
    }
}
```

In many cases, it is useful to combine this trait with `WithoutModelEvents` to create fully silent seeding operations — where no timestamps are updated and no model events are dispatched — resulting in faster, cleaner, and side-effect-free seed executions.

1. Create a reusable `SilentSeeder` base class that disables both model events and timestamp updates:

```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Seeder;
use Illuminate\Database\Console\Seeds\WithoutModelEvents;
use Illuminate\Database\Console\Seeds\WithoutModelTimestamps;

abstract class SilentSeeder extends Seeder
{
    use WithoutModelEvents;
    use WithoutModelTimestamps;
}
```

2. Extend `SilentSeeder` whenever you need fully side-effect-free seeding:

```php
<?php

namespace Database\Seeders;

class UserSeeder extends SilentSeeder
{
    /**
     * Demo: populate the new "external_identifier" column for users using data from a 3rd-party API.
     * This is only to show the concept — not a best-practice implementation.
     *
     * Events and timestamps are suppressed by SilentSeeder.
     */
    public function run()
    {
        // Pseudo-code: fetch user IDs from an external API
        // $externalUsers = Http::get('https://api.example.com/users')->json();

        // match external users with local records and update
        foreach ($externalUsers as $externalUser) {
            $user = \App\Models\User::where('email', $externalUser['email'])->first();

            if ($user) {
                $user->external_identifier = $externalUser['id'];
                $user->save();
            }
        }
    }
}
```