### PR TITLE
[12.x] Add PhpRedis pack ignore numbers option

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -143,6 +143,13 @@ class PhpRedisConnector implements Connector
             if (array_key_exists('compression_level', $config)) {
                 $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $config['compression_level']);
             }
+
+            if (
+                defined('Redis::OPT_PACK_IGNORE_NUMBERS') &&
+                array_key_exists('pack_ignore_numbers', $config)
+            ) {
+                $client->setOption(Redis::OPT_PACK_IGNORE_NUMBERS, $config['pack_ignore_numbers']);
+            }
         });
     }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -144,10 +144,8 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $config['compression_level']);
             }
 
-            if (
-                defined('Redis::OPT_PACK_IGNORE_NUMBERS') &&
-                array_key_exists('pack_ignore_numbers', $config)
-            ) {
+            if (defined('Redis::OPT_PACK_IGNORE_NUMBERS') &&
+                array_key_exists('pack_ignore_numbers', $config)) {
                 $client->setOption(Redis::OPT_PACK_IGNORE_NUMBERS, $config['pack_ignore_numbers']);
             }
         });


### PR DESCRIPTION
**Description:**
- The connector now checks for the `pack_ignore_number` key in the config and sets the corresponding Redis option if present.

**References:**
- Related to [phpredis/phpredis#2616](https://github.com/phpredis/phpredis/pull/2616)

**Testing:**
<img width="552" height="149" alt="image" src="https://github.com/user-attachments/assets/b74c5846-20f3-4846-b748-3b6385f39aa6" />
