### PR TITLE
Ensure cached and uncached routes share same precedence when resolving actions and names

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -79,7 +79,7 @@ class RouteCollection extends AbstractRouteCollection
         // If the route has a name, we will add it to the name look-up table, so that we
         // will quickly be able to find the route associated with a name and not have
         // to iterate through every route every time we need to find a named route.
-        if (($name = $route->getName()) && ! array_key_exists($name, $this->nameList)) {
+        if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
             $this->nameList[$name] = $route;
         }
 
@@ -88,7 +88,7 @@ class RouteCollection extends AbstractRouteCollection
         // processing a request and easily generate URLs to the given controllers.
         $action = $route->getAction();
 
-        if (($controller = $action['controller'] ?? null) && ! array_key_exists($controller, $this->actionList)) {
+        if (($controller = $action['controller'] ?? null) && ! $this->inActionLookup($controller)) {
             $this->addToActionList($action, $route);
         }
     }
@@ -106,6 +106,28 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Determine if the given controller is in the action lookup table.
+     *
+     * @param  string  $controller
+     * @return bool
+     */
+    protected function inActionLookup($controller)
+    {
+        return array_key_exists($controller, $this->actionList);
+    }
+
+    /**
+     * Determine if the given name is in the name lookup table.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function inNameLookup($name)
+    {
+        return array_key_exists($name, $this->nameList);
+    }
+
+    /**
      * Refresh the name look-up table.
      *
      * This is done in case any names are fluently defined or if routes are overwritten.
@@ -117,7 +139,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (($name = $route->getName()) && ! array_key_exists($name, $this->nameList)) {
+            if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
                 $this->nameList[$name] = $route;
             }
         }
@@ -135,7 +157,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->actionList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (($controller = $route->getAction()['controller'] ?? null) && ! array_key_exists($controller, $this->actionList)) {
+            if (($controller = $route->getAction()['controller'] ?? null) && ! $this->inActionLookup($controller)) {
                 $this->addToActionList($route->getAction(), $route);
             }
         }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -79,7 +79,7 @@ class RouteCollection extends AbstractRouteCollection
         // If the route has a name, we will add it to the name look-up table, so that we
         // will quickly be able to find the route associated with a name and not have
         // to iterate through every route every time we need to find a named route.
-        if ($name = $route->getName()) {
+        if (($name = $route->getName()) && ! array_key_exists($name, $this->nameList)) {
             $this->nameList[$name] = $route;
         }
 
@@ -88,7 +88,7 @@ class RouteCollection extends AbstractRouteCollection
         // processing a request and easily generate URLs to the given controllers.
         $action = $route->getAction();
 
-        if (isset($action['controller'])) {
+        if (($controller = $action['controller'] ?? null) && ! array_key_exists($controller, $this->actionList)) {
             $this->addToActionList($action, $route);
         }
     }
@@ -117,8 +117,8 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-            if ($route->getName()) {
-                $this->nameList[$route->getName()] = $route;
+            if (($name = $route->getName()) && ! array_key_exists($name, $this->nameList)) {
+                $this->nameList[$name] = $route;
             }
         }
     }
@@ -135,7 +135,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->actionList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (isset($route->getAction()['controller'])) {
+            if (($controller = $route->getAction()['controller'] ?? null) && ! array_key_exists($controller, $this->actionList)) {
                 $this->addToActionList($route->getAction(), $route);
             }
         }

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -3,12 +3,10 @@
 namespace Illuminate\Tests\Integration\Routing;
 
 use ArrayIterator;
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Artisan;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -121,18 +121,11 @@ class CompiledRouteCollectionTest extends TestCase
 
     public function testCompiledAndNonCompiledUrlResolutionHasSamePrecedenceForNames()
     {
-        @unlink(__DIR__.'/fixtures/cache/routes-v7.php');
-        $this->app->useBootstrapPath(__DIR__.'/fixtures');
-        $app = (static function () {
-            $refresh = true;
+        $this->router->get('/foo/{bar}', ['FooController', 'show'])->name('foo.show');
+        $this->router->get('/foo/{bar}/{baz}', ['FooController', 'show'])->name('foo.show');
+        $this->router->getRoutes()->refreshNameLookups();
 
-            return require __DIR__.'/fixtures/app.php';
-        })();
-        $app['router']->get('/foo/{bar}', ['FooController', 'show'])->name('foo.show');
-        $app['router']->get('/foo/{bar}/{baz}', ['FooController', 'show'])->name('foo.show');
-        $app['router']->getRoutes()->refreshNameLookups();
-
-        $this->assertSame('foo/{bar}', $app['router']->getRoutes()->getByName('foo.show')->uri);
+        $this->assertSame('foo/{bar}', $this->router->getRoutes()->getByName('foo.show')->uri);
     }
 
     public function testRouteCollectionCanGetIterator()

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -96,12 +96,12 @@ class CompiledRouteCollectionTest extends TestCase
 
     public function testCompiledAndNonCompiledUrlResolutionHasSamePrecedenceForActions()
     {
-        @unlink(__DIR__.'/fixtures/cache/routes-v7.php');
-        $this->app->useBootstrapPath(__DIR__.'/fixtures');
+        @unlink(__DIR__.'/Fixtures/cache/routes-v7.php');
+        $this->app->useBootstrapPath(__DIR__.'/Fixtures');
         $app = (static function () {
             $refresh = true;
 
-            return require __DIR__.'/fixtures/app.php';
+            return require __DIR__.'/Fixtures/app.php';
         })();
         $app['router']->get('/foo/{bar}', ['FooController', 'show']);
         $app['router']->get('/foo/{bar}/{baz}', ['FooController', 'show']);
@@ -110,11 +110,11 @@ class CompiledRouteCollectionTest extends TestCase
         $this->assertSame('foo/{bar}', $app['router']->getRoutes()->getByAction('FooController@show')->uri);
 
         $this->artisan('route:cache')->assertExitCode(0);
-        require __DIR__.'/fixtures/cache/routes-v7.php';
+        require __DIR__.'/Fixtures/cache/routes-v7.php';
 
         $this->assertSame('foo/{bar}', $app['router']->getRoutes()->getByAction('FooController@show')->uri);
 
-        unlink(__DIR__.'/fixtures/cache/routes-v7.php');
+        unlink(__DIR__.'/Fixtures/cache/routes-v7.php');
     }
 
     public function testCompiledAndNonCompiledUrlResolutionHasSamePrecedenceForNames()

--- a/tests/Integration/Routing/Fixtures/app.php
+++ b/tests/Integration/Routing/Fixtures/app.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+if (! class_exists(AppCache::class)) {
+    class AppCache
+    {
+        public static $app;
+    }
+}
+
+if (isset($refresh)) {
+    return AppCache::$app = Application::configure(basePath: __DIR__)->create();
+} else {
+    return AppCache::$app ??= Application::configure(basePath: __DIR__)->create();
+}

--- a/tests/Integration/Routing/Fixtures/app.php
+++ b/tests/Integration/Routing/Fixtures/app.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Tests\Integration\Routing\Fixtures;
 
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Configuration\Exceptions;
-use Illuminate\Foundation\Configuration\Middleware;
 
 if (! class_exists(AppCache::class)) {
     class AppCache

--- a/tests/Integration/Routing/Fixtures/bootstrap/cache/.gitignore
+++ b/tests/Integration/Routing/Fixtures/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Integration/Routing/Fixtures/cache/.gitignore
+++ b/tests/Integration/Routing/Fixtures/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -719,6 +719,8 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetScopedOptionOnRegisteredResource()
     {
         $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped();
+        $this->router->getRoutes()->refreshNameLookups();
+
         $this->assertSame(
             ['user' => null],
             $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
@@ -731,6 +733,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped([
             'task' => 'slug',
         ]);
+        $this->router->getRoutes()->refreshNameLookups();
         $this->assertSame(
             ['user' => null],
             $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
@@ -904,6 +907,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two']);
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
@@ -918,6 +922,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two'])
             ->middleware('default');
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
@@ -1448,6 +1453,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two']);
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
@@ -1463,6 +1469,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two'])
             ->middleware('default');
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);


### PR DESCRIPTION
This PR addresses a bug where routes precedence is different than expected when matching actions and names compared to matching URLs.

Also, there is an inconsistency between action matching behaviour with cached and un-cached routes. This is fun because we didn't know about the issue until it was deployed (not in production) where the routes were cached.

---

Given the following two routes:

```php
Route::get('base/{first}/{param?}', [MyController::class, 'show']);
Route::get('base/{second}', [MyController::class, 'show']);
```

Although both of the routes can respond to the following URL, the first route defined takes precedence:

```
/base/foo
```

Precedence is basically: first route to match handles the request.

When it comes to generating URLs for routes, we have some inconsistencies with this behaviour that is inconsistent between cached and uncached routes.

```php
Artisan::call('route:clear');

url()->action([MyController::class, 'show'], ['laravel', 'framework']);
> "/base/laravel?framework"

Artisan::call('route:cache');

url()->action([MyController::class, 'show'], ['laravel', 'framework']);
> "/base/laravel/framework"
```

Notice when the routes were not cached, the second route was used and a query string is present. When the routes are cached, the first route is used and the second parameter becomes a path segment.

When the routes are cached, I feel the expected behaviour occurs. The `CompiledRouteCollection` will match against the first route with the same action.

https://github.com/laravel/framework/blob/5d773d2e3810ba51b563f859f38dcd1371c568b2/src/Illuminate/Routing/CompiledRouteCollection.php#L210-L216

I feel that the un-compiled `RouteCollection` class exhibits the wrong behaviour, and will match on the _last_ route with the same action. The cause of this is the way the `RouteCollection` maintains a key -> value pair of action => route.

https://github.com/laravel/framework/blob/5d773d2e3810ba51b563f859f38dcd1371c568b2/src/Illuminate/Routing/RouteCollection.php#L103-L106

This is called whenever we add a new route:

```php
Route::get('...', [MyController::class, 'show']); 
// $this->actionList['MyControlle@show'] = $route;

Route::get('...', [MyController::class, 'show']);
// $this->actionList['MyControlle@show'] = $route;
```

We also override everything again when the action lookup is refreshed:

https://github.com/laravel/framework/blob/5d773d2e3810ba51b563f859f38dcd1371c568b2/src/Illuminate/Routing/RouteCollection.php#L133-L142

The same precedence issue exists for named routes, where the last one is always matched. This doesn't have the difference between un-cached and cached routes, because you cannot serialize a routes if you have a route name conflict.

That being said, I still feel the precedence for un-cached routes should be addressed.