### PR TITLE
[12.x] remove unnecessary `with()` helper calls

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -168,12 +168,12 @@ class Batch implements Arrayable, JsonSerializable
             if (is_array($job)) {
                 $count += count($job);
 
-                return with($this->prepareBatchedChain($job), function ($chain) {
+                return (function ($chain) {
                     return $chain->first()
                         ->allOnQueue($this->options['queue'] ?? null)
                         ->allOnConnection($this->options['connection'] ?? null)
                         ->chain($chain->slice(1)->values()->all());
-                });
+                })($this->prepareBatchedChain($job));
             } else {
                 $job->withBatchId($this->id);
 

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -51,21 +51,21 @@ class Signals
     {
         $this->previousHandlers[$signal] ??= $this->initializeSignal($signal);
 
-        with($this->getHandlers(), function ($handlers) use ($signal) {
+        (function ($handlers) use ($signal) {
             $handlers[$signal] ??= $this->initializeSignal($signal);
 
             $this->setHandlers($handlers);
-        });
+        })($this->getHandlers());
 
         $this->registry->register($signal, $callback);
 
-        with($this->getHandlers(), function ($handlers) use ($signal) {
+        (function ($handlers) use ($signal) {
             $lastHandlerInserted = array_pop($handlers[$signal]);
 
             array_unshift($handlers[$signal], $lastHandlerInserted);
 
             $this->setHandlers($handlers);
-        });
+        })($this->getHandlers());
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -102,7 +102,7 @@ class HandleExceptions
 
         $options = static::$app['config']->get('logging.deprecations') ?? [];
 
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
+        (function ($log) use ($message, $file, $line, $level, $options) {
             if ($options['trace'] ?? false) {
                 $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
             } else {
@@ -110,7 +110,7 @@ class HandleExceptions
                     $message, $file, $line
                 ));
             }
-        });
+        })($logger->channel('deprecations'));
     }
 
     /**
@@ -132,7 +132,7 @@ class HandleExceptions
      */
     protected function ensureDeprecationLoggerIsConfigured()
     {
-        with(static::$app['config'], function ($config) {
+        (function ($config) {
             if ($config->get('logging.channels.deprecations')) {
                 return;
             }
@@ -146,7 +146,7 @@ class HandleExceptions
             }
 
             $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
-        });
+        })(static::$app['config']);
     }
 
     /**
@@ -156,7 +156,7 @@ class HandleExceptions
      */
     protected function ensureNullLogDriverIsConfigured()
     {
-        with(static::$app['config'], function ($config) {
+        (function ($config) {
             if ($config->get('logging.channels.null')) {
                 return;
             }
@@ -165,7 +165,7 @@ class HandleExceptions
                 'driver' => 'monolog',
                 'handler' => NullHandler::class,
             ]);
-        });
+        })(static::$app['config']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -125,11 +125,11 @@ class DocsCommand extends Command
      */
     protected function openUrl()
     {
-        with($this->url(), function ($url) {
+        (function ($url) {
             $this->components->info("Opening the docs to: <fg=yellow>{$url}</>");
 
             $this->open($url);
-        });
+        })($this->url());
     }
 
     /**
@@ -145,9 +145,9 @@ class DocsCommand extends Command
             ]);
         }
 
-        return with($this->page(), function ($page) {
+        return (function ($page) {
             return trim("https://laravel.com/docs/{$this->version()}/{$page}#{$this->section($page)}", '#/');
-        });
+        })($this->page());
     }
 
     /**
@@ -157,7 +157,7 @@ class DocsCommand extends Command
      */
     protected function page()
     {
-        return with($this->resolvePage(), function ($page) {
+        return (function ($page) {
             if ($page === null) {
                 $this->components->warn('Unable to determine the page you are trying to visit.');
 
@@ -165,7 +165,7 @@ class DocsCommand extends Command
             }
 
             return $page;
-        });
+        })($this->resolvePage());
     }
 
     /**
@@ -441,11 +441,11 @@ class DocsCommand extends Command
      */
     protected function refreshDocs()
     {
-        with($this->fetchDocs(), function ($response) {
+        (function ($response) {
             if ($response->successful()) {
                 $this->cache->put("artisan.docs.{{$this->version()}}.index", $response->collect(), CarbonInterval::months(2));
             }
-        });
+        })($this->fetchDocs());
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -443,7 +443,7 @@ class Handler implements ExceptionHandlerContract
             }
         }
 
-        return rescue(fn () => with($this->throttle($e), function ($throttle) use ($e) {
+        return rescue(fn () => (function ($throttle) use ($e) {
             if ($throttle instanceof Unlimited || $throttle === null) {
                 return false;
             }
@@ -453,12 +453,12 @@ class Handler implements ExceptionHandlerContract
             }
 
             return ! $this->container->make(RateLimiter::class)->attempt(
-                with($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class, fn ($key) => $this->hashThrottleKeys ? hash('xxh128', $key) : $key),
+                (fn ($key) => $this->hashThrottleKeys ? hash('xxh128', $key) : $key)($throttle->key ?: 'illuminate:foundation:exceptions:'.$e::class),
                 $throttle->maxAttempts,
                 fn () => true,
                 $throttle->decaySeconds
             );
-        }), rescue: false, report: false);
+        })($this->throttle($e)), rescue: false, report: false);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -225,7 +225,7 @@ trait InteractsWithDatabase
      */
     public function expectsDatabaseQueryCount($expected, $connection = null)
     {
-        with($this->getConnection($connection), function ($connectionInstance) use ($expected, $connection) {
+        (function ($connectionInstance) use ($expected, $connection) {
             $actual = 0;
 
             $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
@@ -241,7 +241,7 @@ trait InteractsWithDatabase
                     "Expected {$expected} database queries on the [{$connectionInstance->getName()}] connection. {$actual} occurred."
                 );
             });
-        });
+        })($this->getConnection($connection));
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -506,7 +506,7 @@ class Vite implements Htmlable
                 ->reject(fn ($attributes) => isset($this->preloadedAssets[$attributes['href']])))
             ->unique('href')
             ->values()
