### PR TITLE
[12.x] Fix Validator placeholderHash PHPDoc

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -309,7 +309,7 @@ class Validator implements ValidatorContract
     /**
      * The current random hash for the validator.
      *
-     * @var string
+     * @var string|null
      */
     protected static $placeholderHash;
 


### PR DESCRIPTION
Description
---
The `flushState()` method was recently introduced in #56852 and explicitly sets the static `$placeholderHash` to `null`. This PR updates the property's PHPDoc to accurately reflect its possible values.