### PR TITLE
[12.x] Add support for Ordinal Position in validation messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation\Concerns;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -246,6 +247,7 @@ trait FormatsMessages
         $message = $this->replaceInputPlaceholder($message, $attribute);
         $message = $this->replaceIndexPlaceholder($message, $attribute);
         $message = $this->replacePositionPlaceholder($message, $attribute);
+        $message = $this->replaceOrdinalPositionPlaceholder($message, $attribute);
 
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
@@ -380,6 +382,20 @@ trait FormatsMessages
     {
         return $this->replaceIndexOrPositionPlaceholder(
             $message, $attribute, 'position', fn ($segment) => $segment + 1
+        );
+    }
+
+    /**
+     * Replace the :ordinal-position placeholder in the given message.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function replaceOrdinalPositionPlaceholder($message, $attribute)
+    {
+        return $this->replaceIndexOrPositionPlaceholder(
+            $message, $attribute, 'ordinal-position', fn ($segment) => Number::ordinal($segment + 1)
         );
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -853,10 +853,6 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        // $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => ':ordinal-position Name is required.']);
-        // $this->assertFalse($v->passes());
-        // $this->assertSame('1st Name is required.', $v->messages()->first('name'));
-
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'The :ordinal-position Name is required.']);
         $this->assertFalse($v->passes());
         $this->assertSame('The 1st Name is required.', $v->messages()->first('input.*.name'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -853,9 +853,9 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        // $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => 'Name :position is required.']);
+        // $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => ':ordinal-position Name is required.']);
         // $this->assertFalse($v->passes());
-        // $this->assertSame('Name 1 is required.', $v->messages()->first('name'));
+        // $this->assertSame('1st Name is required.', $v->messages()->first('name'));
 
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'The :ordinal-position Name is required.']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -849,6 +849,38 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testOrdinalPositionValuesAreReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        // $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => 'Name :position is required.']);
+        // $this->assertFalse($v->passes());
+        // $this->assertSame('Name 1 is required.', $v->messages()->first('name'));
+
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'The :ordinal-position Name is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The 1st Name is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':ordinal-position :Attribute is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name',
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('1st Name is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'The :ordinal-position Name is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The 2nd Name is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':ordinal-position :Attribute is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name',
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('2nd Name is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :ordinal-position is required.']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testCustomValidationLinesAreRespected()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
### Details
This PR adds support for ordinal based position output in validation error/messages. 

Validation messages already support `:index` and `:position` within validation messages both custom and natively, this clones the functionality offered by the `:position` marker and allows it to use the ordinal version of the same value via the use of the `:ordinal-position` placeholder.

In english locale:
|`:position`|`:ordinal-position`|
|---------------|-------------------------|
| 1               |    1st                     |
| 2               |    2nd                    |
| 3               |    3rd                    |
| 13              |    13th                  |


### Whats New

this adds the `replaceOrdinalPositionPlaceholder` method to the FormatsMessages class and adds the call for it alongside the `replacePositionPlaceholder` to the `makeReplacements` method

### Example usage

```php

use Illuminate\Support\Facades\Validator;

$input = [
    'photos' => [
        [
            'name' => 'BeachVacation.jpg',
            'description' => 'A photo of my beach vacation!',
        ],
        [
            'name' => 'GrandCanyon.jpg',
            'description' => '',
        ],
    ],
];

Validator::validate($input, [
    'photos.*.description' => 'required',
], [
    'photos.*.description.required' => 'Please describe the :ordinal-position photo.',
]);
```
Given the example above, validation will fail and the user will be presented with the following error of "Please describe the 2nd photo."