### PR TITLE
tests: Ensure transaction callbacks run in FIFO order

### DIFF
--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -109,6 +109,31 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertCount(1, $manager->getPendingTransactions()[2]->getCallbacks());
     }
 
+    public function testCallbacksRunInFifoOrder()
+    {
+        $manager = (new DatabaseTransactionsManager);
+
+        $order = [];
+
+        $manager->begin('default', 1);
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 1;
+        });
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 2;
+        });
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 3;
+        });
+
+        $manager->commit('default', 1, 0);
+
+        $this->assertSame([1, 2, 3], $order);
+    }
+
     public function testCommittingTransactionsExecutesCallbacks()
     {
         $callbacks = [];


### PR DESCRIPTION
`DatabaseTransactionsManager` allows registering callbacks with `addCallback()`. The intended behavior is that these callbacks should run in the same order they were added. While existing tests cover that callbacks are executed, there was no explicit test guaranteeing ordering semantics. Without a regression guard, an internal implementation change could unintentionally reverse or reorder callbacks.

- Provides a regression test ensuring deterministic FIFO execution.
- No behavior changes; test-only addition.
- Improves confidence for future refactors around transaction management.