### PR TITLE
[12.x] Fix AWS S3 adapter's constructor not allowing decorated adapter instances

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -4,7 +4,7 @@ namespace Illuminate\Filesystem;
 
 use Aws\S3\S3Client;
 use Illuminate\Support\Traits\Conditionable;
-use League\Flysystem\AwsS3V3\AwsS3V3Adapter as S3Adapter;
+use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
 use League\Flysystem\FilesystemOperator;
 
 class AwsS3V3Adapter extends FilesystemAdapter
@@ -22,11 +22,11 @@ class AwsS3V3Adapter extends FilesystemAdapter
      * Create a new AwsS3V3FilesystemAdapter instance.
      *
      * @param  \League\Flysystem\FilesystemOperator  $driver
-     * @param  \League\Flysystem\AwsS3V3\AwsS3V3Adapter  $adapter
+     * @param  \League\Flysystem\FilesystemAdapter  $adapter
      * @param  array  $config
      * @param  \Aws\S3\S3Client  $client
      */
-    public function __construct(FilesystemOperator $driver, S3Adapter $adapter, array $config, S3Client $client)
+    public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config, S3Client $client)
     {
         parent::__construct($driver, $adapter, $config);
 


### PR DESCRIPTION
**URGENT FIX**

@taylorotwell 

This is follow up of #57167.
AWS S3 adapter's constructor is too tight for decorated adapter instances rn.
This PR fixes this by adjusting its signature to be on par with it's parent constructor.