### PR TITLE
[12.x] Add support for #[UseResource(...)] and #[UseResourceCollection(...)] attributes on models

### DIFF
--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -82,7 +82,7 @@ trait TransformsToResourceCollection
     /**
      * Get the resource class from the class attribute.
      *
-     * @param  class-string<*>  $class
+     * @param  class-string<\Illuminate\Http\Resources\Json\JsonResource>  $class
      * @return class-string<*>|null
      */
     protected function resolveResourceFromAttribute(string $class): ?string
@@ -101,7 +101,7 @@ trait TransformsToResourceCollection
     /**
      * Get the resource collection class from the class attribute.
      *
-     * @param  class-string<*>  $class
+     * @param  class-string<\Illuminate\Http\Resources\Json\ResourceCollection>  $class
      * @return class-string<*>|null
      */
     protected function resolveResourceCollectionFromAttribute(string $class): ?string

--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -51,11 +51,13 @@ trait TransformsToResourceCollection
         throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 
         $useResourceCollection = $this->resolveResourceCollectionFromAttribute($className);
+
         if ($useResourceCollection !== null && class_exists($useResourceCollection)) {
             return new $useResourceCollection($this);
         }
 
         $useResource = $this->resolveResourceFromAttribute($className);
+
         if ($useResource !== null && class_exists($useResource)) {
             return $useResource::collection($this);
         }

--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Support\Traits;
 
+use Illuminate\Database\Eloquent\Attributes\UseResource;
+use Illuminate\Database\Eloquent\Attributes\UseResourceCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use LogicException;
+use ReflectionClass;
 
 trait TransformsToResourceCollection
 {
@@ -47,6 +50,16 @@ trait TransformsToResourceCollection
 
         throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 
+        $useResourceCollection = $this->resolveResourceCollectionFromAttribute($className);
+        if ($useResourceCollection !== null && class_exists($useResourceCollection)) {
+            return new $useResourceCollection($this);
+        }
+
+        $useResource = $this->resolveResourceFromAttribute($className);
+        if ($useResource !== null && class_exists($useResource)) {
+            return $useResource::collection($this);
+        }
+
         $resourceClasses = $className::guessResourceName();
 
         foreach ($resourceClasses as $resourceClass) {
@@ -64,5 +77,43 @@ trait TransformsToResourceCollection
         }
 
         throw new LogicException(sprintf('Failed to find resource class for model [%s].', $className));
+    }
+
+    /**
+     * Get the resource class from the class attribute.
+     *
+     * @param  class-string<*>  $class
+     * @return class-string<*>|null
+     */
+    protected function resolveResourceFromAttribute(string $class): ?string
+    {
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new ReflectionClass($class))->getAttributes(UseResource::class);
+
+        return $attributes !== []
+            ? $attributes[0]->newInstance()->class
+            : null;
+    }
+
+    /**
+     * Get the resource collection class from the class attribute.
+     *
+     * @param  class-string<*>  $class
+     * @return class-string<*>|null
+     */
+    protected function resolveResourceCollectionFromAttribute(string $class): ?string
+    {
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new ReflectionClass($class))->getAttributes(UseResourceCollection::class);
+
+        return $attributes !== []
+            ? $attributes[0]->newInstance()->class
+            : null;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Attributes/UseResource.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseResource
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<*>  $class
+     */
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/UseResourceCollection.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseResourceCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseResourceCollection
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<*>  $class
+     */
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -78,7 +78,7 @@ trait TransformsToResource
     /**
      * Get the resource class from the class attribute.
      *
-     * @param  class-string<*>  $class
+     * @param  class-string<\Illuminate\Http\Resources\Json\JsonResource>  $class
      * @return class-string<*>|null
      */
     protected function resolveResourceFromAttribute(string $class): ?string

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
 use LogicException;
