### PR TITLE
[12.x] Reintroduce short-hand "false" syntax for Blade component props

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -128,6 +128,10 @@ class ComponentTagCompiler
                             )
                             |
                             (?:
+                                (![\w]+)
+                            )
+                            |
+                            (?:
                                 [\w\-:.@%]+
                                 (
                                     =
@@ -190,6 +194,10 @@ class ComponentTagCompiler
                             |
                             (?:
                                 (\:\\\$)(\w+)
+                            )
+                            |
+                            (?:
+                                (![\w]+)
                             )
                             |
                             (?:
@@ -597,6 +605,7 @@ class ComponentTagCompiler
     protected function getAttributesFromAttributeString(string $attributeString)
     {
         $attributeString = $this->parseShortAttributeSyntax($attributeString);
+        $attributeString = $this->parseShortFalseSyntax($attributeString);
         $attributeString = $this->parseAttributeBag($attributeString);
         $attributeString = $this->parseComponentTagClassStatements($attributeString);
         $attributeString = $this->parseComponentTagStyleStatements($attributeString);
@@ -663,6 +672,29 @@ class ComponentTagCompiler
         return preg_replace_callback($pattern, function (array $matches) {
             return " :{$matches[1]}=\"\${$matches[1]}\"";
         }, $value);
+    }
+
+    /**
+     * Parses a short false syntax like !required into a fully-qualified syntax like :required="false".
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function parseShortFalseSyntax(string $value)
+    {
+        $parts = preg_split('/(".*?(?<!\\\\)")/', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        return (new Collection($parts))
+            ->map(function (string $value) {
+                if (preg_match('/^".*"$/s', $value)) {
+                    return $value;
+                }
+
+                return preg_replace_callback('/!(\w+)/', function ($matches) {
+                    return " :{$matches[1]}=\"false\"";
+                }, $value);
+            })
+            ->implode('');
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -303,6 +303,81 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
+    public function testFalseShortSyntax()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool !bool></x-bool>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testFalseShortSyntaxAsValue()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool :bool="!false"></x-bool>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => !false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testFalseShortSyntaxWithinValue()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool :bool="$value && !old(\'value\')"></x-bool>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => \$value && !old('value')])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testSelfClosingComponentWithFalseShortSyntax()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool !bool />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+'@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testSelfClosingComponentWithFalseShortSyntaxAsValue()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool :bool="!false" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => !false])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testSelfClosingComponentWithFalseShortSyntaxWithinValue()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['bool' => TestBoolComponent::class])->compileTags('<x-bool :bool="$value && !old(\'value\')" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestBoolComponent', 'bool', ['bool' => \$value && !old('value')])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php \$attributes = \$attributes->except(\Illuminate\Tests\View\Blade\TestBoolComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
     public function testEscapedColonAttribute()
     {
         $this->mockViewFactory();
@@ -1007,6 +1082,21 @@ class TestInputComponent extends Component
     public function render()
     {
         return 'input';
+    }
+}
+
+class TestBoolComponent extends Component
+{
+    public $bool;
+
+    public function __construct($bool)
+    {
+        $this->bool = $bool;
+    }
+
+    public function render()
+    {
+        return 'bool';
     }
 }
 


### PR DESCRIPTION
This PR is an alternative implementation of https://github.com/laravel/framework/pull/48084 and introduces a new short-hand syntax for `false` properties.

```blade
<x-layout !margin />
```

Is equivalent to:

```blade
<x-layout :margin="false">
```