### PR TITLE
[12.x] Fix PHP 8.5 null-key deprecations

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -230,7 +230,7 @@ class Arr
             return $array->offsetExists($key);
         }
 
-        if (is_float($key)) {
+        if (is_float($key) || is_null($key)) {
             $key = (string) $key;
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -479,6 +479,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function get($key, $default = null)
     {
+        $key ??= '';
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
@@ -497,6 +498,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function getOrPut($key, $value)
     {
+        $key ??= '';
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
@@ -539,6 +541,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                     is_bool($groupKey) => (int) $groupKey,
                     $groupKey instanceof \UnitEnum => enum_value($groupKey),
                     $groupKey instanceof \Stringable => (string) $groupKey,
+                    is_null($groupKey) => (string) $groupKey,
                     default => $groupKey,
                 };
 
@@ -600,7 +603,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $keys = is_array($key) ? $key : func_get_args();
 
-        return array_all($keys, fn ($key) => array_key_exists($key, $this->items));
+        return array_all($keys, fn ($key) => array_key_exists($key ?? '', $this->items));
     }
 
     /**
@@ -617,7 +620,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $keys = is_array($key) ? $key : func_get_args();
 
-        return array_any($keys, fn ($key) => array_key_exists($key, $this->items));
+        return array_any($keys, fn ($key) => array_key_exists($key ?? '', $this->items));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -498,9 +498,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function getOrPut($key, $value)
     {
-        $key ??= '';
-        if (array_key_exists($key, $this->items)) {
-            return $this->items[$key];
+        if (array_key_exists($key ?? '', $this->items)) {
+            return $this->items[$key ?? ''];
         }
 
         $this->offsetSet($key, $value = value($value));

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -480,6 +480,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function get($key, $default = null)
     {
         $key ??= '';
+
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -431,6 +431,7 @@ trait InteractsWithIO
     protected function parseVerbosity($level = null)
     {
         $level ??= '';
+
         if (isset($this->verbosityMap[$level])) {
             $level = $this->verbosityMap[$level];
         } elseif (! is_int($level)) {

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -430,6 +430,7 @@ trait InteractsWithIO
      */
     protected function parseVerbosity($level = null)
     {
+        $level ??= '';
         if (isset($this->verbosityMap[$level])) {
             $level = $this->verbosityMap[$level];
         } elseif (! is_int($level)) {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -195,7 +195,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertEmpty(
-            $this->notifications[get_class($notifiable)][$notifiable->getKey()] ?? [],
+            $this->notifications[get_class($notifiable)][$notifiable->getKey() ?? ''] ?? [],
             'Notifications were sent unexpectedly.',
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2490,6 +2490,18 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('male', $data->get('gender'));
     }
 
+    public function testGetOrPutWithNoKey()
+    {
+        $data = new Collection(['taylor', 'shawn']);
+        $this->assertSame('dayle', $data->getOrPut(null, 'dayle'));
+        $this->assertSame('john', $data->getOrPut(null, 'john'));
+        $this->assertSame(['taylor', 'shawn', 'dayle', 'john'], $data->all());
+
+        $data = new Collection(['taylor', '' => 'shawn']);
+        $this->assertSame('shawn', $data->getOrPut(null, 'dayle'));
+        $this->assertSame(['taylor', '' => 'shawn'], $data->all());
+    }
+
     public function testPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1552,7 +1552,7 @@ trait SupportTestTraitArrayAccess
 
     public function offsetExists($offset): bool
     {
-        return array_key_exists($offset, $this->items);
+        return array_key_exists($offset ?? '', $this->items);
     }
 
     public function offsetGet($offset): mixed


### PR DESCRIPTION
PHP 8.5 deprecates using `null` as array key (accessing, setting, as well as things like `array_key_exists()`):

> Using null as an array offset or when calling array_key_exists() is now deprecated. Instead an empty string should be used. RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

I have personally encountered this deprecation in `parseVerbosity()` as usually it's set to `null` when calling `$this->line('message')`. Other places were discovered by running the test suite. Please note that most likely not all occurrences were found yet.