### PR TITLE
[12.x] Use property promotion in `MessageLogged` and narrow `$level`

### DIFF
--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -5,37 +5,16 @@ namespace Illuminate\Log\Events;
 class MessageLogged
 {
     /**
-     * The log "level".
-     *
-     * @var string
-     */
-    public $level;
-
-    /**
-     * The log message.
-     *
-     * @var string
-     */
-    public $message;
-
-    /**
-     * The log context.
-     *
-     * @var array
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $level
-     * @param  string  $message
-     * @param  array  $context
+     * @param  "emergency"|"alert"|"critical"|"error"|"warning"|"notice"|"info"|"debug"  $level  The log "level".
+     * @param  string  $message  The log message.
+     * @param  array  $context  The log context.
      */
-    public function __construct($level, $message, array $context = [])
-    {
-        $this->level = $level;
-        $this->message = $message;
-        $this->context = $context;
+    public function __construct(
+        public $level,
+        public $message,
+        public array $context = []
+    ) {
     }
 }


### PR DESCRIPTION
`$level` here is a closed set of strings, so they can be typehinted specifically. Constructor property promotion simply because I didn't want to duplicate that closed set in the constructor and on the parameter itself 🤠 