### PR TITLE
[12.x] Add globally hidden & visible to models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -169,7 +169,7 @@ trait HidesAttributes
     /**
      * Set the globally hidden attributes for all models.
      *
-     * @param  array<string> $hidden
+     * @param  array<string>  $hidden
      * @return void
      */
     public static function setGloballyHidden(array $hidden): void
@@ -180,7 +180,7 @@ trait HidesAttributes
     /**
      * Set the globally visible attributes for all models.
      *
-     * @param  array<string> $visible
+     * @param  array<string>  $visible
      * @return void
      */
     public static function setGloballyVisible(array $visible): void

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -169,7 +169,7 @@ trait HidesAttributes
     /**
      * Set the globally hidden attributes for all models.
      *
-     * @param array<string> $hidden
+     * @param  array<string> $hidden
      * @return void
      */
     public static function setGloballyHidden(array $hidden): void
@@ -180,7 +180,7 @@ trait HidesAttributes
     /**
      * Set the globally visible attributes for all models.
      *
-     * @param array<string> $visible
+     * @param  array<string> $visible
      * @return void
      */
     public static function setGloballyVisible(array $visible): void

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -12,11 +12,25 @@ trait HidesAttributes
     protected $hidden = [];
 
     /**
+     * The attributes that should be globally hidden for serialization on all models.
+     *
+     * @var array<string>
+     */
+    protected static array $globalHidden = [];
+
+    /**
      * The attributes that should be visible in serialization.
      *
      * @var array<string>
      */
     protected $visible = [];
+
+    /**
+     * The attributes that should be globally visible for serialization on all models.
+     *
+     * @var array<string>
+     */
+    protected static array $globalVisible = [];
 
     /**
      * Get the hidden attributes for the model.
@@ -25,6 +39,8 @@ trait HidesAttributes
      */
     public function getHidden()
     {
+        $this->mergeHidden(static::$globalHidden);
+
         return $this->hidden;
     }
 
@@ -61,6 +77,8 @@ trait HidesAttributes
      */
     public function getVisible()
     {
+        $this->mergeVisible(static::$globalVisible);
+
         return $this->visible;
     }
 
@@ -146,5 +164,27 @@ trait HidesAttributes
     public function makeHiddenIf($condition, $attributes)
     {
         return value($condition, $this) ? $this->makeHidden($attributes) : $this;
+    }
+
+    /**
+     * Set the globally hidden attributes for all models.
+     *
+     * @param array<string> $hidden
+     * @return void
+     */
+    public static function setGloballyHidden(array $hidden): void
+    {
+        static::$globalHidden = $hidden;
+    }
+
+    /**
+     * Set the globally visible attributes for all models.
+     *
+     * @param array<string> $visible
+     * @return void
+     */
+    public static function setGloballyVisible(array $visible): void
+    {
+        static::$globalVisible = $visible;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -78,6 +78,8 @@ class DatabaseEloquentModelTest extends TestCase
         Carbon::setTestNow(null);
 
         Model::unsetEventDispatcher();
+        Model::setGloballyHidden([]);
+        Model::setGloballyVisible([]);
         Carbon::resetToStringFormat();
     }
 
@@ -1514,6 +1516,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
+    public function testGloballyHidden()
+    {
+        Model::setGloballyHidden(['id']);
+
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->setHidden(['age']);
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('age', $array);
+        $this->assertArrayNotHasKey('id', $array);
+    }
+
     public function testMergeHiddenMergesHidden()
     {
         $model = new EloquentModelHiddenStub;
@@ -1530,6 +1544,17 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setVisible(['name', 'id']);
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('age', $array);
+    }
+
+    public function testGloballyVisible()
+    {
+        Model::setGloballyVisible(['id']);
+
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->setVisible(['name']);
         $array = $model->toArray();
         $this->assertArrayHasKey('name', $array);
         $this->assertArrayNotHasKey('age', $array);


### PR DESCRIPTION
**Example:**
```php
Model::setGloballyHidden(['id', 'password']);
Model::setGloballyVisible(['name']);
```

**Use-case:**
In our application, we extensively use `$hidden` attributes, to hide common database columns, such as `id`, in favour of hashids.
However, we have to add these attributes repeatedly. So, I came up with the idea of globally hidden and visible attributes.
