### PR TITLE
Allow RouteRegistrar to be Macroable

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -7,6 +7,7 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
 /**
@@ -34,6 +35,9 @@ use InvalidArgumentException;
 class RouteRegistrar
 {
     use CreatesRegularExpressionRouteConstraints;
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The router instance.
@@ -280,6 +284,10 @@ class RouteRegistrar
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         if (in_array($method, $this->passthru)) {
             return $this->registerRoute($method, ...$parameters);
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, the `Router` (or `Route` facade) and the `Route` are `Macroable`. But sometimes, some methods on the `Router` will give the intermediate `RouteRegistrar` class. That class is currently not `Macroable` and as such, macros can't be added across the breadth of route setup. This PR adds `Macroable` to `RouteRegistrar` so that macros can now be added and used no matter where the developer is in the route registration.