### PR TITLE
[12.x] Ensure cookie lifetime matches session lifetime in StartSession middleware

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -262,10 +262,10 @@ class StartSession
      */
     protected function getCookieExpirationDate()
     {
-        $config = $this->manager->getSessionConfig();
+        $expiresOnClose = $this->manager->getSessionConfig()['expire_on_close'];
 
-        return $config['expire_on_close'] ? 0 : Date::instance(
-            Carbon::now()->addMinutes((int) $config['lifetime'])
+        return $expiresOnClose ? 0 : Date::instance(
+            Carbon::now()->addSeconds($this->getSessionLifetimeInSeconds())
         );
     }
 


### PR DESCRIPTION
Updated `getCookieExpirationDate()` in `Illuminate\Session\Middleware\StartSession` to use `getSessionLifetimeInSeconds()` instead of directly accessing the `lifetime` config, ensuring consistency between session and cookie expiration times.

## Context

Discovered this while working with a custom middleware extending `StartSession` that overrides `getSessionLifetimeInSeconds()`. Cookie lifetime wasn't respecting the override (expected behavior), as it was reading directly from config instead.

## Tests

No new tests added yet - waiting for feedback first in case the current behavior is intentional. Happy to add tests if the change is acceptable.
