### PR TITLE
[12.x]: Nested translations in JSON

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -130,7 +130,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // For JSON translations, the loaded files will contain the correct line.
         // Otherwise, we must assume we are handling typical translation file
         // and check if the returned line is not the same as the given key.
-        if (! is_null($this->loaded['*']['*'][$locale][$key] ?? null)) {
+        if (Arr::has($this->loaded['*']['*'][$locale], $key)) {
             return true;
         }
 
@@ -155,7 +155,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a
@@ -333,7 +333,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // lines that have already been loaded so that we can easily access them.
         $lines = $this->loader->load($locale, $group, $namespace);
 
-        $this->loaded[$namespace][$group][$locale] = $lines;
+        Arr::set($this->loaded, "$namespace.$group.$locale", $lines);
     }
 
     /**
@@ -346,7 +346,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function isLoaded($namespace, $group, $locale)
     {
-        return isset($this->loaded[$namespace][$group][$locale]);
+        return Arr::has($this->loaded, "$namespace.$group.$locale");
     }
 
     /**

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -43,6 +43,39 @@ class TranslatorTest extends TestCase
         $this->assertTrue($this->app['translator']->hasForLocale('30 Days'));
     }
 
+    public function testItCanCheckKeyExistsHasFromLocaleForJsonWithNestedKeys()
+    {
+        $this->assertTrue($this->app['translator']->has('days.monday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.monday'));
+        $this->assertTrue($this->app['translator']->has('days.wednesday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.wednesday'));
+        $this->assertTrue($this->app['translator']->has('days.friday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.friday'));
+
+        $this->assertFalse($this->app['translator']->has('days.sunday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.sunday'));
+        $this->assertFalse($this->app['translator']->has('days.tuesday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.tuesday'));
+        $this->assertFalse($this->app['translator']->has('days.thursday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.thursday'));
+
+        $this->app->setLocale('fr');
+
+        $this->assertTrue($this->app['translator']->has('days.sunday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.sunday'));
+        $this->assertTrue($this->app['translator']->has('days.tuesday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.tuesday'));
+        $this->assertTrue($this->app['translator']->has('days.thursday'));
+        $this->assertTrue($this->app['translator']->hasForLocale('days.thursday'));
+
+        $this->assertFalse($this->app['translator']->has('days.monday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.monday'));
+        $this->assertFalse($this->app['translator']->has('days.wednesday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.wednesday'));
+        $this->assertFalse($this->app['translator']->has('days.friday'));
+        $this->assertFalse($this->app['translator']->hasForLocale('days.friday'));
+    }
+
     public function testItCanCheckKeyExistsWithoutTriggeringHandleMissingKeys()
     {
         $this->app['translator']->handleMissingKeysUsing(function ($key) {

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -52,12 +52,20 @@ class TranslatorTest extends TestCase
         $this->assertTrue($this->app['translator']->has('days.friday'));
         $this->assertTrue($this->app['translator']->hasForLocale('days.friday'));
 
+        $this->assertSame('Monday', $this->app['translator']->get('days.monday'));
+        $this->assertSame('Wednesday', $this->app['translator']->get('days.wednesday'));
+        $this->assertSame('Friday', $this->app['translator']->get('days.friday'));
+
         $this->assertFalse($this->app['translator']->has('days.sunday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.sunday'));
         $this->assertFalse($this->app['translator']->has('days.tuesday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.tuesday'));
         $this->assertFalse($this->app['translator']->has('days.thursday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.thursday'));
+
+        $this->assertSame('days.sunday', $this->app['translator']->get('days.sunday'));
+        $this->assertSame('days.tuesday', $this->app['translator']->get('days.tuesday'));
+        $this->assertSame('days.thursday', $this->app['translator']->get('days.thursday'));
 
         $this->app->setLocale('fr');
 
@@ -68,12 +76,20 @@ class TranslatorTest extends TestCase
         $this->assertTrue($this->app['translator']->has('days.thursday'));
         $this->assertTrue($this->app['translator']->hasForLocale('days.thursday'));
 
+        $this->assertSame('Dimanche', $this->app['translator']->get('days.sunday'));
+        $this->assertSame('Mardi', $this->app['translator']->get('days.tuesday'));
+        $this->assertSame('Jeudi', $this->app['translator']->get('days.thursday'));
+
         $this->assertFalse($this->app['translator']->has('days.monday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.monday'));
         $this->assertFalse($this->app['translator']->has('days.wednesday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.wednesday'));
         $this->assertFalse($this->app['translator']->has('days.friday'));
         $this->assertFalse($this->app['translator']->hasForLocale('days.friday'));
+
+        $this->assertSame('days.monday', $this->app['translator']->get('days.monday'));
+        $this->assertSame('days.wednesday', $this->app['translator']->get('days.wednesday'));
+        $this->assertSame('days.friday', $this->app['translator']->get('days.friday'));
     }
 
     public function testItCanCheckKeyExistsWithoutTriggeringHandleMissingKeys()

--- a/tests/Integration/Translation/lang/en.json
+++ b/tests/Integration/Translation/lang/en.json
@@ -3,5 +3,10 @@
     "30 Days": "30 Days",
     "365 Days": "365 Days",
     "60 Days": "60 Days",
-    "90 Days": "90 Days"
+    "90 Days": "90 Days",
+    "days": {
+        "monday": "Monday",
+        "wednesday": "Wednesday",
+        "friday": "Friday"
+    }
 }

--- a/tests/Integration/Translation/lang/fr.json
+++ b/tests/Integration/Translation/lang/fr.json
@@ -2,5 +2,10 @@
     "30 Days": "30 jours",
     "365 Days": "365 jours",
     "60 Days": "60 jours",
-    "90 Days": "90 jours"
+    "90 Days": "90 jours",
+    "days": {
+        "sunday": "Dimanche",
+        "tuesday": "Mardi",
+        "thursday": "Jeudi"
+    }
 }


### PR DESCRIPTION
Currently, Laravel only supports flat keys in JSON translation files, which limits translation organization. By allowing nested keys, we can:

- Better organize translations by context (e.g., enum.alert.error → enum > alert > error).
- Maintain consistency between JSON and PHP files, which already support nested arrays.
- Scale large projects without maintaining a huge, hard-to-navigate JSON file.

This makes maintenance easier, improves readability, and makes using JSON as powerful as PHP translation files.

This is similar to several React and Vue libraries, for example. I believe JSON translations are simpler and easier to maintain, so I think support for nested keys in JSON would be excellent.

Examples:

Vue - https://vue-i18n.intlify.dev/
React - https://www.i18next.com/

@taylorotwell Could you please review this PR carefully, please? There are currently several tools for organizing JSON translations, and this would be very helpful.