### PR TITLE
[12.x] Enable dynamic tries() method on Queueable Listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -705,7 +705,7 @@ class Dispatcher implements DispatcherContract
             $job->shouldBeEncrypted = $listener instanceof ShouldBeEncrypted;
             $job->timeout = $listener->timeout ?? null;
             $job->failOnTimeout = $listener->failOnTimeout ?? false;
-            $job->tries = $listener->tries ?? null;
+            $job->tries = method_exists($listener, 'tries') ? $listener->tries(...$data) : ($listener->tries ?? null);
 
             $job->through(array_merge(
                 method_exists($listener, 'middleware') ? $listener->middleware(...$data) : [],


### PR DESCRIPTION
### Overview

It would be cool to be able to allow dynamic tries configuration on Listeners via a tries() method, like Jobs. Right now it is possible only using `tries` property. Enabling tries method gives us the flexibility to add more dynamic values ( ex from a config file or based on the Listener's data)

### Example

```
class TestListener implements ShouldQueue
{
    public function tries(): int
    {
        return config('myfeature.listener.tries');
    }

    ....
```
The above is now allowed and it will propagate the returned tries from the method to the CallQueuedListener.
