### PR TITLE
[12.x] [POC] Allow rate limit hits to only be recorded after successful responses

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -26,6 +26,13 @@ class Limit
     public $decaySeconds;
 
     /**
+     * Whether to only record a hit after a successful response.
+     *
+     * @var bool
+     */
+    public $onSuccess = false;
+
+    /**
      * The response generator callback.
      *
      * @var callable
@@ -125,6 +132,19 @@ class Limit
     public function by($key)
     {
         $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set whether to only record a hit after a successful response.
+     *
+     * @param  bool  $onSuccess
+     * @return $this
+     */
+    public function onSuccess(bool $onSuccess = true)
+    {
+        $this->onSuccess = $onSuccess;
 
         return $this;
     }


### PR DESCRIPTION
No tests yet, as this just a proof of concept for now. Waiting to hear from @taylorotwell if this is how we should implement it.

---

This PR adds the `onSuccess()` method to the `Limit` class, which will only record a hit after a successful response:

```php
RateLimiter::for('signup', function (Request $request) {
    return Limit::perDay(1)
        ->by($request->ip())
        ->onSuccess(); // <-- this is new
});
```

## Background

Imagine the following rate limit:

```php
// In a service provider...
RateLimiter::for('signup', function (Request $request) {
    return Limit::perDay(1)->by($request->ip());
});

// In a routes files...
Route::post('signup', SignupController::class)->middleware('throttle:signup');
```

This will only allow a single signup per day from a given IP address, which is great.

However, if the user submits the signup form with some validation errors, they will use up their rate limit, and will no longer be able to submit the form again until the next day. That's not what we want.

## Solution

By adding `onSuccess()` to the `Limit`:

```php
RateLimiter::for('signup', function (Request $request) {
    return Limit::perDay(1)->by($request->ip())->onSuccess();
});
```

...we can now have a rate limit that only gets a hit after the form is successfully processed. Form submissions with validation errors do not count against the rate limit.

---

It can also be combined with a general, more lax rate limit:

```php
RateLimiter::for('signup', fn (Request $request) => [
    Limit::perMinute(10)->by($request->ip()),
    Limit::perDay(1)->by('.success'.$request->ip())->onSuccess(),
]);
```

This will allow up to 10 failed requests per minute, but only a single successful request per day.