### PR TITLE
[12.x] Fix 'can' function that was defined in RouterRegistrar in #54648

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1007,6 +1007,10 @@ class Route
             $this->domain($this->action['domain']);
         }
 
+        if (isset($this->action['can'])) {
+            $this->can($this->action['can']);
+        }
+
         return $this;
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -900,6 +900,15 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
+    public function testCanSetMiddlewareCanOnGroups()
+    {
+        $this->router->can('test')->group(function ($router) {
+            $router->get('/');
+        });
+
+        $this->seeMiddleware('can:test');
+    }
+
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)


### PR DESCRIPTION
I saw that a `can` function was added to the $allowedAttributes array in PR #54648 but this did not actually work for route groups. This has the potential for security issues in applications that assume `can` works because it's in the allowedAttributes array when it actually doesn't, which for untested endpoints means you could potentially access unauthorized routes. This change adds it to the route middleware when assigning it to the route actions, which makes it work.

The test failed before this PR but works after the changes. 
