### PR TITLE
[13.x] Add missing `Illuminate\Cache\SessionStore::touch()` method

### DIFF
--- a/src/Illuminate/Cache/SessionStore.php
+++ b/src/Illuminate/Cache/SessionStore.php
@@ -195,6 +195,24 @@ class SessionStore implements Store
     }
 
     /**
+     * Adjust the expiration time of a cached item.
+     *
+     * @param  string  $key
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function touch($key, $seconds)
+    {
+        if (! $this->session->exists($this->itemKey($key))) {
+            return;
+        }
+
+        $item = $this->session->get($this->itemKey($key));
+
+        return $this->put($key, $item['value'], (int) max(1, $seconds));
+    }
+
+    /**
      * Get the cache key prefix.
      *
      * @return string


### PR DESCRIPTION
Introduced via https://github.com/laravel/framework/pull/56887

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
