### PR TITLE
feat: add composer events triggered after package installation

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -80,7 +80,7 @@ class ComposerScripts
     /**
      * Collect the installed package name on the post-package-install Composer event.
      *
-     * @param \Composer\Installer\PackageEvent $event
+     * @param  \Composer\Installer\PackageEvent  $event
      * @return void
      */
     public static function collectInstalledPackage(PackageEvent $event)

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -77,12 +77,12 @@ class ComposerScripts
         }
     }
 
-    /**  
-    * Collect the installed package name on the post-package-install Composer event.
-    *
-    * @param \Composer\Installer\PackageEvent $event
-    * @return void
-    */
+    /**
+     * Collect the installed package name on the post-package-install Composer event.
+     *
+     * @param \Composer\Installer\PackageEvent $event
+     * @return void
+     */
     public static function collectInstalledPackage(PackageEvent $event)
     {
         $file = self::getInstalledQueueFile($event);


### PR DESCRIPTION
Allow packages to listen for their own installation event in Laravel and run initialization commands
