### PR TITLE
Replace __wakeup with __unserialize (deprecated in PHP 8.5)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2603,7 +2603,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @return void
      */
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
         $this->bootIfNotBooted();
 

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -160,7 +160,7 @@ class RateLimited
      *
      * @return void
      */
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
         $this->limiter = Container::getInstance()->make(RateLimiter::class);
     }

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -93,9 +93,9 @@ class RateLimitedWithRedis extends RateLimited
      *
      * @return void
      */
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
-        parent::__wakeup();
+        parent::__unserialize($data);
 
         $this->redis = Container::getInstance()->make(Redis::class);
     }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -195,7 +195,7 @@ class CallQueuedHandlerExceptionThrower
         //
     }
 
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
         throw new ModelNotFoundException('Foo');
     }
@@ -209,7 +209,7 @@ class CallQueuedHandlerAttributeExceptionThrower
         //
     }
 
-    public function __wakeup()
+    public function __unserialize(array $data)
     {
         throw new ModelNotFoundException('Foo');
     }


### PR DESCRIPTION
The legacy `__wakeup()` method is deprecated as of **PHP 8.5** in favor of `__unserialize()`.
These newer methods provide more flexible and explicit control over object unserialization.

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods