### PR TITLE
[12.x] feat(schema): allow Schema::table() method to accept array of table names

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -451,13 +451,19 @@ class Builder
     /**
      * Modify a table on the schema.
      *
-     * @param  string  $table
+     * @param  string|array  $table
      * @param  \Closure  $callback
      * @return void
      */
     public function table($table, Closure $callback)
     {
-        $this->build($this->createBlueprint($table, $callback));
+        if (is_array($table)) {
+            foreach ($table as $table) {
+                $this->build($this->createBlueprint($table, $callback));
+            }
+        } else {
+            $this->build($this->createBlueprint($table, $callback));
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -28,7 +28,7 @@ namespace Illuminate\Support\Facades;
  * @method static array getIndexListing(string $table)
  * @method static bool hasIndex(string $table, string|array $index, string|null $type = null)
  * @method static array getForeignKeys(string $table)
- * @method static void table(string $table, \Closure $callback)
+ * @method static void table(string|array $table, \Closure $callback)
  * @method static void create(string $table, \Closure $callback)
  * @method static void drop(string $table)
  * @method static void dropIfExists(string $table)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Summary


 Enables the `Schema::table()` method to accept an array of table names, allowing developers to apply identical schema
  modifications to multiple tables in a single operation.

  ## Changes

  - **Builder**: Updated `table()` method to handle arrays with foreach loop
  - **Facade**: Updated docblock to accept `string|array $table`

## Benefits to End Users

  - **Reduces Code Duplication**: Apply identical schema changes to multiple tables without repetition
  - **Improved Readability**: Single operation instead of multiple blocks for the same change
  - **Faster Development**: Less code to write and maintain for batch operations

  ## Backward Compatibility

  ✅ No breaking changes - all existing single table operations continue to work unchanged


  ## Example Usage

  **Before:**

```php
  Schema::table('users', function (Blueprint $table) {
      $table->timestamp('last_login')->nullable();
  });
  Schema::table('admins', function (Blueprint $table) {
      $table->timestamp('last_login')->nullable();
  });
```
  

  **After:**
```php
  Schema::table(['users', 'admins'], function (Blueprint $table) {
      $table->timestamp('last_login')->nullable();
  });
```