### PR TITLE
[12.x] Add `midday()` method to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -326,6 +326,16 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run at midday (12:00 PM).
+     *
+     * @return $this
+     */
+    public function midday()
+    {
+        return $this->hourBasedSchedule(0, 12);
+    }
+
+    /**
      * Schedule the command at a given time.
      *
      * @param  string  $time

--- a/src/Illuminate/Support/Facades/Schedule.php
+++ b/src/Illuminate/Support/Facades/Schedule.php
@@ -59,6 +59,7 @@ use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes daily()
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes at(string $time)
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes dailyAt(string $time)
+ * @method static \Illuminate\Console\Scheduling\PendingEventAttributes midday()
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes twiceDaily(int $first = 1, int $second = 13)
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes twiceDailyAt(int $first = 1, int $second = 13, int $offset = 0)
  * @method static \Illuminate\Console\Scheduling\PendingEventAttributes weekdays()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -43,6 +43,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 0 * * *', $this->event->daily()->getExpression());
     }
 
+    public function testMidday()
+    {
+        $this->assertSame('0 12 * * *', $this->event->midday()->getExpression());
+    }
+
     public function testDailyAt()
     {
         $this->assertSame('8 13 * * *', $this->event->dailyAt('13:08')->getExpression());


### PR DESCRIPTION
This PR introduces a new `midday()` method to Laravel’s scheduler, allowing developers to schedule tasks to run daily at `12:00 PM` using a more readable syntax:

```php
Schedule::command('foo')->midday();

Schedule::command('foo')
    ->weekdays()
    ->midday()
    ->timezone('America/Chicago') 
```