### PR TITLE
[12.x] Refactor Env option normalization to use match

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -254,26 +254,15 @@ class Env
     {
         return Option::fromValue(static::getRepository()->get($key))
             ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
+                return match (strtolower($value)) {
+                    'true', '(true)' => true,
+                    'false', '(false)' => false,
+                    'empty', '(empty)' => '',
+                    'null', '(null)' => null,
+                    default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)
+                        ? $matches[2]
+                        : $value,
+                };
             });
     }
 


### PR DESCRIPTION
Convert Env::getOption’s string-normalizing switch into a modern match, keeping literal mappings together while preserving the quoted-string fallback for other values.