### PR TITLE
[12.x] Add ability for recursive check relation load

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1081,7 +1081,36 @@ trait HasRelationships
      */
     public function relationLoaded($key)
     {
+        $relations = explode('.', $key);
+        if (count($relations) > 1) {
+            return $this->relationLoadedRecursively($relations, $this);
+        }
+
         return array_key_exists($key, $this->relations);
+    }
+
+    /**
+     * Recursively check loaded relations in relations array.
+     *
+     * @param  array  $relations
+     * @param  Model|null  $model
+     * @return bool
+     */
+    protected function relationLoadedRecursively($relations, $model): bool
+    {
+        // if we get a null model - than relation was loaded, but empty
+        if (is_null($model)) {
+            return false;
+        }
+        $currentRelation = array_shift($relations);
+        // if the count of relations is 0, then we are at the end of recursion
+        if (count($relations) === 0) {
+            return $model->relationLoaded($currentRelation);
+        } elseif ($model->relationLoaded($currentRelation)) {
+            return $this->relationLoadedRecursively($relations, $model->relations[$currentRelation]);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -284,6 +284,30 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertTrue($model->isRelation('parent'));
         $this->assertFalse($model->isRelation('field'));
     }
+
+    public function testSearchRelationsRecursively()
+    {
+        $parent = new EloquentRelationResetModelStub;
+        $child = new EloquentRelationResetModelStub;
+        $relation = new EloquentRelationResetModelStub;
+
+        $child->setRelation('bar', $relation);
+        $parent->setRelation('foo', $child);
+
+        $this->assertTrue($parent->relationLoaded('foo.bar'));
+    }
+
+    public function testNotFailWhenSearchingRelationsRecursivelyWithEmptyModel()
+    {
+        $parent = new EloquentRelationResetModelStub;
+        $child = new EloquentRelationResetModelStub;
+
+        $child->setRelation('bar', null);
+        $parent->setRelation('foo', $child);
+
+        $this->assertTrue($parent->relationLoaded('foo.bar'));
+        $this->assertFalse($parent->relationLoaded('foo.bar.baz'));
+    }
 }
 
 class EloquentRelationResetModelStub extends Model


### PR DESCRIPTION
Hello!

I want to present an improve for `HasRelationships::relationLoaded` function - check loaded state of child relations in dot notation. It same as dot notation in `load` or `with` functions and fully backward compatible. 
Before
```
$model->load('foo.bar')
$model->relationLoaded('foo') //true
$model->relationLoaded('foo.bar') //always false
```
After:
```
$model->load('foo.bar')
$model->relationLoaded('foo') //true
$model->relationLoaded('foo.bar') //true
$model->relationLoaded('foo.bar.baz') //false
```

