### PR TITLE
[12.x] Fixes incorrectly serializing virtual properties

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,6 +4,7 @@ php:
   finder:
     not-name:
       - bad-syntax-strategy.php
+      - "*ExcludedFromStyleCiTest.php"
 js:
   finder:
     exclude:

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2586,14 +2586,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @return string[]
      */
-    public function __sleep()
+    public function __serialize(): array
     {
         $this->mergeAttributesFromCachedCasts();
 
         // When serializing the model, we may accidentally catch up some virtual properties.
-        // We will cast the model to a native array to skip them and then apply a function
-        // to clean each of the property names which is miles faster than using a regex.
-        $props = (array) $this;
+        // We will transform the instance to an array to skip them, and then we will remove
+        // the model caches so those values are not serialized with the rest of the model.
+        $props = get_mangled_object_vars($this);
 
         unset(
             $props["\0*\0classCastCache"],
@@ -2602,12 +2602,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $props["\0*\0relationAutoloadContext"],
         );
 
-        return array_map(
-            fn ($key) => $key[0] === "\0"
-                ? substr($key, strpos($key, "\0", 1) + 1)
-                : $key,
-            array_keys($props)
-        );
+        return $props;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2584,25 +2584,29 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Prepare the object for serialization.
      *
-     * @return array
+     * @return string[]
      */
     public function __sleep()
     {
         $this->mergeAttributesFromCachedCasts();
 
-        $this->classCastCache = [];
-        $this->attributeCastCache = [];
-        $this->relationAutoloadCallback = null;
-        $this->relationAutoloadContext = null;
-
         // When serializing the model, we may accidentally catch up some virtual properties.
         // We will cast the model to a native array to skip them and then apply a function
         // to clean each of the property names which is miles faster than using a regex.
+        $props = (array) $this;
+
+        unset(
+            $props["\0*\0classCastCache"],
+            $props["\0*\0attributeCastCache"],
+            $props["\0*\0relationAutoloadCallback"],
+            $props["\0*\0relationAutoloadContext"],
+        );
+
         return array_map(
             fn ($key) => $key[0] === "\0"
                 ? substr($key, strpos($key, "\0", 1) + 1)
                 : $key,
-            array_keys((array) $this)
+            array_keys($props)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2595,7 +2595,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->relationAutoloadCallback = null;
         $this->relationAutoloadContext = null;
 
-        return array_keys(get_object_vars($this));
+        // When serializing the model, we may accidentally catch up some virtual properties.
+        // We will cast the model to a native array to skip them and then apply a function
+        // to clean each of the property names which is miles faster than using a regex.
+        return array_map(
+            fn ($key) => $key[0] === "\0"
+                ? substr($key, strpos($key, "\0", 1) + 1)
+                : $key,
+            array_keys((array) $this)
+        );
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3949,6 +3949,7 @@ class EloquentModelGetMutatorsStub extends Model
 if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
     class EloquentModelWithVirtualPropertiesStub extends Model
     {
+        // php-cs-fixer-disable
         public $virtualGet {
             get => $this->foo;
         }
@@ -3959,6 +3960,7 @@ if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
                 //
             }
         }
+        // php-cs-fixer-enable
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3356,20 +3356,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->getAttribute('duplicatedAttribute'));
     }
 
-    public function testModelSkipsVirtualPropertiesOnSerialization()
-    {
-        if (!class_exists(EloquentModelWithVirtualPropertiesStub::class)) {
-            $this->markTestSkipped('Virtual properties are not supported for PHP 8.3 or below.');
-        }
-
-        $model = new EloquentModelWithVirtualPropertiesStub();
-
-        $serialized = serialize($model);
-
-        $this->assertStringNotContainsString('virtualGet', $serialized);
-        $this->assertStringNotContainsString('virtualSet', $serialized);
-    }
-
     public function testCastOnArrayFormatWithOneElement()
     {
         $model = new EloquentModelCastingStub;
@@ -3943,24 +3929,6 @@ class EloquentModelGetMutatorsStub extends Model
     public function doNotGetFourthInvalidAttributeEither()
     {
         //
-    }
-}
-
-if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
-    class EloquentModelWithVirtualPropertiesStub extends Model
-    {
-        // php-cs-fixer-disable
-        public $virtualGet {
-            get => $this->foo;
-        }
-
-        public $virtualSet {
-            get => $this->foo;
-            set {
-                //
-            }
-        }
-        // php-cs-fixer-enable
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3356,6 +3356,20 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->getAttribute('duplicatedAttribute'));
     }
 
