### PR TITLE
[12.x] Run tests on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4]
         phpunit: ['10.5.35', '11.5.3', '12.0.0', '12.4.0']
         stability: [prefer-lowest, prefer-stable]
         exclude:
@@ -48,6 +48,9 @@ jobs:
           - php: 8.2
             phpunit: '12.4.0'
         include:
+          - php: 8.5
+            phpunit: '12.4.0'
+            stability: prefer-stable
           - php: 8.3
             phpunit: '12.1.0'
             stability: prefer-stable
@@ -110,7 +113,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
+        php: [8.2, 8.3, 8.4]
         phpunit: ['10.5.35', '11.5.3', '12.0.0', '12.4.0']
         stability: [prefer-lowest, prefer-stable]
         exclude:
@@ -119,6 +122,9 @@ jobs:
           - php: 8.2
             phpunit: '12.4.0'
         include:
+          - php: 8.5
+            phpunit: '12.4.0'
+            stability: prefer-stable
           - php: 8.3
             phpunit: '12.1.0'
             stability: prefer-stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         phpunit: ['10.5.35', '11.5.3', '12.0.0', '12.4.0']
         stability: [prefer-lowest, prefer-stable]
         exclude:
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         phpunit: ['10.5.35', '11.5.3', '12.0.0', '12.4.0']
         stability: [prefer-lowest, prefer-stable]
         exclude:


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
With the first RC now available (see https://www.php.net/archive/2025.php#2025-09-25-3), keeping track of PHP 8.5 support in the test suite is probably worthwhile.

Draft until passing, fixes should probably be addressed in individual PRs.

Observed issues:
- #57141 Fix use of deprecated driver specific PDO constants
- ~~#57032 Replace __wakeup with __unserialize (deprecated in PHP 8.5)~~
- `PHP Warning:  unexpected NAN value was coerced to string in /home/runner/work/framework/framework/vendor/sebastian/exporter/src/Exporter.php on line 354` (and similar messages)
- `51) /home/runner/work/framework/framework/src/Illuminate/Queue/Worker.php:366
Using null as an array offset is deprecated, use an empty string instead`
- and more...

Observed deprecations from dependencies:
- `/home/runner/work/framework/framework/vendor/opis/json-schema/src/SchemaLoader.php:245
Method SplObjectStorage::contains() is deprecated since 8.5, use method SplObjectStorage::offsetExists() instead`
- and more...