### PR TITLE
[12.x] Fix SQS FIFO and fair queue support

### DIFF
--- a/tests/Queue/Fixtures/FakeSqsJob.php
+++ b/tests/Queue/Fixtures/FakeSqsJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class FakeSqsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -326,6 +326,8 @@ class QueueSqsQueueTest extends TestCase
         $id = $queue->push($this->mockedJob, $this->mockedData, $this->fifoQueueName);
         $this->assertEquals($this->mockedMessageId, $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobObjectOntoSqsFifoQueue()
@@ -342,6 +344,8 @@ class QueueSqsQueueTest extends TestCase
         $id = $queue->push($job, $this->mockedData, $this->fifoQueueName);
         $this->assertEquals($this->mockedMessageId, $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 
     public function testPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueue()
@@ -362,6 +366,8 @@ class QueueSqsQueueTest extends TestCase
         FakeSqsJob::dispatch()->onGroup($this->mockedMessageGroupId);
 
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 
     public function testDelayedPushProperlyPushesJobStringOntoSqsFifoQueueWithoutDelay()
@@ -377,6 +383,8 @@ class QueueSqsQueueTest extends TestCase
         $id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->fifoQueueName);
         $this->assertEquals($this->mockedMessageId, $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 
     public function testDelayedPushProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay()
@@ -394,6 +402,8 @@ class QueueSqsQueueTest extends TestCase
         $id = $queue->later($this->mockedDelay, $job, $this->mockedData, $this->fifoQueueName);
         $this->assertEquals($this->mockedMessageId, $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 
     public function testDelayedPendingDispatchProperlyPushesJobObjectOntoSqsFifoQueueWithoutDelay()
@@ -414,5 +424,7 @@ class QueueSqsQueueTest extends TestCase
         FakeSqsJob::dispatch()->onGroup($this->mockedMessageGroupId)->delay($this->mockedDelay);
 
         $container->shouldHaveReceived('bound')->with('events')->twice();
+
+        Str::createUuidsNormally();
     }
 }

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Illuminate\Tests\Queue\Fixtures\FakeSqsJob;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -19,14 +20,17 @@ class QueueSqsQueueTest extends TestCase
     protected $sqs;
     protected $account;
     protected $queueName;
+    protected $fifoQueueName;
     protected $baseUrl;
     protected $prefix;
     protected $queueUrl;
+    protected $fifoQueueUrl;
     protected $mockedJob;
     protected $mockedData;
     protected $mockedPayload;
     protected $mockedDelay;
     protected $mockedMessageGroupId;
+    protected $mockedDeduplicationId;
     protected $mockedMessageId;
     protected $mockedReceiptHandle;
     protected $mockedSendMessageResponseModel;
@@ -46,17 +50,20 @@ class QueueSqsQueueTest extends TestCase
 
         $this->account = '1234567891011';
         $this->queueName = 'emails';
+        $this->fifoQueueName = 'emails.fifo';
         $this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 
         // This is how the modified getQueue builds the queueUrl
         $this->prefix = $this->baseUrl.'/'.$this->account.'/';
         $this->queueUrl = $this->prefix.$this->queueName;
+        $this->fifoQueueUrl = $this->prefix.$this->fifoQueueName;
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
         $this->mockedPayload = json_encode(['job' => $this->mockedJob, 'data' => $this->mockedData]);
         $this->mockedDelay = 10;
         $this->mockedMessageGroupId = 'group-1';
+        $this->mockedDeduplicationId = 'deduplication-id-1';
         $this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
         $this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
@@ -304,6 +311,20 @@ class QueueSqsQueueTest extends TestCase
 
         FakeSqsJob::dispatch()->onGroup($this->mockedMessageGroupId);
 
+        $container->shouldHaveReceived('bound')->with('events')->twice();
+    }
+
+    public function testPushProperlyPushesJobStringOntoSqsFifoQueue()
+    {
+        Str::createUuidsUsing(fn () => $this->mockedDeduplicationId);
+
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])->getMock();
+        $queue->setContainer($container = m::spy(Container::class));
+        $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->fifoQueueName, $this->mockedData)->willReturn($this->mockedPayload);
+        $queue->expects($this->once())->method('getQueue')->with($this->fifoQueueName)->willReturn($this->fifoQueueUrl);
+        $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->fifoQueueUrl, 'MessageBody' => $this->mockedPayload, 'MessageGroupId' => $this->fifoQueueName, 'MessageDeduplicationId' => $this->mockedDeduplicationId])->andReturn($this->mockedSendMessageResponseModel);
+        $id = $queue->push($this->mockedJob, $this->mockedData, $this->fifoQueueName);
+        $this->assertEquals($this->mockedMessageId, $id);
         $container->shouldHaveReceived('bound')->with('events')->twice();
     }
 }


### PR DESCRIPTION
PR #56763 added initial support for SQS FIFO and fair queues. However, there are a couple issues with the implementation.

### Issues

1. The extra options are only added if the queue name ends with ".fifo". This means that fair queues are not actually supported, since the `MessageGroupId` option will only be sent on FIFO queues.

2. The extra options are only added if a job object is dispatched. If the string notation is used to dispatch to a FIFO queue, the extra options will not be added and the code will throw an exception (ex: `Queue::push('ProcessPodcast@handle')`).

3. Depending on how the job is dispatched, the queue name passed into the `getQueueableOptions()` method may be `null`. When this is the case, the method will not recognize the queue as a FIFO queue, the extra options will not be added, and the job dispatch will throw an exception.
    - For example, assume the application default queue is a FIFO queue. `ProcessPodcast::dispatch($podcast)` will attempt to dispatch to the default FIFO queue. However, since the queue name wasn't specified for the job, `$queue->push()` will be called with a `null` queue name, which will be passed into the `getQueuableOptions()` method.

4. If a FIFO job is dispatched with a delay, the code will throw an exception. FIFO queues do not support per-job delays. Delays are defined at the queue level in AWS. Therefore, FIFO queues do not support the `DelaySeconds` option and will throw an exception if present.

### Assumptions

When resolving item 2, we need to determine a message group id to use since there is no dispatched object to provide one. There are two options:
1. every string job goes onto the same message group id, or
2. every string job goes onto a unique message group id.

I chose to put every string job onto the same message group id, using the name of the queue as the message group id to use. I made this assumption so that FIFO processing would maintained for all string jobs if the user is dispatching string jobs. If we used a unique message group id instead, this would not ensure FIFO processing for the dispatched jobs, which is probably not what was intended considering the use of the SQS FIFO queue.

### Resolutions

I would have preferred to create separate PRs to address these issues, but they're pretty much all related to the same method, so I just created the one.

I have added tests that highlight the issues and show they've been fixed.

### Extra Considerations

I allude to this in one of the comments in the code, but the current implementation will always generate a unique deduplication id if the job does not define the `deduplicationId()` method. If the user enables content-based deduplication on the queue in AWS, they will not be able to take advantage of this unless they define a `deduplicationId()` method that returns an empty value. This is not very intuitive, and we may want a more direct solution for this. However, that is not within the scope of this PR.

Please let me know if you need me to make any changes or have any questions. Also, for full disclosure, I am the maintainer of the https://github.com/shiftonelabs/laravel-sqs-fifo-queue package.