### PR TITLE
[12.x] HTTP Client: add mergeUrlParameters() to combine URL parameters without overwriting

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -533,6 +533,21 @@ class PendingRequest
     }
 
     /**
+     * Merge the given URL parameters into the existing map.
+     *
+     * Later values win on key collisions. Nested arrays are replaced recursively.
+     *
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function mergeUrlParameters(array $parameters = [])
+    {
+        return tap($this, function () use ($parameters) {
+            $this->urlParameters = array_replace_recursive($this->urlParameters, $parameters);
+        });
+    }
+
+    /**
      * Specify the cookies that should be included with the request.
      *
      * @param  array  $cookies

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -528,22 +528,7 @@ class PendingRequest
     public function withUrlParameters(array $parameters = [])
     {
         return tap($this, function () use ($parameters) {
-            $this->urlParameters = $parameters;
-        });
-    }
-
-    /**
-     * Merge the given URL parameters into the existing map.
-     *
-     * Later values win on key collisions. Nested arrays are replaced recursively.
-     *
-     * @param  array  $parameters
-     * @return $this
-     */
-    public function mergeUrlParameters(array $parameters = [])
-    {
-        return tap($this, function () use ($parameters) {
-            $this->urlParameters = array_replace_recursive($this->urlParameters, $parameters);
+            $this->urlParameters = array_merge($this->urlParameters, $parameters);
         });
     }
 


### PR DESCRIPTION
This PR introduces `mergeUrlParameters(array $parameters = [])` to `Illuminate\Http\Client\PendingRequest`.

Today, `withUrlParameters()` replaces the entire parameter map, which makes it hard to define global parameters (e.g., in a macro) and then add/override endpoint-specific parameters later. The new method merges into the existing map, letting later calls override only the keys they provide.

##### Backwards compatibility
 - Fully BC: existing withUrlParameters() behavior is unchanged.
 - No impact on public signatures other than the additive new method.

##### Usage example

```php
Http::macro('service', function () {
    return Http::baseUrl('https://api.example.com')
        ->withUrlParameters(['version' => 'v1', 'tenant' => 'acme']);
});

$response = Http::service()
    ->mergeUrlParameters(['tenant' => 'beta'])
    ->get('/{version}/tenants/{tenant}/users');
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
