### PR TITLE
[12.x] Add support for route labels and a routeLabel() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -872,6 +872,30 @@ if (! function_exists('route')) {
     }
 }
 
+if (! function_exists('routeLabel')) {
+    /**
+     * Get the label of a named route.
+     *
+     * @param  \BackedEnum|string  $name
+     * @return string|null
+     */
+    function routeLabel($name): ?string
+    {
+        if ($name instanceof BackedEnum) {
+            $name = $name->value;
+        }
+
+        $route = app('router')->getRoutes()->getByName($name);
+
+        if (! $route) {
+            return null; // route not found at all
+        }
+
+        // Prefer label, but fall back to route name
+        return $route->getLabel() ?? $route->getName();
+    }
+}
+
 if (! function_exists('secure_asset')) {
     /**
      * Generate an asset path for the application.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -926,6 +926,41 @@ class Route
     }
 
     /**
+     * Get the label of the route instance.
+     *
+     * @return string|null
+     */
+    public function getLabel()
+    {
+        return $this->action['label'] ?? null;
+    }
+
+    /**
+     * Add or change the route label.
+     *
+     * @param  \BackedEnum|string  $name
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function label($label)
+    {
+        if (! isset($this->action['as'])) {
+            throw new \LogicException(
+                'Cannot set a route label without a route name. Use ->name() before ->label().'
+            );
+        }
+
+        if ($label instanceof BackedEnum && ! is_string($label = $label->value)) {
+            throw new InvalidArgumentException('Enum must be string backed.');
+        }
+
+        $this->action['label'] = $label;
+
+        return $this;
+    }
+
+    /**
      * Set the handler for the route.
      *
      * @param  \Closure|array|string  $action


### PR DESCRIPTION
This PR introduces optional labels for routes, alongside a new global routeLabel() helper.

* `Route::label($label)` allows developers to assign a human-readable label to a named route.
* A safeguard prevents setting a label on unnamed routes. Labels must always follow `->name()`.
* The `routeLabel($name)` helper retrieves a route’s label.

If a label is not defined, it gracefully falls back to the route name, ensuring a predictable string is always returned.

Example usage in Blade:

```
<a href="{{ route('home') }}">{{ routeLabel('home') }}</a>
```

This provides a simple way to centralise human-friendly labels for links, avoiding hard-coding strings in views.

#### Motivation

Currently, applications either hard-code link texts in Blade templates or manage them separately in translation files. This scatters human-readable labels across the codebase and introduces duplication.

Adding labels to routes provides:

* A single source of truth for both the route name and its display label.
* Easier maintenance: changing a label in one place updates all links.
* Predictable fallback behavior (routeLabel() → label or name).

Why in the framework?

* Labels are a natural extension of the Route class, not just application-specific sugar.
* Navigation, breadcrumbs, and menus are common features across Laravel apps.
* A consistent core solution avoids fragmented custom macros and packages.
* The change is small, self-contained, and backwards-compatible.