### PR TITLE
Add database afterRollback callback support and tests

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -353,4 +353,21 @@ trait ManagesTransactions
 
         throw new RuntimeException('Transactions Manager has not been set.');
     }
+
+    /**
+     * Execute the callback after a transaction rolls back.
+     *
+     * @param  callable  $callback
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function afterRollback($callback)
+    {
+        if ($this->transactionsManager) {
+            return $this->transactionsManager->addCallbackForRollback($callback);
+        }
+
+        throw new RuntimeException('Transactions Manager has not been set.');
+    }
 }

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -362,7 +362,7 @@ trait ManagesTransactions
      *
      * @throws \RuntimeException
      */
-    public function afterRollback($callback)
+    public function afterRollBack($callback)
     {
         if ($this->transactionsManager) {
             return $this->transactionsManager->addCallbackForRollback($callback);

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -114,6 +114,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static void rollBack(int|null $toLevel = null)
  * @method static int transactionLevel()
  * @method static void afterCommit(callable $callback)
+ * @method static void afterRollback(callable $callback)
  *
  * @see \Illuminate\Database\DatabaseManager
  */

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -114,7 +114,7 @@ use Illuminate\Database\Console\WipeCommand;
  * @method static void rollBack(int|null $toLevel = null)
  * @method static int transactionLevel()
  * @method static void afterCommit(callable $callback)
- * @method static void afterRollback(callable $callback)
+ * @method static void afterRollBack(callable $callback)
  *
  * @see \Illuminate\Database\DatabaseManager
  */

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -105,6 +105,31 @@ class DatabaseTransactionsTest extends DatabaseTestCase
         $this->assertTrue($secondObject->ran);
         $this->assertFalse($thirdObject->ran);
     }
+
+    public function testAfterRollbackCallbacksAreExecuted()
+    {
+        $afterCommitRan = false;
+        $afterRollbackRan = false;
+
+        try {
+            DB::transaction(function () use (&$afterCommitRan, &$afterRollbackRan) {
+                DB::afterCommit(function () use (&$afterCommitRan) {
+                    $afterCommitRan = true;
+                });
+
+                DB::afterRollback(function () use (&$afterRollbackRan) {
+                    $afterRollbackRan = true;
+                });
+
+                throw new \RuntimeException('rollback');
+            });
+        } catch (\RuntimeException) {
+            // Ignore the expected rollback exception.
+        }
+
+        $this->assertFalse($afterCommitRan);
+        $this->assertTrue($afterRollbackRan);
+    }
 }
 
 class TestObjectForTransactions

--- a/tests/Integration/Database/DatabaseTransactionsTest.php
+++ b/tests/Integration/Database/DatabaseTransactionsTest.php
@@ -117,7 +117,7 @@ class DatabaseTransactionsTest extends DatabaseTestCase
                     $afterCommitRan = true;
                 });
 
-                DB::afterRollback(function () use (&$afterRollbackRan) {
+                DB::afterRollBack(function () use (&$afterRollbackRan) {
                     $afterRollbackRan = true;
                 });
 


### PR DESCRIPTION
## Summary
- add `DB::afterRollback` to mirror `afterCommit`
- queue rollback callbacks through the transactions manager
- cover the new API with integration tests

## Rationale
- lets applications react immediately after a rollback, e.g. releasing cache locks when a transaction fails
- complements existing `afterCommit` hooks so both success and failure paths can be handled
- touches only the transaction callback plumbing and facade docblocks, so no behaviour changes for existing code

## Testing
- `vendor/bin/phpunit tests/Integration/Database/DatabaseTransactionsTest.php`