### PR TITLE
[12.x] Add `Email::domainIs()` and `Email::domainIsNot()` validation rules

### DIFF
--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -167,6 +167,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Ensure the domain of the email address matches one of the given patterns.
+     *
      * @param  array  $domains
      * @return $this
      */
@@ -178,6 +180,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Ensure the domain of the email address does not match any of the given patterns.
+     *
      * @param  array  $domains
      * @return $this
      */

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -273,7 +273,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 
         if ($this->allowedDomains) {
             $rules[] = function (string $attribute, mixed $value, Closure $fail): void {
-                if (! $this->addressContainsDomain($value, $this->allowedDomains)) {
+                if (! $this->domainMatchesPattern($value, $this->allowedDomains)) {
                     $fail('The :attribute must be a valid email address.');
                 }
             };
@@ -281,7 +281,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 
         if ($this->disallowedDomains) {
             $rules[] = function (string $attribute, mixed $value, Closure $fail): void {
-                if ($this->addressContainsDomain($value, $this->disallowedDomains)) {
+                if ($this->domainMatchesPattern($value, $this->disallowedDomains)) {
                     $fail('The :attribute must be a valid email address.');
                 }
             };
@@ -326,7 +326,14 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
         return $this;
     }
 
-    private function addressContainsDomain($value, $domains)
+    /**
+     * Determine whether the email address matches one of the given domains.
+     *
+     * @param  string  $value
+     * @param  string[]  $domains
+     * @return bool
+     */
+    protected function domainMatchesPattern($value, $domains)
     {
         $domain = explode('@', $value)[1];
 

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
@@ -271,24 +272,16 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
         }
 
         if ($this->allowedDomains) {
-            $rules[] = function ($attribute, $value, $fail) {
-                $domain = explode('@', $value)[1];
-
-                $isAllowed = Str::of($domain)->is($this->allowedDomains, true);
-
-                if (! $isAllowed) {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail): void {
+                if (! $this->addressContainsDomain($value, $this->allowedDomains)) {
                     $fail('The :attribute must be a valid email address.');
                 }
             };
         }
 
         if ($this->disallowedDomains) {
-            $rules[] = function ($attribute, $value, $fail) {
-                $domain = explode('@', $value)[1];
-
-                $isDisallowed = Str::of($domain)->is($this->disallowedDomains, true);
-
-                if ($isDisallowed) {
+            $rules[] = function (string $attribute, mixed $value, Closure $fail): void {
+                if ($this->addressContainsDomain($value, $this->disallowedDomains)) {
                     $fail('The :attribute must be a valid email address.');
                 }
             };
@@ -331,5 +324,12 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
         $this->data = $data;
 
         return $this;
+    }
+
+    private function addressContainsDomain($value, $domains)
+    {
+        $domain = explode('@', $value)[1];
+
+        return Str::of($domain)->is($domains, true);
     }
 }

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -876,6 +876,70 @@ class ValidationEmailRuleTest extends TestCase
         );
     }
 
+    public function testDomainIs()
+    {
+        $this->passes(
+            (new Email())->domainIs(['example.com', 'test.com']),
+            'passes@example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIs(['*']),
+            'passes@example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIs(['*example.com']),
+            'passes@example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIs(['*ex*le.com']),
+            'passes@subdomain.example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIs(['*example.com']),
+            'passes@subdomain.example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIs(['example*']),
+            'passes@example.com',
+        );
+
+        $this->fails(
+            (new Email())->domainIs(['test.com']),
+            'fails@example.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+    }
+
+    public function testDomainIsNot()
+    {
+        $this->passes(
+            (new Email())->domainIsNot(['test.com', 'example.org']),
+            'passes@example.com',
+        );
+
+        $this->passes(
+            (new Email())->domainIsNot(['*test.com']),
+            'passes@example.com',
+        );
+
+        $this->fails(
+            (new Email())->domainIsNot(['example.com']),
+            'passes@example.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+
+        $this->fails(
+            (new Email())->domainIsNot(['example*']),
+            'passes@example.com',
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
+        );
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();


### PR DESCRIPTION
Hey! This PR proposes two new validation rules that can be used to validate the domain of an email address.

At the moment, you can use a combination of the `email` rule and the `ends_with`/`doesnt_end_with` rules to validate that a string is an email and uses (or doesn't use) a given domain name.

But with the two methods I'm proposing, you'll also be able to use wildcards so pattern matching can be used easily.

For example, to check the domain ends with `laravel.com` (including any subdomains), or `amazing-domain.co.uk`, you could do:

```php
$request->validate([
    'email' => [
        'required',
        Rule::email()->domainIs([
          'laravel.com',
          '*.laravel.com',
          'amazing-domain.co.uk',
        ]),
    ],
]);
```

And similarly, to validate that an email doesn't end with a given domain, you can use this:

```php
$request->validate([
    'email' => [
        'required',
        Rule::email()->domainIsNot([
          'spamwebsite.com',
          'another-spam-website.com',
        ]),
    ],
]);
```

## Example Use Cases

I can see this feature being used for things like rejecting registration form submissions if the domain is from a temporary/disposable email provider. Personally, I'd like to keep a config file containing domains that I'd reject. I'd then use it like so:


```php
$request->validate([
    'email' => [
        'required',
        Rule::email()->domainIsNot(config('emails.deny_domains'))
    ],
]);
```

I can also see it being used for things like only allowing users from your organisation to be invited to a web app. 

As I say, I know that this is already pretty much achievable with the existing rules I mentioned above(except for the wildcards), or with a custom rule. So I don't know how valuable this might be to other people. But I thought I'd PR it on the off chance, because I'd only kick myself if I didn't give it a shot. I think it reads pretty nicely and makes it obvious to the reader what the rule is trying to achieve, and it's something I'd personally use.

## Alternative approach

Another approach I'd considered rather than the two separate methods was to use a single `domain` method with named arguments like so:

```php
$request->validate([
    'email' => [
        'required',
        Rule::email()->domain(is: [
            'domain.com',
        ]),
    ],
]);
```

And:

```php
$request->validate([
    'email' => [
        'required',
        Rule::email()->domain(isNot: [
            'domain.com',
        ]),
    ],
]);
```

I couldn't make up my mind which approach would be better, so I opted for the two separate methods.

---

This is my first time delving into this part of the framework, so I do apologise if I've done this completely wrong! But if you do think it's something which might be useful for others, then please give me a shout if you'd like me to change anything 😄