### PR TITLE
[12.x] Ensure name exists when calling job within group

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -200,23 +200,15 @@ class Schedule
                 : $job::class;
         }
 
-        $this->events[] = $event = new CallbackEvent(
-            $this->eventMutex, function () use ($job, $queue, $connection) {
-                $job = is_string($job) ? Container::getInstance()->make($job) : $job;
+        return $this->name($jobName)->call(function () use ($job, $queue, $connection) {
+            $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
-                if ($job instanceof ShouldQueue) {
-                    $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
-                } else {
-                    $this->dispatchNow($job);
-                }
-            }, [], $this->timezone
-        );
-
-        $event->name($jobName);
-
-        $this->mergePendingAttributes($event);
-
-        return $event;
+            if ($job instanceof ShouldQueue) {
+                $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
+            } else {
+                $this->dispatchNow($job);
+            }
+        });
     }
 
     /**
@@ -336,6 +328,8 @@ class Schedule
      */
     protected function mergePendingAttributes(Event $event)
     {
+        $event->name($this->attributes?->description);
+
         if (! empty($this->groupStack)) {
             $group = array_last($this->groupStack);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a follow up improvement based on https://github.com/laravel/framework/pull/57224

The event name fix can be simplified and be done in Scheduling::mergePendingAttributes method while keeping original Job method unchanged.