### PR TITLE
[12.x] Remove leftover workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,15 +76,6 @@ jobs:
       - name: Set Framework version
         run: composer config version "12.x-dev"
 
-      - name: Set Minimum dependencies for `prefer-lowest`
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require opis/string:2.0.1 --no-interaction --no-update
-          shell: bash
-        if: matrix.stability == 'prefer-lowest'
-
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
@@ -153,15 +144,6 @@ jobs:
 
       - name: Set Framework version
         run: composer config version "12.x-dev"
-
-      - name: Set Minimum dependencies for `prefer-lowest`
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require opis/string:2.0.1 --no-interaction --no-update
-          shell: bash
-        if: matrix.stability == 'prefer-lowest'
 
       - name: Install dependencies
         uses: nick-fields/retry@v3


### PR DESCRIPTION
Partially reverts: #57031

---

Description
---
I think the dependency has been removed. When I run:

```sh
composer why opis/string
```

In a fresh Laravel installation, I get:

```
Could not find package "opis/string" in your project
```