### PR TITLE
[12.x] handle all Enum types for default values

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -2,13 +2,15 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use BackedEnum;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use RuntimeException;
+use UnitEnum;
+
+use function Illuminate\Support\enum_value;
 
 abstract class Grammar extends BaseGrammar
 {
@@ -477,8 +479,8 @@ abstract class Grammar extends BaseGrammar
             return $this->getValue($value);
         }
 
-        if ($value instanceof BackedEnum) {
-            return "'".str_replace("'", "''", $value->value)."'";
+        if ($value instanceof UnitEnum) {
+            return "'".str_replace("'", "''", enum_value($value))."'";
         }
 
         return is_bool($value)


### PR DESCRIPTION
by using the internal `enum_value()` helper, we can handle both `UnitEnum`s and `BackedEnum`s, similar to how we do elsewhere in the framework.

we check for `UnitEnum`, because it is the broader of the 2 types.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
