### PR TITLE
[12.x] [Mail] Update `alwaysTo` signature for array usage

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -142,7 +142,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Set the global to address and name.
      *
-     * @param  string  $address
+     * @param  string[]|string  $address
      * @param  string|null  $name
      * @return void
      */

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static void alwaysFrom(string $address, string|null $name = null)
  * @method static void alwaysReplyTo(string $address, string|null $name = null)
  * @method static void alwaysReturnPath(string $address)
- * @method static void alwaysTo(string[]|string $address, string|null $name = null)
+ * @method static void alwaysTo(string $address, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail to(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail cc(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail bcc(mixed $users, string|null $name = null)

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\MailFake;
  * @method static void alwaysFrom(string $address, string|null $name = null)
  * @method static void alwaysReplyTo(string $address, string|null $name = null)
  * @method static void alwaysReturnPath(string $address)
- * @method static void alwaysTo(string $address, string|null $name = null)
+ * @method static void alwaysTo(string[]|string $address, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail to(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail cc(mixed $users, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail bcc(mixed $users, string|null $name = null)


### PR DESCRIPTION
Thanks to `compact` usage, `alwaysTo` handles an array of addresses but this is not reflected in PHPDoc

For dev or testing purpose it can be useful to send mails to several people, this PR aims to align code and doc