### PR TITLE
Refine enum_value docblock with conditional return types

### DIFF
--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -12,8 +12,8 @@ if (! function_exists('Illuminate\Support\enum_value')) {
      * @template TDefault
      *
      * @param  TValue  $value
-     * @param  TDefault|callable(TValue): TDefault  $default
-     * @return ($value is empty ? TDefault : mixed)
+     * @param  TDefault|\Closure(): TDefault  $default
+     * @return ($value is \BackedEnum ? int|string : ($value is \UnitEnum ? string : ($value is null ? TDefault : TValue)))
      */
     function enum_value($value, $default = null)
     {


### PR DESCRIPTION
The `$default` parameter is updated
- from `TDefault|callable(TValue): TDefault`
- to `TDefault|\Closure(): TDefault`

for more precise typing, because The `value()` method check for Closure, not callable!

The return type previously defaulted to `mixed`. It is now expressed as a conditional type:

  `($value is \BackedEnum ? int|string : ($value is \UnitEnum ? string : ($value is null ? TDefault : TValue)))`

This ensures that static analyzers can better infer the actual return type depending on whether the input is a `BackedEnum`, `UnitEnum`, `null`, or another value.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
