### PR TITLE
[13.x] Flush `Str` factories when tearing down test case

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -184,9 +184,7 @@ trait InteractsWithTestCaseLifecycle
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
         Sleep::fake(false);
-        Str::createRandomStringsNormally();
-        Str::createUlidsNormally();
-        Str::createUuidsNormally();
+        Str::resetFactoryState();
         TrimStrings::flushState();
         TrustProxies::flushState();
         TrustHosts::flushState();

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -184,6 +184,9 @@ trait InteractsWithTestCaseLifecycle
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
         Sleep::fake(false);
+        Str::createRandomStringsNormally();
+        Str::createUlidsNormally();
+        Str::createUuidsNormally();
         TrimStrings::flushState();
         TrustProxies::flushState();
         TrustHosts::flushState();

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2089,7 +2089,6 @@ class Str
         static::$studlyCache = [];
     }
 
-
     /**
      * Return all factory functions to their default state.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2088,4 +2088,17 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+
+    /**
+     * Return all factory functions to their default state.
+     *
+     * @return void
+     */
+    public static function resetFactoryState()
+    {
+        static::createRandomStringsNormally();
+        static::createUlidsNormally();
+        static::createUuidsNormally();
+    }
 }


### PR DESCRIPTION
This restores the factories on the Str class to their defaults when tearing down test cases.

Targeting master as https://github.com/laravel/framework/pull/57291 was deemed to be too many potential breaking changes for a minor version release.