### PR TITLE
[12.x] Fix invalid docblock

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -236,7 +236,7 @@ class PendingBatch
      * @param  bool|TParam|array<array-key, TParam>  $param
      * @return $this
      */
-    public function allowFailures(Closure|callable|array|bool $param = true)
+    public function allowFailures($param = true)
     {
         if (! is_bool($param)) {
             $param = Arr::wrap($param);

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -231,7 +231,7 @@ class PendingBatch
      *
      * Optionally, add callbacks to be executed upon each job failure.
      *
-     * @template TParam of Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
+     * @template TParam of (Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
      *
      * @param  bool|TParam|array<array-key, TParam>  $param
      * @return $this


### PR DESCRIPTION
This fixes an invalid doc block that was introduced in #55916. Because there's a hanging parentheses Psalm errors with the following:

```
Uncaught Psalm\Exception\DocblockParseException: Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed) is not a valid type: Invalid string Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
```
