### PR TITLE
[12.x] Make Vite asset path generation extendable via inheritance

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -897,7 +897,7 @@ class Vite implements Htmlable
 
         $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
-        $path = public_path($buildDirectory.'/'.$chunk['file']);
+        $path = $this->publicPath($buildDirectory.'/'.$chunk['file']);
 
         if (! is_file($path) || ! file_exists($path)) {
             throw new ViteException("Unable to locate file from Vite manifest: {$path}.");
@@ -916,6 +916,17 @@ class Vite implements Htmlable
     protected function assetPath($path, $secure = null)
     {
         return ($this->assetPathResolver ?? asset(...))($path, $secure);
+    }
+
+    /**
+     * Generate a public path for an asset.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function publicPath($path)
+    {
+        return public_path($path);
     }
 
     /**


### PR DESCRIPTION
A much trimmed-down version of the proposed change in #57289 which was (rightly) rejected as feature creep.

This adds nothing but only makes the Vite class more extendable via inheritance. It moves the public path generation of Vite assets into a protected method. Any custom setups can extend the Vite class and overwrite this method.

Example usage (remove query string hash before generating disk path):

```php
->withSingletons([
    Vite::class => fn() => new class extends Vite {
        protected function publicPath($path) {
            return parent::publicPath(Str::before($path, '?'));
        }
    }
])
```