### PR TITLE
[12.x] Add Http::batch

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -30,21 +30,21 @@ class Batch
     /**
      * The total number of requests that belong to the batch.
      *
-     * @var int
+     * @var non-negative-int
      */
     public $totalRequests = 0;
 
     /**
      * The total number of requests that are still pending.
      *
-     * @var int
+     * @var non-negative-int
      */
     public $pendingRequests = 0;
 
     /**
      * The total number of requests that have failed.
      *
-     * @var int
+     * @var non-negative-int
      */
     public $failedRequests = 0;
 
@@ -58,30 +58,37 @@ class Batch
     /**
      * The callback to run before the first request from the batch runs.
      *
-     * @var \Closure|null
+     * @var (\Closure($this): void)|null
      */
     protected $beforeCallback = null;
 
     /**
      * The callback to run after a request from the batch succeeds.
      *
-     * @var \Closure|null
+     * @var (\Closure($this, int|string, \Illuminate\Http\Response): void)|null
      */
     protected $progressCallback = null;
 
     /**
      * The callback to run after a request from the batch fails.
      *
-     * @var \Closure|null
+     * @var (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException): void)|null
      */
     protected $catchCallback = null;
 
     /**
      * The callback to run if all the requests from the batch succeeded.
      *
-     * @var \Closure|null
+     * @var (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)|null
      */
     protected $thenCallback = null;
+
+    /**
+     * The callback to run after all the requests from the batch finish.
+     *
+     * @var (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)|null
+     */
+    protected $finallyCallback = null;
 
     /**
      * If the batch already was sent.
@@ -103,13 +110,6 @@ class Batch
      * @var \Carbon\CarbonImmutable|null
      */
     public $finishedAt = null;
