### PR TITLE
[12.x] add forbidding unknown input keys in form requests

### DIFF
--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -229,6 +229,20 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
+    public function testForbidNonRuleAttributesAddsProhibitedErrors()
+    {
+        $payload = ['name' => 'adam', 'should-not-be-here' => '1'];
+
+        $request = $this->createRequest($payload, FoundationTestFormRequestProhibitUnknownStub::class);
+
+        /** @var \Illuminate\Validation\ValidationException $e */
+        $e = $this->catchException(ValidationException::class, function () use ($request) {
+            $request->validateResolved();
+        });
+
+        $this->assertArrayHasKey('should-not-be-here', $e->errors());
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -493,6 +507,21 @@ class InjectedDependency
 
 class FoundationTestFormRequestWithoutRulesMethod extends FormRequest
 {
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestProhibitUnknownStub extends FormRequest
+{
+    protected $forbidNonRuleAttributes = true;
+
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
     public function authorize()
     {
         return true;


### PR DESCRIPTION
## Summary
This PR adds an opt-in feature to `Illuminate\Foundation\Http\FormRequest` that fails validation when the incoming request contains input keys not explicitly covered by the request’s validation rules.

## Motivation
This helps catch typos and unintentional extra data early, simplifying debugging between the frontend and backend (This is inspired by an issue that happens with one of our frontend devs).

Example:
- Intended attribute: `employee`
- Mistakenly sent by frontend: `employee_id`
- With this feature enabled, validation fails with a `prohibited` error for `employee_id`.

Also, this is inspired by `spaite/laravel-query-builder`

```
    /*
     * By default the package will throw an `InvalidFilterQuery` exception when a filter in the
     * URL is not allowed in the `allowedFilters()` method.
     */
    'disable_invalid_filter_query_exception' => false,

```

> [!NOTE]
> because of the usage of `attributes`, `getRules`, and `addFailure` I had to limit this to the default validator, I'm not sure how would I make it work with other validators

## Usage
```php
use Illuminate\Foundation\Http\FormRequest;

class StoreEmployeeRequest extends FormRequest
{
    protected $forbidNonRuleAttributes = true;

    public function authorize(): bool
    {
        return true;
    }

    public function rules(): array
    {
        return [
            'employee' => ['required', 'id'],
        ];
    }
}