### PR TITLE
[12.x] Refactor duplicated logic in ReplacesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -356,7 +356,7 @@ trait ReplacesAttributes
      */
     protected function replaceMimetypes($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceExtensions($message, $attribute, $rule, $parameters);
     }
 
     /**
@@ -370,7 +370,7 @@ trait ReplacesAttributes
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return $this->replaceExtensions($message, $attribute, $rule, $parameters);
     }
 
     /**


### PR DESCRIPTION
Continuation of: #56813

---

Description
---
This PR refactors several validation message replacer methods that shared the same logic:

- replaceExtensions()
- replaceMimetypes()
- replaceMimes()

Instead of duplicating the same code, these methods now delegate to the existing `replaceExtensions()` implementation.

This follows the same approach already used in `replaceNotIn()`, where the logic is centralized in one method and other similar methods simply call it.

https://github.com/laravel/framework/blob/aa671fd476233b5df894445351a562f14b95a4d3/src/Illuminate/Validation/Concerns/ReplacesAttributes.php#L309-L312

This change reduces code duplication and makes the code easier to maintain.