### PR TITLE
[12.x] Add reEncrypt method to Encrypter class for streamlined key rotation.

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\StringEncrypter;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Encrypter implements EncrypterContract, StringEncrypter
@@ -373,5 +374,32 @@ class Encrypter implements EncrypterContract, StringEncrypter
         $this->previousKeys = $keys;
 
         return $this;
+    }
+
+    /**
+     * Re-encrypt the given payload using the current primary key.
+     *
+     * @param  string  $payload
+     * @param bool $unserialize
+     * @return string
+     *
+     */
+    public function reEncrypt(string $payload, bool $unserialize = true): string
+    {
+        if (empty($payload)) {
+            throw new InvalidArgumentException('Payload cannot be empty.');
+        }
+
+        try {
+            $decrypted = $this->decrypt($payload, $unserialize);
+        } catch (DecryptException $e) {
+            throw new DecryptException(
+                'Failed to re-encrypt, unable to decrypt payload.',
+                0,
+                $e
+            );
+        }
+
+        return $this->encrypt($decrypted, $unserialize);
     }
 }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -380,9 +380,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * Re-encrypt the given payload using the current primary key.
      *
      * @param  string  $payload
-     * @param bool $unserialize
+     * @param  bool $unserialize
      * @return string
-     *
      */
     public function reEncrypt(string $payload, bool $unserialize = true): string
     {

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -385,7 +385,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public function reEncrypt(string $payload, bool $unserialize = true): string
     {
-        if (empty($payload)) {
+        if ($payload === '') {
             throw new InvalidArgumentException('Payload cannot be empty.');
         }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -380,7 +380,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * Re-encrypt the given payload using the current primary key.
      *
      * @param  string  $payload
-     * @param  bool $unserialize
+     * @param  bool  $unserialize
      * @return string
      */
     public function reEncrypt(string $payload, bool $unserialize = true): string

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -304,5 +304,4 @@ class EncrypterTest extends TestCase
         $this->assertNotSame($payload, $newPayload);
         $this->assertSame($originalData, $newEncrypter->decrypt($newPayload));
     }
-
 }


### PR DESCRIPTION
## Summary

This PR introduces a new method `reEncrypt()` to the `Illuminate\Encryption\Encrypter` class.  
The purpose of this method is to simplify **key rotation and re-encryption workflows** for developers. While technically developers can achieve the same by manually calling `decrypt()` followed by `encrypt()`, `reEncrypt()` provides a **safe, readable, and consistent API** for this common task.


## Problem

Currently, to rotate encryption keys, developers must:

1. Retrieve encrypted values from the database.
2. Manually decrypt using `decrypt()`.
3. Encrypt again with the new primary key using `encrypt()`.
4. Handle potential serialization issues and exceptions manually.

This is error-prone and requires boilerplate code. `reEncrypt()` standardizes this workflow in a single method.

### Example Usage

You can use the `reEncrypt` method in a migration, command, or any service where encrypted data needs to be rotated to a new key:

```php
use Illuminate\Support\Facades\DB;
use Illuminate\Support\Facades\Crypt;

$users = DB::table('users')->get();

foreach ($users as $user) {
    // Re-encrypt the existing encrypted value with the current primary key
    $reEncryptedData = Crypt::reEncrypt($user->encrypted_data);

    // Update the database with the newly encrypted value
    DB::table('users')->where('id', $user->id)->update([
        'encrypted_data' => $reEncryptedData,
    ]);
}
```

By adding this method, we complete the key rotation workflow within the framework. This removes the need for custom scripts to decrypt and re-encrypt values manually.