### PR TITLE
[12.x] Support Check Constraints

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MariaDbProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MariaDbProcessor.php
@@ -4,22 +4,5 @@ namespace Illuminate\Database\Query\Processors;
 
 class MariaDbProcessor extends MySqlProcessor
 {
-    /**
-     * Process the results of a check constraints query.
-     *
-     * @param  list<array<string, mixed>>  $results
-     * @return list<array{name: string|null, columns: list<string>, definition: string}>
-     */
-    public function processCheckConstraints($results)
-    {
-        return array_map(function ($result) {
-            $result = (object) $result;
-
-            return [
-                'name' => $result->name ?? null,
-                'columns' => explode(',', $result->columns ?? ''),
-                'definition' => '('.$result->definition.')',
-            ];
-        }, $results);
-    }
+    //
 }

--- a/src/Illuminate/Database/Query/Processors/MariaDbProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MariaDbProcessor.php
@@ -4,5 +4,22 @@ namespace Illuminate\Database\Query\Processors;
 
 class MariaDbProcessor extends MySqlProcessor
 {
-    //
+    /**
+     * Process the results of a check constraints query.
+     *
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string|null, columns: list<string>, definition: string}>
+     */
+    public function processCheckConstraints($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name ?? null,
+                'columns' => explode(',', $result->columns ?? ''),
+                'definition' => '('.$result->definition.')',
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -141,4 +141,23 @@ class Processor
     {
         return $results;
     }
+
+    /**
+     * Process the results of a check constraints query.
+     *
+     * @param  list<array<string, mixed>>  $results
+     * @return list<array{name: string|null, columns: list<string>, definition: string}>
+     */
+    public function processCheckConstraints($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'columns' => explode(',', $result->columns ?? ''),
+                'definition' => $result->definition ?? null,
+            ];
+        }, $results);
+    }
 }

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -154,9 +154,9 @@ class Processor
             $result = (object) $result;
 
             return [
-                'name' => $result->name,
+                'name' => $result->name ?? null,
                 'columns' => explode(',', $result->columns ?? ''),
-                'definition' => $result->definition ?? null,
+                'definition' => $result->definition,
             ];
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -96,4 +96,28 @@ class SQLiteProcessor extends Processor
             ];
         }, $results);
     }
+
+    /**
+     * Process the results of a check constraints query.
+     *
+     * @param  list<array<string, mixed>>  $results
+     * @param  string  $sql
+     * @param  list<string>  $columns
+     * @return list<array{name: string|null, columns: list<string>, definition: string}>
+     */
+    public function processCheckConstraints($results, ?string $sql = '', array $columns = [])
+    {
+        preg_match_all(
+            '/(?:constraint\s+"?([^"\s]+)"?)?\s+check\s*(\((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*\))/i',
+            $sql ?? '',
+            $matches,
+            PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL
+        );
+
+        return array_map(fn (array $match) => [
+            'name' => $match[1],
+            'columns' => array_values(array_filter($columns, fn (string $column) => str_contains($match[2], $column))),
+            'definition' => $match[2],
+        ], $matches);
+    }
 }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Query\Expression;
@@ -576,12 +577,12 @@ class Blueprint
     /**
      * Indicate that the given check constraint should be dropped.
      *
-     * @param  string  $name
+     * @param  string|string[]  $nameOrColumns
      * @return \Illuminate\Support\Fluent
      */
-    public function dropCheck(string $name): Fluent
+    public function dropCheck(string|array $nameOrColumns): Fluent
     {
-        return $this->addCommand('dropCheck', ['constraint' => $name]);
+        return $this->addCommand('dropCheck', [(is_array($nameOrColumns) ? 'columns' : 'constraint') => $nameOrColumns]);
     }
 
     /**
@@ -772,12 +773,16 @@ class Blueprint
      * Specify a check constraint for the table.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
-     * @param  string|null  $name
+     * @param  string|string[]|null  $nameOrColumns
      * @return \Illuminate\Support\Fluent
      */
