### PR TITLE
[13.x] Fix scopedBy attribute not following inheritance chain

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use ReflectionAttribute;
 use ReflectionClass;
 
 trait HasGlobalScopes
@@ -31,7 +32,7 @@ trait HasGlobalScopes
     {
         $reflectionClass = new ReflectionClass(static::class);
 
-        return (new Collection($reflectionClass->getAttributes(ScopedBy::class)))
+        return (new Collection($reflectionClass->getAttributes(ScopedBy::class, ReflectionAttribute::IS_INSTANCEOF)))
             ->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
             ->all();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -32,8 +32,13 @@ trait HasGlobalScopes
     {
         $reflectionClass = new ReflectionClass(static::class);
 
-        return (new Collection($reflectionClass->getAttributes(ScopedBy::class, ReflectionAttribute::IS_INSTANCEOF)))
-            ->map(fn ($attribute) => $attribute->getArguments())
+        $attributes = (new Collection($reflectionClass->getAttributes(ScopedBy::class, ReflectionAttribute::IS_INSTANCEOF)));
+
+        foreach ($reflectionClass->getTraits() as $trait) {
+            $attributes->push(...$trait->getAttributes(ScopedBy::class, ReflectionAttribute::IS_INSTANCEOF));
+        }
+
+        return $attributes->map(fn ($attribute) => $attribute->getArguments())
             ->flatten()
             ->all();
     }

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -277,7 +277,8 @@ class ActiveScope implements Scope
 }
 
 #[ScopedBy(ActiveScope::class)]
-trait EloquentGlobalScopeInInheritedAttributeTestTrait {
+trait EloquentGlobalScopeInInheritedAttributeTestTrait
+{
     //
 }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -60,6 +60,14 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testGlobalScopeInInheritedAttributeIsApplied()
+    {
+        $model = new EloquentGlobalScopeInInheritedAttributeTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
     public function testClosureGlobalScopeIsApplied()
     {
         $model = new EloquentClosureGlobalScopesTestModel;
@@ -266,4 +274,16 @@ class ActiveScope implements Scope
     {
         return $builder->where('active', 1);
     }
+}
+
+#[ScopedBy(ActiveScope::class)]
+trait EloquentGlobalScopeInInheritedAttributeTestTrait {
+    //
+}
+
+class EloquentGlobalScopeInInheritedAttributeTestModel extends Model
+{
+    use EloquentGlobalScopeInInheritedAttributeTestTrait;
+
+    protected $table = 'table';
 }


### PR DESCRIPTION
This PR updates the global `ScopedBy` attribute to match the behaviour of global scopes added via the `booted` static method.

## Example

Global Scope with trait attribute (does not work):

```php
class PublishedScope implements Scope
{
    public function apply(Builder $builder, Model $model)
    {
      $builder->where('published', '=', 1);
    }
}

#[ScopedBy([PublishedScope::class])]
trait IsPost {

}

// Will not apply the global scope
class Post extends Model {
   use IsPost;
}
```

Global scope with static booted method (works):

```php
class PublishedScope implements Scope
{
    public function apply(Builder $builder, Model $model)
    {
      $builder->where('published', '=', 1);
    }
}

trait IsPost {
    protected static function booted(): void
    {
        static::addGlobalScope(new PublishedScope);
    }
}

// Applies global scope
class Post extends Model {
   use IsPost;
}
```

After this PR both should work and be handled identically.

Targeting 13.x because I think this may be considered a breaking change. I will also leave in draft while I add a test.