### PR TITLE
[12.x] Extend SQS FIFO and fair queue support

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Laravel\SerializableClosure\SerializableClosure;
 use PHPUnit\Framework\Assert as PHPUnit;
 use RuntimeException;
 
@@ -37,7 +38,7 @@ trait Queueable
     /**
      * The job deduplicator callback the job should use to generate the deduplication id.
      *
-     * @var callable|null
+     * @var \Laravel\SerializableClosure\SerializableClosure|null
      */
     public $deduplicator;
 
@@ -141,7 +142,9 @@ trait Queueable
      */
     public function withDeduplicator($deduplicator)
     {
-        $this->deduplicator = $deduplicator;
+        $this->deduplicator = $deduplicator instanceof Closure
+            ? new SerializableClosure($deduplicator)
+            : $deduplicator;
 
         return $this;
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -35,6 +35,13 @@ trait Queueable
     public $messageGroup;
 
     /**
+     * The job deduplicator callback the job should use to generate the deduplication id.
+     *
+     * @var callable|null
+     */
+    public $deduplicator;
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|array|int|null
@@ -120,6 +127,21 @@ trait Queueable
     public function onGroup($group)
     {
         $this->messageGroup = enum_value($group);
+
+        return $this;
+    }
+
+    /**
+     * Set the desired job deduplicator callback.
+     *
+     * This feature is only supported by some queues, such as Amazon SQS FIFO.
+     *
+     * @param  callable|null  $deduplicator
+     * @return $this
+     */
+    public function withDeduplicator($deduplicator)
+    {
+        $this->deduplicator = $deduplicator;
 
         return $this;
     }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -36,7 +36,7 @@ trait Queueable
     public $messageGroup;
 
     /**
-     * The job deduplicator callback the job should use to generate the deduplication id.
+     * The job deduplicator callback the job should use to generate the deduplication ID.
      *
      * @var \Laravel\SerializableClosure\SerializableClosure|null
      */

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -706,6 +706,10 @@ class Dispatcher implements DispatcherContract
             $job->timeout = $listener->timeout ?? null;
             $job->failOnTimeout = $listener->failOnTimeout ?? false;
             $job->tries = method_exists($listener, 'tries') ? $listener->tries(...$data) : ($listener->tries ?? null);
+            $job->messageGroup = method_exists($listener, 'messageGroup') ? $listener->messageGroup(...$data) : ($listener->messageGroup ?? null);
+            $job->deduplicator = method_exists($listener, 'deduplicator')
+                ? $listener->deduplicator(...$data)
+                : (method_exists($listener, 'deduplicationId') ? $listener->deduplicationId(...) : null);
 
             $job->through(array_merge(
                 method_exists($listener, 'middleware') ? $listener->middleware(...$data) : [],

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -707,9 +707,10 @@ class Dispatcher implements DispatcherContract
             $job->failOnTimeout = $listener->failOnTimeout ?? false;
             $job->tries = method_exists($listener, 'tries') ? $listener->tries(...$data) : ($listener->tries ?? null);
             $job->messageGroup = method_exists($listener, 'messageGroup') ? $listener->messageGroup(...$data) : ($listener->messageGroup ?? null);
-            $job->deduplicator = method_exists($listener, 'deduplicator')
+            $job->withDeduplicator(method_exists($listener, 'deduplicator')
                 ? $listener->deduplicator(...$data)
-                : (method_exists($listener, 'deduplicationId') ? $listener->deduplicationId(...) : null);
+                : (method_exists($listener, 'deduplicationId') ? $listener->deduplicationId(...) : null)
+            );
 
             $job->through(array_merge(
                 method_exists($listener, 'middleware') ? $listener->middleware(...$data) : [],

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -32,6 +32,20 @@ class QueuedClosure
     public $queue;
 
     /**
+     * The job "group" the job should be sent to.
+     *
+     * @var string|null
+     */
+    public $messageGroup;
+
+    /**
+     * The job deduplicator callback the job should use to generate the deduplication id.
+     *
+     * @var callable|null
+     */
+    public $deduplicator;
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|int|null
@@ -82,6 +96,36 @@ class QueuedClosure
     }
 
     /**
+     * Set the desired job "group".
+     *
+     * This feature is only supported by some queues, such as Amazon SQS.
+     *
+     * @param  \UnitEnum|string  $group
+     * @return $this
+     */
+    public function onGroup($group)
+    {
+        $this->messageGroup = enum_value($group);
+
+        return $this;
+    }
+
+    /**
+     * Set the desired job deduplicator callback.
+     *
+     * This feature is only supported by some queues, such as Amazon SQS FIFO.
+     *
+     * @param  callable|null  $deduplicator
+     * @return $this
+     */
+    public function withDeduplicator($deduplicator)
+    {
+        $this->deduplicator = $deduplicator;
+
+        return $this;
+    }
+
+    /**
      * Set the desired delay in seconds for the job.
      *
      * @param  \DateTimeInterface|\DateInterval|int|null  $delay
@@ -121,7 +165,12 @@ class QueuedClosure
                 'catch' => (new Collection($this->catchCallbacks))
                     ->map(fn ($callback) => new SerializableClosure($callback))
                     ->all(),
-            ]))->onConnection($this->connection)->onQueue($this->queue)->delay($this->delay);
+            ]))
+                ->onConnection($this->connection)
+                ->onQueue($this->queue)
+                ->delay($this->delay)
+                ->onGroup($this->messageGroup)
+                ->withDeduplicator($this->deduplicator);
         };
     }
 }

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -41,7 +41,7 @@ class QueuedClosure
     /**
      * The job deduplicator callback the job should use to generate the deduplication id.
      *
-     * @var callable|null
+     * @var \Laravel\SerializableClosure\SerializableClosure|null
      */
     public $deduplicator;
 
@@ -120,7 +120,9 @@ class QueuedClosure
      */
     public function withDeduplicator($deduplicator)
     {
-        $this->deduplicator = $deduplicator;
+        $this->deduplicator = $deduplicator instanceof Closure
+            ? new SerializableClosure($deduplicator)
+            : $deduplicator;
 
         return $this;
     }

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -39,7 +39,7 @@ class QueuedClosure
     public $messageGroup;
 
     /**
-     * The job deduplicator callback the job should use to generate the deduplication id.
+     * The job deduplicator callback the job should use to generate the deduplication ID.
      *
      * @var \Laravel\SerializableClosure\SerializableClosure|null
      */

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -79,6 +79,21 @@ class PendingDispatch
     }
 
     /**
+     * Set the desired job deduplicator callback.
+     *
+     * This feature is only supported by some queues, such as Amazon SQS FIFO.
+     *
+     * @param  callable|null  $deduplicator
+     * @return $this
+     */
+    public function withDeduplicator($deduplicator)
+    {
+        $this->job->withDeduplicator($deduplicator);
+
+        return $this;
+    }
+
+    /**
      * Set the desired connection for the chain.
      *
      * @param  \BackedEnum|string|null  $connection

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -264,6 +264,7 @@ class Mailable implements MailableContract, Renderable
     {
         $messageGroup = $this->messageGroup ?? null;
 
+        /** @phpstan-ignore callable.nonNativeMethod (false positive since method_exists guard is used) */
         $deduplicator = $this->deduplicator ?? (method_exists($this, 'deduplicationId') ? $this->deduplicationId(...) : null);
 
         return Container::getInstance()->make(SendQueuedMailable::class, ['mailable' => $this])

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -262,7 +262,13 @@ class Mailable implements MailableContract, Renderable
      */
     protected function newQueuedJob()
     {
+        $messageGroup = $this->messageGroup ?? null;
+
+        $deduplicator = $this->deduplicator ?? (method_exists($this, 'deduplicationId') ? $this->deduplicationId(...) : null);
+
         return Container::getInstance()->make(SendQueuedMailable::class, ['mailable' => $this])
+            ->onGroup($messageGroup)
+            ->withDeduplicator($deduplicator)
             ->through(array_merge(
                 method_exists($this, 'middleware') ? $this->middleware() : [],
                 $this->middleware ?? []

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -247,6 +247,18 @@ class NotificationSender
                     $delay = $notification->withDelay($notifiable, $channel) ?? null;
                 }
 
+                $messageGroup = $notification->messageGroup ?? null;
+
+                if (method_exists($notification, 'withMessageGroups')) {
+                    $messageGroup = $notification->withMessageGroups($notifiable, $channel) ?? null;
+                }
+
+                $deduplicator = $notification->deduplicator ?? (method_exists($notification, 'deduplicationId') ? $notification->deduplicationId(...) : null);
+
+                if (method_exists($notification, 'withDeduplicators')) {
+                    $deduplicator = $notification->withDeduplicators($notifiable, $channel) ?? null;
+                }
+
                 $middleware = $notification->middleware ?? [];
 
                 if (method_exists($notification, 'middleware')) {
@@ -265,6 +277,8 @@ class NotificationSender
                         ->onConnection($connection)
                         ->onQueue($queue)
                         ->delay(is_array($delay) ? ($delay[$channel] ?? null) : $delay)
+                        ->onGroup(is_array($messageGroup) ? ($messageGroup[$channel] ?? null) : $messageGroup)
+                        ->withDeduplicator(is_array($deduplicator) ? ($deduplicator[$channel] ?? null) : $deduplicator)
                         ->through($middleware)
                 );
             }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -256,6 +256,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         if ($isFifo) {
             $messageDeduplicationId = match (true) {
+                $isObject && isset($job->deduplicator) && is_callable($job->deduplicator) => transform(call_user_func($job->deduplicator, $payload, $queue), $transformToString),
                 $isObject && method_exists($job, 'deduplicationId') => transform($job->deduplicationId($payload, $queue), $transformToString),
                 default => (string) Str::orderedUuid(),
             };

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -163,7 +163,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $queue,
             null,
             function ($payload, $queue) use ($job) {
-                return $this->pushRaw($payload, $queue, $this->getQueueableOptions($job, $queue));
+                return $this->pushRaw($payload, $queue, $this->getQueueableOptions($job, $queue, $payload));
             }
         );
     }
@@ -200,7 +200,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             $queue,
             $delay,
             function ($payload, $queue, $delay) use ($job) {
-                return $this->pushRaw($payload, $queue, $this->getQueueableOptions($job, $queue, $delay));
+                return $this->pushRaw($payload, $queue, $this->getQueueableOptions($job, $queue, $payload, $delay));
             }
         );
     }
@@ -210,10 +210,11 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  mixed  $job
      * @param  string|null  $queue
+     * @param  string  $payload
      * @param  \DateTimeInterface|\DateInterval|int|null  $delay
      * @return array{DelaySeconds?: int, MessageGroupId?: string, MessageDeduplicationId?: string}
      */
-    protected function getQueueableOptions($job, $queue, $delay = null): array
+    protected function getQueueableOptions($job, $queue, $payload, $delay = null): array
     {
         // Make sure we have a queue name to properly determine if it's a FIFO queue...
         $queue ??= $this->default;
@@ -255,7 +256,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
 
         if ($isFifo) {
             $messageDeduplicationId = match (true) {
-                $isObject && method_exists($job, 'deduplicationId') => transform($job->deduplicationId(), $transformToString),
+                $isObject && method_exists($job, 'deduplicationId') => transform($job->deduplicationId($payload, $queue), $transformToString),
                 default => (string) Str::orderedUuid(),
             };
         }

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -197,6 +197,78 @@ class QueuedEventsTest extends TestCase
         });
     }
 
