### PR TITLE
[12.x] Update Faker suggestion to match skeleton version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
         "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
-        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.9.1).",
+        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",


### PR DESCRIPTION
Description
---
Since the skeleton bumped the minimum to "^1.23" almost two years ago, keeping "^1.9.1" in the framework’s suggest section is misleading.

This PR keeps the framework's suggestion consistent with the skeleton and avoids confusion about the supported Faker version.

See
---
https://github.com/laravel/laravel/blob/a696e5fd5169c99ea191adb1aeb746de797abe32/composer.json#L14