### PR TITLE
[12.x] Add `isEmail()` for `Str` and `Stringable`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -694,6 +694,7 @@ class Str
      */
     public static function isEmail(
         \Stringable|string $value,
+        bool $rfc = false,
         bool $strict = false,
         bool $dns = false,
         bool $spoof = false,
@@ -702,6 +703,7 @@ class Str
         array $customValidations = [],
     ): bool {
         $validations = (new Collection())
+            ->when($rfc, fn (Collection $collection) => $collection->push(new RFCValidation()))
             ->when($strict, fn (Collection $collection) => $collection->push(new NoRFCWarningsValidation()))
             ->when($dns, fn (Collection $collection) => $collection->push(new DNSCheckValidation()))
             ->when($spoof, fn (Collection $collection) => $collection->push(new SpoofCheckValidation()))

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -712,8 +712,7 @@ class Str
                     ->filter(fn ($class) => is_string($class) && class_exists($class))
                     ->map(fn ($class) => Container::getInstance()->make($class))
             )
-            ->unique()
-            ->values();
+            ->unique();
 
         if ($validations->isEmpty()) {
             $validations->push(new RFCValidation());

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -690,9 +690,8 @@ class Str
     /**
      * Determine if the given value is a valid email.
      *
-     * @param  mixed $value
+     * @param  mixed  $value
      * @param  array<int, int|string>  $parameters
-     *
      * @return bool
      */
     public static function isEmail($value, $parameters = [])
@@ -709,7 +708,7 @@ class Str
                 $validation === 'spoof' => new SpoofCheckValidation(),
                 $validation === 'filter' => new FilterEmailValidation(),
                 $validation === 'filter_unicode' => FilterEmailValidation::unicode(),
-                is_string($validation) && class_exists($validation) => $this->container->make($validation),
+                is_string($validation) && class_exists($validation) => Container::getInstance()->make($validation),
                 default => new RFCValidation(),
             })
             ->values()

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -414,12 +414,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Determine if the given value is a valid email.
      *
-     * @param  array<int, int|string>  $parameters
-     * @return bool
+     * @param  class-string[]  $customValidations
      */
