### PR TITLE
fix: Flatten empty arrays as `null` in `Arr::dot`.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -169,8 +169,12 @@ class Arr
             foreach ($data as $key => $value) {
                 $newKey = $prefix.$key;
 
-                if (is_array($value) && ! empty($value)) {
-                    $flatten($value, $newKey.'.');
+                if (is_array($value)) {
+                    if (! empty($value)) {
+                        $flatten($value, $newKey.'.');
+                    } else {
+                        $results[$newKey] = null;
+                    }
                 } else {
                     $results[$newKey] = $value;
                 }
@@ -597,7 +601,6 @@ class Arr
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.
      *
-     * @param  array  $array
      * @return bool
      */
     public static function isAssoc(array $array)
@@ -766,8 +769,6 @@ class Arr
     /**
      * Run a map over each of the items in the array.
      *
-     * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function map(array $array, callable $callback)
@@ -967,11 +968,6 @@ class Arr
 
     /**
      * Push an item into an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $values
-     * @return array
      */
     public static function push(ArrayAccess|array &$array, string|int|null $key, mixed ...$values): array
     {
@@ -1152,7 +1148,6 @@ class Arr
      * Filter the array using the given callback.
      *
      * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function where($array, callable $callback)
@@ -1164,7 +1159,6 @@ class Arr
      * Filter the array using the negation of the given callback.
      *
      * @param  array  $array
-     * @param  callable  $callback
      * @return array
      */
     public static function reject($array, callable $callback)

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -217,10 +217,10 @@ class SupportArrTest extends TestCase
         $this->assertSame([], $array);
 
         $array = Arr::dot(['foo' => []]);
-        $this->assertSame(['foo' => []], $array);
+        $this->assertSame(['foo' => null], $array);
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
-        $this->assertSame(['foo.bar' => []], $array);
+        $this->assertSame(['foo.bar' => null], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertSame(['name' => 'taylor', 'languages.php' => true], $array);
@@ -243,7 +243,7 @@ class SupportArrTest extends TestCase
         $array = Arr::dot(['foo' => 'bar', 'empty_array' => [], 'user' => ['name' => 'Taylor'], 'key' => 'value']);
         $this->assertSame([
             'foo' => 'bar',
-            'empty_array' => [],
+            'empty_array' => null,
             'user.name' => 'Taylor',
             'key' => 'value',
         ], $array);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Solves #57305.

The current implementation of `Arr::dot()` doesn't flatten arrays that contain empty arrays. This goes against my intuition, so I'm proposing a change to reflect what I think should happen instead.

Opened the PR preemptively to:
 - Hopefully speed up the process
 - Serve as a clear description of my expectations