+use ReflectionClass;
 
 trait TransformsToResource
 {
@@ -30,6 +32,11 @@ trait TransformsToResource
      */
     protected function guessResource(): JsonResource
     {
+        $resourceClass = $this->resolveResourceFromAttribute(static::class);
+        if ($resourceClass !== null && class_exists($resourceClass)) {
+            return $resourceClass::make($this);
+        }
+
         foreach (static::guessResourceName() as $resourceClass) {
             if (is_string($resourceClass) && class_exists($resourceClass)) {
                 return $resourceClass::make($this);
@@ -66,5 +73,24 @@ trait TransformsToResource
         );
 
         return [$potentialResource.'Resource', $potentialResource];
+    }
+
+    /**
+     * Get the resource class from the class attribute.
+     *
+     * @param  class-string<*>  $class
+     * @return class-string<*>|null
+     */
+    protected function resolveResourceFromAttribute(string $class): ?string
+    {
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new ReflectionClass($class))->getAttributes(UseResource::class);
+
+        return $attributes !== []
+            ? $attributes[0]->newInstance()->class
+            : null;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -33,6 +33,7 @@ trait TransformsToResource
     protected function guessResource(): JsonResource
     {
         $resourceClass = $this->resolveResourceFromAttribute(static::class);
+
         if ($resourceClass !== null && class_exists($resourceClass)) {
             return $resourceClass::make($this);
         }

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceCollectionTestResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel;
 use PHPUnit\Framework\TestCase;
 
@@ -43,9 +44,4 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
-}
-
-class EloquentResourceCollectionTestResource extends JsonResource
-{
-    //
 }

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -3,9 +3,14 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceCollectionTestResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceAttribute;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceCollectionAttribute;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceCollectionTestResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResourceCollection;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceCollectionTest extends TestCase
@@ -43,5 +48,28 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
         $resource = $collection->toResourceCollection();
 
         $this->assertInstanceOf(JsonResource::class, $resource);
+    }
+
+    public function testItCanTransformToResourceViaUseResourceAttribute()
+    {
+        $collection = new Collection([
+            new EloquentResourceTestResourceModelWithUseResourceCollectionAttribute(),
+        ]);
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(EloquentResourceTestJsonResourceCollection::class, $resource);
+    }
+
+    public function testItCanTransformToResourceViaUseResourceCollectionAttribute()
+    {
+        $collection = new Collection([
+            new EloquentResourceTestResourceModelWithUseResourceAttribute(),
+        ]);
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(AnonymousResourceCollection::class, $resource);
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource[0]);
     }
 }

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithGuessableResource;
 use PHPUnit\Framework\TestCase;
@@ -59,9 +59,4 @@ class DatabaseEloquentResourceModelTest extends TestCase
             'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModel',
         ], $model::guessResourceName());
     }
-}
-
-class EloquentResourceTestJsonResource extends JsonResource
-{
-    //
 }

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithGuessableResource;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceAttribute;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceModelTest extends TestCase
@@ -58,5 +59,15 @@ class DatabaseEloquentResourceModelTest extends TestCase
             'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModelResource',
             'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModel',
         ], $model::guessResourceName());
+    }
+
+    public function testItCanTransformToResourceViaUseResourceAttribute()
+    {
+        $model = new EloquentResourceTestResourceModelWithUseResourceAttribute();
+
+        $resource = $model->toResource();
+
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource);
+        $this->assertSame($model, $resource->resource);
     }
 }

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceAttribute.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseResource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
+
+#[UseResource(EloquentResourceTestJsonResource::class)]
+class EloquentResourceTestResourceModelWithUseResourceAttribute extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceCollectionAttribute.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceCollectionAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseResourceCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResourceCollection;
+
+#[UseResourceCollection(EloquentResourceTestJsonResourceCollection::class)]
+class EloquentResourceTestResourceModelWithUseResourceCollectionAttribute extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceCollectionTestResource.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceCollectionTestResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EloquentResourceCollectionTestResource extends JsonResource
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResource.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EloquentResourceTestJsonResource extends JsonResource
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResourceCollection.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResourceCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class EloquentResourceTestJsonResourceCollection extends ResourceCollection
+{
+    //
+}


### PR DESCRIPTION
This PR adds the possibility to define resource classes directly on a model using PHP attributes.

### Background

Right now, `toResource` and `toResourceCollection` automatically resolve the resource class only if it follows the `<ModelName>Resource` naming convention.

In my project, I couldn’t follow the naming convention for resources.
As a result, I need to write calls like this everywhere:

```php
$model->toResource(MyCustomNameResource::class);
$collection->toResourceCollection(MyCustomNameCollectionResource::class);
```

This gets repetitive and makes the code less clean.

### What’s New

With this PR, developers can declare attributes on the model and let Laravel handle the resource resolution automatically:

```php
use App\Http\Resources\MyCustomNameResource;
use App\Http\Resources\MyCustomNameCollectionResource;

#[UseResource(MyCustomNameResource::class)]
#[UseResourceCollection(MyCustomNameCollectionResource::class)]
class MyModel extends Model {}
```

Now you can simply call:

```php
$model->toResource();
$collection->toResourceCollection();
```