### PR TITLE
test(support): add edge-case tuples for preg_replace_array

### DIFF
--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1493,6 +1493,12 @@ class SupportHelpersTest extends TestCase
             ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
             ['//', [], '', ''],
             ['/%s/', ['a'], '', ''],
+            // non-sequential numeric keys → should still consume in natural order
+            ['/%s/', [2 => 'A', 10 => 'B'], '%s %s', 'A B'],
+            // associative keys → order should be insertion order, not keys/pointer
+            ['/%s/', ['first' => 'A', 'second' => 'B'], '%s %s', 'A B'],
+            // values that are "falsy" but must not be treated as empty by mistake, false->'' , null->''
+            ['/%s/', ['0', 0, false, null], '%s|%s|%s|%s', '0|0||'],
             // The internal pointer of this array is not at the beginning
             ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'],
         ];


### PR DESCRIPTION
This adds three data-provider cases to `providesPregReplaceArrayData()` to cover common edge conditions while staying in plain PHP regex land:

1. Non-sequential numeric keys are consumed in insertion order.

2. Associative keys are consumed in insertion order (not by key or pointer).

3. Falsy values ('0', 0, false, null) render as expected → 0|0||.