### PR TITLE
[12.x] Introducing `different()` Password Validation Method

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -126,6 +126,7 @@ return [
         'numbers' => 'The :attribute field must contain at least one number.',
         'symbols' => 'The :attribute field must contain at least one symbol.',
         'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
+        'different' => 'The given :attribute must be different from the current password.',
     ],
     'present' => 'The :attribute field must be present.',
     'present_if' => 'The :attribute field must be present when :other is :value.',

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -436,6 +436,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             'numbers' => $this->numbers,
             'symbols' => $this->symbols,
             'uncompromised' => $this->uncompromised,
+            'different' => $this->different,
             'compromisedThreshold' => $this->compromisedThreshold,
             'customRules' => $this->customRules,
         ];

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -413,6 +413,7 @@ class ValidationPasswordRuleTest extends TestCase
             'numbers' => true,
             'symbols' => true,
             'uncompromised' => false,
+            'different' => false,
             'compromisedThreshold' => 0,
             'customRules' => [],
         ]);
@@ -427,6 +428,7 @@ class ValidationPasswordRuleTest extends TestCase
             'numbers' => false,
             'symbols' => false,
             'uncompromised' => false,
+            'different' => false,
             'compromisedThreshold' => 0,
             'customRules' => [],
         ]);

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -156,17 +156,39 @@ class ValidationPasswordRuleTest extends TestCase
             'password' => $hashed,
         ]);
 
-        $guard = new class($user) {
+        $guard = new class($user)
+        {
             public $user;
-            public function __construct($user) { $this->user = $user; }
-            public function check() { return $this->user !== null; }
-            public function user() { return $this->user; }
+
+            public function __construct($user)
+            {
+                $this->user = $user;
+            }
+
+            public function check()
+            {
+                return $this->user !== null;
+            }
+
+            public function user()
+            {
+                return $this->user;
+            }
         };
 
-        $auth = new class($guard) {
+        $auth = new class($guard)
+        {
             public $guard;
-            public function __construct($guard) { $this->guard = $guard; }
-            public function guard($name = null) { return $this->guard; }
+
+            public function __construct($guard)
+            {
+                $this->guard = $guard;
+            }
+
+            public function guard($name = null)
+            {
+                return $this->guard;
+            }
         };
 
         Container::getInstance()->instance('auth', $auth);


### PR DESCRIPTION
## Motivation

In modern applications, standardizing password rules is no longer just a good practice; it's become a necessity. In Laravel, we can easily define this global standard directly in the AppServiceProvider using Password::defaults(). From there, we can use it anywhere in the application whenever we need to validate passwords consistently and centrally.

But there's an important detail that often goes unnoticed: many systems today don't allow users to reuse the same password when updating it. At first glance, this may seem unnecessary. However, from a security perspective, it makes perfect sense. After all, allowing users to change to the same password offers no practical benefit and even leaves room for insecure behavior.

To solve this problem elegantly, we can apply custom inline validation, ensuring that the new password is always different from the current one. The result is simple, straightforward, and significantly increases system security, as in the example below:

```php
// ...

function ($attribute, $value, $fail) {
    if (Hash::check($value, $this->user->password)) {
        $fail('The new password must be different than the current password.');
    }
},
```

## Solution

While the code demonstrated above is simple and effective, it isn't natively part of the framework. This PR proposes including this logic directly in the core, through a new password validation method called `different()`. This way, we offer an official, reusable, and elegant solution for a recurring scenario across many projects, eliminating the need for repetitive manual implementations.

```php
use Illuminate\Validation\Rules\Password;

Password::defaults(function () {
    return Password::min(8)
        ->letters()
        ->mixedCase()
        ->numbers()
        ->different(guard: null) // 👈
        ->symbols();
});
```
As demonstrated above, we can also specify a different `$guard` when necessary.
