### PR TITLE
Fix PHP_CLI_SERVER_WORKERS inside laravel/sail

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -101,7 +101,13 @@ class ServeCommand extends Command
                 return false;
             }
 
-            return $workers > 1 && ! $this->option('no-reload') ? false : $workers;
+            if ($workers > 1 &&
+                ! $this->option('no-reload') &&
+                ! (int) env('LARAVEL_SAIL', 0)) {
+                return false;
+            }
+
+            return $workers;
         });
 
         parent::initialize($input, $output);


### PR DESCRIPTION
Related to #56922 PHP_CLI_SERVER_WORKERS environment variable did not work correctly in laravel sail due to phpServerWorkers being set to false instead of the set number.
In normal environment the logic is preserved, since `LARAVEL_SAIL` environment variable wouldn't be set