### PR TITLE
[12.x] Improve enum types for RateLimiter & RateLimited

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -41,7 +41,7 @@ class RateLimiter
     /**
      * Register a named limiter configuration.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @param  \Closure  $callback
      * @return $this
      */
@@ -57,7 +57,7 @@ class RateLimiter
     /**
      * Get the given named rate limiter.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return \Closure|null
      */
     public function limiter($name)
@@ -312,7 +312,7 @@ class RateLimiter
     /**
      * Resolve the rate limiter name.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return string
      */
     private function resolveLimiterName($name): string

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -42,7 +42,7 @@ class RateLimited
     /**
      * Create a new middleware instance.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $limiterName
+     * @param  \UnitEnum|string  $limiterName
      */
     public function __construct($limiterName)
     {


### PR DESCRIPTION
Hi team,

`BackedEnum` is `UnitEnum`, so here we remove the `\BackedEnum` type out for RateLimiter & RateLimited