-    public function isEmail($parameters = [])
-    {
-        return Str::isEmail($this->value, $parameters);
+    public function isEmail(
+        bool $strict = false,
+        bool $dns = false,
+        bool $spoof = false,
+        bool $filter = false,
+        bool $filterUnicode = false,
+        array $customValidations = [],
+    ): bool {
+        return Str::isEmail($this, $strict, $dns, $spoof, $filter, $filterUnicode, $customValidations);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -417,6 +417,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  class-string[]  $customValidations
      */
     public function isEmail(
+        bool $rfc = false,
         bool $strict = false,
         bool $dns = false,
         bool $spoof = false,
@@ -424,7 +425,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         bool $filterUnicode = false,
         array $customValidations = [],
     ): bool {
-        return Str::isEmail($this, $strict, $dns, $spoof, $filter, $filterUnicode, $customValidations);
+        return Str::isEmail($this, $rfc, $strict, $dns, $spoof, $filter, $filterUnicode, $customValidations);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -415,7 +415,6 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * Determine if the given value is a valid email.
      *
      * @param  array<int, int|string>  $parameters
-     *
      * @return bool
      */
     public function isEmail($parameters = [])

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -412,6 +412,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the given value is a valid email.
+     *
+     * @param  array<int, int|string>  $parameters
+     *
+     * @return bool
+     */
+    public function isEmail($parameters = [])
+    {
+        return Str::isEmail($this->value, $parameters);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,6 +18,7 @@
         "ext-ctype": "*",
         "ext-filter": "*",
         "ext-mbstring": "*",
+        "egulias/email-validator": "^3.2.5|^4.0",
         "doctrine/inflector": "^2.0",
         "illuminate/collections": "^12.0",
         "illuminate/conditionable": "^12.0",

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -936,6 +936,7 @@ trait ValidatesAttributes
 
         return Str::isEmail(
             $value,
+            $validations->containsStrict('rfc'),
             $validations->containsStrict('strict'),
             $validations->containsStrict('dns'),
             $validations->containsStrict('spoof'),
@@ -943,7 +944,7 @@ trait ValidatesAttributes
             $validations->containsStrict('filter_unicode'),
             $validations
                 ->reject(fn ($param) => in_array($param, [
-                    'strict', 'dns', 'spoof', 'filter', 'filter_unicode',
+                    'rfc', 'strict', 'dns', 'spoof', 'filter', 'filter_unicode',
                 ], true))
                 ->filter(fn ($class) => is_string($class) && class_exists($class))
                 ->values()

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -18,7 +18,6 @@
         "ext-filter": "*",
         "ext-mbstring": "*",
         "brick/math": "^0.11|^0.12|^0.13|^0.14",
-        "egulias/email-validator": "^3.2.5|^4.0",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -699,6 +699,8 @@ class SupportStrTest extends TestCase
 
         $this->assertFalse(Str::isEmail('test👨‍💻@domain.com'));
 
+        $this->assertFalse(Str::isEmail('test👨‍💻@domain.com', rfc: true));
+
         $this->assertTrue(Str::isEmail('foo@bar.com', strict: true));
 
         $this->assertFalse(Str::isEmail('test@example.com', dns: true));
@@ -714,6 +716,8 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isEmail(new Stringable('foo@bar.com')));
 
         $this->assertTrue(Str::isEmail('foo@bar.com', customValidations: ['NonExistentClass']));
+
+        $this->assertFalse(Str::isEmail('test👨‍💻@domain.com', rfc: true, spoof: true));
 
         $this->assertFalse(Str::isEmail(''));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Exception;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -688,6 +689,43 @@ class SupportStrTest extends TestCase
     public function testIsUuidWithVersion($uuid, $version, $passes)
     {
         $this->assertSame(Str::isUuid($uuid, $version), $passes);
+    }
+
+    public function testIsEmail(): void
+    {
+        $this->assertTrue(Str::isEmail('foo@bar.com'));
+
+        $this->assertFalse(Str::isEmail('foo-bar'));
+
+        $this->assertTrue(Str::isEmail('foo@bar.com', ['strict']));
+
+        $this->assertTrue(Str::isEmail('taylor@laravel.com', ['dns']));
+
+        $this->assertTrue(Str::isEmail('foo@bar.com', ['spoof']));
+
+        $this->assertTrue(Str::isEmail('foo@bar.com', ['filter']));
+
+        $this->assertTrue(Str::isEmail('unicode@xn--r8jz45g.xn--zckzah', ['filter_unicode']));
+
+        $this->assertTrue(Str::isEmail(new Stringable('foo@bar.com')));
+
+        $this->assertFalse(Str::isEmail(new \stdClass));
+
+        $this->assertFalse(Str::isEmail(['foo@bar.com']));
+
+        $this->assertTrue(Str::isEmail('support@laravel.com', ['strict', 'strict', 'dns', 'dns']));
+
+        $this->assertTrue(Str::isEmail('foo@bar.com', ['NonExistentClass']));
+
+        $this->assertFalse(Str::isEmail(''));
+
+        $this->assertFalse(Str::isEmail(null));
+
+        $this->assertFalse(Str::isEmail(12345));
+
+        $this->assertFalse(Str::isEmail(123.45));
+
+        $this->assertFalse(Str::isEmail(true));
     }
 
     public function testIsJson()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -697,35 +697,23 @@ class SupportStrTest extends TestCase
 
         $this->assertFalse(Str::isEmail('foo-bar'));
 
-        $this->assertTrue(Str::isEmail('foo@bar.com', ['strict']));
+        $this->assertTrue(Str::isEmail('foo@bar.com', strict: true));
 
-        $this->assertTrue(Str::isEmail('taylor@laravel.com', ['dns']));
+        $this->assertFalse(Str::isEmail('test@example.com', dns: true));
 
-        $this->assertTrue(Str::isEmail('foo@bar.com', ['spoof']));
+        $this->assertTrue(Str::isEmail('taylor@laravel.com', dns: true));
 
-        $this->assertTrue(Str::isEmail('foo@bar.com', ['filter']));
+        $this->assertTrue(Str::isEmail('foo@bar.com', spoof: true));
 
-        $this->assertTrue(Str::isEmail('unicode@xn--r8jz45g.xn--zckzah', ['filter_unicode']));
+        $this->assertTrue(Str::isEmail('foo@bar.com', filter: true));
+
+        $this->assertTrue(Str::isEmail('unicode@xn--r8jz45g.xn--zckzah', filterUnicode: true));
 
         $this->assertTrue(Str::isEmail(new Stringable('foo@bar.com')));
 
-        $this->assertFalse(Str::isEmail(new \stdClass));
-
-        $this->assertFalse(Str::isEmail(['foo@bar.com']));
-
-        $this->assertTrue(Str::isEmail('support@laravel.com', ['strict', 'strict', 'dns', 'dns']));
-
-        $this->assertTrue(Str::isEmail('foo@bar.com', ['NonExistentClass']));
+        $this->assertTrue(Str::isEmail('foo@bar.com', customValidations: ['NonExistentClass']));
 
         $this->assertFalse(Str::isEmail(''));
-
-        $this->assertFalse(Str::isEmail(null));
-
-        $this->assertFalse(Str::isEmail(12345));
-
-        $this->assertFalse(Str::isEmail(123.45));
-
-        $this->assertFalse(Str::isEmail(true));
     }
 
     public function testIsJson()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -697,6 +697,8 @@ class SupportStrTest extends TestCase
 
         $this->assertFalse(Str::isEmail('foo-bar'));
 
+        $this->assertFalse(Str::isEmail('test👨‍💻@domain.com'));
+
         $this->assertTrue(Str::isEmail('foo@bar.com', strict: true));
 
         $this->assertFalse(Str::isEmail('test@example.com', dns: true));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -70,6 +70,8 @@ class SupportStringableTest extends TestCase
 
         $this->assertFalse($this->stringable('foo-bar')->isEmail());
 
+        $this->assertFalse($this->stringable('test👨‍💻@domain.com')->isEmail());
+
         $this->assertTrue($this->stringable('foo@bar.com')->isEmail(strict: true));
 
         $this->assertFalse($this->stringable('test@example.com')->isEmail(dns: true));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -70,19 +70,19 @@ class SupportStringableTest extends TestCase
 
         $this->assertFalse($this->stringable('foo-bar')->isEmail());
 
-        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['strict']));
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(strict: true));
 
