### PR TITLE
Add groupJoin method to Collections for joining related cached or in-memory data

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1959,5 +1959,4 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return $resultSelector($outerItem, $matchingGroup->values());
         });
     }
-
 }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1931,4 +1931,33 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Perform a group join between this collection (outer) and another (inner).
+     *
+     * @template TOuterKey
+     * @template TInnerKey
+     * @template TResult
+     *
+     * @param  \Illuminate\Support\Collection|iterable  $inner
+     * @param  callable(TValue): TOuterKey  $outerKeySelector
+     * @param  callable(mixed): TInnerKey  $innerKeySelector
+     * @param  callable(TValue, \Illuminate\Support\Collection): TResult  $resultSelector
+     * @return static<int, TResult>
+     */
+    public function groupJoin(iterable $inner, callable $outerKeySelector, callable $innerKeySelector, callable $resultSelector)
+    {
+        $inner = collect($inner);
+
+        return $this->map(function ($outerItem) use ($inner, $outerKeySelector, $innerKeySelector, $resultSelector) {
+            $outerKey = $outerKeySelector($outerItem);
+
+            $matchingGroup = $inner->filter(function ($innerItem) use ($outerKey, $innerKeySelector) {
+                return $innerKeySelector($innerItem) == $outerKey;
+            });
+
+            return $resultSelector($outerItem, $matchingGroup->values());
+        });
+    }
+
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1982,4 +1982,33 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             ? Sleep::usleep($microseconds)
             : usleep($microseconds);
     }
+
+    /**
+     * Perform a group join between this collection (outer) and another (inner).
+     *
+     * @template TOuterKey
+     * @template TInnerKey
+     * @template TResult
+     *
+     * @param  \Illuminate\Support\Collection|iterable  $inner
+     * @param  callable(TValue): TOuterKey  $outerKeySelector
+     * @param  callable(mixed): TInnerKey  $innerKeySelector
+     * @param  callable(TValue, \Illuminate\Support\Collection): TResult  $resultSelector
+     * @return static<int, TResult>
+     */
+    public function groupJoin(iterable $inner, callable $outerKeySelector, callable $innerKeySelector, callable $resultSelector)
+    {
+        $inner = collect($inner);
+
+        return $this->map(function ($outerItem) use ($inner, $outerKeySelector, $innerKeySelector, $resultSelector) {
+            $outerKey = $outerKeySelector($outerItem);
+
+            $matchingGroup = $inner->filter(function ($innerItem) use ($outerKey, $innerKeySelector) {
+                return $innerKeySelector($innerItem) == $outerKey;
+            });
+
+            return $resultSelector($outerItem, $matchingGroup->values());
+        });
+    }
+
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -2010,5 +2010,4 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             return $resultSelector($outerItem, $matchingGroup->values());
         });
     }
-
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -376,12 +376,12 @@ class Str
     public static function deduplicate(string $string, array|string $characters = ' ')
     {
         if (is_string($characters)) {
-            return preg_replace('/' . preg_quote($characters, '/') . '+/u', $characters, $string);
+            return preg_replace('/'.preg_quote($characters, '/').'+/u', $characters, $string);
         }
 
         return array_reduce(
             $characters,
-            fn($carry, $character) => preg_replace('/' . preg_quote($character, '/') . '+/u', $character, $carry),
+            fn ($carry, $character) => preg_replace('/'.preg_quote($character, '/').'+/u', $character, $carry),
             $string
         );
     }
