### PR TITLE
[12.x] Ensure calling job within a group works as expected

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -200,7 +200,8 @@ class Schedule
                 : $job::class;
         }
 
-        return $this->name($jobName)->call(function () use ($job, $queue, $connection) {
+        $this->events[] = $event = new CallbackEvent(
+            $this->eventMutex, function () use ($job, $queue, $connection) {
             $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
             if ($job instanceof ShouldQueue) {
@@ -208,7 +209,14 @@ class Schedule
             } else {
                 $this->dispatchNow($job);
             }
-        });
+        }, [], $this->timezone
+        );
+
+        $event->name($jobName);
+
+        $this->mergePendingAttributes($event);
+
+        return $event;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -202,14 +202,14 @@ class Schedule
 
         $this->events[] = $event = new CallbackEvent(
             $this->eventMutex, function () use ($job, $queue, $connection) {
-            $job = is_string($job) ? Container::getInstance()->make($job) : $job;
+                $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
-            if ($job instanceof ShouldQueue) {
-                $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
-            } else {
-                $this->dispatchNow($job);
-            }
-        }, [], $this->timezone
+                if ($job instanceof ShouldQueue) {
+                    $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
+                } else {
+                    $this->dispatchNow($job);
+                }
+            }, [], $this->timezone
         );
 
         $event->name($jobName);

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -200,17 +200,16 @@ class ScheduleGroupTest extends TestCase
     public function testGroupedPendingEventAttributesWithoutOverlap()
     {
         $schedule = new ScheduleClass;
-        $schedule->weekdays()
-            ->withoutOverlapping()->group(function ($schedule) {
-                $schedule->command('inspire')->at('00:00'); // this is event, not pending attribute
-                $schedule->at('01:00')->command('inspire'); // this is pending attribute
-                $schedule->command('inspire');  // this goes back to group pending attribute
-                $schedule->job(JobToTestWithSchedule::class)->at('04:00'); // this is event, not pending attribute
-            });
+        $schedule->weekdays()->withoutOverlapping()->group(function ($schedule) {
+            $schedule->command('inspire')->at('14:00'); // this is event, not pending attribute
+            $schedule->at('03:00')->command('inspire'); // this is pending attribute
+            $schedule->command('inspire');  // this goes back to group pending attribute
+            $schedule->job(JobToTestWithSchedule::class)->at('04:00');  // this is pending attribute
+        });
 
         $events = $schedule->events();
-        $this->assertSame('0 0 * * 1-5', $events[0]->expression);
-        $this->assertSame('0 1 * * 1-5', $events[1]->expression);
+        $this->assertSame('0 14 * * 1-5', $events[0]->expression);
+        $this->assertSame('0 3 * * 1-5', $events[1]->expression);
         $this->assertSame('* * * * 1-5', $events[2]->expression);
         $this->assertSame('0 4 * * 1-5', $events[3]->expression);
     }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -7,6 +7,7 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 use Illuminate\Console\Scheduling\Schedule as ScheduleClass;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schedule;
+use Illuminate\Tests\Console\Fixtures\JobToTestWithSchedule;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -194,5 +195,22 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('0 0 * * 1-5', $events[0]->expression);
         $this->assertSame('0 1 * * 1-5', $events[1]->expression);
         $this->assertSame('* * * * 1-5', $events[2]->expression);
+    }
+
+    public function testGroupedPendingEventAttributesWithoutOverlap() {
+        $schedule = new ScheduleClass;
+        $schedule->weekdays()
+            ->withoutOverlapping()->group(function ($schedule) {
+                $schedule->command('inspire')->at('00:00'); // this is event, not pending attribute
+                $schedule->at('01:00')->command('inspire'); // this is pending attribute
+                $schedule->command('inspire');  // this goes back to group pending attribute
+                $schedule->job(JobToTestWithSchedule::class)->at('04:00'); // this is event, not pending attribute
+            });
+
+        $events = $schedule->events();
+        $this->assertSame('0 0 * * 1-5', $events[0]->expression);
+        $this->assertSame('0 1 * * 1-5', $events[1]->expression);
+        $this->assertSame('* * * * 1-5', $events[2]->expression);
+        $this->assertSame('0 4 * * 1-5', $events[3]->expression);
     }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -197,7 +197,7 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('* * * * 1-5', $events[2]->expression);
     }
 
-    public function testGroupedPendingEventAttributesWithoutOverlap()
+    public function testGroupedPendingEventAttributesWithoutOverlapping()
     {
         $schedule = new ScheduleClass;
         $schedule->weekdays()->withoutOverlapping()->group(function ($schedule) {

--- a/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleGroupTest.php
@@ -197,7 +197,8 @@ class ScheduleGroupTest extends TestCase
         $this->assertSame('* * * * 1-5', $events[2]->expression);
     }
 
-    public function testGroupedPendingEventAttributesWithoutOverlap() {
+    public function testGroupedPendingEventAttributesWithoutOverlap()
+    {
         $schedule = new ScheduleClass;
         $schedule->weekdays()
             ->withoutOverlapping()->group(function ($schedule) {


### PR DESCRIPTION
When upgrading from 12.31 to 12.32  its stopping composer from updating: 

```
> @php artisan package:discover --ansi

In CallbackEvent.php line 141:
                                                                               
  A scheduled event name is required to prevent overlapping. Use the 'name' m  
  ethod before 'withoutOverlapping'.                                           
                                                                               

Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
                                   
``` 

This happens due to using Schedule::job within a group that uses `withoutOverlapping` and seems to have been introduced via https://github.com/laravel/framework/pull/57156

This approach makes the event directly, and merges any pending attributes afterwards and ensures the name is set, which works as expected.

The alternative is to revert the above change, but then groups won't work as expected either 😢 