### PR TITLE
[12.x] Add $limit Parameter to latest() and oldest() Methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -426,15 +426,16 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function latest($column = null)
+    public function latest($column = null, $limit = null)
     {
         if (is_null($column)) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
-        $this->query->latest($column);
+        $this->query->latest($column, $limit);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -444,15 +444,16 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function oldest($column = null)
+    public function oldest($column = null, $limit = null)
     {
         if (is_null($column)) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
-        $this->query->oldest($column);
+        $this->query->oldest($column, $limit);
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2724,7 +2724,11 @@ class Builder implements BuilderContract
      */
     public function latest($column = 'created_at', $limit = null)
     {
-        return $this->orderBy($column, 'desc')->limit($limit);
+        if (! is_null($limit)) {
+            $this->limit($limit);
+        }
+
+        return $this->orderBy($column, 'desc');
     }
 
     /**
@@ -2736,7 +2740,11 @@ class Builder implements BuilderContract
      */
     public function oldest($column = 'created_at', $limit = null)
     {
-        return $this->orderBy($column, 'asc')->limit($limit);
+        if (! is_null($limit)) {
+            $this->limit($limit);
+        }
+
+        return $this->orderBy($column, 'asc');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2724,6 +2724,13 @@ class Builder implements BuilderContract
      */
     public function latest($column = 'created_at', $limit = null)
     {
+        // If only one integer argument is passed, treat it as the limit and default the column to 'created_at'.
+        // This allows calling "latest(11)" instead of "latest('created_at', 11)" or "latest(limit: 11)"
+        if (is_null($limit) && is_int($column)) {
+            $limit = $column;
+            $column = 'created_at';
+        }
+
         if (! is_null($limit)) {
             $this->limit($limit);
         }
@@ -2740,6 +2747,13 @@ class Builder implements BuilderContract
      */
     public function oldest($column = 'created_at', $limit = null)
     {
+        // If only one integer argument is passed, treat it as the limit and default the column to 'created_at'.
+        // This allows calling "oldest(11)" instead of "oldest('created_at', 11)" or "oldest(limit: 11)"
+        if (is_null($limit) && is_int($column)) {
+            $limit = $column;
+            $column = 'created_at';
+        }
+
         if (! is_null($limit)) {
             $this->limit($limit);
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2731,11 +2731,12 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function oldest($column = 'created_at')
+    public function oldest($column = 'created_at', $limit = null)
     {
-        return $this->orderBy($column, 'asc');
+        return $this->orderBy($column, 'asc')->limit($limit);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2719,11 +2719,12 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function latest($column = 'created_at')
+    public function latest($column = 'created_at', $limit = null)
     {
-        return $this->orderBy($column, 'desc');
+        return $this->orderBy($column, 'desc')->limit($limit);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2451,9 +2451,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('foo', 5);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo', 1);
 
-        $builder->latest(limit: 5);
+        $builder->latest(limit: 1);
     }
 
     public function testLatestWithLimitWithoutCreatedAtColumn()
@@ -2462,9 +2462,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at', 7);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at', 1);
 
-        $builder->latest(limit: 7);
+        $builder->latest(limit: 1);
     }
 
     public function testLatestWithExplicitColumnAndLimit()
@@ -2472,9 +2472,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('updated_at', 3);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('updated_at', 1);
 
-        $builder->latest('updated_at', 3);
+        $builder->latest('updated_at', 1);
     }
 
     public function testOldestWithoutColumnWithCreatedAt()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2472,9 +2472,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('my_timestamp', 3);
+        $builder->getQuery()->shouldReceive('latest')->once()->with('updated_at', 3);
 
-        $builder->latest('my_timestamp', 3);
+        $builder->latest('updated_at', 3);
     }
 
     public function testOldestWithoutColumnWithCreatedAt()
@@ -2536,9 +2536,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('oldest')->once()->with('my_timestamp', 1);
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('updated_at', 1);
 
-        $builder->oldest('my_timestamp', 1);
+        $builder->oldest('updated_at', 1);
     }
 
     public function testUpdate()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2483,7 +2483,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('oldest')->once()->with('foo');
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('foo', null);
 
         $builder->oldest();
     }
@@ -2494,7 +2494,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('oldest')->once()->with('created_at');
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('created_at', null);
 
         $builder->oldest();
     }
@@ -2504,9 +2504,41 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('oldest')->once()->with('foo');
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('foo', null);
 
         $builder->oldest('foo');
