### PR TITLE
[12.x] add --whisper option to schedule:work command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -19,9 +19,8 @@ class ScheduleWorkCommand extends Command
      * @var string
      */
     protected $signature = 'schedule:work
-        {--whisper : Do not output message indicating that no jobs were ready to run}
         {--run-output-file= : The file to direct <info>schedule:run</info> output to}
-    ';
+        {--whisper : Do not output message indicating that no jobs were ready to run}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -18,7 +18,10 @@ class ScheduleWorkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schedule:work {--run-output-file= : The file to direct <info>schedule:run</info> output to}';
+    protected $signature = 'schedule:work
+        {--whisper : Do not output message indicating that no jobs were ready to run}
+        {--run-output-file= : The file to direct <info>schedule:run</info> output to}
+    ';
 
     /**
      * The console command description.
@@ -42,6 +45,10 @@ class ScheduleWorkCommand extends Command
         [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
         $command = Application::formatCommandString('schedule:run');
+
+        if ($this->option('whisper')) {
+            $command .= ' --whisper';
+        }
 
         if ($this->option('run-output-file')) {
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';


### PR DESCRIPTION
This add the `--whisper` option to the `schedule:work` command.

It just passes it trough to the schedule:run command, to hide the `No scheduled commands are ready to run.` message.