### PR TITLE
[12.x] whereTrue and whereFalse methods added to query builder and EnumeratesValues

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -651,6 +651,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where the value for the given key is true.
+     *
+     * @param  string|null  $key
+     * @return static
+     */
+    public function whereTrue($key)
+    {
+        return $this->where($key, '===', true);
+    }
+
+    /**
+     * Filter items where the value for the given key is false.
+     *
+     * @param  string|null  $key
+     * @return static
+     */
+    public function whereFalse($key)
+    {
+        return $this->where($key, '===', false);
+    }
+
+    /**
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1382,6 +1382,52 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where true" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereTrue($column, $boolean = 'and')
+    {
+        return $this->where($column, '=', true, $boolean);
+    }
+
+    /**
+     * Add an "or where true" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function orWhereTrue($column)
+    {
+        return $this->whereTrue($column, 'or');
+    }
+
+    /**
+     * Add a "where false" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereFalse($column, $boolean = 'and')
+    {
+        return $this->where($column, '=', false, $boolean);
+    }
+
+    /**
+     * Add an "or where false" clause to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function orWhereFalse($column)
+    {
+        return $this->whereFalse($column, 'or');
+    }
+
+    /**
      * Add a where between statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2020,6 +2020,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testBasicWhereTrue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTrue('is_active');
+        $this->assertSame('select * from "users" where "is_active" = ?', $builder->toSql());
+        $this->assertEquals([0 => true], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereTrue('is_active');
+        $this->assertSame('select * from "users" where "id" = ? or "is_active" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => true], $builder->getBindings());
+    }
+
+    public function testBasicWhereFalse()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereFalse('is_active');
+        $this->assertSame('select * from "users" where "is_active" = ?', $builder->toSql());
+        $this->assertEquals([0 => false], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereFalse('is_active');
+        $this->assertSame('select * from "users" where "id" = ? or "is_active" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => false], $builder->getBindings());
+    }
+
     public function testGroupBys()
     {
         $builder = $this->getBuilder();

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5640,6 +5640,39 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testWhereTrue($collection)
+    {
+        $data = new $collection([
+            ['active' => true],
+            ['active' => false],
+            ['active' => true],
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+
+        $this->assertSame([
+            0 => ['active' => true],
+            2 => ['active' => true],
+        ], $data->whereTrue('active')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testWhereFalse($collection)
+    {
+        $data = new $collection([
+            ['active' => true],
+            ['active' => false],
+            ['active' => true],
+            ['active' => 1],
+            ['active' => 0],
+        ]);
+
+        $this->assertSame([
+            1 => ['active' => false],
+        ], $data->whereFalse('active')->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCollect($collection)
     {
         $data = $collection::make([


### PR DESCRIPTION
## Add whereTrue() and whereFalse() methods to Query Builder and Collections

This pull request adds convenient whereTrue(), whereFalse(), orWhereTrue() and orWhereFalse() methods to the Query Builder and whereTrue(), whereFalse() Collections, providing a more expressive way to handle boolean filtering.

### Query Builder

Adds the following methods:

`whereTrue($column, $boolean = 'and')`

`orWhereTrue($column)`

`whereFalse($column, $boolean = 'and')`

`orWhereFalse($column)`

These methods make boolean checks more readable and fluent:

instead of:

```
$users = DB::table('users')->where('is_active', '=', true)->get();
$users = User::where('is_active', true)->get();
```

you can just use:

```
$users = DB::table('users')->whereTrue('is_active')->get();
$users = User::whereTrue('is_active')->get();
```


This brings the same clarity as other expressive methods like whereNull(), whereBetween() or whereLike(), and fits naturally into Laravel’s fluent query style.

### Collections

Adds corresponding whereTrue() and whereFalse() methods to EnumeratesValues:

```
$active = $users->whereTrue('is_active');
$inactive = $users->whereFalse('is_active');
```

This keeps the API consistent between querying and in-memory collection filtering.

### Why

These additions improve readability, reduce boilerplate, and make intent crystal clear when working with boolean flags such as is_active, is_private, or is_ignored.
They also provide a consistent developer experience across database queries and collections.

### Tests

Comprehensive tests are included for both the Query Builder and Collection methods.

### Summary

This is a small but meaningful improvement that makes everyday boolean filtering more expressive, fluent, and consistent with the rest of Laravel’s query language.