### PR TITLE
Feat(Collection): add whereStartsWith && whereEndsWith  && whereContains methods

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -768,6 +768,54 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where the value for the given key starts with a string.
+     *
+     * @param  string  $key
+     * @param  string  $needle
+     * @return static
+     */
+    public function whereStartsWith(string $key, string $needle)
+    {
+        return $this->filter(function ($item) use ($key, $needle) {
+            $value = data_get($item, $key);
+
+            return is_string($value) && str_starts_with($value, $needle);
+        });
+    }
+
+    /**
+     * Filter items where the value for the given key ends with a string.
+     *
+     * @param  string  $key
+     * @param  string  $needle
+     * @return static
+     */
+    public function whereEndsWith(string $key, string $needle)
+    {
+        return $this->filter(function ($item) use ($key, $needle) {
+            $value = data_get($item, $key);
+
+            return is_string($value) && str_ends_with($value, $needle);
+        });
+    }
+
+    /**
+     * Filter items where the value for the given key contains a string.
+     *
+     * @param  string  $key
+     * @param  string  $needle
+     * @return static
+     */
+    public function whereContains(string $key, string $needle)
+    {
+        return $this->filter(function ($item) use ($key, $needle) {
+            $value = data_get($item, $key);
+
+            return is_string($value) && str_contains($value, $needle);
+        });
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @template TPipeReturnType

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1109,6 +1109,82 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testWhereStartsWithFiltersItemsCorrectly($collection)
+    {
+        $c = new $collection([
+            ['name' => 'Taylor'],
+            ['name' => 'Tayfun'],
+            ['name' => 'Nuno'],
+            ['name' => 'Otwell'],
+        ]);
+
+        $result = $c->whereStartsWith('name', 'Tay')->pluck('name')->all();
+
+        $this->assertSame(['Taylor', 'Tayfun'], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testWhereEndsWithFiltersItemsCorrectly($collection)
+    {
+        $c = new $collection([
+            ['email' => 'taylor@example.com'],
+            ['email' => 'nuno@test.org'],
+            ['email' => 'support@example.com'],
+        ]);
+
+        $result = $c->whereEndsWith('email', '@example.com')->pluck('email')->all();
+
+        $this->assertSame(['taylor@example.com', 'support@example.com'], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testWhereContainsFiltersItemsCorrectly($collection)
+    {
+        $c = new $collection([
+            ['title' => 'Laravel Framework'],
+            ['title' => 'Symfony Components'],
+            ['title' => 'Livewire for Laravel'],
+        ]);
+
+        $result = $c->whereContains('title', 'Laravel')->pluck('title')->all();
+
+        $this->assertSame(['Laravel Framework', 'Livewire for Laravel'], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testStringBasedWhereFiltersReturnEmptyWhenNoMatch($collection)
+    {
+        $c = new $collection([
+            ['city' => 'Cairo'],
+            ['city' => 'Alexandria'],
+        ]);
+
+        $this->assertSame([], $c->whereStartsWith('city', 'Z')->all());
+        $this->assertSame([], $c->whereEndsWith('city', 'land')->all());
+        $this->assertSame([], $c->whereContains('city', 'zzz')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testCanChainStringFilters($collection)
+    {
+        $c = new $collection([
+            ['value' => 'Laravel 11.x'],
+            ['value' => 'Laravel 10.x'],
+            ['value' => 'Symfony'],
+            ['value' => 'Livewire for Laravel'],
+        ]);
+
+        $result = $c
+            ->whereStartsWith('value', 'Laravel')
+            ->whereEndsWith('value', '.x')
+            ->whereContains('value', '11')
+            ->pluck('value')
+            ->all();
+
+        $this->assertSame(['Laravel 11.x'], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testWhereIn($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
This PR adds three new helper methods to the Collection class:

- whereStartsWith($key, $needle) – Filters items where the given key’s value begins with the specified needle.
- whereEndsWith($key, $needle) – Filters items where the given key’s value ends with the specified needle.
- whereContains($key, $needle) – Filters items where the given key’s value contains the specified needle.

These methods make collections more expressive and readable when filtering string-based values.

Example Usage:

```
$c = collect([
            ['value' => 'Laravel 11.x'],
            ['value' => 'Laravel 10.x'],
            ['value' => 'Symfony'],
            ['value' => 'Livewire for Laravel'],
        ]);

        $result = $c
            ->whereStartsWith('value', 'Laravel')
            ->whereEndsWith('value', '.x')
            ->whereContains('value', '11')
            ->pluck('value')
            ->all();
```
