### PR TITLE
[12.x] Replace logger helper and log function concrete return type ?LogManager with abstract ?LoggerInterface

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -560,9 +560,9 @@ if (! function_exists('logger')) {
      * Log a debug message to the logs.
      *
      * @param  string|null  $message
-     * @return ($message is null ? \Illuminate\Log\LogManager : null)
+     * @return ($message is null ? \Psr\Log\LoggerInterface : null)
      */
-    function logger($message = null, array $context = []): ?LogManager
+    function logger($message = null, array $context = []): ?LoggerInterface
     {
         if (is_null($message)) {
             return app('log');

--- a/src/Illuminate/Log/functions.php
+++ b/src/Illuminate/Log/functions.php
@@ -2,15 +2,17 @@
 
 namespace Illuminate\Log;
 
+use Psr\Log\LoggerInterface;
+
 if (! function_exists('Illuminate\Log\log')) {
     /**
      * Log a debug message to the logs.
      *
      * @param  string|null  $message
      * @param  array  $context
-     * @return ($message is null ? \Illuminate\Log\LogManager : null)
+     * @return ($message is null ? \Psr\Log\LoggerInterface: null)
      */
-    function log($message = null, array $context = []): ?LogManager
+    function log($message = null, array $context = []): ?LoggerInterface
     {
         return logger($message, $context);
     }

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -29,7 +29,7 @@ assertType('Symfony\Component\HttpFoundation\Cookie', cookie('foo'));
 assertType('Illuminate\Foundation\Bus\PendingDispatch', dispatch('foo'));
 assertType('Illuminate\Foundation\Bus\PendingClosureDispatch', dispatch(fn () => 1));
 
-assertType('Illuminate\Log\LogManager', logger());
+assertType('Psr\Log\LoggerInterface', logger());
 assertType('null', logger('foo'));
 
 assertType('Illuminate\Log\LogManager', logs());


### PR DESCRIPTION
###  Change
Change helper function `logger` return type to `?LoggerInterface` instead of `?LoggerManager`. `LoggerManager` implements `LoggerInterface`, which means any code expecting a `LogManager` should still work fine since this is the wider type.

### Motivation
The return type was introduced in a recent PR #56684 . Introducing the change to our codebase broke multiple tests where we mocked the logger function using a `LoggerInterface` mock instance. 
Programming for interfaces is a widely accepted practice in the industry, thus the function should be returning an Interface instead of a concrete type to be flexible enough for any more logger classes in the future.
