### PR TITLE
[12.x] Refactor: remove unused `array` from doc block

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -198,7 +198,7 @@ class PendingResourceRegistration
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -222,7 +222,7 @@ class PendingSingletonResourceRegistration
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {


### PR DESCRIPTION
wrong docblock:
```
    /**
     * Specify middleware that should be removed from the resource routes.
     *
     * @param  array|string  $middleware
     * @return $this|array
     */
    public function withoutMiddleware($middleware)
    {
        $this->options['excluded_middleware'] = array_merge(
            (array) ($this->options['excluded_middleware'] ?? []), Arr::wrap($middleware)
        );

        return $this;
    }
```
    
right docblock:
```
    /**
     * Specify middleware that should be removed from the resource routes.
     *
     * @param  array|string  $middleware
     * @return $this
     */
    public function withoutMiddleware($middleware)
    {
        $this->options['excluded_middleware'] = array_merge(
            (array) ($this->options['excluded_middleware'] ?? []), Arr::wrap($middleware)
        );

        return $this;
    }
```

in two files:
src/Illuminate/Routing/PendingResourceRegistration.php
src/Illuminate/Routing/PendingSingletonResourceRegistration.php