-            ->pipe(fn ($assets) => with(Js::from($assets), fn ($assets) => match ($this->prefetchStrategy) {
+            ->pipe(fn ($assets) => (fn ($assets) => match ($this->prefetchStrategy) {
                 'waterfall' => new HtmlString($base.<<<HTML
 
                     <script{$this->nonceAttribute()}>
@@ -570,7 +570,7 @@ class Vite implements Htmlable
                          }))
                     </script>
                     HTML),
-            }));
+            })(Js::from($assets)));
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -135,7 +135,7 @@ class LogManager implements LoggerInterface
     protected function get($name, ?array $config = null)
     {
         try {
-            return $this->channels[$name] ?? with($this->resolve($name, $config), function ($logger) use ($name) {
+            return $this->channels[$name] ?? (function ($logger) use ($name) {
                 $loggerWithContext = $this->tap(
                     $name,
                     new Logger($logger, $this->app['events'])
@@ -146,7 +146,7 @@ class LogManager implements LoggerInterface
                 }
 
                 return $this->channels[$name] = $loggerWithContext;
-            });
+            })($this->resolve($name, $config));
         } catch (Throwable $e) {
             return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
                 $logger->emergency('Unable to create configured logger. Using emergency logger.', [

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -206,15 +206,15 @@ class Attachment
      */
     public function isEquivalent(Attachment $attachment, $options = [])
     {
-        return with([
-            'as' => $options['as'] ?? $attachment->as,
-            'mime' => $options['mime'] ?? $attachment->mime,
-        ], fn ($options) => $this->attachWith(
+        return (fn ($options) => $this->attachWith(
             fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
             fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
         ) === $attachment->attachWith(
             fn ($path) => [$path, $options],
             fn ($data) => [$data(), $options],
-        ));
+        ))([
+            'as' => $options['as'] ?? $attachment->as,
+            'mime' => $options['mime'] ?? $attachment->mime,
+        ]);
     }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -472,10 +472,9 @@ trait ValidatesAttributes
         $this->requireParameterCount(2, $parameters, 'between');
 
         try {
-            return with(
-                BigNumber::of($this->getSize($attribute, $value)),
-                fn ($size) => $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]))
-            );
+            return (function ($size) use ($parameters) {
+                return $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]));
+            })(BigNumber::of($this->getSize($attribute, $value)));
         } catch (MathException) {
             return false;
         }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -29,9 +29,9 @@ class HandleExceptionsTest extends TestCase
     protected function handleExceptions()
     {
         return tap(new HandleExceptions(), function ($instance) {
-            with(new ReflectionClass($instance), function ($reflection) use ($instance) {
+            (function ($reflection) use ($instance) {
                 $reflection->getProperty('app')->setValue($instance, $this->app);
-            });
+            })(new ReflectionClass($instance));
         });
     }
 
@@ -381,11 +381,11 @@ class HandleExceptionsTest extends TestCase
     {
         $instance = $this->handleExceptions();
 
-        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
+        $appResolver = fn () => (function ($reflection) use ($instance) {
             $property = $reflection->getProperty('app');
 
             return $property->getValue($instance);
-        });
+        })(new ReflectionClass($instance));
 
         $this->assertNotNull($appResolver());
 
@@ -398,11 +398,11 @@ class HandleExceptionsTest extends TestCase
     {
         $instance = $this->handleExceptions();
 
-        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
+        $appResolver = fn () => (function ($reflection) use ($instance) {
             $property = $reflection->getProperty('app');
 
             return $property->getValue($instance);
-        });
+        })(new ReflectionClass($instance));
 
         $this->assertSame($this->app, $appResolver());
 


### PR DESCRIPTION
when we have a clearly defined closure passed as the second argument, there is no reason to defer to the `with()` helper when we can just immediately execute the closure with the given value.

since we have a well defined closure and well defined input, you might ask "why do we even bother with the closure?"  the only real benefit the closure is giving us is essentially a hacky-ish way to define temporary variables. using the closure method also gives us much more complicated opcodes.  so another solution, and one I'd be open to doing *instead* of this PR, is to just write them like normal code with temporary variables.

to illustrate in code with a simplified example, this is the closure way:

```php
function someExpensiveFunction() {
    return 'foo';
}

echo (function($test) {
    return $test . ' ' . $test;
})(someExpensiveFunction());
```

and this would become the non-closure way:

```php
$temp = someExpensiveFunction();

return $temp . ' ' . $temp;
```

I think the non-closure pattern would also improve readability for most of these cases.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
