### PR TITLE
[12.x] Correct APC cache store docblock types

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -36,7 +36,7 @@ class ApcStore extends TaggableStore
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @return mixed
+     * @return mixed|null
      */
     public function get($key)
     {
@@ -60,8 +60,8 @@ class ApcStore extends TaggableStore
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
+     * @param  int  $value
+     * @return int|false
      */
     public function increment($key, $value = 1)
     {
@@ -72,8 +72,8 @@ class ApcStore extends TaggableStore
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
+     * @param  int  $value
+     * @return int|false
      */
     public function decrement($key, $value = 1)
     {

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -8,7 +8,7 @@ class ApcWrapper
      * Get an item from the cache.
      *
      * @param  string  $key
-     * @return mixed
+     * @return mixed|null
      */
     public function get($key)
     {
@@ -23,7 +23,7 @@ class ApcWrapper
      * @param  string  $key
      * @param  mixed  $value
      * @param  int  $seconds
-     * @return array|bool
+     * @return bool
      */
     public function put($key, $value, $seconds)
     {
@@ -34,8 +34,8 @@ class ApcWrapper
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
+     * @param  int  $value
+     * @return int|false
      */
     public function increment($key, $value)
     {
@@ -46,8 +46,8 @@ class ApcWrapper
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
+     * @param  int  $value
+     * @return int|false
      */
     public function decrement($key, $value)
     {


### PR DESCRIPTION
Corrects docblock types in `ApcWrapper` and `ApcStore`, using accurate types and standalone false