### PR TITLE
[12.x] Clean up redundant type hints in docblocks

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -36,7 +36,7 @@ class ApcStore extends TaggableStore
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @return mixed|null
+     * @return mixed
      */
     public function get($key)
     {

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -8,7 +8,7 @@ class ApcWrapper
      * Get an item from the cache.
      *
      * @param  string  $key
-     * @return mixed|null
+     * @return mixed
      */
     public function get($key)
     {


### PR DESCRIPTION
Description
---
PR #56411 removed those instances, but these two were newly introduced in #57020.