### PR TITLE
Replace __sleep with __serialize (deprecated in PHP 8.5)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2586,7 +2586,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @return array
      */
-    public function __sleep()
+    public function __serialize()
     {
         $this->mergeAttributesFromCachedCasts();
 
@@ -2595,7 +2595,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->relationAutoloadCallback = null;
         $this->relationAutoloadContext = null;
 
-        return array_keys(get_object_vars($this));
+        return get_object_vars($this);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -147,11 +147,11 @@ class RateLimited
      *
      * @return array
      */
-    public function __sleep()
+    public function __unserialize(array $data)
     {
         return [
-            'limiterName',
-            'shouldRelease',
+            'limiterName' => $this->limiterName,
+            'shouldRelease' => $this->shouldRelease,
         ];
     }
 

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -147,7 +147,7 @@ class RateLimited
      *
      * @return array
      */
-    public function __unserialize(array $data)
+    public function __serialize()
     {
         return [
             'limiterName' => $this->limiterName,

--- a/tests/Integration/Cache/Fixtures/Unserializable.php
+++ b/tests/Integration/Cache/Fixtures/Unserializable.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Unserializable
 {
-    public function __unserialize(array $data)
+    public function __serialize()
     {
         throw new Exception('Not serializable');
     }

--- a/tests/Integration/Cache/Fixtures/Unserializable.php
+++ b/tests/Integration/Cache/Fixtures/Unserializable.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Unserializable
 {
-    public function __sleep()
+    public function __unserialize(array $data)
     {
         throw new Exception('Not serializable');
     }


### PR DESCRIPTION
The legacy `__sleep()` method is deprecated as of **PHP 8.5** in favor of`__serialize()`. 
These newer methods provide more flexible and explicit control over object serialization.

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods