### PR TITLE
Fix: add support for full list of boolean values for validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -491,8 +491,8 @@ trait ValidatesAttributes
     public function validateBoolean($attribute, $value, $parameters)
     {
         $acceptable = [
-          ...$this->truthyValues(),
-          ...$this->falsyValues(),
+            ...$this->truthyValues(),
+            ...$this->falsyValues(),
         ];
 
         if (($parameters[0] ?? null) === 'strict') {
@@ -2905,7 +2905,7 @@ trait ValidatesAttributes
      */
     protected function truthyValues(): array
     {
-        return [ 'yes', 'on', '1', 1, true, 'true' ];
+        return ['yes', 'on', '1', 1, true, 'true'];
     }
 
     /**
@@ -2913,6 +2913,6 @@ trait ValidatesAttributes
      */
     protected function falsyValues(): array
     {
-        return [ 'no', 'off', '0', 0, false, 'false' ];
+        return ['no', 'off', '0', 0, false, 'false'];
     }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -43,7 +43,7 @@ trait ValidatesAttributes
      */
     public function validateAccepted($attribute, $value)
     {
-        $acceptable = ['yes', 'on', '1', 1, true, 'true'];
+        $acceptable = $this->truthyValues();
 
         return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
     }
@@ -58,7 +58,7 @@ trait ValidatesAttributes
      */
     public function validateAcceptedIf($attribute, $value, $parameters)
     {
-        $acceptable = ['yes', 'on', '1', 1, true, 'true'];
+        $acceptable = $this->truthyValues();
 
         $this->requireParameterCount(2, $parameters, 'accepted_if');
 
@@ -82,7 +82,7 @@ trait ValidatesAttributes
      */
     public function validateDeclined($attribute, $value)
     {
-        $acceptable = ['no', 'off', '0', 0, false, 'false'];
+        $acceptable = $this->falsyValues();
 
         return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
     }
@@ -97,7 +97,7 @@ trait ValidatesAttributes
      */
     public function validateDeclinedIf($attribute, $value, $parameters)
     {
-        $acceptable = ['no', 'off', '0', 0, false, 'false'];
+        $acceptable = $this->falsyValues();
 
         $this->requireParameterCount(2, $parameters, 'declined_if');
 
@@ -490,7 +490,10 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value, $parameters)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [
+          ...$this->truthyValues(),
+          ...$this->falsyValues(),
+        ];
 
         if (($parameters[0] ?? null) === 'strict') {
             $acceptable = [true, false];
@@ -2895,5 +2898,21 @@ trait ValidatesAttributes
         }
 
         return $value;
+    }
+
+    /**
+     * Returns a list of truthy values.
+     */
+    protected function truthyValues(): array
+    {
+        return [ 'yes', 'on', '1', 1, true, 'true' ];
+    }
+
+    /**
+     * Returns a list of falsy values.
+     */
+    protected function falsyValues(): array
+    {
+        return [ 'no', 'off', '0', 0, false, 'false' ];
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3217,7 +3217,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool:strict']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3083,16 +3083,22 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'off'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -3158,16 +3164,22 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'off'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
I'm not sure why `boolean` in validations has only supported a subset of values from `accepted` and `declined`, but from my point of view, it stands to reason that the set of values should be the same. So far, the values `"on"`, `"yes"`, `"off"`, and `"no"` have not been supported by `boolean` but they have been by `accepted` and `declined`. Even if I cast a value to a boolean via Fluent, these values are accepted.