### PR TITLE
[12.x] Remove unnecessary parentheses

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -39,9 +39,9 @@ class SqliteSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
-        ($process = $this->makeProcess(
+        $process = $this->makeProcess(
             $this->baseCommand().' ".dump \''.$this->getMigrationTable().'\'"'
-        ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
+        )->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));
 


### PR DESCRIPTION
Reopen: #57055

---

Description
---
The `mustRun()` returns `this`, making parentheses redundant.

Reference
---
https://github.com/symfony/process/blob/f24f8f316367b30810810d4eb30c543d7003ff3b/Process.php#L254-L273