### PR TITLE
[12.x] remove unecessary `with()` helper calls

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -174,7 +174,6 @@ class Batch implements Arrayable, JsonSerializable
                     ->allOnQueue($this->options['queue'] ?? null)
                     ->allOnConnection($this->options['connection'] ?? null)
                     ->chain($chain->slice(1)->values()->all());
-
             } else {
                 $job->withBatchId($this->id);
 

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -168,12 +168,13 @@ class Batch implements Arrayable, JsonSerializable
             if (is_array($job)) {
                 $count += count($job);
 
-                return with($this->prepareBatchedChain($job), function ($chain) {
-                    return $chain->first()
-                        ->allOnQueue($this->options['queue'] ?? null)
-                        ->allOnConnection($this->options['connection'] ?? null)
-                        ->chain($chain->slice(1)->values()->all());
-                });
+                $chain = $this->prepareBatchedChain($job);
+
+                return $chain->first()
+                    ->allOnQueue($this->options['queue'] ?? null)
+                    ->allOnConnection($this->options['connection'] ?? null)
+                    ->chain($chain->slice(1)->values()->all());
+
             } else {
                 $job->withBatchId($this->id);
 

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -51,21 +51,21 @@ class Signals
     {
         $this->previousHandlers[$signal] ??= $this->initializeSignal($signal);
 
-        with($this->getHandlers(), function ($handlers) use ($signal) {
-            $handlers[$signal] ??= $this->initializeSignal($signal);
+        $handlers = $this->getHandlers();
 
-            $this->setHandlers($handlers);
-        });
+        $handlers[$signal] ??= $this->initializeSignal($signal);
+
+        $this->setHandlers($handlers);
 
         $this->registry->register($signal, $callback);
 
-        with($this->getHandlers(), function ($handlers) use ($signal) {
-            $lastHandlerInserted = array_pop($handlers[$signal]);
+        $handlers = $this->getHandlers();
 
-            array_unshift($handlers[$signal], $lastHandlerInserted);
+        $lastHandlerInserted = array_pop($handlers[$signal]);
 
-            $this->setHandlers($handlers);
-        });
+        array_unshift($handlers[$signal], $lastHandlerInserted);
+
+        $this->setHandlers($handlers);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -102,15 +102,15 @@ class HandleExceptions
 
         $options = static::$app['config']->get('logging.deprecations') ?? [];
 
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level, $options) {
-            if ($options['trace'] ?? false) {
-                $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
-            } else {
-                $log->warning(sprintf('%s in %s on line %s',
-                    $message, $file, $line
-                ));
-            }
-        });
+        $log = $logger->channel('deprecations');
+
+        if ($options['trace'] ?? false) {
+            $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
+        } else {
+            $log->warning(sprintf('%s in %s on line %s',
+                $message, $file, $line
+            ));
+        }
     }
 
     /**
@@ -132,21 +132,21 @@ class HandleExceptions
      */
     protected function ensureDeprecationLoggerIsConfigured()
     {
-        with(static::$app['config'], function ($config) {
-            if ($config->get('logging.channels.deprecations')) {
-                return;
-            }
+        $config = static::$app['config'];
 
-            $this->ensureNullLogDriverIsConfigured();
+        if ($config->get('logging.channels.deprecations')) {
+            return;
+        }
 
-            if (is_array($options = $config->get('logging.deprecations'))) {
-                $driver = $options['channel'] ?? 'null';
-            } else {
-                $driver = $options ?? 'null';
-            }
+        $this->ensureNullLogDriverIsConfigured();
 
-            $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
-        });
+        if (is_array($options = $config->get('logging.deprecations'))) {
+            $driver = $options['channel'] ?? 'null';
+        } else {
+            $driver = $options ?? 'null';
+        }
+
+        $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
     }
 
     /**
@@ -156,16 +156,16 @@ class HandleExceptions
      */
     protected function ensureNullLogDriverIsConfigured()
     {
-        with(static::$app['config'], function ($config) {
-            if ($config->get('logging.channels.null')) {
-                return;
-            }
+        $config = static::$app['config'];
 
-            $config->set('logging.channels.null', [
-                'driver' => 'monolog',
-                'handler' => NullHandler::class,
-            ]);
-        });
+        if ($config->get('logging.channels.null')) {
+            return;
+        }
+
+        $config->set('logging.channels.null', [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ]);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -125,11 +125,11 @@ class DocsCommand extends Command
      */
     protected function openUrl()
     {
-        with($this->url(), function ($url) {
-            $this->components->info("Opening the docs to: <fg=yellow>{$url}</>");
+        $url = $this->url();
 
-            $this->open($url);
-        });
+        $this->components->info("Opening the docs to: <fg=yellow>{$url}</>");
+
+        $this->open($url);
     }
 
     /**
@@ -145,9 +145,9 @@ class DocsCommand extends Command
             ]);
         }
 
-        return with($this->page(), function ($page) {
-            return trim("https://laravel.com/docs/{$this->version()}/{$page}#{$this->section($page)}", '#/');
-        });
+        $page = $this->page();
+
+        return trim("https://laravel.com/docs/{$this->version()}/{$page}#{$this->section($page)}", '#/');
     }
 
     /**
@@ -157,15 +157,15 @@ class DocsCommand extends Command
      */
     protected function page()
     {
-        return with($this->resolvePage(), function ($page) {
-            if ($page === null) {
-                $this->components->warn('Unable to determine the page you are trying to visit.');
+        $page = $this->resolvePage();
 
-                return '/';
-            }
+        if ($page === null) {
+            $this->components->warn('Unable to determine the page you are trying to visit.');
 
-            return $page;
-        });
+            return '/';
+        }
+
+        return $page;
     }
 
     /**
@@ -441,11 +441,11 @@ class DocsCommand extends Command
      */
     protected function refreshDocs()
     {
-        with($this->fetchDocs(), function ($response) {
-            if ($response->successful()) {
-                $this->cache->put("artisan.docs.{{$this->version()}}.index", $response->collect(), CarbonInterval::months(2));
-            }
-        });
+        $response = $this->fetchDocs();
+
+        if ($response->successful()) {
+            $this->cache->put("artisan.docs.{{$this->version()}}.index", $response->collect(), CarbonInterval::months(2));
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -225,22 +225,22 @@ trait InteractsWithDatabase
      */
     public function expectsDatabaseQueryCount($expected, $connection = null)
     {
-        with($this->getConnection($connection), function ($connectionInstance) use ($expected, $connection) {
-            $actual = 0;
+        $connectionInstance = $this->getConnection($connection);
 
-            $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
-                if (is_null($connection) || $connectionInstance === $event->connection) {
-                    $actual++;
-                }
-            });
+        $actual = 0;
 
-            $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connectionInstance) {
-                $this->assertSame(
-                    $expected,
-                    $actual,
-                    "Expected {$expected} database queries on the [{$connectionInstance->getName()}] connection. {$actual} occurred."
-                );
-            });
+        $connectionInstance->listen(function (QueryExecuted $event) use (&$actual, $connectionInstance, $connection) {
+            if (is_null($connection) || $connectionInstance === $event->connection) {
+                $actual++;
+            }
+        });
+
+        $this->beforeApplicationDestroyed(function () use (&$actual, $expected, $connectionInstance) {
+            $this->assertSame(
+                $expected,
+                $actual,
+                "Expected {$expected} database queries on the [{$connectionInstance->getName()}] connection. {$actual} occurred."
+            );
         });
 
         return $this;

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -212,11 +212,11 @@ class Attachment
         ];
 
         return $this->attachWith(
-                fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
-                fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
-            ) === $attachment->attachWith(
-                fn ($path) => [$path, $newOptions],
-                fn ($data) => [$data(), $newOptions],
-            );
+            fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
+            fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
+        ) === $attachment->attachWith(
+            fn ($path) => [$path, $newOptions],
+            fn ($data) => [$data(), $newOptions],
+        );
     }
 }

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -206,15 +206,17 @@ class Attachment
      */
     public function isEquivalent(Attachment $attachment, $options = [])
     {
-        return with([
+        $newOptions = [
             'as' => $options['as'] ?? $attachment->as,
             'mime' => $options['mime'] ?? $attachment->mime,
-        ], fn ($options) => $this->attachWith(
-            fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
-            fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
-        ) === $attachment->attachWith(
-            fn ($path) => [$path, $options],
-            fn ($data) => [$data(), $options],
-        ));
+        ];
+
+        return $this->attachWith(
+                fn ($path) => [$path, ['as' => $this->as, 'mime' => $this->mime]],
+                fn ($data) => [$data(), ['as' => $this->as, 'mime' => $this->mime]],
+            ) === $attachment->attachWith(
+                fn ($path) => [$path, $newOptions],
+                fn ($data) => [$data(), $newOptions],
+            );
     }
 }

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -134,16 +134,17 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->bind(ServerRequestInterface::class, function ($app) {
             if (class_exists(PsrHttpFactory::class)) {
-                return with((new PsrHttpFactory)
-                    ->createRequest($illuminateRequest = $app->make('request')), function (ServerRequestInterface $request) use ($illuminateRequest) {
-                        if ($illuminateRequest->getContentTypeFormat() !== 'json' && $illuminateRequest->request->count() === 0) {
-                            return $request;
-                        }
 
-                        return $request->withParsedBody(
-                            array_merge($request->getParsedBody() ?? [], $illuminateRequest->getPayload()->all())
-                        );
-                    });
+                $illuminateRequest = $app->make('request');
+                $request = (new PsrHttpFactory)->createRequest($illuminateRequest);
+
+                if ($illuminateRequest->getContentTypeFormat() !== 'json' && $illuminateRequest->request->count() === 0) {
+                    return $request;
+                }
+
+                return $request->withParsedBody(
+                    array_merge($request->getParsedBody() ?? [], $illuminateRequest->getPayload()->all())
+                );
             }
 
             throw new BindingResolutionException('Unable to resolve PSR request. Please install the "symfony/psr-http-message-bridge" package.');

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -134,7 +134,6 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->bind(ServerRequestInterface::class, function ($app) {
             if (class_exists(PsrHttpFactory::class)) {
-
                 $illuminateRequest = $app->make('request');
                 $request = (new PsrHttpFactory)->createRequest($illuminateRequest);
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -472,11 +472,9 @@ trait ValidatesAttributes
         $this->requireParameterCount(2, $parameters, 'between');
 
         try {
-
             $size = BigNumber::of($this->getSize($attribute, $value));
 
             return $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]));
-
         } catch (MathException) {
             return false;
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -472,10 +472,11 @@ trait ValidatesAttributes
         $this->requireParameterCount(2, $parameters, 'between');
 
         try {
-            return with(
-                BigNumber::of($this->getSize($attribute, $value)),
-                fn ($size) => $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]))
-            );
+
+            $size = BigNumber::of($this->getSize($attribute, $value));
+
+            return $size->isGreaterThanOrEqualTo($this->trim($parameters[0])) && $size->isLessThanOrEqualTo($this->trim($parameters[1]));
+
         } catch (MathException) {
             return false;
         }

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -29,9 +29,7 @@ class HandleExceptionsTest extends TestCase
     protected function handleExceptions()
     {
         return tap(new HandleExceptions(), function ($instance) {
-            with(new ReflectionClass($instance), function ($reflection) use ($instance) {
-                $reflection->getProperty('app')->setValue($instance, $this->app);
-            });
+            (new ReflectionClass($instance))->getProperty('app')->setValue($instance, $this->app);
         });
     }
 
