### PR TITLE
[12.x] Make docblock return type in line with actual return type

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,7 +64,7 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      *
-     * @return array|null
+     * @return array
      */
     public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null)
     {


### PR DESCRIPTION
This fixes a phpstan error, where the value returned from this method apparantly could be null. Because of the guard clause in this method, the method itself assures that nothing else but an array can ever be returned. Otherwise, an exceptions is thrown.

Therefor, the null in the docblock is incorrect.

This changes fixes this.