### PR TITLE
[12.x] Narrow type after `Str::is*(...)` check

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -569,6 +569,8 @@ class Str
      *
      * @param  mixed  $value
      * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
      */
     public static function isJson($value)
     {
@@ -585,6 +587,8 @@ class Str
      * @param  mixed  $value
      * @param  array  $protocols
      * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
      */
     public static function isUrl($value, array $protocols = [])
     {
@@ -628,6 +632,8 @@ class Str
      * @param  mixed  $value
      * @param  int<0, 8>|'nil'|'max'|null  $version
      * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
      */
     public static function isUuid($value, $version = null)
     {
@@ -669,6 +675,8 @@ class Str
      *
      * @param  mixed  $value
      * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
      */
     public static function isUlid($value)
     {

--- a/types/Support/Str.php
+++ b/types/Support/Str.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Str;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @var mixed $json
+ * @var mixed $ulid
+ * @var mixed $url
+ * @var mixed $uuid
+ */
+if (Str::isJson($json)) {
+    assertType('non-empty-string', $json);
+} else {
+    assertType('mixed', $json);
+}
+
+if (Str::isUlid($ulid)) {
+    assertType('non-empty-string', $ulid);
+} else {
+    assertType('mixed', $ulid);
+}
+
+if (Str::isUrl($url)) {
+    assertType('non-empty-string', $url);
+} else {
+    assertType('mixed', $url);
+}
+
+if (Str::isUuid($uuid)) {
+    assertType('non-empty-string', $uuid);
+} else {
+    assertType('mixed', $uuid);
+}


### PR DESCRIPTION
With this PR, tools like PHPStan understand that when `Str::isUuid($var)` equals `true` that means that `$var` must be a string.

This has been implemented for `Str::isJson(...)`, `Str::isUlid(...)`, `Str::isUrl(...)` and `Str::isUuid(...)`