### PR TITLE
[12.x] Remove one redundant array access

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -446,7 +446,7 @@ class Arr
         }
 
         if (! str_contains($key, '.')) {
-            return $array[$key] ?? value($default);
+            return value($default);
         }
 
         foreach (explode('.', $key) as $segment) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -442,7 +442,7 @@ class Arr
         }
 
         if (static::exists($array, $key)) {
-            return $array[$key]; 
+            return $array[$key];
         }
 
         if (! str_contains($key, '.')) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -442,7 +442,7 @@ class Arr
         }
 
         if (static::exists($array, $key)) {
-            return $array[$key];
+            return $array[$key]; 
         }
 
         if (! str_contains($key, '.')) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR removes a redundant array check in the Arr helper. It's very minor, and removing it does not break any tests, nor - I think - require any new tests to be added.