### PR TITLE
Fix Arr::array default to use empty array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
+.DS_Store
+.phpunit.result.cache
+/.fleet
+/.idea
 /.phpunit.cache
+/phpunit.xml
+/.vscode
 /vendor
 composer.phar
 composer.lock
-.DS_Store
 Thumbs.db
-/phpunit.xml
-/.idea
-/.fleet
-/.vscode
-.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Release Notes for 12.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v12.28.0...12.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v12.28.1...12.x)
+
+## [v12.28.1](https://github.com/laravel/framework/compare/v12.28.0...v12.28.1) - 2025-09-04
+
+* [12.x] Rename `group` to `messageGroup` property by [@crynobone](https://github.com/crynobone) in https://github.com/laravel/framework/pull/56919
+* Fix PHP_CLI_SERVER_WORKERS inside laravel/sail by [@akyrey](https://github.com/akyrey) in https://github.com/laravel/framework/pull/56923
+* Allow RouteRegistrar to be Macroable by [@moshe-autoleadstar](https://github.com/moshe-autoleadstar) in https://github.com/laravel/framework/pull/56921
+* [12.x] Fix SesV2Transport docblock by [@dwightwatson](https://github.com/dwightwatson) in https://github.com/laravel/framework/pull/56917
+* [12.x] Prevent unnecessary query logging on exceptions with a custom renderer by [@luanfreitasdev](https://github.com/luanfreitasdev) in https://github.com/laravel/framework/pull/56874
+* [12.x] Reduce meaningless intermediate variables by [@AhmedAlaa4611](https://github.com/AhmedAlaa4611) in https://github.com/laravel/framework/pull/56927
 
 ## [v12.28.0](https://github.com/laravel/framework/compare/v12.27.1...v12.28.0) - 2025-09-03
 

--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
         "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
-        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.9.1).",
+        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",

--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
         "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
-        "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+        "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.9.1).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",

--- a/config/cache.php
+++ b/config/cache.php
@@ -38,6 +38,11 @@ return [
             'serialize' => false,
         ],
 
+        'session' => [
+            'driver' => 'session',
+            'key' => env('SESSION_CACHE_KEY', '_cache'),
+        ],
+
         'database' => [
             'driver' => 'database',
             'connection' => env('DB_CACHE_CONNECTION'),

--- a/config/database.php
+++ b/config/database.php
@@ -42,6 +42,7 @@ return [
             'journal_mode' => null,
             'synchronous' => null,
             'transaction_mode' => 'DEFERRED',
+            'pragmas' => [],
         ],
 
         'mysql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -38,12 +38,11 @@ return [
             'prefix' => '',
             'prefix_indexes' => null,
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'pragmas' => [
-                'busy_timeout' => null,
-                'journal_mode' => null,
-                'synchronous' => null,
-                'transaction_mode' => 'DEFERRED',
-            ],
+            'busy_timeout' => null,
+            'journal_mode' => null,
+            'synchronous' => null,
+            'transaction_mode' => 'DEFERRED',
+            'pragmas' => [],
         ],
 
         'mysql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -38,11 +38,12 @@ return [
             'prefix' => '',
             'prefix_indexes' => null,
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'busy_timeout' => null,
-            'journal_mode' => null,
-            'synchronous' => null,
-            'transaction_mode' => 'DEFERRED',
-            'pragmas' => [],
+            'pragmas' => [
+                'busy_timeout' => null,
+                'journal_mode' => null,
+                'synchronous' => null,
+                'transaction_mode' => 'DEFERRED',
+            ],
         ],
 
         'mysql' => [

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -186,7 +186,7 @@ class Gate implements GateContract
             $response = $condition;
         }
 
-        return with($response instanceof Response ? $response : new Response(
+        return ($response instanceof Response ? $response : new Response(
             (bool) $response === $allowWhenResponseIs, $message, $code
         ))->authorize();
     }

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -188,7 +188,7 @@ class BroadcastEvent implements ShouldQueue
     /**
      * Handle a job failure.
      *
-     * @param  \Throwable  $e
+     * @param  \Throwable|null  $e
      * @return void
      */
     public function failed(?Throwable $e = null): void

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -170,71 +170,6 @@ class CacheManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the file cache driver.
-     *
-     * @param  array  $config
-     * @return \Illuminate\Cache\Repository
-     */
-    protected function createFileDriver(array $config)
-    {
-        return $this->repository(
-            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))
-                ->setLockDirectory($config['lock_path'] ?? null),
-            $config
-        );
-    }
-
-    /**
-     * Create an instance of the Memcached cache driver.
-     *
-     * @param  array  $config
-     * @return \Illuminate\Cache\Repository
-     */
-    protected function createMemcachedDriver(array $config)
-    {
-        $prefix = $this->getPrefix($config);
-
-        $memcached = $this->app['memcached.connector']->connect(
-            $config['servers'],
-            $config['persistent_id'] ?? null,
-            $config['options'] ?? [],
-            array_filter($config['sasl'] ?? [])
-        );
-
-        return $this->repository(new MemcachedStore($memcached, $prefix), $config);
-    }
-
-    /**
-     * Create an instance of the Null cache driver.
-     *
-     * @return \Illuminate\Cache\Repository
-     */
-    protected function createNullDriver()
-    {
-        return $this->repository(new NullStore, []);
-    }
-
-    /**
-     * Create an instance of the Redis cache driver.
-     *
-     * @param  array  $config
-     * @return \Illuminate\Cache\Repository
-     */
-    protected function createRedisDriver(array $config)
-    {
-        $redis = $this->app['redis'];
-
-        $connection = $config['connection'] ?? 'default';
-
-        $store = new RedisStore($redis, $this->getPrefix($config), $connection);
-
-        return $this->repository(
-            $store->setLockConnection($config['lock_connection'] ?? $connection),
-            $config
-        );
-    }
-
-    /**
      * Create an instance of the database cache driver.
      *
      * @param  array  $config
@@ -308,6 +243,106 @@ class CacheManager implements FactoryContract
         }
 
         return new DynamoDbClient($dynamoConfig);
+    }
+
+    /**
+     * Create an instance of the file cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createFileDriver(array $config)
+    {
+        return $this->repository(
+            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))
+                ->setLockDirectory($config['lock_path'] ?? null),
+            $config
+        );
+    }
+
+    /**
+     * Create an instance of the Memcached cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createMemcachedDriver(array $config)
+    {
+        $prefix = $this->getPrefix($config);
+
+        $memcached = $this->app['memcached.connector']->connect(
+            $config['servers'],
+            $config['persistent_id'] ?? null,
+            $config['options'] ?? [],
+            array_filter($config['sasl'] ?? [])
+        );
+
+        return $this->repository(new MemcachedStore($memcached, $prefix), $config);
+    }
+
+    /**
+     * Create an instance of the Null cache driver.
+     *
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createNullDriver()
+    {
+        return $this->repository(new NullStore, []);
+    }
+
+    /**
+     * Create an instance of the Redis cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createRedisDriver(array $config)
+    {
+        $redis = $this->app['redis'];
+
+        $connection = $config['connection'] ?? 'default';
+
+        $store = new RedisStore($redis, $this->getPrefix($config), $connection);
+
+        return $this->repository(
+            $store->setLockConnection($config['lock_connection'] ?? $connection),
+            $config
+        );
+    }
+
+    /**
+     * Create an instance of the session cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createSessionDriver(array $config)
+    {
+        return $this->repository(
+            new SessionStore(
+                $this->getSession(),
+                $config['key'] ?? '_cache',
+            ),
+            $config
+        );
+    }
+
+    /**
+     * Get the session store implementation.
+     *
+     * @return \Illuminate\Contracts\Session\Session
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function getSession()
+    {
+        $session = $this->app['session'] ?? null;
+
+        if (! $session) {
+            throw new InvalidArgumentException('Session store requires session manager to be available in container.');
+        }
+
+        return $session;
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -462,7 +462,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function shouldBeStoredWithoutSerialization($value): bool
     {
-        return is_numeric($value) && ! in_array($value, [INF, -INF]) && ! is_nan($value);
+        return is_numeric($value) && is_finite($value);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -13,7 +13,7 @@ class RedisTagSet extends TagSet
      *
      * @param  string  $key
      * @param  int|null  $ttl
-     * @param  string  $updateWhen
+     * @param  string|null  $updateWhen
      * @return void
      */
     public function addEntry(string $key, ?int $ttl = null, $updateWhen = null)

--- a/src/Illuminate/Cache/SessionStore.php
+++ b/src/Illuminate/Cache/SessionStore.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\InteractsWithTime;
+
+class SessionStore implements Store
+{
+    use InteractsWithTime, RetrievesMultipleKeys;
+
+    /**
+     * The key for cache items.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * The session instance.
+     *
+     * @var \Illuminate\Contracts\Session\Session
+     */
+    public $session;
+
+    /**
+     * Create a new session cache store.
+     *
+     * @param  \Illuminate\Contracts\Session\Session  $session
+     * @param  string  $key
+     */
+    public function __construct($session, $key = '_cache')
+    {
+        $this->key = $key;
+        $this->session = $session;
+    }
+
+    /**
+     * Get all of the cached values and their expiration times.
+     *
+     * @return array<string, array{value: mixed, expiresAt: float}>
+     */
+    public function all()
+    {
+        return $this->session->get($this->key, []);
+    }
+
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        if (! $this->session->exists($this->itemKey($key))) {
+            return;
+        }
+
+        $item = $this->session->get($this->itemKey($key));
+
+        $expiresAt = $item['expiresAt'] ?? 0;
+
+        if ($this->isExpired($expiresAt)) {
+            $this->forget($key);
+
+            return;
+        }
+
+        return $item['value'];
+    }
+
+    /**
+     * Determine if the given expiration time is expired.
+     *
+     * @param  int|float  $expiresAt
+     * @return bool
+     */
+    protected function isExpired($expiresAt)
+    {
+        return $expiresAt !== 0 && (Carbon::now()->getPreciseTimestamp(3) / 1000) >= $expiresAt;
+    }
+
+    /**
+     * Store an item in the cache for a given number of seconds.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function put($key, $value, $seconds)
+    {
+        $this->session->put($this->itemKey($key), [
+            'value' => $value,
+            'expiresAt' => $this->toTimestamp($seconds),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Get the UNIX timestamp, with milliseconds, for the given number of seconds in the future.
+     *
+     * @param  int  $seconds
+     * @return float
+     */
+    protected function toTimestamp($seconds)
+    {
+        return $seconds > 0 ? (Carbon::now()->getPreciseTimestamp(3) / 1000) + $seconds : 0;
+    }
+
+    /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int
+     */
+    public function increment($key, $value = 1)
+    {
+        if (! is_null($existing = $this->get($key))) {
+            return tap(((int) $existing) + $value, function ($incremented) use ($key) {
+                $this->session->put($this->itemKey("{$key}.value"), $incremented);
+            });
+        }
+
+        $this->forever($key, $value);
+
+        return $value;
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int
+     */
+    public function decrement($key, $value = 1)
+    {
+        return $this->increment($key, $value * -1);
+    }
+
+    /**
+     * Store an item in the cache indefinitely.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function forever($key, $value)
+    {
+        return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Remove an item from the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forget($key)
+    {
+        if ($this->session->exists($this->itemKey($key))) {
+            $this->session->forget($this->itemKey($key));
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove all items from the cache.
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        $this->session->put($this->key, []);
+
+        return true;
+    }
+
+    /**
+     * Get the cache key prefix.
+     *
+     * @return string
+     */
+    public function itemKey($key)
+    {
+        return "{$this->key}.{$key}";
+    }
+
+    /**
+     * Get the cache key prefix.
+     *
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return '';
+    }
+}

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -446,7 +446,7 @@ class Arr
         }
 
         if (! str_contains($key, '.')) {
-            return $array[$key] ?? value($default);
+            return value($default);
         }
 
         foreach (explode('.', $key) as $segment) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,7 +64,7 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): array
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = []): array
     {
         $value = Arr::get($array, $key, $default);
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1386,7 +1386,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -985,7 +985,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1630,17 +1630,22 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Take items in the collection until a given point in time.
+     * Take items in the collection until a given point in time, with an optional callback on timeout.
      *
      * @param  \DateTimeInterface  $timeout
+     * @param  callable(TValue|null, TKey|null): mixed|null  $callback
      * @return static<TKey, TValue>
      */
-    public function takeUntilTimeout(DateTimeInterface $timeout)
+    public function takeUntilTimeout(DateTimeInterface $timeout, ?callable $callback = null)
     {
         $timeout = $timeout->getTimestamp();
 
-        return new static(function () use ($timeout) {
+        return new static(function () use ($timeout, $callback) {
             if ($this->now() >= $timeout) {
+                if ($callback) {
+                    $callback(null, null);
+                }
+
                 return;
             }
 
@@ -1648,6 +1653,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 yield $key => $value;
 
                 if ($this->now() >= $timeout) {
+                    if ($callback) {
+                        $callback($value, $key);
+                    }
+
                     break;
                 }
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1344,7 +1344,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue
@@ -1369,7 +1369,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
-     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -62,7 +62,7 @@ class QuestionHelper extends SymfonyQuestionHelper
 
         if ($question instanceof ChoiceQuestion) {
             foreach ($question->getChoices() as $key => $value) {
-                with(new TwoColumnDetail($output))->render($value, $key);
+                (new TwoColumnDetail($output))->render($value, $key);
             }
         }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -18,7 +18,9 @@ class ScheduleWorkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schedule:work {--run-output-file= : The file to direct <info>schedule:run</info> output to}';
+    protected $signature = 'schedule:work
+        {--run-output-file= : The file to direct <info>schedule:run</info> output to}
+        {--whisper : Do not output message indicating that no jobs were ready to run}';
 
     /**
      * The console command description.
@@ -42,6 +44,10 @@ class ScheduleWorkCommand extends Command
         [$lastExecutionStartedAt, $executions] = [Carbon::now()->subMinutes(10), []];
 
         $command = Application::formatCommandString('schedule:run');
+
+        if ($this->option('whisper')) {
+            $command .= ' --whisper';
+        }
 
         if ($this->option('run-output-file')) {
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';

--- a/src/Illuminate/Console/View/Components/Ask.php
+++ b/src/Illuminate/Console/View/Components/Ask.php
@@ -10,7 +10,7 @@ class Ask extends Component
      * Renders the component using the given arguments.
      *
      * @param  string  $question
-     * @param  string  $default
+     * @param  string|null  $default
      * @param  bool  $multiline
      * @return mixed
      */

--- a/src/Illuminate/Console/View/Components/AskWithCompletion.php
+++ b/src/Illuminate/Console/View/Components/AskWithCompletion.php
@@ -11,7 +11,7 @@ class AskWithCompletion extends Component
      *
      * @param  string  $question
      * @param  array|callable  $choices
-     * @param  string  $default
+     * @param  string|null  $default
      * @return mixed
      */
     public function render($question, $choices, $default = null)

--- a/src/Illuminate/Console/View/Components/Choice.php
+++ b/src/Illuminate/Console/View/Components/Choice.php
@@ -12,7 +12,7 @@ class Choice extends Component
      * @param  string  $question
      * @param  array<array-key, string>  $choices
      * @param  mixed  $default
-     * @param  int  $attempts
+     * @param  int|null  $attempts
      * @param  bool  $multiple
      * @return mixed
      */

--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -103,7 +103,7 @@ abstract class Component
      */
     protected function usingQuestionHelper($callable)
     {
-        $property = with(new ReflectionClass(OutputStyle::class))
+        $property = (new ReflectionClass(OutputStyle::class))
             ->getParentClass()
             ->getProperty('questionHelper');
 

--- a/src/Illuminate/Console/View/Components/Error.php
+++ b/src/Illuminate/Console/View/Components/Error.php
@@ -15,6 +15,6 @@ class Error extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('error', $string, $verbosity);
+        (new Line($this->output))->render('error', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -56,6 +56,6 @@ class Factory
             'Console component [%s] not found.', $method
         )));
 
-        return with(new $component($this->output))->render(...$parameters);
+        return (new $component($this->output))->render(...$parameters);
     }
 }

--- a/src/Illuminate/Console/View/Components/Info.php
+++ b/src/Illuminate/Console/View/Components/Info.php
@@ -15,6 +15,6 @@ class Info extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('info', $string, $verbosity);
+        (new Line($this->output))->render('info', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Success.php
+++ b/src/Illuminate/Console/View/Components/Success.php
@@ -15,6 +15,6 @@ class Success extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))->render('success', $string, $verbosity);
+        (new Line($this->output))->render('success', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/Warn.php
+++ b/src/Illuminate/Console/View/Components/Warn.php
@@ -15,7 +15,6 @@ class Warn extends Component
      */
     public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        with(new Line($this->output))
-            ->render('warn', $string, $verbosity);
+        (new Line($this->output))->render('warn', $string, $verbosity);
     }
 }

--- a/src/Illuminate/Container/Attributes/Give.php
+++ b/src/Illuminate/Container/Attributes/Give.php
@@ -19,7 +19,7 @@ class Give implements ContextualAttribute
      */
     public function __construct(
         public string $class,
-        public array $params = []
+        public array $params = [],
     ) {
     }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -166,7 +166,7 @@ class BoundMethod
         $container,
         $parameter,
         array &$parameters,
-        &$dependencies
+        &$dependencies,
     ) {
         $pendingDependencies = [];
 

--- a/src/Illuminate/Contracts/Database/Eloquent/SupportsPartialRelations.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/SupportsPartialRelations.php
@@ -9,7 +9,7 @@ interface SupportsPartialRelations
      *
      * @param  string|null  $column
      * @param  string|\Closure|null  $aggregate
-     * @param  string  $relation
+     * @param  string|null  $relation
      * @return $this
      */
     public function ofMany($column = 'id', $aggregate = 'MAX', $relation = null);

--- a/src/Illuminate/Database/ConcurrencyErrorDetector.php
+++ b/src/Illuminate/Database/ConcurrencyErrorDetector.php
@@ -33,6 +33,7 @@ class ConcurrencyErrorDetector implements ConcurrencyErrorDetectorContract
             'has been chosen as the deadlock victim',
             'Lock wait timeout exceeded; try restarting transaction',
             'WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction',
+            'Record has changed since last read in table',
         ]);
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -876,7 +876,7 @@ class Connection implements ConnectionInterface
      * Register a callback to be invoked when the connection queries for longer than a given amount of time.
      *
      * @param  \DateTimeInterface|\Carbon\CarbonInterval|float|int  $threshold
-     * @param  (callable(\Illuminate\Database\Connection, class-string<\Illuminate\Database\Events\QueryExecuted>): mixed)  $handler
+     * @param  (callable(\Illuminate\Database\Connection, \Illuminate\Database\Events\QueryExecuted): mixed)  $handler
      * @return void
      */
     public function whenQueryingForLongerThan($threshold, $handler)

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -20,6 +20,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
 
         $connection = $this->createConnection("sqlite:{$path}", $config, $options);
 
+        $this->configurePragmas($connection, $config);
         $this->configureForeignKeyConstraints($connection, $config);
         $this->configureBusyTimeout($connection, $config);
         $this->configureJournalMode($connection, $config);
@@ -60,6 +61,24 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         }
 
         return $path;
