### PR TITLE
[12.x] Fix using pushIf blade directive with complex conditions (#57264)

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -379,7 +379,18 @@ trait CompilesConditionals
      */
     protected function compilePushIf($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression), 2);
+        $parts = explode(',', $this->stripParentheses($expression));
+
+        /**
+         * @see https://github.com/laravel/framework/issues/57264
+         */
+        if (count($parts) > 2) {
+            $last = array_pop($parts);
+            $parts = [
+                0 => implode(',', $parts),
+                1 => trim($last),
+            ];
+        }
 
         return "<?php if({$parts[0]}): \$__env->startPush({$parts[1]}); ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -381,11 +381,9 @@ trait CompilesConditionals
     {
         $parts = explode(',', $this->stripParentheses($expression));
 
-        /**
-         * @see https://github.com/laravel/framework/issues/57264
-         */
         if (count($parts) > 2) {
             $last = array_pop($parts);
+
             $parts = [
                 0 => implode(',', $parts),
                 1 => trim($last),

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -385,8 +385,8 @@ trait CompilesConditionals
             $last = array_pop($parts);
 
             $parts = [
-                0 => implode(',', $parts),
-                1 => trim($last),
+                implode(',', $parts),
+                trim($last),
             ];
         }
 

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -70,6 +70,32 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testPushIfWithMoreThanOneCommaIsCompiled()
+    {
+        $string = '@pushIf(Str::startsWith(\'abc\', \'a\'), \'body-end\')
+test
+@endPushIf';
+
+        $expected = '<?php if(Str::startsWith(\'abc\', \'a\')): $__env->startPush(\'body-end\'); ?>
+test
+<?php $__env->stopPush(); endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPushIfWithCommaInStringIsCompiled()
+    {
+        $string = '@pushIf(Str::startsWith(\'abc,,,\', \'a,,,\'), \'body-end\')
+test
+@endPushIf';
+
+        $expected = '<?php if(Str::startsWith(\'abc,,,\', \'a,,,\')): $__env->startPush(\'body-end\'); ?>
+test
+<?php $__env->stopPush(); endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testPushIfElseIsCompiled()
     {
         $string = '@pushIf(true, \'stack\')


### PR DESCRIPTION
This PR fixes an issue where the `@pushIf` directive incorrectly parsed expressions containing multiple commas within nested function calls or array arguments.
This caused the directive to generate invalid PHP during compilation when the condition itself contained commas.

### **Before**

```blade
@pushIf(Str::startsWith('abc', 'a'), 'body-end')
test
@endPushIf
```
To:
```php
<?php if(Str::startsWith('abc'): $__env->startPush( 'a'), 'body-end'); ?>
test
<?php $__env->stopPush(); endif; ?>
```
❌ Compiled incorrectly, broken expression.

### **After**

✅ Compiles correctly:

```php
@pushIf(Str::startsWith('abc', 'a'), 'body-end')
test
@endPushIf
```
To:
```php
<?php if(Str::startsWith('abc', 'a')): $__env->startPush('body-end'); ?>
test
<?php $__env->stopPush(); endif; ?>
```

This is related to issue: #57264