### PR TITLE
[12.x] Track filesystem adapter decoration

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -328,7 +328,7 @@ class FilesystemManager implements FactoryContract
      * @param  array  $config
      * @return \League\Flysystem\FilesystemOperator
      */
-    protected function createFlysystem(FlysystemAdapter $adapter, array $config)
+    protected function createFlysystem(FlysystemAdapter &$adapter, array $config)
     {
         if (($config['read-only'] ?? false) === true) {
             $adapter = new ReadOnlyFilesystemAdapter($adapter);

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
+use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\UnableToReadFile;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
@@ -210,5 +211,25 @@ class FilesystemManagerTest extends TestCase
             rmdir(__DIR__.'/../../to-be-scoped/path-prefix');
             rmdir(__DIR__.'/../../to-be-scoped');
         }
+    }
+
+    public function testKeepTrackOfAdapterDecoration()
+    {
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = [
+                'filesystems.disks.local' => [
+                    'driver' => 'local',
+                    'root' => 'to-be-scoped',
+                ],
+            ];
+        }));
+
+        $scoped = $filesystem->build([
+            'driver' => 'scoped',
+            'disk' => 'local',
+            'prefix' => 'path-prefix',
+        ]);
+
+        $this->assertInstanceOf(PathPrefixedAdapter::class, $scoped->getAdapter());
     }
 }


### PR DESCRIPTION
This PR fixes discrepancy between _Flysystem_ adapter passed as a 2nd argument to _Laravel_ adapter, and actual used adapter in case it was decorated by `ReadOnlyFilesystemAdapter` and/or `PathPrefixedAdapter` within `createFlysystem` method.
It was done by passing `FlysystemAdapter` into `createFlysystem` by reference.