+    public function testQueuePropagateMessageGroupProperty()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherWithMessageGroupProperty::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return $job->messageGroup === 'group-property';
+        });
+    }
+
+    public function testQueuePropagateMessageGroupMethodOverProperty()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherWithMessageGroupMethod::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return $job->messageGroup === 'group-method';
+        });
+    }
+
+    public function testQueuePropagateDeduplicationIdMethod()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherWithDeduplicationIdMethod::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return is_callable($job->deduplicator) && call_user_func($job->deduplicator, '', null) === 'deduplication-id-method';
+        });
+    }
+
+    public function testQueuePropagateDeduplicatorMethodOverDeduplicationIdMethod()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherWithDeduplicatorMethod::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            return is_callable($job->deduplicator) && call_user_func($job->deduplicator, '', null) === 'deduplicator-method';
+        });
+    }
+
     public function testQueuePropagateMiddleware()
     {
         $d = new Dispatcher;
@@ -320,6 +392,62 @@ class TestDispatcherOptions implements ShouldQueue
     public function handle()
     {
         //
+    }
+}
+
+class TestDispatcherWithMessageGroupProperty implements ShouldQueue
+{
+    public $messageGroup = 'group-property';
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class TestDispatcherWithMessageGroupMethod implements ShouldQueue
+{
+    public $messageGroup = 'group-property';
+
+    public function handle()
+    {
+        //
+    }
+
+    public function messageGroup($event)
+    {
+        return 'group-method';
+    }
+}
+
+class TestDispatcherWithDeduplicationIdMethod implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+
+    public function deduplicationId($payload, $queue)
+    {
+        return 'deduplication-id-method';
+    }
+}
+
+class TestDispatcherWithDeduplicatorMethod implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+
+    public function deduplicationId($payload, $queue)
+    {
+        return 'deduplication-id-method';
+    }
+
+    public function deduplicator($event)
+    {
+        return fn ($payload, $queue) => 'deduplicator-method';
     }
 }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -247,6 +248,8 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+
             return is_callable($job->deduplicator) && call_user_func($job->deduplicator, '', null) === 'deduplication-id-method';
         });
     }
