### PR TITLE
[12.x] Add `@maybe` Blade directive for conditional HTML attributes

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -435,7 +435,7 @@ trait CompilesConditionals
             throw new ViewCompilationException('The @maybe directive requires exactly 2 parameters.');
         }
 
-        [ $attribute, $data ] = array_map('trim', $parts);
+        [$attribute, $data] = array_map('trim', $parts);
 
         return "<?php if($data !== '' && $data !== null && trim(is_bool($data) ? ($data ? 'true' : 'false') : $data) !== '') echo $attribute . '=\"' . e(is_bool($data) ? ($data ? 'true' : 'false') : $data) . '\"'; ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Contracts\View\ViewCompilationException;
 use Illuminate\Support\Str;
 
 trait CompilesConditionals
@@ -416,5 +417,26 @@ trait CompilesConditionals
     protected function compileEndPushIf()
     {
         return '<?php $__env->stopPush(); endif; ?>';
+    }
+
+    /**
+     * Compile conditional HTML attributes into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\View\ViewCompilationException
+     */
+    protected function compileMaybe($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression), 2);
+
+        if (2 !== count($parts)) {
+            throw new ViewCompilationException('The @maybe directive requires exactly 2 parameters.');
+        }
+
+        [ $attribute, $data ] = array_map('trim', $parts);
+
+        return "<?php if($data !== '' && $data !== null && trim(is_bool($data) ? ($data ? 'true' : 'false') : $data) !== '') echo $attribute . '=\"' . e(is_bool($data) ? ($data ? 'true' : 'false') : $data) . '\"'; ?>";
     }
 }

