### PR TITLE
[Feature/Fix] Add support for PHPStorm using Jetbrains Toolbox

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -171,7 +171,7 @@ trait ResolvesDumpSource
 
         $project = $editor['project'] ?? null;
 
-        if (in_array($editorName, ['jetbrains-phpstorm']) && empty($project)){
+        if (in_array($editorName, ['jetbrains-phpstorm']) && empty($project)) {
             $project = basename($this->basePath);
         }
 
@@ -179,7 +179,7 @@ trait ResolvesDumpSource
             $href = str_replace('{project}', $project, $href);
         }
 
-        if (in_array($editorName, ['jetbrains-phpstorm'])){
+        if (in_array($editorName, ['jetbrains-phpstorm'])) {
             $file = str_replace($this->basePath, '', $file);
         }
 

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -171,7 +171,7 @@ trait ResolvesDumpSource
 
         $project = $editor['project'] ?? null;
 
-        if(in_array($editorName, ['jetbrains-phpstorm']) && empty($project)){
+        if (in_array($editorName, ['jetbrains-phpstorm']) && empty($project)){
             $project = basename($this->basePath);
         }
 
@@ -179,7 +179,7 @@ trait ResolvesDumpSource
             $href = str_replace('{project}', $project, $href);
         }
 
-        if(in_array($editorName, ['jetbrains-phpstorm'])){
+        if (in_array($editorName, ['jetbrains-phpstorm'])){
             $file = str_replace($this->basePath, '', $file);
         }
 


### PR DESCRIPTION
**Good Editor URL :** jetbrains://php-storm/navigate/reference?project={project}&path={file}:{line}

**{project}** = name of the project from Jetbrains Toolbox, and most of the time is the same as the basename($this->basePath)

**{file}** = relative path to the project folder not the full path to file 

I used in_array($editorName, ['jetbrains-phpstorm']) to be ready for future situations, maybe for 'jetbrains-idea' IntelliJ IDEA editor

I cannot test the IntelliJ IDEA editor, but I suspect there is the same situation when you use Jetbrains Toolbox and I don't know the url.

Suggestion:
It will be nice to have some documentation about the use of `app.editor` config because I didn't find anywhere, and maybe like others, I lost a lot of time checking and testing. And about docs, I didn't find a good place to add it.

Observation:
1) current ugly working hack without this fix:
`config/app.php`:
```
editor => env('APP_EDITOR_HREF') ? [
  'name' => env('APP_EDITOR', 'phpstorm'),
  'href' => env('APP_EDITOR_HREF'),
  'base_path' => env('APP_EDITOR_BASE_PATH', ''),
] : env('APP_EDITOR', 'phpstorm')
```
and `.env`:
```
APP_EDITOR_HREF = jetbrains://php-storm/navigate/reference?project=project-laravel&path{file}:{line} 
APP_EDITOR_BASE_PATH = "="
```
because I need it to remove the base path to the project, I made use of 'base_path' (that cannot be empty) and in href I use "path{file}" not "path={file}" and the "=" I add it back using 'base_path' :)

2) after implementation of this fix
`config/app.php`:
```
editor => env('APP_EDITOR_HREF') || env('APP_EDITOR_PROJECT') ? [
  'name' => env('APP_EDITOR', 'jetbrains-phpstorm'),
  'href' => env('APP_EDITOR_HREF', ''),
  'project' => env('APP_EDITOR_PROJECT', ''),
  'base_path' => env('APP_EDITOR_BASE_PATH', ''),
] : env('APP_EDITOR', 'jetbrains-phpstorm')
```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