@@ -265,6 +268,8 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+
             return is_callable($job->deduplicator) && call_user_func($job->deduplicator, '', null) === 'deduplicator-method';
         });
     }

--- a/tests/Integration/Events/QueuedClosureListenerTest.php
+++ b/tests/Integration/Events/QueuedClosureListenerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\InvokeQueuedClosure;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
+use Laravel\SerializableClosure\SerializableClosure;
 use Orchestra\Testbench\TestCase;
 
 class QueuedClosureListenerTest extends TestCase
@@ -61,6 +62,8 @@ class QueuedClosureListenerTest extends TestCase
         Event::dispatch(new TestEvent);
 
         Bus::assertDispatched(CallQueuedListener::class, function ($job) {
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+
             return is_callable($job->deduplicator) && call_user_func($job->deduplicator, '', null) == 'deduplicator-1';
         });
     }

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -13,6 +13,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Support\Testing\Fakes\QueueFake;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Transport\TransportInterface;
@@ -122,7 +123,8 @@ class MailableQueuedTest extends TestCase
         $queueFake->assertPushedOn(null, SendQueuedMailable::class);
 
         $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
-        $this->assertEquals($mockedDeduplicator, $pushedJob->deduplicator);
+        $this->assertInstanceOf(SerializableClosure::class, $pushedJob->deduplicator);
+        $this->assertEquals($mockedDeduplicator, $pushedJob->deduplicator->getClosure());
     }
 
     public function testQueuedMailableForwardsDeduplicationIdMethodToQueueJob(): void
