### PR TITLE
[12.x]feat: Support custom response classes without modifying the exception handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -22,7 +22,6 @@ use Illuminate\Database\RecordNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Renderer\Renderer;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
@@ -985,7 +984,7 @@ class Handler implements ExceptionHandlerContract
                 $response->getTargetUrl(), $response->getStatusCode(), $response->headers->all()
             );
         } else {
-            $response = new Response(
+            $response = response(
                 $response->getContent(), $response->getStatusCode(), $response->headers->all()
             );
         }
@@ -1002,7 +1001,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function prepareJsonResponse($request, Throwable $e)
     {
-        return new JsonResponse(
+        return response()->json(
             $this->convertExceptionToArray($e),
             $this->isHttpException($e) ? $e->getStatusCode() : 500,
             $this->isHttpException($e) ? $e->getHeaders() : [],


### PR DESCRIPTION
We may customize the response class, but the exception handler does not use the factory method of the response class, which results in it being unable to use the custom response class.

Edit: add use case

For example, we customized the JSON response like this:
```php
$this->app->singleton(ResponseFactoryContract::class, function ($app) {
            return new class($app['view'], $app['redirect']) extends ResponseFactory
            {
                public function json($data = [], $status = 200, array $headers = [], $options = 0)
                {
                    $msg = $data['message'] ?? $data['msg'] ?? null;
                    if ($msg) {
                        unset($data['message']);
                        $wrapData = [
                            'msg' => $msg,
                            'success' => $status >= 200 && $status < 300,
                        ] + $data;
                    } else {
                        $wrapData = [
                            'msg' => 'success',
                            'success' => true,
                            'data' => $data,
                        ];
                    }

                    return new JsonResponse($wrapData, 200, $headers, $options);
                }
            };
        });
```

Before PR, the exception response:
```json
{
    "message": "Server Error"
}
```
We can see that did not use our customized JSON format.

We have 3 ways to maintain consistency.

- Customize the exception handler response
- Enable prepareJsonResponse support callbak like shouldReturnJson method
- Make exception handler use response factory (Accept this PR)

After PR:

```json
{
    "msg": "Server Error",
    "success": false
}
```