### PR TITLE
[12.x] Reorder .gitignore entries for consistency and readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
+.DS_Store
+.phpunit.result.cache
+/.fleet
+/.idea
 /.phpunit.cache
+/phpunit.xml
+/.vscode
 /vendor
 composer.phar
 composer.lock
-.DS_Store
 Thumbs.db
-/phpunit.xml
-/.idea
-/.fleet
-/.vscode
-.phpunit.result.cache


### PR DESCRIPTION
Description
---
This PR reorders the `.gitignore` entries in the framework core to match the ordering style recently applied in the Laravel skeleton repo https://github.com/laravel/laravel/pull/6619/commits/a9200af75d04db58094965753fb8a8f270fbcd8b:

- Files starting with a dot (.) are listed first.
- Directories come next.
- Normal files are listed last.

This improves readability and makes it easier to quickly scan the file. No entries were added or removed (only reordered).