### PR TITLE
Add missing waitUntil method to FakeInvokedProcess

### DIFF
--- a/src/Illuminate/Contracts/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Process/InvokedProcess.php
@@ -61,4 +61,12 @@ interface InvokedProcess
      * @return \Illuminate\Process\ProcessResult
      */
     public function wait(?callable $output = null);
+
+    /**
+     * Wait until the given callback returns true.
+     *
+     * @param  callable|null  $output
+     * @return \Illuminate\Process\ProcessResult
+     */
+    public function waitUntil(?callable $output = null);
 }

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -294,15 +294,20 @@ class FakeInvokedProcess implements InvokedProcessContract
      */
     public function waitUntil(?callable $output = null)
     {
-        $this->outputHandler = $output ?: $this->outputHandler;
-
+        $shouldStop = false;
+        $this->outputHandler = $output 
+            ? function ($type, $buffer) use ($output, &$shouldStop) {
+                $shouldStop = call_user_func($output, $type, $buffer);
+            } 
+            : $this->outputHandler;
+        
         if (! $this->outputHandler) {
             $this->remainingRunIterations = 0;
 
             return $this->predictProcessResult();
         }
 
-        while ($this->running() && ! call_user_func($this->outputHandler, 'out', $this->latestOutput())) {
+        while ($this->running() && ! $shouldStop) {
             //
         }
 

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -295,6 +295,7 @@ class FakeInvokedProcess implements InvokedProcessContract
     public function waitUntil(?callable $output = null)
     {
         $shouldStop = false;
+
         $this->outputHandler = $output 
             ? function ($type, $buffer) use ($output, &$shouldStop) {
                 $shouldStop = call_user_func($output, $type, $buffer);

--- a/src/Illuminate/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Process/FakeInvokedProcess.php
@@ -287,6 +287,31 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Wait until the given callback returns true.
+     *
+     * @param  callable|null  $output
+     * @return \Illuminate\Contracts\Process\ProcessResult
+     */
+    public function waitUntil(?callable $output = null)
+    {
+        $this->outputHandler = $output ?: $this->outputHandler;
+
+        if (! $this->outputHandler) {
+            $this->remainingRunIterations = 0;
+
+            return $this->predictProcessResult();
+        }
+
+        while ($this->running() && ! call_user_func($this->outputHandler, 'out', $this->latestOutput())) {
+            //
+        }
+
+        $this->remainingRunIterations = 0;
+
+        return $this->process->toProcessResult($this->command);
+    }
+
+    /**
      * Get the ultimate process result that will be returned by this "process".
      *
      * @return \Illuminate\Contracts\Process\ProcessResult

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -783,6 +783,7 @@ class ProcessTest extends TestCase
 
         $result = $process->waitUntil(function ($type, $buffer) use (&$callbackInvoked) {
             $callbackInvoked[] = $buffer;
+
             return str_contains($buffer, 'READY');
         });
 
@@ -828,6 +829,7 @@ class ProcessTest extends TestCase
 
         $result = $process->waitUntil(function ($type, $buffer) use (&$callbackCount) {
             $callbackCount++;
+
             return str_contains($buffer, 'TARGET');
         });
 


### PR DESCRIPTION
# Add missing waitUntil method to FakeInvokedProcess

### Problem

The FakeInvokedProcess class was missing the waitUntil method that exists in InvokedProcess, causing test failures when using faked processes.

### Solution

Added waitUntil method to both the contract interface and FakeInvokedProcess implementation with comprehensive tests.

### Example

Before: This would fail with faked processes
```php
//test 
Process::fake([
    'long-process *' => Process::describe()
          ->output('booting')
          ->output('ready')
          ->iterations(2),
]);

// code
$process = Process::start('long-process');
$result = $process->waitUntil(fn($type, $buffer) => str_contains($buffer, 'ready'));

After: Now works perfectly
// Same code now works with faked processes
$this->assertTrue($result->successful());
```

### Benefits
  - Consistent behavior between real and faked processes
  - Enables proper testing of asynchronous process workflows
  - Fully backward compatible
