### PR TITLE
[12.x] Add `Arr::convertKeyCase` for recursive array key casing

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -19,55 +19,6 @@ class Arr
     use Macroable;
 
     /**
-     * Conversion mode for converting keys to uppercase.
-     *
-     * @var int
-     */
-    const KEY_MODE_UPPER_CASE = MB_CASE_UPPER;
-
-    /**
-     * Conversion mode for converting keys to lowercase.
-     *
-     * @var int
-     */
-    const KEY_MODE_LOWER_CASE = MB_CASE_LOWER;
-
-    /**
-     * Conversion mode for converting keys to the title case.
-     *
-     * @var int
-     */
-    const KEY_MODE_TITLE_CASE = MB_CASE_TITLE;
-
-    /**
-     * Conversion mode for converting keys to snake case.
-     *
-     * @var int
-     */
-    const KEY_MODE_SNAKE_CASE = 10_0;
-
-    /**
-     * Conversion mode for converting keys to camel case.
-     *
-     * @var int
-     */
-    const KEY_MODE_CAMEL_CASE = 10_1;
-
-    /**
-     * Conversion mode for converting keys to kebab case.
-     *
-     * @var int
-     */
-    const KEY_MODE_KEBAB_CASE = 10_2;
-
-    /**
-     * Conversion mode for converting keys to studly case.
-     *
-     * @var int
-     */
-    const KEY_MODE_STUDLY_CASE = 10_3;
-
-    /**
      * Determine whether the given value is array accessible.
      *
      * @param  mixed  $value
@@ -148,25 +99,14 @@ class Arr
      * Recursively converts the keys of an array to a specified casing mode.
      *
      * @param  array  $array
-     * @param  int  $mode  Use one of the `KEY_MODE_*` constants.
+     * @param  CaseMode  $mode
      * @param  int  $depth
      * @return array
      */
