### PR TITLE
[12.x] Fix operator precedence

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -326,7 +326,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function createFlysystem(FlysystemAdapter $adapter, array $config)
     {
-        if ($config['read-only'] ?? false === true) {
+        if ($config['read-only'] ?? false) {
             $adapter = new ReadOnlyFilesystemAdapter($adapter);
         }
 


### PR DESCRIPTION
`===` have higher precedence than `??`, hence `false === true` always return `false`.
Logic is unaffected by this PR, just a small cosmetical fix to avoid confusion.