### PR TITLE
Allow parameters in can method on route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -297,6 +297,13 @@ class RouteRegistrar
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
             }
 
+            if ($method === 'can') {
+                return $this->attribute(
+                    $method,
+                    $parameters[0].(array_key_exists(1, $parameters) ? ','.implode(',', $parameters[1]) : ''),
+                );
+            }
+
             return $this->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1516,6 +1516,10 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
+        if ($method === 'can') {
+            return (new RouteRegistrar($this))->can(...$parameters);
+        }
+
         if ($method !== 'where' && Str::startsWith($method, 'where')) {
             return (new RouteRegistrar($this))->{$method}(...$parameters);
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -909,6 +909,24 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('can:test');
     }
 
+    public function testCanSetMiddlewareCanWithSingleParameterOnGroups()
+    {
+        $this->router->can('test', 'param')->group(function ($router) {
+            $router->get('/');
+        });
+
+        $this->seeMiddleware('can:test,param');
+    }
+
+    public function testCanSetMiddlewareCanWithMultipleParametersOnGroups()
+    {
+        $this->router->can('test', ['param1', 'param2'])->group(function ($router) {
+            $router->get('/');
+        });
+
+        $this->seeMiddleware('can:test,param1,param2');
+    }
+
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)


### PR DESCRIPTION
Intends to fix #55114.

Work in progress.

Description TBD.
