### PR TITLE
[13.x] Add lockAndRemember method

### DIFF
--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -100,6 +100,23 @@ interface Repository extends CacheInterface
     public function rememberForever($key, Closure $callback);
 
     /**
+     * Get an item from the cache, or execute the given Closure and store the result.
+     * Uses a lock to prevent cache stampede.
+     *
+     * @template TCacheValue
+     *
+     * @param  string  $key
+     * @param  int  $lockTtl
+     * @param  int  $blockTtl
+     * @param  \DateTimeInterface|\DateInterval|int|null  $cacheTtl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     *
+     * @throws \Illuminate\Contracts\Cache\LockTimeoutException
+     */
+    public function lockAndRemember($key, $lockTtl, $blockTtl, $cacheTtl, Closure $callback);
+
+    /**
      * Set the expiration of a cached item; null TTL will retain the item forever.
      *
      * @param  string  $key


### PR DESCRIPTION
## Summary

This adds a new `Cache::lockAndRemember()` method that's a proxy method for locking and remembering at the same time.

## Use Case

Locking the generation of cache for a heavy endpoint. If multiple clients hit at the same time, one request will generate the cache while the others will wait and only consume it, instead of all trying to generate the cache at the same time.

## Example

Instead of this:

```php
$result = Cache::lock($cacheKey, 10)->block(5, function () {
    return Cache::remember($cacheKey, 600, function () {
         // code here
    });
});
```

We can do it like this:

```php
$result = Cache::lockAndRemember($cacheKey, $lockTTL, $blockTTL, $cacheTTL, function () {
    // code here
});
```