### PR TITLE
[12.x] Redis: allow skipping prefix for keyspace events

### DIFF
--- a/tests/Redis/Connections/PhpRedisConnectionTest.php
+++ b/tests/Redis/Connections/PhpRedisConnectionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use PHPUnit\Framework\TestCase;
+
+class PhpRedisConnectionTest extends TestCase
+{
+    public function test_applies_prefix_to_normal_channel()
+    {
+        $mockClient = $this->createMock(\Redis::class);
+        $mockClient->method('getOption')
+            ->with(\Redis::OPT_PREFIX)
+            ->willReturn('myprefix:');
+
+        $conn = new PhpRedisConnection($mockClient, null, ['options' => []]);
+
+        $method = new \ReflectionMethod($conn, 'channelsWithAppliedPrefix');
+        $method->setAccessible(true);
+
+        $this->assertSame(['myprefix:orders'], $method->invoke($conn, ['orders']));
+    }
+
+    public function test_skips_prefix_for_keyevent_channel()
+    {
+        $mockClient = $this->createMock(\Redis::class);
+        $mockClient->method('getOption')
+            ->with(\Redis::OPT_PREFIX)
+            ->willReturn('myprefix:');
+
+        $conn = new PhpRedisConnection($mockClient, null, ['options' => []]);
+
+        $method = new \ReflectionMethod($conn, 'channelsWithAppliedPrefix');
+        $method->setAccessible(true);
+
+        $this->assertSame(['__keyevent@0__:expired'], $method->invoke($conn, ['__keyevent@0__:expired']));
+    }
+}

--- a/tests/Redis/Connections/PredisConnectionTest.php
+++ b/tests/Redis/Connections/PredisConnectionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Redis\Connections;
+
+use Illuminate\Redis\Connections\PredisConnection;
+use PHPUnit\Framework\TestCase;
+
+class PredisConnectionTest extends TestCase
+{
+    public function test_applies_prefix_to_normal_channel()
+    {
+        $mockClient = $this->createMock(\Predis\Client::class);
+        $mockClient->method('getOptions')
+            ->willReturn((object) ['prefix' => 'myprefix:']);
+
+        $conn = new PredisConnection($mockClient);
+
+        $method = new \ReflectionMethod($conn, 'channelsWithAppliedPrefix');
+        $method->setAccessible(true);
+
+        $this->assertSame(['myprefix:orders'], $method->invoke($conn, ['orders']));
+    }
+
+    public function test_skips_prefix_for_keyevent_channel()
+    {
+        $mockClient = $this->createMock(\Predis\Client::class);
+        $mockClient->method('getOptions')
+            ->willReturn((object) ['prefix' => 'myprefix:']);
+
+        $conn = new PredisConnection($mockClient);
+
+        $method = new \ReflectionMethod($conn, 'channelsWithAppliedPrefix');
+        $method->setAccessible(true);
+
+        $this->assertSame(['__keyevent@0__:expired'], $method->invoke($conn, ['__keyevent@0__:expired']));
+    }
+}


### PR DESCRIPTION
This PR allows subscribing to Redis global keyspace/keyevent notifications
without applying the configured prefix.

**What’s changed**
- Implement `channelsWithAppliedPrefix` in PhpRedis and Predis connections.
- `subscribe` / `psubscribe` temporarily disable the client prefix and apply it manually only when needed.
- Add tests to ensure global channels (`__keyevent@*__:` / `__keyspace@*__:`) are subscribed without a prefix, while normal channels keep the prefix.

**Why**
Redis reserves these channels for keyspace notifications; prefixing them prevents receiving events (e.g., `expired`). This enables listening to global events without removing the app’s prefix.

**BC**
No breaking changes. Existing behavior is preserved for normal channels. Global channels are exempt from prefixing.

**Notes**
Applications may optionally expose a config option (e.g. `skip_prefix_for_channels`) to customize patterns; this PR doesn’t change the default app config in `laravel/laravel`.


Closes #57161
