### PR TITLE
[12.x] Refactor: add `|null` in doc block

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -271,8 +271,6 @@ trait ValidatesAttributes
         if ($result = $this->getRule($attribute, 'DateFormat')) {
             return $result[1][0];
         }
-
-        return null;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -271,19 +271,21 @@ trait ValidatesAttributes
         if ($result = $this->getRule($attribute, 'DateFormat')) {
             return $result[1][0];
         }
+
+        return null;
     }
 
     /**
      * Get the date timestamp.
      *
      * @param  mixed  $value
-     * @return int
+     * @return int|null
      */
     protected function getDateTimestamp($value)
     {
         $date = is_null($value) ? null : $this->getDateTime($value);
 
-        return $date ? $date->getTimestamp() : null;
+        return $date?->getTimestamp();
     }
 
     /**


### PR DESCRIPTION
add return null in this function
```
    /**
     * Get the date format for an attribute if it has one.
     *
     * @param  string  $attribute
     * @return string|null
     */
    protected function getDateFormat($attribute)
    {
        if ($result = $this->getRule($attribute, 'DateFormat')) {
            return $result[1][0];
        }

        return null;
    }
```
and add |null in this docblock
```
    /**
     * Get the date timestamp.
     *
     * @param  mixed  $value
     * @return int|null
     */
    protected function getDateTimestamp($value)
    {
        $date = is_null($value) ? null : $this->getDateTime($value);

        return $date?->getTimestamp();
    }
```