### PR TITLE
[12.x] add trailing commas in multiline method signatures

### DIFF
--- a/src/Illuminate/Container/Attributes/Give.php
+++ b/src/Illuminate/Container/Attributes/Give.php
@@ -19,7 +19,7 @@ class Give implements ContextualAttribute
      */
     public function __construct(
         public string $class,
-        public array $params = []
+        public array $params = [],
     ) {
     }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -166,7 +166,7 @@ class BoundMethod
         $container,
         $parameter,
         array &$parameters,
-        &$dependencies
+        &$dependencies,
     ) {
         $pendingDependencies = [];
 

--- a/src/Illuminate/Database/Events/ModelPruningStarting.php
+++ b/src/Illuminate/Database/Events/ModelPruningStarting.php
@@ -10,7 +10,7 @@ class ModelPruningStarting
      * @param  array<class-string>  $models  The class names of the models that will be pruned.
      */
     public function __construct(
-        public $models
+        public $models,
     ) {
     }
 }

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -16,7 +16,7 @@ class Expression implements ExpressionContract
      * @param  TValue  $value
      */
     public function __construct(
-        protected $value
+        protected $value,
     ) {
     }
 

--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -14,7 +14,7 @@ class MessageLogged
     public function __construct(
         public $level,
         public $message,
-        public array $context = []
+        public array $context = [],
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -14,7 +14,7 @@ class WorkerStarting
     public function __construct(
         public $connectionName,
         public $queue,
-        public $workerOptions
+        public $workerOptions,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -12,7 +12,7 @@ class WorkerStopping
      */
     public function __construct(
         public $status = 0,
-        public $workerOptions = null
+        public $workerOptions = null,
     ) {
     }
 }


### PR DESCRIPTION
helps with better diffs

used the following regex to find them, not perfect, but it gets you close:

```
[^,]
(\ *)\)\ \{
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