-    public static function convertKeyCase(array $array, int $mode = Arr::KEY_MODE_SNAKE_CASE, $depth = INF): array
+    public static function convertKeyCase(array $array, CaseMode $mode = CaseMode::SNAKE, $depth = INF): array
     {
         return static::mapWithKeys($array, function ($value, $key) use ($mode, $depth): array {
-            $str = Str::of((string) $key);
-
-            $converted = match ($mode) {
-                static::KEY_MODE_UPPER_CASE => $str->upper()->value(),
-                static::KEY_MODE_LOWER_CASE => $str->lower()->value(),
-                static::KEY_MODE_TITLE_CASE => $str->title()->value(),
-                static::KEY_MODE_SNAKE_CASE => $str->snake()->value(),
-                static::KEY_MODE_CAMEL_CASE => $str->camel()->value(),
-                static::KEY_MODE_KEBAB_CASE => $str->kebab()->value(),
-                static::KEY_MODE_STUDLY_CASE => $str->studly()->value(),
-                default => throw new InvalidArgumentException("The mode [{$mode}] is not supported."),
-            };
+            $converted = $mode->convert((string) $key);
 
             if (is_array($value) && $depth > 1) {
                 $value = static::convertKeyCase($value, $mode, $depth - 1);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -19,6 +19,55 @@ class Arr
     use Macroable;
 
     /**
+     * Conversion mode for converting keys to uppercase.
+     *
+     * @var int
+     */
+    const KEY_MODE_UPPER_CASE = MB_CASE_UPPER;
+
+    /**
+     * Conversion mode for converting keys to lowercase.
+     *
+     * @var int
+     */
+    const KEY_MODE_LOWER_CASE = MB_CASE_LOWER;
+
+    /**
+     * Conversion mode for converting keys to the title case.
+     *
+     * @var int
+     */
+    const KEY_MODE_TITLE_CASE = MB_CASE_TITLE;
+
+    /**
+     * Conversion mode for converting keys to snake case.
+     *
+     * @var int
+     */
+    const KEY_MODE_SNAKE_CASE = 10_0;
+
+    /**
+     * Conversion mode for converting keys to camel case.
+     *
+     * @var int
+     */
+    const KEY_MODE_CAMEL_CASE = 10_1;
+
+    /**
+     * Conversion mode for converting keys to kebab case.
+     *
+     * @var int
+     */
+    const KEY_MODE_KEBAB_CASE = 10_2;
+
+    /**
+     * Conversion mode for converting keys to studly case.
+     *
+     * @var int
+     */
+    const KEY_MODE_STUDLY_CASE = 10_3;
+
+    /**
      * Determine whether the given value is array accessible.
      *
      * @param  mixed  $value
@@ -93,6 +142,38 @@ class Arr
         }
 
         return $value;
+    }
+
+    /**
+     * Recursively converts the keys of an array to a specified casing mode.
+     *
+     * @param  array  $array
+     * @param  int  $mode  Use one of the `KEY_MODE_*` constants.
+     * @param  int  $depth
+     * @return array
+     */
+    public static function convertKeyCase(array $array, int $mode = Arr::KEY_MODE_SNAKE_CASE, $depth = INF): array
+    {
+        return static::mapWithKeys($array, function ($value, $key) use ($mode, $depth): array {
+            $str = Str::of((string) $key);
+
+            $converted = match ($mode) {
+                static::KEY_MODE_UPPER_CASE => $str->upper()->value(),
+                static::KEY_MODE_LOWER_CASE => $str->lower()->value(),
+                static::KEY_MODE_TITLE_CASE => $str->title()->value(),
+                static::KEY_MODE_SNAKE_CASE => $str->snake()->value(),
+                static::KEY_MODE_CAMEL_CASE => $str->camel()->value(),
+                static::KEY_MODE_KEBAB_CASE => $str->kebab()->value(),
+                static::KEY_MODE_STUDLY_CASE => $str->studly()->value(),
+                default => throw new InvalidArgumentException("The mode [{$mode}] is not supported."),
+            };
+
+            if (is_array($value) && $depth > 1) {
+                $value = static::convertKeyCase($value, $mode, $depth - 1);
+            }
+
+            return [$converted => $value];
+        });
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -103,16 +103,26 @@ class Arr
      * @param  int  $depth
      * @return array
      */
-    public static function convertKeyCase(array $array, CaseMode $mode = CaseMode::SNAKE, $depth = INF): array
+    public static function convertKeyCase(array $array, CaseMode $mode = CaseMode::Snake, $depth = INF): array
     {
         return static::mapWithKeys($array, function ($value, $key) use ($mode, $depth): array {
-            $converted = $mode->convert((string) $key);
+            $str = Str::of($key);
+
+            $converted = match ($mode) {
+                CaseMode::Upper => $str->upper(),
+                CaseMode::Lower => $str->lower(),
+                CaseMode::Title => $str->title(),
+                CaseMode::Snake => $str->snake(),
+                CaseMode::Camel => $str->camel(),
+                CaseMode::Kebab => $str->kebab(),
+                CaseMode::Studly => $str->studly(),
+            };
 
             if (is_array($value) && $depth > 1) {
                 $value = static::convertKeyCase($value, $mode, $depth - 1);
             }
 
-            return [$converted => $value];
+            return [$converted->value() => $value];
         });
     }
 

--- a/src/Illuminate/Collections/CaseMode.php
+++ b/src/Illuminate/Collections/CaseMode.php
@@ -4,29 +4,11 @@ namespace Illuminate\Support;
 
 enum CaseMode
 {
-    case UPPER;
-    case LOWER;
-    case TITLE;
-    case SNAKE;
-    case CAMEL;
-    case KEBAB;
-    case STUDLY;
-
-    /**
-     * Convert the given string to the case mode.
-     */
-    public function convert(string $key): string
-    {
-        $str = Str::of($key);
-
-        return match ($this) {
-            self::UPPER => $str->upper()->value(),
-            self::LOWER => $str->lower()->value(),
-            self::TITLE => $str->title()->value(),
-            self::SNAKE => $str->snake()->value(),
-            self::CAMEL => $str->camel()->value(),
-            self::KEBAB => $str->kebab()->value(),
-            self::STUDLY => $str->studly()->value(),
-        };
-    }
+    case Upper;
+    case Lower;
+    case Title;
+    case Snake;
+    case Camel;
+    case Kebab;
+    case Studly;
 }

--- a/src/Illuminate/Collections/CaseMode.php
+++ b/src/Illuminate/Collections/CaseMode.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Support;
 
-enum CaseMode: int
+enum CaseMode
 {
-    case UPPER = 1;
-    case LOWER = 2;
-    case TITLE = 3;
-    case SNAKE = 4;
-    case CAMEL = 5;
-    case KEBAB = 6;
-    case STUDLY = 7;
+    case UPPER;
+    case LOWER;
+    case TITLE;
+    case SNAKE;
+    case CAMEL;
+    case KEBAB;
+    case STUDLY;
 
     /**
      * Convert the given string to the case mode.

--- a/src/Illuminate/Collections/CaseMode.php
+++ b/src/Illuminate/Collections/CaseMode.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Support;
+
+enum CaseMode: int
+{
+    case UPPER = 1;
+    case LOWER = 2;
+    case TITLE = 3;
+    case SNAKE = 4;
+    case CAMEL = 5;
+    case KEBAB = 6;
+    case STUDLY = 7;
+
+    /**
+     * Convert the given string to the case mode.
+     */
+    public function convert(string $key): string
+    {
+        $str = Str::of($key);
+
+        return match ($this) {
+            self::UPPER => $str->upper()->value(),
+            self::LOWER => $str->lower()->value(),
+            self::TITLE => $str->title()->value(),
+            self::SNAKE => $str->snake()->value(),
+            self::CAMEL => $str->camel()->value(),
+            self::KEBAB => $str->kebab()->value(),
+            self::STUDLY => $str->studly()->value(),
+        };
+    }
+}

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -134,7 +134,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::SNAKE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Snake, 1));
 
         // Case CaseMode::UPPER_CASE and depth INF
         $this->assertEquals([
@@ -147,7 +147,7 @@ class SupportArrTest extends TestCase
                 'PREFERENCES' => ['LANGUAGECODE' => 'en', 'THEME_COLOR' => 'dark', 'FONT-SIZE' => 'medium'],
             ],
             'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::UPPER));
+        ], Arr::convertKeyCase($data, CaseMode::Upper));
 
         // Case CaseMode::UPPER_CASE and depth 1
         $this->assertEquals([
@@ -160,7 +160,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::UPPER, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Upper, 1));
 
         // Case CaseMode::LOWER_CASE and depth INF
         $this->assertEquals([
@@ -173,7 +173,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['languagecode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::LOWER));
+        ], Arr::convertKeyCase($data, CaseMode::Lower));
 
         // Case CaseMode::LOWER_CASE and depth 1
         $this->assertEquals([
@@ -186,7 +186,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::LOWER, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Lower, 1));
 
         // Case CaseMode::TITLE_CASE and depth INF
         $this->assertEquals([
@@ -199,7 +199,7 @@ class SupportArrTest extends TestCase
                 'Preferences' => ['Languagecode' => 'en', 'Theme_Color' => 'dark', 'Font-Size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::TITLE));
+        ], Arr::convertKeyCase($data, CaseMode::Title));
 
         // Case CaseMode::TITLE_CASE and depth 1
         $this->assertEquals([
@@ -212,7 +212,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::TITLE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Title, 1));
 
         // Case CaseMode::CAMEL_CASE and depth INF
         $this->assertEquals([
@@ -225,7 +225,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['languageCode' => 'en', 'themeColor' => 'dark', 'fontSize' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::CAMEL));
+        ], Arr::convertKeyCase($data, CaseMode::Camel));
 
         // Case CaseMode::CAMEL_CASE and depth 1
         $this->assertEquals([
@@ -238,7 +238,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::CAMEL, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Camel, 1));
 
         // Case CaseMode::KEBAB_CASE and depth INF
         $this->assertEquals([
@@ -251,7 +251,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['language-code' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::KEBAB));
+        ], Arr::convertKeyCase($data, CaseMode::Kebab));
 
         // Case CaseMode::KEBAB_CASE and depth 1
         $this->assertEquals([
@@ -264,7 +264,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::KEBAB, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Kebab, 1));
 
         // Case CaseMode::STUDLY_CASE and depth INF
         $this->assertEquals([
@@ -277,7 +277,7 @@ class SupportArrTest extends TestCase
                 'Preferences' => ['LanguageCode' => 'en', 'ThemeColor' => 'dark', 'FontSize' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::STUDLY));
+        ], Arr::convertKeyCase($data, CaseMode::Studly));
 
         // Case CaseMode::STUDLY_CASE and depth 1
         $this->assertEquals([
@@ -290,7 +290,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, CaseMode::STUDLY, 1));
+        ], Arr::convertKeyCase($data, CaseMode::Studly, 1));
     }
 
     public function testCollapse()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\CaseMode;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
