### PR TITLE
[12.x] Fix exception frame file path on Windows

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -5,6 +5,8 @@ namespace Illuminate\Foundation\Exceptions\Renderer;
 use Illuminate\Foundation\Concerns\ResolvesDumpSource;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
+use function Illuminate\Filesystem\join_paths;
+
 class Frame
 {
     use ResolvesDumpSource;
@@ -206,7 +208,7 @@ class Frame
     public function isFromVendor()
     {
         return ! str_starts_with($this->frame['file'], $this->basePath)
-            || str_starts_with($this->frame['file'], $this->basePath.DIRECTORY_SEPARATOR.'vendor');
+            || str_starts_with($this->frame['file'], join_paths($this->basePath, 'vendor'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -114,7 +114,7 @@ class Frame
         return match (true) {
             ! isset($this->frame['file']) => '[internal function]',
             ! is_string($this->frame['file']) => '[unknown file]',
-            default => str_replace($this->basePath.'/', '', $this->frame['file']),
+            default => str_replace($this->basePath.DIRECTORY_SEPARATOR, '', $this->frame['file']),
         };
     }
 
@@ -206,7 +206,7 @@ class Frame
     public function isFromVendor()
     {
         return ! str_starts_with($this->frame['file'], $this->basePath)
-            || str_starts_with($this->frame['file'], $this->basePath.'/vendor');
+            || str_starts_with($this->frame['file'], $this->basePath.DIRECTORY_SEPARATOR.'vendor');
     }
 
     /**

--- a/tests/Foundation/Exceptions/Renderer/FrameTest.php
+++ b/tests/Foundation/Exceptions/Renderer/FrameTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions\Renderer;
+
+use Illuminate\Foundation\Exceptions\Renderer\Frame;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+
+class FrameTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    #[RequiresOperatingSystem('Linux|DAR')]
+    #[DataProvider('unixFileDataProvider')]
+    public function test_it_normalizes_file_path_on_unix($frameData, $basePath, $expected)
+    {
+        $exception = m::mock(FlattenException::class);
+        $classMap = [];
+        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+
+        $this->assertEquals($expected, $frame->file());
+    }
+
+    public static function unixFileDataProvider()
+    {
+        yield 'internal function' => [
+            ['line' => 10],
+            '/path/to/your-app',
+            '[internal function]',
+        ];
+        yield 'unknown file' => [
+            ['file' => 123, 'line' => 10],
+            '/path/to/your-app',
+            '[unknown file]',
+        ];
+        yield 'file with base path' => [
+            ['file' => '/path/to/your-app/app/Http/Controllers/UserController.php', 'line' => 10],
+            '/path/to/your-app',
+            'app/Http/Controllers/UserController.php',
+        ];
+        yield 'file without base path' => [
+            ['file' => '/other/path/app/Http/Controllers/UserController.php', 'line' => 10],
+            '/path/to/your-app',
+            '/other/path/app/Http/Controllers/UserController.php',
+        ];
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    #[DataProvider('windowsFileDataProvider')]
+    public function test_it_normalizes_file_path_on_windows($frameData, $basePath, $expected)
+    {
+        $exception = m::mock(FlattenException::class);
+        $classMap = [];
+        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+
+        $this->assertEquals($expected, $frame->file());
+    }
+
+    public static function windowsFileDataProvider()
+    {
+        yield 'internal function' => [
+            ['line' => 10],
+            'C:\path\to\your-app',
+            '[internal function]',
+        ];
+        yield 'unknown file' => [
+            ['file' => 123, 'line' => 10],
+            'C:\path\to\your-app',
+            '[unknown file]',
+        ];
+        yield 'file with base path' => [
+            ['file' => 'C:\path\to\your-app\app\Http\Controllers\UserController.php', 'line' => 10],
+            'C:\path\to\your-app',
+            'app\Http\Controllers\UserController.php',
+        ];
+        yield 'file without base path' => [
+            ['file' => 'D:\other\path\app\Http\Controllers\UserController.php', 'line' => 10],
+            'C:\path\to\your-app',
+            'D:\other\path\app\Http\Controllers\UserController.php',
+        ];
+    }
+
+    #[RequiresOperatingSystem('Linux|DAR')]
+    #[DataProvider('unixIsFromVendorDataProvider')]
+    public function test_it_determines_if_frame_is_from_vendor_on_unix($frameData, $basePath, $expected)
+    {
+        $exception = m::mock(FlattenException::class);
+        $classMap = [];
+        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+
+        $this->assertEquals($expected, $frame->isFromVendor());
+    }
+
+    public static function unixIsFromVendorDataProvider()
+    {
+        yield 'vendor file' => [
+            ['file' => '/path/to/your-app/vendor/laravel/framework/src/File.php', 'line' => 10],
+            '/path/to/your-app',
+            true,
+        ];
+        yield 'app file' => [
+            ['file' => '/path/to/your-app/app/Models/User.php', 'line' => 10],
+            '/path/to/your-app',
+            false,
+        ];
+        yield 'outside base path' => [
+            ['file' => '/other/path/file.php', 'line' => 10],
+            '/path/to/your-app',
+            true,
+        ];
+        yield 'vendor in filename' => [
+            ['file' => '/path/to/your-app/app/vendorfile.php', 'line' => 10],
+            '/path/to/your-app',
+            false,
+        ];
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    #[DataProvider('windowsIsFromVendorDataProvider')]
+    public function test_it_determines_if_frame_is_from_vendor_on_windows($frameData, $basePath, $expected)
+    {
+        $exception = m::mock(FlattenException::class);
+        $classMap = [];
+        $frame = new Frame($exception, $classMap, $frameData, $basePath);
+
+        $this->assertEquals($expected, $frame->isFromVendor());
+    }
+
+    public static function windowsIsFromVendorDataProvider()
+    {
+        yield 'vendor file' => [
+            ['file' => 'C:\path\to\your-app\vendor\laravel\framework\src\File.php', 'line' => 10],
+            'C:\path\to\your-app',
+            true,
+        ];
+        yield 'app file' => [
+            ['file' => 'C:\path\to\your-app\app\Models\User.php', 'line' => 10],
+            'C:\path\to\your-app',
+            false,
+        ];
+        yield 'outside base path' => [
+            ['file' => 'D:\other\path\file.php', 'line' => 10],
+            'C:\path\to\your-app',
+            true,
+        ];
+        yield 'vendor in filename' => [
+            ['file' => 'C:\path\to\your-app\app\vendorfile.php', 'line' => 10],
+            'C:\path\to\your-app',
+            false,
+        ];
+    }
+}


### PR DESCRIPTION
This PR fixes the following issues on the local exception page on Windows.

1. On Windows, vendor frames are incorrectly identified as non-vendor frames, preventing them from being properly collapsed in the trace.

2. On windows, frame file paths display absolute path instead of relative path from the base path.

## Solution

Replace the hardcoded forward slash with `DIRECTORY_SEPARATOR` to ensure proper cross-platform compatibility.

## Related issue

https://github.com/laravel/framework/issues/57082#issuecomment-3305332499