### PR TITLE
Add callback support to takeUntilTimeout in LazyCollection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1630,17 +1630,22 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Take items in the collection until a given point in time.
+     * Take items in the collection until a given point in time, with an optional callback on timeout.
      *
      * @param  \DateTimeInterface  $timeout
+     * @param  callable(TValue|null, TKey|null): mixed|null  $callback
      * @return static<TKey, TValue>
      */
-    public function takeUntilTimeout(DateTimeInterface $timeout)
+    public function takeUntilTimeout(DateTimeInterface $timeout, ?callable $callback = null)
     {
         $timeout = $timeout->getTimestamp();
 
-        return new static(function () use ($timeout) {
+        return new static(function () use ($timeout, $callback) {
             if ($this->now() >= $timeout) {
+                if ($callback) {
+                    $callback(null, null);
+                }
+
                 return;
             }
 
@@ -1648,6 +1653,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 yield $key => $value;
 
                 if ($this->now() >= $timeout) {
+                    if ($callback) {
+                        $callback($value, $key);
+                    }
+
                     break;
                 }
             }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -186,6 +186,8 @@ class SupportLazyCollectionTest extends TestCase
 
         $mock = m::mock(LazyCollection::class.'[now]');
 
+        $timedOutWith = [null, null];
+
         $results = $mock
             ->times(10)
             ->tap(function ($collection) use ($mock, $timeout) {
@@ -200,10 +202,13 @@ class SupportLazyCollectionTest extends TestCase
                         $timeout->getTimestamp()
                     );
             })
-            ->takeUntilTimeout($timeout)
+            ->takeUntilTimeout($timeout, function ($value, $key) use (&$timedOutWith) {
+                $timedOutWith = [$value, $key];
+            })
             ->all();
 
         $this->assertSame([1, 2], $results);
+        $this->assertSame([2, 1], $timedOutWith);
 
         m::close();
     }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -186,7 +186,7 @@ class SupportLazyCollectionTest extends TestCase
 
         $mock = m::mock(LazyCollection::class.'[now]');
 
-        $timedOutWith = [null, null];
+        $timedOutWith = [];
 
         $results = $mock
             ->times(10)

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -753,7 +753,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUnti
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime()));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime(), function ($user, $int) {
     assertType('User|null', $user);
-   // assertType('int|null', $int);
+    // assertType('int|null', $int);
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeWhile(1));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -751,6 +751,10 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUnti
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime()));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime(), function ($user, $int) {
+    assertType('User|null', $user);
+   // assertType('int|null', $int);
+}));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeWhile(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeWhile(new User));


### PR DESCRIPTION
## `takeUntilTimeout()` — optional callback support

This PR adds an optional `$callback` parameter to `takeUntilTimeout()`.
The callback is executed when the timeout is reached and receives the last processed item and key (or `null, null` if the timeout occurs before iteration).

### Benefits

* **Resumable processing**: store the last processed key and continue from there on the next run.
* **Queue integration**: throw an exception in the callback, catch it in a Job, and re-release the job back to the queue.

### Examples

```php
$users = User::cursor()->takeUntilTimeout(now()->addMinutes(14), function ($user, $key) {
    Cache::put('last_user_id', $user?->id);
});

foreach ($users as $user) {
    // ...
}
```

```php
$users = User::cursor()->takeUntilTimeout(now()->addMinutes(14), function () {
    throw TimeboxExceededException::forReleaseJob();
});
```

### Compatibility

* Callback is optional (`null` by default).
* Existing behavior is unchanged when no callback is passed.