-    public function check(Expression|string $expression, ?string $name = null): Fluent
+    public function check(ExpressionContract|string $expression, string|array|null $nameOrColumns = null): Fluent
     {
-        return $this->addCommand('check', ['expression' => $expression, 'constraint' => $name]);
+        if (is_array($nameOrColumns)) {
+            $nameOrColumns = $this->createIndexName('check', $nameOrColumns);
+        }
+
+        return $this->addCommand('check', ['expression' => $expression, 'constraint' => $nameOrColumns]);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -449,6 +449,25 @@ class Builder
     }
 
     /**
+     * Get the check constraints for a given table.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    public function getCheckConstraints($table)
+    {
+        [$schema, $table] = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processCheckConstraints(
+            $this->connection->selectFromWriteConnection(
+                $this->grammar->compileCheckConstraints($schema, $table)
+            )
+        );
+    }
+
+    /**
      * Modify a table on the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Fluent;
  * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
+ * @method $this check(\Illuminate\Contracts\Database\Query\Expression|string $expression) Specify a check constraint for the column
  * @method $this collation(string $collation) Specify a collation for the column
  * @method $this comment(string $comment) Add a comment to the column (MySQL/PostgreSQL)
  * @method $this default(mixed $value) Specify a "default" value for the column

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -289,6 +289,37 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a check constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string|null
+     */
+    public function compileCheck(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s add%s check (%s)',
+            $this->wrapTable($blueprint),
+            $command->constraint ? ' constraint '.$this->wrap($command->constraint) : '',
+            $this->getValue($command->expression)
+        );
+    }
+
+    /**
+     * Compile a drop check constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string|null
+     */
+    public function compileDropCheck(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s drop constraint %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->constraint)
+        );
+    }
+
+    /**
      * Compile the blueprint's added column definitions.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -165,6 +165,20 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile the query to determine the check constraints.
+     *
+     * @param  string|null  $schema
+     * @param  string  $table
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileCheckConstraints($schema, $table)
+    {
+        throw new RuntimeException('This database driver does not support retrieving check constraints.');
+    }
+
+    /**
      * Compile a rename column command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -969,11 +969,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeEnum(Fluent $column)
     {
-        return sprintf(
-            'varchar(255) check ("%s" in (%s))',
-            $column->name,
-            $this->quoteString($column->allowed)
-        );
+        return 'varchar(255)';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -504,6 +504,21 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a drop constraints command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string|null
+     */
+    public function compileDropConstraints(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s drop constraint %s',
+            $this->wrapTable($blueprint),
+            implode(', ', $this->wrapArray($command->constraints))
+        );
+    }
+
+    /**
      * Compile a rename table command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -760,11 +760,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeEnum(Fluent $column)
     {
-        return sprintf(
-            'nvarchar(255) check ("%s" in (%s))',
-            $column->name,
-            $this->quoteString($column->allowed)
-        );
+        return 'nvarchar(255)';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -89,6 +89,22 @@ class SQLiteBuilder extends Builder
         );
     }
 
+    /** @inheritDoc */
+    public function getCheckConstraints($table)
+    {
+        $columns = $this->getColumnListing($table);
+
+        [$schema, $table] = $this->parseSchemaAndTable($table);
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return $this->connection->getPostProcessor()->processCheckConstraints(
+            [],
+            $this->connection->scalar($this->grammar->compileSqlCreateStatement($schema, $table)),
+            $columns
+        );
+    }
+
     /**
      * Drop all tables from the database.
      *

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -28,6 +28,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getIndexListing(string $table)
  * @method static bool hasIndex(string $table, string|array $index, string|null $type = null)
  * @method static array getForeignKeys(string $table)
+ * @method static array getCheckConstraints(string $table)
  * @method static void table(string $table, \Closure $callback)
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -783,9 +783,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->enum('status', Foo::cases());
         $statements = $blueprint->toSql();
 
-        $this->assertCount(2, $statements);
-        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
-        $this->assertSame('alter table "users" add column "status" varchar(255) check ("status" in (\'bar\')) not null', $statements[1]);
+        $this->assertCount(4, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "status" varchar(255) not null', $statements[1]);
+        $this->assertSame('alter table "users" add constraint "users_role_check" check ("role" in (\'member\', \'admin\'))', $statements[2]);
+        $this->assertSame('alter table "users" add constraint "users_status_check" check ("status" in (\'bar\'))', $statements[3]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -602,9 +602,11 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->enum('status', Foo::cases());
         $statements = $blueprint->toSql();
 
-        $this->assertCount(2, $statements);
-        $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
-        $this->assertSame('alter table "users" add "status" nvarchar(255) check ("status" in (N\'bar\')) not null', $statements[1]);
+        $this->assertCount(4, $statements);
+        $this->assertSame('alter table "users" add "role" nvarchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "status" nvarchar(255) not null', $statements[1]);
+        $this->assertSame('alter table "users" add constraint "users_role_check" check ("role" in (N\'member\', N\'admin\'))', $statements[2]);
+        $this->assertSame('alter table "users" add constraint "users_status_check" check ("status" in (N\'bar\'))', $statements[3]);
     }
 
     public function testAddingJson()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -579,20 +579,20 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $constraints = Schema::getCheckConstraints('test');
 
-        $this->assertCount($this->driver === 'mysql' ? 2 : 3, $constraints);
+        $this->assertCount(in_array($this->driver, ['mysql', 'mariadb']) ? 2 : 3, $constraints);
         $this->assertContains(['name' => 'test_c1_check', 'columns' => ['c1'], 'definition' => match ($this->driver) {
-            'mysql' => '(`c1` > 100)',
+            'mysql', 'mariadb' => '(`c1` > 100)',
             'sqlsrv' => '([c1]>(100))',
             default => '(c1 > 100)',
         }], $constraints);
         $this->assertContains(['name' => 'my_constraint', 'columns' => ['c1', 'c2'], 'definition' => match ($this->driver) {
-            'mysql' => '((`c1` > 0) and (`c2` < 0))',
+            'mysql', 'mariadb' => '((`c1` > 0) and (`c2` < 0))',
             'pgsql' => '(c1 > 0 AND c2 < 0)',
             'sqlsrv' => '([c1]>(0) AND [c2]<(0))',
             default => '(c1 > 0 and c2 < 0)',
         }], $constraints);
 
-        if ($this->driver !== 'mysql') {
+        if (! in_array($this->driver, ['mysql', 'mariadb'])) {
             $this->assertContains(['name' => 'test_c3_check', 'columns' => ['c3'], 'definition' => match ($this->driver) {
                 'pgsql' => "(c3::text = ANY (ARRAY['foo'::character varying, 'bar'::character varying, 'baz'::character varying]::text[]))",
                 'sqlsrv' => "([c3]=N'baz' OR [c3]=N'bar' OR [c3]=N'foo')",
@@ -609,25 +609,25 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $constraints = Schema::getCheckConstraints('test');
 
-        $this->assertCount($this->driver === 'mysql' ? 3 : 5, $constraints);
+        $this->assertCount(in_array($this->driver, ['mysql', 'mariadb']) ? 3 : 5, $constraints);
         $this->assertContains(['name' => 'test_c1_check', 'columns' => ['c1'], 'definition' => match ($this->driver) {
-            'mysql' => '(`c1` > 100)',
+            'mysql', 'mariadb' => '(`c1` > 100)',
             'sqlsrv' => '([c1]>(100))',
             default => '(c1 > 100)',
         }], $constraints);
         $this->assertContains(['name' => 'unsigned_columns', 'columns' => ['c1', 'c4'], 'definition' => match ($this->driver) {
-            'mysql' => '((`c1` > 0) and (`c4` > 0))',
+            'mysql', 'mariadb' => '((`c1` > 0) and (`c4` > 0))',
             'pgsql' => '(c1 > 0 AND c4 > 0)',
             'sqlsrv' => '([c1]>(0) AND [c4]>(0))',
             default => '(c1 > 0 and c4 > 0)',
         }], $constraints);
         $this->assertContains(['name' => 'test_c4_check', 'columns' => ['c4'], 'definition' => match ($this->driver) {
-            'mysql' => '(`c4` < 100)',
+            'mysql', 'mariadb' => '(`c4` < 100)',
             'sqlsrv' => '([c4]<(100))',
             default => '(c4 < 100)',
         }], $constraints);
 
-        if ($this->driver !== 'mysql') {
+        if (! in_array($this->driver, ['mysql', 'mariadb'])) {
             $this->assertContains(['name' => 'test_c3_check', 'columns' => ['c3'], 'definition' => match ($this->driver) {
                 'pgsql' => "(c3::text = ANY (ARRAY['foo'::character varying, 'bar'::character varying, 'baz'::character varying]::text[]))",
                 'sqlsrv' => "([c3]=N'baz' OR [c3]=N'bar' OR [c3]=N'foo')",

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -581,12 +581,14 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $this->assertCount(in_array($this->driver, ['mysql', 'mariadb']) ? 2 : 3, $constraints);
         $this->assertContains(['name' => 'test_c1_check', 'columns' => ['c1'], 'definition' => match ($this->driver) {
-            'mysql', 'mariadb' => '(`c1` > 100)',
+            'mysql' => '(`c1` > 100)',
+            'mariadb' => '`c1` > 100',
             'sqlsrv' => '([c1]>(100))',
             default => '(c1 > 100)',
         }], $constraints);
         $this->assertContains(['name' => 'my_constraint', 'columns' => ['c1', 'c2'], 'definition' => match ($this->driver) {
-            'mysql', 'mariadb' => '((`c1` > 0) and (`c2` < 0))',
+            'mysql' => '((`c1` > 0) and (`c2` < 0))',
+            'mariadb' => '`c1` > 0 and `c2` < 0',
             'pgsql' => '(c1 > 0 AND c2 < 0)',
             'sqlsrv' => '([c1]>(0) AND [c2]<(0))',
             default => '(c1 > 0 and c2 < 0)',
@@ -611,18 +613,21 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         $this->assertCount(in_array($this->driver, ['mysql', 'mariadb']) ? 3 : 5, $constraints);
         $this->assertContains(['name' => 'test_c1_check', 'columns' => ['c1'], 'definition' => match ($this->driver) {
-            'mysql', 'mariadb' => '(`c1` > 100)',
+            'mysql' => '(`c1` > 100)',
+            'mariadb' => '`c1` > 100',
             'sqlsrv' => '([c1]>(100))',
             default => '(c1 > 100)',
         }], $constraints);
         $this->assertContains(['name' => 'unsigned_columns', 'columns' => ['c1', 'c4'], 'definition' => match ($this->driver) {
-            'mysql', 'mariadb' => '((`c1` > 0) and (`c4` > 0))',
+            'mysql' => '((`c1` > 0) and (`c4` > 0))',
+            'mariadb' => '`c1` > 0 and `c4` > 0',
             'pgsql' => '(c1 > 0 AND c4 > 0)',
             'sqlsrv' => '([c1]>(0) AND [c4]>(0))',
             default => '(c1 > 0 and c4 > 0)',
         }], $constraints);
         $this->assertContains(['name' => 'test_c4_check', 'columns' => ['c4'], 'definition' => match ($this->driver) {
-            'mysql', 'mariadb' => '(`c4` < 100)',
+            'mysql' => '(`c4` < 100)',
+            'mariadb' => '`c4` < 100',
             'sqlsrv' => '([c4]<(100))',
             default => '(c4 < 100)',
         }], $constraints);

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBuilderTest.php
@@ -140,7 +140,7 @@ class DatabaseSchemaBuilderTest extends TestCase
 
     public function testGetCheckConstraints()
     {
-        DB::statement(<<<SQL
+        DB::statement(<<<'SQL'
             CREATE TABLE products (
                 id INT PRIMARY KEY,
                 status VARCHAR(255) CHECK ("status" in ('pending', 'processing', 'shipped', 'delivered')),


### PR DESCRIPTION
Closes #56523
Fixes #56151
Related to #51373, #45487
Previous attempts #46512, #46883, #56000, #41078

This PR adds support for inspecting, adding, and dropping check constraints on all database drivers (Yes, even SQLite!).

## Why?
Check constraints are a valuable feature at the database layer, and adding support for them is now straightforward (after #51373). Managing check constraints manually can be cumbersome, especially in SQLite.

We currently rely on check constraints for enum column types (except on MySQL and MariaDB, which have a native enum type). Without proper support, modifying enum columns has been difficult. This PR addresses that by allowing developers to:  
- Inspect existing constraints  
- Drop specific constraints  
- Define new constraints, including adding values to enum lists by redefining/modifying the column

## Usage

#### Create a table with check constraints
```php
Schema::create('orders', function (Blueprint $table) {
    $table->id();
    $table->enum('status', ['pending', 'processing', 'shipped']);
    $table->decimal('price')->check('price > 0');
    $table->integer('discount_percent')->check('discount_percent >= 0 and discount_percent <= 100');
    $table->timestamps();

    $table->check('price * (1 - discount_percent / 100.0) > 0', 'orders_price_discount_check');
});
```

#### Modify a table with check constraints
```php
Schema::table('orders', function (Blueprint $table) {
    $table->dropCheck(['status']);
    $table->enum('status', ['pending', 'processing', 'shipped', 'delivered'])->change();
    $table->timestamp('delivered_at')->nullable()->check('delivered_at > created_at');
});
```

#### Drop check constraints of a table
```php
Schema::table('orders', function (Blueprint $table) {
    $table->dropCheck(['status']);            // drop by columns, drops all check constraints of the "status" column.
    $table->dropCheck('orders_status_check'); // drop by name
});
```

#### Inspect check constraints of a table
```php
use Illuminate\Support\Facades\Schema;

$constraints = Schema::getCheckConstraints('orders'); 

/*[
    ['name' => 'orders_status_check', 'columns' => ['status'], 'definition' => "(status in ('pending', 'processing', 'shipped', 'delivered'))"],
    ['name' => 'orders_price_check', 'columns' => ['price'], 'definition' => '(price > 0)'],
    ['name' => 'orders_price_discount_check', 'columns' => ['price', 'discount_percent'], '(price * (1 - discount_percent / 100.0) > 0)'],
    ['name' => 'orders_delivered_at_check', 'columns' => ['delivered_at', 'created_at'], 'definition' => '(delivered_at > created_at)'],
]*/
```

* `name` (`?string`): Name of the constraint
* `columns` (`string[]`): Array of constrained columns
* `definition` (`string`): Constraint definition expression

## Notes
1. Similar to other implemented constraints (e.g., foreign keys, unique, etc.), check constraints are always added through separate commands rather than at the column level.
2. A check constraint defined on a column (e.g. `$table->integer('price')->check('price > 0')`)  will be assigned a default name following the same convention as other constraints:  `table_column_check`.  

    However, a check constraint defined at the table level (e.g. `$table->check('price > 0')`) will not receive a default name (hard to generate a random one using the expression!)

    It is highly recommended to assign explicit names to your constraints. You can do this:
    * by passing a string as the second argument :`$table->check('price > 0', 'orders_price_check')`
    * or column names as the second argument:  `$table->check('price > 0', ['price'])`

3. On PostgreSQL, SQL Server, and SQLite, the enum column type is defined as a string with a check constraint (i.e. `$table->enum('foo', ['a', 'b', 'c'])` was equivalent to `foo varchar check (foo in ('a', 'b', 'c'))`) . As a result, modifying or redefining an enum column was not previously supported on these DB drivers.

   This PR resolves that. You can now drop the previous check constraint of an enum column and redefine it as needed:

    ```php
    Schema::table('orders', function (Blueprint $table) {
        $table->dropCheck(['status']);                           // drop the previous check constraint
        $table->enum('status', ['foo', 'bar', 'new'])->change(); // redefine the enum and add a new value to the allowed list
    });
    ```

    Previously, this check constraint of an enum column did not have a default name. As a result, PostgreSQL and SQL Server automatically assigned their own names to the constraint. This PR now explicitly assigns names (as explained in Note 2). The assigned name matches PostgreSQL’s behavior but differs from SQL Server’s default.

    **Q:** Why do I have to manually drop the constraint? Why doesn't the `change` modifier handle it automatically?
    **A:** As a rule of thumb, the `change` modifier only modifies column attributes (e.g., type, default, nullable, comment, etc.) and does not affect indexes, foreign keys, or check constraints. Therefore, constraints must be dropped manually when needed. 

4. You can drop check constraints either by name or by columns. Dropping by columns is possible thanks to the table inspection functionality:
    * When dropping check constraints by columns (e.g., `$table->dropCheck(['c1'])`),  the command will drop every constraint that involves **only** `c1`.  That means a constraints that include both `c1` and `c2` columns will not be dropped.
    *  The order of columns does not matter when dropping check constraints by columns. For example, `$table->dropCheck(['c1', 'c2'])` and `$table->dropCheck(['c2', 'c1'])` are equivalent and will drop any constraints that have both of these columns only.
    * Although most databases do not allow duplicate constraint names, SQLite does. This means you can create multiple constraints with the same name in SQLite. Therefore, when dropping a constraint by name (e.g.,  `$table->dropCheck('orders_price_check')`),  SQLite will drop all constraints with that name.