### PR TITLE
[12.x] Use `Container::getInstance()` in `ComposerScripts::prePackageUninstall()`

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Composer\Installer\PackageEvent;
 use Composer\Script\Event;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 
 class ComposerScripts
@@ -67,9 +68,10 @@ class ComposerScripts
             define('LARAVEL_START', microtime(true));
         }
 
-        /** @var Application $app */
-        $app = require_once $bootstrapFile;
+        require_once $bootstrapFile;
 
+        /** @var Application $app */
+        $app = Container::getInstance();
         $app->make(Kernel::class)->bootstrap();
 
         /** @var \Composer\DependencyResolver\Operation\UninstallOperation $uninstallOperation */


### PR DESCRIPTION
relying on the result of `require_once` doesn't work if multiple packages are being uninstalled 😓  `require_once` returns true the second time it's called (TIL).

Instead, we leverage `Container::getInstance()` and live happily ever after. 🤞 

See discussion: https://github.com/laravel/framework/issues/57220

Thanks to @htulibacki for reporting this and helping test.