### PR TITLE
[12.x] Fix: Apply intl extension check to ordinal position to prevent issues

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -394,6 +394,10 @@ trait FormatsMessages
      */
     protected function replaceOrdinalPositionPlaceholder($message, $attribute)
     {
+        if (! extension_loaded('intl')) {
+            return $message;
+        }
+
         return $this->replaceIndexOrPositionPlaceholder(
             $message, $attribute, 'ordinal-position', fn ($segment) => Number::ordinal($segment + 1)
         );

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -849,6 +849,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    #[RequiresPhpExtension('intl')]
     public function testOrdinalPositionValuesAreReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
### Description

A follow up to https://github.com/laravel/framework/pull/57109

After merge it was reported that the ordinal-position update was breaking validation messages when the Intl extension is not loaded (see [comment](https://github.com/laravel/framework/pull/57109#issuecomment-3309061723) from @vidrosoftware) .
This was missed as most laravel installs I have require the intl extension. 

As Laravel doesn't have a core requirement for the intl extension at this time, this fix will skip the replacement of ordinal-position where the intl extension is not loaded

### Whats new
- added quick return of message when intl extension is not loaded
- marked test case requiring the intl extension to prevent false failures

### Usage
No changes of usage from before.