### PR TITLE
[12.x] Add Str::isEmpty() and Str::isNotEmpty() to match API symmetry

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -688,6 +688,28 @@ class Str
     }
 
     /**
+     * Determine if the given string is empty.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isEmpty($value)
+    {
+        return $value === '';
+    }
+
+    /**
+     * Determine if the given string is not empty.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isNotEmpty($value)
+    {
+        return $value !== '';
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -708,6 +708,26 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isJson([]));
     }
 
+    public function testIsEmpty()
+    {
+        $this->assertTrue(Str::isEmpty(''));
+        $this->assertFalse(Str::isEmpty('0'));
+        $this->assertFalse(Str::isEmpty(' '));
+        $this->assertFalse(Str::isEmpty('hello'));
+        $this->assertFalse(Str::isEmpty('false'));
+        $this->assertFalse(Str::isEmpty('null'));
+    }
+
+    public function testIsNotEmpty()
+    {
+        $this->assertFalse(Str::isNotEmpty(''));
+        $this->assertTrue(Str::isNotEmpty('0'));
+        $this->assertTrue(Str::isNotEmpty(' '));
+        $this->assertTrue(Str::isNotEmpty('hello'));
+        $this->assertTrue(Str::isNotEmpty('false'));
+        $this->assertTrue(Str::isNotEmpty('null'));
+    }
+
     public function testIsMatch()
     {
         $this->assertTrue(Str::isMatch('/.*,.*!/', 'Hello, Laravel!'));


### PR DESCRIPTION
This PR adds the missing `isEmpty()` and `isNotEmpty()` static methods to the `Str` class to provide symmetry with the `Stringable` class methods.

  ### Changes
  - Add `Str::isEmpty($value)` method
  - Add `Str::isNotEmpty($value)` method
  - Add tests for both methods

  ### Motivation
  Currently, `Str` provides various `is*` validation methods (`isAscii`, `isJson`, `isUrl`, `isUuid`, `isUlid`) but lacks `isEmpty` and `isNotEmpty`, which are available in `Stringable`. This creates an API inconsistency where these are the only
  validation methods missing from the static interface.

  ## Notes

  This is related to #57279, as both PRs work in the same area (increasing API symmetry between `Str` and `Stringable`). However, I wasn't sure if you want to extend `Str` in this regard, as I can see arguments in both directions for having these two methods. I hope submitting 2 separate PRs is okay! 🙂