### PR TITLE
[12.x] Use null coalescing for memoryExceededExitCode

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -314,7 +314,7 @@ class Worker
     {
         return match (true) {
             $this->shouldQuit => static::EXIT_SUCCESS,
-            $this->memoryExceeded($options->memory) => static::$memoryExceededExitCode ?: static::EXIT_MEMORY_LIMIT,
+            $this->memoryExceeded($options->memory) => static::$memoryExceededExitCode ?? static::EXIT_MEMORY_LIMIT,
             $this->queueShouldRestart($lastRestart) => static::EXIT_SUCCESS,
             $options->stopWhenEmpty && is_null($job) => static::EXIT_SUCCESS,
             $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => static::EXIT_SUCCESS,

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -104,7 +104,7 @@ class Worker
      *
      * @var int|null
      */
-    public static $memoryExceededExitCode = null;
+    public static $memoryExceededExitCode;
 
     /**
      * Create a new queue worker.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -104,7 +104,7 @@ class Worker
      *
      * @var int|null
      */
-    public static $memoryExceededExitCode;
+    public static $memoryExceededExitCode = null;
 
     /**
      * Create a new queue worker.

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -167,14 +167,14 @@ class WorkCommandTest extends QueueTestCase
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$memoryExceededExitCode = 25;
+        Worker::$memoryExceededExitCode = 0;
 
         Queue::push(new FirstJob);
         Queue::push(new SecondJob);
 
         $this->artisan('queue:work', [
             '--memory' => 0.1,
-        ])->assertExitCode(25);
+        ])->assertExitCode(0);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::size());


### PR DESCRIPTION
If anyone sets `$memoryExceededExitCode` to 0, it'll return to the `EXIT_MEMORY_LIMIT`  

Ideally I'd like the ability to force it as successful to prevent infrastructure consequences 

Feel free to adjust!

