### PR TITLE
[12.x] Adds `Macroable` trait to `Illuminate/Support/Benchmark`

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Support\Traits\Macroable;
 
 class Benchmark
 {
+    use Macroable;
+
     /**
      * Measure a callable or array of callables over the given number of iterations.
      *

--- a/tests/Support/SupportBenchmarkTest.php
+++ b/tests/Support/SupportBenchmarkTest.php
@@ -21,4 +21,17 @@ class SupportBenchmarkTest extends TestCase
     {
         $this->assertIsArray(Benchmark::value(fn () => 1 + 1));
     }
+
+    public function testMacroable(): void
+    {
+        $macroName = __FUNCTION__;
+
+        $this->assertFalse(Benchmark::hasMacro($macroName));
+
+        // Register a macro to test
+        Benchmark::macro($macroName, fn () => true);
+
+        $this->assertTrue(Benchmark::hasMacro($macroName));
+        $this->assertTrue(Benchmark::$macroName());
+    }
 }


### PR DESCRIPTION
Greetings All:

This simple PR updates `Benchmark` with the `Macroable` trait to allow arbitrary macro registration. For example, a macro `log` could be registered to log benchmark data:

```
use Closure;
use Illuminate\Support\Benchmark;
use Illuminate\Support\Facades\Log;

Benchmark::macro('log', fn (Closure $callback) =>
    Log::debug(Benchmark::measure($callback))
);
```

Which could then be invoked:

```
Benchmark::log(fn () => sleep(1));

// [2025-09-18 07:21:56] local.DEBUG: 1000.447882
```

Customization of how benchmark data is reported would now be possible.

Thanks in advance!

--
Andrew