### PR TITLE
[12.x] Add --json option to ScheduleListCommand

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -24,6 +24,7 @@ class ScheduleListCommand extends Command
     protected $signature = 'schedule:list
         {--timezone= : The timezone that times should be displayed in}
         {--next : Sort the listed tasks by their next due date}
+        {--json : Output the scheduled tasks as JSON}
     ';
 
     /**
@@ -53,28 +54,20 @@ class ScheduleListCommand extends Command
         $events = new Collection($schedule->events());
 
         if ($events->isEmpty()) {
-            $this->components->info('No scheduled tasks have been defined.');
+            if ($this->option('json')) {
+                $this->output->writeln('[]');
+            } else {
+                $this->components->info('No scheduled tasks have been defined.');
+            }
 
             return;
         }
-
-        $terminalWidth = self::getTerminalWidth();
-
-        $expressionSpacing = $this->getCronExpressionSpacing($events);
-
-        $repeatExpressionSpacing = $this->getRepeatExpressionSpacing($events);
 
         $timezone = new DateTimeZone($this->option('timezone') ?? config('app.timezone'));
 
         $events = $this->sortEvents($events, $timezone);
 
-        $events = $events->map(function ($event) use ($terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone) {
-            return $this->listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone);
-        });
-
-        $this->line(
-            $events->flatten()->filter()->prepend('')->push('')->toArray()
-        );
+        $this->display($events, $timezone);
     }
 
     /**
@@ -192,6 +185,83 @@ class ScheduleListCommand extends Command
         return $this->option('next')
             ? $events->sortBy(fn ($event) => $this->getNextDueDateForEvent($event, $timezone))
             : $events;
+    }
+
+    /**
+     * Render the scheduled tasks information.
+     *
+     * @param  \Illuminate\Support\Collection  $events
+     * @param  \DateTimeZone  $timezone
+     * @return void
+     */
+    protected function display(Collection $events, DateTimeZone $timezone)
+    {
+        $this->option('json') ? $this->displayJson($events, $timezone) : $this->displayForCli($events, $timezone);
+    }
+
+    /**
+     * Render the scheduled tasks information as JSON.
+     *
+     * @param  \Illuminate\Support\Collection  $events
+     * @param  \DateTimeZone  $timezone
+     * @return void
+     */
+    protected function displayJson(Collection $events, DateTimeZone $timezone)
+    {
+        $data = $events->map(function ($event) use ($timezone) {
+            $nextDueDate = $this->getNextDueDateForEvent($event, $timezone);
+
+            $command = $event->command ?? '';
+
+            if (! $this->output->isVerbose()) {
+                $command = $event->normalizeCommand($command);
+            }
+
+            if ($event instanceof CallbackEvent) {
+                $command = $event->getSummaryForDisplay();
+
+                if (in_array($command, ['Closure', 'Callback'])) {
+                    $command = 'Closure at: '.$this->getClosureLocation($event);
+                }
+            }
+
+            return [
+                'expression' => $event->expression,
+                'repeat_seconds' => $event->isRepeatable() ? $event->repeatSeconds : null,
+                'command' => $command,
+                'description' => $event->description ?? null,
+                'next_due_date' => $nextDueDate->format('Y-m-d H:i:s P'),
+                'next_due_date_human' => $nextDueDate->diffForHumans(),
+                'timezone' => $timezone->getName(),
+                'has_mutex' => $event->mutex->exists($event),
+            ];
+        })->values();
+
+        $this->output->writeln($data->toJson());
+    }
+
+    /**
+     * Render the scheduled tasks information formatted for the CLI.
+     *
+     * @param  \Illuminate\Support\Collection  $events
+     * @param  \DateTimeZone  $timezone
+     * @return void
+     */
+    protected function displayForCli(Collection $events, DateTimeZone $timezone)
+    {
+        $terminalWidth = self::getTerminalWidth();
+
+        $expressionSpacing = $this->getCronExpressionSpacing($events);
+
+        $repeatExpressionSpacing = $this->getRepeatExpressionSpacing($events);
+
+        $events = $events->map(function ($event) use ($terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone) {
+            return $this->listEvent($event, $terminalWidth, $expressionSpacing, $repeatExpressionSpacing, $timezone);
+        });
+
+        $this->line(
+            $events->flatten()->filter()->prepend('')->push('')->toArray()
+        );
     }
 
     /**

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Console\Scheduling;
 
+use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
@@ -29,6 +30,15 @@ class ScheduleListCommandTest extends TestCase
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
             ->expectsOutputToContain('No scheduled tasks have been defined.');
+    }
+
+    public function testDisplayEmptyScheduleAsJson()
+    {
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, ['--json' => true]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $this->assertJsonStringEqualsJsonString('[]', $output);
     }
 
     public function testDisplaySchedule()
@@ -63,6 +73,128 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
+    }
+
+    public function testDisplayScheduleAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->twiceDaily(14, 18);
+        $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
+        $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->everyMinute();
+        $this->schedule->job(FooJob::class)->name('foo-named-job')->everyMinute();
+        $this->schedule->job(new FooParamJob('test'))->name('foo-named-param-job')->everyMinute();
+        $this->schedule->command('inspire')->cron('0 9,17 * * *');
+        $this->schedule->call(fn () => '')->everyMinute();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, ['--json' => true]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(9, $data);
+
+        $this->assertSame('0 0 1 1-12/3 *', $data[0]['expression']);
+        $this->assertNull($data[0]['repeat_seconds']);
+        $this->assertSame('php artisan foo:command', $data[0]['command']);
+        $this->assertSame('This is the description of the command.', $data[0]['description']);
+        $this->assertStringContainsString('2023-04-01 00:00:00', $data[0]['next_due_date']);
+        $this->assertSame('3 months from now', $data[0]['next_due_date_human']);
+        $this->assertFalse($data[0]['has_mutex']);
+
+        $this->assertSame('* * * * *', $data[2]['expression']);
+        $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[2]['command']);
+        $this->assertNull($data[2]['description']);
+        $this->assertSame('1 minute from now', $data[2]['next_due_date_human']);
+
+        $this->assertSame('Illuminate\Tests\Integration\Console\Scheduling\FooJob', $data[3]['command']);
+
+        $this->assertSame('foo-named-job', $data[5]['command']);
+
+        $this->assertStringContainsString('Closure at:', $data[8]['command']);
+        $this->assertStringContainsString('ScheduleListCommandTest.php', $data[8]['command']);
+    }
+
+    public function testDisplayScheduleWithSortAsJson()
+    {
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->twiceDaily(14, 18);
+        $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--next' => true,
+            '--json' => true,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(3, $data);
+
+        $this->assertSame('* * * * *', $data[0]['expression']);
+        $this->assertSame('1 minute from now', $data[0]['next_due_date_human']);
+        $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[0]['command']);
+
+        $this->assertSame('0 14,18 * * *', $data[1]['expression']);
+        $this->assertSame('14 hours from now', $data[1]['next_due_date_human']);
+        $this->assertSame('php artisan inspire', $data[1]['command']);
+
+        $this->assertSame('0 0 1 1-12/3 *', $data[2]['expression']);
+        $this->assertSame('3 months from now', $data[2]['next_due_date_human']);
+        $this->assertSame('php artisan foo:command', $data[2]['command']);
+    }
+
+    public function testDisplayScheduleAsJsonWithTimezone()
+    {
+        $this->schedule->command('inspire')->daily();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--timezone' => 'America/Chicago',
+            '--json' => true,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+        $this->assertSame('America/Chicago', $data[0]['timezone']);
+        $this->assertStringContainsString('-06:00', $data[0]['next_due_date']);
+        $this->assertSame('php artisan inspire', $data[0]['command']);
+    }
+
+    public function testDisplayScheduleAsJsonInVerboseMode()
+    {
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->everyMinute();
+        $this->schedule->call(fn () => '')->everyMinute();
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, [
+            '--json' => true,
+            '-v' => true,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+
+        $this->assertIsArray($data);
+        $this->assertCount(3, $data);
+
+        $this->assertSame('0 0 1 1-12/3 *', $data[0]['expression']);
+        $this->assertSame(Application::phpBinary().' '.Application::artisanBinary().' foo:command', $data[0]['command']);
+        $this->assertSame('This is the description of the command.', $data[0]['description']);
+
+        $this->assertSame('* * * * *', $data[1]['expression']);
+        $this->assertSame(Application::phpBinary().' '.Application::artisanBinary().' inspire', $data[1]['command']);
+
+        $this->assertStringContainsString('Closure at:', $data[2]['command']);
+        $this->assertStringContainsString('ScheduleListCommandTest.php', $data[2]['command']);
     }
 
     public function testDisplayScheduleWithSort()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Summary

This PR adds a `--json` flag to the `schedule:list` command to allow programmatic consumption of scheduled task data for monitoring and integration purposes. This is implemented in a way that aligns with other Laravel commands like `route:list`, `model:show`, `event:list`, and `db:table`.

#### JSON Output
```json
[
  {
    "expression": "0 0 15 * *",
    "repeat_seconds": null,
    "command": "php artisan backup:run",
    "description": "Run daily backup process",
    "next_due_date": "2025-09-15 00:00:00 +00:00",
    "next_due_date_human": "5 days from now",
    "timezone": "UTC",
    "has_mutex": false
  }
]
```

#### Example Use Cases

- Validate schedules after deployment
	- `php artisan schedule:list --json | jq 'length'` 
- Monitor critical tasks
	- `php artisan schedule:list --json | jq '.[] | select(.command | contains("backup"))'`
- Transparency into automated processes in a user-friendly interface
	- ```php
	  $output = Artisan::call('schedule:list', ['--json' => true]);
	  $schedules = json_decode(Artisan::output(), true);
	  return view('admin.schedules', compact('schedules'));
	  ```
	- ```html
      @foreach($schedules as $schedule)
          <tr>
              <td>{{ $schedule['command'] }}</td>
              <td><code>{{ $schedule['expression'] }}</code></td>
              <td>{{ $schedule['next_due_date_human'] }}</td>
          </tr>
      @endforeach
      ```




