### PR TITLE
[12.x] Expressive cast configuration and standardization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
@@ -9,7 +9,7 @@ class ArrayObjectCast extends IterableCast
     /**
      * Instances the target iterable class.
      *
-     * @param  \Illuminate\Support\Collection $data
+     * @param  \Illuminate\Support\Collection  $data
      * @return \Illuminate\Database\Eloquent\Casts\ArrayObject
      */
     protected function makeIterableObject($data)

--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
@@ -2,8 +2,21 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
+use ArrayObject;
+
 class ArrayObjectCast extends IterableCast
 {
+    /**
+     * Instances the target iterable class.
+     *
+     * @param  \Illuminate\Support\Collection $data
+     * @return \Illuminate\Database\Eloquent\Casts\ArrayObject
+     */
+    protected function makeIterableObject($data)
+    {
+        return new ($this->using)($data->all(), ArrayObject::ARRAY_AS_PROPS);
+    }
+
     /**
      * Serializes the given value to an array format.
      *

--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObjectCast.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+class ArrayObjectCast extends IterableCast
+{
+    /**
+     * Serializes the given value to an array format.
+     *
+     * @param  mixed  $model
+     * @param  string  $key
+     * @param  \ArrayObject  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function serialize($model, string $key, $value, array $attributes)
+    {
+        return $value->getArrayCopy();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
@@ -13,7 +13,7 @@ trait NormalizesArguments
      */
     protected function normalize(): void
     {
-        if (!$this->using) {
+        if (! $this->using) {
             $this->using = $this->class;
         } elseif (! is_a($this->using, $this->class, true)) {
             throw new InvalidArgumentException("The provided class must extend [$this->class].");

--- a/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts\Concerns;
+
+use InvalidArgumentException;
+
+trait NormalizesArguments
+{
+    /**
+     * Normalize the arguments received by the Cast Attributes.
+     *
+     * @return void
+     */
+    protected function normalize(): void
+    {
+        if (!$this->using) {
+            $this->using = $this->class;
+        } elseif (! is_a($this->using, $this->class, true)) {
+            throw new InvalidArgumentException("The provided class must extend [$this->class].");
+        }
+
+        if ($this->withoutObjectCaching !== '') {
+            $this->withoutObjectCaching = filter_var($this->withoutObjectCaching, FILTER_VALIDATE_BOOL);
+        }
+
+        if ($this->encrypt !== '') {
+            $this->encrypt = filter_var($this->encrypt, FILTER_VALIDATE_BOOL);
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Concerns/NormalizesArguments.php
@@ -19,12 +19,8 @@ trait NormalizesArguments
             throw new InvalidArgumentException("The provided class must extend [$this->class].");
         }
 
-        if ($this->withoutObjectCaching !== '') {
-            $this->withoutObjectCaching = filter_var($this->withoutObjectCaching, FILTER_VALIDATE_BOOL);
-        }
+        $this->withoutObjectCaching = filter_var($this->withoutObjectCaching, FILTER_VALIDATE_BOOL);
 
-        if ($this->encrypt !== '') {
-            $this->encrypt = filter_var($this->encrypt, FILTER_VALIDATE_BOOL);
-        }
+        $this->encrypt = filter_var($this->encrypt, FILTER_VALIDATE_BOOL);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
@@ -84,14 +84,25 @@ class IterableCast implements CastsAttributes
         $data = new Collection($data);
 
         if ($this->map) {
-            $this->map = Str::parseCallback($this->map);
-
-            $data = is_callable($this->map)
-                ? $data->map($this->map)
-                : $data->mapInto($this->map[0]);
+            $data = $this->mapItems($data) ?? $data;
         }
 
         return $this->makeIterableObject($data);
+    }
+
+    /**
+     * Maps the items using a callback, if any.
+     *
+     * @param  \Illuminate\Support\Collection  $data
+     * @return \Illuminate\Support\Collection|null
+     */
+    protected function mapItems($data)
+    {
+        $this->map = Str::parseCallback($this->map);
+
+        return is_callable($this->map)
+            ? $data->map($this->map)
+            : $data->mapInto($this->map[0]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
+
+/**
+ * @template TBaseClass of \Illuminate\Database\Eloquent\Casts\ArrayObject|\Illuminate\Support\Collection
+ *
+ * @extends \Illuminate\Contracts\Database\Eloquent\CastsAttributes<TBaseClass, iterable>
+ */
+class IterableCast implements CastsAttributes
+{
+    use Concerns\NormalizesArguments;
+
+    /**
+     * The base iterable class to cast
+     *
+     * @var class-string<TBaseClass>
+     */
+    public $class;
+
+    /**
+     * Should the resulting object instance not be cached.
+     *
+     * @var string|null
+     */
+    public $withoutObjectCaching;
+
+    /**
+     * Encrypt the storable value in the database.
+     *
+     * @var string|null
+     */
+    public $encrypt;
+
+    /**
+     * A custom iterable class to hold the items.
+     *
+     * @var class-string<TBaseClass>|null
+     */
+    public $using;
+
+    /**
+     * The base iterable class to cast
+     *
+     * @var string|null
+     */
+    public $map;
+
+    /**
+     * Create a new Cast Iterable Attribute instance.
+     *
+     * @param  array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null, string|null}  $arguments
+     */
+    public function __construct(array $arguments)
+    {
+        [$this->class, $this->withoutObjectCaching, $this->encrypt, $this->using, $this->map] = $arguments;
+
+        $this->normalize();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (!isset($attributes[$key])) {
+            return;
+        }
+
+        $data = $this->encrypt
+            ? Json::decode(Crypt::decryptString($attributes[$key]))
+            : Json::decode($attributes[$key]);
+
+        if (!is_array($data)) {
+            return;
+        }
+
+        $data = new Collection($data);
+
+        if ($this->map) {
+            $this->map = Str::parseCallback($this->map);
+
+            $data = is_callable($this->map)
+                ? $data->map($this->map)
+                : $data->mapInto($this->map[0]);
+        }
+
+        return new ($this->using)(
+            $this->class === ArrayObject::class
+                ? [$data->all(), ArrayObject::ARRAY_AS_PROPS]
+                : [$data->all()],
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (! is_null($value)) {
+            return [
+                $key => $this->encrypt
+                    ? Crypt::encryptString(Json::encode($value))
+                    : Json::encode($value),
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
@@ -18,7 +18,7 @@ class IterableCast implements CastsAttributes
     use Concerns\NormalizesArguments;
 
     /**
-     * The base iterable class to cast
+     * The base iterable class to cast.
      *
      * @var class-string<TBaseClass>
      */
@@ -69,7 +69,7 @@ class IterableCast implements CastsAttributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes)
     {
-        if (!isset($attributes[$key])) {
+        if (! isset($attributes[$key])) {
             return;
         }
 
@@ -77,7 +77,7 @@ class IterableCast implements CastsAttributes
             ? Json::decode(Crypt::decryptString($attributes[$key]))
             : Json::decode($attributes[$key]);
 
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             return;
         }
 
@@ -97,7 +97,7 @@ class IterableCast implements CastsAttributes
     /**
      * Instances the target iterable class.
      *
-     * @param  \Illuminate\Support\Collection $data
+     * @param  \Illuminate\Support\Collection  $data
      * @return \Illuminate\Support\Collection|\Illuminate\Support\Fluent
      */
     protected function makeIterableObject($data)

--- a/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/IterableCast.php
@@ -32,7 +32,7 @@ class IterableCast implements CastsAttributes
     public $withoutObjectCaching;
 
     /**
-     * Encrypt the storable value in the database.
+     * Should encrypt the storable value in the database.
      *
      * @var string|null
      */
@@ -46,7 +46,7 @@ class IterableCast implements CastsAttributes
     public $using;
 
     /**
-     * The base iterable class to cast
+     * The callback in "class@method" notation or class name to map items into.
      *
      * @var string|null
      */
@@ -91,11 +91,18 @@ class IterableCast implements CastsAttributes
                 : $data->mapInto($this->map[0]);
         }
 
-        return new ($this->using)(
-            $this->class === ArrayObject::class
-                ? [$data->all(), ArrayObject::ARRAY_AS_PROPS]
-                : [$data->all()],
-        );
+        return $this->makeIterableObject($data);
+    }
+
+    /**
+     * Instances the target iterable class.
+     *
+     * @param  \Illuminate\Support\Collection $data
+     * @return \Illuminate\Support\Collection|\Illuminate\Support\Fluent
+     */
+    protected function makeIterableObject($data)
+    {
+        return new ($this->using)($data->all());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
@@ -60,7 +60,7 @@ class StringableCast implements CastsAttributes
      */
     public function get(Model $model, string $key, mixed $value, array $attributes)
     {
-        if (!isset($attributes[$key])) {
+        if (! isset($attributes[$key])) {
             return;
         }
 
@@ -74,7 +74,7 @@ class StringableCast implements CastsAttributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes)
     {
-        if (!is_null($value)) {
+        if (! is_null($value)) {
             return [
                 $key => $this->encrypt
                     ? Crypt::encryptString($value)

--- a/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * @template TBaseClass
+ *
+ * @extends \Illuminate\Contracts\Database\Eloquent\CastsAttributes<TBaseClass, \Stringable|string>
+ */
+class StringableCast implements CastsAttributes
+{
+    use Concerns\NormalizesArguments;
+
+    /**
+     * The base iterable class to cast
+     *
+     * @var class-string<TBaseClass>
+     */
+    public $class;
+
+    /**
+     * Should the resulting object instance not be cached.
+     *
+     * @var string|null
+     */
+    public $withoutObjectCaching;
+
+    /**
+     * Encrypt the storable value in the database.
+     *
+     * @var string|null
+     */
+    public $encrypt;
+
+    /**
+     * A custom iterable class to hold the items.
+     *
+     * @var class-string<TBaseClass>|null
+     */
+    public $using;
+
+    /**
+     * Create a new Cast Iterable Attribute instance.
+     *
+     * @param  array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null}  $arguments
+     */
+    public function __construct(array $arguments)
+    {
+        [$this->class, $this->withoutObjectCaching, $this->encrypt, $this->using] = $arguments;
+
+        $this->normalize();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (!isset($attributes[$key])) {
+            return;
+        }
+
+        return new ($this->using)($this->encrypt
+            ? Crypt::decryptString($attributes[$key])
+            : $attributes[$key]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes)
+    {
+        if (!is_null($value)) {
+            return [
+                $key => $this->encrypt
+                    ? Crypt::encryptString($value)
+                    : $value,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
+++ b/src/Illuminate/Database/Eloquent/Casts/StringableCast.php
@@ -16,7 +16,7 @@ class StringableCast implements CastsAttributes
     use Concerns\NormalizesArguments;
 
     /**
-     * The base iterable class to cast
+     * The base iterable class to cast.
      *
      * @var class-string<TBaseClass>
      */
@@ -30,14 +30,14 @@ class StringableCast implements CastsAttributes
     public $withoutObjectCaching;
 
     /**
-     * Encrypt the storable value in the database.
+     * Should encrypt the storable value in the database.
      *
      * @var string|null
      */
     public $encrypt;
 
     /**
-     * A custom iterable class to hold the items.
+     * A custom iterable class to hold the item.
      *
      * @var class-string<TBaseClass>|null
      */

--- a/src/Illuminate/Database/Eloquent/Casts/To.php
+++ b/src/Illuminate/Database/Eloquent/Casts/To.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
+
+class To
+{
+    /**
+     * Create a new cast definition for a Stringable instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToString<\Illuminate\Support\Stringable>
+     */
+    public static function stringable()
+    {
+        return new ToString(Stringable::class);
+    }
+
+    /**
+     * Create a new cast definition for an HtmlString instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToString<\Illuminate\Support\HtmlString>
+     */
+    public static function htmlString()
+    {
+        return new ToString(HtmlString::class);
+    }
+
+    /**
+     * Create a new cast definition for a Uri instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToString<\Illuminate\Support\Uri>
+     */
+    public static function uri()
+    {
+        return new ToString(Uri::class);
+    }
+
+    /**
+     * Create a new cast definition for an ArrayObject.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToIterable<\Illuminate\Database\Eloquent\Casts\ArrayObject>
+     */
+    public static function arrayObject()
+    {
+        return new ToIterable(ArrayObject::class);
+    }
+
+    /**
+     * Create a new cast definition for a Collection.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToIterable<\Illuminate\Support\Collection>
+     */
+    public static function collection()
+    {
+        return new ToIterable(Collection::class);
+    }
+
+    /**
+     * Create a new cast definition for a Fluent instance.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\ToIterable<\Illuminate\Support\Fluent>
+     */
+    public static function fluent()
+    {
+        return new ToIterable(Fluent::class);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/ToIterable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ToIterable.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use InvalidArgumentException;
+use Stringable;
+
+/**
+ * @template TBaseClass of \Illuminate\Database\Eloquent\Casts\ArrayObject|\Illuminate\Support\Collection|\Illuminate\Support\Fluent
+ */
+class ToIterable implements Stringable, Castable
+{
+    /**
+     * Create a new To Enumerable instance.
+     *
+     * @param  class-string<TBaseClass>  $class
+     * @param  boolean|null  $withoutCaching
+     * @param  boolean|null  $encrypt
+     * @param  class-string<TBaseClass>|null  $using
+     * @param  callable-string|array{class-string, string}|null  $map
+     */
+    public function __construct(
+        protected $class,
+        protected $withoutCaching = null,
+        protected $encrypt = null,
+        protected $using = null,
+        protected $map = null,
+    ) {
+        //
+    }
+
+    /**
+     * Disables object caching for the cast.
+     *
+     * @return $this
+     */
+    public function withoutCaching()
+    {
+        $this->withoutCaching = true;
+
+        return $this;
+    }
+
+    /**
+     * Encrypts the database values.
+     *
+     * @return $this
+     */
+    public function encrypted()
+    {
+        $this->encrypt = true;
+
+        return $this;
+    }
+
+    /**
+     * Uses a different Collection or Array Object class to build the enumerable object.
+     *
+     * @param  class-string<TBaseClass>  $class
+     * @return $this
+     */
+    public function using($class)
+    {
+        $this->using = $class;
+
+        return $this;
+    }
+
+    /**
+     * Maps the items into the given class.
+     *
+     * @param  class-string  $class
+     * @return $this
+     */
+    public function mappedInto(string $class)
+    {
+        $this->map = $class;
+
+        return $this;
+    }
+
+    /**
+     * Maps the items into the given class.
+     *
+     * @param  class-string  $class
+     * @return $this
+     */
+    public function of(string $class)
+    {
+        return $this->mappedInto($class);
+    }
+
+    /**
+     * Maps the items into the given backed enum.
+     *
+     * @param  class-string<\BackedEnum>  $enum
+     * @return $this
+     */
+    public function enum($enum)
+    {
+        return $this->mappedInto($enum);
+    }
+
+    /**
+     * Maps the items using the given string or array callable, or "method@class" notation.
+     *
+     * @param  \Closure|string|array  $callable
+     * @return $this
+     */
+    public function mapped($callable)
+    {
+        $this->map = $this->decomposeCallable($callable);
+
+        return $this;
+    }
+
+    /**
+     * Maps the items using the `fromArray()` static method of the given class.
+     *
+     * @param  class-string  $class
+     * @return $this
+     */
+    public function mappedFromArray($class)
+    {
+        return $this->mapped([$class, 'fromArray']);
+    }
+
+    /**
+     * Decompose the callable into a string.
+     *
+     * @param  callable  $callable
+     * @return string
+     */
+    protected function decomposeCallable($callable): string
+    {
+        if (is_string($callable)) {
+            return $callable;
+        }
+
+        if (is_array($callable) && is_callable($callable)) {
+            return $callable[0].'@'.$callable[1];
+        }
+
+        throw new InvalidArgumentException(
+            'The callable must be an array, string, or a string in "method@class" notation.'
+        );
+    }
+
+    /**
+     * Create a string representation of the cast.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return static::class.':'.implode(',', [
+            $this->class, $this->withoutCaching, $this->encrypt, $this->using, $this->map
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null, string|null}  $arguments
+     */
+    public static function castUsing(array $arguments)
+    {
+        // The Array Object CastAttribute has a custom serialization method.
+        return $arguments[0] === ArrayObject::class
+            ? new ArrayObjectCast($arguments)
+            : new IterableCast($arguments);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/ToIterable.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ToIterable.php
@@ -15,8 +15,8 @@ class ToIterable implements Stringable, Castable
      * Create a new To Enumerable instance.
      *
      * @param  class-string<TBaseClass>  $class
-     * @param  boolean|null  $withoutCaching
-     * @param  boolean|null  $encrypt
+     * @param  bool|null  $withoutCaching
+     * @param  bool|null  $encrypt
      * @param  class-string<TBaseClass>|null  $using
      * @param  callable-string|array{class-string, string}|null  $map
      */
@@ -155,14 +155,14 @@ class ToIterable implements Stringable, Castable
     public function __toString(): string
     {
         return static::class.':'.implode(',', [
-            $this->class, $this->withoutCaching, $this->encrypt, $this->using, $this->map
+            $this->class, $this->withoutCaching, $this->encrypt, $this->using, $this->map,
         ]);
     }
 
     /**
      * @inheritDoc
      *
-     * @param array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null, string|null}  $arguments
+     * @param  array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null, string|null}  $arguments
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/ToString.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ToString.php
@@ -14,8 +14,8 @@ class ToString implements Stringable, Castable
      * Create a new To Enumerable instance.
      *
      * @param  class-string<TBaseClass>  $class
-     * @param  boolean|null  $withoutCaching
-     * @param  boolean|null  $encrypt
+     * @param  bool|null  $withoutCaching
+     * @param  bool|null  $encrypt
      * @param  class-string<TBaseClass>|null  $using
      */
     public function __construct(
@@ -77,7 +77,7 @@ class ToString implements Stringable, Castable
     /**
      * @inheritDoc
      *
-     * @param array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null}  $arguments
+     * @param  array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null}  $arguments
      * @return \Illuminate\Database\Eloquent\Casts\StringableCast<TBaseClass>
      */
     public static function castUsing(array $arguments)

--- a/src/Illuminate/Database/Eloquent/Casts/ToString.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ToString.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Stringable;
+
+/**
+ * @template TBaseClass of \Illuminate\Support\HtmlString|\Illuminate\Support\Stringable|\Illuminate\Support\Uri
+ */
+class ToString implements Stringable, Castable
+{
+    /**
+     * Create a new To Enumerable instance.
+     *
+     * @param  class-string<TBaseClass>  $class
+     * @param  boolean|null  $withoutCaching
+     * @param  boolean|null  $encrypt
+     * @param  class-string<TBaseClass>|null  $using
+     */
+    public function __construct(
+        protected $class,
+        protected $withoutCaching = null,
+        protected $encrypt = null,
+        protected $using = null,
+    ) {
+        //
+    }
+
+    /**
+     * Disables object caching for the cast.
+     *
+     * @return $this
+     */
+    public function withoutCaching()
+    {
+        $this->withoutCaching = true;
+
+        return $this;
+    }
+
+    /**
+     * Encrypts the database values.
+     *
+     * @return $this
+     */
+    public function encrypted()
+    {
+        $this->encrypt = true;
+
+        return $this;
+    }
+
+    /**
+     * Uses a different Collection or Array Object class to build the enumerable object.
+     *
+     * @param  class-string<TBaseClass>  $class
+     * @return $this
+     */
+    public function using($class)
+    {
+        $this->using = $class;
+
+        return $this;
+    }
+
+    /**
+     * Create a string representation of the cast.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return static::class.':'.implode(',', [$this->class, $this->withoutCaching, $this->encrypt, $this->using]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array{class-string<TBaseClass>, string|null, string|null, class-string<TBaseClass>|null}  $arguments
+     * @return \Illuminate\Database\Eloquent\Casts\StringableCast<TBaseClass>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new StringableCast($arguments);
+    }
+}

--- a/tests/Database/DatabaseEloquentCastTo.php
+++ b/tests/Database/DatabaseEloquentCastTo.php
@@ -1,0 +1,756 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
+use Illuminate\Database\Eloquent\Casts\To;
+use Illuminate\Database\Eloquent\Casts\ToIterable;
+use Illuminate\Database\Eloquent\Casts\ToString;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
+use Illuminate\Tests\Database\Fixtures\Enums\Foo;
+use Illuminate\Tests\Database\Fixtures\Models\EloquentModelWithCastTo;
+use InvalidArgumentException;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use function implode;
+
+class DatabaseEloquentCastTo extends TestCase
+{
+    protected $encrypter;
+    protected $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+
+        $this->container = new Application();
+        $this->container->singleton('encrypter', fn() => $this->encrypter);
+
+        Facade::setFacadeApplication($this->container);
+
+        EloquentModelWithCastTo::$useCasts = null;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->container->flush();
+
+        Facade::clearResolvedInstances();
+
+        EloquentModelWithCastTo::$useCasts = null;
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->text('castable')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function crypt(): MockInterface
+    {
+        return $this->encrypter ??= m::mock(Encrypter::class);
+    }
+
+    protected function model(ToString|ToIterable $castTo, mixed $value): EloquentModelWithCastTo
+    {
+        EloquentModelWithCastTo::$useCasts = ['castable' => $castTo];
+
+        return new EloquentModelWithCastTo(['castable' => $value]);
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    public function test_to_stringable(): void
+    {
+        $model = $this->model(To::stringable(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Stringable::class, $instance);
+        $this->assertEquals('test_string', $instance->toString());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_stringable_without_caching(): void
+    {
+        $model = $this->model(To::stringable()->withoutCaching(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Stringable::class, $instance);
+        $this->assertEquals('test_string', $instance->toString());
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_stringable_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('test_string')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('test_string');
+
+        $model = $this->model(To::stringable()->encrypted(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Stringable::class, $instance);
+        $this->assertEquals('test_string', $instance->toString());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_stringable_using(): void
+    {
+        $model = $this->model(To::stringable()->using(CustomStringable::class), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomStringable::class, $instance);
+        $this->assertEquals('test_string', $instance->toString());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_stringable_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . Stringable::class . '].');
+
+        $this->model(To::stringable()->using(Fluent::class), 'test_string');
+    }
+
+    public function test_to_html_string(): void
+    {
+        $model = $this->model(To::htmlString(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(HtmlString::class, $instance);
+        $this->assertEquals('test_string', $instance->toHtml());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_html_string_without_caching(): void
+    {
+        $model = $this->model(To::htmlString()->withoutCaching(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(HtmlString::class, $instance);
+        $this->assertEquals('test_string', $instance->toHtml());
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_html_string_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('test_string')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('test_string');
+
+        $model = $this->model(To::htmlString()->encrypted(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(HtmlString::class, $instance);
+        $this->assertEquals('test_string', $instance->toHtml());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_html_string_using(): void
+    {
+        $model = $this->model(To::htmlString()->using(CustomHtmlString::class), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomHtmlString::class, $instance);
+        $this->assertEquals('test_string', $instance->toHtml());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_html_string_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . HtmlString::class . '].');
+
+        $this->model(To::htmlString()->using(Fluent::class), 'test_string');
+    }
+
+    public function test_to_uri(): void
+    {
+        $model = $this->model(To::uri(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Uri::class, $instance);
+        $this->assertEquals('test_string', (string) $instance);
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_uri_without_caching(): void
+    {
+        $model = $this->model(To::uri()->withoutCaching(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Uri::class, $instance);
+        $this->assertEquals('test_string', (string) $instance);
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_uri_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('test_string')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('test_string');
+
+        $model = $this->model(To::uri()->encrypted(), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Uri::class, $instance);
+        $this->assertEquals('test_string', (string) $instance);
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_uri_using(): void
+    {
+        $model = $this->model(To::htmlString()->using(CustomHtmlString::class), 'test_string');
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomHtmlString::class, $instance);
+        $this->assertEquals('test_string', $instance->toHtml());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('test_string', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_uri_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . Uri::class . '].');
+
+        $this->model(To::uri()->using(Fluent::class), 'test_string');
+    }
+
+    public function test_to_array_object(): void
+    {
+        $model = $this->model(To::arrayObject(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertSame('bar', $instance->foo);
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_without_caching(): void
+    {
+        $model = $this->model(To::arrayObject()->withoutCaching(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('{"foo":"bar"}')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('{"foo":"bar"}');
+
+        $model = $this->model(To::arrayObject()->encrypted(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_using(): void
+    {
+        $model = $this->model(To::arrayObject()->using(CustomArrayObject::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . ArrayObject::class . '].');
+
+        $this->model(To::arrayObject()->using(Fluent::class), 'test_string');
+    }
+
+    public function test_to_array_object_mapped_into(): void
+    {
+        $model = $this->model(To::arrayObject()->mappedInto(Stringable::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => new Stringable('bar')], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_mapped_into_enum(): void
+    {
+        $model = $this->model(To::arrayObject()->mappedInto(Foo::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => Foo::BAR], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_mapped(): void
+    {
+        $model = $this->model(To::arrayObject()->mapped([Str::class, 'upper']), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'BAR'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"BAR"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_array_object_mapped_from_array(): void
+    {
+        $model = $this->model(To::arrayObject()->mappedFromArray(MappedFromArray::class), ['foo' => ['bar', 'baz']]);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(ArrayObject::class, $instance);
+        $this->assertEquals(['foo' => 'bar+baz'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar+baz"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection(): void
+    {
+        $model = $this->model(To::collection(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertSame('bar', $instance->get('foo'));
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_without_caching(): void
+    {
+        $model = $this->model(To::collection()->withoutCaching(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('{"foo":"bar"}')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('{"foo":"bar"}');
+
+        $model = $this->model(To::collection()->encrypted(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_using(): void
+    {
+        $model = $this->model(To::collection()->using(CustomCollection::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomCollection::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . Collection::class . '].');
+
+        $this->model(To::collection()->using(Fluent::class), 'test_string');
+    }
+
+    public function test_to_collection_mapped_into(): void
+    {
+        $model = $this->model(To::collection()->mappedInto(Stringable::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => new Stringable('bar')], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_mapped_into_enum(): void
+    {
+        $model = $this->model(To::collection()->mappedInto(Foo::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => Foo::BAR], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_mapped(): void
+    {
+        $model = $this->model(To::collection()->mapped([Str::class, 'upper']), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => 'BAR'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"BAR"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_collection_mapped_from_array(): void
+    {
+        $model = $this->model(To::collection()->mappedFromArray(MappedFromArray::class), ['foo' => ['bar', 'baz']]);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Collection::class, $instance);
+        $this->assertEquals(['foo' => 'bar+baz'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar+baz"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent(): void
+    {
+        $model = $this->model(To::fluent(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertSame('bar', $instance->get('foo'));
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_without_caching(): void
+    {
+        $model = $this->model(To::fluent()->withoutCaching(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertNotSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_encrypted(): void
+    {
+        $this->crypt()->expects('encryptString')->with('{"foo":"bar"}')->andReturn('encrypted');
+        $this->crypt()->expects('decryptString')->with('encrypted')->andReturn('{"foo":"bar"}');
+
+        $model = $this->model(To::fluent()->encrypted(), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('encrypted', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_using(): void
+    {
+        $model = $this->model(To::fluent()->using(CustomFluent::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(CustomFluent::class, $instance);
+        $this->assertEquals(['foo' => 'bar'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_using_throws_when_incorrect_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must extend [' . Fluent::class . '].');
+
+        $this->model(To::fluent()->using(Collection::class), 'test_string');
+    }
+
+    public function test_to_fluent_mapped_into(): void
+    {
+        $model = $this->model(To::fluent()->mappedInto(Stringable::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => new Stringable('bar')], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_mapped_into_enum(): void
+    {
+        $model = $this->model(To::fluent()->mappedInto(Foo::class), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => Foo::BAR], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_mapped(): void
+    {
+        $model = $this->model(To::fluent()->mapped([Str::class, 'upper']), ['foo' => 'bar']);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => 'BAR'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"BAR"}', DB::table('users')->value('castable'));
+    }
+
+    public function test_to_fluent_mapped_from_array(): void
+    {
+        $model = $this->model(To::fluent()->mappedFromArray(MappedFromArray::class), ['foo' => ['bar', 'baz']]);
+
+        $instance = $model->castable;
+
+        $this->assertInstanceOf(Fluent::class, $instance);
+        $this->assertEquals(['foo' => 'bar+baz'], $instance->toArray());
+        $this->assertSame($instance, $model->castable);
+
+        $model->save();
+
+        $this->assertSame('{"foo":"bar+baz"}', DB::table('users')->value('castable'));
+    }
+}
+
+class CustomStringable extends Stringable
+{
+    //
+}
+
+class CustomHtmlString extends HtmlString
+{
+    //
+}
+
+class CustomUri extends Uri
+{
+    //
+}
+
+class CustomArrayObject extends ArrayObject
+{
+    //
+}
+
+class CustomCollection extends Collection
+{
+    //
+}
+
+class CustomFluent extends Fluent
+{
+    //
+}
+
+class MappedFromArray
+{
+    public static function fromArray($array)
+    {
+        return implode('+', $array);
+    }
+}

--- a/tests/Database/DatabaseEloquentCastTo.php
+++ b/tests/Database/DatabaseEloquentCastTo.php
@@ -23,6 +23,7 @@ use InvalidArgumentException;
 use Mockery as m;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+
 use function implode;
 
 class DatabaseEloquentCastTo extends TestCase
@@ -47,7 +48,7 @@ class DatabaseEloquentCastTo extends TestCase
         $this->createSchema();
 
         $this->container = new Application();
-        $this->container->singleton('encrypter', fn() => $this->encrypter);
+        $this->container->singleton('encrypter', fn () => $this->encrypter);
 
         Facade::setFacadeApplication($this->container);
 
@@ -170,7 +171,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_stringable_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . Stringable::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.Stringable::class.'].');
 
         $this->model(To::stringable()->using(Fluent::class), 'test_string');
     }
@@ -241,7 +242,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_html_string_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . HtmlString::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.HtmlString::class.'].');
 
         $this->model(To::htmlString()->using(Fluent::class), 'test_string');
     }
@@ -312,7 +313,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_uri_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . Uri::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.Uri::class.'].');
 
         $this->model(To::uri()->using(Fluent::class), 'test_string');
     }
@@ -385,7 +386,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_array_object_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . ArrayObject::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.ArrayObject::class.'].');
 
         $this->model(To::arrayObject()->using(Fluent::class), 'test_string');
     }
@@ -518,7 +519,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_collection_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . Collection::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.Collection::class.'].');
 
         $this->model(To::collection()->using(Fluent::class), 'test_string');
     }
@@ -651,7 +652,7 @@ class DatabaseEloquentCastTo extends TestCase
     public function test_to_fluent_using_throws_when_incorrect_class(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided class must extend [' . Fluent::class . '].');
+        $this->expectExceptionMessage('The provided class must extend ['.Fluent::class.'].');
 
         $this->model(To::fluent()->using(Collection::class), 'test_string');
     }

--- a/tests/Database/Fixtures/Models/EloquentModelWithCastTo.php
+++ b/tests/Database/Fixtures/Models/EloquentModelWithCastTo.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property mixed $castable
+ */
+class EloquentModelWithCastTo extends Model
+{
+    public static $useCasts = null;
+
+    protected $table = 'users';
+
+    protected $fillable = ['castable'];
+
+    protected function casts(): array
+    {
+        return static::$useCasts;
+    }
+}


### PR DESCRIPTION
# What?

This is basically a refactoring of the Eloquent Casts that allows to expressively configure a casts, and standardize features like encryption, caching and mapping (for iterable casts like Collections or even Fluent).

This PR solves some problems for the built-in casts:

- Cannot disable object caching. To do that, the developer must create its own cast.
- `AsFluent`, `AsHtmlString` and `AsUri` are not encryptable.
- Cannot use `map` or `using` on an `AsArrayObject`, while `AsCollection` does.

This is opt-in, meaning, there are no changes to the already included casts, but I believe the new way to declare casts should be preferred when possible when the developer requires the new features. Aka, **this PR is non breaking**.

## How?

The way it works is by introducing an entry-point class called `To`, with static methods that return an object that configure the selected cast enabled by #56687.

> [!NOTE]
>
> `As` is reserved by PHP and won't work, that's why I decanted to use `To`.

```php
use Illuminate\Database\Eloquent\Casts\AsCollection;
use Illuminate\Database\Eloquent\Casts\To;

// Before
public function casts()
{
    return [
         'colors' => AsCollection::of(Color::class)   
    ];   
}

// After
public function casts()
{
    return [
         'colors' => To::collection()->of(Color::class)
    ];   
}
```

The static methods are:

| Method              | Equivalent       |
|---------------------|------------------|
| `To::fluent()`      | `AsFluent`       |
| `To::htmlString()`  | `AsHtmlString`   |
| `To::stringable()`  | `AsStringable`   |
| `To::uri()`         | `AsUri`          |
| `To::arrayObject()` | `AsArrayObject`  |
| `To::collection()`  | `AsCollection`   |

For example, we can now fluently configure an `ArrayObject` to use a custom Array Object class and items or even disable caching for a Fluent object.

```php
use Illuminate\Database\Eloquent\Casts\To;

// An Array Object using a custom class and custom item instances.
To::arrayObject()->using(MyCustomArrayObject::class)->of(Color::class);

// An HTML String instance that is not cached.
To::fluent()->withoutCaching();

// An encrypted collection that maps "KeyParser" using the `fromArray()` static method.
To::collection()->encrypted()->mappedFromArray(KeyParser::class);
```

To achieve all this, the `To` class instances two objects depending on what is being casted: `ToIterable` or `ToString`. Once these are set into the cast array, these will serialize into strings with the cast configuration. 

A minor adjustment had to be made for the `ArrayObject`. Due to the `serialize()` method present in the original cast, the `ArrayObjectCast` had to be created. Aside from that, I believe this implementation is _cleaner_ in the sense that one Cast handles iterable objects, while other does for stringable objects. 

Finally, if the developer is using a custom class with `using()`, the class check is deferred until the cast is used, like currently is done.

# Extensibility

The `IterableCast` can also be extended by developers since both mapping and final instantiation is done using `mapItems()` and `makeIterableObject()`, respectively.

```php
class MyIterableCast extends IterableCast
{
    protected function mapItems($data)
    {
        // Instance each item here...
    }

    protected function makeIterableObject($data)
    {
        // Make the final iterable object here...
    }
}

class MyIterable implements Castable
{
    public function castUsing(array $arguments)
    {
        return new MyIterableCast();
    }
}
```
