### PR TITLE
[12.x] Fixing when helper issue in relation instance

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -68,12 +68,31 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
+        $target = $this->conditionalTarget();
+
         if (! $value) {
-            return $callback($this, $value) ?? $this;
+            $result = $callback ? $callback($target, $value) : null;
+
+            return $target === $this ? ($result ?? $this) : $this;
         } elseif ($default) {
-            return $default($this, $value) ?? $this;
+            $result = $default($target, $value);
+
+            return $target === $this ? ($result ?? $this) : $this;
         }
 
+        return $this;
+    }
+
+    /**
+     * Determine which object should be passed to conditional callbacks.
+     *
+     * By default, the current object ($this) is provided. Classes may override this
+     * to customize the callback target.
+     *
+     * @return mixed
+     */
+    protected function conditionalTarget(): mixed
+    {
         return $this;
     }
 }

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -30,10 +30,16 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition($value);
         }
 
+        $target = $this->conditionalTarget();
+
         if ($value) {
-            return $callback($this, $value) ?? $this;
+            $result = $callback ? $callback($target, $value) : null;
+
+            return $target === $this ? ($result ?? $this) : $this;
         } elseif ($default) {
-            return $default($this, $value) ?? $this;
+            $result = $default($target, $value);
+
+            return $target === $this ? ($result ?? $this) : $this;
         }
 
         return $this;
@@ -62,12 +68,31 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
+        $target = $this->conditionalTarget();
+
         if (! $value) {
-            return $callback($this, $value) ?? $this;
+            $result = $callback ? $callback($target, $value) : null;
+
+            return $target === $this ? ($result ?? $this) : $this;
         } elseif ($default) {
-            return $default($this, $value) ?? $this;
+            $result = $default($target, $value);
+
+            return $target === $this ? ($result ?? $this) : $this;
         }
 
+        return $this;
+    }
+
+    /**
+     * Determine which object should be passed to conditional callbacks.
+     *
+     * By default, the current object ($this) is provided. Classes may override this
+     * to customize the callback target.
+     *
+     * @return mixed
+     */
+    protected function conditionalTarget(): mixed
+    {
         return $this;
     }
 }

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -68,31 +68,12 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
-        $target = $this->conditionalTarget();
-
         if (! $value) {
-            $result = $callback ? $callback($target, $value) : null;
-
-            return $target === $this ? ($result ?? $this) : $this;
+            return $callback($this, $value) ?? $this;
         } elseif ($default) {
-            $result = $default($target, $value);
-
-            return $target === $this ? ($result ?? $this) : $this;
+            return $default($this, $value) ?? $this;
         }
 
-        return $this;
-    }
-
-    /**
-     * Determine which object should be passed to conditional callbacks.
-     *
-     * By default, the current object ($this) is provided. Classes may override this
-     * to customize the callback target.
-     *
-     * @return mixed
-     */
-    protected function conditionalTarget(): mixed
-    {
         return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -425,9 +425,9 @@ abstract class Relation implements BuilderContract
     protected function whereInMethod(Model $model, $key)
     {
         return $model->getKeyName() === last(explode('.', $key))
-        && in_array($model->getKeyType(), ['int', 'integer'])
-            ? 'whereIntegerInRaw'
-            : 'whereIn';
+            && in_array($model->getKeyType(), ['int', 'integer'])
+                ? 'whereIntegerInRaw'
+                : 'whereIn';
     }
 
     /**
@@ -523,8 +523,6 @@ abstract class Relation implements BuilderContract
     {
         return array_search($className, static::$morphMap, strict: true) ?: $className;
     }
-
-
 
     /**
      * Determine which object should be passed to conditional callbacks.

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -556,10 +556,6 @@ abstract class Relation implements BuilderContract
             return $this->macroCall($method, $parameters);
         }
 
-        if ($this->query->hasMacro($method)) {
-            return $this->forwardDecoratedCallTo($this->query, $method, $parameters);
-        }
-
         return $this->forwardDecoratedCallTo($this->query, $method, $parameters);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Conditionable;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -26,6 +27,8 @@ abstract class Relation implements BuilderContract
     use ForwardsCalls, Macroable {
         Macroable::__call as macroCall;
     }
+
+    use Conditionable;
 
     /**
      * The Eloquent query builder instance.
@@ -423,9 +426,9 @@ abstract class Relation implements BuilderContract
     protected function whereInMethod(Model $model, $key)
     {
         return $model->getKeyName() === last(explode('.', $key))
-            && in_array($model->getKeyType(), ['int', 'integer'])
-                ? 'whereIntegerInRaw'
-                : 'whereIn';
+        && in_array($model->getKeyType(), ['int', 'integer'])
+            ? 'whereIntegerInRaw'
+            : 'whereIn';
     }
 
     /**
@@ -533,6 +536,10 @@ abstract class Relation implements BuilderContract
     {
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
+        }
+
+        if ($this->query->hasMacro($method)) {
+            return $this->forwardDecoratedCallTo($this->query, $method, $parameters);
         }
 
         return $this->forwardDecoratedCallTo($this->query, $method, $parameters);

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -400,6 +400,9 @@ abstract class Relation implements BuilderContract
     /**
      * Add a whereIn eager constraint for the given set of model keys to be loaded.
      *
+     * @param  string  $whereIn
+     * @param  string  $key
+     * @param  array  $modelKeys
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>|null  $query
      * @return void
      */
@@ -415,6 +418,7 @@ abstract class Relation implements BuilderContract
     /**
      * Get the name of the "where in" method for eager loading.
      *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @return string
      */
@@ -520,11 +524,15 @@ abstract class Relation implements BuilderContract
         return array_search($className, static::$morphMap, strict: true) ?: $className;
     }
 
