### PR TITLE
[12.x] Add Stringable::doesntContain() to match API symmetry

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -223,6 +223,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string doesn't contain a given substring.
+     *
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public function doesntContain($needles, $ignoreCase = false)
+    {
+        return Str::doesntContain($this->value, $needles, $ignoreCase);
+    }
+
+    /**
      * Convert the case of a string.
      *
      * @param  int  $mode

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -848,6 +848,19 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
     }
 
+    public function testDoesntContain()
+    {
+        $this->assertTrue($this->stringable('taylor')->doesntContain('xxx'));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(['xxx']));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(['xxx', 'yyy']));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(collect(['xxx', 'yyy'])));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(''));
+        $this->assertFalse($this->stringable('taylor')->doesntContain('ylo'));
+        $this->assertFalse($this->stringable('taylor')->doesntContain('taylor'));
+        $this->assertFalse($this->stringable('taylor')->doesntContain(['xxx', 'ylo']));
+        $this->assertFalse($this->stringable('taylor')->doesntContain(['LOR'], true));
+    }
+
     public function testParseCallback()
     {
         $this->assertEquals(['Class', 'method'], $this->stringable('Class@method')->parseCallback('foo'));


### PR DESCRIPTION
This PR adds the missing `doesntContain()` method to the `Stringable` class to provide symmetry with the existing `contains()` method.

  ### Changes
  - Add `Stringable::doesntContain($needles, $ignoreCase = false)` method
  - Method proxies to existing `Str::doesntContain()` implementation
  - Add tests for the new method

  ### Motivation
  Currently, `Stringable` has a `contains()` method but lacks the corresponding `doesntContain()` method, while `Str` has both. This creates an API inconsistency where developers expect both methods to be available in the fluent interface.
