### PR TITLE
[12.x] - Support `Castable` on `Enum`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1788,6 +1788,10 @@ trait HasAttributes
             return false;
         }
 
+        if (is_subclass_of($castType, Castable::class)) {
+            return false;
+        }
+
         return enum_exists($castType);
     }
 


### PR DESCRIPTION
Implementing `Castable` on an `Enum` does not currently work. Eloquent prioritizes `Enum` casting over Object Casting -- which seems like an artificial limitation.

I went back and forth on how to implement this. My initial thought was to flip [these blocks](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L880-L886) in `HasAttributes`.

However, `isClassCastable()` surprisingly does NOT confirm the `$castType` is a `Castable` which poses challenges to that approach. So I decided on a more simple and narrowly scoped solution by just returning `false` in `isEnumCastable()` if the `$castType` is a `Castable`.

### Motivation
An `enum` is great way to represent a State Machine. For a State Machine to be useful in the context of a `Model`  it needs access to the `Model` instance . Unfortunately an `Enum` can not define properties -- limiting how usable it is when cast to an `Enum` by Eloquent -- as the context of the `Model` is lost.

A simple decorator pattern would provide a layer to store the `Model` instance and proxy calls into the `Enum`.
Supporting `Castable` on an  `Enum` unlocks a streamlined path to using this pattern (and likely many others).

### Backwards compatibility
I don't see any substantive concerns since `Castable` is an opt-in feature, which doesn't currently work on an `Enum` so it'd be rather odd for it to exist in the wild.