+    public function testModelSkipsVirtualPropertiesOnSerialization()
+    {
+        if (!class_exists(EloquentModelWithVirtualPropertiesStub::class)) {
+            $this->markTestSkipped('Virtual properties are not supported for PHP 8.3 or below.');
+        }
+
+        $model = new EloquentModelWithVirtualPropertiesStub();
+
+        $serialized = serialize($model);
+
+        $this->assertStringNotContainsString('virtualGet', $serialized);
+        $this->assertStringNotContainsString('virtualSet', $serialized);
+    }
+
     public function testCastOnArrayFormatWithOneElement()
     {
         $model = new EloquentModelCastingStub;
@@ -3929,6 +3943,22 @@ class EloquentModelGetMutatorsStub extends Model
     public function doNotGetFourthInvalidAttributeEither()
     {
         //
+    }
+}
+
+if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
+    class EloquentModelWithVirtualPropertiesStub extends Model
+    {
+        public $virtualGet {
+            get => $this->foo;
+        }
+
+        public $virtualSet {
+            get => $this->foo;
+            set {
+                //
+            }
+        }
     }
 }
 

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Foundation\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
 {

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\TestCase;
+
+class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
+{
+    public function testModelSkipsVirtualPropertiesOnSerialization()
+    {
+        if (version_compare(PHP_VERSION, '8.4.0-dev', '<')) {
+            $this->markTestSkipped('Requires Virtual Properties.');
+        }
+
+        $model = new EloquentModelWithVirtualPropertiesStub();
+
+        $serialized = serialize($model);
+
+        $this->assertStringNotContainsString('virtualGet', $serialized);
+        $this->assertStringNotContainsString('virtualSet', $serialized);
+    }
+}
+
+class EloquentModelWithVirtualPropertiesStub extends Model
+{
+    public $virtualGet {
+        get => $this->foo;
+    }
+
+    public $virtualSet {
+        get => $this->foo;
+        set {
+            //
+        }
+    }
+}

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -22,16 +22,18 @@ class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
     }
 }
 
-class EloquentModelWithVirtualPropertiesStub extends Model
-{
-    public $virtualGet {
-        get => $this->foo;
-    }
+if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
+    class EloquentModelWithVirtualPropertiesStub extends Model
+    {
+        public $virtualGet {
+            get => $this->foo;
+        }
 
-    public $virtualSet {
-        get => $this->foo;
-        set {
-            //
+        public $virtualSet {
+            get => $this->foo;
+            set {
+                //
+            }
         }
     }
 }

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\TestCase;
 
 class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
@@ -23,17 +22,26 @@ class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
 }
 
 if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
-    class EloquentModelWithVirtualPropertiesStub extends Model
-    {
-        public $virtualGet {
-            get => $this->foo;
-        }
+    eval(<<<'MODEL'
+<?php
 
-        public $virtualSet {
-            get => $this->foo;
-            set {
-                //
-            }
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelWithVirtualPropertiesStub extends Model
+{
+    public $virtualGet {
+        get => $this->foo;
+    }
+
+    public $virtualSet {
+        get => $this->foo;
+        set {
+            //
         }
     }
+}
+MODEL
+    );
 }

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -22,9 +22,7 @@ class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
 }
 
 if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
-    eval(<<<'MODEL'
-<?php
-
+    eval(<<<'PHP'
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Eloquent\Model;
@@ -42,6 +40,7 @@ class EloquentModelWithVirtualPropertiesStub extends Model
         }
     }
 }
-MODEL
+
+PHP
     );
 }

--- a/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
+++ b/tests/Database/DatabaseEloquentSerializationExcludedFromStyleCiTest.php
@@ -13,11 +13,18 @@ class DatabaseEloquentSerializationExcludedFromStyleCiTest extends TestCase
         }
 
         $model = new EloquentModelWithVirtualPropertiesStub();
+        $model->foo = 'bar';
 
         $serialized = serialize($model);
 
         $this->assertStringNotContainsString('virtualGet', $serialized);
         $this->assertStringNotContainsString('virtualSet', $serialized);
+
+        // Ensure attributes and protected normal attributes are also serialized.
+        $this->assertStringContainsString('foo', $serialized);
+        $this->assertStringContainsString('bar', $serialized);
+        $this->assertStringContainsString('isVisible', $serialized);
+        $this->assertStringContainsString('yes', $serialized);
     }
 }
 
@@ -39,6 +46,8 @@ class EloquentModelWithVirtualPropertiesStub extends Model
             //
         }
     }
+
+    protected $isVisible = 'yes';
 }
 
 PHP


### PR DESCRIPTION
# The problem

When adding virtual properties to models, serializing them (like when happens when these are stored in a cache store) will return an error.

For example, consider the following model:

```php
class Cart extends Model
{

    public $total {
        get => $this->items->sumBy('net') * $this->items->sumBy('amount');
        set {
            $count = $this->items->sumBy('amount');

            $this->items->each(fn ($item) => $item->net = $value / $count);
        }
    }

    // ..
}
```

When trying to serialize it with `serialize($model)`, like it happens when using the application cache, it will return an error like this:

    serialize(): &quot;total&quot; returned as member variable from __sleep() but does not exist

This may be cumbersome if someone is adding virtual properties to a model for whatever reason, like live calculation or else, because the patchwork is to alter the `__sleep()` method **on each offending class**, or use alternative abstract Model and hope nothing breaks in between.

# The Fix

The fix uses a simple `(array)` cast to the model instance to get the non-virtual keys, and an `array_map` to clean the name of each key returned.