### PR TITLE
[12.x ]Introduce a JsonSchema validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -17,12 +17,14 @@ use Egulias\EmailValidator\Validation\RFCValidation;
 use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Exceptions\MathException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\JsonSchema as JsonSchemaRule;
 use Illuminate\Validation\Rules\Unique;
 use Illuminate\Validation\ValidationData;
 use InvalidArgumentException;
@@ -1631,6 +1633,25 @@ trait ValidatesAttributes
         }
 
         return json_validate($value);
+    }
+
+    /**
+     * Validate that an attribute matches a JSON schema.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateJsonSchema($attribute, $value, $parameters): bool
+    {
+        if (! isset($parameters[0]) || ! $parameters[0] instanceof Type) {
+            throw new InvalidArgumentException('The json_schema rule requires a JsonSchema Type instance.');
+        }
+
+        $rule = new JsonSchemaRule($parameters[0]);
+
+        return $rule->passes($attribute, $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1645,13 +1645,11 @@ trait ValidatesAttributes
      */
     public function validateJsonSchema($attribute, $value, $parameters): bool
     {
-        if (! isset($parameters[0]) || ! $parameters[0] instanceof Type) {
+        if (! ($parameters[0] ?? null) instanceof Type) {
             throw new InvalidArgumentException('The json_schema rule requires a JsonSchema Type instance.');
         }
 
-        $rule = new JsonSchemaRule($parameters[0]);
-
-        return $rule->passes($attribute, $value);
+        return (new JsonSchemaRule($parameters[0]))->passes($attribute, $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\AnyOf;
@@ -17,6 +18,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Validation\Rules\ImageFile;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\JsonSchema as JsonSchemaRule;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\Numeric;
 use Illuminate\Validation\Rules\ProhibitedIf;
@@ -245,6 +247,17 @@ class Rule
     public static function numeric()
     {
         return new Numeric;
+    }
+
+    /**
+     * Create a JSON Schema validation rule.
+     *
+     * @param  \Illuminate\JsonSchema\Types\Type  $schema
+     * @return \Illuminate\Validation\Rules\JsonSchema
+     */
+    public static function jsonSchema(Type $schema)
+    {
+        return new JsonSchemaRule($schema);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/JsonSchema.php
+++ b/src/Illuminate/Validation/Rules/JsonSchema.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Exception;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\JsonSchema\JsonSchema as Schema;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Validator;
+
+class JsonSchema implements Rule
+{
+    /**
+     * The JSON schema instance.
+     */
+    protected Schema $schema;
+
+    /**
+     * The validation error message.
+     */
+    protected ?string $errorMessage = null;
+
+    /**
+     * Create a new JSON schema validation rule.
+     *
+     */
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function passes($attribute, $value): bool
+    {
+        $this->errorMessage = null;
+
+        // Normalize the data to what Opis expects
+        $data = $this->normalizeData($value);
+
+        if ($data === null && $this->errorMessage) {
+            return false;
+        }
+
+        try {
+            $validator = new Validator;
+            $schemaString = $this->schema->toString();
+            $result = $validator->validate($data, $schemaString);
+
+            if (! $result->isValid()) {
+                $this->errorMessage = $this->formatValidationError($result->error());
+
+                return false;
+            }
+
+            return true;
+        } catch (Exception $e) {
+            $this->errorMessage = "Schema validation error: {$e->getMessage()}";
+
+            return false;
+        }
+    }
+
+    /**
+     * Normalize input data for Opis validation.
+     *
+     * @param  mixed  $value
+     * @return mixed|null
+     */
+    protected function normalizeData($value)
+    {
+        if (is_string($value)) {
+            $decoded = json_decode($value);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $this->errorMessage = 'Invalid JSON format: '.json_last_error_msg();
+
+                return null;
+            }
+
+            return $decoded;
+        }
+
+        if (is_array($value) || is_object($value)) {
+            // Convert to JSON and back to ensure proper object/array structure for Opis
+            return json_decode(json_encode($value, JSON_FORCE_OBJECT), false);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format the validation error message.
+     */
+    protected function formatValidationError(?ValidationError $error): string
+    {
+        $keyword = $error->keyword();
+        $dataPath = implode('.', $error->data()->path() ?? []);
+
+        if ($dataPath) {
+            return "Validation failed at '{$dataPath}': {$keyword}";
+        }
+
+        return "Validation failed: {$keyword}";
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    public function message(): string
+    {
+        return $this->errorMessage ?? 'The :attribute does not match the required schema.';
+    }
+}

--- a/src/Illuminate/Validation/Rules/JsonSchema.php
+++ b/src/Illuminate/Validation/Rules/JsonSchema.php
@@ -22,7 +22,6 @@ class JsonSchema implements Rule
 
     /**
      * Create a new JSON schema validation rule.
-     *
      */
     public function __construct(Schema $schema)
     {

--- a/src/Illuminate/Validation/Rules/JsonSchema.php
+++ b/src/Illuminate/Validation/Rules/JsonSchema.php
@@ -97,7 +97,7 @@ class JsonSchema implements Rule
         $keyword = $error->keyword();
         $dataPath = implode('.', $error->data()->path() ?? []);
 
-        return  $dataPath !== '' ?
+        return $dataPath !== '' ?
             "Validation failed at '$dataPath': $keyword" :
             "Validation failed: $keyword";
     }

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -25,6 +25,7 @@
         "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0",
         "illuminate/translation": "^12.0",
+        "opis/json-schema": "^2.4.1",
         "symfony/http-foundation": "^7.2",
         "symfony/mime": "^7.2",
         "symfony/polyfill-php83": "^1.33"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -22,6 +22,7 @@
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",
+        "illuminate/json-schema": "^12.0",
         "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0",
         "illuminate/translation": "^12.0",

--- a/tests/Validation/JsonSchemaRuleTest.php
+++ b/tests/Validation/JsonSchemaRuleTest.php
@@ -1,0 +1,171 @@
+<?php
+
+// File: tests/Validation/JsonSchemaRuleTest.php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rules\JsonSchema as JsonSchemaRule;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaRuleTest extends TestCase
+{
+    public function test_passes_with_valid_json_object(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+            'age' => JsonSchema::integer()->min(0),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $validData = json_encode(['name' => 'John', 'age' => 25]);
+
+        $this->assertTrue($rule->passes('data', $validData));
+    }
+
+    public function test_fails_with_missing_required_field(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+            'age' => JsonSchema::integer()->min(0),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $invalidData = json_encode(['age' => 25]); // missing required 'name'
+
+        $this->assertFalse($rule->passes('data', $invalidData));
+    }
+
+    public function test_fails_with_wrong_data_type(): void
+    {
+        $schema = JsonSchema::object([
+            'age' => JsonSchema::integer()->min(0),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $invalidData = json_encode(['age' => 'not-a-number']);
+
+        $this->assertFalse($rule->passes('data', $invalidData));
+    }
+
+    public function test_works_with_already_decoded_data(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $validData = ['name' => 'John']; // already decoded array
+
+        $this->assertTrue($rule->passes('data', $validData));
+    }
+
+    public function test_fails_with_invalid_json_string(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $invalidJson = '{"name": "John"'; // malformed JSON
+
+        $this->assertFalse($rule->passes('data', $invalidJson));
+        $this->assertStringContainsString('Invalid JSON format', $rule->message());
+    }
+
+    public function test_handles_json_decode_errors_gracefully(): void
+    {
+        $schema = JsonSchema::object([
+            'name' => JsonSchema::string()->required(),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+        $invalidJson = 'not-json-at-all';
+
+        $this->assertFalse($rule->passes('data', $invalidJson));
+        $this->assertStringContainsString('Invalid JSON format', $rule->message());
+    }
+
+    public function test_handles_complex_nested_schema(): void
+    {
+        $schema = JsonSchema::object([
+            'user' => JsonSchema::object([
+                'profile' => JsonSchema::object([
+                    'name' => JsonSchema::string()->required(),
+                    'age' => JsonSchema::integer()->min(0)->max(150),
+                ])->required(),
+                'preferences' => JsonSchema::object([
+                    'theme' => JsonSchema::string()->enum(['light', 'dark']),
+                    'notifications' => JsonSchema::boolean()->default(true),
+                ]),
+            ])->required(),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+
+        // Valid complex data
+        $validData = json_encode([
+            'user' => [
+                'profile' => [
+                    'name' => 'John Doe',
+                    'age' => 30,
+                ],
+                'preferences' => [
+                    'theme' => 'dark',
+                    'notifications' => true,
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($rule->passes('data', $validData));
+
+        // Invalid complex data (missing required field)
+        $invalidData = json_encode([
+            'user' => [
+                'profile' => [
+                    'age' => 30, // missing required 'name'
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($rule->passes('data', $invalidData));
+    }
+
+    public function test_validates_array_schemas(): void
+    {
+        $schema = JsonSchema::object([
+            'tags' => JsonSchema::array()->items(JsonSchema::string())->min(1)->max(5),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+
+        // Valid array data
+        $validData = json_encode(['tags' => ['php', 'laravel', 'json']]);
+        $this->assertTrue($rule->passes('data', $validData));
+
+        // Invalid array data (too many items)
+        $invalidData = json_encode(['tags' => ['a', 'b', 'c', 'd', 'e', 'f']]);
+        $this->assertFalse($rule->passes('data', $invalidData));
+
+        // Invalid array data (empty array)
+        $emptyData = json_encode(['tags' => []]);
+        $this->assertFalse($rule->passes('data', $emptyData));
+    }
+
+    public function test_validates_enum_values(): void
+    {
+        $schema = JsonSchema::object([
+            'status' => JsonSchema::string()->enum(['draft', 'published', 'archived']),
+        ]);
+
+        $rule = new JsonSchemaRule($schema);
+
+        // Valid enum value
+        $validData = json_encode(['status' => 'published']);
+        $this->assertTrue($rule->passes('data', $validData));
+
+        // Invalid enum value
+        $invalidData = json_encode(['status' => 'invalid-status']);
+        $this->assertFalse($rule->passes('data', $invalidData));
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a `json_schema` validation rule to Laravel’s validator, allowing attributes to be validated against JSON Schemas. It introduces a new `JsonSchema` rule class, integrates with `opis/json-schema`, and includes a fluent `Rule::jsonSchema()` helper.

This is made possible by he introduction of `illuminate/json-schema`, see https://github.com/laravel/framework/pull/56903 by @nunomaduro 

This is still very much ***Work in progress.***

---

### What's Changed

* Added `validateJsonSchema()` method in `ValidatesAttributes`.
* Added `Rule::jsonSchema(Type $schema)` convenience method.
* New `Illuminate\Validation\Rules\JsonSchema` class with support for normalization, malformed JSON detection, and detailed error messages.
* Added `opis/json-schema` dependency.
* Test coverage for valid/invalid payloads, malformed JSON, nested schemas, arrays, enums, and required fields.

---

### Motivation

* Native JSON Schema validation in Laravel.
* Accurate, schema-based validation with clear error messages.

---

### Example

```php
use Illuminate\Validation\Rule;
use Illuminate\JsonSchema\Types\Type;

$schema = Type::object([
    'name' => Type::string()->required(),
    'age'  => Type::integer()->min(0),
]);

$request->validate([
    'data' => [Rule::jsonSchema($schema)],
]);
```
