### PR TITLE
[12.x] Fix nested `can` and inherit models on route groups

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1008,7 +1008,9 @@ class Route
         }
 
         if (isset($this->action['can'])) {
-            $this->can($this->action['can']);
+            foreach ($this->action['can'] as $can) {
+                $this->can($can[0], $can[1] ?? []);
+            }
         }
 
         return $this;

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -297,6 +297,10 @@ class RouteRegistrar
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
             }
 
+            if ($method === 'can') {
+                return $this->attribute($method, [$parameters]);
+            }
+
             return $this->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1516,6 +1516,10 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
+        if ($method === 'can') {
+            return (new RouteRegistrar($this))->attribute($method, [$parameters]);
+        }
+
         if ($method !== 'where' && Str::startsWith($method, 'where')) {
             return (new RouteRegistrar($this))->{$method}(...$parameters);
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -909,6 +909,29 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('can:test');
     }
 
+    public function testCanSetMiddlewareCanWithModelsOnGroups()
+    {
+        $this->router->can('view', 'post')->group(function ($router) {
+            $router->get('/post/{post}');
+        });
+
+        $this->seeMiddleware('can:view,post');
+    }
+
+    public function testCanSetMiddlewareCanNestedOnGroups()
+    {
+        $this->router->can('access-admin')->group(function ($router) {
+            $router->can('edit', 'post')->group(function ($router) {
+                $router->get('/post/{post}/edit');
+            });
+        });
+
+        $this->assertEquals([
+            'can:access-admin',
+            'can:edit,post',
+        ], $this->getRoute()->middleware());
+    }
+
     public function testCanSetMiddlewareForSpecifiedMethodsOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2219,6 +2219,15 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals([
             'can:create',
         ], $route->middleware());
+
+        $route = new Route(['GET'], '/', []);
+        $route->can('create');
+        $route->can('update');
+
+        $this->assertEquals([
+            'can:create',
+            'can:update',
+        ], $route->middleware());
     }
 
     public function testItDispatchesEventsWhilePreparingRequest()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This fixes two issues with the `can` method on route groups. First, an exception if you defined `can` on multiple nested group levels. Second, that the models (second parameter) would not be inherited.

### Exception with multiple nested group levels

```
  ErrorException 

  Array to string conversion

  at vendor/laravel/framework/src/Illuminate/Routing/Route.php:1103
    1099▕     {
    1100▕         $ability = enum_value($ability);
    1101▕ 
    1102▕         return empty($models)
  ➜ 1103▕             ? $this->middleware(['can:'.$ability])
    1104▕             : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
    1105▕     }
    1106▕ 
    1107▕     /**
```

### Failing test result for testCanSetMiddlewareCanWithModelsOnGroups
```
Failed asserting that two strings are equal.
Expected :'can:view,post'
Actual   :'can:view'
```

### Failing test result for testCanSetMiddlewareCanNestedOnGroups
```
Failed asserting that two arrays are equal.

Expected:
Array (
    0 => 'can:access-admin'
    1 => 'can:edit,post'
)

Actual:
Array (
    0 => 'can:Array'
)

```