### PR TITLE
[12.x] Add `ShouldBeUnique` and `ShouldBeUniqueUntilProcessing` support for event listeners

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -27,46 +27,49 @@ class UniqueLock
      * Attempt to acquire a lock for the given job.
      *
      * @param  mixed  $job
+     * @param  mixed  $arguments
      * @return bool
      */
-    public function acquire($job)
+    public function acquire($job, ...$arguments)
     {
         $uniqueFor = method_exists($job, 'uniqueFor')
-            ? $job->uniqueFor()
+            ? $job->uniqueFor(...$arguments)
             : ($job->uniqueFor ?? 0);
 
         $cache = method_exists($job, 'uniqueVia')
-            ? $job->uniqueVia()
+            ? $job->uniqueVia(...$arguments)
             : $this->cache;
 
-        return (bool) $cache->lock($this->getKey($job), $uniqueFor)->get();
+        return (bool) $cache->lock($this->getKey($job, ...$arguments), $uniqueFor)->get();
     }
 
     /**
      * Release the lock for the given job.
      *
      * @param  mixed  $job
+     * @param  mixed  $arguments
      * @return void
      */
-    public function release($job)
+    public function release($job, ...$arguments)
     {
         $cache = method_exists($job, 'uniqueVia')
-            ? $job->uniqueVia()
+            ? $job->uniqueVia(...$arguments)
             : $this->cache;
 
-        $cache->lock($this->getKey($job))->forceRelease();
+        $cache->lock($this->getKey($job, ...$arguments))->forceRelease();
     }
 
     /**
      * Generate the lock key for the given job.
      *
      * @param  mixed  $job
+     * @param  mixed  $arguments
      * @return string
      */
-    public static function getKey($job)
+    public static function getKey($job, ...$arguments)
     {
         $uniqueId = method_exists($job, 'uniqueId')
-            ? $job->uniqueId()
+            ? $job->uniqueId(...$arguments)
             : ($job->uniqueId ?? '');
 
         return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -636,7 +636,7 @@ class Dispatcher implements DispatcherContract
             : true;
 
         if ($shouldQueue && $instance instanceof ShouldBeUnique) {
-            return (new UniqueLock($this->container->make(Cache::class)))->acquire($instance, ...$arguments);;
+            return (new UniqueLock($this->container->make(Cache::class)))->acquire($instance, ...$arguments);
         }
 
         return $shouldQueue;

--- a/tests/Integration/Events/QueuedUniqueListenerTest.php
+++ b/tests/Integration/Events/QueuedUniqueListenerTest.php
@@ -33,5 +33,7 @@ class UniqueListenerTestEvent
 
 class UniqueListener implements ShouldQueue, ShouldBeUnique
 {
-    public function handle() {}
+    public function handle()
+    {
+    }
 }

--- a/tests/Integration/Events/QueuedUniqueListenerTest.php
+++ b/tests/Integration/Events/QueuedUniqueListenerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+
+class QueuedUniqueListenerTest extends TestCase
+{
+    public function testUniqueListenersPushedToQueue()
+    {
+        Event::listen(UniqueListenerTestEvent::class, UniqueListener::class);
+
+        Queue::fake();
+
+        UniqueListenerTestEvent::dispatch();
+        UniqueListenerTestEvent::dispatch();
+        UniqueListenerTestEvent::dispatch();
+
+        Queue::assertPushed(CallQueuedListener::class, 1);
+    }
+}
+
+class UniqueListenerTestEvent
+{
+    use Dispatchable;
+}
+
+class UniqueListener implements ShouldQueue, ShouldBeUnique
+{
+    public function handle() {}
+}

--- a/tests/Integration/Events/QueuedUniqueUntilProcessingListenerTest.php
+++ b/tests/Integration/Events/QueuedUniqueUntilProcessingListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\TestCase;
+
+#[WithMigration]
+#[WithMigration('cache')]
+#[WithMigration('queue')]
+class QueuedUniqueUntilProcessingListenerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+        $app['config']->set('queue.default', 'database');
+        $app['config']->set('cache.default', 'database');
+    }
+
+
+    public function testUniqueListenersPushedToQueue()
+    {
+        Event::listen(UniqueUntilProcessingListenerTestEvent::class, UniqueUntilProcessingListener::class);
+
+        UniqueUntilProcessingListenerTestEvent::dispatch();
+        UniqueUntilProcessingListenerTestEvent::dispatch();
+
+        $this->assertDatabaseCount('jobs', 1);
+        $this->assertDatabaseCount('cache_locks', 1);
+
+        $this->artisan('queue:work', [
+            '--memory' => 1024,
+            '--once' => true,
+        ])->assertSuccessful();
+
+        $this->assertEquals(UniqueUntilProcessingListener::$lockedCountsInProcessing, 0);
+
+        $this->assertDatabaseCount('jobs', 0);
+        $this->assertDatabaseCount('cache_locks', 0);
+    }
+}
+
+class UniqueUntilProcessingListenerTestEvent
+{
+    use Dispatchable;
+}
+
+class UniqueUntilProcessingListener implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    public static $lockedCountsInProcessing = null;
+
+    public function handle()
+    {
+        static::$lockedCountsInProcessing = DB::table('cache_locks')->count();
+    }
+}

--- a/tests/Integration/Events/QueuedUniqueUntilProcessingListenerTest.php
+++ b/tests/Integration/Events/QueuedUniqueUntilProcessingListenerTest.php
@@ -25,7 +25,6 @@ class QueuedUniqueUntilProcessingListenerTest extends TestCase
         $app['config']->set('cache.default', 'database');
     }
 
-
     public function testUniqueListenersPushedToQueue()
     {
         Event::listen(UniqueUntilProcessingListenerTestEvent::class, UniqueUntilProcessingListener::class);


### PR DESCRIPTION
# Overview

This PR adds support for the `Illuminate\Contracts\Queue\ShouldBeUnique` and `Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing` interfaces for event listeners.

# Use Case

Updates the available size of the user's storage space when a file is deleted, and ensures that listeners are unique when deleting files in a batch.

# Example
```php
namespace App\Listeners;

use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;

class UpdateSpaceAvailableSize implements ShouldQueueAfterCommit, ShouldBeUniqueUntilProcessing
{
    public function handle(FileDeleted $event): void
    {
        // Do something
    }

    public function uniqueId(FileDeleted $event): int|string
    {
        return $event->userId;
    }
}
```

# Related issues
https://github.com/laravel/framework/issues/36632