### PR TITLE
[12.x] Add tags() support for scheduled events and --tags option for schedule:run

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -877,7 +877,7 @@ class Event
     /**
      * Assign a set of tags to the event.
      *
-     * @param array|string $tags
+     * @param array|string  $tags
      * @return $this
      */
     public function tags(array|string $tags): static

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -91,6 +91,13 @@ class Event
     public $exitCode;
 
     /**
+     * The array of tags for the event.
+     *
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -855,5 +862,32 @@ class Event
             'php',
             preg_replace("#['\"]#", '', Application::artisanBinary()),
         ], $command);
+    }
+
+    /**
+     * Get the tags assigned to the event.
+     *
+     * @return array
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * Assign a set of tags to the event.
+     *
+     * @param array|string $tags
+     * @return $this
+     */
+    public function tags(array|string $tags): static
+    {
+        $tags = is_array($tags) ? $tags : func_get_args();
+
+        $this->tags = array_values(array_unique(
+            array_merge($this->tags, array_map('trim', $tags))
+        ));
+
+        return $this;
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -26,7 +26,8 @@ class ScheduleRunCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schedule:run {--whisper : Do not output message indicating that no jobs were ready to run}';
+    protected $signature = 'schedule:run {--whisper : Do not output message indicating that no jobs were ready to run} 
+                                         {--tags= : Comma-separated list of tags to filter the scheduled tasks}';
 
     /**
      * The console command description.
@@ -112,6 +113,18 @@ class ScheduleRunCommand extends Command
         $this->phpBinary = Application::phpBinary();
 
         $events = $this->schedule->dueEvents($this->laravel);
+
+        if ($this->option('tags')) {
+            $tags = array_filter(array_map('trim', explode(',', $this->option('tags'))));
+            $tags = array_unique(array_filter($tags, 'strlen'));
+
+            if (!empty($tags)) {
+                $events = $events->filter(function (Event $event) use ($tags) {
+                    return !empty(array_intersect($event->getTags(), $tags));
+                });
+            }
+
+        }
 
         if ($events->contains->isRepeatable()) {
             $this->clearInterruptSignal();

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -118,9 +118,9 @@ class ScheduleRunCommand extends Command
             $tags = array_filter(array_map('trim', explode(',', $this->option('tags'))));
             $tags = array_unique(array_filter($tags, 'strlen'));
 
-            if (!empty($tags)) {
+            if (! empty($tags)) {
                 $events = $events->filter(function (Event $event) use ($tags) {
-                    return !empty(array_intersect($event->getTags(), $tags));
+                    return ! empty(array_intersect($event->getTags(), $tags));
                 });
             }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -20,7 +20,8 @@ class ScheduleWorkCommand extends Command
      */
     protected $signature = 'schedule:work
         {--run-output-file= : The file to direct <info>schedule:run</info> output to}
-        {--whisper : Do not output message indicating that no jobs were ready to run}';
+        {--whisper : Do not output message indicating that no jobs were ready to run}
+        {--tags= : Comma-separated list of tags to filter the scheduled tasks}';
 
     /**
      * The console command description.
@@ -51,6 +52,10 @@ class ScheduleWorkCommand extends Command
 
         if ($this->option('run-output-file')) {
             $command .= ' >> '.ProcessUtils::escapeArgument($this->option('run-output-file')).' 2>&1';
+        }
+
+        if ($this->option('tags')) {
+            $command .= ' --tags='.ProcessUtils::escapeArgument($this->option('tags'));
         }
 
         while (true) {

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -104,4 +104,26 @@ class EventTest extends TestCase
 
         $this->assertSame('fancy-command-description', $event->mutexName());
     }
+
+    public function testEventTags()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $this->assertEmpty($event->getTags());
+
+        $event->tags(['emails', 'marketing']);
+        $this->assertEquals(['emails', 'marketing'], $event->getTags());
+
+        $event->tags('billing', 'notifications');
+        $this->assertEquals(['emails', 'marketing', 'billing', 'notifications'], $event->getTags());
+
+        $event->tags('emails', 'billing');
+        $this->assertEquals(['emails', 'marketing', 'billing', 'notifications'], $event->getTags());
+
+        $result = $event->tags('maintenance');
+        $this->assertSame($event, $result);
+        $this->assertEquals(['emails', 'marketing', 'billing', 'notifications', 'maintenance'], $event->getTags());
+
+        $event->tags('  test  ');
+        $this->assertContains('test', $event->getTags());
+    }
 }


### PR DESCRIPTION
Benefit to end users

This feature allows developers to explicitly group scheduled tasks using tags and selectively run only specific groups of tasks.

End-user benefits:
	•	Easier separation of concerns: developers can isolate “emails”, “maintenance”, or “reports” tasks into their own groups.
	•	Simplified infrastructure: multiple scheduler containers or workers can be configured to run only the tasks they are responsible for, without relying on custom environment variables or conditionals.
	•	More declarative and self-documenting scheduling configuration: tags make the scheduler setup clearer and easier to understand.

No breaking changes
	•	If no tags are used, behavior remains unchanged.
	•	If the --tags option is not provided, schedule:run continues to execute all due events.
	•	Existing applications require no modifications.

How this makes development easier
	•	Running multiple scheduler instances in containerized or distributed environments becomes simpler and more explicit.
	•	Developers can clearly see which tasks belong to which logical group just by reading the schedule definition.
	•	No need for workarounds with environment variables or duplicated schedule configuration.
	
Example
```php
$schedule->command('emails:send')
    ->hourly()
    ->tags(['emails', 'marketing']);

$schedule->command('cache:clear')
    ->daily()
    ->tags('maintenance');
```

```bash
php artisan schedule:run --tags=emails

php artisan schedule:work --tags=emails
```
