### PR TITLE
[12.x] SQLite: Allow setting any pragmas

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -42,6 +42,7 @@ return [
             'journal_mode' => null,
             'synchronous' => null,
             'transaction_mode' => 'DEFERRED',
+            'pragmas' => [],
         ],
 
         'mysql' => [

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -20,6 +20,8 @@ class SQLiteConnector extends Connector implements ConnectorInterface
 
         $connection = $this->createConnection("sqlite:{$path}", $config, $options);
 
+        $this->configurePragmas($connection, $config);
+
         $this->configureForeignKeyConstraints($connection, $config);
         $this->configureBusyTimeout($connection, $config);
         $this->configureJournalMode($connection, $config);
@@ -126,5 +128,23 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         $connection->prepare("pragma synchronous = {$config['synchronous']}")->execute();
+    }
+
+    /**
+     * Set other user-configured pragmas.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configurePragmas($connection, array $config): void
+    {
+        if (! isset($config['pragmas'])) {
+            return;
+        }
+
+        foreach ($config['pragmas'] as $pragma => $value) {
+            $connection->prepare("pragma {$pragma} = {$value}")->execute();
+        }
     }
 }

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -21,7 +21,6 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         $connection = $this->createConnection("sqlite:{$path}", $config, $options);
 
         $this->configurePragmas($connection, $config);
-
         $this->configureForeignKeyConstraints($connection, $config);
         $this->configureBusyTimeout($connection, $config);
         $this->configureJournalMode($connection, $config);
@@ -62,6 +61,24 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         return $path;
+    }
+
+    /**
+     * Set miscellaneous user-configured pragmas.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configurePragmas($connection, array $config): void
+    {
+        if (! isset($config['pragmas'])) {
+            return;
+        }
+
+        foreach ($config['pragmas'] as $pragma => $value) {
+            $connection->prepare("pragma {$pragma} = {$value}")->execute();
+        }
     }
 
     /**
@@ -128,23 +145,5 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         $connection->prepare("pragma synchronous = {$config['synchronous']}")->execute();
-    }
-
-    /**
-     * Set other user-configured pragmas.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return void
-     */
-    protected function configurePragmas($connection, array $config): void
-    {
-        if (! isset($config['pragmas'])) {
-            return;
-        }
-
-        foreach ($config['pragmas'] as $pragma => $value) {
-            $connection->prepare("pragma {$pragma} = {$value}")->execute();
-        }
     }
 }

--- a/tests/Integration/Database/Sqlite/ConnectorTest.php
+++ b/tests/Integration/Database/Sqlite/ConnectorTest.php
@@ -41,12 +41,16 @@ class ConnectorTest extends DatabaseTestCase
             'busy_timeout' => 12345,
             'journal_mode' => 'wal',
             'synchronous' => 'normal',
+            'pragmas' => [
+                'query_only' => true,
+            ],
         ])->getSchemaBuilder();
 
         $this->assertSame(1, $schema->pragma('foreign_keys'));
         $this->assertSame(12345, $schema->pragma('busy_timeout'));
         $this->assertSame('wal', $schema->pragma('journal_mode'));
         $this->assertSame(1, $schema->pragma('synchronous'));
+        $this->assertSame(1, $schema->pragma('query_only'));
 
         $schema->pragma('foreign_keys', 0);
         $schema->pragma('busy_timeout', 54321);


### PR DESCRIPTION
Recently a couple config options were added for specific SQLite pragmas. The actual list of pragmas supported by SQLite is [extensive](https://www.sqlite.org/pragma.html#toc) and it doesn't make much sense for Laravel to have to add a dedicated config option for each one.

Instead, letting the user set any pragmas in the `'pragmas' => [ ... ]` array seems more reasonable.

However, adding this creates two ways the pragmas with existing options can be configured. For instance `journal_mode` can be set as either one of:
```
'journal_mode' => 'wal',
'pragmas' => [
    'journal_mode' => 'wal',
],
```

I'd be fine with targeting 13.x here and removing all of the existing options in favor of pragma. But I can also see that we might want to keep dedicated options for the most common pragmas.

So the way I implemented this is that all of the existing options are kept and *take precedence* over anything set in `pragmas` (`configurePragmas()` is called first so anything after that (`configureJournalMode` etc) will override conflicting pragmas).