-        $this->assertTrue($this->stringable('taylor@laravel.com')->isEmail(['dns']));
+        $this->assertFalse($this->stringable('test@example.com')->isEmail(dns: true));
 
-        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['spoof']));
+        $this->assertTrue($this->stringable('taylor@laravel.com')->isEmail(dns: true));
 
-        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['filter']));
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(spoof: true));
 
-        $this->assertTrue($this->stringable('unicode@xn--r8jz45g.xn--zckzah')->isEmail(['filter_unicode']));
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(filter: true));
 
-        $this->assertTrue($this->stringable('support@laravel.com')->isEmail(['strict', 'strict', 'dns', 'dns']));
+        $this->assertTrue($this->stringable('unicode@xn--r8jz45g.xn--zckzah')->isEmail(filterUnicode: true));
 
-        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['NonExistentClass']));
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(customValidations: ['NonExistentClass']));
 
         $this->assertFalse($this->stringable()->isEmail());
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -64,6 +64,29 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('01GJSNW9MAF-792C0XYY8RX6ssssss-QFT')->isUlid());
     }
 
+    public function testIsEmail(): void
+    {
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail());
+
+        $this->assertFalse($this->stringable('foo-bar')->isEmail());
+
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['strict']));
+
+        $this->assertTrue($this->stringable('taylor@laravel.com')->isEmail(['dns']));
+
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['spoof']));
+
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['filter']));
+
+        $this->assertTrue($this->stringable('unicode@xn--r8jz45g.xn--zckzah')->isEmail(['filter_unicode']));
+
+        $this->assertTrue($this->stringable('support@laravel.com')->isEmail(['strict', 'strict', 'dns', 'dns']));
+
+        $this->assertTrue($this->stringable('foo@bar.com')->isEmail(['NonExistentClass']));
+
+        $this->assertFalse($this->stringable()->isEmail());
+    }
+
     public function testIsJson()
     {
         $this->assertTrue($this->stringable('1')->isJson());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -72,6 +72,8 @@ class SupportStringableTest extends TestCase
 
         $this->assertFalse($this->stringable('test👨‍💻@domain.com')->isEmail());
 
+        $this->assertFalse($this->stringable('test👨‍💻@domain.com')->isEmail(rfc: true));
+
         $this->assertTrue($this->stringable('foo@bar.com')->isEmail(strict: true));
 
         $this->assertFalse($this->stringable('test@example.com')->isEmail(dns: true));
@@ -85,6 +87,8 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('unicode@xn--r8jz45g.xn--zckzah')->isEmail(filterUnicode: true));
 
         $this->assertTrue($this->stringable('foo@bar.com')->isEmail(customValidations: ['NonExistentClass']));
+
+        $this->assertFalse($this->stringable('test👨‍💻@domain.com')->isEmail(rfc: true, spoof: true));
 
         $this->assertFalse($this->stringable()->isEmail());
     }


### PR DESCRIPTION
This PR introduces a new method to determine if a value is a valid email. Currently, the only way to check this is using the `Validator`. This change transfers the logic of  `ValidatesAttributes::validateEmail()` into `Str::isEmail()`

### Signature

```php
public static function isEmail(
        \Stringable|string $value,
        bool $rfc = false,
        bool $strict = false,
        bool $dns = false,
        bool $spoof = false,
        bool $filter = false,
        bool $filterUnicode = false,
        array $customValidations = [],
    ): bool {}
```

### Usage

#### Basic

```php
Str::isEmail('foo@bar.com'); // true

Str::isEmail('invalid-email'); // false
```

#### Validation Mode

``` php
Str::isEmail('taylor@laravel.com', dns: true); // true

Str::isEmail('test👨‍💻@domain.com', rfc: true); // false
```

> [!NOTE]
> RFC validation will be used by default if all the flags are set to false and there aren't any custom validations added.

#### `Stringable` class

```php
(new Stringable('test@example.com'))->isEmail(); // true
```