### PR TITLE
[12.x] Handle `Storage::url()` for scoped disks

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -20,6 +20,7 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Ftp\FtpAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter as LocalAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\PathPrefixing\PathPrefixedAdapter;
 use League\Flysystem\PhpseclibV3\SftpAdapter;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
@@ -736,7 +737,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             return $this->driver->getUrl($path);
         } elseif ($adapter instanceof FtpAdapter || $adapter instanceof SftpAdapter) {
             return $this->getFtpUrl($path);
-        } elseif ($adapter instanceof LocalAdapter) {
+        } elseif ($adapter instanceof LocalAdapter || $adapter instanceof PathPrefixedAdapter) {
             return $this->getLocalUrl($path);
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -240,4 +240,35 @@ class FilesystemManagerTest extends TestCase
             rmdir(__DIR__.'/../../to-be-scoped');
         }
     }
+
+    public function testScopedFilesystemDiskCanCallUrl()
+    {
+        try {
+            $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+                $app['config'] = [
+                    'filesystems.disks.local' => [
+                        'driver' => 'local',
+                        'root' => 'to-be-scoped',
+                    ],
+                ];
+            }));
+
+            $local = $filesystem->disk('local');
+            $scoped = $filesystem->build([
+                'driver' => 'scoped',
+                'disk' => 'local',
+                'prefix' => 'path-prefix',
+            ]);
+
+            $scoped->put('dirname/filename.txt', 'file content');
+
+            $scopedUrl = $scoped->url('dirname/filename.txt');
+            $this->assertEquals('/storage/path-prefix/dirname/filename.txt', $scopedUrl);
+        } finally {
+            unlink(__DIR__.'/../../to-be-scoped/path-prefix/dirname/filename.txt');
+            rmdir(__DIR__.'/../../to-be-scoped/path-prefix/dirname');
+            rmdir(__DIR__.'/../../to-be-scoped/path-prefix');
+            rmdir(__DIR__.'/../../to-be-scoped');
+        }
+    }
 }


### PR DESCRIPTION
To resolve https://github.com/laravel/framework/issues/57223

Prior to the change in https://github.com/laravel/framework/pull/57167/ the `$adapter` would've been an instance of `LocalFilesystemAdapter`, but now it is a `PathPrefixedAdapter`.

TODO: does this work for S3?