@@ -139,7 +141,8 @@ class MailableQueuedTest extends TestCase
         $queueFake->assertPushedOn(null, SendQueuedMailable::class);
 
         $pushedJob = $queueFake->pushed(SendQueuedMailable::class)->first();
-        $this->assertEquals($mailable->deduplicationId(...), $pushedJob->deduplicator);
+        $this->assertInstanceOf(SerializableClosure::class, $pushedJob->deduplicator);
+        $this->assertEquals($mailable->deduplicationId(...), $pushedJob->deduplicator->getClosure());
     }
 
     protected function getMocks()

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -18,6 +18,7 @@ use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -259,7 +260,8 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Bus::class, $bus = m::mock());
         $bus->shouldReceive('dispatch')->once()->withArgs(function ($job) use ($mockedDeduplicator) {
             $this->assertInstanceOf(SendQueuedNotifications::class, $job);
-            $this->assertEquals($mockedDeduplicator, $job->deduplicator);
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+            $this->assertEquals($mockedDeduplicator, $job->deduplicator->getClosure());
 
             return true;
         });
@@ -284,7 +286,8 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Bus::class, $bus = m::mock());
         $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) use ($mockedDeduplicatorSet) {
             $this->assertInstanceOf(SendQueuedNotifications::class, $job);
-            $this->assertEquals($mockedDeduplicatorSet[$job->channels[0]], $job->deduplicator);
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+            $this->assertEquals($mockedDeduplicatorSet[$job->channels[0]], $job->deduplicator->getClosure());
 
             return true;
         });
