### PR TITLE
[12.x] Handle MariaDB innodb_snapshot_isolation=ON

### DIFF
--- a/src/Illuminate/Database/ConcurrencyErrorDetector.php
+++ b/src/Illuminate/Database/ConcurrencyErrorDetector.php
@@ -33,6 +33,7 @@ class ConcurrencyErrorDetector implements ConcurrencyErrorDetectorContract
             'has been chosen as the deadlock victim',
             'Lock wait timeout exceeded; try restarting transaction',
             'WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction',
+            'Record has changed since last read in table',
         ]);
     }
 }


### PR DESCRIPTION
Fixes #56944

No tests for this since none of these other cases have tests.