### PR TITLE
[12.x] Simplify driver instance decoration in manager

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -75,7 +75,21 @@ abstract class Manager
         // If the given driver has not been created before, we will create the instances
         // here and cache it so we can return it next time very quickly. If there is
         // already a driver created by this name, we'll just return that instance.
-        return $this->drivers[$driver] ??= $this->createDriver($driver);
+        return $this->drivers[$driver] ??= $this->decorateInstance(
+            $this->createDriver($driver), $driver
+        );
+    }
+
+    /**
+     * Optionally decorate a driver instance.
+     *
+     * @param  mixed  $instance
+     * @param  string  $driver
+     * @return mixed
+     */
+    protected function decorateInstance($instance, $driver)
+    {
+        return $instance;
     }
 
     /**


### PR DESCRIPTION
Simple stub method has been added to manager in order to simplify driver instance decoration.
It can be useful if you want to decorate all your drivers at once with, for example, caching layer or similar.

Current alternatives are:
- Decorate drivers separately in their own `create{...}Driver` methods (see `CacheManager`);
- Override `driver` or `createDriver` method in your manager (too much boilerplate code);
- Decorate in service provider with `extend` (downside that it'll decorate only default driver).