### PR TITLE
[12.x] Add `ServiceProvider@registerPackageUninstallingListener()`

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -504,6 +504,18 @@ abstract class ServiceProvider
     }
 
     /**
+     * Register a callback when a composer package is being uninstalled.
+     *
+     * @param  string  $packageName
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function registerPackageUninstallingListener(string $packageName, callable $callback)
+    {
+        $this->app['events']->listen("composer_package.{$packageName}:pre_uninstall", $callback);
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return array

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -237,6 +237,25 @@ return [
 PHP
             , trim(file_get_contents($this->tempFile)));
     }
+
+    public function test_can_register_uninstalling_callback()
+    {
+        $app = new Application();
+
+        $provider = new class ($app) extends ServiceProvider
+        {
+            public static int $timesCalled = 0;
+            public function boot()
+            {
+                $this->registerPackageUninstallingListener('laravel/framework', fn () => static::$timesCalled++);
+            }
+        };
+
+        $provider->boot();
+        $app['events']->hasListeners('composer_package.laravel/framework:pre_uninstall');
+        $app['events']->dispatch('composer_package.laravel/framework:pre_uninstall');
+        $this->assertEquals(1, $provider::$timesCalled);
+    }
 }
 
 class ServiceProviderForTestingOne extends ServiceProvider


### PR DESCRIPTION
We introduced the ability to listen for uninstall events in https://github.com/laravel/framework/pull/57144. This adds a method to the ServiceProvider class to simplify registering those.