### PR TITLE
Add `connection` method for HTTP client configuration

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -270,6 +270,34 @@ class PendingRequest
     }
 
     /**
+     * Configure the pending request using a named connection configuration.
+     *
+     * @param  string  $connection
+     * @return $this
+     */
+    public function connection(string $connection)
+    {
+        return tap($this, function () use ($connection) {
+            $config = config("services.{$connection}") 
+                ?: throw new \InvalidArgumentException("Connection [{$connection}] is not defined.");
+
+            foreach ($config as $key => $value) {
+                match ($key) {
+                    'base_url' => $this->baseUrl($value),
+                    'timeout' => $this->timeout($value),
+                    'connect_timeout' => $this->connectTimeout($value),
+                    'headers' => $this->withHeaders($value),
+                    'token' => $this->withToken($value),
+                    'basic_auth' => $this->withBasicAuth($value['username'], $value['password']),
+                    'digest_auth' => $this->withDigestAuth($value['username'], $value['password']),
+                    'ntlm_auth' => $this->withNtlmAuth($value['username'], $value['password']),
+                    default => null,
+                };
+            }
+        });
+    }
+
+    /**
      * Attach a raw body to the request.
      *
      * @param  \Psr\Http\Message\StreamInterface|string  $content

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -278,7 +278,7 @@ class PendingRequest
     public function connection(string $connection)
     {
         return tap($this, function () use ($connection) {
-            $config = config("services.{$connection}") 
+            $config = config("services.{$connection}")
                 ?: throw new \InvalidArgumentException("Connection [{$connection}] is not defined.");
 
             foreach ($config as $key => $value) {

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -58,9 +58,9 @@ class HttpClientTest extends TestCase
         ]);
 
         Http::fake();
-        
+
         $response = Http::connection('github')->get('/user');
-        
+
         Http::assertSent(function ($request) {
             return $request->url() === 'https://api.github.com/user' &&
                    $request->hasHeader('Authorization', 'Bearer test-token') &&


### PR DESCRIPTION
This PR adds a `connection()`  method to `PendingRequest`, allowing HTTP clients to be configured directly from `config/services.php`. As Laravel already encourages centralizing third-party credentials in this file, this addition lets the HTTP client honor that convention.

### The Problem

When working with APIs, the same setup code is repeated everywhere:

```php
Http::baseUrl('https://api.github.com')
    ->withToken(config('services.github.token'))
    ->withHeaders(['Accept' => 'application/vnd.github.v3+json'])
    ->get('/user/repos');
```

Developers often reach for macros (`Http::github()`) or even dedicated service classes to avoid this repetition. Often times, the “service” is nothing more than a handful of configuration values.

### The Solution

The `connection()` method makes this pattern first-class by pulling settings directly from `config/services.php`:

```php
$repos = Http::connection('github')->get('/user/repos');
```

```php
// config/services.php

'github' => [
    'base_url' => 'https://api.github.com',
    'token' => env('GITHUB_TOKEN'),
    'headers' => ['Accept' => 'application/vnd.github.v3+json'],
],

'stripe' => [
    'base_url' => env('STRIPE_BASE_URL', 'https://api.stripe.com/v1'),
    'token' => env('STRIPE_SECRET'),
    'timeout' => 15,
    'headers' => ['X-Stripe-Version' => '2023-10-16'],
],
```

Once defined, consuming those services is as simple as:

```php
$repos = Http::connection('github')->get('/user/repos');

$charge = Http::connection('stripe')->post('/charges', $data);
```

### Supported Options

The following configuration keys are supported out of the box:

- `base_url`
- `timeout`
- `connect_timeout`
- `headers`
- `token`
- `basic_auth`
- `digest_auth`
- `ntlm_auth`

For example, defining an external API with basic auth credentials:

```php
// config/services.php

'external' => [
    'base_url' => env('EXTERNAL_API'),
    'basic_auth' => [
        'username' => env('EXTERNAL_USERNAME'),
        'password' => env('EXTERNAL_PASSWORD'),
    ],
],


$users = Http::connection('external')->get('/users');
```

It’s small, predictable, and removes a significant amount of repetitive boilerplate across applications.

If accepted, I’m happy to contribute documentation.