### PR TITLE
[12.x] fix static analysis error 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -479,7 +479,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function get($key, $default = null)
     {
-        $key ??= '';
+        $key ??= ''; // @phpstan-ignore nullCoalesce.variable
 
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -473,13 +473,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @template TGetDefault
      *
-     * @param  TKey  $key
+     * @param  TKey|null  $key
      * @param  TGetDefault|(\Closure(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
     {
-        $key ??= ''; // @phpstan-ignore nullCoalesce.variable
+        $key ??= '';
 
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];


### PR DESCRIPTION
I see this is failing in many of the PRs. This fixes the typehint in the get() method to know that `$key` may be null.