### PR TITLE
[12.x] Improve docblocks for nullable parameters

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -188,7 +188,7 @@ class BroadcastEvent implements ShouldQueue
     /**
      * Handle a job failure.
      *
-     * @param  \Throwable  $e
+     * @param  \Throwable|null  $e
      * @return void
      */
     public function failed(?Throwable $e = null): void

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1386,7 +1386,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -985,7 +985,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Console/View/Components/Ask.php
+++ b/src/Illuminate/Console/View/Components/Ask.php
@@ -10,7 +10,7 @@ class Ask extends Component
      * Renders the component using the given arguments.
      *
      * @param  string  $question
-     * @param  string  $default
+     * @param  string|null  $default
      * @param  bool  $multiline
      * @return mixed
      */

--- a/src/Illuminate/Console/View/Components/AskWithCompletion.php
+++ b/src/Illuminate/Console/View/Components/AskWithCompletion.php
@@ -11,7 +11,7 @@ class AskWithCompletion extends Component
      *
      * @param  string  $question
      * @param  array|callable  $choices
-     * @param  string  $default
+     * @param  string|null  $default
      * @return mixed
      */
     public function render($question, $choices, $default = null)

--- a/src/Illuminate/Console/View/Components/Choice.php
+++ b/src/Illuminate/Console/View/Components/Choice.php
@@ -12,7 +12,7 @@ class Choice extends Component
      * @param  string  $question
      * @param  array<array-key, string>  $choices
      * @param  mixed  $default
-     * @param  int  $attempts
+     * @param  int|null  $attempts
      * @param  bool  $multiple
      * @return mixed
      */

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -80,7 +80,7 @@ class AsCollection implements Castable
      * Specify the collection type for the cast.
      *
      * @param  class-string  $class
-     * @param  array{class-string, string}|class-string  $map
+     * @param  array{class-string, string}|class-string|null  $map
      * @return string
      */
     public static function using($class, $map = null)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -79,7 +79,7 @@ class AsEncryptedCollection implements Castable
      * Specify the collection for the cast.
      *
      * @param  class-string  $class
-     * @param  array{class-string, string}|class-string  $map
+     * @param  array{class-string, string}|class-string|null  $map
      * @return string
      */
     public static function using($class, $map = null)

--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -24,7 +24,7 @@ class AddLinkHeadersForPreloadedAssets
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  int  $limit
+     * @param  int|null  $limit
      * @return \Illuminate\Http\Response
      */
     public function handle($request, $next, $limit = null)

--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -18,7 +18,7 @@ class FilterEmailValidation implements EmailValidation
     /**
      * Create a new validation instance.
      *
-     * @param  int  $flags
+     * @param  int|null  $flags
      */
     public function __construct($flags = null)
     {


### PR DESCRIPTION
This PR updates docblocks for parameters with a default value of null that are currently documented as non-nullable.

- Follows the existing convention used elsewhere in the Laravel Framework source code.
- Applies the changes consistently across the codebase.

**Due to the large volume of changes, these updates will be covered across 3 separate PRs (10 files each) for easier review.**