### PR TITLE
[12.x] Add ability to control QueueWorker memory exceeded exit code

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -170,7 +170,7 @@ class WorkCommand extends Command
             $this->option('max-jobs'),
             $this->option('max-time'),
             $this->option('rest'),
-            $this->option('memory-exit-code'),
+            $this->option('memory-exit-code')
         );
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -43,7 +43,6 @@ class WorkCommand extends Command
                             {--max-time=0 : The maximum number of seconds the worker should run}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
-                            {--memory-exit-code=12 : The exit code to use when the memory limit is exceeded}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
@@ -170,7 +169,6 @@ class WorkCommand extends Command
             $this->option('max-jobs'),
             $this->option('max-time'),
             $this->option('rest'),
-            $this->option('memory-exit-code')
         );
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -43,6 +43,7 @@ class WorkCommand extends Command
                             {--max-time=0 : The maximum number of seconds the worker should run}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
+                            {--memory-exit-code=12 : The exit code to use when the memory limit is exceeded}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
@@ -168,7 +169,8 @@ class WorkCommand extends Command
             $this->option('stop-when-empty'),
             $this->option('max-jobs'),
             $this->option('max-time'),
-            $this->option('rest')
+            $this->option('rest'),
+            $this->option('memory-exit-code')
         );
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -43,6 +43,7 @@ class WorkCommand extends Command
                             {--max-time=0 : The maximum number of seconds the worker should run}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
+                            {--memory-exit-code=12 : The exit code to use when the memory limit is exceeded}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
@@ -168,7 +169,8 @@ class WorkCommand extends Command
             $this->option('stop-when-empty'),
             $this->option('max-jobs'),
             $this->option('max-time'),
-            $this->option('rest')
+            $this->option('rest'),
+            $this->option('memory-exit-code'),
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -100,6 +100,13 @@ class Worker
     protected static $popCallbacks = [];
 
     /**
+     * The custom exit code to be used when memory is exceeded.
+     *
+     * @var int|null
+     */
+    public static $memoryExceededExitCode;
+
+    /**
      * Create a new queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $manager
@@ -307,7 +314,7 @@ class Worker
     {
         return match (true) {
             $this->shouldQuit => static::EXIT_SUCCESS,
-            $this->memoryExceeded($options->memory) => $options->memoryExitCode,
+            $this->memoryExceeded($options->memory) => static::$memoryExceededExitCode ?: static::EXIT_MEMORY_LIMIT,
             $this->queueShouldRestart($lastRestart) => static::EXIT_SUCCESS,
             $options->stopWhenEmpty && is_null($job) => static::EXIT_SUCCESS,
             $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => static::EXIT_SUCCESS,

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -27,7 +27,6 @@ class Worker
 
     const EXIT_SUCCESS = 0;
     const EXIT_ERROR = 1;
-    const EXIT_MEMORY_LIMIT = 12;
 
     /**
      * The name of the worker.
@@ -307,7 +306,7 @@ class Worker
     {
         return match (true) {
             $this->shouldQuit => static::EXIT_SUCCESS,
-            $this->memoryExceeded($options->memory) => static::EXIT_MEMORY_LIMIT,
+            $this->memoryExceeded($options->memory) => $options->memoryExitCode,
             $this->queueShouldRestart($lastRestart) => static::EXIT_SUCCESS,
             $options->stopWhenEmpty && is_null($job) => static::EXIT_SUCCESS,
             $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => static::EXIT_SUCCESS,

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -27,6 +27,7 @@ class Worker
 
     const EXIT_SUCCESS = 0;
     const EXIT_ERROR = 1;
+    const EXIT_MEMORY_LIMIT = 12;
 
     /**
      * The name of the worker.

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -82,6 +82,13 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * The exit code when the memory limit is exceeded.
+     *
+     * @var int
+     */
+    public $memoryExitCode;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -95,6 +102,7 @@ class WorkerOptions
      * @param  int  $maxJobs
      * @param  int  $maxTime
      * @param  int  $rest
+     * @param  int  $memoryExitCode
      */
     public function __construct(
         $name = 'default',
@@ -108,6 +116,7 @@ class WorkerOptions
         $maxJobs = 0,
         $maxTime = 0,
         $rest = 0,
+        $memoryExitCode = 12,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -120,5 +129,6 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->memoryExitCode = $memoryExitCode;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -82,13 +82,6 @@ class WorkerOptions
     public $maxTime;
 
     /**
-     * The exit code when the memory limit is exceeded.
-     *
-     * @var int
-     */
-    public $memoryExitCode;
-
-    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -102,7 +95,6 @@ class WorkerOptions
      * @param  int  $maxJobs
      * @param  int  $maxTime
      * @param  int  $rest
-     * @param  int  $memoryExitCode
      */
     public function __construct(
         $name = 'default',
@@ -116,7 +108,6 @@ class WorkerOptions
         $maxJobs = 0,
         $maxTime = 0,
         $rest = 0,
-        $memoryExitCode = Worker::EXIT_MEMORY_LIMIT,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -129,6 +120,5 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
-        $this->memoryExitCode = $memoryExitCode;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -116,7 +116,7 @@ class WorkerOptions
         $maxJobs = 0,
         $maxTime = 0,
         $rest = 0,
-        $memoryExitCode = 12,
+        $memoryExitCode = Worker::EXIT_MEMORY_LIMIT,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -171,11 +171,11 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 0.1,
-            '--memory-exit-code' => 25,
-        ])->assertExitCode(25);
+            '--memory-exit-code' => 13,
+        ])->assertExitCode(13);
 
         // Memory limit isn't checked until after the first job is attempted.
