### PR TITLE
[12.x] do not use `with()` helper when no second argument is passed

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -186,7 +186,7 @@ class Gate implements GateContract
             $response = $condition;
         }
 
-        return with($response instanceof Response ? $response : new Response(
+        return ($response instanceof Response ? $response : new Response(
             (bool) $response === $allowWhenResponseIs, $message, $code
         ))->authorize();
     }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -16,7 +16,7 @@ class SqliteSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
-        with($process = $this->makeProcess(
+        ($process = $this->makeProcess(
             $this->baseCommand().' ".schema --indent"'
         ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
@@ -39,7 +39,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
-        with($process = $this->makeProcess(
+        ($process = $this->makeProcess(
             $this->baseCommand().' ".dump \''.$this->getMigrationTable().'\'"'
         ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -50,7 +50,7 @@ abstract class Seeder
             $name = get_class($seeder);
 
             if ($silent === false && isset($this->command)) {
-                with(new TwoColumnDetail($this->command->getOutput()))->render(
+                (new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,
                     '<fg=yellow;options=bold>RUNNING</>'
                 );
@@ -63,7 +63,7 @@ abstract class Seeder
             if ($silent === false && isset($this->command)) {
                 $runTime = number_format((microtime(true) - $startTime) * 1000);
 
-                with(new TwoColumnDetail($this->command->getOutput()))->render(
+                (new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,
                     "<fg=gray>$runTime ms</> <fg=green;options=bold>DONE</>"
                 );

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1046,12 +1046,12 @@ class Handler implements ExceptionHandlerContract
             if (! empty($alternatives = $e->getAlternatives())) {
                 $message .= '. Did you mean one of these?';
 
-                with(new Error($output))->render($message);
-                with(new BulletList($output))->render($alternatives);
+                (new Error($output))->render($message);
+                (new BulletList($output))->render($alternatives);
 
                 $output->writeln('');
             } else {
-                with(new Error($output))->render($message);
+                (new Error($output))->render($message);
             }
 
             return;

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -21,7 +21,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Alert($output))->render('The application is in the [production] environment');
+        (new Components\Alert($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString(
             'THE APPLICATION IS IN THE [PRODUCTION] ENVIRONMENT.',
@@ -33,7 +33,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\BulletList($output))->render([
+        (new Components\BulletList($output))->render([
             'ls -la',
             'php artisan inspire',
         ]);
@@ -48,7 +48,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Success($output))->render('The application is in the [production] environment');
+        (new Components\Success($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('SUCCESS  The application is in the [production] environment.', $output->fetch());
     }
@@ -57,7 +57,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Error($output))->render('The application is in the [production] environment');
+        (new Components\Error($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('ERROR  The application is in the [production] environment.', $output->fetch());
     }
@@ -66,7 +66,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Info($output))->render('The application is in the [production] environment');
+        (new Components\Info($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('INFO  The application is in the [production] environment.', $output->fetch());
     }
@@ -80,7 +80,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturnTrue();
 
-        $result = with(new Components\Confirm($output))->render('Question?');
+        $result = (new Components\Confirm($output))->render('Question?');
         $this->assertTrue($result);
 
         $output->shouldReceive('confirm')
@@ -88,7 +88,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturnTrue();
 
-        $result = with(new Components\Confirm($output))->render('Question?', true);
+        $result = (new Components\Confirm($output))->render('Question?', true);
         $this->assertTrue($result);
     }
 
@@ -101,7 +101,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturn('a');
 
-        $result = with(new Components\Choice($output))->render('Question?', ['a', 'b']);
+        $result = (new Components\Choice($output))->render('Question?', ['a', 'b']);
         $this->assertSame('a', $result);
     }
 
@@ -109,17 +109,17 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Success->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Success->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('DONE', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Failure->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Failure->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('FAIL', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('SKIPPED', $result);
@@ -129,7 +129,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\TwoColumnDetail($output))->render('First', 'Second');
+        (new Components\TwoColumnDetail($output))->render('First', 'Second');
         $result = $output->fetch();
         $this->assertStringContainsString('First', $result);
         $this->assertStringContainsString('Second', $result);
@@ -139,7 +139,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Warn($output))->render('The application is in the [production] environment');
+        (new Components\Warn($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('WARN  The application is in the [production] environment.', $output->fetch());
     }


### PR DESCRIPTION
if no second argument is passed to `with()` it simply returns the value, so there's no reason to call it when we only pass 1 argument.

while the performance impact it probably negligible, it does take 1 thing out of the call stack, which is helpful.

the only remaining uses of `with()` with only 1 argument are the tests that are testing the helper itself.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