+    }
+
+    public function testOldestWithLimitAndCreatedAtColumn()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('foo', 1);
+
+        $builder->oldest(limit: 1);
+    }
+
+    public function testOldestWithLimitWithoutCreatedAtColumn()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('created_at', 1);
+
+        $builder->oldest(limit: 1);
+    }
+
+    public function testOldestWithExplicitColumnAndLimit()
+    {
+        $model = $this->getMockModel();
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('oldest')->once()->with('my_timestamp', 1);
+
+        $builder->oldest('my_timestamp', 1);
     }
 
     public function testUpdate()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2419,7 +2419,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo', null);
 
         $builder->latest();
     }
@@ -2430,7 +2430,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at');
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at', null);
 
         $builder->latest();
     }
@@ -2440,9 +2440,41 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = $this->getMockModel();
         $builder = $this->getBuilder()->setModel($model);
 
-        $builder->getQuery()->shouldReceive('latest')->once()->with('foo');
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo', null);
 
         $builder->latest('foo');
+    }
+
+    public function testLatestWithLimitAndCreatedAtColumn()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn('foo');
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('foo', 5);
+
+        $builder->latest(limit: 5);
+    }
+
+    public function testLatestWithLimitWithoutCreatedAtColumn()
+    {
+        $model = $this->getMockModel();
+        $model->shouldReceive('getCreatedAtColumn')->andReturn(null);
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('created_at', 7);
+
+        $builder->latest(limit: 7);
+    }
+
+    public function testLatestWithExplicitColumnAndLimit()
+    {
+        $model = $this->getMockModel();
+        $builder = $this->getBuilder()->setModel($model);
+
+        $builder->getQuery()->shouldReceive('latest')->once()->with('my_timestamp', 3);
+
+        $builder->latest('my_timestamp', 3);
     }
 
     public function testOldestWithoutColumnWithCreatedAt()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2113,6 +2113,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->oldest('updated_at');
         $this->assertSame('select * from "users" order by "updated_at" asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->oldest(limit: 1);
+        $this->assertSame('select * from "users" order by "created_at" asc limit 1', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->oldest('updated_at', 1);
+        $this->assertSame('select * from "users" order by "updated_at" asc limit 1', $builder->toSql());
     }
 
     public function testInRandomOrderMySql()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2090,6 +2090,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->latest('updated_at');
         $this->assertSame('select * from "users" order by "updated_at" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->latest(limit: 1);
+        $this->assertSame('select * from "users" order by "created_at" desc limit 1', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->latest('updated_at', 1);
+        $this->assertSame('select * from "users" order by "updated_at" desc limit 1', $builder->toSql());
     }
 
     public function testOldest()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2098,6 +2098,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->latest('updated_at', 1);
         $this->assertSame('select * from "users" order by "updated_at" desc limit 1', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('users')->latest(1);
+        $this->assertSame('select * from "users" order by "created_at" desc limit 1', $builder->toSql());
+        $this->assertSame(1, $builder->limit);
     }
 
     public function testOldest()
@@ -2121,6 +2126,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->oldest('updated_at', 1);
         $this->assertSame('select * from "users" order by "updated_at" asc limit 1', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('users')->oldest(1);
+        $this->assertSame('select * from "users" order by "created_at" asc limit 1', $builder->toSql());
+        $this->assertSame(1, $builder->limit);
     }
 
     public function testInRandomOrderMySql()


### PR DESCRIPTION
This PR introduces a new `$limit` parameter to the `latest()` and `oldest()` methods, allowing developers to limit results without chaining `take()`.  

---

## Before  
Previously, limiting results required chaining `take()` after `latest()` or `oldest()`:  

```php
// Using Eloquent
User::latest()->take(10)->get();

// Using Query Builder
DB::table('users')->latest()->take(10)->get();

// Oldest examples
User::oldest()->take(10)->get();
DB::table('users')->oldest()->take(10)->get();
```  

---

## After  
Now, you can pass the limit directly as an argument to `latest()` or `oldest()`.  

```php
// Specify both column and limit
User::latest('updated_at', 10)->get();
DB::table('users')->latest('updated_at', 10)->get();

User::oldest('updated_at', 10)->get();
DB::table('users')->oldest('updated_at', 10)->get();
```  

You can also use **named arguments** for clarity:  

```php
User::latest(limit: 10)->get();
DB::table('users')->latest(limit: 10)->get();

User::oldest(limit: 10)->get();
DB::table('users')->oldest(limit: 10)->get();
```  

---

## Shortcut  
If you don’t need to change the default column (`created_at`), you can pass only the limit:  

```php
// Defaults to ordering by 'created_at'
User::latest(10)->get();
DB::table('users')->latest(10)->get();

User::oldest(10)->get();
DB::table('users')->oldest(10)->get();
```  