### PR TITLE
[12.x] Allow newer versions for phiki/phiki than 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^3.8.4",
         "nunomaduro/termwind": "^2.0",
-        "phiki/phiki": "v2.0.0",
+        "phiki/phiki": "^2.0.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
 i don't see any reason why phiki/phiki is pinned to v2.0.0, which is now [outdated already](https://github.com/phikiphp/phiki/releases/tag/v2.0.1). 

introduced in 2d0d6f5f72272a0a0999a10ad12b18fd6564ccc9 PR #57036