### PR TITLE
[12.x] Utilize the is_finite() PHP function

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -462,7 +462,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function shouldBeStoredWithoutSerialization($value): bool
     {
-        return is_numeric($value) && ! in_array($value, [INF, -INF]) && ! is_nan($value);
+        return is_numeric($value) && is_finite($value);
     }
 
     /**


### PR DESCRIPTION
Description
---
As discussed in: https://github.com/laravel/framework/pull/54337#issuecomment-2632570619 and https://github.com/laravel/framework/pull/56968#issuecomment-3272531951 we may utilize the [is_finite() PHP function](https://www.php.net/manual/en/function.is-finite.php) to refactor this code.

This code was originally introduced in: #31348 to address the issue reported in: #31345.