### PR TITLE
[12.x] add Arr::some and Arr::every helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1223,4 +1223,40 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+     /**
+     * Determine if at least one item in the array passes the truth test.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return bool
+     */
+    public static function some(array $array, callable $callback): bool
+    {
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if all items in the array pass the truth test.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return bool
+     */
+    public static function every(array $array, callable $callback): bool
+    {
+        foreach ($array as $key => $value) {
+            if (! $callback($value, $key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1812,4 +1812,44 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+     public function testArrSomeReturnsTrueIfAtLeastOneElementPasses()
+    {
+        $array = [1, 2, 3, 4];
+
+        $this->assertTrue(Arr::some($array, fn ($value) => $value % 2 === 0));
+        $this->assertTrue(Arr::some($array, fn ($value) => $value > 3));
+    }
+
+    public function testArrSomeReturnsFalseIfNoElementPasses()
+    {
+        $array = [1, 3, 5];
+
+        $this->assertFalse(Arr::some($array, fn ($value) => $value % 2 === 0));
+        $this->assertFalse(Arr::some($array, fn ($value) => $value > 10));
+    }
+
+    public function testArrEveryReturnsTrueIfAllElementsPass()
+    {
+        $array = [2, 4, 6, 8];
+
+        $this->assertTrue(Arr::every($array, fn ($value) => $value % 2 === 0));
+        $this->assertTrue(Arr::every($array, fn ($value) => $value > 0));
+    }
+
+    public function testArrEveryReturnsFalseIfAnyElementFails()
+    {
+        $array = [2, 4, 5, 8];
+
+        $this->assertFalse(Arr::every($array, fn ($value) => $value % 2 === 0));
+        $this->assertFalse(Arr::every($array, fn ($value) => $value < 5));
+    }
+
+    public function testArrSomeAndEveryWithEmptyArray()
+    {
+        $array = [];
+
+        $this->assertFalse(Arr::some($array, fn ($value) => true));
+        $this->assertTrue(Arr::every($array, fn ($value) => true));
+    }
 }


### PR DESCRIPTION
##  Add `Arr::some` and `Arr::every` helpers

This PR adds two new helper methods to the `Illuminate\Support\Arr` class, inspired by JavaScript’s `Array.prototype.some()` and `Array.prototype.every()`.  
Both methods are **fully backward compatible** and introduced as minor utilities to improve developer ergonomics when working with arrays.

---

### New Methods

- **`Arr::some(array $array, callable $callback): bool`**  
  Returns `true` if **at least one** item in the array passes the given truth test.

- **`Arr::every(array $array, callable $callback): bool`**  
  Returns `true` if **all** items in the array pass the given truth test.

---

### Example Usage

```php
Arr::some([1, 2, 3], fn ($v) => $v > 2);
// true

Arr::every([2, 4, 6], fn ($v) => $v % 2 === 0);
// true