### PR TITLE
[12.x] Improve `php artisan config:cache` and `php artisan optimize` error messages for non-serializable values

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
@@ -69,7 +70,13 @@ class ConfigCacheCommand extends Command
         } catch (Throwable $e) {
             $this->files->delete($configPath);
 
-            throw new LogicException('Your configuration files are not serializable.', 0, $e);
+            foreach (Arr::dot($config) as $key => $value) {
+                try {
+                    eval(var_export($value, true).';');
+                } catch (Throwable $e) {
+                    throw new LogicException("Your configuration files could not be serialized because The value at \"{$key}\" contains a non-serializable type.", 0, $e);
+                }
+            }
         }
 
         $this->components->info('Configuration cached successfully.');

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -77,6 +77,8 @@ class ConfigCacheCommand extends Command
                     throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" contains a non-serializable value.", 0, $e);
                 }
             }
+
+            throw new LogicException('Your configuration files are not serializable.', 0, $e);
         }
 
         $this->components->info('Configuration cached successfully.');

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -74,7 +74,7 @@ class ConfigCacheCommand extends Command
                 try {
                     eval(var_export($value, true).';');
                 } catch (Throwable $e) {
-                    throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" contains a non-serializable value.", 0, $e);
+                    throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" is non-serializable.", 0, $e);
                 }
             }
 

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -74,7 +74,7 @@ class ConfigCacheCommand extends Command
                 try {
                     eval(var_export($value, true).';');
                 } catch (Throwable $e) {
-                    throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" contains a non-serializable type.", 0, $e);
+                    throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" contains a non-serializable value.", 0, $e);
                 }
             }
         }

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -74,7 +74,7 @@ class ConfigCacheCommand extends Command
                 try {
                     eval(var_export($value, true).';');
                 } catch (Throwable $e) {
-                    throw new LogicException("Your configuration files could not be serialized because The value at \"{$key}\" contains a non-serializable type.", 0, $e);
+                    throw new LogicException("Your configuration files could not be serialized because the value at \"{$key}\" contains a non-serializable type.", 0, $e);
                 }
             }
         }

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -72,7 +72,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" contains a non-serializable type.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" contains a non-serializable value.');
 
         $this->artisan('config:cache');
     }
@@ -96,7 +96,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" contains a non-serializable type.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" contains a non-serializable value.');
 
         $this->artisan('config:cache');
     }

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -72,7 +72,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" contains a non-serializable value.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" is non-serializable.');
 
         $this->artisan('config:cache');
     }
@@ -96,7 +96,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" contains a non-serializable value.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.');
 
         $this->artisan('config:cache');
     }

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Tests\Integration\Generators\TestCase;
+use LogicException;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+
+class ConfigCacheCommandTest extends TestCase
+{
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'bootstrap/cache/config.php',
+        'config/testconfig.php',
+    ];
+
+    protected function setUp(): void
+    {
+        $files = new Filesystem;
+
+        $this->afterApplicationCreated(function () use ($files) {
+            $files->ensureDirectoryExists($this->app->configPath());
+        });
+
+        $this->beforeApplicationDestroyed(function () use ($files) {
+            $files->delete($this->app->configPath('testconfig.php'));
+        });
+
+        parent::setUp();
+    }
+
+    public function testConfigurationCanBeCachedSuccessfully()
+    {
+        $files = new Filesystem;
+        $files->put($this->app->configPath('testconfig.php'), <<<'PHP'
+            <?php
+
+            return [
+                'string' => 'value',
+                'number' => 123,
+                'boolean' => true,
+                'array' => ['foo', 'bar'],
+                'from_env' => env('SOMETHING_FROM_ENV', 10),
+                'nested' => [
+                    'key' => 'value',
+                ],
+            ];
+            PHP
+        );
+
+        $this->artisan('config:cache')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Configuration cached successfully');
+
+        $this->assertFileExists($this->app->getCachedConfigPath());
+    }
+
+    public function testConfigurationCacheFailsWithNonSerializableValue()
+    {
+        $files = new Filesystem;
+        $files->put($this->app->configPath('testconfig.php'), <<<'PHP'
+            <?php
+
+            return [
+                'closure' => function () {
+                    return 'test';
+                },
+            ];
+            PHP
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Your configuration files could not be serialized because The value at "testconfig.closure" contains a non-serializable type.');
+
+        $this->artisan('config:cache');
+    }
+
+    public function testConfigurationCacheFailsWithNestedNonSerializableValue()
+    {
+        $files = new Filesystem;
+        $files->put($this->app->configPath('testconfig.php'), <<<'PHP'
+            <?php
+
+            return [
+                'nested' => [
+                    'deep' => [
+                        'closure' => function () {
+                            return 'test';
+                        },
+                    ],
+                ],
+            ];
+            PHP
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Your configuration files could not be serialized because The value at "testconfig.nested.deep.closure" contains a non-serializable type.');
+
+        $this->artisan('config:cache');
+    }
+
+    public function testConfigurationCacheIsDeletedWhenSerializationFails()
+    {
+        $files = new Filesystem;
+        $files->put($this->app->configPath('testconfig.php'), <<<'PHP'
+            <?php
+
+            return [
+                'closure' => function () {
+                    return 'test';
+                },
+            ];
+            PHP
+        );
+
+        try {
+            $this->artisan('config:cache');
+            $this->fail('should have thrown an exception');
+        } catch (LogicException) {
+            // Expected exception
+        }
+
+        $this->assertFileDoesNotExist($this->app->getCachedConfigPath());
+    }
+}

--- a/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigCacheCommandTest.php
@@ -72,7 +72,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because The value at "testconfig.closure" contains a non-serializable type.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.closure" contains a non-serializable type.');
 
         $this->artisan('config:cache');
     }
@@ -96,7 +96,7 @@ class ConfigCacheCommandTest extends TestCase
         );
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Your configuration files could not be serialized because The value at "testconfig.nested.deep.closure" contains a non-serializable type.');
+        $this->expectExceptionMessage('Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" contains a non-serializable type.');
 
         $this->artisan('config:cache');
     }


### PR DESCRIPTION
Enhanced `ConfigCacheCommand` to provide precise error messages when configuration values cannot be serialized during caching. When serialization fails, the command now iterates through the flattened config array to identify the exact configuration key containing the non-serializable value, rather than throwing a generic error.

The improved error messages help developers quickly locate and fix configuration issues when running `php artisan config:cache` or `php artisan optimize`.

## Before

> Your configuration files are not serializable.


## After

> Your configuration files could not be serialized because the value at "testconfig.nested.deep.closure" is non-serializable.