### PR TITLE
[12.x] Fix session value is missing assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1711,9 +1711,9 @@ class TestResponse implements ArrayAccess
                 "Session has unexpected key [{$key}]."
             );
         } elseif ($value instanceof Closure) {
-            PHPUnit::withResponse($this)->assertTrue($value($this->session()->get($key)));
+            PHPUnit::withResponse($this)->assertFalse($value($this->session()->get($key)));
         } else {
-            PHPUnit::withResponse($this)->assertEquals($value, $this->session()->get($key));
+            PHPUnit::withResponse($this)->assertNotEquals($value, $this->session()->get($key));
         }
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2808,16 +2808,60 @@ class TestResponseTest extends TestCase
         $response->assertSessionMissing('foo');
     }
 
-    #[TestWith(['foo', 'badvalue'])]
-    #[TestWith(['foo', null])]
-    #[TestWith([['foo', 'bar'], null])]
-    public function testAssertSessionMissingValue(array|string $key, mixed $value): void
+    #[TestWith(['foo', 'goodvalue'])]
+    #[TestWith([['foo', 'bar'], 'goodvalue'])]
+    public function testAssertSessionMissingValueIsPresent(array|string $key, mixed $value): void
     {
         $this->expectException(AssertionFailedError::class);
 
         app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
 
         $store->put('foo', 'goodvalue');
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertSessionMissing($key, $value);
+    }
+
+    public function testAssertSessionMissingValueIsPresentClosure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('foo', 'goodvalue');
+
+        $key = 'foo';
+
+        $value = function ($value) {
+            return $value === 'goodvalue';
+        };
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertSessionMissing($key, $value);
+    }
+
+    #[TestWith(['foo', 'badvalue'])]
+    public function testAssertSessionMissingValueIsMissing(array|string $key, mixed $value): void
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('foo', 'goodvalue');
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertSessionMissing($key, $value);
+    }
+
+    public function testAssertSessionMissingValueIsMissingClosure(): void
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('foo', 'goodvalue');
+
+        $key = 'foo';
+
+        $value = function ($value) {
+            return $value === 'badvalue';
+        };
 
         $response = TestResponse::fromBaseResponse(new Response());
         $response->assertSessionMissing($key, $value);


### PR DESCRIPTION
When a value was passed to assertSesionMissing($key, $value), 

- If that value was null, we only checked whether there was _any_ value with the key passed, if there was wasnt we passed, and if there was we failed the assertion (session was _not_ missing such key, so makes sense it failed).
- If we passed a key and a value, we checked for that key in session and if the value was the **same** as the one we passed the assertion was succesful (session was _not_ missing such key/value combination and it passed, doesn't make sense).
- Passing a closure had the same issue.

That part of the code for assertSessionMissing was the same in assertSessionHas which hinted something was strange.

Fixed the assertion and added more tests for the different cases.