### PR TITLE
Adding the Redirectable interface to improve type hinting of RedirectResponse

### DIFF
--- a/src/Illuminate/Contracts/Support/Redirectable.php
+++ b/src/Illuminate/Contracts/Support/Redirectable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Redirectable
+{
+}

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http;
 
 use Illuminate\Contracts\Support\MessageProvider;
+use Illuminate\Contracts\Support\Redirectable;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -12,7 +13,7 @@ use Illuminate\Support\ViewErrorBag;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
-class RedirectResponse extends BaseRedirectResponse
+class RedirectResponse extends BaseRedirectResponse implements Redirectable
 {
     use ForwardsCalls, ResponseTrait, Macroable {
         Macroable::__call as macroCall;


### PR DESCRIPTION
This PR introduces a new marker interface Illuminate\Contracts\Support\Redirectable, which is implemented by the Illuminate\Http\RedirectResponse class. This allows for more precise return type declarations from controllers when methods return either a Responsable response or a redirect response implementing Redirectable.