+
+
     /**
      * Determine which object should be passed to conditional callbacks.
      *
      * For relations that support pivot helpers, return the relation itself; otherwise
      * return the underlying Eloquent Builder instance.
+     *
+     * @return mixed
      */
     protected function conditionalTarget(): mixed
     {

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -525,6 +525,25 @@ abstract class Relation implements BuilderContract
         return array_search($className, static::$morphMap, strict: true) ?: $className;
     }
 
+
+
+    /**
+     * Determine which object should be passed to conditional callbacks.
+     *
+     * For relations that support pivot helpers, return the relation itself; otherwise
+     * return the underlying Eloquent Builder instance.
+     *
+     * @return mixed
+     */
+    protected function conditionalTarget(): mixed
+    {
+        if (method_exists($this, 'wherePivotBetween') || method_exists($this, 'wherePivot')) {
+            return $this;
+        }
+
+        return $this->query;
+    }
+
     /**
      * Handle dynamic method calls to the relationship.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -11,9 +11,9 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Support\Traits\Conditionable;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -24,11 +24,10 @@ use Illuminate\Support\Traits\Conditionable;
  */
 abstract class Relation implements BuilderContract
 {
+    use Conditionable;
     use ForwardsCalls, Macroable {
         Macroable::__call as macroCall;
     }
-
-    use Conditionable;
 
     /**
      * The Eloquent query builder instance.
@@ -401,9 +400,6 @@ abstract class Relation implements BuilderContract
     /**
      * Add a whereIn eager constraint for the given set of model keys to be loaded.
      *
-     * @param  string  $whereIn
-     * @param  string  $key
-     * @param  array  $modelKeys
      * @param  \Illuminate\Database\Eloquent\Builder<TRelatedModel>|null  $query
      * @return void
      */
@@ -419,7 +415,6 @@ abstract class Relation implements BuilderContract
     /**
      * Get the name of the "where in" method for eager loading.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
      * @return string
      */
@@ -525,15 +520,11 @@ abstract class Relation implements BuilderContract
         return array_search($className, static::$morphMap, strict: true) ?: $className;
     }
 
-
-
     /**
      * Determine which object should be passed to conditional callbacks.
      *
      * For relations that support pivot helpers, return the relation itself; otherwise
      * return the underlying Eloquent Builder instance.
-     *
-     * @return mixed
      */
     protected function conditionalTarget(): mixed
     {

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
@@ -13,7 +14,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {


### PR DESCRIPTION
Fixes #53292

# Description
When using the `when()` method on a `BelongsToMany` relationship, the query builder instance was being returned instead of the relationship instance, preventing the use of relationship-specific methods like `wherePivot`.

This PR fixes the issue by maintaining the relationship instance within the `when()` method specifically for `BelongsToMany` relationships while preserving existing behavior for other relationship types.

# Example Usage
```php
return MyModel::find(2)
    ->someRelationship()
    ->when(true, function($query) {
        // $query is now BelongsToMany instance
        return $query->wherePivotBetween('updated_at', ['2000-05-05', '2024-05-05']);
    })
    ->get();
````