@@ -109,7 +110,7 @@ class SupportArrTest extends TestCase
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
         ];
 
-        // Case Arr::KEY_MODE_SNAKE_CASE and depth INF
+        // Case CaseMode::SNAKE_CASE and depth INF
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -122,7 +123,7 @@ class SupportArrTest extends TestCase
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
         ], Arr::convertKeyCase($data));
 
-        // Case Arr::KEY_MODE_SNAKE_CASE and depth 1
+        // Case CaseMode::SNAKE_CASE and depth 1
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -133,9 +134,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_SNAKE_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::SNAKE, 1));
 
-        // Case Arr::KEY_MODE_UPPER_CASE and depth INF
+        // Case CaseMode::UPPER_CASE and depth INF
         $this->assertEquals([
             'FIRST_NAME' => 'Taylor',
             'EMAIL-ADDRESS' => 'taylor@laravel.com',
@@ -146,9 +147,9 @@ class SupportArrTest extends TestCase
                 'PREFERENCES' => ['LANGUAGECODE' => 'en', 'THEME_COLOR' => 'dark', 'FONT-SIZE' => 'medium'],
             ],
             'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_UPPER_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::UPPER));
 
-        // Case Arr::KEY_MODE_UPPER_CASE and depth 1
+        // Case CaseMode::UPPER_CASE and depth 1
         $this->assertEquals([
             'FIRST_NAME' => 'Taylor',
             'EMAIL-ADDRESS' => 'taylor@laravel.com',
@@ -159,9 +160,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_UPPER_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::UPPER, 1));
 
-        // Case Arr::KEY_MODE_LOWER_CASE and depth INF
+        // Case CaseMode::LOWER_CASE and depth INF
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -172,9 +173,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['languagecode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_LOWER_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::LOWER));
 
-        // Case Arr::KEY_MODE_LOWER_CASE and depth 1
+        // Case CaseMode::LOWER_CASE and depth 1
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -185,9 +186,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_LOWER_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::LOWER, 1));
 
