### PR TITLE
[12.x] Dispatch framework events on composer `pre-package-uninstall` event

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -72,9 +72,8 @@ class ComposerScripts
 
         /** @var \Composer\DependencyResolver\Operation\UninstallOperation $uninstallOperation */
         $uninstallOperation = $event->getOperation()->getPackage();
-        $packageName = $uninstallOperation->getName();
 
-        $app['events']->dispatch('composer_package.'.$packageName.':pre_uninstall');
+        $app['events']->dispatch('composer_package.'.$uninstallOperation->getName().':pre_uninstall');
     }
 
 

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -74,7 +74,7 @@ class ComposerScripts
         $packageName = $uninstallOperation->getName();
         $isDev = $uninstallOperation->isDev();
 
-        $app['events']->dispatch('composer_package:'.$packageName.':uninstall', [
+        $app['events']->dispatch('composer_package:'.$packageName.':pre_uninstall', [
             'package' => $packageName,
             'isDev' => $isDev,
         ]);

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Composer\Installer\PackageEvent;
 use Composer\Script\Event;
+use Illuminate\Contracts\Console\Kernel;
 
 class ComposerScripts
 {
@@ -54,8 +55,6 @@ class ComposerScripts
      */
     public static function prePackageUninstall(PackageEvent $event)
     {
-        $bootstrapFile = $event->getComposer()->getConfig()->get('base-dir');
-
         $bootstrapFile = dirname($vendorDir = $event->getComposer()->getConfig()->get('vendor-dir')).'/bootstrap/app.php';
 
         if (! file_exists($bootstrapFile)) {
@@ -69,16 +68,15 @@ class ComposerScripts
         /** @var Application $app */
         $app = require_once $bootstrapFile;
 
+        $app->make(Kernel::class)->bootstrap();
+
         /** @var \Composer\DependencyResolver\Operation\UninstallOperation $uninstallOperation */
         $uninstallOperation = $event->getOperation()->getPackage();
         $packageName = $uninstallOperation->getName();
-        $isDev = $uninstallOperation->isDev();
 
-        $app['events']->dispatch('composer_package:'.$packageName.':pre_uninstall', [
-            'package' => $packageName,
-            'isDev' => $isDev,
-        ]);
+        $app['events']->dispatch('composer_package.'.$packageName.':pre_uninstall');
     }
+
 
     /**
      * Clear the cached Laravel bootstrapping files.

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -74,7 +74,7 @@ class ComposerScripts
         $packageName = $uninstallOperation->getName();
         $isDev = $uninstallOperation->isDev();
 
-        $app['events']->dispatch('composer_package:uninstall:'.$packageName, [
+        $app['events']->dispatch('composer_package:'.$packageName.':uninstall', [
             'package' => $packageName,
             'isDev' => $isDev,
         ]);

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 class SupportServiceProviderTest extends TestCase
 {
     protected $app;
+    protected string $tempFile;
 
     protected function setUp(): void
     {
@@ -30,11 +31,16 @@ class SupportServiceProviderTest extends TestCase
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
         $two->boot();
+
+        $this->tempFile = __DIR__ . '/providers.php';
     }
 
     protected function tearDown(): void
     {
         m::close();
+        if ($this->tempFile && file_exists($this->tempFile)) {
+            @unlink($this->tempFile);
+        }
     }
 
     public function testPublishableServiceProviders()
@@ -190,6 +196,46 @@ class SupportServiceProviderTest extends TestCase
 
         $provider = new ServiceProviderForTestingOne($this->app);
         $provider->loadTranslationsFrom(__DIR__.'/translations', 'namespace');
+    }
+
+    public function test_can_remove_provider()
+    {
+
+        $r = file_put_contents($this->tempFile, $contents = <<< PHP
+<?php
+
+return [
+    App\Providers\AppServiceProvider::class,
+    App\Providers\TelescopeServiceProvider::class,
+];
+PHP
+    );
+        ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider', $this->tempFile, true);
+
+        // Should have deleted nothing
+        $this->assertSame($contents, trim(file_get_contents($this->tempFile)));
+
+        ServiceProvider::removeProviderFromBootstrapFile('App\Providers\TelescopeServiceProvider', $this->tempFile, true);
+
+        $this->assertSame(<<< PHP
+<?php
+
+return [
+    App\Providers\AppServiceProvider::class,
+];
+PHP
+            , trim(file_get_contents($this->tempFile)));
+
+        ServiceProvider::removeProviderFromBootstrapFile('AppServiceProvider', $this->tempFile);
+
+        $this->assertSame(<<< 'PHP'
+<?php
+
+return [
+
+];
+PHP
+            , trim(file_get_contents($this->tempFile)));
     }
 }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -31,14 +31,12 @@ class SupportServiceProviderTest extends TestCase
         $one->boot();
         $two = new ServiceProviderForTestingTwo($app);
         $two->boot();
-
-        $this->tempFile = __DIR__ . '/providers.php';
     }
 
     protected function tearDown(): void
     {
         m::close();
-        if ($this->tempFile && file_exists($this->tempFile)) {
+        if (isset($this->tempFile) && file_exists($this->tempFile)) {
             @unlink($this->tempFile);
         }
     }
@@ -200,7 +198,7 @@ class SupportServiceProviderTest extends TestCase
 
     public function test_can_remove_provider()
     {
-
+        $this->tempFile = __DIR__.'/providers.php';
         file_put_contents($this->tempFile, $contents = <<< PHP
 <?php
 
@@ -209,12 +207,13 @@ return [
     App\Providers\TelescopeServiceProvider::class,
 ];
 PHP
-    );
+        );
         ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider', $this->tempFile, true);
 
         // Should have deleted nothing
         $this->assertStringEqualsStringIgnoringLineEndings($contents, trim(file_get_contents($this->tempFile)));
 
+        // Should delete the telescope provider
         ServiceProvider::removeProviderFromBootstrapFile('App\Providers\TelescopeServiceProvider', $this->tempFile, true);
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<< PHP
@@ -226,6 +225,7 @@ return [
 PHP
             , trim(file_get_contents($this->tempFile)));
 
+        // Should fuzzily delete the App\Providers\AppServiceProvider class
         ServiceProvider::removeProviderFromBootstrapFile('AppServiceProvider', $this->tempFile);
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<< 'PHP'

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -201,7 +201,7 @@ class SupportServiceProviderTest extends TestCase
     public function test_can_remove_provider()
     {
 
-        $r = file_put_contents($this->tempFile, $contents = <<< PHP
+        file_put_contents($this->tempFile, $contents = <<< PHP
 <?php
 
 return [
@@ -213,11 +213,11 @@ PHP
         ServiceProvider::removeProviderFromBootstrapFile('TelescopeServiceProvider', $this->tempFile, true);
 
         // Should have deleted nothing
-        $this->assertSame($contents, trim(file_get_contents($this->tempFile)));
+        $this->assertStringEqualsStringIgnoringLineEndings($contents, trim(file_get_contents($this->tempFile)));
 
         ServiceProvider::removeProviderFromBootstrapFile('App\Providers\TelescopeServiceProvider', $this->tempFile, true);
 
-        $this->assertSame(<<< PHP
+        $this->assertStringEqualsStringIgnoringLineEndings(<<< PHP
 <?php
 
 return [
@@ -228,7 +228,7 @@ PHP
 
         ServiceProvider::removeProviderFromBootstrapFile('AppServiceProvider', $this->tempFile);
 
-        $this->assertSame(<<< 'PHP'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<< 'PHP'
 <?php
 
 return [


### PR DESCRIPTION
Looking at [this issue in the Telescope directory](https://github.com/laravel/telescope/issues/1637), Telescope is not cleaning up after itself during the uninstall process. While this can definitely be added to Telescope (and some kind of polyfill functionality WILL need to be added), it seems like something other packages might want to clean up after themselves with this functionality. Probably via the [composer `pre-package-uninstall` hook](https://getcomposer.org/doc/articles/scripts.md#:~:text=pre%2Dpackage%2Duninstall%3A%20occurs%20before%20a%20package%20is%20uninstalled.).

Looked into this a bit further, and it seems like we'll need to add a `ComposerScript::prePackageUninstall()` method, and then some way for service providers to register their package clean up scripts. The pre-package-uninstall hook isn't fired for children, only the project root.