### PR TITLE
Refactor: remove redundant empty() check before foreachForeach

### DIFF
--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -367,11 +367,10 @@ class Middleware
             $this->removeFromGroup($group, $remove);
         }
 
-        if (! empty($replace)) {
-            foreach ($replace as $search => $replace) {
-                $this->replaceInGroup($group, $search, $replace);
-            }
+        foreach ((array) $replace as $search => $replace) {
+            $this->replaceInGroup($group, $search, $replace);
         }
+        
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -370,7 +370,6 @@ class Middleware
         foreach ((array) $replace as $search => $replace) {
             $this->replaceInGroup($group, $search, $replace);
         }
-        
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Configuration/Middleware.php
+++ b/src/Illuminate/Foundation/Configuration/Middleware.php
@@ -367,7 +367,7 @@ class Middleware
             $this->removeFromGroup($group, $remove);
         }
 
-        foreach ((array) $replace as $search => $replace) {
+        foreach ($replace as $search => $replace) {
             $this->replaceInGroup($group, $search, $replace);
         }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -215,17 +215,14 @@ class MailChannel
 
         $mailMessage->to($this->getRecipients($notifiable, $notification, $message));
 
-        if (! empty($message->cc)) {
-            foreach ($message->cc as $cc) {
-                $mailMessage->cc($cc[0], Arr::get($cc, 1));
-            }
+        foreach ((array) $message->cc as $cc) {
+            $mailMessage->cc($cc[0], Arr::get($cc, 1));
         }
 
-        if (! empty($message->bcc)) {
-            foreach ($message->bcc as $bcc) {
-                $mailMessage->bcc($bcc[0], Arr::get($bcc, 1));
-            }
+        foreach ((array) $message->bcc as $bcc) {
+            $mailMessage->bcc($bcc[0], Arr::get($bcc, 1));
         }
+        
     }
 
     /**
@@ -241,11 +238,10 @@ class MailChannel
             $mailMessage->from($message->from[0], Arr::get($message->from, 1));
         }
 
-        if (! empty($message->replyTo)) {
-            foreach ($message->replyTo as $replyTo) {
-                $mailMessage->replyTo($replyTo[0], Arr::get($replyTo, 1));
-            }
+        foreach ((array) $message->replyTo as $replyTo) {
+            $mailMessage->replyTo($replyTo[0], Arr::get($replyTo, 1));
         }
+        
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -222,7 +222,6 @@ class MailChannel
         foreach ((array) $message->bcc as $bcc) {
             $mailMessage->bcc($bcc[0], Arr::get($bcc, 1));
         }
-        
     }
 
     /**
@@ -241,7 +240,6 @@ class MailChannel
         foreach ((array) $message->replyTo as $replyTo) {
             $mailMessage->replyTo($replyTo[0], Arr::get($replyTo, 1));
         }
-        
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -324,10 +324,8 @@ abstract class Queue
      */
     protected function withCreatePayloadHooks($queue, array $payload)
     {
-        if (! empty(static::$createPayloadCallbacks)) {
-            foreach (static::$createPayloadCallbacks as $callback) {
-                $payload = array_merge($payload, $callback($this->getConnectionName(), $queue, $payload));
-            }
+        foreach ((array) static::$createPayloadCallbacks as $callback) {
+            $payload = array_merge($payload, $callback($this->getConnectionName(), $queue, $payload));
         }
 
         return $payload;

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -511,16 +511,14 @@ class PendingCommand
             $this->test->fail('Question "'.Arr::first($this->test->expectedQuestions)[0].'" was not asked.');
         }
 
-        if (count($this->test->expectedChoices) > 0) {
-            foreach ($this->test->expectedChoices as $question => $answers) {
-                $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
+        foreach ((array) $this->test->expectedChoices as $question => $answers) {
+            $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
 
-                $this->test->{$assertion}(
-                    $answers['expected'],
-                    $answers['actual'],
-                    'Question "'.$question.'" has different options.'
-                );
-            }
+            $this->test->{$assertion}(
+                $answers['expected'],
+                $answers['actual'],
+                'Question "'.$question.'" has different options.'
+            );
         }
 
         if (count($this->test->expectedOutput)) {


### PR DESCRIPTION
The explicit `if (!empty(...))` condition was removed since `foreach` 
already handles empty arrays gracefully. This makes the code simpler 
and avoids unnecessary nesting.

Also renamed loop variable for better clarity in case of shadowing.