### PR TITLE
[12.x] Correct the type of $handler from Connection::whenQueryingForLongerThan

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -876,7 +876,7 @@ class Connection implements ConnectionInterface
      * Register a callback to be invoked when the connection queries for longer than a given amount of time.
      *
      * @param  \DateTimeInterface|\Carbon\CarbonInterval|float|int  $threshold
-     * @param  (callable(\Illuminate\Database\Connection, class-string<\Illuminate\Database\Events\QueryExecuted>): mixed)  $handler
+     * @param  (callable(\Illuminate\Database\Connection, \Illuminate\Database\Events\QueryExecuted): mixed)  $handler
      * @return void
      */
     public function whenQueryingForLongerThan($threshold, $handler)


### PR DESCRIPTION
From the previous PR #56459, it gave the second parameter of $handler a wrong type; it should be a `QueryExecuted` instance, not a `class-string`

Docs: https://laravel.com/docs/12.x/database#monitoring-cumulative-query-time

This also fixes an issue from phpstan:

<img width="821" height="310" alt="image" src="https://github.com/user-attachments/assets/5039da5f-4d92-450a-a09e-1278499428f2" />
