### PR TITLE
Pass $attributes and $parent arguments to Factory Sequence

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -51,11 +51,13 @@ class Sequence implements Countable
     /**
      * Get the next value in the sequence.
      *
+     * @param  array<string, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
      * @return mixed
      */
-    public function __invoke()
+    public function __invoke($attributes = [], $parent = null)
     {
-        return tap(value($this->sequence[$this->index % $this->count], $this), function () {
+        return tap(value($this->sequence[$this->index % $this->count], $this, $attributes, $parent), function () {
             $this->index = $this->index + 1;
         });
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR passes the `$attributes` and `$parent` arguments to the callback form of the Factory `Sequence` class, so they can be used for generating more realistic data.

```php
$perSeries = 3;
LectureSeries::factory()
    ->sequence(fn ($sequence) => [
        'title' => 'Intro to '.fake()->word(),
        'start_date' => now()->addDays($sequence->index * 7),
    ])
    ->has(
        Lecture::factory()
            ->sequence(fn ($sequence, $attributes, $parent) => [
                'title' => $parent->title.', Lecture '.($sequence->index % $perSeries + 1),
                'start_date' => $parent->start_date->copy()->addDays($sequence->index % $perSeries),
            ])
            ->count($perSeries)
    )
    ->create();
```