### PR TITLE
[12.x] `FailOnException` middleware can accept an array of closures

### DIFF
--- a/src/Illuminate/Queue/Middleware/FailOnException.php
+++ b/src/Illuminate/Queue/Middleware/FailOnException.php
@@ -47,7 +47,7 @@ class FailOnException
             $isCallable = is_callable($exception);
 
             if (! $isExceptionString && ! $isCallable) {
-                throw new LogicException('Provided callback should be an array containing only Throwable class strings or callables.');
+                throw new LogicException('Callback should be an array containing only Throwable class strings or callables.');
             }
         });
     }
@@ -67,8 +67,9 @@ class FailOnException
                         return true;
                     }
                 }
-
-                return (bool) call_user_func($exception, $throwable, $job);
+                elseif (is_callable($exception)) {
+                    return (bool) call_user_func($exception, $throwable, $job);
+                }
             }
 
             return false;

--- a/tests/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Queue/FailOnExceptionMiddlewareTest.php
@@ -68,6 +68,9 @@ class FailOnExceptionMiddlewareTest extends TestCase
             ]);
             $this->fail('Did not throw exception');
         } catch (Throwable $e) {
+            if (! $e instanceof $thrown) {
+                dd($e);
+            }
             $this->assertInstanceOf($thrown, $e);
         }
 
@@ -103,7 +106,7 @@ class FailOnExceptionMiddlewareTest extends TestCase
     public function test_cannot_construct_invariants(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Provided exceptions should be a Throwable or a callable.');
+        $this->expectExceptionMessage('Callback should be an array containing only Throwable class strings or callables.');
         new FailOnException(['abc']);
     }
 }

--- a/tests/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Queue/FailOnExceptionMiddlewareTest.php
@@ -41,6 +41,11 @@ class FailOnExceptionMiddlewareTest extends TestCase
                 new FailOnException([InvalidArgumentException::class]),
                 false,
             ],
+            'exception is in list with closure' => [
+                TestingExceptionForMiddlewareException::class,
+                new FailOnException([LogicException::class, static fn ($throwable) => $throwable->getMessage() === 'zzz']),
+                true,
+            ],
         ];
     }
 
@@ -94,6 +99,13 @@ class FailOnExceptionMiddlewareTest extends TestCase
 
         $expectedToFail ? $job->assertFailed() : $job->assertNotFailed();
     }
+
+    public function test_cannot_construct_invariants(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Provided exceptions should be a Throwable or a callable.');
+        new FailOnException(['abc']);
+    }
 }
 
 class FailOnExceptionMiddlewareTestJob implements ShouldQueue
@@ -116,5 +128,13 @@ class FailOnExceptionMiddlewareTestJob implements ShouldQueue
     public function middleware(): array
     {
         return self::$_middleware;
+    }
+}
+
+class TestingExceptionForMiddlewareException extends \Exception {
+
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct("zzz", $code, $previous);
     }
 }


### PR DESCRIPTION
I actually got to use the FailOnException middleware today 🥳 and realized it would be really nice to be able to offer a list of Closures or Closures + class strings.

```php
// Before
new FailOnException(
    fn ($throwable) => $throwable instanceof \LogicException
        || ($throwable instanceof MyCustomException && $throwable->specialValue === 'abc')
);

// After
new FailOnException([
    \LogicException::class,
    fn ($throwable) => $throwable instanceof MyCustomException & $throwable->specialValue === 'abc'
]);
```