+    }
+
+    /**
+     * Set miscellaneous user-configured pragmas.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configurePragmas($connection, array $config): void
+    {
+        if (! isset($config['pragmas'])) {
+            return;
+        }
+
+        foreach ($config['pragmas'] as $pragma => $value) {
+            $connection->prepare("pragma {$pragma} = {$value}")->execute();
+        }
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -96,6 +96,10 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerFakerGenerator()
     {
+        if (! class_exists(FakerGenerator::class)) {
+            return;
+        }
+
         $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
             $locale = $parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US');
 

--- a/src/Illuminate/Database/Eloquent/Attributes/UseResource.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseResource
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<*>  $class
+     */
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/UseResourceCollection.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/UseResourceCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class UseResourceCollection
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<*>  $class
+     */
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -243,6 +243,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Remove all global scopes except the given scopes.
+     *
+     * @param  array  $scopes
+     * @return $this
+     */
+    public function withoutGlobalScopesExcept(array $scopes = [])
+    {
+        $this->withoutGlobalScopes(
+            array_diff(array_keys($this->scopes), $scopes)
+        );
+
+        return $this;
+    }
+
+    /**
      * Get an array of global scopes that were removed from the query.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -80,7 +80,7 @@ class AsCollection implements Castable
      * Specify the collection type for the cast.
      *
      * @param  class-string  $class
-     * @param  array{class-string, string}|class-string  $map
+     * @param  array{class-string, string}|class-string|null  $map
      * @return string
      */
     public static function using($class, $map = null)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -79,7 +79,7 @@ class AsEncryptedCollection implements Castable
      * Specify the collection for the cast.
      *
      * @param  class-string  $class
