### PR TITLE
feat(Validation): Add Verbose Reporting Mode

### DIFF
--- a/tests/Validation/ValidatorVerboseModeTest.php
+++ b/tests/Validation/ValidatorVerboseModeTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidatorVerboseModeTest extends TestCase
+{
+    /**
+     * Helper to create a new validator instance.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @return \Illuminate\Validation\Validator
+     */
+    protected function makeValidator(array $data, array $rules): Validator
+    {
+        $loader = new ArrayLoader();
+
+        $translator = new Translator($loader, 'en');
+
+        return new Validator($translator, $data, $rules);
+    }
+
+    public function testReportIsEmptyWhenVerboseModeIsNotEnabled()
+    {
+        $validator = $this->makeValidator(['name' => 'Taylor'], ['name' => 'required']);
+
+        $validator->passes();
+
+        $this->assertEmpty($validator->getReport());
+    }
+
+    public function testReportCapturesSuccessfulValidationSteps()
+    {
+        $validator = $this->makeValidator(
+            ['name' => 'Taylor', 'email' => 'taylor@laravel.com'],
+            ['name' => 'required|string', 'email' => 'required|email']
+        )->verbose();
+
+        $this->assertTrue($validator->passes());
+
+        $report = $validator->getReport();
+
+        $this->assertArrayHasKey('name', $report);
+        $this->assertArrayHasKey('email', $report);
+
+        $this->assertEquals('Required', $report['name'][0]['rule']);
+        $this->assertTrue($report['name'][0]['result']);
+        $this->assertEquals('String', $report['name'][1]['rule']);
+        $this->assertTrue($report['name'][1]['result']);
+
+        $this->assertEquals('Required', $report['email'][0]['rule']);
+        $this->assertTrue($report['email'][0]['result']);
+        $this->assertEquals('Email', $report['email'][1]['rule']);
+        $this->assertTrue($report['email'][1]['result']);
+    }
+
+    public function testReportCapturesFailedValidationSteps()
+    {
+        $validator = $this->makeValidator(
+            ['password' => '123'],
+            ['password' => 'required|min:8']
+        )->verbose();
+
+        $this->assertTrue($validator->fails());
+
+        $report = $validator->getReport();
+
+        $this->assertArrayHasKey('password', $report);
+
+        $this->assertEquals('Required', $report['password'][0]['rule']);
+        $this->assertEquals('123', $report['password'][0]['value']);
+        $this->assertTrue($report['password'][0]['result']);
+
+        $this->assertEquals('Min', $report['password'][1]['rule']);
+        $this->assertEquals(['8'], $report['password'][1]['parameters']);
+        $this->assertFalse($report['password'][1]['result']);
+    }
+
+    public function testReportWorksWithCustomRuleObjects()
+    {
+        $customRule = new class implements Rule
+        {
+            public function passes($attribute, $value)
+            {
+                return $value === 'laravel';
+            }
+
+            public function message()
+            {
+                return 'The value must be "laravel".';
+            }
+        };
+
+        $validator = $this->makeValidator(
+            ['framework' => 'laravel'],
+            ['framework' => ['required', $customRule]]
+        )->verbose();
+
+        $validator->passes();
+        $report = $validator->getReport();
+
+        $this->assertArrayHasKey('framework', $report);
+
+        $this->assertEquals(get_class($customRule), $report['framework'][1]['rule']);
+        $this->assertEquals('laravel', $report['framework'][1]['value']);
+        $this->assertTrue($report['framework'][1]['result']);
+    }
+
+    public function testReportIsClearedOnEachValidationRun()
+    {
+        $validator = $this->makeValidator(['name' => 'A'], ['name' => 'min:2'])->verbose();
+
+        $validator->fails();
+        $report1 = $validator->getReport();
+        $this->assertCount(1, $report1['name']);
+        $this->assertFalse($report1['name'][0]['result']);
+
+        $validator->setData(['name' => 'Correct']);
+        $validator->passes();
+        $report2 = $validator->getReport();
+
+        $this->assertCount(1, $report2['name']);
+        $this->assertTrue($report2['name'][0]['result']);
+    }
+}


### PR DESCRIPTION
### What does this PR do? / Why is this change needed?
This pull request introduces an opt-in "verbose" or "trace" mode to the Validator class. The primary goal is to improve the developer experience (DX) when debugging complex forms or API validation logic.

Currently, when a validation rule fails, developers only receive the final error message. It can be difficult to determine exactly why a specific rule failed, especially with custom rules or complex data structures. This new feature provides a step-by-step report of the entire validation process, showing the outcome of every single rule that was executed.

### How does it work?
- A new public method, ->verbose(), is added to the Validator. Calling this method enables the reporting mode for that validator instance.

- When enabled, a new protected property, $report, is populated during the passes() execution.

- The core logic inside validateAttribute() and validateUsingCustomRule() now calls a helper method, recordValidationStep(), to log the result of each validation check.

- A new public method, ->getReport(), allows the developer to retrieve the generated report as an array.

- The reporting logic is wrapped in an if ($this->verbose) condition, ensuring zero performance impact for users who do not use this feature.

### How to use it? (Code Example)

```php
use Illuminate\Support\Facades\Validator;

$data = ['password' => '12345'];
$rules = ['password' => 'required|min:8'];

// Enable verbose mode by chaining the method
$validator = Validator::make($data, $rules)->verbose();

if ($validator->fails()) {
    // Get the detailed report for debugging
    $report = $validator->getReport();
    
    /*
    $report will be:
    [
        "password" => [
            ["rule" => "Required", "parameters" => [], "value" => "12345", "result" => true],
            ["rule" => "Min", "parameters" => ["8"], "value" => "12345", "result" => false],
        ]
    ]
    */
    dd($report);
}
```