### PR TITLE
[12.x] Allow for BackedEnum on dynamic blade component

### DIFF
--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 
+use function Illuminate\Support\enum_value;
+
 class DynamicComponent extends Component
 {
     /**

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -38,7 +38,7 @@ class DynamicComponent extends Component
      */
     public function __construct(BackedEnum|string $component)
     {
-        $this->component = $component instanceof BackedEnum ? $component->value : $component;
+        $this->component = (string) enum_value($component);
     }
 
     /**

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View;
 
+use BackedEnum;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -33,11 +34,11 @@ class DynamicComponent extends Component
     /**
      * Create a new component instance.
      *
-     * @param  string  $component
+     * @param  \BackedEnum|string  $component
      */
-    public function __construct(string $component)
+    public function __construct(BackedEnum|string $component)
     {
-        $this->component = $component;
+        $this->component = $component instanceof BackedEnum ? $component->value : $component;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for `BackedEnums` on the `DynamicComponent`.

This is helpful when you store the component names in an enum. A good use case for this is to store all available icons in an enum. Here is an example:

```php
// app/Enums/Icons.php

<?php

namespace App\Enums;

enum Icons: string
{
    case Group = 'icons.group';
    case User = 'icons.user';
    // ...
}
```

```blade
// my-component.blade.php

<x-dynamic-component :component="\App\Enums\Icons::User" class="size-4" />
```

Without this PR, this is already possible, but we can not pass the enum directly. Instead, we can only pass the string representation:

```blade
// my-component.blade.php

<x-dynamic-component :component="\App\Enums\Icons::User->value" class="size-4" />
```

Actually, this isn't a big change but a small quality of life improvement and nothing that would break any existing application.