### PR TITLE
[12.x] helpers: simplify preg_replace_array() callback (remove redundant loop)

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }


### PR DESCRIPTION
Replaces a redundant foreach+return inside the preg_replace_callback() with a direct call to array_shift(). No behavior change.


### Alternative (maintainers’ option for perf)
If desired, we can switch to an index-based approach to avoid array_shift’s reindexing cost (making total work O(R) rather than O(R²) for R matches):

[Using array_shift over larger array was fairly slow.](https://www.php.net/manual/en/function.array-shift.php#86783)

```php
function preg_replace_array($pattern, array $replacements, $subject): string
{
    $i = 0;

    return preg_replace_callback($pattern, function () use (&$replacements, &$i) {
        return $replacements[$i++] ?? '';
    }, $subject);
}
```
This keeps behavior, but avoids repeated reindexing.