### PR TITLE
[13.x] Match the typehints for the `make` method on the `App` facade to those in the `Application` class

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -53,7 +53,7 @@ namespace Illuminate\Support\Facades;
  * @method static void loadDeferredProviders()
  * @method static void loadDeferredProvider(string $service)
  * @method static void registerDeferredProvider(string $provider, string|null $service = null)
- * @method static object|mixed make(string $abstract, array $parameters = [])
+ * @method static ($abstract is class-string<TClass> ? TClass : mixed) make(string|class-string<TClass> $abstract, array $parameters = [])
  * @method static bool bound(string $abstract)
  * @method static bool isBooted()
  * @method static void boot()


### PR DESCRIPTION
This PR updates the typehints for the `make` method on the 'App' facade to match those on the `make` method [in the `Illuminate\Foundation\Application` class](https://github.com/laravel/framework/blob/7b5e185e500093841c3f42ac943067131226331a/src/Illuminate/Foundation/Application.php#L1048-L1050) that it calls. The `app` helper function already has this, which is great, but sometimes I'm using the facade and want the assigned variable to resolve to the correct type in my editor.