### PR TITLE
[12.x] Bump phiki to 2.0.4 to fix UTF-8 issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^3.8.4",
         "nunomaduro/termwind": "^2.0",
-        "phiki/phiki": "^2.0.0",
+        "phiki/phiki": "^2.0.4",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
UTF-8 in the exception code were crashing Phiki (#57126).

This was solved (https://github.com/phikiphp/phiki/pull/122) and released with v2.0.4