### PR TITLE
Refactor: remove unnecessary type recasting

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -438,7 +438,7 @@ trait FormatsMessages
             8 => 'eighth',
             9 => 'ninth',
             10 => 'tenth',
-        ][(int) $value] ?? 'other';
+        ][$value] ?? 'other';
     }
 
     /**


### PR DESCRIPTION
Eliminated redundant type casts to simplify the code and rely on native types where possible. 
This improves readability without changing behavior.