### PR TITLE
feat: add check for existing migration before creation

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -74,6 +74,12 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // to be freshly created so we can create the appropriate migrations.
         $name = Str::snake(trim($this->input->getArgument('name')));
 
+        if ($this->migrationExists($name)) {
+            $this->components->error('Migration already exists.');
+
+            return 1;
+        }
+
         $table = $this->input->getOption('table');
 
         $create = $this->input->getOption('create') ?: false;
@@ -92,12 +98,6 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // of creating migrations that create new tables for the application.
         if (! $table) {
             [$table, $create] = TableGuesser::guess($name);
-        }
-
-        if ($this->migrationExists($name)) {
-            $this->components->error('Migration already exists.');
-
-            return 1;
         }
 
         // Now we are ready to write the migration out to disk. Once we've written

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -95,7 +95,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         }
 
         if ($this->migrationExists($name)) {
-            $this->components->error('Migration '.$name.' already exists.');
+            $this->components->error('Migration already exists.');
 
             return 1;
         }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -66,7 +66,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
     /**
      * Execute the console command.
      *
-     * @return int
+     * @return self::SUCCESS|self::FAILURE|self::INVALID
      */
     public function handle()
     {
@@ -76,14 +76,15 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         $name = Str::snake(trim($this->input->getArgument('name')));
 
         if ($this->migrationExists($name)) {
-            $message = 'Migration already exists.';
+            $message = 'Migration '.$name.' already exists.';
 
             if ($this->option('check-duplicate')) {
                 $this->components->error($message);
-                return 1;
+
+                return self::FAILURE;
             }
 
-            $this->components->warn($message . ' Make sure the name is unique if needed.');
+            $this->components->warn($message.' Make sure the name is unique if needed.');
         }
 
         $table = $this->input->getOption('table');
@@ -111,7 +112,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // make sure that the migrations are registered by the class loaders.
         $this->writeMigration($name, $table, $create);
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**
@@ -172,7 +173,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
     protected function migrationExists(string $name): bool
     {
         return count(glob(
-            join_paths($this->laravel->databasePath('migrations'), '*_*_*_*_'.$name.'.php')
+            join_paths($this->getMigrationPath(), '*_*_*_*_'.$name.'.php')
         )) !== 0;
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -23,7 +23,8 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
-        {--fullpath : Output the full path of the migration (Deprecated)}';
+        {--fullpath : Output the full path of the migration (Deprecated)}
+        {--check-duplicate : Prevent duplicate migration creation}';
 
     /**
      * The console command description.
@@ -75,9 +76,14 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         $name = Str::snake(trim($this->input->getArgument('name')));
 
         if ($this->migrationExists($name)) {
-            $this->components->error('Migration already exists.');
+            $message = 'Migration already exists.';
 
-            return 1;
+            if ($this->option('check-duplicate')) {
+                $this->components->error($message);
+                return 1;
+            }
+
+            $this->components->warn($message . ' Make sure the name is unique if needed.');
         }
 
         $table = $this->input->getOption('table');


### PR DESCRIPTION
Added a warning that the migration name already exists and included the `--check-duplicate` option to prevent creating duplicate migrations with the same name, regardless of the timestamp.