### PR TITLE
[13.x] Replace __wakeup with __unserialize (deprecated in PHP 8.5)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2601,8 +2601,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Prepare the object for serialization.
      *
      * @return array
-     */
-    public function __sleep()
+     */ 
+    public function __serialize()
     {
         $this->mergeAttributesFromCachedCasts();
 
@@ -2611,16 +2611,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->relationAutoloadCallback = null;
         $this->relationAutoloadContext = null;
 
-        return array_keys(get_object_vars($this));
+        return get_object_vars($this);
     }
 
     /**
      * When a model is being unserialized, check if it needs to be booted.
      *
      * @return void
-     */
-    public function __wakeup()
+     */ 
+    public function __unserialize($data)
     {
+        foreach ($data as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
         $this->bootIfNotBooted();
 
         $this->initializeTraits();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2601,7 +2601,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * Prepare the object for serialization.
      *
      * @return array
-     */ 
+     */
     public function __serialize()
     {
         $this->mergeAttributesFromCachedCasts();
@@ -2618,7 +2618,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * When a model is being unserialized, check if it needs to be booted.
      *
      * @return void
-     */ 
+     */
     public function __unserialize($data)
     {
         foreach ($data as $property => $value) {

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -147,11 +147,11 @@ class RateLimited
      *
      * @return array
      */
-    public function __sleep()
+    public function __serialize()
     {
         return [
-            'limiterName',
-            'shouldRelease',
+            'limiterName' => $this->limiterName,
+            'shouldRelease' => $this->shouldRelease,
         ];
     }
 
@@ -160,8 +160,13 @@ class RateLimited
      *
      * @return void
      */
-    public function __wakeup()
+    public function __unserialize($data)
     {
+        foreach ($data as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
         $this->limiter = Container::getInstance()->make(RateLimiter::class);
     }
 }

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -93,9 +93,14 @@ class RateLimitedWithRedis extends RateLimited
      *
      * @return void
      */
-    public function __wakeup()
+    public function __unserialize($data)
     {
-        parent::__wakeup();
+        foreach ($data as $property => $value) {
+            if (property_exists($this, $property)) {
+                $this->{$property} = $value;
+            }
+        }
+        parent::__unserialize($data);
 
         $this->redis = Container::getInstance()->make(Redis::class);
     }

--- a/tests/Integration/Cache/Fixtures/Unserializable.php
+++ b/tests/Integration/Cache/Fixtures/Unserializable.php
@@ -6,7 +6,7 @@ use Exception;
 
 class Unserializable
 {
-    public function __sleep()
+    public function __serialize()
     {
         throw new Exception('Not serializable');
     }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -195,7 +195,7 @@ class CallQueuedHandlerExceptionThrower
         //
     }
 
-    public function __wakeup()
+    public function __unserialize($data)
     {
         throw new ModelNotFoundException('Foo');
     }
@@ -209,7 +209,7 @@ class CallQueuedHandlerAttributeExceptionThrower
         //
     }
 
-    public function __wakeup()
+    public function __unserialize($data)
     {
         throw new ModelNotFoundException('Foo');
     }


### PR DESCRIPTION
The legacy `__wakeup()` method is deprecated as of **PHP 8.5** in favor of `__unserialize()`.
These newer methods provide more flexible and explicit control over object unserialization.

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods

https://github.com/laravel/framework/pull/57021