### PR TITLE
[12.x] Clean up after filesystem manager tests

### DIFF
--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -167,25 +167,29 @@ class FilesystemManagerTest extends TestCase
 
     public function testCanBuildScopedDisksWithThrow()
     {
-        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
-            $app['config'] = [
-                'filesystems.disks.local' => [
-                    'driver' => 'local',
-                    'root' => 'to-be-scoped',
-                    'throw' => false,
-                ],
-            ];
-        }));
+        try {
+            $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+                $app['config'] = [
+                    'filesystems.disks.local' => [
+                        'driver' => 'local',
+                        'root' => 'to-be-scoped',
+                        'throw' => false,
+                    ],
+                ];
+            }));
 
-        $scoped = $filesystem->build([
-            'driver' => 'scoped',
-            'disk' => 'local',
-            'prefix' => 'path-prefix',
-            'throw' => true,
-        ]);
+            $scoped = $filesystem->build([
+                'driver' => 'scoped',
+                'disk' => 'local',
+                'prefix' => 'path-prefix',
+                'throw' => true,
+            ]);
 
-        $this->expectException(UnableToReadFile::class);
-        $scoped->get('dirname/filename.txt');
+            $this->expectException(UnableToReadFile::class);
+            $scoped->get('dirname/filename.txt');
+        } finally {
+            rmdir(__DIR__.'/../../to-be-scoped');
+        }
     }
 
     public function testCanBuildInlineScopedDisks()
@@ -215,21 +219,25 @@ class FilesystemManagerTest extends TestCase
 
     public function testKeepTrackOfAdapterDecoration()
     {
-        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
-            $app['config'] = [
-                'filesystems.disks.local' => [
-                    'driver' => 'local',
-                    'root' => 'to-be-scoped',
-                ],
-            ];
-        }));
+        try {
+            $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+                $app['config'] = [
+                    'filesystems.disks.local' => [
+                        'driver' => 'local',
+                        'root' => 'to-be-scoped',
+                    ],
+                ];
+            }));
 
-        $scoped = $filesystem->build([
-            'driver' => 'scoped',
-            'disk' => 'local',
-            'prefix' => 'path-prefix',
-        ]);
+            $scoped = $filesystem->build([
+                'driver' => 'scoped',
+                'disk' => 'local',
+                'prefix' => 'path-prefix',
+            ]);
 
-        $this->assertInstanceOf(PathPrefixedAdapter::class, $scoped->getAdapter());
+            $this->assertInstanceOf(PathPrefixedAdapter::class, $scoped->getAdapter());
+        } finally {
+            rmdir(__DIR__.'/../../to-be-scoped');
+        }
     }
 }


### PR DESCRIPTION
#57163 and #57167 added some test cases, but no cleanup afterwards. This PR fixes that.