### PR TITLE
fix namespace errors:: 

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/401.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/401.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Unauthorized'))
 @section('code', '401')

--- a/src/Illuminate/Foundation/Exceptions/views/402.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/402.blade.php
@@ -1,6 +1,5 @@
 @extends('errors.minimal')
 
-
 @section('title', __('Payment Required'))
 @section('code', '402')
 @section('message', __('Payment Required'))

--- a/src/Illuminate/Foundation/Exceptions/views/402.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/402.blade.php
@@ -1,4 +1,5 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
+
 
 @section('title', __('Payment Required'))
 @section('code', '402')

--- a/src/Illuminate/Foundation/Exceptions/views/403.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/403.blade.php
@@ -1,6 +1,5 @@
 @extends('errors.minimal')
 
-
 @section('title', __('Forbidden'))
 @section('code', '403')
 @section('message', __($exception->getMessage() ?: 'Forbidden'))

--- a/src/Illuminate/Foundation/Exceptions/views/403.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/403.blade.php
@@ -1,4 +1,5 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
+
 
 @section('title', __('Forbidden'))
 @section('code', '403')

--- a/src/Illuminate/Foundation/Exceptions/views/404.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/404.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Not Found'))
 @section('code', '404')

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Page Expired'))
 @section('code', '419')

--- a/src/Illuminate/Foundation/Exceptions/views/429.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/429.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Too Many Requests'))
 @section('code', '429')

--- a/src/Illuminate/Foundation/Exceptions/views/500.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/500.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Server Error'))
 @section('code', '500')

--- a/src/Illuminate/Foundation/Exceptions/views/503.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/503.blade.php
@@ -1,4 +1,4 @@
-@extends('errors::minimal')
+@extends('errors.minimal')
 
 @section('title', __('Service Unavailable'))
 @section('code', '503')


### PR DESCRIPTION
### Fix incorrect view reference in error pages (Laravel 12)

#### Problem
In Laravel 12, the default published error views contain an invalid namespace reference:

```blade
@extends('errors::minimal')
```

This causes the following exception when rendering error views (e.g., 500.blade.php):

InvalidArgumentException
**No hint path defined for [errors].**

Cause

In Laravel 12, the error view namespace errors:: is no longer registered automatically. Therefore, using @extends('errors::minimal') results in an undefined hint path.

Solution

The fix is to change the view inheritance to a relative reference:

`@extends('errors.minimal')`
