### PR TITLE
[12.x] Pass ReflectionParameter to attribute resolving

### DIFF
--- a/src/Illuminate/Container/Attributes/RouteParameter.php
+++ b/src/Illuminate/Container/Attributes/RouteParameter.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use ReflectionParameter;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class RouteParameter implements ContextualAttribute
@@ -12,7 +13,7 @@ class RouteParameter implements ContextualAttribute
     /**
      * Create a new class instance.
      */
-    public function __construct(public string $parameter)
+    public function __construct(public ?string $parameter = null)
     {
     }
 
@@ -21,10 +22,11 @@ class RouteParameter implements ContextualAttribute
      *
      * @param  self  $attribute
      * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \ReflectionParameter  $parameter
      * @return mixed
      */
-    public static function resolve(self $attribute, Container $container)
+    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter)
     {
-        return $container->make('request')->route($attribute->parameter);
+        return $container->make('request')->route($attribute->parameter ?? $parameter->getName());
     }
 }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -175,7 +175,7 @@ class BoundMethod
 
             unset($parameters[$paramName]);
         } elseif ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
-            $pendingDependencies[] = $container->resolveFromAttribute($attribute);
+            $pendingDependencies[] = $container->resolveFromAttribute($attribute, $parameter);
         } elseif (! is_null($className = Util::getParameterClassName($parameter))) {
             if (array_key_exists($className, $parameters)) {
                 $pendingDependencies[] = $parameters[$className];

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1267,7 +1267,7 @@ class Container implements ArrayAccess, ContainerContract
             $result = null;
 
             if (! is_null($attribute = Util::getContextualAttributeFromDependency($dependency))) {
-                $result = $this->resolveFromAttribute($attribute);
+                $result = $this->resolveFromAttribute($attribute, $dependency);
             }
 
             // If the class is null, it means the dependency is a string or some other
@@ -1416,9 +1416,10 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve a dependency based on an attribute.
      *
      * @param  \ReflectionAttribute  $attribute
+     * @param  \ReflectionParameter  $parameter
      * @return mixed
      */
-    public function resolveFromAttribute(ReflectionAttribute $attribute)
+    public function resolveFromAttribute(ReflectionAttribute $attribute, ReflectionParameter $parameter)
     {
         $handler = $this->contextualAttributes[$attribute->getName()] ?? null;
 
@@ -1432,7 +1433,7 @@ class Container implements ArrayAccess, ContainerContract
             throw new BindingResolutionException("Contextual binding attribute [{$attribute->getName()}] has no registered handler.");
         }
 
-        return $handler($instance, $this);
+        return $handler($instance, $this, $parameter);
     }
 
     /**

--- a/src/Illuminate/Routing/ResolvesRouteDependencies.php
+++ b/src/Illuminate/Routing/ResolvesRouteDependencies.php
@@ -76,7 +76,7 @@ trait ResolvesRouteDependencies
     protected function transformDependency(ReflectionParameter $parameter, $parameters, $skippableValue)
     {
         if ($attribute = Util::getContextualAttributeFromDependency($parameter)) {
-            return $this->container->resolveFromAttribute($attribute);
+            return $this->container->resolveFromAttribute($attribute, $parameter);
         }
 
         $className = Reflector::getParameterClassName($parameter);


### PR DESCRIPTION
For custom Attributes using `ContextualAttribute` it can be sometimes useful to access the `ReflectionParameter` i.e. to get the name or type-hint. This PR simply passes the `ReflectionParameter` to the static `resolve` method so that it can be used.

In this PR I have also adjusted the `RouteParameter` making the parameter optional and if not provided we simply use the name of the parameter, which simplifies a little bit the usage since often the name of the variable is identical to the parameter name.

Before:
```php
public function show(#[RouteParameter('id')] string $id): View
```

After:
```php
public function show(#[RouteParameter] string $id): View
```

The static `resolve` callback method accepts now the `ReflectionParameter` as third argument:

Before:
```php
public static function resolve(self $attribute, Container $container)
```

After:
```php
public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter)
```

Since we only add a new parameter it should be no breaking change for any existing code. New code simply can add the parameter if needed.
