### PR TITLE
[12.x] PostgreSQL virtual columns

### DIFF
--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -94,6 +94,7 @@ class PostgresProcessor extends Processor
                 'generation' => $result->generated ? [
                     'type' => match ($result->generated) {
                         's' => 'stored',
+                        'v' => 'virtual',
                         default => null,
                     },
                     'expression' => $result->default,

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1257,7 +1257,7 @@ class PostgresGrammar extends Grammar
         }
 
         if (! is_null($column->virtualAs)) {
-            return " generated always as ({$this->getValue($column->virtualAs)})";
+            return " generated always as ({$this->getValue($column->virtualAs)}) virtual";
         }
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -966,7 +966,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
-            'alter table "users" add column "bar" boolean not null generated always as (foo is not null)',
+            'alter table "users" add column "bar" boolean not null generated always as (foo is not null) virtual',
         ], $statements);
 
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -976,7 +976,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertCount(2, $statements);
         $this->assertSame([
             'alter table "users" add column "foo" integer null',
-            'alter table "users" add column "bar" boolean not null generated always as (foo is not null)',
+            'alter table "users" add column "bar" boolean not null generated always as (foo is not null) virtual',
         ], $statements);
     }
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -636,7 +636,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         ));
     }
 
-    #[RequiresDatabase('pgsql', '>=12.0')]
+    #[RequiresDatabase('pgsql', '>=18')]
     public function testGettingGeneratedColumns()
     {
         Schema::create('test', function (Blueprint $table) {
@@ -646,9 +646,7 @@ class SchemaBuilderTest extends DatabaseTestCase
                 $table->computed('virtual_price', 'price - 5');
                 $table->computed('stored_price', 'price - 10')->persisted();
             } else {
-                if ($this->driver !== 'pgsql') {
-                    $table->integer('virtual_price')->virtualAs('price - 5');
-                }
+                $table->integer('virtual_price')->virtualAs('price - 5');
                 $table->integer('stored_price')->storedAs('price - 10');
             }
         });
@@ -658,18 +656,17 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertTrue(collect($columns)->contains(
             fn ($column) => $column['name'] === 'price' && is_null($column['generation'])
         ));
-        if ($this->driver !== 'pgsql') {
-            $this->assertTrue(collect($columns)->contains(
-                fn ($column) => $column['name'] === 'virtual_price'
-                    && $column['generation']['type'] === 'virtual'
-                    && match ($this->driver) {
-                        'mysql' => $column['generation']['expression'] === '(`price` - 5)',
-                        'mariadb' => $column['generation']['expression'] === '`price` - 5',
-                        'sqlsrv' => $column['generation']['expression'] === '([price]-(5))',
-                        default => $column['generation']['expression'] === 'price - 5',
-                    }
-            ));
-        }
+        $this->assertTrue(collect($columns)->contains(
+            fn ($column) => $column['name'] === 'virtual_price'
+                && $column['generation']['type'] === 'virtual'
+                && match ($this->driver) {
+                    'mysql' => $column['generation']['expression'] === '(`price` - 5)',
+                    'mariadb' => $column['generation']['expression'] === '`price` - 5',
+                    'sqlsrv' => $column['generation']['expression'] === '([price]-(5))',
+                    'pgsql' => $column['generation']['expression'] === '(price - 5)',
+                    default => $column['generation']['expression'] === 'price - 5',
+                }
+        ));
         $this->assertTrue(collect($columns)->contains(
             fn ($column) => $column['name'] === 'stored_price'
                 && $column['generation']['type'] === 'stored'


### PR DESCRIPTION
About two weeks ago, PostgreSQL 18 was released which finally supports virtual generated columns. This PR adds support for it - in a backwards compatible manner.

The `virtualAs()` column modifier was officially not support for PostgreSQL and produced SQL that was invalid:

```sql
alter table "users" add column "email_lower2" text not null generated always as (lower(email));
-- ERROR:  syntax error at or near ";"
-- LINE 1: ...il_lower2" text not null generated always as (lower(email));
```

With PostgreSQL 18, this syntax is now supported and defaults to a virtual generated column. However, the current implementation was changed to explicitly add the `virtual` keyword to the DDL query - just to be sure in case defaults may change in the future.

Additionally, the tests schema builder tests have been changed to now also test virtual columns which had been excluded in the past - because PG didn't support it.

