### PR TITLE
[12.x] Improve BroadcastManager error messages when trying to get a Broadcaster

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -21,6 +21,8 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
+use RuntimeException;
+use Throwable;
 
 /**
  * @mixin \Illuminate\Contracts\Broadcasting\Broadcaster
@@ -294,8 +296,8 @@ class BroadcastManager implements FactoryContract
 
         try {
             return $this->{$driverMethod}($config);
-        } catch (\Throwable $e) {
-            throw new BroadcastException("Failed to create broadcaster for connection \"{$name}\" with error: {$e->getMessage()}.", 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException("Failed to create broadcaster for connection \"{$name}\" with error: {$e->getMessage()}.", 0, $e);
         }
     }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -292,7 +292,11 @@ class BroadcastManager implements FactoryContract
             throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
         }
 
-        return $this->{$driverMethod}($config);
+        try {
+            return $this->{$driverMethod}($config);
+        } catch (\Throwable $e) {
+            throw new BroadcastException("Failed to create broadcaster for connection \"{$name}\" with error: {$e->getMessage()}.", 0, $e);
+        }
     }
 
     /**

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -101,35 +101,13 @@ class BroadcastManagerTest extends TestCase
         $broadcastManager->connection('alien_connection');
     }
 
-    public function testThrowExceptionWhenUnsupportedDriverIsUsed()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Driver [unsupported_driver] is not supported.');
-
-        $userConfig = [
-            'broadcasting' => [
-                'connections' => [
-                    'my_connection' => [
-                        'driver' => 'unsupported_driver',
-                    ],
-                ],
-            ],
-        ];
-
-        $app = $this->getApp($userConfig);
-
-        $broadcastManager = new BroadcastManager($app);
-
-        $broadcastManager->connection('my_connection');
-    }
-
     public function testThrowExceptionWhenPusherDriverCreationFailsWithMissingConfig()
     {
         $userConfig = [
             'broadcasting' => [
                 'connections' => [
-                    'pusher_connection' => [
-                        'driver' => 'pusher',
+                    'reverb_connection_1' => [
+                        'driver' => 'reverb',
                         // Missing required 'key', 'secret', 'app_id' configuration
                     ],
                 ],
@@ -141,10 +119,10 @@ class BroadcastManagerTest extends TestCase
         $broadcastManager = new BroadcastManager($app);
 
         try {
-            $broadcastManager->connection('pusher_connection');
+            $broadcastManager->connection('reverb_connection_1');
             $this->fail('Expected BroadcastException was not thrown');
         } catch (BroadcastException $e) {
-            $this->assertStringContainsString('Failed to create broadcaster for connection "pusher_connection"', $e->getMessage());
+            $this->assertStringContainsString('Failed to create broadcaster for connection "reverb_connection_1"', $e->getMessage());
             $this->assertNotNull($e->getPrevious());
         }
     }
@@ -154,8 +132,8 @@ class BroadcastManagerTest extends TestCase
         $userConfig = [
             'broadcasting' => [
                 'connections' => [
-                    'pusher_connection' => [
-                        'driver' => 'pusher',
+                    'reverb_connection_2' => [
+                        'driver' => 'reverb',
                         'key' => null,
                         'secret' => null,
                         'app_id' => null,
@@ -169,10 +147,10 @@ class BroadcastManagerTest extends TestCase
         $broadcastManager = new BroadcastManager($app);
 
         try {
-            $broadcastManager->connection('pusher_connection');
+            $broadcastManager->connection('reverb_connection_2');
             $this->fail('Expected BroadcastException was not thrown');
         } catch (BroadcastException $e) {
-            $this->assertStringContainsString('Failed to create broadcaster for connection "pusher_connection"', $e->getMessage());
+            $this->assertStringContainsString('Failed to create broadcaster for connection "reverb_connection_2"', $e->getMessage());
             $this->assertNotNull($e->getPrevious());
         }
     }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
 
 class BroadcastManagerTest extends TestCase
 {
@@ -123,7 +124,7 @@ class BroadcastManagerTest extends TestCase
         try {
             $broadcastManager->connection('log_connection_1');
             $this->fail('Expected BroadcastException was not thrown');
-        } catch (BroadcastException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('Failed to create broadcaster for connection "log_connection_1"', $e->getMessage());
             $this->assertStringContainsString('Logger service not available', $e->getMessage());
             $this->assertInstanceOf(\RuntimeException::class, $e->getPrevious());

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -101,7 +101,7 @@ class BroadcastManagerTest extends TestCase
         $broadcastManager->connection('alien_connection');
     }
 
-    public function testThrowExceptionWhenDriverCreationFailsWithServiceError()
+    public function testThrowExceptionWhenDriverCreationFails()
     {
         $userConfig = [
             'broadcasting' => [

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -123,36 +123,6 @@ class BroadcastManagerTest extends TestCase
         $broadcastManager->connection('my_connection');
     }
 
-    public function testThrowExceptionWithConnectionNameWhenBuiltInDriverCreationFails()
-    {
-        $userConfig = [
-            'broadcasting' => [
-                'connections' => [
-                    'redis_connection' => [
-                        'driver' => 'redis',
-                        'connection' => 'invalid_connection',
-                    ],
-                ],
-            ],
-        ];
-
-        $app = $this->getApp($userConfig);
-        $app->singleton('redis', function () {
-            throw new \RuntimeException('Redis service not available');
-        });
-
-        $broadcastManager = new BroadcastManager($app);
-
-        try {
-            $broadcastManager->connection('redis_connection');
-            $this->fail('Expected BroadcastException was not thrown');
-        } catch (BroadcastException $e) {
-            $this->assertStringContainsString('Failed to create broadcaster for connection "redis_connection"', $e->getMessage());
-            $this->assertStringContainsString('Redis service not available', $e->getMessage());
-            $this->assertInstanceOf(\RuntimeException::class, $e->getPrevious());
-        }
-    }
-
     public function testThrowExceptionWhenPusherDriverCreationFailsWithMissingConfig()
     {
         $userConfig = [


### PR DESCRIPTION
Previously, when a broadcaster driver failed to initialize, the error message would only show the underlying exception without indicating which broadcasting connection configuration was responsible, and it was hard to identify it was actually coming from a broadcaster.

Missing to provide a value for `REVERB_APP_KEY`, `REVERB_APP_ID` or `REVERB_APP_SECRET` would throw an error such as `TypeError: Pusher\Pusher::__construct(): Argument #3 ($app_id) must be of type string, null given` and it would occur after running `composer install`, `php artisan migrate`,`php artisan optimize` or any command that would cause the broadcasting to be booted.

This change wraps driver creation in a try-catch block that throws a `BroadcastException` with the connection name, making it immediately clear where the error originates and which configuration needs to be corrected.

Before:
 ``` 
TypeError: Pusher\Pusher::__construct(): Argument #3 ($app_id) must be of type string, null given
```

After:
```
BroadcastException: Failed to create broadcaster for connection "my-connection" with error: Pusher\Pusher::__construct(): Argument #3 ($app_id) must be of type string, null given
```

Testing using the `LogBroadcaster` since it is always available, while `Pusher\Pusher` is not.