### PR TITLE
[12.x] Introduce "after" rate limiting

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -26,6 +26,13 @@ class Limit
     public $decaySeconds;
 
     /**
+     * Whether to only record a hit after a successful response.
+     *
+     * @var bool
+     */
+    public $onSuccess = false;
+
+    /**
      * The response generator callback.
      *
      * @var callable
@@ -125,6 +132,19 @@ class Limit
     public function by($key)
     {
         $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set whether to only record a hit after a successful response.
+     *
+     * @param  bool  $onSuccess
+     * @return $this
+     */
+    public function onSuccess(bool $onSuccess = true)
+    {
+        $this->onSuccess = $onSuccess;
 
         return $this;
     }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -26,11 +26,11 @@ class Limit
     public $decaySeconds;
 
     /**
-     * Whether to only record a hit after a successful response.
+     * The after callback used to determine if the limiter should be hit.
      *
-     * @var bool
+     * @var ?callable
      */
-    public $onSuccess = false;
+    public $afterCallback = null;
 
     /**
      * The response generator callback.
@@ -137,14 +137,14 @@ class Limit
     }
 
     /**
-     * Set whether to only record a hit after a successful response.
+     * Set the callback to determine if the limiter should be hit.
      *
-     * @param  bool  $onSuccess
+     * @param  callable  $callback
      * @return $this
      */
-    public function onSuccess(bool $onSuccess = true)
+    public function after($callback)
     {
-        $this->onSuccess = $onSuccess;
+        $this->afterCallback = $callback;
 
         return $this;
     }

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -10,14 +10,19 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Exceptions\MissingRateLimiterException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\RateLimiter as RateLimiterFacade;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 #[WithConfig('hashing.driver', 'bcrypt')]
@@ -409,6 +414,81 @@ class ThrottleRequestsTest extends TestCase
             $this->assertEquals(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
+    }
+
+    public function testItCanThrottleBasedOnResponse()
+    {
+        RateLimiterFacade::for('throttle-not-found', function (Request $request) {
+            return Limit::perMinute(1)->after(fn ($response) => $response->status() === 404);
+        });
+        Route::get('/', fn () => match(request('status')) {
+            '404' => abort(404),
+            default => 'ok',
+        })->middleware(ThrottleRequests::using('throttle-not-found'));
+
+        $this->travelTo('2000-01-01 00:00:00');
+        $this->get('?status=404')->assertNotFound();
+        $this->get('?status=404')->assertTooManyRequests();
+        $this->get('?status=404')->assertTooManyRequests();
+
+        $this->travelTo('2000-01-01 00:00:59');
+        $this->get('?status=404')->assertTooManyRequests();
+        $this->get('?status=404')->assertTooManyRequests();
+
+        $this->travelTo('2000-01-01 00:01:00');
+        $this->get('?status=404')->assertNotFound();
+        $this->get('?status=404')->assertTooManyRequests();
+        $this->get('?status=404')->assertTooManyRequests();
+
+        $this->travelTo('2000-01-01 00:01:59');
+        $this->get('?status=404')->assertTooManyRequests();
+        $this->get('?status=404')->assertTooManyRequests();
+
+        $this->travelTo('2000-01-01 00:02:00');
+        $this->get('?status=404')->assertNotFound();
+        $this->get('?status=404')->assertTooManyRequests();
+        $this->get('?status=404')->assertTooManyRequests();
+    }
+
+    public function testItDoesNotHitLimiterUntilResponseHasBeenGenerated()
+    {
+        ThrottleRequests::shouldHashKeys(false);
+        RateLimiterFacade::for('throttle-not-found', function (Request $request) {
+            return Limit::perMinute(1)->after(fn ($response) => $response->status() === 404);
+        });
+        $duringRequest = null;
+        Route::get('/', function () use (&$duringRequest) {
+            $duringRequest = [
+                Cache::get('throttle-not-found:'),
+                Cache::get('throttle-not-found::timer'),
+            ];
+
+            abort(404);
+        })->middleware(ThrottleRequests::using('throttle-not-found'));
+
+        $this->travelTo('2000-01-01 00:00:00');
+        $this->get('?status=404')->assertNotFound();
+
+        $this->assertSame([null, null], $duringRequest);
+        $this->assertSame([1, 946684860], [
+            Cache::get('throttle-not-found:'),
+            Cache::get('throttle-not-found::timer'),
+        ]);
+    }
+
+    public function testItReturnsConfiguredResponseWhenUsingAfterLimit(): void
+    {
+        ThrottleRequests::shouldHashKeys(false);
+        RateLimiterFacade::for('throttle-not-found', function (Request $request) {
+            return Limit::perMinute(1)
+                ->after(fn ($response) => $response->status() === 404)
+                ->response(fn () => response('ah ah ah', status: 429));
+        });
+        Route::get('/', fn () => abort(404))->middleware(ThrottleRequests::using('throttle-not-found'));
+
+        $this->travelTo('2000-01-01 00:00:00');
+        $this->get('?status=404')->assertNotFound();
+        $this->get('?status=404')->assertTooManyRequests()->assertContent('ah ah ah');
     }
 }
 


### PR DESCRIPTION
This PR continues the amazing work, by @JosephSilber, in https://github.com/laravel/framework/pull/56933 by extending it to allow for a generic callback hook.

Currently, it is only possible to rate limit based on the request. Often, it can be useful to rate limit based on the response.

_From the original PR_: For example, imagine you have a sign up endpoint that could return validation errors. If you want to throttle to a single sign up per day for an IP address, any validation response would trigger the rate limiter making it impossible to sign up again for the day.

Another example is rate limiting 404 responses to mitigate enumeration attacks on resource identifiers. If a single user hits a certain level of 404 responses in a short time frame, they could be attempting enumeration attacks.

Below is an example of an _after_ limiter that would restrict user's from hitting too many 404 responses in a single minute:

```php
use Illuminate\Http\Request;
use Illuminate\Support\Facades\RateLimiter;
use Symfony\Component\HttpFoundation\Response;

/*
 * Ensure a user can only hit ten 404 responses in a minute before they are
 * rate limited to ensure user's cannot enumerate resource IDs.
 */
RateLimiter::for('resource-not-found', function (Request $request) {
    return Limit::perMinute(10)
        ->by("user:{$request->user()->id}")

        // The new `after` hook...

        ->after(function (Response $response) {                 
            return $response->getStatusCode() === 404;
        });
});
```

## Yet to be solved caveat

Due to the nature of _after_ limiters, it is possible that more than 10 requests could come through per minute. Given the above limiter, if there were already 9 requests and then two requests came in at the same time, a race condition occurs where two requests could make it through. This would effectively mean that 11 requests were made within the minute.

I think we could solve this but I've left it for now to open discussion.

Initial solution idea: I was thinking we could offer the ability to use a cache lock to pause the second incoming request until the first has finished. Replicating what the `Route::block` method achieves:

```php
->after(function (Response $response) {                 
    return $response->getStatusCode() === 404;
}, lockSeconds: 10, waitSeconds: 10);
```

This would use the limit's `key` to determine when to block.