### PR TITLE
Fix bug with number #54910

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1114,9 +1114,13 @@ trait EnumeratesValues
                 return in_array($operator, ['!=', '<>', '!==']);
             }
 
+            if ((is_int($retrieved) || is_float($retrieved)) && $retrieved == 0 && $value === true) {
+                return true;
+            }
+      
             switch ($operator) {
-                default:
-                case '=':
+                default:  
+                case '=':       
                 case '==':  return $retrieved == $value;
                 case '!=':
                 case '<>':  return $retrieved != $value;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -953,7 +953,17 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testWhere($collection)
     {
-        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 0],['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+     
+        $this->assertEquals(
+            [['v' => 0]],
+            $c->where('v', 0)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 0.0]],
+            $c->where('v', 0.0)->values()->all()
+        );
 
         $this->assertEquals(
             [['v' => 3], ['v' => '3']],
@@ -977,19 +987,19 @@ class SupportCollectionTest extends TestCase
         );
 
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 4]],
             $c->where('v', '<>', 3)->values()->all()
         );
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 4]],
             $c->where('v', '!=', 3)->values()->all()
         );
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => '3'], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => '3'], ['v' => 4]],
             $c->where('v', '!==', 3)->values()->all()
         );
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3']],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3']],
             $c->where('v', '<=', 3)->values()->all()
         );
         $this->assertEquals(
@@ -997,7 +1007,7 @@ class SupportCollectionTest extends TestCase
             $c->where('v', '>=', 3)->values()->all()
         );
         $this->assertEquals(
-            [['v' => 1], ['v' => 2]],
+            [['v' => 0],['v' => 1], ['v' => 2]],
             $c->where('v', '<', 3)->values()->all()
         );
         $this->assertEquals(
@@ -1013,17 +1023,17 @@ class SupportCollectionTest extends TestCase
         );
 
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
             $c->where('v', '<>', $object)->values()->all()
         );
 
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
             $c->where('v', '!=', $object)->values()->all()
         );
 
         $this->assertEquals(
-            [['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
+            [['v' => 0],['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
             $c->where('v', '!==', $object)->values()->all()
         );
 
@@ -1086,6 +1096,18 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['v' => 2, 'g' => 3]], $c->where('v', 2)->where('g', '>', 2)->values()->all());
         $this->assertEquals([], $c->where('v', 2)->where('g', 4)->values()->all());
         $this->assertEquals([['v' => 2, 'g' => null]], $c->where('v', 2)->whereNull('g')->values()->all());
+   
+        $c = new $collection([ 
+            ['name' => 'c', 'v' => null],
+            ['name' => 'd', 'v' => 0],
+            ['name' => 'e', 'v' => 0.0],
+            ['name' => 'f', 'v' => 0.1],
+        ]);
+        
+        $this->assertSame($c->where('name' , 'c')->value('v') , null);
+        $this->assertSame($c->where('name' , 'd')->value('v') , 0);
+        $this->assertSame($c->where('name' , 'e')->value('v') , 0.0);
+        $this->assertSame($c->where('name' , 'f')->value('v') , 0.1);
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
## Laravel Version

12.x

## PHP Version

8.2.28

## Description

This PR fixes an issue where calling where on a collection returns null instead of 0. #54910
## Problem

When we write an array that contains 0, it goes into EnumeratesValues inside collections. There, it interprets 0 as false and compares it with $value. For normal numbers, it works correctly because numbers greater than 0 are interpreted as true, and when compared, the callback function works as expected.