### PR TITLE
[12.x] Add missing Closure type to Collection::pluck() docblock 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -792,8 +792,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|int|array<array-key, string>|\Closure|null  $value
-     * @param  string|\Closure|null  $key
+     * @param  \Closure|string|int|array<array-key, string>|null  $value
+     * @param  \Closure|string|null  $key
      * @return static<array-key, mixed>
      */
     public function pluck($value, $key = null)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -792,8 +792,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|int|array<array-key, string>|null  $value
-     * @param  string|null  $key
+     * @param  string|int|array<array-key, string>|\Closure|null  $value
+     * @param  string|\Closure|null  $key
      * @return static<array-key, mixed>
      */
     public function pluck($value, $key = null)


### PR DESCRIPTION
This pull request updates the docblock of Illuminate\Support\Collection::pluck().

Callable support was added to Arr::pluck() (see #56188), so Collection::pluck() also 
accepts callables for $value and $key. The current docblock does not reflect this, 
causing false-positive IDE/static analysis errors.
