### PR TITLE
[12.x] Add withoutGlobalScopesExcept() to keep only specified global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -243,6 +243,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Remove all except passed registered global scopes.
+     *
+     * @param  array|string  $scopes
+     * @return $this
+     */
+    public function withoutGlobalScopesExcept(array $scopes = [])
+    {
+        $this->withoutGlobalScopes(
+            array_diff(array_keys($this->scopes), $scopes)
+        );
+
+        return $this;
+    }
+
+    /**
      * Get an array of global scopes that were removed from the query.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -243,7 +243,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Remove all except passed registered global scopes.
+     * Remove all global scopes except the given scopes.
      *
      * @param  array  $scopes
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -245,7 +245,7 @@ class Builder implements BuilderContract
     /**
      * Remove all except passed registered global scopes.
      *
-     * @param  array|string  $scopes
+     * @param  array  $scopes
      * @return $this
      */
     public function withoutGlobalScopesExcept(array $scopes = [])

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -108,6 +108,18 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
+    public function testAllGlobalScopesCanBeRemovedExceptSpecified()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel;
+        $query = $model->newQuery()->withoutGlobalScopesExcept(['active_scope']);
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+
+        $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopesExcept(['active_scope']);
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testGlobalScopesWithOrWhereConditionsAreNested()
     {
         $model = new EloquentClosureGlobalScopesWithOrTestModel;


### PR DESCRIPTION
This PR introduces a new Eloquent query builder method:

```PHP
withoutGlobalScopesExcept(array $scopes = [])
```

This method allows disabling all global scopes except the ones explicitly listed.

**Example usage**

```PHP
class Post extends Model
{
    protected static function booted()
    {
        static::addGlobalScope('published', fn ($q) => $q->where('published', true));
        static::addGlobalScope('not_deleted', fn ($q) => $q->whereNull('deleted_at'));
        static::addGlobalScope('tenant', fn ($q) => $q->where('tenant_id', auth()->id()));
        static::addGlobalScope('locale', fn ($q) => $q->where('locale', app()->getLocale()));
        static::addGlobalScope('approved', fn ($q) => $q->where('approved', true));
    }
}
```

**Current approach**

```PHP
// Want to keep only the "tenant" scope

// Option 1: Disable all, then reapply manually
$posts = Post::withoutGlobalScopes()
    ->where('tenant_id', auth()->id())
    ->get();

// Option 2: Disable unwanted scopes using withoutGlobalScopes([])
$posts = Post::withoutGlobalScopes([
    'published',
    'not_deleted',
    'locale',
    'approved',
])->get();
```

**With this PR**

```PHP
// Disable all scopes except "tenant"
$posts = Post::withoutGlobalScopesExcept(['tenant'])->get();
```
