### PR TITLE
[13.x] Add command method to contract

### DIFF
--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -12,6 +12,13 @@ interface InvokedProcess
     public function id();
 
     /**
+     * Get the command line for the process.
+     *
+     * @return string
+     */
+    public function command();
+
+    /**
      * Send a signal to the process.
      *
      * @param  int  $signal


### PR DESCRIPTION
Follow-up of PR #56886

**This PR**

- Adds the `command()` method to the `Illuminate\Contracts\Process\InvokedProcess` interface


The `InvokedProcess@command` method was added to the concrete class on PR #56886. 

As it was merged, this PR ensures its contract is updated for the upcoming Laravel version.