### PR TITLE
[12.x] Fix pending attributes in schedule group

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -312,7 +312,8 @@ class Schedule
             throw new RuntimeException('Invoke an attribute method such as Schedule::daily() before defining a schedule group.');
         }
 
-        $this->groupStack[] = clone $this->attributes;
+        $this->groupStack[] = $this->attributes;
+        $this->attributes = null;
 
         $events($this);
 
@@ -327,16 +328,16 @@ class Schedule
      */
     protected function mergePendingAttributes(Event $event)
     {
-        if (isset($this->attributes)) {
-            $this->attributes->mergeAttributes($event);
-
-            $this->attributes = null;
-        }
-
         if (! empty($this->groupStack)) {
             $group = array_last($this->groupStack);
 
             $group->mergeAttributes($event);
+        }
+
+        if (isset($this->attributes)) {
+            $this->attributes->mergeAttributes($event);
+
+            $this->attributes = null;
         }
     }
 
@@ -476,7 +477,7 @@ class Schedule
         }
 
         if (method_exists(PendingEventAttributes::class, $method)) {
-            $this->attributes ??= array_last($this->groupStack) ?: new PendingEventAttributes($this);
+            $this->attributes ??= $this->groupStack ? clone array_last($this->groupStack) : new PendingEventAttributes($this);
 
             return $this->attributes->$method(...$parameters);
         }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -180,4 +180,18 @@ class ScheduleGroupTest extends TestCase
             ],
         ];
     }
+
+    public function testGroupedPendingEventAttribute(){
+        $schedule = new ScheduleClass;
+        $schedule->weekdays()->group(function ($schedule)  {
+            $schedule->command('inspire')->at('00:00'); // this is event, not pending attribute
+            $schedule->at('01:00')->command('inspire'); // this is pending attribute
+            $schedule->command('inspire');  // this goes back to group pending attribute
+        });
+
+        $events = $schedule->events();
+        $this->assertSame('0 0 * * 1-5', $events[0]->expression);
+        $this->assertSame('0 1 * * 1-5', $events[1]->expression);
+        $this->assertSame('* * * * 1-5', $events[2]->expression);
+    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -181,9 +181,10 @@ class ScheduleGroupTest extends TestCase
         ];
     }
 
-    public function testGroupedPendingEventAttribute(){
+    public function testGroupedPendingEventAttribute()
+    {
         $schedule = new ScheduleClass;
-        $schedule->weekdays()->group(function ($schedule)  {
+        $schedule->weekdays()->group(function ($schedule) {
             $schedule->command('inspire')->at('00:00'); // this is event, not pending attribute
             $schedule->at('01:00')->command('inspire'); // this is pending attribute
             $schedule->command('inspire');  // this goes back to group pending attribute


### PR DESCRIPTION
Fixes #57147 

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Previous attempt #56677 was a partial solution and caused side effects #57147 .

Proposing way of dealing with pending attributes in schedule group properly. The main principles are

1. Keep group stack unchanged by using copy.
2. In side a group, pending attributes are stored in `$this->attributes`

The flow

```text
when entering a group, copy current pending attributes into group stack
    while in the group, store new pending attributes in $this->attributes
    on merge,
        apply group attributes first, 
        then pending attributes
on leaving a group, pop current group attributes
```