### PR TITLE
[12.x] Add enum support to `Schedule::useCache()`

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -432,11 +432,13 @@ class Schedule
     /**
      * Specify the cache store that should be used to store mutexes.
      *
-     * @param  string  $store
+     * @param  \UnitEnum|string  $store
      * @return $this
      */
     public function useCache($store)
     {
+        $store = enum_value($store);
+
         if ($this->eventMutex instanceof CacheAware) {
             $this->eventMutex->useStore($store);
         }

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -14,7 +14,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
  * @method static bool serverShouldRun(\Illuminate\Console\Scheduling\Event $event, \DateTimeInterface $time)
  * @method static \Illuminate\Support\Collection dueEvents(\Illuminate\Contracts\Foundation\Application $app)
  * @method static \Illuminate\Console\Scheduling\Event[] events()
- * @method static \Illuminate\Console\Scheduling\Schedule useCache(string $store)
+ * @method static \Illuminate\Console\Scheduling\Schedule useCache(\UnitEnum|string $store)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)


### PR DESCRIPTION
Continuation of #56271 
