### PR TITLE
[12.x] Improved manager typehints

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -269,7 +269,7 @@ class SessionManager extends Manager
     /**
      * Get the default session driver name.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultDriver()
     {

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -50,7 +50,7 @@ abstract class Manager
     /**
      * Get the default driver name.
      *
-     * @return string
+     * @return string|null
      */
     abstract public function getDefaultDriver();
 

--- a/tests/Integration/Support/Fixtures/NullableManager.php
+++ b/tests/Integration/Support/Fixtures/NullableManager.php
@@ -9,7 +9,7 @@ class NullableManager extends Manager
     /**
      * Get the default driver name.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultDriver()
     {


### PR DESCRIPTION
Looking at this code, `getDefaultDriver` definitely _can_ return `null`:
https://github.com/laravel/framework/blob/7b5e185e500093841c3f42ac943067131226331a/src/Illuminate/Support/Manager.php#L67-L73

This PR adjusts typehint on abstract method in `Manager` class itself, and also in `SessionManager` because it has nullable default config value.