### PR TITLE
[12.x] Infinite method chaining in contextual binding builder

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -57,24 +57,26 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      * Define the implementation for the contextual binding.
      *
      * @param  \Closure|string|array  $implementation
-     * @return void
+     * @return $this
      */
     public function give($implementation)
     {
         foreach (Util::arrayWrap($this->concrete) as $concrete) {
             $this->container->addContextualBinding($concrete, $this->needs, $implementation);
         }
+
+        return $this;
     }
 
     /**
      * Define tagged services to be used as the implementation for the contextual binding.
      *
      * @param  string  $tag
-     * @return void
+     * @return $this
      */
     public function giveTagged($tag)
     {
-        $this->give(function ($container) use ($tag) {
+        return $this->give(function ($container) use ($tag) {
             $taggedServices = $container->tagged($tag);
 
             return is_array($taggedServices) ? $taggedServices : iterator_to_array($taggedServices);
@@ -86,10 +88,10 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @return void
+     * @return $this
      */
     public function giveConfig($key, $default = null)
     {
-        $this->give(fn ($container) => $container->get('config')->get($key, $default));
+        return $this->give(fn ($container) => $container->get('config')->get($key, $default));
     }
 }

--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -16,7 +16,7 @@ interface ContextualBindingBuilder
      * Define the implementation for the contextual binding.
      *
      * @param  \Closure|string|array  $implementation
-     * @return void
+     * @return $this
      */
     public function give($implementation);
 
@@ -24,7 +24,7 @@ interface ContextualBindingBuilder
      * Define tagged services to be used as the implementation for the contextual binding.
      *
      * @param  string  $tag
-     * @return void
+     * @return $this
      */
     public function giveTagged($tag);
 
@@ -33,7 +33,7 @@ interface ContextualBindingBuilder
      *
      * @param  string  $key
      * @param  mixed  $default
-     * @return void
+     * @return $this
      */
     public function giveConfig($key, $default = null);
 }


### PR DESCRIPTION
This PR enables infinite chaining of `ContextualBindingBuilder` methods.

Before:
```php
$this->app->when(MyService::class)->needs(Repository::class)->give(
    fn () => Cache::store(config('my-service.cache.store'))
);
$this->app->when(MyService::class)->needs('$ttl')->giveConfig('my-service.cache.ttl');
```

After:
```php
$this->app->when(MyService::class)
    ->needs(Repository::class)->give(
        fn () => Cache::store(config('my-service.cache.store'))
    )
    ->needs('$ttl')->giveConfig('my-service.cache.ttl');
```
