### PR TITLE
[12.x] Ensure `laravel-cloud-socket` respects `LOG_LEVEL`

### DIFF
--- a/src/Illuminate/Foundation/Cloud.php
+++ b/src/Illuminate/Foundation/Cloud.php
@@ -123,6 +123,9 @@ class Cloud
 
         $app['config']->set('logging.channels.laravel-cloud-socket', [
             'driver' => 'monolog',
+            'level' => $_ENV['LOG_LEVEL'] ??
+                       $_SERVER['LOG_LEVEL'] ??
+                       'debug',
             'handler' => SocketHandler::class,
             'formatter' => JsonFormatter::class,
             'formatter_with' => [

--- a/tests/Integration/Foundation/CloudTest.php
+++ b/tests/Integration/Foundation/CloudTest.php
@@ -52,4 +52,23 @@ class CloudTest extends TestCase
 
         unset($_SERVER['LARAVEL_CLOUD_DISK_CONFIG']);
     }
+
+    public function test_it_respects_log_levels()
+    {
+        if (isset($_SERVER['LOG_LEVEL'])) {
+            $logLevelBackup = $_SERVER['LOG_LEVEL'];
+        }
+
+        $_SERVER['LOG_LEVEL'] = 'notice';
+
+        Cloud::configureCloudLogging($this->app);
+
+        $this->assertEquals('notice', $this->app['config']->get('logging.channels.laravel-cloud-socket.level'));
+
+        unset($_SERVER['LOG_LEVEL']);
+
+        if (isset($logLevelBackup)) {
+            $_SERVER['LOG_LEVEL'] = $logLevelBackup;
+        }
+    }
 }


### PR DESCRIPTION
In Laravel Cloud, all logs are reported regardless of the `LOG_LEVEL` configured.

This pull request improves the configuration of cloud logging in the application by allowing the log level to be set via environment variables, and adds a test to verify this behavior.

**Cloud logging configuration:**

* Updated `configureCloudLogging` in `Cloud.php` to set the log level using the `LOG_LEVEL` environment variable, falling back to `'debug'` if not set.

**Testing enhancements:**

* Added `test_it_respects_log_levels` in `CloudTest.php` to ensure the log level configuration respects the `LOG_LEVEL` environment variable.
