### PR TITLE
[12.x] Cleanup redundant DocBlocks 

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -24,7 +24,7 @@ class AuthenticationException extends Exception
     /**
      * The callback that should be used to generate the authentication redirect path.
      *
-     * @var callable
+     * @var callable(Request): string|null
      */
     protected static $redirectToCallback;
 
@@ -56,7 +56,6 @@ class AuthenticationException extends Exception
     /**
      * Get the path the user should be redirected to.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return string|null
      */
     public function redirectTo(Request $request)
@@ -73,7 +72,7 @@ class AuthenticationException extends Exception
     /**
      * Specify the callback that should be used to generate the redirect path.
      *
-     * @param  callable  $redirectToCallback
+     * @param  callable(Request $request): string|null  $redirectToCallback
      * @return void
      */
     public static function redirectUsing(callable $redirectToCallback)

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -94,7 +94,6 @@ class DatabaseUserProvider implements UserProvider
     /**
      * Retrieve a user by the given credentials.
      *
-     * @param  array  $credentials
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */
     public function retrieveByCredentials(#[\SensitiveParameter] array $credentials)
@@ -169,8 +168,6 @@ class DatabaseUserProvider implements UserProvider
      * Rehash the user's password if required and supported.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  array  $credentials
-     * @param  bool  $force
      * @return void
      */
     public function rehashPasswordIfRequired(UserContract $user, #[\SensitiveParameter] array $credentials, bool $force = false)

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -105,7 +105,6 @@ class EloquentUserProvider implements UserProvider
     /**
      * Retrieve a user by the given credentials.
      *
-     * @param  array  $credentials
      * @return (\Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model)|null
      */
     public function retrieveByCredentials(#[\SensitiveParameter] array $credentials)
@@ -142,7 +141,6 @@ class EloquentUserProvider implements UserProvider
      * Validate a user against the given credentials.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  array  $credentials
      * @return bool
      */
     public function validateCredentials(UserContract $user, #[\SensitiveParameter] array $credentials)
@@ -162,8 +160,6 @@ class EloquentUserProvider implements UserProvider
      * Rehash the user's password if required and supported.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable&\Illuminate\Database\Eloquent\Model  $user
-     * @param  array  $credentials
-     * @param  bool  $force
      * @return void
      */
     public function rehashPasswordIfRequired(UserContract $user, #[\SensitiveParameter] array $credentials, bool $force = false)

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -15,8 +15,6 @@ class GenericUser implements UserContract
 
     /**
      * Create a new generic User object.
-     *
-     * @param  array  $attributes
      */
     public function __construct(array $attributes)
     {

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -116,7 +116,6 @@ trait GuardHelpers
     /**
      * Set the user provider used by the guard.
      *
-     * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
      * @return void
      */
     public function setProvider(UserProvider $provider)

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -14,7 +14,7 @@ class RequestGuard implements Guard
     /**
      * The guard callback.
      *
-     * @var callable
+     * @var callable(Request, UserProvider|null): \Illuminate\Contracts\Auth\Authenticatable|null
      */
     protected $callback;
 
@@ -28,9 +28,7 @@ class RequestGuard implements Guard
     /**
      * Create a new authentication guard.
      *
-     * @param  callable  $callback
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Auth\UserProvider|null  $provider
+     * @param  callable(Request, UserProvider|null): \Illuminate\Contracts\Auth\Authenticatable|null  $callback
      */
     public function __construct(callable $callback, Request $request, ?UserProvider $provider = null)
     {
@@ -61,7 +59,6 @@ class RequestGuard implements Guard
     /**
      * Validate a user's credentials.
      *
-     * @param  array  $credentials
      * @return bool
      */
     public function validate(#[\SensitiveParameter] array $credentials = [])
@@ -74,7 +71,6 @@ class RequestGuard implements Guard
     /**
      * Set the current request instance.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return $this
      */
     public function setRequest(Request $request)

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -35,8 +35,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * The name of the guard. Typically "web".
      *
      * Corresponds to guard name in authentication configuration.
-     *
-     * @var string
      */
     public readonly string $name;
 
@@ -255,7 +253,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Log a user into the application without sessions or cookies.
      *
-     * @param  array  $credentials
      * @return bool
      */
     public function once(array $credentials = [])
@@ -295,7 +292,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Validate a user's credentials.
      *
-     * @param  array  $credentials
      * @return bool
      */
     public function validate(array $credentials = [])

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -116,7 +116,6 @@ class TokenGuard implements Guard
     /**
      * Validate a user's credentials.
      *
-     * @param  array  $credentials
      * @return bool
      */
     public function validate(array $credentials = [])
@@ -137,7 +136,6 @@ class TokenGuard implements Guard
     /**
      * Set the current request instance.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return $this
      */
     public function setRequest(Request $request)


### PR DESCRIPTION
**PR Description**

This PR performs a careful cleanup of redundant DocBlocks and adds safe type hints in the Auth namespace. The changes are scoped to this namespace to keep the PR small and manageable. If approved, similar incremental PRs will follow for other parts of the framework.

Summary of changes made in this PR:

1.Focused on the Auth namespace to keep the PR small; similar changes will be applied incrementally to other namespaces if approved.

2.Removed DocBlocks where type hints fully specify all parameter, return types or both, following Laravel’s documentation style.

3.Preserved DocBlocks in methods where only some parameters are type-hinted to maintain consistency and avoid introducing potential BC breaks. The goal is to apply safe changes only at this stage.

4.Kept DocBlocks for parameters that are type-hinted but imported with an alias via use statements for better readability.

"If this PR is not approved, I would appreciate guidance on how to improve it or how to create similar safe PRs in the future."

Thanks for reviewing 🙏