-
-    /**
-     * The callback to run after all the requests from the batch finish.
-     *
-     * @var \Closure|null
-     */
-    protected $finallyCallback = null;
 
     /**
      * Create a new request batch instance.
@@ -145,7 +145,7 @@ class Batch
     /**
      * Get the total number of requests that have been processed by the batch thus far.
      *
-     * @return int
+     * @return non-negative-int
      */
     public function processedRequests(): int
     {
@@ -155,7 +155,7 @@ class Batch
     /**
      * Get the percentage of requests that have been processed (between 0-100).
      *
-     * @return int
+     * @return non-negative-int
      */
     public function completion(): int
     {
@@ -185,7 +185,7 @@ class Batch
     /**
      * Register a callback to run before the first request from the batch runs.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure($this): void)  $callback
      * @return Batch
      */
     public function before(Closure $callback): self
@@ -198,7 +198,7 @@ class Batch
     /**
      * Retrieve the before callback in the batch.
      *
-     * @return \Closure|null
+     * @return (\Closure($this): void)|null
      */
     public function beforeCallback(): ?Closure
     {
@@ -208,7 +208,7 @@ class Batch
     /**
      * Register a callback to run after a request from the batch succeeds.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure($this, int|string, \Illuminate\Http\Response): void)  $callback
      * @return Batch
      */
     public function progress(Closure $callback): self
@@ -221,7 +221,7 @@ class Batch
     /**
      * Retrieve the progress callback in the batch.
      *
-     * @return \Closure|null
+     * @return (\Closure($this, int|string, \Illuminate\Http\Response): void)|null
      */
     public function progressCallback(): ?Closure
     {
@@ -231,7 +231,7 @@ class Batch
     /**
      * Register a callback to run after a request from the batch fails.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException): void)  $callback
      * @return Batch
      */
     public function catch(Closure $callback): self
@@ -244,7 +244,7 @@ class Batch
     /**
      * Retrieve the catch callback in the batch.
      *
-     * @return \Closure|null
+     * @return (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException): void)|null
      */
     public function catchCallback(): ?Closure
     {
@@ -254,7 +254,7 @@ class Batch
     /**
      * Register a callback to run after all the requests from the batch succeed.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)  $callback
      * @return Batch
      */
     public function then(Closure $callback): self
@@ -267,7 +267,7 @@ class Batch
     /**
      * Retrieve the then callback in the batch.
      *
-     * @return \Closure|null
+     * @return (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)|null
      */
     public function thenCallback(): ?Closure
     {
@@ -277,7 +277,7 @@ class Batch
     /**
      * Register a callback to run after all the requests from the batch finish.
      *
-     * @param  \Closure  $callback
+     * @param  (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)  $callback
      * @return Batch
      */
     public function finally(Closure $callback): self
@@ -290,7 +290,7 @@ class Batch
     /**
      * Retrieve the finally callback in the batch.
      *
-     * @return \Closure|null
+     * @return (\Closure($this, array<int|string, \Illuminate\Http\Response>): void)|null
      */
     public function finallyCallback(): ?Closure
     {

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -38,42 +38,42 @@ class Batch
      *
      * @var int
      */
-    public $totalRequests;
+    public $totalRequests = 0;
 
     /**
      * The total number of requests that are still pending.
      *
      * @var int
      */
-    public $pendingRequests;
+    public $pendingRequests = 0;
 
     /**
      * The total number of requests that have failed.
      *
      * @var int
      */
-    public $failedRequests;
+    public $failedRequests = 0;
 
     /**
      * The date indicating when the batch was created.
      *
      * @var \Carbon\CarbonImmutable
      */
-    public $createdAt;
+    public $createdAt = null;
 
     /**
      * The date indicating when the batch was cancelled.
      *
      * @var \Carbon\CarbonImmutable|null
      */
-    public $cancelledAt;
+    public $cancelledAt = null;
 
     /**
      * The date indicating when the batch was finished.
      *
      * @var \Carbon\CarbonImmutable|null
      */
-    public $finishedAt;
+    public $finishedAt = null;
 
     /**
      * The callback to run before the first request from the batch runs.
@@ -114,12 +114,7 @@ class Batch
     {
         $this->factory = $factory ?: new Factory();
         $this->handler = Utils::chooseHandler();
-
-        $this->totalRequests = 0;
-        $this->pendingRequests = 0;
-        $this->failedRequests = 0;
         $this->createdAt = new CarbonImmutable();
-        $this->finishedAt = null;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -352,7 +352,12 @@ class Batch
                 break;
             }
 
-            $result = $item->getPromise()->wait();
+            $result = match (true) {
+                $item instanceof static => $item->getPromise()->wait(),
+                $item instanceof PendingRequest => $item->getPromise()->wait(),
+                default => $item->wait(),
+            };
+
             $results[$key] = $result;
             $this->decrementPendingRequests();
 

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -370,15 +370,15 @@ class Batch
             }
         }
 
-        if (! $this->hasFailures() && $thenCallback !== null) {
-            $thenCallback($this, $results);
-        }
-
-        if ($finallyCallback !== null) {
-            $finallyCallback($this, $results);
-        }
-
         if (! $this->cancelled()) {
+            if (! $this->hasFailures() && $thenCallback !== null) {
+                $thenCallback($this, $results);
+            }
+
+            if ($finallyCallback !== null) {
+                $finallyCallback($this, $results);
+            }
+
             $this->finishedAt = new CarbonImmutable();
         }
 

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -6,7 +6,6 @@ use Carbon\CarbonImmutable;
 use Closure;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\EachPromise;
-use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Utils;
 
 /**

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -309,16 +309,6 @@ class Batch
     }
 
     /**
-     * Get the percentage of requests that have been processed (between 0-100).
-     *
-     * @return non-negative-int
-     */
-    public function completion(): int
-    {
-        return $this->totalRequests > 0 ? round(($this->processedRequests() / $this->totalRequests) * 100) : 0;
-    }
-
-    /**
      * Determine if the batch has finished executing.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -367,7 +367,7 @@ class Batch
 
                     return $result;
                 },
-                'rejected' => function ($reason, $key) use (&$results, $catchCallback) {
+                'rejected' => function ($reason, $key) use ($catchCallback) {
                     $this->decrementPendingRequests();
 
                     if ($reason instanceof RequestException) {

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -1,0 +1,400 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Carbon\CarbonImmutable;
+use Closure;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Utils;
+
+/**
+ * @mixin \Illuminate\Http\Client\Factory
+ */
+class Batch
+{
+    /**
+     * The factory instance.
+     *
+     * @var \Illuminate\Http\Client\Factory
+     */
+    protected $factory;
+
+    /**
+     * The handler function for the Guzzle client.
+     *
+     * @var callable
+     */
+    protected $handler;
+
+    /**
+     * The list of requests.
+     *
+     * @var array<array-key, \Illuminate\Http\Client\PendingRequest>
+     */
+    protected $requests = [];
+
+    /**
+     * The total number of requests that belong to the batch.
+     *
+     * @var int
+     */
+    public $totalRequests;
+
+    /**
+     * The total number of requests that are still pending.
+     *
+     * @var int
+     */
+    public $pendingRequests;
+
+    /**
+     * The total number of requests that have failed.
+     *
+     * @var int
+     */
+    public $failedRequests;
+
+    /**
+     * The date indicating when the batch was created.
+     *
+     * @var \Carbon\CarbonImmutable
+     */
+    public $createdAt;
+
+    /**
+     * The date indicating when the batch was finished.
+     *
+     * @var \Carbon\CarbonImmutable|null
+     */
+    public $finishedAt;
+
+    /**
+     * The callback to run before the first request from the batch runs.
+     *
+     * @var \Closure|null
+     */
+    protected $beforeCallback = null;
+
+    /**
+     * The callback to run after a request from the batch succeeds.
+     *
+     * @var \Closure|null
+     */
+    protected $progressCallback = null;
+
+    /**
+     * The callback to run after a request from the batch fails.
+     *
+     * @var \Closure|null
+     */
+    protected $catchCallback = null;
+
+    /**
+     * The callback to run if all the requests from the batch succeeded.
+     *
+     * @var \Closure|null
+     */
+    protected $thenCallback = null;
+
+    /**
+     * The callback to run after all the requests from the batch finish.
+     *
+     * @var \Closure|null
+     */
+    protected $finallyCallback = null;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->factory = $factory ?: new Factory();
+        $this->handler = Utils::chooseHandler();
+
+        $this->totalRequests = 0;
+        $this->pendingRequests = 0;
+        $this->failedRequests = 0;
+        $this->createdAt = new CarbonImmutable();
+        $this->finishedAt = null;
+    }
+
+    /**
+     * Add a request to the batch with a key.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function as(string $key)
+    {
+        $this->incrementPendingRequests();
+
+        return $this->requests[$key] = $this->asyncRequest();
+    }
+
+    /**
+     * Retrieve the requests in the batch.
+     *
+     * @return array<array-key, \Illuminate\Http\Client\PendingRequest>
+     */
+    public function getRequests(): array
+    {
+        return $this->requests;
+    }
+
+    /**
+     * Add a request to the batch with a numeric index.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\Promise
+     */
+    public function __call(string $method, array $parameters)
+    {
+        $this->incrementPendingRequests();
+
+        return $this->requests[] = $this->asyncRequest()->$method(...$parameters);
+    }
+
+    /**
+     * Get the total number of requests that have been processed by the batch thus far.
+     *
+     * @return int
+     */
+    public function processedRequests(): int
+    {
+        return $this->totalRequests - $this->pendingRequests;
+    }
+
+    /**
+     * Get the percentage of requests that have been processed (between 0-100).
+     *
+     * @return int
+     */
+    public function completion(): int
+    {
+        return $this->totalRequests > 0 ? round(($this->processedRequests() / $this->totalRequests) * 100) : 0;
+    }
+
+    /**
+     * Determine if the batch has job failures.
+     *
+     * @return bool
+     */
+    public function hasFailures(): bool
+    {
+        return $this->failedRequests > 0;
+    }
+
+    /**
+     * Determine if the batch has finished executing.
+     *
+     * @return bool
+     */
+    public function finished(): bool
+    {
+        return ! is_null($this->finishedAt);
+    }
+
+    /**
+     * Register a callback to run before the first request from the batch runs.
+     *
+     * @param  \Closure  $callback
+     * @return Batch
+     */
+    public function before(Closure $callback): self
+    {
+        $this->beforeCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the before callback in the batch.
+     *
+     * @return \Closure|null
+     */
+    public function beforeCallback(): ?Closure
+    {
+        return $this->beforeCallback;
+    }
+
+    /**
+     * Register a callback to run after a request from the batch succeeds.
+     *
+     * @param  \Closure  $callback
+     * @return Batch
+     */
+    public function progress(Closure $callback): self
+    {
+        $this->progressCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the progress callback in the batch.
+     *
+     * @return \Closure|null
+     */
+    public function progressCallback(): ?Closure
+    {
+        return $this->progressCallback;
+    }
+
+    /**
+     * Register a callback to run after a request from the batch fails.
+     *
+     * @param  \Closure  $callback
+     * @return Batch
+     */
+    public function catch(Closure $callback): self
+    {
+        $this->catchCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the catch callback in the batch.
+     *
+     * @return \Closure|null
+     */
+    public function catchCallback(): ?Closure
+    {
+        return $this->catchCallback;
+    }
+
+    /**
+     * Register a callback to run after all the requests from the batch succeed.
+     *
+     * @param  \Closure  $callback
+     * @return Batch
+     */
+    public function then(Closure $callback): self
+    {
+        $this->thenCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the then callback in the batch.
+     *
+     * @return \Closure|null
+     */
+    public function thenCallback(): ?Closure
+    {
+        return $this->thenCallback;
+    }
+
+    /**
+     * Register a callback to run after all the requests from the batch finish.
+     *
+     * @param  \Closure  $callback
+     * @return Batch
+     */
+    public function finally(Closure $callback): self
+    {
+        $this->finallyCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the finally callback in the batch.
+     *
+     * @return \Closure|null
+     */
+    public function finallyCallback(): ?Closure
+    {
+        return $this->finallyCallback;
+    }
+
+    /**
+     * @return array<int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException>
+     */
+    public function send(): array
+    {
+        $results = [];
+
+        $requests = $this->getRequests();
+        $beforeCallback = $this->beforeCallback();
+        $progressCallback = $this->progressCallback();
+        $catchCallback = $this->catchCallback();
+        $thenCallback = $this->thenCallback();
+        $finallyCallback = $this->finallyCallback();
+
+        if ($beforeCallback !== null) {
+            $beforeCallback($this);
+        }
+
+        foreach ($requests as $key => $item) {
+            $result = $item->getPromise()->wait();
+            $results[$key] = $result;
+            $this->decrementPendingRequests();
+
+            if ($result instanceof Response && $result->successful()) {
+                if ($progressCallback !== null) {
+                    $progressCallback($this, $key, $result);
+                }
+            }
+
+            if (($result instanceof Response && $result->failed()) || $result instanceof RequestException) {
+                $this->incrementFailedRequests();
+                if ($catchCallback !== null) {
+                    $catchCallback($this, $key, $result);
+                }
+            }
+        }
+
+        if (! $this->hasFailures() && $thenCallback !== null) {
+            $thenCallback($this, $results);
+        }
+
+        if ($finallyCallback !== null) {
+            $finallyCallback($this, $results);
+        }
+
+        $this->finishedAt = new CarbonImmutable();
+
+        return $results;
+    }
+
+    /**
+     * Retrieve a new async pending request.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function asyncRequest()
+    {
+        return $this->factory->setHandler($this->handler)->async();
+    }
+
+    /**
+     * Increment the count of total and pending requests in the batch.
+     *
+     * @return void
+     */
+    protected function incrementPendingRequests(): void
+    {
+        $this->totalRequests++;
+        $this->pendingRequests++;
+    }
+
+    /**
+     * Decrement the count of pending requests in the batch.
+     *
+     * @return void
+     */
+    protected function decrementPendingRequests(): void
+    {
+        $this->pendingRequests--;
+    }
+
+    /**
+     * Increment the count of failed requests in the batch.
+     *
+     * @return void
+     */
+    protected function incrementFailedRequests(): void
+    {
+        $this->failedRequests++;
+    }
+}

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -20,13 +20,6 @@ class Batch
     protected $factory;
 
     /**
-     * The handler function for the Guzzle client.
-     *
-     * @var callable
-     */
-    protected $handler;
-
-    /**
      * The list of requests.
      *
      * @var array<array-key, \Illuminate\Http\Client\PendingRequest>
@@ -55,25 +48,11 @@ class Batch
     public $failedRequests = 0;
 
     /**
-     * The date indicating when the batch was created.
+     * The handler function for the Guzzle client.
      *
-     * @var \Carbon\CarbonImmutable
+     * @var callable
      */
-    public $createdAt = null;
-
-    /**
-     * The date indicating when the batch was cancelled.
-     *
-     * @var \Carbon\CarbonImmutable|null
-     */
-    public $cancelledAt = null;
-
-    /**
-     * The date indicating when the batch was finished.
-     *
-     * @var \Carbon\CarbonImmutable|null
-     */
-    public $finishedAt = null;
+    protected $handler;
 
     /**
      * The callback to run before the first request from the batch runs.
@@ -104,17 +83,43 @@ class Batch
     protected $thenCallback = null;
 
     /**
+     * The date when the batch was created.
+     *
+     * @var \Carbon\CarbonImmutable
+     */
+    public $createdAt = null;
+
+    /**
+     * The date when the batch was cancelled.
+     *
+     * @var \Carbon\CarbonImmutable|null
+     */
+    public $cancelledAt = null;
+
+    /**
+     * The date when the batch was finished.
+     *
+     * @var \Carbon\CarbonImmutable|null
+     */
+    public $finishedAt = null;
+
+    /**
      * The callback to run after all the requests from the batch finish.
      *
      * @var \Closure|null
      */
     protected $finallyCallback = null;
 
+    /**
+     * Create a new request batch instance.
+     *
+     * @return void
+     */
     public function __construct(?Factory $factory = null)
     {
-        $this->factory = $factory ?: new Factory();
+        $this->factory = $factory ?: new Factory;
         $this->handler = Utils::chooseHandler();
-        $this->createdAt = new CarbonImmutable();
+        $this->createdAt = new CarbonImmutable;
     }
 
     /**
@@ -128,30 +133,6 @@ class Batch
         $this->incrementPendingRequests();
 
         return $this->requests[$key] = $this->asyncRequest();
-    }
-
-    /**
-     * Retrieve the requests in the batch.
-     *
-     * @return array<array-key, \Illuminate\Http\Client\PendingRequest>
-     */
-    public function getRequests(): array
-    {
-        return $this->requests;
-    }
-
-    /**
-     * Add a request to the batch with a numeric index.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\Promise
-     */
-    public function __call(string $method, array $parameters)
-    {
-        $this->incrementPendingRequests();
-
-        return $this->requests[] = $this->asyncRequest()->$method(...$parameters);
     }
 
     /**
@@ -424,5 +405,29 @@ class Batch
     protected function incrementFailedRequests(): void
     {
         $this->failedRequests++;
+    }
+
+    /**
+     * Get the requests in the batch.
+     *
+     * @return array<array-key, \Illuminate\Http\Client\PendingRequest>
+     */
+    public function getRequests(): array
+    {
+        return $this->requests;
+    }
+
+    /**
+     * Add a request to the batch with a numeric index.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\Promise
+     */
+    public function __call(string $method, array $parameters)
+    {
+        $this->incrementPendingRequests();
+
+        return $this->requests[] = $this->asyncRequest()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Http/Client/BatchInProgressException.php
+++ b/src/Illuminate/Http/Client/BatchInProgressException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class BatchInProgressException extends HttpClientException
+{
+    public function __construct()
+    {
+        parent::__construct('You cannot add requests to a batch that is already in progress.');
+    }
+}

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -899,6 +899,12 @@ class PendingRequest
         return $results;
     }
 
+    /**
+     * Send a pool of asynchronous requests concurrently, with callbacks for introspection.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Http\Client\Batch
+     */
     public function batch(callable $callback): Batch
     {
         return tap(new Batch($this->factory), $callback);

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -893,6 +893,7 @@ class PendingRequest
         $pool = tap(new Pool($this->factory), $callback);
         $requests = $pool->getRequests();
         $progressCallback = $pool->progressCallback();
+        $catchCallback = $pool->catchCallback();
         $success = 0;
 
         foreach ($requests as $key => $item) {
@@ -904,6 +905,13 @@ class PendingRequest
                 if ($progressCallback !== null) {
                     $progressCallback($key, $result);
                 }
+            }
+
+            if (
+                (($result instanceof Response && $result->failed()) || $result instanceof RequestException)
+                && $catchCallback !== null
+            ) {
+                $catchCallback($key, $result);
             }
         }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -894,6 +894,7 @@ class PendingRequest
         $requests = $pool->getRequests();
         $progressCallback = $pool->progressCallback();
         $catchCallback = $pool->catchCallback();
+        $thenCallback = $pool->thenCallback();
         $success = 0;
 
         foreach ($requests as $key => $item) {
@@ -913,6 +914,10 @@ class PendingRequest
             ) {
                 $catchCallback($key, $result);
             }
+        }
+
+        if ($success === count($requests) && $thenCallback !== null) {
+            $thenCallback($results);
         }
 
         return $results;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -895,6 +895,7 @@ class PendingRequest
         $progressCallback = $pool->progressCallback();
         $catchCallback = $pool->catchCallback();
         $thenCallback = $pool->thenCallback();
+        $finallyCallback = $pool->finallyCallback();
         $success = 0;
 
         foreach ($requests as $key => $item) {
@@ -918,6 +919,10 @@ class PendingRequest
 
         if ($success === count($requests) && $thenCallback !== null) {
             $thenCallback($results);
+        }
+
+        if ($finallyCallback !== null) {
+            $finallyCallback($results);
         }
 
         return $results;

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -46,6 +46,13 @@ class Pool
     protected $catchCallback = null;
 
     /**
+     * The callback to run if all the requests from the pool succeeded.
+     *
+     * @var \Closure|null
+     */
+    protected $thenCallback = null;
+
+    /**
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -139,5 +146,26 @@ class Pool
     public function catchCallback(): ?Closure
     {
         return $this->catchCallback;
+    }
+
+    /**
+     * Register a callback to run after all the requests from the pool succeed.
+     *
+     * @param  Closure  $callback
+     * @return void
+     */
+    public function then(Closure $callback)
+    {
+        $this->thenCallback = $callback;
+    }
+
+    /**
+     * Retrieve the then callback in the pool.
+     *
+     * @return \Closure|null
+     */
+    public function thenCallback(): ?Closure
+    {
+        return $this->thenCallback;
     }
 }

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use Closure;
 use GuzzleHttp\Utils;
 
 /**
@@ -30,34 +29,6 @@ class Pool
      * @var array<array-key, \Illuminate\Http\Client\PendingRequest>
      */
     protected $pool = [];
-
-    /**
-     * The callback to run after a request from the pool succeeds.
-     *
-     * @var \Closure|null
-     */
-    protected $progressCallback = null;
-
-    /**
-     * The callback to run after a request from the pool fails.
-     *
-     * @var \Closure|null
-     */
-    protected $catchCallback = null;
-
-    /**
-     * The callback to run if all the requests from the pool succeeded.
-     *
-     * @var \Closure|null
-     */
-    protected $thenCallback = null;
-
-    /**
-     * The callback to run after all the requests from the pool finish.
-     *
-     * @var \Closure|null
-     */
-    protected $finallyCallback = null;
 
     /**
      * Create a new requests pool.
@@ -111,89 +82,5 @@ class Pool
     public function __call($method, $parameters)
     {
         return $this->pool[] = $this->asyncRequest()->$method(...$parameters);
-    }
-
-    /**
-     * Register a callback to run after a request from the pool succeeds.
-     *
-     * @param  Closure  $callback
-     * @return void
-     */
-    public function progress(Closure $callback)
-    {
-        $this->progressCallback = $callback;
-    }
-
-    /**
-     * Retrieve the progress callback in the pool.
-     *
-     * @return \Closure|null
-     */
-    public function progressCallback(): ?Closure
-    {
-        return $this->progressCallback;
-    }
-
-    /**
-     * Register a callback to run after a request from the pool fails.
-     *
-     * @param  Closure  $callback
-     * @return void
-     */
-    public function catch(Closure $callback)
-    {
-        $this->catchCallback = $callback;
-    }
-
-    /**
-     * Retrieve the catch callback in the pool.
-     *
-     * @return \Closure|null
-     */
-    public function catchCallback(): ?Closure
-    {
-        return $this->catchCallback;
-    }
-
-    /**
-     * Register a callback to run after all the requests from the pool succeed.
-     *
-     * @param  Closure  $callback
-     * @return void
-     */
-    public function then(Closure $callback)
-    {
-        $this->thenCallback = $callback;
-    }
-
-    /**
-     * Retrieve the then callback in the pool.
-     *
-     * @return \Closure|null
-     */
-    public function thenCallback(): ?Closure
-    {
-        return $this->thenCallback;
-    }
-
-    /**
-     * Register a callback to run after all the requests from the pool finish.
-     *
-     * @param  Closure  $callback
-     * @return void
-     */
-    public function finally(Closure $callback)
-    {
-        $this->finallyCallback = $callback;
-    }
-
-    /**
-     * Retrieve the finally callback in the pool.
-     *
-     * @return \Closure|null
-     */
-    public function finallyCallback(): ?Closure
-    {
-        return $this->finallyCallback;
     }
 }

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -39,6 +39,13 @@ class Pool
     protected $progressCallback = null;
 
     /**
+     * The callback to run after a request from the pool fails.
+     *
+     * @var \Closure|null
+     */
+    protected $catchCallback = null;
+
+    /**
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -111,5 +118,26 @@ class Pool
     public function progressCallback(): ?Closure
     {
         return $this->progressCallback;
+    }
+
+    /**
+     * Register a callback to run after a request from the pool fails.
+     *
+     * @param  Closure  $callback
+     * @return void
+     */
+    public function catch(Closure $callback)
+    {
+        $this->catchCallback = $callback;
+    }
+
+    /**
+     * Retrieve the catch callback in the pool.
+     *
+     * @return \Closure|null
+     */
+    public function catchCallback(): ?Closure
+    {
+        return $this->catchCallback;
     }
 }

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
+use Closure;
 use GuzzleHttp\Utils;
 
 /**
@@ -29,6 +30,13 @@ class Pool
      * @var array<array-key, \Illuminate\Http\Client\PendingRequest>
      */
     protected $pool = [];
+
+    /**
+     * The callback to run after a request from the pool succeeds.
+     *
+     * @var \Closure|null
+     */
+    protected $progressCallback = null;
 
     /**
      * Create a new requests pool.
@@ -82,5 +90,26 @@ class Pool
     public function __call($method, $parameters)
     {
         return $this->pool[] = $this->asyncRequest()->$method(...$parameters);
+    }
+
+    /**
+     * Register a callback to run after a request from the pool succeeds.
+     *
+     * @param  Closure  $callback
+     * @return void
+     */
+    public function progress(Closure $callback)
+    {
+        $this->progressCallback = $callback;
+    }
+
+    /**
+     * Retrieve the progress callback in the pool.
+     *
+     * @return \Closure|null
+     */
+    public function progressCallback(): ?Closure
+    {
+        return $this->progressCallback;
     }
 }

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -53,6 +53,13 @@ class Pool
     protected $thenCallback = null;
 
     /**
+     * The callback to run after all the requests from the pool finish.
+     *
+     * @var \Closure|null
+     */
+    protected $finallyCallback = null;
+
+    /**
      * Create a new requests pool.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -167,5 +174,26 @@ class Pool
     public function thenCallback(): ?Closure
     {
         return $this->thenCallback;
+    }
+
+    /**
+     * Register a callback to run after all the requests from the pool finish.
+     *
+     * @param  Closure  $callback
+     * @return void
+     */
+    public function finally(Closure $callback)
+    {
+        $this->finallyCallback = $callback;
+    }
+
+    /**
+     * Retrieve the finally callback in the pool.
+     *
+     * @return \Closure|null
+     */
+    public function finallyCallback(): ?Closure
+    {
+        return $this->finallyCallback;
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3824,45 +3824,6 @@ class HttpClientTest extends TestCase
         $this->assertTrue($batch->finished());
     }
 
-    public function testBatchCancel(): void
-    {
-        $this->markTestSkipped('SKIPPING UNTIL DECISION IS MADE TO KEEP OR REMOVE CANCEL FEATURE');
-        $this->factory->fake([
-            'https://200.com' => $this->factory::response('OK', 200),
-            'https://500.com' => $this->factory::response('Error', 500),
-            'https://201.com' => $this->factory::response('Created', 201),
-        ]);
-
-        $batch = $this->factory->batch(function (Batch $batch) {
-            return [
-                $batch->as('first')->get('https://200.com'),
-                $batch->as('second')->get('https://500.com'),
-                $batch->as('third')->get('https://201.com'),
-            ];
-        })->catch(function (Batch $batch, int|string $key, Response|RequestException $response) {
-            $batch->cancel();
-        });
-
-        $this->assertSame(3, $batch->totalRequests);
-        $this->assertSame(0, $batch->completion());
-        $this->assertFalse($batch->finished());
-        $this->assertFalse($batch->cancelled());
-
-        $responses = $batch->send();
-
-        $this->assertCount(2, $responses);
-        $this->assertSame(200, $responses['first']->status());
-        $this->assertSame(500, $responses['second']->status());
-
-        $this->assertSame(3, $batch->totalRequests);
-        $this->assertSame(1, $batch->pendingRequests);
-        $this->assertSame(1, $batch->failedRequests);
-        $this->assertSame(67, $batch->completion());
-        $this->assertTrue($batch->hasFailures());
-        $this->assertFalse($batch->finished());
-        $this->assertTrue($batch->cancelled());
-    }
-
     public function testBatchBeforeHook(): void
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3824,6 +3824,44 @@ class HttpClientTest extends TestCase
         $this->assertTrue($batch->finished());
     }
 
+    public function testBatchCancel(): void
+    {
+        $this->factory->fake([
+            'https://200.com' => $this->factory::response('OK', 200),
+            'https://500.com' => $this->factory::response('Error', 500),
+            'https://201.com' => $this->factory::response('Created', 201),
+        ]);
+
+        $batch = $this->factory->batch(function (Batch $batch) {
+            return [
+                $batch->as('first')->get('https://200.com'),
+                $batch->as('second')->get('https://500.com'),
+                $batch->as('third')->get('https://201.com'),
+            ];
+        })->catch(function (Batch $batch, int|string $key, Response|RequestException $response) {
+            $batch->cancel();
+        });
+
+        $this->assertSame(3, $batch->totalRequests);
+        $this->assertSame(0, $batch->completion());
+        $this->assertFalse($batch->finished());
+        $this->assertFalse($batch->cancelled());
+
+        $responses = $batch->send();
+
+        $this->assertCount(2, $responses);
+        $this->assertSame(200, $responses['first']->status());
+        $this->assertSame(500, $responses['second']->status());
+
+        $this->assertSame(3, $batch->totalRequests);
+        $this->assertSame(1, $batch->pendingRequests);
+        $this->assertSame(1, $batch->failedRequests);
+        $this->assertSame(67, $batch->completion());
+        $this->assertTrue($batch->hasFailures());
+        $this->assertFalse($batch->finished());
+        $this->assertTrue($batch->cancelled());
+    }
+
     public function testBatchBeforeHook(): void
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3826,6 +3826,7 @@ class HttpClientTest extends TestCase
 
     public function testBatchCancel(): void
     {
+        $this->markTestSkipped('SKIPPING UNTIL DECISION IS MADE TO KEEP OR REMOVE CANCEL FEATURE');
         $this->factory->fake([
             'https://200.com' => $this->factory::response('OK', 200),
             'https://500.com' => $this->factory::response('Error', 500),

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3808,7 +3808,7 @@ class HttpClientTest extends TestCase
         });
 
         $this->assertSame(3, $batch->totalRequests);
-        $this->assertSame(0, $batch->completion());
+        // $this->assertSame(0, $batch->completion());
         $this->assertFalse($batch->finished());
 
         $responses = $batch->send();
@@ -3820,7 +3820,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(3, $batch->totalRequests);
         $this->assertSame(0, $batch->pendingRequests);
         $this->assertSame(1, $batch->failedRequests);
-        $this->assertSame(100, $batch->completion());
+        // $this->assertSame(100, $batch->completion());
         $this->assertTrue($batch->hasFailures());
         $this->assertTrue($batch->finished());
     }


### PR DESCRIPTION
## Overview

Inspired by the hooks from the `Bus::batch`, this PR adds a new `Http::batch` with the same hooks that are available in the `Bus::batch`.


## Use Case

Imagine that your application needs to connect to 3 different 3rd-party services to setup configurations for your customers, and you want to track the progress of the overall and also take actions after each one of these calls finish (handling success and error cases) and after everything finished you want to send a notification to the client.

With the current `Http::pool`, this is not possible. But with the new `Http::batch`, you can do that easily by setting up hooks that can run to cover all of these needs.

## Example
```php
$responses = Http::batch(fn (Batch $batch) => [
    $batch->get('http://localhost/first'),
    $batch->get('http://localhost/second'),
    $batch->get('http://localhost/third'),
])->before(function (Batch $batch) {
    // This runs before the first HTTP request is executed.
})->progress(function (Batch $batch, int|string $key, Response $response) {
    // This runs after each successful HTTP request from the Batch.
})->catch(function (Batch $batch, int|string $key, Response|RequestException $response) {
    // This runs after each failed HTTP request from the Batch.
})->then(function (Batch $batch, array $results) {
    // This runs ONLY IF all the HTTP requests from the Batch are successful and the batch is not cancelled.
})->finally(function (Batch $batch, array $results) {
    // This runs after all the HTTP requests from the Batch finish and the batch is not cancelled.
})->send();
```

## Exception

Because of the nature on how the async requests are handled, it's not possible to add requests after the batch started processing, if you attempt to do that, a `\Illuminate\Http\Client\BatchInProgressException` will be thrown.

## Helper Methods/Properties

Besides the Hooks, the `\Illuminate\Http\Client\Batch` class also provides some helper methods and properties to check details from the batch of requests:

`$batch->totalRequests` gives you the count of requests in the batch.

`$batch->pendingRequests` gives you the count of pending requests in the batch.

`$batch->failedRequests` gives you the count of failed requests in the batch.

`$batch->createdAt` gives you the datetime that the batch was created.

`$batch->cancelledAt` gives you the datetime that the batch was cancelled.

`$batch->finishedAt` gives you the datetime that the batch finished to execute all the HTTP requests.

`$batch->processedRequests()` gives you the total number of requests that have been processed by the batch.

`$batch->completion()` gives you the percentage of requests that have been processed (between 0-100).

`$batch->hasFailures()` returns true if the batch has at least one failed request.

`$batch->finished()` returns true if the batch has finished executing.