-        // Case Arr::KEY_MODE_TITLE_CASE and depth INF
+        // Case CaseMode::TITLE_CASE and depth INF
         $this->assertEquals([
             'First_Name' => 'Taylor',
             'Email-Address' => 'taylor@laravel.com',
@@ -198,9 +199,9 @@ class SupportArrTest extends TestCase
                 'Preferences' => ['Languagecode' => 'en', 'Theme_Color' => 'dark', 'Font-Size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_TITLE_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::TITLE));
 
-        // Case Arr::KEY_MODE_TITLE_CASE and depth 1
+        // Case CaseMode::TITLE_CASE and depth 1
         $this->assertEquals([
             'First_Name' => 'Taylor',
             'Email-Address' => 'taylor@laravel.com',
@@ -211,9 +212,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_TITLE_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::TITLE, 1));
 
-        // Case Arr::KEY_MODE_CAMEL_CASE and depth INF
+        // Case CaseMode::CAMEL_CASE and depth INF
         $this->assertEquals([
             'firstName' => 'Taylor',
             'emailAddress' => 'taylor@laravel.com',
@@ -224,9 +225,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['languageCode' => 'en', 'themeColor' => 'dark', 'fontSize' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_CAMEL_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::CAMEL));
 
-        // Case Arr::KEY_MODE_CAMEL_CASE and depth 1
+        // Case CaseMode::CAMEL_CASE and depth 1
         $this->assertEquals([
             'firstName' => 'Taylor',
             'emailAddress' => 'taylor@laravel.com',
@@ -237,9 +238,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_CAMEL_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::CAMEL, 1));
 
-        // Case Arr::self::KEY_MODE_KEBAB_CASE and depth INF
+        // Case CaseMode::KEBAB_CASE and depth INF
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -250,9 +251,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['language-code' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_KEBAB_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::KEBAB));
 
-        // Case Arr::self::KEY_MODE_KEBAB_CASE and depth 1
+        // Case CaseMode::KEBAB_CASE and depth 1
         $this->assertEquals([
             'first_name' => 'Taylor',
             'email-address' => 'taylor@laravel.com',
@@ -263,9 +264,9 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_KEBAB_CASE, 1));
+        ], Arr::convertKeyCase($data, CaseMode::KEBAB, 1));
 
-        // Case Arr::self::self::KEY_MODE_STUDLY_CASE and depth INF
+        // Case CaseMode::STUDLY_CASE and depth INF
         $this->assertEquals([
             'FirstName' => 'Taylor',
             'EmailAddress' => 'taylor@laravel.com',
@@ -276,9 +277,9 @@ class SupportArrTest extends TestCase
                 'Preferences' => ['LanguageCode' => 'en', 'ThemeColor' => 'dark', 'FontSize' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_STUDLY_CASE));
+        ], Arr::convertKeyCase($data, CaseMode::STUDLY));
 