@@ -437,7 +437,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)(' . preg_quote((string) $phrase, '/') . ')(.*)$/iu', (string) $text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -446,15 +446,15 @@ class Str
         $start = ltrim($matches[1]);
 
         $start = Str::of(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
-            fn($startWithRadius) => $startWithRadius->exactly($start),
-            fn($startWithRadius) => $startWithRadius->prepend($omission),
+            fn ($startWithRadius) => $startWithRadius->exactly($start),
+            fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
         $end = Str::of(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
-            fn($endWithRadius) => $endWithRadius->exactly($end),
-            fn($endWithRadius) => $endWithRadius->append($omission),
+            fn ($endWithRadius) => $endWithRadius->exactly($end),
+            fn ($endWithRadius) => $endWithRadius->append($omission),
         );
 
         return $start->append($matches[2], $end)->toString();
@@ -471,7 +471,7 @@ class Str
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
     }
 
     /**
@@ -484,7 +484,7 @@ class Str
      */
     public static function wrap($value, $before, $after = null)
     {
-        return $before . $value . ($after ?? $before);
+        return $before.$value.($after ?? $before);
     }
 
     /**
@@ -545,7 +545,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^' . $pattern . '\z#' . ($ignoreCase ? 'isu' : 'su'), $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#'.($ignoreCase ? 'isu' : 'su'), $value) === 1) {
                 return true;
             }
         }
@@ -718,7 +718,7 @@ class Str
         }
 
         if (! $preserveWords) {
-            return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
+            return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
         }
 
         $value = trim(preg_replace('/[\n\r]+/', ' ', strip_tags($value)));
@@ -726,10 +726,10 @@ class Str
         $trimmed = rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8'));
 
         if (mb_substr($value, $limit, 1, 'UTF-8') === ' ') {
-            return $trimmed . $end;
+            return $trimmed.$end;
         }
 
-        return preg_replace("/(.*)\s.*/", '$1', $trimmed) . $end;
+        return preg_replace("/(.*)\s.*/", '$1', $trimmed).$end;
     }
 
     /**
@@ -753,13 +753,13 @@ class Str
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
+        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 
         if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
             return $value;
         }
 
-        return rtrim($matches[0]) . $end;
+        return rtrim($matches[0]).$end;
     }
 
     /**
@@ -840,7 +840,7 @@ class Str
         $segmentLen = mb_strlen($segment, $encoding);
         $end = mb_substr($string, $startIndex + $segmentLen);
 
-        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen) . $end;
+        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
     }
 
     /**
@@ -988,7 +988,7 @@ class Str
      */
     public static function plural($value, $count = 2, $prependCount = false)
     {
-        return ($prependCount ? Number::format($count) . ' ' : '') . Pluralizer::plural($value, $count);
+        return ($prependCount ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
     }
 
     /**
@@ -1004,7 +1004,7 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts) . self::plural($lastWord, $count);
+        return implode('', $parts).self::plural($lastWord, $count);
     }
 
     /**
@@ -1131,13 +1131,13 @@ class Str
             'spaces' => $spaces === true ? [' '] : null,
         ]))
             ->filter()
-            ->each(fn($c) => $password->push($c[random_int(0, count($c) - 1)]))
+            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
             ->flatten();
 
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn($c) => Collection::times($length, fn() => $c[random_int(0, $c->count() - 1)])
+            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
@@ -1266,7 +1266,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= self::toStringOr(array_shift($replace) ?? $search, $search) . $segment;
+            $result .= self::toStringOr(array_shift($replace) ?? $search, $search).$segment;
         }
 
         return $result;
@@ -1471,7 +1471,7 @@ class Str
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
+        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
     }
 
     /**
@@ -1581,7 +1581,7 @@ class Str
                 $hyphenatedWords = array_map(function ($part) use ($minorWords) {
                     return (in_array($part, $minorWords) && mb_strlen($part) <= 3)
                         ? $part
-                        : mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1);
+                        : mb_strtoupper(mb_substr($part, 0, 1)).mb_substr($part, 1);
                 }, $hyphenatedWords);
 
                 $words[$i] = implode('-', $hyphenatedWords);
@@ -1593,7 +1593,7 @@ class Str
                 ) {
                     $words[$i] = $lowercaseWord;
                 } else {
-                    $words[$i] = mb_strtoupper(mb_substr($lowercaseWord, 0, 1)) . mb_substr($lowercaseWord, 1);
+                    $words[$i] = mb_strtoupper(mb_substr($lowercaseWord, 0, 1)).mb_substr($lowercaseWord, 1);
                 }
             }
         }
@@ -1628,20 +1628,20 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
         // Replace dictionary words
         foreach ($dictionary as $key => $value) {
-            $dictionary[$key] = $separator . $value . $separator;
+            $dictionary[$key] = $separator.$value.$separator;
         }
 
         $title = str_replace(array_keys($dictionary), array_values($dictionary), $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace
-        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -1664,7 +1664,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
@@ -1682,7 +1682,7 @@ class Str
         if ($charlist === null) {
             $trimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~^[\s' . self::INVISIBLE_CHARACTERS . $trimDefaultCharacters . ']+|[\s' . self::INVISIBLE_CHARACTERS . $trimDefaultCharacters . ']+$~u', '', $value) ?? trim($value);
+            return preg_replace('~^[\s'.self::INVISIBLE_CHARACTERS.$trimDefaultCharacters.']+|[\s'.self::INVISIBLE_CHARACTERS.$trimDefaultCharacters.']+$~u', '', $value) ?? trim($value);
         }
 
         return trim($value, $charlist);
@@ -1700,7 +1700,7 @@ class Str
         if ($charlist === null) {
             $ltrimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~^[\s' . self::INVISIBLE_CHARACTERS . $ltrimDefaultCharacters . ']+~u', '', $value) ?? ltrim($value);
+            return preg_replace('~^[\s'.self::INVISIBLE_CHARACTERS.$ltrimDefaultCharacters.']+~u', '', $value) ?? ltrim($value);
         }
 
         return ltrim($value, $charlist);
@@ -1718,7 +1718,7 @@ class Str
         if ($charlist === null) {
             $rtrimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~[\s' . self::INVISIBLE_CHARACTERS . $rtrimDefaultCharacters . ']+$~u', '', $value) ?? rtrim($value);
+            return preg_replace('~[\s'.self::INVISIBLE_CHARACTERS.$rtrimDefaultCharacters.']+$~u', '', $value) ?? rtrim($value);
         }
 
         return rtrim($value, $charlist);
@@ -1789,7 +1789,7 @@ class Str
 
         $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
 
-        $studlyWords = array_map(fn($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }
@@ -1914,7 +1914,7 @@ class Str
      */
     public static function lcfirst($string)
     {
-        return static::lower(static::substr($string, 0, 1)) . static::substr($string, 1);
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**
@@ -1925,7 +1925,7 @@ class Str
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**
@@ -2070,7 +2070,7 @@ class Str
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(fn() => $uuid);
+        Str::createUuidsUsing(fn () => $uuid);
 
         if ($callback !== null) {
             try {
@@ -2177,7 +2177,7 @@ class Str
     {
         $ulid = Str::ulid();
 
-        Str::createUlidsUsing(fn() => $ulid);
+        Str::createUlidsUsing(fn () => $ulid);
 
         if ($callback !== null) {
             try {
@@ -2210,10 +2210,10 @@ class Str
      * and optionally keeps only tokens that exactly match the given list.
      *
      * @param  string  $subject
-     * @param  array<string>  $remove   Characters or substrings to strip from each token
-     * @param  array<string>  $ignore   Tokens containing these values will be discarded
-     * @param  array<string,string> $replace  Key/value pairs to replace within each token
-     * @param  array<string>  $match    Tokens must exactly match one of these values to be kept
+     * @param  array<string>  $remove  Characters or substrings to strip from each token
+     * @param  array<string>  $ignore  Tokens containing these values will be discarded
+     * @param  array<string,string>  $replace  Key/value pairs to replace within each token
+     * @param  array<string>  $match  Tokens must exactly match one of these values to be kept
      * @return \Illuminate\Support\Collection<string>
      */
     public static function tokens(
@@ -2226,18 +2226,14 @@ class Str
         return collect(
             preg_split('/[\s,;]+/', $subject, -1, PREG_SPLIT_NO_EMPTY) ?: []
         )
-        ->when(! empty($remove), fn ($c) =>
-            $c->map(fn ($t) => static::remove($remove, $t))
-        )
-        ->when(! empty($replace), fn ($c) =>
-            $c->map(fn ($t) => strtr($t, $replace))
-        )
-        ->when(! empty($ignore), fn ($c) =>
-            $c->reject(fn ($t) => static::contains($t, $ignore))
-        )
-        ->when(! empty($match), fn ($c) =>
-            $c->filter(fn ($t) => static::is($match, $t))
-        )
-        ->values();
+            ->when(! empty($remove), fn ($c) => $c->map(fn ($t) => static::remove($remove, $t))
+            )
+            ->when(! empty($replace), fn ($c) => $c->map(fn ($t) => strtr($t, $replace))
+            )
+            ->when(! empty($ignore), fn ($c) => $c->reject(fn ($t) => static::contains($t, $ignore))
+            )
+            ->when(! empty($match), fn ($c) => $c->filter(fn ($t) => static::is($match, $t))
+            )
+            ->values();
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -376,12 +376,12 @@ class Str
     public static function deduplicate(string $string, array|string $characters = ' ')
     {
         if (is_string($characters)) {
-            return preg_replace('/'.preg_quote($characters, '/').'+/u', $characters, $string);
+            return preg_replace('/' . preg_quote($characters, '/') . '+/u', $characters, $string);
         }
 
         return array_reduce(
             $characters,
-            fn ($carry, $character) => preg_replace('/'.preg_quote($character, '/').'+/u', $character, $carry),
+            fn($carry, $character) => preg_replace('/' . preg_quote($character, '/') . '+/u', $character, $carry),
             $string
         );
     }
@@ -437,7 +437,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase, '/').')(.*)$/iu', (string) $text, $matches);
+        preg_match('/^(.*?)(' . preg_quote((string) $phrase, '/') . ')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -446,15 +446,15 @@ class Str
         $start = ltrim($matches[1]);
 
         $start = Str::of(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
-            fn ($startWithRadius) => $startWithRadius->exactly($start),
-            fn ($startWithRadius) => $startWithRadius->prepend($omission),
+            fn($startWithRadius) => $startWithRadius->exactly($start),
+            fn($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
         $end = rtrim($matches[3]);
 
         $end = Str::of(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
-            fn ($endWithRadius) => $endWithRadius->exactly($end),
-            fn ($endWithRadius) => $endWithRadius->append($omission),
+            fn($endWithRadius) => $endWithRadius->exactly($end),
+            fn($endWithRadius) => $endWithRadius->append($omission),
         );
 
         return $start->append($matches[2], $end)->toString();
@@ -471,7 +471,7 @@ class Str
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
     }
 
     /**
@@ -484,7 +484,7 @@ class Str
      */
     public static function wrap($value, $before, $after = null)
     {
-        return $before.$value.($after ?? $before);
+        return $before . $value . ($after ?? $before);
     }
 
     /**
@@ -545,7 +545,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#'.($ignoreCase ? 'isu' : 'su'), $value) === 1) {
+            if (preg_match('#^' . $pattern . '\z#' . ($ignoreCase ? 'isu' : 'su'), $value) === 1) {
                 return true;
             }
         }
@@ -718,7 +718,7 @@ class Str
         }
 
         if (! $preserveWords) {
-            return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+            return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
         }
 
         $value = trim(preg_replace('/[\n\r]+/', ' ', strip_tags($value)));
@@ -726,10 +726,10 @@ class Str
         $trimmed = rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8'));
 
         if (mb_substr($value, $limit, 1, 'UTF-8') === ' ') {
-            return $trimmed.$end;
+            return $trimmed . $end;
         }
 
-        return preg_replace("/(.*)\s.*/", '$1', $trimmed).$end;
+        return preg_replace("/(.*)\s.*/", '$1', $trimmed) . $end;
     }
 
     /**
@@ -753,13 +753,13 @@ class Str
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
 
         if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
             return $value;
         }
 
-        return rtrim($matches[0]).$end;
+        return rtrim($matches[0]) . $end;
     }
 
     /**
@@ -840,7 +840,7 @@ class Str
         $segmentLen = mb_strlen($segment, $encoding);
         $end = mb_substr($string, $startIndex + $segmentLen);
 
-        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
+        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen) . $end;
     }
 
     /**
@@ -988,7 +988,7 @@ class Str
      */
     public static function plural($value, $count = 2, $prependCount = false)
     {
-        return ($prependCount ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
+        return ($prependCount ? Number::format($count) . ' ' : '') . Pluralizer::plural($value, $count);
     }
 
     /**
@@ -1004,7 +1004,7 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts).self::plural($lastWord, $count);
+        return implode('', $parts) . self::plural($lastWord, $count);
     }
 
     /**
@@ -1035,30 +1035,109 @@ class Str
 
         $options = (new Collection([
             'letters' => $letters === true ? [
-                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
-                'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+                'j',
+                'k',
+                'l',
+                'm',
+                'n',
+                'o',
+                'p',
+                'q',
+                'r',
+                's',
+                't',
+                'u',
+                'v',
+                'w',
+                'x',
+                'y',
+                'z',
+                'A',
+                'B',
+                'C',
+                'D',
+                'E',
+                'F',
+                'G',
+                'H',
+                'I',
+                'J',
+                'K',
+                'L',
+                'M',
+                'N',
+                'O',
+                'P',
+                'Q',
+                'R',
+                'S',
+                'T',
+                'U',
+                'V',
+                'W',
+                'X',
+                'Y',
+                'Z',
             ] : null,
             'numbers' => $numbers === true ? [
-                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                '0',
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '6',
+                '7',
+                '8',
+                '9',
             ] : null,
             'symbols' => $symbols === true ? [
-                '~', '!', '#', '$', '%', '^', '&', '*', '(', ')', '-',
-                '_', '.', ',', '<', '>', '?', '/', '\\', '{', '}', '[',
-                ']', '|', ':', ';',
+                '~',
+                '!',
+                '#',
+                '$',
+                '%',
+                '^',
+                '&',
+                '*',
+                '(',
+                ')',
+                '-',
+                '_',
+                '.',
+                ',',
+                '<',
+                '>',
+                '?',
+                '/',
+                '\\',
+                '{',
+                '}',
+                '[',
+                ']',
+                '|',
+                ':',
+                ';',
             ] : null,
             'spaces' => $spaces === true ? [' '] : null,
         ]))
             ->filter()
-            ->each(fn ($c) => $password->push($c[random_int(0, count($c) - 1)]))
+            ->each(fn($c) => $password->push($c[random_int(0, count($c) - 1)]))
             ->flatten();
 
         $length = $length - $password->count();
 
         return $password->merge($options->pipe(
-            fn ($c) => Collection::times($length, fn () => $c[random_int(0, $c->count() - 1)])
+            fn($c) => Collection::times($length, fn() => $c[random_int(0, $c->count() - 1)])
         ))->shuffle()->implode('');
     }
 
@@ -1187,7 +1266,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= self::toStringOr(array_shift($replace) ?? $search, $search).$segment;
+            $result .= self::toStringOr(array_shift($replace) ?? $search, $search) . $segment;
         }
 
         return $result;
@@ -1392,7 +1471,7 @@ class Str
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
     }
 
     /**
@@ -1451,9 +1530,41 @@ class Str
         }
 
         $minorWords = [
-            'and', 'as', 'but', 'for', 'if', 'nor', 'or', 'so', 'yet', 'a', 'an',
-            'the', 'at', 'by', 'for', 'in', 'of', 'off', 'on', 'per', 'to', 'up', 'via',
-            'et', 'ou', 'un', 'une', 'la', 'le', 'les', 'de', 'du', 'des', 'par', 'à',
+            'and',
+            'as',
+            'but',
+            'for',
+            'if',
+            'nor',
+            'or',
+            'so',
+            'yet',
+            'a',
+            'an',
+            'the',
+            'at',
+            'by',
+            'for',
+            'in',
+            'of',
+            'off',
+            'on',
+            'per',
+            'to',
+            'up',
+            'via',
+            'et',
+            'ou',
+            'un',
+            'une',
+            'la',
+            'le',
+            'les',
+            'de',
+            'du',
+            'des',
+            'par',
+            'à',
         ];
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
@@ -1470,17 +1581,19 @@ class Str
                 $hyphenatedWords = array_map(function ($part) use ($minorWords) {
                     return (in_array($part, $minorWords) && mb_strlen($part) <= 3)
                         ? $part
-                        : mb_strtoupper(mb_substr($part, 0, 1)).mb_substr($part, 1);
+                        : mb_strtoupper(mb_substr($part, 0, 1)) . mb_substr($part, 1);
                 }, $hyphenatedWords);
 
                 $words[$i] = implode('-', $hyphenatedWords);
             } else {
-                if (in_array($lowercaseWord, $minorWords) &&
+                if (
+                    in_array($lowercaseWord, $minorWords) &&
                     mb_strlen($lowercaseWord) <= 3 &&
-                    ! ($i === 0 || in_array(mb_substr($words[$i - 1], -1), $endPunctuation))) {
+                    ! ($i === 0 || in_array(mb_substr($words[$i - 1], -1), $endPunctuation))
+                ) {
                     $words[$i] = $lowercaseWord;
                 } else {
-                    $words[$i] = mb_strtoupper(mb_substr($lowercaseWord, 0, 1)).mb_substr($lowercaseWord, 1);
+                    $words[$i] = mb_strtoupper(mb_substr($lowercaseWord, 0, 1)) . mb_substr($lowercaseWord, 1);
                 }
             }
         }
@@ -1515,20 +1628,20 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
 
         // Replace dictionary words
         foreach ($dictionary as $key => $value) {
-            $dictionary[$key] = $separator.$value.$separator;
+            $dictionary[$key] = $separator . $value . $separator;
         }
 
         $title = str_replace(array_keys($dictionary), array_values($dictionary), $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -1551,7 +1664,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
@@ -1569,7 +1682,7 @@ class Str
         if ($charlist === null) {
             $trimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~^[\s'.self::INVISIBLE_CHARACTERS.$trimDefaultCharacters.']+|[\s'.self::INVISIBLE_CHARACTERS.$trimDefaultCharacters.']+$~u', '', $value) ?? trim($value);
+            return preg_replace('~^[\s' . self::INVISIBLE_CHARACTERS . $trimDefaultCharacters . ']+|[\s' . self::INVISIBLE_CHARACTERS . $trimDefaultCharacters . ']+$~u', '', $value) ?? trim($value);
         }
 
         return trim($value, $charlist);
@@ -1587,7 +1700,7 @@ class Str
         if ($charlist === null) {
             $ltrimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~^[\s'.self::INVISIBLE_CHARACTERS.$ltrimDefaultCharacters.']+~u', '', $value) ?? ltrim($value);
+            return preg_replace('~^[\s' . self::INVISIBLE_CHARACTERS . $ltrimDefaultCharacters . ']+~u', '', $value) ?? ltrim($value);
         }
 
         return ltrim($value, $charlist);
@@ -1605,7 +1718,7 @@ class Str
         if ($charlist === null) {
             $rtrimDefaultCharacters = " \n\r\t\v\0";
 
-            return preg_replace('~[\s'.self::INVISIBLE_CHARACTERS.$rtrimDefaultCharacters.']+$~u', '', $value) ?? rtrim($value);
+            return preg_replace('~[\s' . self::INVISIBLE_CHARACTERS . $rtrimDefaultCharacters . ']+$~u', '', $value) ?? rtrim($value);
         }
 
         return rtrim($value, $charlist);
@@ -1676,7 +1789,7 @@ class Str
 
         $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
 
-        $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
+        $studlyWords = array_map(fn($word) => static::ucfirst($word), $words);
 
         return static::$studlyCache[$key] = implode($studlyWords);
     }
@@ -1801,7 +1914,7 @@ class Str
      */
     public static function lcfirst($string)
     {
-        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::lower(static::substr($string, 0, 1)) . static::substr($string, 1);
     }
 
     /**
@@ -1812,7 +1925,7 @@ class Str
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
     }
 
     /**
@@ -1957,7 +2070,7 @@ class Str
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(fn () => $uuid);
+        Str::createUuidsUsing(fn() => $uuid);
 
         if ($callback !== null) {
             try {
@@ -2064,7 +2177,7 @@ class Str
     {
         $ulid = Str::ulid();
 
-        Str::createUlidsUsing(fn () => $ulid);
+        Str::createUlidsUsing(fn() => $ulid);
 
         if ($callback !== null) {
             try {
@@ -2087,5 +2200,44 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
+    }
+
+    /**
+     * Tokenize a string into parts, then remove, ignore, replace, or match tokens.
+     *
+     * Removes given characters from each token, drops tokens that contain
+     * any of the given "ignore" strings, optionally replaces substrings,
+     * and optionally keeps only tokens that exactly match the given list.
+     *
+     * @param  string  $subject
+     * @param  array<string>  $remove   Characters or substrings to strip from each token
+     * @param  array<string>  $ignore   Tokens containing these values will be discarded
+     * @param  array<string,string> $replace  Key/value pairs to replace within each token
+     * @param  array<string>  $match    Tokens must exactly match one of these values to be kept
+     * @return \Illuminate\Support\Collection<string>
+     */
+    public static function tokens(
+        string $subject,
+        array $remove = [],
+        array $ignore = [],
+        array $replace = [],
+        array $match = []
+    ) {
+        return collect(
+            preg_split('/[\s,;]+/', $subject, -1, PREG_SPLIT_NO_EMPTY) ?: []
+        )
+        ->when(! empty($remove), fn ($c) =>
+            $c->map(fn ($t) => static::remove($remove, $t))
+        )
+        ->when(! empty($replace), fn ($c) =>
+            $c->map(fn ($t) => strtr($t, $replace))
+        )
+        ->when(! empty($ignore), fn ($c) =>
+            $c->reject(fn ($t) => static::contains($t, $ignore))
+        )
+        ->when(! empty($match), fn ($c) =>
+            $c->filter(fn ($t) => static::is($match, $t))
+        )
+        ->values();
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2439,10 +2439,10 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model{
+        $model = new class extends Model {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model{
+        $modelTwo = new class extends Model {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2439,12 +2439,10 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model
-        {
+        $model = new class extends Model{
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model
-        {
+        $modelTwo = new class extends Model{
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1893,42 +1893,42 @@ class SupportStrTest extends TestCase
 
     public function testTokensCanRemoveCharacters()
     {
-        $text = "foo=1, bar=2";
+        $text = 'foo=1, bar=2';
         $result = Str::tokens($text, remove: ['=', ',']);
         $this->assertEquals(['foo1', 'bar2'], $result->all());
     }
 
     public function testTokensCanReplaceCharacters()
     {
-        $text = "hello_user test@example.com";
+        $text = 'hello_user test@example.com';
         $result = Str::tokens($text, replace: ['_' => '-', '@' => '[at]']);
         $this->assertEquals(['hello-user', 'test[at]example.com'], $result->all());
     }
 
     public function testTokensCanIgnoreTokens()
     {
-        $text = "ignoreme keepme";
+        $text = 'ignoreme keepme';
         $result = Str::tokens($text, ignore: ['ignoreme']);
         $this->assertEquals(['keepme'], $result->all());
     }
 
     public function testTokensCanMatchExactTokens()
     {
-        $text = "red green blue";
+        $text = 'red green blue';
         $result = Str::tokens($text, match: ['green']);
         $this->assertEquals(['green'], $result->all());
     }
 
     public function testTokensCanMatchWithWildcard()
     {
-        $text = "email@example.com test@example.org";
+        $text = 'email@example.com test@example.org';
         $result = Str::tokens($text, match: ['*example.com']);
         $this->assertEquals(['email@example.com'], $result->all());
     }
 
     public function testTokensCanParseLogEntry()
     {
-        $text = "2025-09-09 12:30:01, ERROR: User john_doe@example.com failed login attempt from IP=192.168.1.10.";
+        $text = '2025-09-09 12:30:01, ERROR: User john_doe@example.com failed login attempt from IP=192.168.1.10.';
 
         $result = Str::tokens(
             $text,
@@ -1943,7 +1943,6 @@ class SupportStrTest extends TestCase
             $result->all()
         );
     }
-
 
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1890,6 +1890,61 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testTokensCanRemoveCharacters()
+    {
+        $text = "foo=1, bar=2";
+        $result = Str::tokens($text, remove: ['=', ',']);
+        $this->assertEquals(['foo1', 'bar2'], $result->all());
+    }
+
+    public function testTokensCanReplaceCharacters()
+    {
+        $text = "hello_user test@example.com";
+        $result = Str::tokens($text, replace: ['_' => '-', '@' => '[at]']);
+        $this->assertEquals(['hello-user', 'test[at]example.com'], $result->all());
+    }
+
+    public function testTokensCanIgnoreTokens()
+    {
+        $text = "ignoreme keepme";
+        $result = Str::tokens($text, ignore: ['ignoreme']);
+        $this->assertEquals(['keepme'], $result->all());
+    }
+
+    public function testTokensCanMatchExactTokens()
+    {
+        $text = "red green blue";
+        $result = Str::tokens($text, match: ['green']);
+        $this->assertEquals(['green'], $result->all());
+    }
+
+    public function testTokensCanMatchWithWildcard()
+    {
+        $text = "email@example.com test@example.org";
+        $result = Str::tokens($text, match: ['*example.com']);
+        $this->assertEquals(['email@example.com'], $result->all());
+    }
+
+    public function testTokensCanParseLogEntry()
+    {
+        $text = "2025-09-09 12:30:01, ERROR: User john_doe@example.com failed login attempt from IP=192.168.1.10.";
+
+        $result = Str::tokens(
+            $text,
+            remove: ['=', '.', ','],
+            replace: ['_' => '-', '@' => '[at]'],
+            ignore: ['2025-09-09', '12:30:01'],
+            match: ['*[at]examplecom', 'IP*']
+        );
+
+        $this->assertEquals(
+            ['john-doe[at]examplecom', 'IP192168110'],
+            $result->all()
+        );
+    }
+
+
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1943,7 +1943,6 @@ class SupportStrTest extends TestCase
             $result->all()
         );
     }
-
 }
 
 class StringableObjectStub


### PR DESCRIPTION
This PR adds a new groupJoin method to both Collection and LazyCollection.
The method provides an expressive way to perform a left join-like operation between an outer collection and an inner iterable (array, collection, or JSON string).

It is especially useful when working with cached or in-memory data, where you want to hydrate relationships without hitting the database.