### PR TITLE
Sanitize invalid UTF-8 user agent in database sessions

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -255,7 +255,13 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     protected function userAgent()
     {
-        return substr((string) $this->container->make('request')->header('User-Agent'), 0, 500);
+        $userAgent = (string) $this->container->make('request')->header('User-Agent');
+
+        if (! mb_check_encoding($userAgent, 'UTF-8')) {
+            $userAgent = (string) mb_convert_encoding($userAgent, 'UTF-8', 'UTF-8');
+        }
+
+        return substr($userAgent, 0, 500);
     }
 
     /**


### PR DESCRIPTION
Some crawlers have invalid characters in their user agent strings and every once and a while when one visits my app I get a lovely ding by Sentry that an exception occurred. Finally got sick of seeing it. 