### PR TITLE
Refactor: simplify file condition by dropping redundant null check

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -193,7 +193,7 @@ trait InteractsWithInput
     protected function convertUploadedFiles(array $files)
     {
         return array_map(function ($file) {
-            if (is_null($file) || (is_array($file) && empty(array_filter($file)))) {
+            if (is_array($file) && empty(array_filter($file))) {
                 return $file;
             }
 


### PR DESCRIPTION
Removed the `is_null($file)` part from the condition.  
The logic now only checks for empty `arrays` via `is_array($file) && empty(array_filter($file))`.