### PR TITLE
[12.x] Add total event count to CLI output of `event:list` command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -96,6 +96,8 @@ class EventListCommand extends Command
         });
 
         $this->newLine();
+
+        $this->info('Total events: ' . $events->count());
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -97,7 +97,7 @@ class EventListCommand extends Command
 
         $this->newLine();
 
-        $this->info('Total events: ' . $events->count());
+        $this->info('Total events: '.$events->count());
     }
 
     /**


### PR DESCRIPTION
This PR enhances the `php artisan event:list` command by displaying
the total number of events at the end of the CLI output.

- The change only affects CLI output; JSON output remains unchanged.
- Improves developer experience by providing a quick overview of total events.
- No breaking changes are introduced.

Example CLI output after this change:

EventName
  › Listener1
  › Listener2

Total events: 42
