### PR TITLE
feat: use STDERR for console components auxiliary output

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -172,7 +173,15 @@ class Command extends SymfonyCommand
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 
-        $this->components = $this->laravel->make(Factory::class, ['output' => $this->output]);
+        $componentsOutput = $this->output;
+
+        if ($output instanceof ConsoleOutputInterface) {
+            $componentsOutput = $this->laravel->make(
+                OutputStyle::class, ['input' => $input, 'output' => $output->getErrorOutput()]
+            );
+        }
+
+        $this->components = $this->laravel->make(Factory::class, ['output' => $componentsOutput]);
 
         $this->configurePrompts($input);
 

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -29,11 +29,11 @@ trait ConfiguresPrompts
     {
         Prompt::setOutput($this->output);
 
-        Prompt::interactive(($input->isInteractive() && defined('STDIN') && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
+        Prompt::interactive(($input->isInteractive() && defined('STDIN') && stream_isatty(STDIN)) || (method_exists($this->laravel, 'runningUnitTests') && $this->laravel->runningUnitTests()));
 
         Prompt::validateUsing(fn (Prompt $prompt) => $this->validatePrompt($prompt->value(), $prompt->validate));
 
-        Prompt::fallbackWhen(windows_os() || $this->laravel->runningUnitTests());
+        Prompt::fallbackWhen(windows_os() || (method_exists($this->laravel, 'runningUnitTests') && $this->laravel->runningUnitTests()));
 
         TextPrompt::fallbackUsing(fn (TextPrompt $prompt) => $this->promptUntilValid(
             fn () => $this->components->ask($prompt->label, $prompt->default ?: null) ?? '',


### PR DESCRIPTION
As described in issue [#56602](https://github.com/laravel/framework/issues/56602), this PR modifies Laravel's console components to write auxiliary output (task progress, prompts, etc.) to STDERR when available, while maintaining full backwards compatibility. This allows commands with --json flags to pipe output without UI contamination.

Currently, console components like task(), progress bars, and prompts write to STDOUT, which contaminates piped output:

```
# Current behavior - task output breaks JSON
php artisan some:command --json > output.json
$ head -n+3 output.json
Doing work ...................................... 1s DONE  # ← Breaks JSON!
[
  {
```

Console components now use STDERR for auxiliary output when ConsoleOutputInterface is available:
```
# New behavior - clean JSON output
php artisan some:command --json > output.json
$ head -n+3 output.json
[
  {
    "nice": "valid JSON!"
```


