### PR TITLE
[12.x] remove unnecessary `with()` helper call

### DIFF
--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -62,7 +62,7 @@ class QuestionHelper extends SymfonyQuestionHelper
 
         if ($question instanceof ChoiceQuestion) {
             foreach ($question->getChoices() as $key => $value) {
-                with(new TwoColumnDetail($output))->render($value, $key);
+                (new TwoColumnDetail($output))->render($value, $key);
             }
         }
 

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -103,7 +103,7 @@ abstract class Component
      */
     protected function usingQuestionHelper($callable)
     {
-        $property = with(new ReflectionClass(OutputStyle::class))
+        $property = (new ReflectionClass(OutputStyle::class))
             ->getParentClass()
             ->getProperty('questionHelper');
 

--- a/src/Illuminate/Console/View/Components/Error.php
+++ b/src/Illuminate/Console/View/Components/Error.php
@@ -15,6 +15,6 @@ class Error extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('error', $string, $verbosity);
+        (new Line($this->output))->render('error', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -56,6 +56,6 @@ class Factory
             'Console component [%s] not found.', $method
         )));
 
-        return with(new $component($this->output))->render(...$parameters);
+        return (new $component($this->output))->render(...$parameters);
     }
 }

--- a/src/Illuminate/Console/View/Components/Info.php
+++ b/src/Illuminate/Console/View/Components/Info.php
@@ -15,6 +15,6 @@ class Info extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('info', $string, $verbosity);
+        (new Line($this->output))->render('info', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Success.php
+++ b/src/Illuminate/Console/View/Components/Success.php
@@ -15,6 +15,6 @@ class Success extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('success', $string, $verbosity);
+        (new Line($this->output))->render('success', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Warn.php
+++ b/src/Illuminate/Console/View/Components/Warn.php
@@ -15,7 +15,6 @@ class Warn extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))
-            ->render('warn', $string, $verbosity);
+        (new Line($this->output))->render('warn', $string, $verbosity);
     }
 }


### PR DESCRIPTION
if you're not passing a second parameter with a closure to `with()`, it doesn't do anything other than return the value. this is verrrry old legacy code from 10+ years ago that isn't necessary anymore to chain.

there are many more instances of this I will be cleaning up this evening and putting into separate PRs.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
