### PR TITLE
[12.x] Json schema nullable

### DIFF
--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -33,6 +33,12 @@ class Serializer
             default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
         };
 
+        $nullable = self::isNullable($type);
+
+        if ($nullable) {
+            $attributes['type'] = [$attributes['type'], 'null'];
+        }
+
         $attributes = array_filter($attributes, static function (mixed $value, string $key) {
             if (in_array($key, static::$ignore, true)) {
                 return false;
@@ -78,5 +84,15 @@ class Serializer
         $attributes = (fn () => get_object_vars($type))->call($type);
 
         return isset($attributes['required']) && $attributes['required'] === true;
+    }
+
+    /**
+     * Determine if the given type is nullable.
+     */
+    protected static function isNullable(Types\Type $type): bool
+    {
+        $attributes = (fn () => get_object_vars($type))->call($type);
+
+        return isset($attributes['nullable']) && $attributes['nullable'] === true;
     }
 }

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -11,7 +11,7 @@ class Serializer
      *
      * @var array<int, string>
      */
-    protected static array $ignore = ['required'];
+    protected static array $ignore = ['required', 'nullable'];
 
     /**
      * Serialize the given property to an array.

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -33,7 +33,7 @@ class Serializer
             default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
         };
 
-        $nullable = self::isNullable($type);
+        $nullable = static::isNullable($type);
 
         if ($nullable) {
             $attributes['type'] = [$attributes['type'], 'null'];

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -42,9 +42,11 @@ abstract class Type extends JsonSchema
     /**
      * Indicate that the type is required.
      */
-    public function required(): static
+    public function required(bool $required = true): static
     {
-        $this->required = true;
+        if ($required) {
+            $this->required = true;
+        }
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -28,16 +28,16 @@ abstract class Type extends JsonSchema
     protected mixed $default = null;
 
     /**
-     * The type's nullability.
-     */
-    protected ?bool $nullable = null;
-
-    /**
      * The set of allowed values for the type.
      *
      * @var array<int, mixed>|null
      */
     protected ?array $enum = null;
+
+    /**
+     * Indicates if the type is nullable.
+     */
+    protected ?bool $nullable = null;
 
     /**
      * Indicate that the type is required.

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -28,6 +28,11 @@ abstract class Type extends JsonSchema
     protected mixed $default = null;
 
     /**
+     * The type's nullability.
+     */
+    protected ?bool $nullable = null;
+
+    /**
      * The set of allowed values for the type.
      *
      * @var array<int, mixed>|null
@@ -40,6 +45,18 @@ abstract class Type extends JsonSchema
     public function required(): static
     {
         $this->required = true;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the type is optional.
+     */
+    public function nullable(bool $nullable = true): static
+    {
+        if ($nullable) {
+            $this->nullable = true;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Based on [opis.io](https://opis.io/json-schema/2.x/generics.html) Json Schema, there is a nullable Type.
A type can be nullable if set so. I extended the serializer to check for nullable and conditionally replace the type of the schema with an array to extend it to be nullable.

Additionally the required function has a new argument to conditionally add required within method chaining.