### PR TITLE
[12.x] Refactor `RedisTaggedCache@flush()` to allow for custom connections

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -145,15 +145,12 @@ class RedisTaggedCache extends TaggedCache
             end
         LUA;
 
-        $this->store->connection()->eval(
+        $connection->eval(
             $script,
             count($keysToBeDeleted),
             ...$keysToBeDeleted,
             ...[$cachePrefix, ...$cacheTags]
         );
-
-        // $this->flushValues();
-        // $this->tags->flush();
 
         $this->event(new CacheFlushed($this->getName()));
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -112,9 +112,11 @@ class RedisTaggedCache extends TaggedCache
     {
         $this->event(new CacheFlushing($this->getName()));
 
-        $redisPrefix = match ($this->store->connection()::class) {
-            PhpRedisConnection::class => $this->store->connection()->client()->getOption(\Redis::OPT_PREFIX),
-            PredisConnection::class => $this->store->connection()->client()->getOptions()->prefix,
+        $connection = $this->store->connection();
+        
+        $redisPrefix = match (true) {
+            $connection instanceof PhpRedisConnection => $connection->client()->getOption(\Redis::OPT_PREFIX),
+            $connection instanceof PredisConnection => $connection->client()->getOptions()->prefix,
         };
 
         $cachePrefix = $redisPrefix.$this->store->getPrefix();


### PR DESCRIPTION
To resolve: https://github.com/laravel/framework/issues/57120

@miskith reports that using a the Redis Sentinel Connection package no longer allows for cache flushing. In that particular library, their Redis Connection class ([PhpRedisSentinelConnection](https://github.com/Namoshek/laravel-redis-sentinel/blob/master/src/Connections/PhpRedisSentinelConnection.php)) extends `Illuminate\Redis\Connections\PhpRedisConnection`.

Rather than checking the class of the connection, we can just check if it is an instanceof one of the Laravel-provided connections.