### PR TITLE
[12.x] Allow not having "fakerphp/faker" installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
         "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
-        "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.9.1).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -96,6 +96,10 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerFakerGenerator()
     {
+        if (! class_exists(FakerGenerator::class)) {
+            return;
+        }
+
         $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
             $locale = $parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US');
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -953,10 +953,14 @@ abstract class Factory
     /**
      * Get a new Faker instance.
      *
-     * @return \Faker\Generator
+     * @return \Faker\Generator|null
      */
     protected function withFaker()
     {
+        if (! class_exists(Generator::class)) {
+            return;
+        }
+
         return Container::getInstance()->make(Generator::class);
     }
 


### PR DESCRIPTION
I have somewhat of an obsession to keep my dependency count low and my bundle size small. For basic applications I can get away with using only:

```json
"require": {  
    "php": "^8.4",  
    "laravel/framework": "^12.0",  
    "laravel/tinker": "^2.10.1"  
},  
"require-dev": {  
    "fakerphp/faker": "^1.23",  
    "laravel/pint": "^1.24",  
    "mockery/mockery": "^1.6",  
    "phpunit/phpunit": "^11.5.3"  
},
```

Right now, I can't remove "fakerphp/faker", because that causes factories to throw exceptions (even if my factories don't use Faker).

This PR allows me to remove Faker from my dependencies. With the above set of minimal packages, this shrinks my development `vendor` directory by:
- Size: 72 mb -> 61 mb (-11 mb, -15%)
- Files: 8040 -> 7526 (-514 files, -7%)

For reference, the [`fake()` helper already checks if Faker is available](https://github.com/laravel/framework/blob/5a0715f939b6b4da078610b596ca0b3d7f37d58a/src/Illuminate/Foundation/helpers.php#L509) before it is registered.

Also, one of the reasons the creator of Faker decided to [sunset the original Faker package](https://marmelab.com/blog/2020/10/21/sunsetting-faker.html) was because of its environmental impact. This PR allows environmentally conscious Laravel developers to remove Faker from their dependencies.

When not using Faker in basic applications, it is still possible to write good factories:
```php
class UserFactory extends Factory  
{  
    public function definition(): array  
    {  
        return [  
            'uuid' => Str::uuid()->toString(),  
            'first_name' => Arr::random(['Hank', 'Bill', 'Dale', 'Bobby', 'Boomhauer']),  
            'email' => 'email-'.mt_rand().'.@example.com',  
        ];  
    }
}
```