### PR TITLE
[13.x] Compile full DELETE with JOIN including ORDER BY and LIMIT in MySQL grammar

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -461,7 +461,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a delete query that does not use joins.
+     * Compile a delete statement without joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $table
@@ -472,9 +472,33 @@ class MySqlGrammar extends Grammar
     {
         $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
 
-        // When using MySQL, delete statements may contain order by statements and limits
-        // so we will compile both of those here. Once we have finished compiling this
-        // we will return the completed SQL statement so it will be executed for us.
+        if (! empty($query->orders)) {
+            $sql .= ' '.$this->compileOrders($query, $query->orders);
+        }
+
+        if (isset($query->limit)) {
+            $sql .= ' '.$this->compileLimit($query, $query->limit);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Compile a delete statement with joins into SQL.
+     *
+     * Adds ORDER BY and LIMIT if present, for platforms that allow them (e.g., PlanetScale).
+     *
+     * Standard MySQL does not support ORDER BY or LIMIT with joined deletes and will throw a syntax error.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $table
+     * @param  string  $where
+     * @return string
+     */
+    protected function compileDeleteWithJoins(Builder $query, $table, $where)
+    {
+        $sql = parent::compileDeleteWithJoins($query, $table, $where);
+
         if (! empty($query->orders)) {
             $sql .= ' '.$this->compileOrders($query, $query->orders);
         }

--- a/tests/Database/DatabaseMySqlBuilderTest.php
+++ b/tests/Database/DatabaseMySqlBuilderTest.php
@@ -3,22 +3,25 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
-use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar as MySqlGrammarSchema;
 use Illuminate\Database\Schema\MySqlBuilder;
-use Mockery as m;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseMySqlBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
-        m::close();
+        Mockery::close();
     }
 
-    public function testCreateDatabase()
+    public function testCreateDatabase(): void
     {
-        $connection = m::mock(Connection::class);
-        $grammar = new MySqlGrammar($connection);
+        $connection = Mockery::mock(Connection::class);
+        $grammar = new MySqlGrammarSchema($connection);
 
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8mb4');
         $connection->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
@@ -33,8 +36,8 @@ class DatabaseMySqlBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $connection = m::mock(Connection::class);
-        $grammar = new MySqlGrammar($connection);
+        $connection = Mockery::mock(Connection::class);
+        $grammar = new MySqlGrammarSchema($connection);
 
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
@@ -44,5 +47,29 @@ class DatabaseMySqlBuilderTest extends TestCase
         $builder = new MySqlBuilder($connection);
 
         $builder->dropDatabaseIfExists('my_database_a');
+    }
+
+    public function testDeleteWithJoinCompilesOrderByAndLimit(): void
+    {
+        $connection = Mockery::mock(Connection::class);
+        $processor = Mockery::mock(Processor::class);
+        $grammar = new MySqlGrammar($connection);
+
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+
+        $builder = new Builder($connection, $grammar, $processor);
+
+        $builder
+            ->from('users')
+            ->join('contacts', 'users.id', '=', 'contacts.id')
+            ->where('email', '=', 'foo')
+            ->orderBy('users.id')
+            ->limit(5);
+
+        $sql = $grammar->compileDelete($builder);
+
+        $this->assertStringContainsString('order by `users`.`id` asc', $sql);
+        $this->assertStringContainsString('limit 5', $sql);
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4478,17 +4478,17 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `email` = ?', ['foo'])->andReturn(1);
-        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
+        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->delete();
         $this->assertEquals(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `a` from `users` as `a` inner join `users` as `b` on `a`.`id` = `b`.`user_id` where `email` = ?', ['foo'])->andReturn(1);
-        $result = $builder->from('users AS a')->join('users AS b', 'a.id', '=', 'b.user_id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();
+        $result = $builder->from('users AS a')->join('users AS b', 'a.id', '=', 'b.user_id')->where('email', '=', 'foo')->delete();
         $this->assertEquals(1, $result);
 
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `users`.`id` = ?', [1])->andReturn(1);
-        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->orderBy('id')->limit(1)->delete(1);
+        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete(1);
         $this->assertEquals(1, $result);
 
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
### Problem

By default, Laravel silently ignores `ORDER BY` and `LIMIT` on `DELETE … JOIN` queries when using the MySQL grammar.
This results in unexpected behavior: instead of deleting rows in small batches, the query deletes *all* matching rows at once.

Example:

```php
$batchSize = 500;
$totalDeleted = 0;

do {
	$deleted = DB::table('cross_product_references as cpr')
		->leftJoin('products as p1', fn($join) => $join
			->on('cpr.article', '=', 'p1.article')
			->on('cpr.brand_id', '=', 'p1.brand_id'))
		->leftJoin('products as p2', fn($join) => $join
			->on('cpr.cross_article', '=', 'p2.article')
			->on('cpr.cross_brand_id', '=', 'p2.brand_id'))
		->where(fn($query) => $query
			->whereNull('p1.id')
			->orWhereNull('p2.id'))
		->limit($batchSize)
		->orderBy('cpr.id')
		->delete();
	$totalDeleted += $deleted;
} while ($deleted > 0);

$this->line("Deleted <info>$totalDeleted</info> rows.");
```

**Expected:** delete in batches of 500
**Actual:** deletes all 500k+ rows in one query

---

### Fix

* Added `compileDeleteWithJoins` override in `MySqlGrammar`.
* Now compiles full SQL with `JOIN`, `ORDER BY`, and `LIMIT` instead of stripping them.
* Leaves it to the underlying MySQL/MariaDB/Vitess implementation to decide whether the query is valid.

---

### Why

* Avoids silent ignoring of `ORDER BY` and `LIMIT`, which could lead to **accidental mass deletions**.
* Provides consistent behavior: Laravel now generates the full query requested by the developer.
* Compatible with systems like Vitess, which do support `DELETE … JOIN … ORDER BY/LIMIT`.
* On vanilla MySQL, developers will now get `QueryException`.