### PR TITLE
Regenerate session during Auth::login()

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -566,7 +566,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Update the session with the given user ID and regenerate the session's token.
+     * Update the session with the given ID and regenerate the session's token.
      *
      * @param  string  $id
      * @return void

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -575,7 +575,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $this->session->put($this->getName(), $id);
 
-        $this->session->migrate(true);
+        $this->session->regenerate(true);
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -566,7 +566,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Update the session with the given user ID and regenerate.
+     * Update the session with the given user ID and regenerate the session's token.
      *
      * @param  string  $id
      * @return void

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -566,7 +566,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Update the session with the given ID.
+     * Update the session with the given user ID and regenerate.
      *
      * @param  string  $id
      * @return void

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -158,7 +158,7 @@ class AuthGuardTest extends TestCase
         $mock->expects($this->once())->method('getName')->willReturn('foo');
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $mock->getProvider()->shouldReceive('retrieveByCredentials')->times(3)->with(['foo'])->andReturn($user);
         $mock->getProvider()->shouldReceive('validateCredentials')->twice()->andReturnTrue();
         $mock->getProvider()->shouldReceive('validateCredentials')->once()->andReturnFalse();
@@ -233,7 +233,7 @@ class AuthGuardTest extends TestCase
         $mock->expects($this->once())->method('getName')->willReturn('foo');
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $mock->login($user);
     }
 
@@ -261,7 +261,7 @@ class AuthGuardTest extends TestCase
         $mock->expects($this->once())->method('getName')->willReturn('foo');
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $mock->login($user);
     }
 
@@ -501,7 +501,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 576000)->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('bar');
@@ -521,7 +521,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 5000)->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('bar');
@@ -540,7 +540,7 @@ class AuthGuardTest extends TestCase
         $cookie->shouldReceive('make')->once()->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
         $user->shouldReceive('getAuthPassword')->andReturn('foo');
@@ -608,7 +608,7 @@ class AuthGuardTest extends TestCase
         $guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $guard->getSession()->shouldReceive('put')->with($guard->getName(), 'bar')->once();
-        $session->shouldReceive('migrate')->once();
+        $session->shouldReceive('regenerate')->once();
         $this->assertSame($user, $guard->user());
         $this->assertTrue($guard->viaRemember());
     }


### PR DESCRIPTION
Use `Session::regenerate()` instead of `Session::migrate()` during the login flow.