### PR TITLE
Fix: Improve validateInteger ergonomics and fix BC break

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1556,7 +1556,7 @@ trait ValidatesAttributes
      * @param  array{0: 'strict'}  $parameters
      * @return bool
      */
-    public function validateInteger($attribute, $value, array $parameters)
+    public function validateInteger($attribute, $value, array $parameters = [])
     {
         if (($parameters[0] ?? null) === 'strict') {
             return is_int($value);


### PR DESCRIPTION
This pull request addresses a breaking change from PR #56503 and improves the ergonomics of the validateInteger method.

The signature for validateInteger was updated in v12.22.0, introducing a new mandatory $parameters argument. This caused an ArgumentCountError for the common pattern of calling this method directly within a custom validation Closure, breaking backward compatibility.

Beyond just fixing the regression, this PR also improves the developer experience. Forcing developers to pass an empty array ([]) for the most common use case (a simple integer check without strict mode) adds unnecessary verbosity to the code.

An API should be simple for common tasks. By making the $parameters argument optional, we restore the previous behavior and also create a cleaner, more intuitive method call.

Before (in v12.22.0+ to avoid error):
```php
$validator->validateInteger($attribute, $value, []); // Unnecessary empty array
```
After this PR:
```php
$validator->validateInteger($attribute, $value); // Clean and concise
```

**Solution**
This PR makes the $parameters argument optional by providing a default empty array. This change is completely backward compatible, fixes the breaking change, and simplifies the API for its primary use case, without affecting the new strict functionality.
```diff
- protected function validateInteger($attribute, $value, array $parameters)
+ protected function validateInteger($attribute, $value, array $parameters = [])