### PR TITLE
Fix compiling queries that use orderByRaw with expressions

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -987,7 +987,10 @@ class Grammar extends BaseGrammar
      */
     protected function compileOrdersToArray(Builder $query, $orders)
     {
-        return array_map(function ($order) {
+        return array_map(function ($order) use ($query) {
+            if (isset($order['sql']) && $order['sql'] instanceof Expression) {
+                return $order['sql']->getValue($query->getGrammar());
+            }
             return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'];
         }, $orders);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -991,6 +991,7 @@ class Grammar extends BaseGrammar
             if (isset($order['sql']) && $order['sql'] instanceof Expression) {
                 return $order['sql']->getValue($query->getGrammar());
             }
+
             return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'];
         }, $orders);
     }


### PR DESCRIPTION
This fixes an issue caused by the removal of automatic casting of Expression objects to strings in Laravel 10.

```php
$sql = DB::table('users')
        ->select('id')
        ->orderByRaw(DB::raw('length(name) desc'))
        ->toSql();
```

fails without this change.

Related: #48652 