-     * @param  array{class-string, string}|class-string  $map
+     * @param  array{class-string, string}|class-string|null  $map
      * @return string
      */
     public static function using($class, $map = null)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1788,6 +1788,10 @@ trait HasAttributes
             return false;
         }
 
+        if (is_subclass_of($castType, Castable::class)) {
+            return false;
+        }
+
         return enum_exists($castType);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -837,7 +837,7 @@ trait QueriesRelationships
      *
      * @param  mixed  $relations
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $function
+     * @param  string|null  $function
      * @return $this
      */
     public function withAggregate($relations, $column, $function = null)

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
 use LogicException;
+use ReflectionClass;
 
 trait TransformsToResource
 {
@@ -30,6 +32,12 @@ trait TransformsToResource
      */
     protected function guessResource(): JsonResource
     {
+        $resourceClass = $this->resolveResourceFromAttribute(static::class);
+
+        if ($resourceClass !== null && class_exists($resourceClass)) {
+            return $resourceClass::make($this);
+        }
+
         foreach (static::guessResourceName() as $resourceClass) {
             if (is_string($resourceClass) && class_exists($resourceClass)) {
                 return $resourceClass::make($this);
@@ -66,5 +74,24 @@ trait TransformsToResource
         );
 
         return [$potentialResource.'Resource', $potentialResource];
+    }
+
+    /**
+     * Get the resource class from the class attribute.
+     *
+     * @param  class-string<\Illuminate\Http\Resources\Json\JsonResource>  $class
+     * @return class-string<*>|null
+     */
+    protected function resolveResourceFromAttribute(string $class): ?string
+    {
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        $attributes = (new ReflectionClass($class))->getAttributes(UseResource::class);
+
+        return $attributes !== []
+            ? $attributes[0]->newInstance()->class
+            : null;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -42,7 +42,7 @@ trait TransformsToResource
     /**
      * Guess the resource class name for the model.
      *
-     * @return array<class-string<\Illuminate\Http\Resources\Json\JsonResource>>
+     * @return array{class-string<\Illuminate\Http\Resources\Json\JsonResource>, class-string<\Illuminate\Http\Resources\Json\JsonResource>}
      */
     public static function guessResourceName(): array
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -953,10 +953,14 @@ abstract class Factory
     /**
      * Get a new Faker instance.
      *
-     * @return \Faker\Generator
+     * @return \Faker\Generator|null
      */
     protected function withFaker()
     {
+        if (! class_exists(Generator::class)) {
+            return;
+        }
+
         return Container::getInstance()->make(Generator::class);
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -51,11 +51,13 @@ class Sequence implements Countable
     /**
      * Get the next value in the sequence.
      *
+     * @param  array<string, mixed>  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
      * @return mixed
      */
-    public function __invoke()
+    public function __invoke($attributes = [], $parent = null)
     {
-        return tap(value($this->sequence[$this->index % $this->count], $this), function () {
+        return tap(value($this->sequence[$this->index % $this->count], $this, $attributes, $parent), function () {
             $this->index = $this->index + 1;
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -468,7 +468,7 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  int|null  $perPage
      * @param  array  $columns
      * @param  string  $pageName
-     * @param  int  $page
+     * @param  int|null  $page
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)

--- a/src/Illuminate/Database/Events/ModelPruningStarting.php
+++ b/src/Illuminate/Database/Events/ModelPruningStarting.php
@@ -10,7 +10,7 @@ class ModelPruningStarting
      * @param  array<class-string>  $models  The class names of the models that will be pruned.
      */
     public function __construct(
-        public $models
+        public $models,
     ) {
     }
 }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -82,7 +82,7 @@ class MigrationCreator
      * Ensure that a migration with the given name doesn't already exist.
      *
      * @param  string  $name
-     * @param  string  $migrationPath
+     * @param  string|null  $migrationPath
      * @return void
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -16,7 +16,7 @@ class Expression implements ExpressionContract
      * @param  TValue  $value
      */
     public function __construct(
-        protected $value
+        protected $value,
     ) {
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -46,7 +46,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * Specify which column this foreign ID references on another table.
      *
      * @param  string  $column
-     * @param  string  $indexName
+     * @param  string|null  $indexName
      * @return \Illuminate\Database\Schema\ForeignKeyDefinition
      */
     public function references($column, $indexName = null)

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -16,7 +16,7 @@ class SqliteSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
-        with($process = $this->makeProcess(
+        ($process = $this->makeProcess(
             $this->baseCommand().' ".schema --indent"'
         ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
@@ -39,7 +39,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
-        with($process = $this->makeProcess(
+        ($process = $this->makeProcess(
             $this->baseCommand().' ".dump \''.$this->getMigrationTable().'\'"'
         ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -50,7 +50,7 @@ abstract class Seeder
             $name = get_class($seeder);
 
             if ($silent === false && isset($this->command)) {
-                with(new TwoColumnDetail($this->command->getOutput()))->render(
+                (new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,
                     '<fg=yellow;options=bold>RUNNING</>'
                 );
@@ -63,7 +63,7 @@ abstract class Seeder
             if ($silent === false && isset($this->command)) {
                 $runTime = number_format((microtime(true) - $startTime) * 1000);
 
-                with(new TwoColumnDetail($this->command->getOutput()))->render(
+                (new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,
                     "<fg=gray>$runTime ms</> <fg=green;options=bold>DONE</>"
                 );

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -555,8 +555,8 @@ class Middleware
     /**
      * Configure where users are redirected by the authentication and guest middleware.
      *
-     * @param  callable|string  $guests
-     * @param  callable|string  $users
+     * @param  callable|string|null  $guests
+     * @param  callable|string|null  $users
      * @return $this
      */
     public function redirectTo(callable|string|null $guests = null, callable|string|null $users = null)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1046,12 +1046,12 @@ class Handler implements ExceptionHandlerContract
             if (! empty($alternatives = $e->getAlternatives())) {
                 $message .= '. Did you mean one of these?';
 
-                with(new Error($output))->render($message);
-                with(new BulletList($output))->render($alternatives);
+                (new Error($output))->render($message);
+                (new BulletList($output))->render($alternatives);
 
                 $output->writeln('');
             } else {
-                with(new Error($output))->render($message);
+                (new Error($output))->render($message);
             }
 
             return;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -285,7 +285,7 @@ trait InteractsWithDatabase
      * Get the database connection.
      *
      * @param  string|null  $connection
-     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|class-string<\Illuminate\Database\Eloquent\Model>|string|null  $table
      * @return \Illuminate\Database\Connection
      */
     protected function getConnection($connection = null, $table = null)

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -250,7 +250,7 @@ trait InteractsWithInput
     /**
      * Retrieve data from the instance.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  mixed  $default
      * @return mixed
      */

--- a/src/Illuminate/Http/Exceptions/HttpResponseException.php
+++ b/src/Illuminate/Http/Exceptions/HttpResponseException.php
@@ -19,7 +19,7 @@ class HttpResponseException extends RuntimeException
      * Create a new HTTP response exception instance.
      *
      * @param  \Symfony\Component\HttpFoundation\Response  $response
-     * @param  \Throwable  $previous
+     * @param  \Throwable|null  $previous
      */
     public function __construct(Response $response, ?Throwable $previous = null)
     {

--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -24,7 +24,7 @@ class AddLinkHeadersForPreloadedAssets
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  int  $limit
+     * @param  int|null  $limit
      * @return \Illuminate\Http\Response
      */
     public function handle($request, $next, $limit = null)

--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -14,7 +14,7 @@ class MessageLogged
     public function __construct(
         public $level,
         public $message,
-        public array $context = []
+        public array $context = [],
     ) {
     }
 }

--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -5,37 +5,16 @@ namespace Illuminate\Log\Events;
 class MessageLogged
 {
     /**
-     * The log "level".
-     *
-     * @var string
-     */
-    public $level;
-
-    /**
-     * The log message.
-     *
-     * @var string
-     */
-    public $message;
-
-    /**
-     * The log context.
-     *
-     * @var array
-     */
-    public $context;
-
-    /**
      * Create a new event instance.
      *
-     * @param  string  $level
-     * @param  string  $message
-     * @param  array  $context
+     * @param  "emergency"|"alert"|"critical"|"error"|"warning"|"notice"|"info"|"debug"  $level  The log "level".
+     * @param  string  $message  The log message.
+     * @param  array  $context  The log context.
      */
-    public function __construct($level, $message, array $context = [])
-    {
-        $this->level = $level;
-        $this->message = $message;
-        $this->context = $context;
+    public function __construct(
+        public $level,
+        public $message,
+        public array $context = []
+    ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -14,7 +14,7 @@ class WorkerStarting
     public function __construct(
         public $connectionName,
         public $queue,
-        public $workerOptions
+        public $workerOptions,
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerStopping.php
+++ b/src/Illuminate/Queue/Events/WorkerStopping.php
@@ -12,7 +12,7 @@ class WorkerStopping
      */
     public function __construct(
         public $status = 0,
-        public $workerOptions = null
+        public $workerOptions = null,
     ) {
     }
 }

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -211,7 +211,7 @@ trait InteractsWithQueue
     /**
      * Assert that the job was released back onto the queue.
      *
-     * @param  \DateTimeInterface|\DateInterval|int  $delay
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @return $this
      */
     public function assertReleased($delay = null)

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -170,7 +170,7 @@ abstract class Connection
     }
 
     /**
-     * Set the connections name.
+     * Set the connection's name.
      *
      * @param  string  $name
      * @return $this

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -143,6 +143,11 @@ class PhpRedisConnector implements Connector
             if (array_key_exists('compression_level', $config)) {
                 $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $config['compression_level']);
             }
+
+            if (defined('Redis::OPT_PACK_IGNORE_NUMBERS') &&
+                array_key_exists('pack_ignore_numbers', $config)) {
+                $client->setOption(Redis::OPT_PACK_IGNORE_NUMBERS, $config['pack_ignore_numbers']);
+            }
         });
     }
 

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -198,7 +198,7 @@ class PendingResourceRegistration
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {

--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -222,7 +222,7 @@ class PendingSingletonResourceRegistration
      * Specify middleware that should be removed from the resource routes.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -79,7 +79,7 @@ class RouteCollection extends AbstractRouteCollection
         // If the route has a name, we will add it to the name look-up table, so that we
         // will quickly be able to find the route associated with a name and not have
         // to iterate through every route every time we need to find a named route.
-        if ($name = $route->getName()) {
+        if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
             $this->nameList[$name] = $route;
         }
 
@@ -88,7 +88,7 @@ class RouteCollection extends AbstractRouteCollection
         // processing a request and easily generate URLs to the given controllers.
         $action = $route->getAction();
 
-        if (isset($action['controller'])) {
+        if (($controller = $action['controller'] ?? null) && ! $this->inActionLookup($controller)) {
             $this->addToActionList($action, $route);
         }
     }
@@ -106,6 +106,28 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Determine if the given controller is in the action lookup table.
+     *
+     * @param  string  $controller
+     * @return bool
+     */
+    protected function inActionLookup($controller)
+    {
+        return array_key_exists($controller, $this->actionList);
+    }
+
+    /**
+     * Determine if the given name is in the name lookup table.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function inNameLookup($name)
+    {
+        return array_key_exists($name, $this->nameList);
+    }
+
+    /**
      * Refresh the name look-up table.
      *
      * This is done in case any names are fluently defined or if routes are overwritten.
@@ -117,8 +139,8 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-            if ($route->getName()) {
-                $this->nameList[$route->getName()] = $route;
+            if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
+                $this->nameList[$name] = $route;
             }
         }
     }
@@ -135,7 +157,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->actionList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (isset($route->getAction()['controller'])) {
+            if (($controller = $route->getAction()['controller'] ?? null) && ! $this->inActionLookup($controller)) {
                 $this->addToActionList($route->getAction(), $route);
             }
         }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -117,7 +117,7 @@ class RouteUrlGenerator
      *
      * @param  \Illuminate\Routing\Route  $route
      * @param  array  $parameters
-     * @return string
+     * @return string|null
      */
     protected function getRouteDomain($route, &$parameters)
     {

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -537,6 +538,16 @@ class Store implements Session
     public function flashInput(array $value)
     {
         $this->flash('_old_input', $value);
+    }
+
+    /**
+     * Get the session cache instance.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    public function cache()
+    {
+        return Cache::store('session');
     }
 
     /**

--- a/src/Illuminate/Support/AggregateServiceProvider.php
+++ b/src/Illuminate/Support/AggregateServiceProvider.php
@@ -7,14 +7,14 @@ class AggregateServiceProvider extends ServiceProvider
     /**
      * The provider class names.
      *
-     * @var array
+     * @var array<int, class-string<\Illuminate\Support\ServiceProvider>>
      */
     protected $providers = [];
 
     /**
      * An array of the service provider instances.
      *
-     * @var array
+     * @var array<int, \Illuminate\Support\ServiceProvider>
      */
     protected $instances = [];
 
@@ -35,7 +35,7 @@ class AggregateServiceProvider extends ServiceProvider
     /**
      * Get the services provided by the provider.
      *
-     * @return array
+     * @return array<int, string>
      */
     public function provides()
     {

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -285,7 +285,7 @@ class Env
      */
     protected static function prepareQuotedValue(string $input)
     {
-        return strpos($input, '"') !== false
+        return str_contains($input, '"')
             ? "'".self::addSlashesExceptFor($input, ['"'])."'"
             : '"'.self::addSlashesExceptFor($input, ["'"]).'"';
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -117,7 +117,7 @@ class Http extends Facade
     /**
      * Register a stub callable that will intercept requests and be able to return stub responses.
      *
-     * @param  \Closure|array  $callback
+     * @param  \Closure|array|null  $callback
      * @return \Illuminate\Http\Client\Factory
      */
     public static function fake($callback = null)

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -41,6 +41,7 @@ namespace Illuminate\Support\Facades;
  * @method static void reflash()
  * @method static void keep(mixed $keys = null)
  * @method static void flashInput(array $value)
+ * @method static \Illuminate\Contracts\Cache\Repository cache()
  * @method static mixed remove(string $key)
  * @method static void forget(string|array $keys)
  * @method static void flush()

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -153,7 +153,7 @@ class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, Jso
     /**
      * Get data from the fluent instance.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  mixed  $default
      * @return mixed
      */

--- a/src/Illuminate/Support/InteractsWithTime.php
+++ b/src/Illuminate/Support/InteractsWithTime.php
@@ -67,7 +67,7 @@ trait InteractsWithTime
      * Given a start time, format the total run time for human readability.
      *
      * @param  float  $startTime
-     * @param  float  $endTime
+     * @param  float|null  $endTime
      * @return string
      */
     protected function runTimeForHumans($startTime, $endTime = null)

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -547,7 +547,7 @@ abstract class ServiceProvider
      * Add the given provider to the application's provider bootstrap file.
      *
      * @param  string  $provider
-     * @param  string  $path
+     * @param  string|null  $path
      * @return bool
      */
     public static function addProviderToBootstrapFile(string $provider, ?string $path = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1045,7 +1045,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Trim the string of the given characters.
      *
-     * @param  string  $characters
+     * @param  string|null  $characters
      * @return static
      */
     public function trim($characters = null)
@@ -1056,7 +1056,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Left trim the string of the given characters.
      *
-     * @param  string  $characters
+     * @param  string|null  $characters
      * @return static
      */
     public function ltrim($characters = null)
@@ -1067,7 +1067,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Right trim the string of the given characters.
      *
-     * @param  string  $characters
+     * @param  string|null  $characters
      * @return static
      */
     public function rtrim($characters = null)

--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -18,7 +18,7 @@ class FilterEmailValidation implements EmailValidation
     /**
      * Create a new validation instance.
      *
-     * @param  int  $flags
+     * @param  int|null  $flags
      */
     public function __construct($flags = null)
     {

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -598,7 +598,7 @@ trait ReplacesAttributes
      * @param  array<int,string>  $parameters
      * @return string
      */
-    public function replaceRequiredIfDeclined($message, $attribute, $rule, $parameters)
+    protected function replaceRequiredIfDeclined($message, $attribute, $rule, $parameters)
     {
         return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }
@@ -662,7 +662,7 @@ trait ReplacesAttributes
      * @param  array<int,string>  $parameters
      * @return string
      */
-    public function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
+    protected function replaceProhibitedIfDeclined($message, $attribute, $rule, $parameters)
     {
         return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -309,7 +309,7 @@ class Validator implements ValidatorContract
     /**
      * The current random hash for the validator.
      *
-     * @var string
+     * @var string|null
      */
     protected static $placeholderHash;
 

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\View;
 
+use BackedEnum;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\ComponentTagCompiler;
+
+use function Illuminate\Support\enum_value;
 
 class DynamicComponent extends Component
 {
@@ -33,11 +36,11 @@ class DynamicComponent extends Component
     /**
      * Create a new component instance.
      *
-     * @param  string  $component
+     * @param  \BackedEnum|string  $component
      */
-    public function __construct(string $component)
+    public function __construct(BackedEnum|string $component)
     {
-        $this->component = $component;
+        $this->component = (string) enum_value($component);
     }
 
     /**

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\SessionStore;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class CacheSessionStoreTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
+    public function testItemsCanBeSetAndRetrieved()
+    {
+        $store = new SessionStore(self::getSession());
+        $result = $store->put('foo', 'bar', 10);
+        $this->assertTrue($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testCacheTtl(): void
+    {
+        $store = new SessionStore(self::getSession());
+
+        Carbon::setTestNow('2000-01-01 00:00:00.500'); // 500 milliseconds past
+        $store->put('hello', 'world', 1);
+
+        Carbon::setTestNow('2000-01-01 00:00:01.499'); // progress 0.999 seconds
+        $this->assertSame('world', $store->get('hello'));
+
+        Carbon::setTestNow('2000-01-01 00:00:01.500'); // progress 0.001 seconds. 1 second since putting into cache.
+        $this->assertNull($store->get('hello'));
+    }
+
+    public function testMultipleItemsCanBeSetAndRetrieved()
+    {
+        $store = new SessionStore(self::getSession());
+        $result = $store->put('foo', 'bar', 10);
+        $resultMany = $store->putMany([
+            'fizz' => 'buz',
+            'quz' => 'baz',
+        ], 10);
+        $this->assertTrue($result);
+        $this->assertTrue($resultMany);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'fizz' => 'buz',
+            'quz' => 'baz',
+            'norf' => null,
+        ], $store->many(['foo', 'fizz', 'quz', 'norf']));
+    }
+
+    public function testItemsCanExpire()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new SessionStore(self::getSession());
+
+        $store->put('foo', 'bar', 10);
+        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        $result = $store->get('foo');
+
+        $this->assertNull($result);
+    }
+
+    public function testStoreItemForeverProperlyStoresInArray()
+    {
+        $mock = $this->getMockBuilder(SessionStore::class)
+            ->setConstructorArgs([self::getSession()])
+            ->onlyMethods(['put'])
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
+            ->willReturn(true);
+        $result = $mock->forever('foo', 'bar');
+        $this->assertTrue($result);
+    }
+
+    public function testValuesCanBeIncremented()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 1, 10);
+        $result = $store->increment('foo');
+        $this->assertEquals(2, $result);
+        $this->assertEquals(2, $store->get('foo'));
+
+        $result = $store->increment('foo', 2);
+        $this->assertEquals(4, $result);
+        $this->assertEquals(4, $store->get('foo'));
+    }
+
+    public function testValuesGetCastedByIncrementOrDecrement()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', '1', 10);
+        $result = $store->increment('foo');
+        $this->assertEquals(2, $result);
+        $this->assertEquals(2, $store->get('foo'));
+
+        $store->put('bar', '1', 10);
+        $result = $store->decrement('bar');
+        $this->assertEquals(0, $result);
+        $this->assertEquals(0, $store->get('bar'));
+    }
+
+    public function testIncrementNonNumericValues()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'I am string', 10);
+        $result = $store->increment('foo');
+        $this->assertEquals(1, $result);
+        $this->assertEquals(1, $store->get('foo'));
+    }
+
+    public function testNonExistingKeysCanBeIncremented()
+    {
+        $store = new SessionStore(self::getSession());
+        $result = $store->increment('foo');
+        $this->assertEquals(1, $result);
+        $this->assertEquals(1, $store->get('foo'));
+
+        // Will be there forever
+        Carbon::setTestNow(Carbon::now()->addYears(10));
+        $this->assertEquals(1, $store->get('foo'));
+    }
+
+    public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new SessionStore(self::getSession());
+
+        $store->put('foo', 999, 10);
+        Carbon::setTestNow(Carbon::now()->addSeconds(10)->addSecond());
+        $result = $store->increment('foo');
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testValuesCanBeDecremented()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 1, 10);
+        $result = $store->decrement('foo');
+        $this->assertEquals(0, $result);
+        $this->assertEquals(0, $store->get('foo'));
+
+        $result = $store->decrement('foo', 2);
+        $this->assertEquals(-2, $result);
+        $this->assertEquals(-2, $store->get('foo'));
+    }
+
+    public function testItemsCanBeRemoved()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'bar', 10);
+        $this->assertTrue($store->forget('foo'));
+        $this->assertNull($store->get('foo'));
+        $this->assertFalse($store->forget('foo'));
+    }
+
+    public function testItemsCanBeFlushed()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'bar', 10);
+        $store->put('baz', 'boom', 10);
+        $result = $store->flush();
+        $this->assertTrue($result);
+        $this->assertNull($store->get('foo'));
+        $this->assertNull($store->get('baz'));
+    }
+
+    public function testCacheKey()
+    {
+        $store = new SessionStore(self::getSession());
+        $this->assertEmpty($store->getPrefix());
+    }
+
+    public function testItemKey()
+    {
+        $store = new SessionStore(self::getSession(), 'custom_prefix');
+        $this->assertEquals('custom_prefix.foo', $store->itemKey('foo'));
+    }
+
+    public function testValuesAreStoredByReference()
+    {
+        $store = new SessionStore(self::getSession());
+        $object = new stdClass;
+        $object->foo = true;
+
+        $store->put('object', $object, 10);
+        $object->bar = true;
+
+        $retrievedObject = $store->get('object');
+
+        $this->assertTrue($retrievedObject->foo);
+        $this->assertTrue($retrievedObject->bar);
+    }
+
+    public function testCanGetAll()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'bar', 10);
+
+        $this->assertEquals([
+            'foo' => ['value' => 'bar', 'expiresAt' => Carbon::now()->addSeconds(10)->getPreciseTimestamp(3) / 1000],
+        ], $store->all());
+    }
+
+    protected static function getSession()
+    {
+        return new Store(
+            name: 'name',
+            serialization: 'php',
+            handler: new ArraySessionHandler(10),
+            id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        );
+    }
+}

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -21,7 +21,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Alert($output))->render('The application is in the [production] environment');
+        (new Components\Alert($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString(
             'THE APPLICATION IS IN THE [PRODUCTION] ENVIRONMENT.',
@@ -33,7 +33,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\BulletList($output))->render([
+        (new Components\BulletList($output))->render([
             'ls -la',
             'php artisan inspire',
         ]);
@@ -48,7 +48,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Success($output))->render('The application is in the [production] environment');
+        (new Components\Success($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('SUCCESS  The application is in the [production] environment.', $output->fetch());
     }
@@ -57,7 +57,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Error($output))->render('The application is in the [production] environment');
+        (new Components\Error($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('ERROR  The application is in the [production] environment.', $output->fetch());
     }
@@ -66,7 +66,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Info($output))->render('The application is in the [production] environment');
+        (new Components\Info($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('INFO  The application is in the [production] environment.', $output->fetch());
     }
@@ -80,7 +80,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturnTrue();
 
-        $result = with(new Components\Confirm($output))->render('Question?');
+        $result = (new Components\Confirm($output))->render('Question?');
         $this->assertTrue($result);
 
         $output->shouldReceive('confirm')
@@ -88,7 +88,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturnTrue();
 
-        $result = with(new Components\Confirm($output))->render('Question?', true);
+        $result = (new Components\Confirm($output))->render('Question?', true);
         $this->assertTrue($result);
     }
 
@@ -101,7 +101,7 @@ class ComponentsTest extends TestCase
             ->once()
             ->andReturn('a');
 
-        $result = with(new Components\Choice($output))->render('Question?', ['a', 'b']);
+        $result = (new Components\Choice($output))->render('Question?', ['a', 'b']);
         $this->assertSame('a', $result);
     }
 
@@ -109,17 +109,17 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Success->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Success->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('DONE', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Failure->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Failure->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('FAIL', $result);
 
-        with(new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped->value);
+        (new Components\Task($output))->render('My task', fn () => MigrationResult::Skipped->value);
         $result = $output->fetch();
         $this->assertStringContainsString('My task', $result);
         $this->assertStringContainsString('SKIPPED', $result);
@@ -129,7 +129,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\TwoColumnDetail($output))->render('First', 'Second');
+        (new Components\TwoColumnDetail($output))->render('First', 'Second');
         $result = $output->fetch();
         $this->assertStringContainsString('First', $result);
         $this->assertStringContainsString('Second', $result);
@@ -139,7 +139,7 @@ class ComponentsTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        with(new Components\Warn($output))->render('The application is in the [production] environment');
+        (new Components\Warn($output))->render('The application is in the [production] environment');
 
         $this->assertStringContainsString('WARN  The application is in the [production] environment.', $output->fetch());
     }

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -108,6 +108,18 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
+    public function testAllGlobalScopesCanBeRemovedExceptSpecified()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel;
+        $query = $model->newQuery()->withoutGlobalScopesExcept(['active_scope']);
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+
+        $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopesExcept(['active_scope']);
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testGlobalScopesWithOrWhereConditionsAreNested()
     {
         $model = new EloquentClosureGlobalScopesWithOrTestModel;

--- a/tests/Database/DatabaseEloquentResourceCollectionTest.php
+++ b/tests/Database/DatabaseEloquentResourceCollectionTest.php
@@ -3,8 +3,14 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceCollectionTestModel;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceAttribute;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceCollectionAttribute;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceCollectionTestResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResourceCollection;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceCollectionTest extends TestCase
@@ -43,9 +49,27 @@ class DatabaseEloquentResourceCollectionTest extends TestCase
 
         $this->assertInstanceOf(JsonResource::class, $resource);
     }
-}
 
-class EloquentResourceCollectionTestResource extends JsonResource
-{
-    //
+    public function testItCanTransformToResourceViaUseResourceAttribute()
+    {
+        $collection = new Collection([
+            new EloquentResourceTestResourceModelWithUseResourceCollectionAttribute(),
+        ]);
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(EloquentResourceTestJsonResourceCollection::class, $resource);
+    }
+
+    public function testItCanTransformToResourceViaUseResourceCollectionAttribute()
+    {
+        $collection = new Collection([
+            new EloquentResourceTestResourceModelWithUseResourceAttribute(),
+        ]);
+
+        $resource = $collection->toResourceCollection();
+
+        $this->assertInstanceOf(AnonymousResourceCollection::class, $resource);
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource[0]);
+    }
 }

--- a/tests/Database/DatabaseEloquentResourceModelTest.php
+++ b/tests/Database/DatabaseEloquentResourceModelTest.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModel;
 use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithGuessableResource;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentResourceTestResourceModelWithUseResourceAttribute;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentResourceModelTest extends TestCase
@@ -59,9 +60,14 @@ class DatabaseEloquentResourceModelTest extends TestCase
             'Illuminate\Tests\Database\Fixtures\Http\Resources\EloquentResourceTestResourceModel',
         ], $model::guessResourceName());
     }
-}
 
-class EloquentResourceTestJsonResource extends JsonResource
-{
-    //
+    public function testItCanTransformToResourceViaUseResourceAttribute()
+    {
+        $model = new EloquentResourceTestResourceModelWithUseResourceAttribute();
+
+        $resource = $model->toResource();
+
+        $this->assertInstanceOf(EloquentResourceTestJsonResource::class, $resource);
+        $this->assertSame($model, $resource->resource);
+    }
 }

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -109,6 +109,31 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertCount(1, $manager->getPendingTransactions()[2]->getCallbacks());
     }
 
+    public function testCallbacksRunInFifoOrder()
+    {
+        $manager = (new DatabaseTransactionsManager);
+
+        $order = [];
+
+        $manager->begin('default', 1);
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 1;
+        });
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 2;
+        });
+
+        $manager->addCallback(function () use (&$order) {
+            $order[] = 3;
+        });
+
+        $manager->commit('default', 1, 0);
+
+        $this->assertSame([1, 2, 3], $order);
+    }
+
     public function testCommittingTransactionsExecutesCallbacks()
     {
         $callbacks = [];

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceAttribute.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseResource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResource;
+
+#[UseResource(EloquentResourceTestJsonResource::class)]
+class EloquentResourceTestResourceModelWithUseResourceAttribute extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceCollectionAttribute.php
+++ b/tests/Database/Fixtures/Models/EloquentResourceTestResourceModelWithUseResourceCollectionAttribute.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseResourceCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Resources\EloquentResourceTestJsonResourceCollection;
+
+#[UseResourceCollection(EloquentResourceTestJsonResourceCollection::class)]
+class EloquentResourceTestResourceModelWithUseResourceCollectionAttribute extends Model
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceCollectionTestResource.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceCollectionTestResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EloquentResourceCollectionTestResource extends JsonResource
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResource.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EloquentResourceTestJsonResource extends JsonResource
+{
+    //
+}

--- a/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResourceCollection.php
+++ b/tests/Database/Fixtures/Resources/EloquentResourceTestJsonResourceCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class EloquentResourceTestJsonResourceCollection extends ResourceCollection
+{
+    //
+}

--- a/tests/Integration/Database/Sqlite/ConnectorTest.php
+++ b/tests/Integration/Database/Sqlite/ConnectorTest.php
@@ -41,12 +41,16 @@ class ConnectorTest extends DatabaseTestCase
             'busy_timeout' => 12345,
             'journal_mode' => 'wal',
             'synchronous' => 'normal',
+            'pragmas' => [
+                'query_only' => true,
+            ],
         ])->getSchemaBuilder();
 
         $this->assertSame(1, $schema->pragma('foreign_keys'));
         $this->assertSame(12345, $schema->pragma('busy_timeout'));
         $this->assertSame('wal', $schema->pragma('journal_mode'));
         $this->assertSame(1, $schema->pragma('synchronous'));
+        $this->assertSame(1, $schema->pragma('query_only'));
 
         $schema->pragma('foreign_keys', 0);
         $schema->pragma('busy_timeout', 54321);

--- a/tests/Integration/Routing/Fixtures/app.php
+++ b/tests/Integration/Routing/Fixtures/app.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Illuminate\Foundation\Application;
+
+if (! class_exists(AppCache::class)) {
+    class AppCache
+    {
+        public static $app;
+    }
+}
+
+if (isset($refresh)) {
+    return AppCache::$app = Application::configure(basePath: __DIR__)->create();
+} else {
+    return AppCache::$app ??= Application::configure(basePath: __DIR__)->create();
+}

--- a/tests/Integration/Routing/Fixtures/bootstrap/cache/.gitignore
+++ b/tests/Integration/Routing/Fixtures/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Integration/Routing/Fixtures/cache/.gitignore
+++ b/tests/Integration/Routing/Fixtures/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -719,6 +719,8 @@ class RouteRegistrarTest extends TestCase
     public function testCanSetScopedOptionOnRegisteredResource()
     {
         $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped();
+        $this->router->getRoutes()->refreshNameLookups();
+
         $this->assertSame(
             ['user' => null],
             $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
@@ -731,6 +733,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped([
             'task' => 'slug',
         ]);
+        $this->router->getRoutes()->refreshNameLookups();
         $this->assertSame(
             ['user' => null],
             $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
@@ -904,6 +907,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor('index', RouteRegistrarMiddlewareStub::class)
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two']);
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), ['default', RouteRegistrarMiddlewareStub::class]);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
@@ -918,6 +922,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two'])
             ->middleware('default');
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.index')->gatherMiddleware(), [RouteRegistrarMiddlewareStub::class, 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
@@ -1448,6 +1453,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor('show', RouteRegistrarMiddlewareStub::class)
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two']);
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['default', 'one']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['default', 'one']);
@@ -1463,6 +1469,7 @@ class RouteRegistrarTest extends TestCase
             ->middlewareFor(['create', 'store'], 'one')
             ->middlewareFor(['edit'], ['one', 'two'])
             ->middleware('default');
+        $this->router->getRoutes()->refreshNameLookups();
 
         $this->assertEquals($this->router->getRoutes()->getByName('users.create')->gatherMiddleware(), ['one', 'default']);
         $this->assertEquals($this->router->getRoutes()->getByName('users.store')->gatherMiddleware(), ['one', 'default']);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1595,7 +1595,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1595,8 +1595,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
+        $items[$temp = new class {
         }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -664,6 +664,13 @@ class SupportArrTest extends TestCase
         Arr::array($test_array, 'string');
     }
 
+    public function testItReturnsEmptyArrayForMissingKeyByDefault()
+    {
+        $data = ['name' => 'Taylor'];
+
+        $this->assertSame([], Arr::array($data, 'missing_key'));
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1595,8 +1595,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {
-        }] = 'bar';
+        $items[$temp = new class {}] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1493,6 +1493,12 @@ class SupportHelpersTest extends TestCase
             ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
             ['//', [], '', ''],
             ['/%s/', ['a'], '', ''],
+            // non-sequential numeric keys → should still consume in natural order
+            ['/%s/', [2 => 'A', 10 => 'B'], '%s %s', 'A B'],
+            // associative keys → order should be insertion order, not keys/pointer
+            ['/%s/', ['first' => 'A', 'second' => 'B'], '%s %s', 'A B'],
+            // values that are "falsy" but must not be treated as empty by mistake, false->'' , null->''
+            ['/%s/', ['0', 0, false, null], '%s|%s|%s|%s', '0|0||'],
             // The internal pointer of this array is not at the beginning
             ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'],
         ];

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -186,6 +186,8 @@ class SupportLazyCollectionTest extends TestCase
 
         $mock = m::mock(LazyCollection::class.'[now]');
 
+        $timedOutWith = [];
+
         $results = $mock
             ->times(10)
             ->tap(function ($collection) use ($mock, $timeout) {
@@ -200,10 +202,13 @@ class SupportLazyCollectionTest extends TestCase
                         $timeout->getTimestamp()
                     );
             })
-            ->takeUntilTimeout($timeout)
+            ->takeUntilTimeout($timeout, function ($value, $key) use (&$timedOutWith) {
+                $timedOutWith = [$value, $key];
+            })
             ->all();
 
         $this->assertSame([1, 2], $results);
+        $this->assertSame([2, 1], $timedOutWith);
 
         m::close();
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1357,8 +1357,8 @@ class SupportStrTest extends TestCase
         $this->assertEquals(2, Str::wordCount('Hello, world!'));
         $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
 
-        // $this->assertEquals(0, Str::wordCount('мама'));
-        // $this->assertEquals(0, Str::wordCount('мама мыла раму'));
+        $this->assertEquals(0, Str::wordCount('мама'));
+        $this->assertEquals(0, Str::wordCount('мама мыла раму'));
 
         $this->assertEquals(1, Str::wordCount('мама', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
         $this->assertEquals(3, Str::wordCount('мама мыла раму', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -751,6 +751,10 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUnti
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime()));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime(), function ($user, $int) {
+    assertType('User|null', $user);
+    // assertType('int|null', $int);
+}));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeWhile(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeWhile(new User));


### PR DESCRIPTION
This PR updates the Arr::array() method to use an empty array ([]) as the default return value when no key exists, instead of null.

Previously, the method signature allowed a null default (?array $default = null), but this created a mismatch with the strict : array return type. If a developer passed null as the default, the method would still throw an exception because null is not an array.