@@ -324,7 +327,8 @@ class NotificationChannelManagerTest extends TestCase
         $container->instance(Bus::class, $bus = m::mock());
         $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) {
             $this->assertInstanceOf(SendQueuedNotifications::class, $job);
-            $this->assertEquals($job->notification->deduplicationId(...), $job->deduplicator);
+            $this->assertInstanceOf(SerializableClosure::class, $job->deduplicator);
+            $this->assertEquals($job->notification->deduplicationId(...), $job->deduplicator->getClosure());
 
             return true;
         });

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -176,6 +176,165 @@ class NotificationChannelManagerTest extends TestCase
 
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestQueuedNotification);
     }
+
+    public function testQueuedNotificationForwardsMessageGroupToQueueJob()
+    {
+        $mockedMessageGroupId = 'group-1';
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->once()->withArgs(function ($job) use ($mockedMessageGroupId) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($mockedMessageGroupId, $job->messageGroup);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotification)->onGroup($mockedMessageGroupId);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsMessageGroupSetToQueueJob()
+    {
+        $mockedMessageGroupSet = [
+            'test' => 'group-1',
+            'test2' => 'group-2',
+        ];
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) use ($mockedMessageGroupSet) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($mockedMessageGroupSet[$job->channels[0]], $job->messageGroup);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotificationWithTwoChannels)->onGroup($mockedMessageGroupSet);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsMessageGroupSetFromClassToQueueJob()
+    {
+        $mockedMessageGroupSet = [
+            'test' => 'group-1',
+            'test2' => 'group-2',
+        ];
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) use ($mockedMessageGroupSet) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($mockedMessageGroupSet[$job->channels[0]], $job->messageGroup);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotificationWithMessageGroups);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsDeduplicatorToQueueJob()
+    {
+        $mockedDeduplicator = fn ($payload, $queue) => 'deduplication-id-1';
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->once()->withArgs(function ($job) use ($mockedDeduplicator) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($mockedDeduplicator, $job->deduplicator);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotification)->withDeduplicator($mockedDeduplicator);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsDeduplicatorSetToQueueJob()
+    {
+        $mockedDeduplicatorSet = [
+            'test' => fn ($payload, $queue) => 'deduplication-id-1',
+            'test2' => fn ($payload, $queue) => 'deduplication-id-2',
+        ];
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) use ($mockedDeduplicatorSet) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($mockedDeduplicatorSet[$job->channels[0]], $job->deduplicator);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotificationWithTwoChannels)->withDeduplicator($mockedDeduplicatorSet);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsDeduplicatorSetFromClassToQueueJob()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($job->notification->deduplicatorResults[$job->channels[0]], call_user_func($job->deduplicator, '', null));
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotificationWithDeduplicators);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
+
+    public function testQueuedNotificationForwardsDeduplicationIdMethodToQueueJob()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Bus::class, $bus = m::mock());
+        $bus->shouldReceive('dispatch')->twice()->withArgs(function ($job) {
+            $this->assertInstanceOf(SendQueuedNotifications::class, $job);
+            $this->assertEquals($job->notification->deduplicationId(...), $job->deduplicator);
+
+            return true;
+        });
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('listen')->once();
+
+        $notification = (new NotificationChannelManagerTestQueuedNotificationWithDeduplicationId);
+        $manager->send([new NotificationChannelManagerTestNotifiable], $notification);
+    }
 }
 
 class TestSendQueuedNotifications implements ShouldQueue
