### PR TITLE
[12.x] Adds support enums for `ThrottleRequests::using` method

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+use function Illuminate\Support\enum_value;
 
 class ThrottleRequests
 {
@@ -44,12 +45,12 @@ class ThrottleRequests
     /**
      * Specify the named rate limiter to use for the middleware.
      *
-     * @param  string  $name
+     * @param  string|\UnitEnum  $name
      * @return string
      */
     public static function using($name)
     {
-        return static::class.':'.$name;
+        return static::class.':'.enum_value($name);
     }
 
     /**

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -46,7 +46,7 @@ class ThrottleRequests
     /**
      * Specify the named rate limiter to use for the middleware.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return string
      */
     public static function using($name)

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -45,7 +45,7 @@ class ThrottleRequests
     /**
      * Specify the named rate limiter to use for the middleware.
      *
-     * @param  string|\UnitEnum  $name
+     * @param  \BackedEnum|\UnitEnum|string  $name
      * @return string
      */
     public static function using($name)

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+
 use function Illuminate\Support\enum_value;
 
 class ThrottleRequests


### PR DESCRIPTION
Hi guys,

Since our `RateLimiter` & `RateLimited` are already supporting enums, `ThrottleRequests::using` should too ✌️ 

Personally, I enjoy using this method (together with enums - of course - we have many rate limiters in our app)