### PR TITLE
[13.x] require a second parameter for `with()` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -510,7 +510,7 @@ if (! function_exists('with')) {
      * @param  (callable(TValue): (TReturn))|null  $callback
      * @return ($callback is null ? TValue : TReturn)
      */
-    function with($value, ?callable $callback = null)
+    function with($value, ?callable $callback)
     {
         return is_null($callback) ? $value : $callback($value);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1137,8 +1137,6 @@ class SupportHelpersTest extends TestCase
 
     public function testWith()
     {
-        $this->assertEquals(10, with(10));
-
         $this->assertEquals(10, with(5, function ($five) {
             return $five + 5;
         }));

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -83,8 +83,6 @@ assertType('null', transform('', fn () => 1));
 assertType('true', transform('', fn () => 1, true));
 assertType('true', transform('', fn () => 1, fn () => true));
 
-assertType('User', with(new User()));
-assertType('bool', with(new User())->save());
 assertType('10', with(new User(), function ($user) {
     assertType('User', $user);
 


### PR DESCRIPTION
if no second parameter is passed, there is no point to even using the helper, so we'll start requiring it.

all usages without a second parameter have been removed from the 12.x branch, and I'm assuming they'll get merged forward at some point.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