@@ -381,11 +379,7 @@ class HandleExceptionsTest extends TestCase
     {
         $instance = $this->handleExceptions();
 
-        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
-            $property = $reflection->getProperty('app');
-
-            return $property->getValue($instance);
-        });
+        $appResolver = fn () => (new ReflectionClass($instance))->getProperty('app')->getValue($instance);
 
         $this->assertNotNull($appResolver());
 
@@ -398,11 +392,7 @@ class HandleExceptionsTest extends TestCase
     {
         $instance = $this->handleExceptions();
 
-        $appResolver = fn () => with(new ReflectionClass($instance), function ($reflection) use ($instance) {
-            $property = $reflection->getProperty('app');
-
-            return $property->getValue($instance);
-        });
+        $appResolver = fn () => (new ReflectionClass($instance))->getProperty('app')->getValue($instance);
 
         $this->assertSame($this->app, $appResolver());
 


### PR DESCRIPTION
when we have a well defined closure, there is no reason to use the `with()` helper, or even the closure at all. in most cases, by using a temporary variable we achieve the same effect with arguably cleaner easier to read code.

this is an alternative to #56999 . it removes the `with()` calls and closures entirely, and refactors to use a temporary variable. there are a couple remaining uses that the other PR covered that this one does not, just because they were a little more complicated, and I wanted to show the simple cases first.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
