### PR TITLE
Run tests on PostgreSQL version 18

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -147,6 +147,55 @@ jobs:
         env:
           DB_CONNECTION: mariadb
 
+  pgsql_18:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    services:
+      postgresql:
+        image: postgres:18
+        env:
+          POSTGRES_DB: laravel
+          POSTGRES_USER: forge
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: true
+
+    name: PostgreSQL 18
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql, :php-psr
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "12.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database
+        env:
+          DB_CONNECTION: pgsql
+          DB_USERNAME: forge
+          DB_PASSWORD: password
+
   pgsql_14:
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, CI only tests PostgreSQL up to version 14 ([released September 30, 2021](https://www.postgresql.org/support/versioning/)).
This PR updates the workflow to also include testing on the latest PostgreSQL version, ensuring compatibility with newer releases.

