### PR TITLE
Remove unnecessary parameters

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -63,9 +63,9 @@ trait ManagesFrequencies
 
         if ($endTime->lessThan($startTime)) {
             if ($startTime->greaterThan($now)) {
-                $startTime = $startTime->subDay(1);
+                $startTime = $startTime->subDay();
             } else {
-                $endTime = $endTime->addDay(1);
+                $endTime = $endTime->addDay();
             }
         }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
@@ -32,7 +32,7 @@ class ScheduleClearCacheCommand extends Command
     {
         $mutexCleared = false;
 
-        foreach ($schedule->events($this->laravel) as $event) {
+        foreach ($schedule->events() as $event) {
             if ($event->mutex->exists($event)) {
                 $this->components->info(sprintf('Deleting mutex for [%s]', $event->command));
 

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -55,7 +55,7 @@ class SQLiteBuilder extends Builder
 
         return $this->connection->getPostProcessor()->processTables(
             $this->connection->selectFromWriteConnection(
-                $this->grammar->compileTables($schema, $withSize)
+                $this->grammar->compileTables($schema)
             )
         );
     }


### PR DESCRIPTION
Cleaned up code by dropping extra arguments from method calls where parameters are no longer required.