### PR TITLE
[12.x] Improve typing of `\Illiminate\Testing\TestResponse::assertSessionMissing()`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1692,6 +1692,7 @@ class TestResponse implements ArrayAccess
      * Assert that the session does not have a given key.
      *
      * @template T of (\Closure(mixed): bool)|mixed
+     *
      * @param  string|T[]  $key
      * @param  T  $value
      * @return $this

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1691,8 +1691,9 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the session does not have a given key.
      *
-     * @param  string|array  $key
-     * @param  mixed  $value
+     * @template T of (\Closure(mixed): bool)|mixed
+     * @param  string|T[]  $key
+     * @param  T  $value
      * @return $this
      */
     public function assertSessionMissing($key, $value = null)


### PR DESCRIPTION
Continuation of #57096