### PR TITLE
 [12.x] Add catch method to pipeline 

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -173,6 +173,7 @@ class Pipeline implements PipelineContract
     /**
      * Set a catch callback to be executed after an exception is thrown.
      *
+     * @param (\Closure(\Throwable, mixed): void) $callback
      * @return $this
      */
     public function catch(Closure $callback)

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -173,7 +173,7 @@ class Pipeline implements PipelineContract
     /**
      * Set a catch callback to be executed after an exception is thrown.
      *
-     * @param (\Closure(\Throwable, mixed): void) $callback
+     * @param  \Closure(\Throwable, mixed): void  $callback
      * @return $this
      */
     public function catch(Closure $callback)

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -311,6 +311,29 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
+    public function testPipelineCatch()
+    {
+        $pipeTwo = function ($piped, $next) {
+            throw new Exception('Message');
+        };
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $pipeTwo])
+            ->catch(function (Exception $exception, $piped) {
+                $_SERVER['__test.pipe.catch'] = $exception->getMessage();
+            })
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame(null, $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('Message', $_SERVER['__test.pipe.catch']);
+
+        unset($_SERVER['__test.pipe.one'], $_SERVER['__test.pipe.catch']);
+    }
+
     public function testPipelineFinally()
     {
         $pipeTwo = function ($piped, $next) {


### PR DESCRIPTION
This PR adds the `catch` method to the `Pipeline` class, also removes some unnecessary dockblocks.

Currently, we have to wrap the pipeline into a `try` - `catch` block to handle exceptions thrown inside the pipeline. This PR tries to provide a solution for that by adding the chainable `catch` method:

```php
Pipeline::send($value)
    ->through([$pipes])
    ->catch(function (Exception $exception, $value) {
        // Handle exception, log, rethrow, etc.
    })
    ->finally(function ($value) {
        //
    })
    ->thenReturn();
```