### PR TITLE
Fix Arr::array default to use empty array

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,7 +64,7 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): array
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = []): array
     {
         $value = Arr::get($array, $key, $default);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1595,7 +1595,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1595,8 +1595,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
+        $items[$temp = new class {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -664,6 +664,13 @@ class SupportArrTest extends TestCase
         Arr::array($test_array, 'string');
     }
 
+    public function testItReturnsEmptyArrayForMissingKeyByDefault()
+    {
+        $data = ['name' => 'Taylor'];
+
+        $this->assertSame([], Arr::array($data, 'missing_key'));
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
This PR updates the Arr::array() method to use an empty array ([]) as the default return value when no key exists, instead of null.

Previously, the method signature allowed a null default (?array $default = null), but this created a mismatch with the strict : array return type. If a developer passed null as the default, the method would still throw an exception because null is not an array.