### PR TITLE
[12.x] Pass "throw" option from scoped to parent disk

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -313,6 +313,10 @@ class FilesystemManager implements FactoryContract
                 if (isset($config['visibility'])) {
                     $parent['visibility'] = $config['visibility'];
                 }
+
+                if (isset($config['throw'])) {
+                    $parent['throw'] = $config['throw'];
+                }
             }
         ));
     }


### PR DESCRIPTION
This PR allows to configure `throw` option on scoped disks separately from their parents.