### PR TITLE
[12.x] Add `assertResourcePagination()` to test responses

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2978,6 +2978,237 @@ class TestResponseTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function testAssertResourcePagination(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                    ['id' => 2, 'name' => 'Jane'],
+                ],
+                'links' => [
+                    'first' => 'http://example.com/users?page=1',
+                    'last' => 'http://example.com/users?page=3',
+                    'prev' => null,
+                    'next' => 'http://example.com/users?page=2',
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                    'total' => 45,
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination();
+    }
+
+    public function testAssertResourcePaginationWithExcludedKeys(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'links' => [
+                    'first' => 'http://example.com/users?page=1',
+                    'last' => 'http://example.com/users?page=3',
+                    'prev' => null,
+                    'next' => 'http://example.com/users?page=2',
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination(exclude: ['meta.total']);
+    }
+
+    public function testAssertResourcePaginationWithExcludedTopLevelKeys(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                    'total' => 45,
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination(exclude: ['links']);
+    }
+
+    public function testAssertResourcePaginationWithMultipleExcludedKeys(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'links' => [
+                    'first' => 'http://example.com/users?page=1',
+                    'last' => 'http://example.com/users?page=3',
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination(exclude: ['links.prev', 'links.next', 'meta.links', 'meta.to', 'meta.total']);
+    }
+
+    public function testAssertResourcePaginationWithIncludedFields(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'links' => [
+                    'first' => 'http://example.com/users?page=1',
+                    'last' => 'http://example.com/users?page=3',
+                    'prev' => null,
+                    'next' => 'http://example.com/users?page=2',
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                    'total' => 45,
+                    'custom_meta_field' => 'custom_value',
+                ],
+                'custom_top_level_field' => 'some_value',
+            ])
+        );
+
+        $response->assertResourcePagination([
+            'custom_top_level_field',
+            'meta.custom_meta_field',
+        ]);
+    }
+
+    public function testAssertResourcePaginationWithIncludedStructuredFields(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'links' => [
+                    'first' => 'http://example.com/users?page=1',
+                    'last' => 'http://example.com/users?page=3',
+                    'prev' => null,
+                    'next' => 'http://example.com/users?page=2',
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                    'total' => 45,
+                    'nested_object' => [
+                        'nested_field1' => 'value1',
+                        'nested_field2' => 'value2',
+                    ],
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination([
+            'meta.nested_object' => [
+                'nested_field1',
+                'nested_field2',
+            ],
+        ]);
+    }
+
+    public function testAssertResourcePaginationWithExcludeAndInclude(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            new JsonResponse([
+                'data' => [
+                    ['id' => 1, 'name' => 'John'],
+                ],
+                'meta' => [
+                    'current_page' => 1,
+                    'from' => 1,
+                    'last_page' => 3,
+                    'links' => [
+                        'url' => 'http://example.com/users?page=1',
+                        'label' => '&laquo; Previous',
+                        'page' => null,
+                        'active' => false,
+                    ],
+                    'path' => 'http://example.com/users',
+                    'per_page' => 15,
+                    'to' => 15,
+                    'total' => 45,
+                    'custom_field' => 'custom_value',
+                ],
+            ])
+        );
+
+        $response->assertResourcePagination(['meta.custom_field'], ['links']);
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {


### PR DESCRIPTION
Howdy! I thought it would be helpful to see if I could land this `TestResponse` helper that I find pretty helpful when testing API resource routes in an application. This usually ends help as something that gets added to the base `TestCase`, and I figured it could probably help other folks out there that want to verify their paginated APIs are acting as expected.

This change adds a new `assertResourcePagination()` method to the `TestResponse` with the goal being a one-liner fluent-able assertion that one could use when testing routes in an application. It's intended for testing resource collections that use pagination. For example:

```php
// In a `routes/` file somewhere

Route::get('/users', fn () => User::paginate()->toResourceCollection());
```

```php
#[Test]
public function returns_paginated_users()
{
    $response = $this->get('/users');
    $response->assertOk()
        ->assertResourcePagination();
}
```

I added some tuning knobs so users could opt-in or out to fields they want verified on responses with `$include` and `$exclude` params, so asserting against custom data on the resource API response would be included:

```php
#[Test]
public function returns_paginated_users_without_links()
{
    $response = $this->get('/users');
    $response->assertOk()
        ->assertResourcePagination(exclude: ['links', 'meta.links']);
}

#[Test]
public function returns_paginated_users_with_custom_data()
{
    $response = $this->get('/users');
    $response->assertOk()
        ->assertResourcePagination(include: ['links.custom']);
}
```

In case their application uses [custom pagination data](https://laravel.com/docs/12.x/eloquent-resources#customizing-the-pagination-information).

In terms of implementation, the `removeKeyFromStructure()` internal `TestResponse` method was added to crawl values in the expected pagination structure array and remove them if needed. Similar to `Arr::forget()`, but more specific to the array values on the `$structure` array.

Hopefully someone finds this useful!