### PR TITLE
Refactor: replace strpos check with str_contains for clarity

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -285,7 +285,7 @@ class Env
      */
     protected static function prepareQuotedValue(string $input)
     {
-        return strpos($input, '"') !== false
+        return str_contains($input, '"')
             ? "'".self::addSlashesExceptFor($input, ['"'])."'"
             : '"'.self::addSlashesExceptFor($input, ["'"]).'"';
     }


### PR DESCRIPTION
Replaced `strpos($input, '"') !== false` with `str_contains($input, '"')`
