### PR TITLE
[12.x] Fix rounded issue in exception frame component

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/frame.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/frame.blade.php
@@ -5,7 +5,7 @@
         expanded: {{ $frame->isMain() ? 'true' : 'false' }},
         hasCode: {{ $frame->snippet() ? 'true' : 'false' }}
     }"
-    class="group rounded-lg border border-neutral-200 dark:border-white/10 shadow-xs"
+    class="group rounded-lg border border-neutral-200 dark:border-white/10 overflow-hidden shadow-xs"
     :class="{ 'dark:border-white/5': expanded }"
 >
     <div


### PR DESCRIPTION
Issue
---
The border radius was not being applied correctly, so the element appeared with sharp corners instead of rounded ones. This fix ensures the expected rounded styling is applied.

Note
---
I am not entirely sure if there are other Tailwind-related styles that also need updating alongside this change.

Before
---

<img width="1116" height="42" alt="Screenshot (1)" src="https://github.com/user-attachments/assets/72401d16-24c2-44b1-a5b2-4e8238b5a264" />

After
---

<img width="1117" height="43" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/364f8a0f-7079-425c-b7f8-b0c88c208b0c" />
