### PR TITLE
[12.x] Fix remaining PHP 8.5 null index array deprecations

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -141,7 +141,7 @@ class BroadcastEvent implements ShouldQueue
      * Get the channels for the given connection.
      *
      * @param  array  $channels
-     * @param  string  $connection
+     * @param  string|null  $connection
      * @return array
      */
     protected function getConnectionChannels($channels, $connection)
@@ -155,7 +155,7 @@ class BroadcastEvent implements ShouldQueue
      * Get the payload for the given connection.
      *
      * @param  array  $payload
-     * @param  string  $connection
+     * @param  string|null  $connection
      * @return array
      */
     protected function getConnectionPayload($payload, $connection)

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -146,8 +146,8 @@ class BroadcastEvent implements ShouldQueue
      */
     protected function getConnectionChannels($channels, $connection)
     {
-        return is_array($channels[$connection] ?? null)
-            ? $channels[$connection]
+        return is_array($channels[$connection ?? ''] ?? null)
+            ? $channels[$connection ?? '']
             : $channels;
     }
 
@@ -160,8 +160,8 @@ class BroadcastEvent implements ShouldQueue
      */
     protected function getConnectionPayload($payload, $connection)
     {
-        $connectionPayload = is_array($payload[$connection] ?? null)
-            ? $payload[$connection]
+        $connectionPayload = is_array($payload[$connection ?? ''] ?? null)
+            ? $payload[$connection ?? '']
             : $payload;
 
         if (isset($payload['socket'])) {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -168,8 +168,8 @@ class BelongsTo extends Relation
         foreach ($models as $model) {
             $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($model));
 
-            if (isset($dictionary[$attribute])) {
-                $model->setRelation($relation, $dictionary[$attribute]);
+            if (isset($dictionary[$attribute ?? ''])) {
+                $model->setRelation($relation, $dictionary[$attribute ?? '']);
             }
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -32,7 +32,7 @@ class Worker
     /**
      * The name of the worker.
      *
-     * @var string
+     * @var string|null
      */
     protected $name;
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -363,8 +363,8 @@ class Worker
         $this->raiseBeforeJobPopEvent($connection->getConnectionName());
 
         try {
-            if (isset(static::$popCallbacks[$this->name])) {
-                if (! is_null($job = (static::$popCallbacks[$this->name])($popJobCallback, $queue))) {
+            if (isset(static::$popCallbacks[$this->name ?? ''])) {
+                if (! is_null($job = (static::$popCallbacks[$this->name ?? ''])($popJobCallback, $queue))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
                 }
 


### PR DESCRIPTION
Following up #57137 and #57231 - fixing remaining `null` array index accessors.

Remaining deprecations include:
- [ ] `PDO::MYSQL_*` constants in `orchestra/testbench-core` - tracked in #57141
- [x] `SplObjectStorage::contains()` in `opis/json-schema` - fixing in https://github.com/opis/json-schema/pull/156
- [x] Using null as an array offset is deprecated, use an empty string instead in `league/uri` - fixed in https://github.com/thephpleague/uri-src/pull/157, unreleased