### PR TITLE
[Support] Fix Arr::array to return [] by default

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,7 +64,7 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): array
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = []): array
     {
         $value = Arr::get($array, $key, $default);
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -65,33 +65,23 @@ class Arr
      * Get an array item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|null     $key
-     * @param  array|null          $default
-     * @param  bool                $throwOnNotFound
+     * @param  string|int|null  $key
+     * @param  array|null  $default
+     * @param  bool  $throwOnNotFound
      * @return array
      *
      * @throws \InvalidArgumentException
      * @throws \Illuminate\Support\ItemNotFoundException
      */
-    public static function array(
-        ArrayAccess|array $array,
-        string|int|null $key,
-        array $default = [],
-        bool $throwOnNotFound = false
-    ): array {
-
-        if(! Arr::has($array, $key)){
-
-            if ($throwOnNotFound) {
-                throw new ItemNotFoundException(
-                    sprintf('Array key [%s] not found.', $key)
-                );
-            }
-
-            return $default;
-        }
-
+    public static function array(ArrayAccess|array $array, string|int|null $key, array $default = [], bool $throwOnNotFound = false): array
+    {
         $value = Arr::get($array, $key, $default);
+
+        if ($throwOnNotFound && $value === $default && ! Arr::has($array, $key)) {
+            throw new ItemNotFoundException(
+                sprintf('Array key [%s] not found.', $key)
+            );
+        }
 
         if (! is_array($value)) {
             throw new InvalidArgumentException(

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -77,7 +77,7 @@ class Arr
     {
         $value = Arr::get($array, $key, $default);
 
-        if ($throwOnNotFound && $value === $default && ! Arr::has($array, $key)) {
+        if ($throwOnNotFound && ! Arr::has($array, $key)) {
             throw new ItemNotFoundException(
                 sprintf('Array key [%s] not found.', $key)
             );

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -63,9 +63,34 @@ class Arr
 
     /**
      * Get an array item from an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null     $key
+     * @param  array|null          $default
+     * @param  bool                $throwOnNotFound
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Illuminate\Support\ItemNotFoundException
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = []): array
-    {
+    public static function array(
+        ArrayAccess|array $array,
+        string|int|null $key,
+        array $default = [],
+        bool $throwOnNotFound = false
+    ): array {
+
+        if(! Arr::has($array, $key)){
+
+            if ($throwOnNotFound) {
+                throw new ItemNotFoundException(
+                    sprintf('Array key [%s] not found.', $key)
+                );
+            }
+
+            return $default;
+        }
+
         $value = Arr::get($array, $key, $default);
 
         if (! is_array($value)) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1648,9 +1648,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class
-        {
-        }] = 'bar';
+        $items[$temp = new class{}] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -671,6 +671,61 @@ class SupportArrTest extends TestCase
         $this->assertSame([], Arr::array($data, 'missing_key'));
     }
 
+    public function test_it_throws_item_not_found_exception_when_array_is_empty_and_throw_on_not_found_is_true()
+    {
+        $this->expectException(ItemNotFoundException::class);
+        $this->expectExceptionMessage('Array key [roles] not found.');
+
+        $data = [];
+
+        Arr::array($data, 'roles', [], true);
+    }
+
+    public function test_it_throws_item_not_found_exception_when_key_is_missing_and_throw_on_not_found_is_true()
+    {
+        $this->expectException(ItemNotFoundException::class);
+        $this->expectExceptionMessage('Array key [roles] not found.');
+
+        $data = ['name' => 'Taylor'];
+
+        Arr::array($data, 'roles', [], true);
+    }
+
+    public function test_it_supports_nested_keys_with_dot_notation()
+    {
+        $data = ['user' => ['roles' => ['admin']]];
+
+        $result = Arr::array($data, 'user.roles');
+
+        $this->assertSame(['admin'], $result);
+    }
+
+    public function test_it_throws_for_nested_non_array_value()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches(
+            '#^Array value for key \[user.name\] must be an array, string found.#'
+        );
+
+        $data = ['user' => ['name' => 'Taylor']];
+
+        Arr::array($data, 'user.name');
+    }
+
+    public function test_it_should_not_throw_when_key_exists_even_if_equal_to_default()
+    {
+        $data = ['roles' => []];
+
+        // In the current (buggy) version without Arr::has(),
+        // this will wrongly throw ItemNotFoundException
+        // because $value === $default ([] === []).
+        $result = Arr::array($data, 'roles', [], true);
+
+        $this->assertSame([], $result); // expected to return the actual empty array
+    }
+
+
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -724,8 +724,6 @@ class SupportArrTest extends TestCase
         $this->assertSame([], $result); // expected to return the actual empty array
     }
 
-
-
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];
@@ -1650,7 +1648,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1648,7 +1648,7 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class{}] = 'bar';
+        $items[$temp = new class {}] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -664,6 +664,13 @@ class SupportArrTest extends TestCase
         Arr::array($test_array, 'string');
     }
 
+    public function testItReturnsEmptyArrayForMissingKeyByDefault()
+    {
+        $data = ['name' => 'Taylor'];
+
+        $this->assertSame([], Arr::array($data, 'missing_key'));
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
This PR updates the Arr::array() method to use an empty array ([]) as the default return value when no key exists, instead of null.

Previously, the method signature allowed a null default (?array $default = null), but this created a mismatch with the strict : array return type. If a developer passed null as the default, the method would still throw an exception because null is not an array.