### PR TITLE
Fix: use static:: instead of $this in static methods

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -39,7 +39,7 @@ class UniqueLock
             ? $job->uniqueVia()
             : $this->cache;
 
-        return (bool) $cache->lock($this->getKey($job), $uniqueFor)->get();
+        return (bool) $cache->lock(static::getKey($job), $uniqueFor)->get();
     }
 
     /**
@@ -54,7 +54,7 @@ class UniqueLock
             ? $job->uniqueVia()
             : $this->cache;
 
-        $cache->lock($this->getKey($job))->forceRelease();
+        $cache->lock(static::getKey($job))->forceRelease();
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -812,7 +812,7 @@ class Event
         }
 
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.
-            sha1($this->expression.$this->normalizeCommand($this->command ?? ''));
+            sha1($this->expression.static::normalizeCommand($this->command ?? ''));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1766,7 +1766,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function callNamedScope($scope, array $parameters = [])
     {
-        if ($this->isScopeMethodWithAttribute($scope)) {
+        if (static::isScopeMethodWithAttribute($scope)) {
             return $this->{$scope}(...$parameters);
         }
 

--- a/src/Illuminate/Foundation/Console/ChannelListCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelListCommand.php
@@ -78,7 +78,7 @@ class ChannelListCommand extends Command
             return mb_strlen($channelName);
         });
 
-        $terminalWidth = $this->getTerminalWidth();
+        $terminalWidth = static::getTerminalWidth();
 
         $channelCount = $this->determineChannelCountOutput($channels, $terminalWidth);
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -361,7 +361,7 @@ class RouteListCommand extends Command
 
         $maxMethod = mb_strlen($routes->max('method'));
 
-        $terminalWidth = $this->getTerminalWidth();
+        $terminalWidth = static::getTerminalWidth();
 
         $routeCount = $this->determineRouteCountOutput($routes, $terminalWidth);
 


### PR DESCRIPTION
Replaced `$this` calls inside static methods with `static::` to ensure proper late static binding.