### PR TITLE
[12.x] Add `roman()` method for `Number` helper to convert integers to Roman numerals

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -343,6 +343,12 @@ class Number
         return json_decode(json_encode($number));
     }
 
+    /**
+     * Convert the given number to its Roman numeral equivalent.
+     *
+     * @param int<1, 3999> $number
+     * @return string
+     */
     public static function roman(int $number): string
     {
         if ($number < 1 || $number > 3999) {
@@ -353,9 +359,9 @@ class Number
         $symbols = ['M', 'CM', 'D', 'CD', 'C', 'XC', 'L', 'XL', 'X', 'IX', 'V', 'IV', 'I'];
 
         $roman = '';
-        for ($i = 0; $i < count($values); $i++) {
-            while ($number >= $values[$i]) {
-                $number -= $values[$i];
+        foreach ($values as $i => $value) {
+            while ($number >= $value) {
+                $number -= $value;
                 $roman .= $symbols[$i];
             }
         }

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use NumberFormatter;
 use RuntimeException;
 
@@ -340,6 +341,26 @@ class Number
     public static function trim(int|float $number)
     {
         return json_decode(json_encode($number));
+    }
+
+    public static function roman(int $number): string
+    {
+        if ($number < 1 || $number > 3999) {
+            throw new InvalidArgumentException('Number must be between 1 and 3999');
+        }
+
+        $values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
+        $symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
+
+        $roman = '';
+        for ($i = 0; $i < count($values); $i++) {
+            while ($number >= $values[$i]) {
+                $number -= $values[$i];
+                $roman .= $symbols[$i];
+            }
+        }
+
+        return $roman;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -346,7 +346,7 @@ class Number
     /**
      * Convert the given number to its Roman numeral equivalent.
      *
-     * @param int<1, 3999> $number
+     * @param  int<1, 3999>  $number
      * @return string
      */
     public static function roman(int $number): string

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -350,7 +350,7 @@ class Number
         }
 
         $values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
-        $symbols = ["M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"];
+        $symbols = ['M', 'CM', 'D', 'CD', 'C', 'XC', 'L', 'XL', 'X', 'IX', 'V', 'IV', 'I'];
 
         $roman = '';
         for ($i = 0; $i < count($values); $i++) {

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -307,6 +309,60 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1.1T', Number::abbreviate(-1100000000000, maxPrecision: 1));
         $this->assertSame('-1Q', Number::abbreviate(-1000000000000000));
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
+    }
+
+    public static function romanNumberProvider()
+    {
+        return [
+            [1, 'I', null],
+            [2, 'II', null],
+            [3, 'III', null],
+            [4, 'IV', null],
+            [5, 'V', null],
+            [6, 'VI', null],
+            [7, 'VII', null],
+            [8, 'VIII', null],
+            [9, 'IX', null],
+            [10, 'X', null],
+            [11, 'XI', null],
+            [12, 'XII', null],
+            [13, 'XIII', null],
+            [14, 'XIV', null],
+            [15, 'XV', null],
+            [16, 'XVI', null],
+            [17, 'XVII', null],
+            [18, 'XVIII', null],
+            [19, 'XIX', null],
+            [20, 'XX', null],
+            [21, 'XXI', null],
+            [30, 'XXX', null],
+            [32, 'XXXII', null],
+            [43, 'XLIII', null],
+            [54, 'LIV', null],
+            [71, 'LXXI', null],
+            [93, 'XCIII', null],
+            [144, 'CXLIV', null],
+            [171, 'CLXXI', null],
+            [271, 'CCLXXI', null],
+            [871, 'DCCCLXXI', null],
+            [1913, 'MCMXIII', null],
+            [2021, 'MMXXI', null],
+            [3999, 'MMMCMXCIX', null],
+            [3999, 'MMMCMXCIX', null],
+            [0, null, InvalidArgumentException::class],
+            [4000, null, InvalidArgumentException::class],
+        ];
+    }
+
+    #[DataProvider('romanNumberProvider')]
+    public function testRoman(int $number, ?string $expected, ?string $exception)
+    {
+        if ($exception) {
+            $this->expectException($exception);
+            Number::roman($number);
+        } else {
+            $this->assertSame($expected, Number::roman($number));
+        }
     }
 
     public function testPairs()


### PR DESCRIPTION
## Overview

The `Number::roman()` function converts positive integers to their corresponding Roman numeral representation.

- **Input**: Integer from 1 to 3999
- **Output**: Roman numeral string

### Limitations:
- Only supports numbers from 1-3999 (traditional Roman numeral limit)
- Does not handle negative numbers or zero
- No decimal number support

---

## Use Cases

### 1. **Document Formatting**
- Chapter and section numbering in formal documents
- Creating ordered lists with Roman numerals
- Formatting outlines and document structures

### 2. **Clock & Time Display**
- Classic and luxury watch displays
- Desktop clock applications with retro themes
- Time display widgets for websites

### 3. **Events & Ceremonies**
- Event numbering (Olympic Games, World Cup editions)
- Royal and noble titles (King Henry VIII, Pope John XXIII)
- Premium product version numbering

### 4. **Gaming & Entertainment**
- RPG games with medieval/historical themes
- Mathematical puzzle games
- Achievement badges and level systems

### 5. **Legal & Formal Documents**
- Contract clauses and legal sections
- Academic paper citations
- Government document formatting

### 6. **Architecture & Construction**
- Building floor numbers (luxury buildings)
- Monuments and historical markers
- Cornerstone dates and inscriptions

---

## Examples

```php
// Simple numbers
echo Number::roman(1);     // Output: "I"
echo Number::roman(2);     // Output: "II"
echo Number::roman(3);     // Output: "III"
echo Number::roman(4);     // Output: "IV"  (5-1)
echo Number::roman(5);     // Output: "V"
echo Number::roman(6);     // Output: "VI"
echo Number::roman(7);     // Output: "VII"
echo Number::roman(8);     // Output: "VIII"
echo Number::roman(9);     // Output: "IX"  (10-1)
echo Number::roman(10);    // Output: "X"
echo Number::roman(21);    // Output: "XXI"
echo Number::roman(32);    // Output: "XXXII"
echo Number::roman(43);    // Output: "XLIII"
echo Number::roman(54);    // Output: "LIV"
echo Number::roman(144);    // Output: "CXLIV"
echo Number::roman(1913);    // Output: "MCMXIII"
echo Number::roman(3999);    // Output: "MMMCMXCIX"
```