--- a/tests/View/Blade/BladeMaybeStatementsTest.php
+++ b/tests/View/Blade/BladeMaybeStatementsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Contracts\View\ViewCompilationException;
+
+class BladeMaybeStatementsTest extends AbstractBladeTestCase
+{
+    public function testMaybeWithMissingParameter()
+    {
+        $this->expectException(ViewCompilationException::class);
+        $this->expectExceptionMessage('The @maybe directive requires exactly 2 parameters.');
+
+        $string = "@maybe('title')";
+        $this->compiler->compileString($string);
+    }
+
+    public function testMaybeWithSimpleVariable()
+    {
+        $string = '<a @maybe(\'title\', $title)>Link</a>';
+        $expected = '<a <?php if($title !== \'\' && $title !== null && trim(is_bool($title) ? ($title ? \'true\' : \'false\') : $title) !== \'\') echo \'title\' . \'="\' . e(is_bool($title) ? ($title ? \'true\' : \'false\') : $title) . \'"\'; ?>>Link</a>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaybeWithObjectProperty()
+    {
+        $string = '<a @maybe(\'title\', $link->title)>Link</a>';
+        $expected = '<a <?php if($link->title !== \'\' && $link->title !== null && trim(is_bool($link->title) ? ($link->title ? \'true\' : \'false\') : $link->title) !== \'\') echo \'title\' . \'="\' . e(is_bool($link->title) ? ($link->title ? \'true\' : \'false\') : $link->title) . \'"\'; ?>>Link</a>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaybeWithArrayAccess()
+    {
+        $string = '<a @maybe(\'title\', $data[\'title\'])>Link</a>';
+        $expected = '<a <?php if($data[\'title\'] !== \'\' && $data[\'title\'] !== null && trim(is_bool($data[\'title\']) ? ($data[\'title\'] ? \'true\' : \'false\') : $data[\'title\']) !== \'\') echo \'title\' . \'="\' . e(is_bool($data[\'title\']) ? ($data[\'title\'] ? \'true\' : \'false\') : $data[\'title\']) . \'"\'; ?>>Link</a>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaybeWithMultipleAttributes()
+    {
+        $string = '<img @maybe(\'alt\', $alt) @maybe(\'data-src\', $src)/>';
+        $expected = '<img <?php if($alt !== \'\' && $alt !== null && trim(is_bool($alt) ? ($alt ? \'true\' : \'false\') : $alt) !== \'\') echo \'alt\' . \'="\' . e(is_bool($alt) ? ($alt ? \'true\' : \'false\') : $alt) . \'"\'; ?> <?php if($src !== \'\' && $src !== null && trim(is_bool($src) ? ($src ? \'true\' : \'false\') : $src) !== \'\') echo \'data-src\' . \'="\' . e(is_bool($src) ? ($src ? \'true\' : \'false\') : $src) . \'"\'; ?>/>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaybeWithSpacesAroundParameters()
+    {
+        $string = '<a @maybe( \'title\' ,   $title )>Link</a>';
+        $expected = '<a <?php if($title !== \'\' && $title !== null && trim(is_bool($title) ? ($title ? \'true\' : \'false\') : $title) !== \'\') echo \'title\' . \'="\' . e(is_bool($title) ? ($title ? \'true\' : \'false\') : $title) . \'"\'; ?>>Link</a>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testMaybeWithNonEmptyString()
+    {
+        $this->assertSame(
+            "<?php if(\$title !== '' && \$title !== null && trim(is_bool(\$title) ? (\$title ? 'true' : 'false') : \$title) !== '') echo 'title' . '=\"' . e(is_bool(\$title) ? (\$title ? 'true' : 'false') : \$title) . '\"'; ?>",
+            $this->compiler->compileString("@maybe('title', \$title)")
+        );
+    }
+
+    public function testMaybeWithEmptyString()
+    {
+        $string = "@maybe('title', \$title)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('', $this->evaluateBlade($compiled, ['title' => '']));
+    }
+
+    public function testMaybeWithNull()
+    {
+        $string = "@maybe('title', \$title)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('', $this->evaluateBlade($compiled, ['title' => null]));
+    }
+
+    public function testMaybeWithZero()
+    {
+        $string = "@maybe('data-count', \$count)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('data-count="0"', $this->evaluateBlade($compiled, ['count' => 0]));
+    }
+
+    public function testMaybeWithFalse()
+    {
+        $string = "@maybe('data-active', \$active)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('data-active="false"', $this->evaluateBlade($compiled, ['active' => false]));
+    }
+
+    public function testMaybeWithTrue()
+    {
+        $string = "@maybe('data-active', \$active)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('data-active="true"', $this->evaluateBlade($compiled, ['active' => true]));
+    }
+
+    public function testMaybeWithValidString()
+    {
+        $string = "@maybe('title', \$title)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('title="You can just do things"', $this->evaluateBlade($compiled, ['title' => 'You can just do things']));
+    }
+
+    public function testMaybeEscapesHtmlEntities()
+    {
+        $string = "@maybe('title', \$title)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('title="&lt;script&gt;alert(&#039;xss&#039;)&lt;/script&gt;"',
+            $this->evaluateBlade($compiled, ['title' => "<script>alert('xss')</script>"]));
+    }
+
+    public function testMaybeWithWhitespaceOnlyString()
+    {
+        $string = "@maybe('title', \$title)";
+        $compiled = $this->compiler->compileString($string);
+
+        // Whitespace-only strings are considered empty.
+        $this->assertSame('', $this->evaluateBlade($compiled, ['title' => '   ']));
+    }
+
+    public function testMaybeWithNumericString()
+    {
+        $string = "@maybe('data-id', \$id)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('data-id="123"', $this->evaluateBlade($compiled, ['id' => '123']));
+    }
+
+    public function testMaybeWithInt()
+    {
+        $string = "@maybe('data-id', \$id)";
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('data-id="123"', $this->evaluateBlade($compiled, ['id' => 123]));
+    }
+
+    public function testMaybeInHtmlContext()
+    {
+        $string = '<a href="#" @maybe(\'title\', $title)>Link</a>';
+        $compiled = $this->compiler->compileString($string);
+
+        $this->assertSame('<a href="#" title="click">Link</a>',
+            $this->evaluateBlade($compiled, ['title' => 'click']));
+
+        $this->assertSame('<a href="#" >Link</a>',
+            $this->evaluateBlade($compiled, ['title' => '']));
+    }
+
+    protected function evaluateBlade(string $compiled, array $data = []): string
+    {
+        extract($data);
+        ob_start();
+        eval('?>' . $compiled);
+        return ob_get_clean();
+    }
+}

--- a/tests/View/Blade/BladeMaybeStatementsTest.php
+++ b/tests/View/Blade/BladeMaybeStatementsTest.php
@@ -161,7 +161,7 @@ class BladeMaybeStatementsTest extends AbstractBladeTestCase
     {
         extract($data);
         ob_start();
-        eval('?>' . $compiled);
+        eval('?>'.$compiled);
         return ob_get_clean();
     }
 }

--- a/tests/View/Blade/BladeMaybeStatementsTest.php
+++ b/tests/View/Blade/BladeMaybeStatementsTest.php
@@ -162,6 +162,7 @@ class BladeMaybeStatementsTest extends AbstractBladeTestCase
         extract($data);
         ob_start();
         eval('?>'.$compiled);
+
         return ob_get_clean();
     }
 }


### PR DESCRIPTION
**Edit:** Based on the discusstion here, I released an advanced version as a package for the time being:
https://github.com/NickSdot/blade-html-attributes

---

This PR adds a new `@maybe` directive that conditionally renders HTML attributes with values, complementing the existing boolean attribute directives like `@checked`, `@selected`, `@disabled`, `@required`, and `@readonly`.

### Problem

While we have directives for boolean attributes, we still need verbose `@if  ... @endif` blocks for attributes with values:

```blade
<a href="#" @if($title) title="{{ $title }}" @endif>Link</a>
```

We cannot keep adding specific directives for every possible attribute, so we need a dynamic solution.

### Solution

The `@maybe` directive renders an attribute with a value only when the value is not `null`, not an empty string, and not whitespace-only:

```blade
<a href="#" @maybe('title', $title)>Link</a>
```

### Before/After

```blade
{{-- before --}}
<a href="{{ $link->route }}" @if($link->title) title="{{ $link->title }} @endif" @if($link->rel) rel="{{ $link->rel }} @endif">
    {{ $link->label }}
</a>


{{-- after --}}
<a href="{{ $link->route }}" @maybe('title', $link->title) @maybe('rel', $link->rel)>
    {{ $link->label }}
</a>

{{-- before --}}
<img src="{{ $image->url }}" @if($image->alt) alt="{{ $image->alt }}" @endif @if($image->caption) data-caption="{{ $image->caption }}" @endif />

{{-- after --}}
<img src="{{ $image->url }}" @maybe('alt', $image->alt) @maybe('data-caption', $image->caption) />
```

### Behaviour Matrix

The directive intentionally differs from a simple `@if()` check by treating `0` and `false` as valid values, since these are common in data attributes for counts, flags, and boolean states.

| Value | Renders |
|-------|---------|
| `'foo'` | `data-attribute="foo"` |
| `0` | `data-attribute="0"` |
| `false` | `data-attribute="false"` |
| `true` | `data-attribute="true"` |
| `''` | _(nothing)_ |
| `null` | _(nothing)_ |
| `'   '` | _(nothing)_ |

### Naming

I considered several alternatives: `@when` (too generic, likely better for other future use cases), `@flag` (implies boolean values only, whereas this handles strings, numbers, bools), `@attribute` and `@optional` (too long), `@attr` and `@set` (don’t make the conditional nature clear).

`@has` was tempting as it reads well: “has `$title`, then render `title`”. However, the parameter order would need reversing to `@has($title, 'title')`, which breaks the pattern of other Blade directives where the static value comes first.

`@opt` is appealingly terse but perhaps too cryptic.

`@maybe` has the right balance. It’s short, clearly conditional, and reads naturally with the attribute name first: “maybe render title if `$title`”.