### PR TITLE
[12.x] Make visibility consistent

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -598,7 +598,7 @@ trait ReplacesAttributes
      * @param  array<int,string>  $parameters
      * @return string
      */
-    public function replaceRequiredIfDeclined($message, $attribute, $rule, $parameters)
+    protected function replaceRequiredIfDeclined($message, $attribute, $rule, $parameters)
     {
         return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }
@@ -662,7 +662,7 @@ trait ReplacesAttributes
      * @param  array<int,string>  $parameters
      * @return string
      */
-    public function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
+    protected function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
     {
         return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }


### PR DESCRIPTION
Description
---
In the `ReplacesAttributes` trait, all methods are declared as protected, except for only two methods, which are currently public.

These methods do not need to be public, since they are only intended for internal use by the validator. This PR changes them to protected to align with the visibility of the other methods and maintain consistency within the trait.