### PR TITLE
[12.x] Define LARAVEL_START if not already defined

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -63,7 +63,9 @@ class ComposerScripts
 
         require_once $vendorDir.'/autoload.php';
 
+        if (! defined('LARAVEL_START')) {
         define('LARAVEL_START', microtime(true));
+        }
 
         /** @var Application $app */
         $app = require_once $bootstrapFile;

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -64,7 +64,7 @@ class ComposerScripts
         require_once $vendorDir.'/autoload.php';
 
         if (! defined('LARAVEL_START')) {
-        define('LARAVEL_START', microtime(true));
+            define('LARAVEL_START', microtime(true));
         }
 
         /** @var Application $app */


### PR DESCRIPTION
Prevent failure from attempting to redefine an already defined constant. Related: https://github.com/laravel/framework/issues/57220