### PR TITLE
[12.x] Support kebab-case names in `make:migration` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -70,7 +70,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs
         // to be freshly created so we can create the appropriate migrations.
-        $name = Str::snake(trim($this->input->getArgument('name')));
+        $name = Str::snake(trim(str_replace('-', ' ', $this->input->getArgument('name'))));
 
         $table = $this->input->getOption('table');
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -66,6 +66,22 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $this->runCommand($command, ['name' => 'CreateFoo']);
     }
 
+    public function testBasicCreateGivesCreatorProperArgumentsWhenNameIsKebabCase()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->andReturn(__DIR__.'/migrations/2025_09_03_110457_create_foo.php');
+
+        $this->runCommand($command, ['name' => 'create-foo']);
+    }
+
     public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
     {
         $command = new MigrateMakeCommand(


### PR DESCRIPTION
This PR improves the `make:migration` command by allowing developers to use `kebab-case` migration names.

## Why?

- Supported cases would be:

  - snake_case
  - PascalCase
  - camelCase
  - kebab-case

All of these are converted to `snake_case`, ensuring consistency in migration file names.

- Improves the DX by treating dashes as word separators.
