### PR TITLE
[12.x] Add replaceHeader method to PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -451,6 +451,18 @@ class PendingRequest
     }
 
     /**
+     * Replace the given header on the request.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function replaceHeader($name, $value)
+    {
+        return $this->replaceHeaders([$name => $value]);
+    }
+
+    /**
      * Specify the basic authentication username and password for the request.
      *
      * @param  string  $username


### PR DESCRIPTION
## Add `replaceHeader()` method to HTTP Client

### Description
This PR adds a `replaceHeader()` convenience method to the `PendingRequest` class for replacing a single header value, following the same pattern as the existing `withHeader()` method.

### Motivation
Currently, the HTTP client provides:
- `withHeaders()` - to add multiple headers
- `withHeader()` - to add a single header (convenience wrapper)
- `replaceHeaders()` - to replace multiple headers

However, there's no convenience method for replacing a single header. Users must call `replaceHeaders()` with an array containing a single item