### PR TITLE
fix : validate JSON format in Request::json() method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -425,13 +425,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function json($key = null, $default = null)
     {
         if (! isset($this->json)) {
-            $this->json = new InputBag((array) json_decode($this->getContent() ?: '[]', true));
+            $content = $this->getContent() ?: '[]';
+            $decoded = json_decode($content, true);
+            
+            // Check for JSON parsing errors
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException(
+                    'Invalid JSON in request body: ' . json_last_error_msg()
+                );
+            }
+            
+            $this->json = new InputBag((array) $decoded);
         }
-
+    
         if (is_null($key)) {
             return $this->json;
         }
-
+    
         return data_get($this->json->all(), $key, $default);
     }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -427,21 +427,21 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         if (! isset($this->json)) {
             $content = $this->getContent() ?: '[]';
             $decoded = json_decode($content, true);
-            
+
             // Check for JSON parsing errors
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new \Symfony\Component\HttpKernel\Exception\BadRequestHttpException(
-                    'Invalid JSON in request body: ' . json_last_error_msg()
+                    'Invalid JSON in request body: '.json_last_error_msg()
                 );
             }
-            
+
             $this->json = new InputBag((array) $decoded);
         }
-    
+
         if (is_null($key)) {
             return $this->json;
         }
-    
+
         return data_get($this->json->all(), $key, $default);
     }
 


### PR DESCRIPTION
Add JSON parsing validation to the Request::json() method to throw  BadRequestHttpException when malformed JSON is encountered instead  of silently returning empty arrays.

Previously, malformed JSON (e.g., trailing commas, missing braces)  would be silently converted to empty arrays via json_decode(),  causing applications to process requests with empty data without  any indication of the parsing failure.

Changes:
- Extract content before decoding to enable error checking
- Add json_last_error() validation after json_decode()
- Throw BadRequestHttpException with descriptive error message
- Maintain backward compatibility for valid JSON requests

This ensures developers receive clear 400 Bad Request responses  when sending invalid JSON, improving API debugging and preventing silent data loss scenarios.
