### PR TITLE
[12.x] Consistent docblock formatting

### DIFF
--- a/src/Illuminate/Log/Events/MessageLogged.php
+++ b/src/Illuminate/Log/Events/MessageLogged.php
@@ -7,9 +7,9 @@ class MessageLogged
     /**
      * Create a new event instance.
      *
-     * @param  "emergency"|"alert"|"critical"|"error"|"warning"|"notice"|"info"|"debug"  $level  The log "level".
-     * @param  string  $message  The log message.
-     * @param  array  $context  The log context.
+     * @param  "emergency"|"alert"|"critical"|"error"|"warning"|"notice"|"info"|"debug"  $level
+     * @param  string  $message
+     * @param  array  $context
      */
     public function __construct(
         public $level,


### PR DESCRIPTION
Description
---
This PR updates the docblocks for consistency with the common style used across the framework, removing trailing inline descriptions and keeping only parameter names and types.