### PR TITLE
[12.x] Custom public path resolver for Vite assets

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -84,6 +84,13 @@ class Vite implements Htmlable
     protected $preloadTagAttributesResolvers = [];
 
     /**
+     * The public path resolver.
+     *
+     * @var callable|null
+     */
+    protected $publicPathResolver = null;
+
+    /**
      * The preloaded assets.
      *
      * @var array
@@ -211,6 +218,19 @@ class Vite implements Htmlable
     public function createAssetPathsUsing($resolver)
     {
         $this->assetPathResolver = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * Resolve public paths using the provided resolver.
+     *
+     * @param  callable|null  $resolver
+     * @return $this
+     */
+    public function createPublicPathsUsing($resolver)
+    {
+        $this->publicPathResolver = $resolver;
 
         return $this;
     }
@@ -897,7 +917,7 @@ class Vite implements Htmlable
 
         $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
-        $path = public_path($buildDirectory.'/'.$chunk['file']);
+        $path = $this->publicPath($buildDirectory.'/'.$chunk['file']);
 
         if (! is_file($path) || ! file_exists($path)) {
             throw new ViteException("Unable to locate file from Vite manifest: {$path}.");
@@ -916,6 +936,17 @@ class Vite implements Htmlable
     protected function assetPath($path, $secure = null)
     {
         return ($this->assetPathResolver ?? asset(...))($path, $secure);
+    }
+
+    /**
+     * Generate a public path for an asset.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function publicPath($path)
+    {
+        return ($this->publicPathResolver ?? public_path(...))($path);
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1761,9 +1761,9 @@ class FoundationViteTest extends TestCase
         }
     }
 
-    protected function makeAsset($asset, $content)
+    protected function makeAsset($asset, $content, $buildDir = 'build')
     {
-        $path = public_path('build/assets');
+        $path = public_path($buildDir.'/assets');
 
         if (! file_exists($path)) {
             mkdir($path, recursive: true);
@@ -1772,9 +1772,9 @@ class FoundationViteTest extends TestCase
         file_put_contents($path.'/'.$asset, $content);
     }
 
-    protected function cleanAsset($asset)
+    protected function cleanAsset($asset, $buildDir = 'build')
     {
-        $path = public_path('build/assets');
+        $path = public_path($buildDir.'/assets');
 
         unlink($path.$asset);
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -705,7 +705,7 @@ class FoundationViteTest extends TestCase
             ],
         ], $buildDir = Str::random());
         $vite = app(Vite::class)->useBuildDirectory($buildDir);
-        $this->makeAsset('/assets/style.css', 'some content');
+        $this->makeAsset('/style.css', 'some content', $buildDir);
 
         // default behaviour: exception caused by appended version param
         $this->assertThrows(fn () => $vite->content('resources/style.css'), ViteException::class);
@@ -721,6 +721,7 @@ class FoundationViteTest extends TestCase
 
         $this->assertThrows(fn () => $vite->content('resources/style.css'), ViteException::class);
 
+        $this->cleanAsset('/style.css', $buildDir);
         $this->cleanViteManifest($buildDir);
     }
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -711,7 +711,7 @@ class FoundationViteTest extends TestCase
         $this->assertThrows(fn () => $vite->content('resources/style.css'), ViteException::class);
 
         // custom behaviour: works because we strip the version param
-        $vite->createPublicPathsUsing(fn ($path) => Str::before($path, '?'));
+        $vite->createPublicPathsUsing(fn ($path) => public_path(Str::before($path, '?')));
 
         $this->assertDoesntThrow(fn () => $vite->content('resources/style.css'));
         $this->assertSame('some content', $vite->content('resources/style.css'));


### PR DESCRIPTION
### Current state

- `Vite::content()`, introduced in 10.x, allows inlining raw contents of Vite assets
- The disk paths for reading the contents are hardcoded to use `public_path`
- This currently does not support some custom setups like e.g. hashes in query strings

### Proposed change

- Add a customizable resolver for asset disk paths
- API: `$vite->createPublicPathsUsing(fn ($path) => $path)`
- Mirrors `$vite->createAssetPathsUsing()` for a consistent API: one for URLs, one for disk paths

### Example use case

- Move asset hash into query string using [vite-plugin-query-string-versioning](https://www.npmjs.com/package/vite-plugin-query-string-versioning)
  - Default manifest `file` property: `assets/font.356cadeb.woff`
  - With plugin: `assets/font.woff?v=356cadeb`
- The plugin cannot rewrite the manifest’s `file` key as it is used to construct both the URL and the disk path
- Allowing a custom resolver lets users strip query strings or otherwise transform the path before disk access

```php
$vite->createPublicPathsUsing(
  fn ($path) => public_path(Str::before($path, '?'))
};
```

### Backward compatibility

- No breaking changes
- If no resolver is registered, current behavior remains: paths are resolved via `public_path`

### Tests

- Added tests for adding and removing custom resolver
- Added a param to two test helpers for creating test assets