-        // Case Arr::self::self::KEY_MODE_STUDLY_CASE and depth 1
+        // Case CaseMode::STUDLY_CASE and depth 1
         $this->assertEquals([
             'FirstName' => 'Taylor',
             'EmailAddress' => 'taylor@laravel.com',
@@ -289,11 +290,7 @@ class SupportArrTest extends TestCase
                 'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
             ],
             'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
-        ], Arr::convertKeyCase($data, Arr::KEY_MODE_STUDLY_CASE, 1));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The mode [999] is not supported.");
-        Arr::convertKeyCase($data, 999);
+        ], Arr::convertKeyCase($data, CaseMode::STUDLY, 1));
     }
 
     public function testCollapse()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -95,6 +95,207 @@ class SupportArrTest extends TestCase
         Arr::push($array, 'foo.bar', 'baz');
     }
 
+    public function testConvertKeysCase()
+    {
+        $data = [
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'UserID' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ];
+
+        // Case Arr::KEY_MODE_SNAKE_CASE and depth INF
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'user_i_d' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['language_code' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data));
+
+        // Case Arr::KEY_MODE_SNAKE_CASE and depth 1
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'user_i_d' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_SNAKE_CASE, 1));
+
+        // Case Arr::KEY_MODE_UPPER_CASE and depth INF
+        $this->assertEquals([
+            'FIRST_NAME' => 'Taylor',
+            'EMAIL-ADDRESS' => 'taylor@laravel.com',
+            'USERID' => 100,
+            'ACCOUNT_SETTINGS' => [
+                'IS_ACTIVE' => true,
+                'LOGIN-ATTEMPTS' => 3,
+                'PREFERENCES' => ['LANGUAGECODE' => 'en', 'THEME_COLOR' => 'dark', 'FONT-SIZE' => 'medium'],
+            ],
+            'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_UPPER_CASE));
+
+        // Case Arr::KEY_MODE_UPPER_CASE and depth 1
+        $this->assertEquals([
+            'FIRST_NAME' => 'Taylor',
+            'EMAIL-ADDRESS' => 'taylor@laravel.com',
+            'USERID' => 100,
+            'ACCOUNT_SETTINGS' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'LOGS' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_UPPER_CASE, 1));
+
+        // Case Arr::KEY_MODE_LOWER_CASE and depth INF
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'userid' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['languagecode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_LOWER_CASE));
+
+        // Case Arr::KEY_MODE_LOWER_CASE and depth 1
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'userid' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_LOWER_CASE, 1));
+
+        // Case Arr::KEY_MODE_TITLE_CASE and depth INF
+        $this->assertEquals([
+            'First_Name' => 'Taylor',
+            'Email-Address' => 'taylor@laravel.com',
+            'Userid' => 100,
+            'Account_Settings' => [
+                'Is_Active' => true,
+                'Login-Attempts' => 3,
+                'Preferences' => ['Languagecode' => 'en', 'Theme_Color' => 'dark', 'Font-Size' => 'medium'],
+            ],
+            'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_TITLE_CASE));
+
+        // Case Arr::KEY_MODE_TITLE_CASE and depth 1
+        $this->assertEquals([
+            'First_Name' => 'Taylor',
+            'Email-Address' => 'taylor@laravel.com',
+            'Userid' => 100,
+            'Account_Settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_TITLE_CASE, 1));
+
+        // Case Arr::KEY_MODE_CAMEL_CASE and depth INF
+        $this->assertEquals([
+            'firstName' => 'Taylor',
+            'emailAddress' => 'taylor@laravel.com',
+            'userID' => 100,
+            'accountSettings' => [
+                'isActive' => true,
+                'loginAttempts' => 3,
+                'preferences' => ['languageCode' => 'en', 'themeColor' => 'dark', 'fontSize' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_CAMEL_CASE));
+
+        // Case Arr::KEY_MODE_CAMEL_CASE and depth 1
+        $this->assertEquals([
+            'firstName' => 'Taylor',
+            'emailAddress' => 'taylor@laravel.com',
+            'userID' => 100,
+            'accountSettings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_CAMEL_CASE, 1));
+
+        // Case Arr::self::KEY_MODE_KEBAB_CASE and depth INF
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'user-i-d' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['language-code' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_KEBAB_CASE));
+
+        // Case Arr::self::KEY_MODE_KEBAB_CASE and depth 1
+        $this->assertEquals([
+            'first_name' => 'Taylor',
+            'email-address' => 'taylor@laravel.com',
+            'user-i-d' => 100,
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_KEBAB_CASE, 1));
+
+        // Case Arr::self::self::KEY_MODE_STUDLY_CASE and depth INF
+        $this->assertEquals([
+            'FirstName' => 'Taylor',
+            'EmailAddress' => 'taylor@laravel.com',
+            'UserID' => 100,
+            'AccountSettings' => [
+                'IsActive' => true,
+                'LoginAttempts' => 3,
+                'Preferences' => ['LanguageCode' => 'en', 'ThemeColor' => 'dark', 'FontSize' => 'medium'],
+            ],
+            'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_STUDLY_CASE));
+
+        // Case Arr::self::self::KEY_MODE_STUDLY_CASE and depth 1
+        $this->assertEquals([
+            'FirstName' => 'Taylor',
+            'EmailAddress' => 'taylor@laravel.com',
+            'UserID' => 100,
+            'AccountSettings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+            'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+        ], Arr::convertKeyCase($data, Arr::KEY_MODE_STUDLY_CASE, 1));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The mode [999] is not supported.");
+        Arr::convertKeyCase($data, 999);
+    }
+
     public function testCollapse()
     {
         // Normal case: a two-dimensional array with different elements


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request seeks to introduce a new static method `convertKeyCase` to the Illuminate\Support\Arr class. This function will recursively convert all keys within an array (or up to a specified depth) with the specified mode.

This new method `Arr::convertKeyCase` provides a native, recursive way to convert all array keys to the specified mode.

This eliminates the need for developers to write repetitive, custom recursive key-transformation logic, leading to cleaner, more consistent, and maintainable code.

### Usage

```php
use Illuminate\Support\Arr;
use Illuminate\Support\CaseMode;

$data = [
    'first_name' => 'Taylor',
    'email-address' => 'taylor@laravel.com',
    'UserID' => 100,
    'account_settings' => [
        'is_active' => true,
        'login-attempts' => 3,
        'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
    ],
    'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
];

// Full recursive conversion (default behavior)
$converted = Arr::convertKeyCase($array);

/*
[
    'first_name' => 'Taylor',
    'email-address' => 'taylor@laravel.com',
    'user_i_d' => 100,
    'account_settings' => [
        'is_active' => true,
        'login-attempts' => 3,
        'preferences' => ['language_code' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
    ],
    'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
]
*/

// Conversion limited to depth 1 (only top-level keys changed)
$shallowCased = Arr::convertKeyCase($array, CaseMode::Snake, 1);

/*
[
    'first_name' => 'Taylor',
    'email-address' => 'taylor@laravel.com',
    'user_i_d' => 100,
    'account_settings' => [
        'is_active' => true,
        'login-attempts' => 3,
        'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
    ],
    'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
]
*/
```
