### PR TITLE
[12.x] Allow Number parse helpers to return false

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -56,7 +56,7 @@ class Number
      * @param  string|null  $locale
      * @return int|float|false
      */
-    public static function parse(string $string, ?int $type = NumberFormatter::TYPE_DOUBLE, ?string $locale = null): int|float
+    public static function parse(string $string, ?int $type = NumberFormatter::TYPE_DOUBLE, ?string $locale = null): int|float|false
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -72,7 +72,7 @@ class Number
      * @param  string|null  $locale
      * @return int|false
      */
-    public static function parseInt(string $string, ?string $locale = null): int
+    public static function parseInt(string $string, ?string $locale = null): int|false
     {
         return self::parse($string, NumberFormatter::TYPE_INT32, $locale);
     }
@@ -84,7 +84,7 @@ class Number
      * @param  string|null  $locale
      * @return float|false
      */
-    public static function parseFloat(string $string, ?string $locale = null): float
+    public static function parseFloat(string $string, ?string $locale = null): float|false
     {
         return self::parse($string, NumberFormatter::TYPE_DOUBLE, $locale);
     }


### PR DESCRIPTION
This PR updates Laravel’s number parsing helpers to include false in their return types, matching the documented behavior of Number::parse*() when parsing fails and preventing unexpected TypeError exceptions in userland code.