@@ -262,5 +421,93 @@ class NotificationChannelManagerTestQueuedNotification extends Notification impl
     public function message()
     {
         return $this->line('test')->action('Text', 'url');
+    }
+}
+
+class NotificationChannelManagerTestQueuedNotificationWithTwoChannels extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via()
+    {
+        return ['test', 'test2'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+}
+
+class NotificationChannelManagerTestQueuedNotificationWithMessageGroups extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via()
+    {
+        return ['test', 'test2'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+
+    public function withMessageGroups($notifiable, $channel)
+    {
+        return match ($channel) {
+            'test' => 'group-1',
+            'test2' => 'group-2',
+            default => null,
+        };
+    }
+}
+
+class NotificationChannelManagerTestQueuedNotificationWithDeduplicators extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public $deduplicatorResults = [
+        'test' => 'deduplication-id-1',
+        'test2' => 'deduplication-id-2',
+    ];
+
+    public function via()
+    {
+        return ['test', 'test2'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+
+    public function withDeduplicators($notifiable, $channel)
+    {
+        return match ($channel) {
+            'test' => fn ($payload, $queue) => $this->deduplicatorResults['test'],
+            'test2' => fn ($payload, $queue) => $this->deduplicatorResults['test2'],
+            default => null,
+        };
+    }
+}
+
+class NotificationChannelManagerTestQueuedNotificationWithDeduplicationId extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via()
+    {
+        return ['test', 'test2'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+
+    public function deduplicationId($payload, $queue)
+    {
+        return 'deduplication-id-1';
     }
 }

--- a/tests/Queue/Fixtures/FakeSqsJobWithDeduplication.php
+++ b/tests/Queue/Fixtures/FakeSqsJobWithDeduplication.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class FakeSqsJobWithDeduplication implements ShouldQueue
+{
+    use Queueable;
+
+    protected $testDeduplicationId = 'test-deduplication-id';
+
+    public function handle(): void
+    {
+        //
+    }
+
+    /**
+     * Deduplication ID method called by SqsQueue.
+     *
+     * @return string
+     */
+    public function deduplicationId(): string
+    {
+        return (string) $this->testDeduplicationId;
+    }
+
+    /**
+     * Helper method to allow a test to specify the deduplication ID to use.
+     *
+     * @param  string  $id
+     * @return $this
+     */
+    public function useDeduplicationId($id): static
+    {
+        $this->testDeduplicationId = $id;
+
+        return $this;
+    }
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -351,7 +351,9 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPushProperlyPushesJobObjectOntoSqsFifoQueueWithDeduplicationId()
     {
-        $job = (new FakeSqsJobWithDeduplication())->onGroup($this->mockedMessageGroupId)->useDeduplicationId($this->mockedDeduplicationId);
+        $job = $this->getMockBuilder(FakeSqsJobWithDeduplication::class)->onlyMethods(['deduplicationId'])->getMock();
+        $job->expects($this->once())->method('deduplicationId')->with($this->mockedPayload, $this->fifoQueueName)->willReturn($this->mockedDeduplicationId);
+        $job->onGroup($this->mockedMessageGroupId);
 
         $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->fifoQueueName, $this->account])->getMock();
         $queue->setContainer($container = m::spy(Container::class));


### PR DESCRIPTION
This is a follow up to the previous PR #57080 that fixed SQS FIFO and fair queues for user defined queued jobs. This PR adds SQS FIFO and fair queue support to internally queued jobs (mailables, notifications, event listeners).

### Summary

SQS FIFO and fair queues work for user defined queued jobs now. However, there are other components that can be queued that will still throw an error. For example, queueing mailables, notifications, or event listeners will throw an error. When attempting to queue one of these components, it is wrapped by an internal job that is sent to the queue, but the message group and deduplication logic is not propagated to this new internal job.

- Mailables queue a `SendQueuedMailable` job.
- Notifications queue a `SendQueuedNotifications` job.
- Events queue a `CallQueuedListener` job.
- Anonymous events generate a `QueuedClosure` object that queues a `CallQueuedListener` job.

### Updates

1. Enhanced the existing `deduplicationId()` method by passing in the job payload and queue name.
    
    This data can be useful to the method in generating the deduplication id. For example, when content deduplication is enabled on the queue in AWS, AWS generates the deduplication id using a sha256 hash of the payload. If content deduplication is disabled in AWS and the developer would like to emulate this behavior, the payload is now available to the `deduplicationId()` method.

2. Added a new `$deduplicator` property and `withDeduplicator()` method to the `Queueable` trait.
    
    Currently, the queue looks for the `deduplicationId()` method on the queued job to generate the deduplication id. However, this method cannot be propagated to internal jobs. For example, when queueing a `Mailable` object, one may define the `deduplicationId()` method on the mailable. However, since the mailable is not the object that is actually queued, the method won't be found or called. We need a way to propagate this logic of this method to the internal queued job.

    The `$deduplicator` property can now hold a callback that is to be used to generate the deduplication id. If set, it will take precedence over the `deduplicationId()` method if one is also defined. The callback will take the payload and queue name as parameters.

3. Update the `Mailable` to forward the message group and deduplication logic to the internal `SendQueuedMailable` job.

    When the `Mailable` is queued, it gets wrapped in an instance of a `SendQueuedMailable` job object that is actually sent to the queue. The job creation logic has been updated to forward any message group id or deduplication logic defined on the mailable to the internal queued job.
    
    If the mailable has a `$deduplicator` callback defined, it will forward that. Otherwise, if the mailable has a `deduplicationId()` method defined, it will convert that to a closure and forward that.

4. Update the `NotificationSender` to forward the message group and deduplication logic to the internal `SendQueuedNotifications` job.

    When a `Notification` is queued, it gets wrapped in an instance of a `SendQueuedNotifications` job object that is actually sent to the queue. The job creation logic has been updated to forward any message group id or deduplication logic defined on the notification to the internal queued job.
    
    An extra part to this, however, is that logic may differ based on the notification channel. To support per-channel logic, new support for a `withMessageGroups()` method and a `withDeduplicators()` method was added. The methods act the same as the `viaConnections()`, `viaQueues()`, and `withDelay()` method support.

5. Update the event `Dispatcher` to forward the message group and deduplication logic to the internal `CallQueuedListener` job.

    When an event listener is queued, it gets wrapped in an instance of a `CallQueuedListener` job object that is actually sent to the queue. The job creation logic has been updated to forward any message group id or deduplication logic defined on the listener to the internal queued job.
    
    An extra part to this, however, is that logic may differ based on the event being handled. To support per-event logic, new support for a `messageGroup($event)` method and a `deduplicator($event)` method was added. The methods act the same as the other queue related methods (`backoff()`, `retryUntil()`, `tries()`, etc.).
    
    For the message group id, if the `messageGroup()` method exists, it takes precedence. Otherwise, it falls back to the `$messageGroup` property.
    
    For the deduplication id, if the `deduplicator()` method exists, it takes precedence. Otherwise, it falls back to converting the `deduplicationId()` method on the listener to a callback and forwarding that, if it exists.
    
    Note, there is no attempt to forward the `$deduplicator` property from the listener to the queued job. This is on purpose. The dispatcher creates a new instance of the listener using reflection and without calling the constructor. Since a closure cannot be used as a default value for a class property (at least not until PHP 8.5), and the constructor will not be called, there is currently no way for the `$deduplicator` property to be set to a closure on the listener object being used to propagate data to the queued job.

6. Update the event `QueuedClosure` to support message groups and deduplication and forward it to the internal `CallQueuedListener` job.
    
    Queued anonymous event listeners get converted to a `QueuedClosure` object, which in turn creates an instance of a `CallQueuedListener` job object that is actually sent to the queue. The `QueuedClosure` object has been updated to support setting the `$messageGroup` and `$deduplicator` properties, and forwarding those properties to the internal queued job.

### Notes

- I have added tests that highlight the issues and show they've been fixed.

- Job batching and job chaining seems to work as long as each batched/chained job defines the message group and deduplicator. We may want to consider adding logic that allows defining a message group and deduplicator to apply to all jobs in the batch/chain. If desired, this can be done in another PR.

- With method naming, I tried to be consistent with the existing code within the component. There may be room improving consistency across components, but that would be a bigger job and not within the scope of this PR.

- I think the `onGroup()` method should be renamed to `onMessageGroup()` across all components. Especially since the original property was called `$group` and was later renamed to `$messageGroup`. However, this would be a breaking change and something for another PR.

- The commits in the PR line up with the updates described above, starting with the second commit. The first commit was just adding an extra test that was missed before, and is not addressed in the update section.

Please let me know if you need me to make any changes or have any questions.