### PR TITLE
Fix: Handle non-string returns from Htmlable::toHtml() in e() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -127,7 +127,7 @@ if (! function_exists('e')) {
         }
 
         if ($value instanceof Htmlable) {
-            return $value->toHtml();
+            return $value->toHtml() ?? '';
         }
 
         if ($value instanceof BackedEnum) {


### PR DESCRIPTION
This adds null coalescing to maintain backward compatibility when Htmlable::toHtml() returns non-string values.

**Breaking Change Context:**
The addition of explicit `: string` return type creates a BC break because Htmlable::toHtml() only has PHPDoc type hints, not runtime enforcement.
 IMHO it should probably be reverted, this commit provides at least some backward compatibility.

**Example of previously valid code that now breaks:**
```php
class CustomHtmlable implements Htmlable
{
    public function toHtml()
    {
        // Valid before: PHPDoc says @return string but no runtime enforcement
        return $this->hasContent() ? $this->content : null;
    }
}

// This worked before but now causes TypeError
echo e(new CustomHtmlable());