### PR TITLE
Bug in __sleep method in Model if use Hooks php8.4 (get, set)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2595,7 +2595,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->relationAutoloadCallback = null;
         $this->relationAutoloadContext = null;
 
-        return array_keys(get_object_vars($this));
+        return array_keys(get_mangled_object_vars($this));
     }
 
     /**


### PR DESCRIPTION
There is a bug in Laravel

If new get-set Hooks are used in the model, an error pops up when executing queues or Events using redis.

I use this bug fix in my work projects. The solution to get away from Attributes is to get away from using magic methods for simple calculations.


Error message: "Failed to serialize job of type [Illuminate\Events\CallQueuedListener]: serialize(): &quot;full_name&quot; returned as member variable from __sleep() but does not exist"

Code in Model

```php
<?php

namespace App\Models;

use Laravel\Passport\HasApiTokens;
use Illuminate\Notifications\Notifiable;
use Illuminate\Database\Eloquent\Prunable;
use Illuminate\Database\Eloquent\SoftDeletes;
use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Foundation\Auth\User as Authenticatable;

final class Client extends Authenticatable
{
    use HasApiTokens;
    use HasFactory;
    use Notifiable;
    use Prunable;
    use SoftDeletes;

    protected $connection = 'mariadb';

    protected $fillable = [
        'first_name',
        'last_name',
        'middle_name',
    ];

    public string $full_name {
        get => "{$this->last_name} {$this->first_name} {$this->middle_name}";
    }
    ...
    
}
```

I'm using this fix in Laravel version 12.32.5.