-        $this->assertSame(1, Queue::size());
+        $this->assertSame(2, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
     }

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -177,7 +177,7 @@ class WorkCommandTest extends QueueTestCase
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
-        $this->assertFalse(SecondJob::$ran);
+        $this->assertFalse(SecondJob::$ra);
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Exceptions;
@@ -166,18 +167,21 @@ class WorkCommandTest extends QueueTestCase
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
+        Worker::$memoryExceededExitCode = 25;
+
         Queue::push(new FirstJob);
         Queue::push(new SecondJob);
 
         $this->artisan('queue:work', [
             '--memory' => 0.1,
-            '--memory-exit-code' => 25,
         ])->assertExitCode(25);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
+
+        Worker::$memoryExceededExitCode = null;
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -165,19 +165,15 @@ class WorkCommandTest extends QueueTestCase
     public function testMemoryExitCode()
     {
         Queue::push(new FirstJob);
-        Queue::push(new SecondJob);
 
         $this->artisan('queue:work', [
-            '--daemon' => true,
-            '--stop-when-empty' => true,
             '--memory' => 0.1,
             '--memory-exit-code' => 13,
         ])->assertExitCode(13);
 
         // Memory limit isn't checked until after the first job is attempted.
-        $this->assertSame(2, Queue::size());
-        $this->assertTrue(FirstJob::$ran);
-        $this->assertFalse(SecondJob::$ran);
+        $this->assertSame(1, Queue::size());
+        $this->assertFalse(FirstJob::$ran);
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -162,6 +162,24 @@ class WorkCommandTest extends QueueTestCase
         $this->assertFalse(SecondJob::$ran);
     }
 
+    public function testMemoryExitCode()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 0.1,
+            '--memory-exit-code' => 25
+        ])->assertExitCode(25);
+
+        // Memory limit isn't checked until after the first job is attempted.
+        $this->assertSame(1, Queue::size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
+
     public function testFailedJobListenerOnlyRunsOnce()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -171,7 +171,7 @@ class WorkCommandTest extends QueueTestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--memory' => 0.1,
-            '--memory-exit-code' => 25
+            '--memory-exit-code' => 25,
         ])->assertExitCode(25);
 
         // Memory limit isn't checked until after the first job is attempted.

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -164,16 +164,21 @@ class WorkCommandTest extends QueueTestCase
 
     public function testMemoryExitCode()
     {
+        $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
+
         Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
 
         $this->artisan('queue:work', [
             '--memory' => 0.1,
-            '--memory-exit-code' => 13,
-        ])->assertExitCode(13);
+            '--memory-exit-code' => 25,
+        ])->assertExitCode(25);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
-        $this->assertFalse(FirstJob::$ran);
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -162,6 +162,24 @@ class WorkCommandTest extends QueueTestCase
         $this->assertFalse(SecondJob::$ran);
     }
 
+    public function testMemoryExitCode()
+    {
+        Queue::push(new FirstJob);
+        Queue::push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 0.1,
+            '--memory-exit-code' => 13,
+        ])->assertExitCode(13);
+
+        // Memory limit isn't checked until after the first job is attempted.
+        $this->assertSame(2, Queue::size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
+
     public function testFailedJobListenerOnlyRunsOnce()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -178,7 +178,6 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
-
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -177,7 +177,7 @@ class WorkCommandTest extends QueueTestCase
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());
         $this->assertTrue(FirstJob::$ran);
-        $this->assertFalse(SecondJob::$ra);
+        $this->assertFalse(SecondJob::$ran);
     }
 
     public function testFailedJobListenerOnlyRunsOnce()


### PR DESCRIPTION
This PR adds the ability to control the memory exceeded exit code. 

Any exit code other than 1 is treated as an error. Currently, Laravel uses a hard coded exit code of 12 for memory limits, which can trigger infrastructure-level consequences on some managed hosting platforms.

Real case scenario : 
- I have many workers running 
- I can only have so much memory between them 
- Occasionally - depending on the amount of jobs a worker may hit a memory limit and exit - it's restarted.
- The managed hosting provider restarts the whole worker container after 3x errors within 24 hrs (memory limits included) which make all the workers restart, even if they're working through something. 
- I basically want to force a success if this happens, so I'd use `0` as it'll restart as expected, but with no infrastructure consequences 

- Kept the constant in place for backward compatibility (in case anyone extends Worker and relies on it).
- Added a test to confirm the static works.

Any thoughts or improvements lmk 🫡 