### PR TITLE
Add firstFrom method to MessageBag

### DIFF
--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -48,6 +48,15 @@ interface MessageBag extends Arrayable, Countable
     public function first($key = null, $format = null);
 
     /**
+     * Get the first message from the bag for given list of keys.
+     *
+     * @param  array  $keys
+     * @param  string|null  $format
+     * @return string
+     */
+    public function firstFrom($keys, $format = null);
+
+    /**
      * Get all of the messages from the bag for a given key.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -189,6 +189,26 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     }
 
     /**
+     * Get the first message from the bag for given list of keys.
+     *
+     * @param  array  $keys
+     * @param  string|null  $format
+     * @return string
+     */
+    public function firstFrom($keys, $format = null)
+    {
+        foreach ($keys as $key) {
+            $message = $this->first($key, $format);
+
+            if ($message !== '') {
+                return $message;
+            }
+        }
+
+        return '';
+    }
+
+    /**
      * Get all of the messages from the message bag for a given key.
      *
      * @param  string  $key


### PR DESCRIPTION
This pull request adds new `firstFrom` method to `MessageBag`.

This method allows retrieval of first found message from given array of keys, not just the first message of strictly one key.
For example, a component that shows only one error message needs to pick the first error message from multiple validated fields.

```blade
<x-comment-input
    {{--  other props --}}
    
    :error="$errors->firstFrom(['content', 'attachment'])"
/>
```
This would allow the component to show first error message of `content` (if there are any), and if there aren't any, then the first error message of `attachment`.

Currently a way to do this is to use match or some other if/else construction, which feels a excessive.

```blade
<x-comment-input
    {{--  other props --}}
    
    :error="match(true) {
        $errors->has('content') => $errors->first('content'),
        $errors->has('attachment') => $errors->first('attachment'),
        default => ''
    }"
/>
```