### PR TITLE
Add `union()` method to Eloquent collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -509,6 +509,17 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Union the collection with the given items.
+     *
+     * @param  iterable<array-key, TModel>  $items
+     * @return static
+     */
+    public function union($items)
+    {
+        return new static(array_values($this->getDictionary() + $items->getDictionary()));
+    }
+
+    /**
      * Return only unique items from the collection.
      *
      * @param  (callable(TModel, TKey): mixed)|string|null  $key

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -752,6 +752,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['John (US)', 'Jane (NL)', 'Taylor (US)'], $c->pluck(fn (TestEloquentCollectionModel $model) => "{$model->name} ({$model->country})")->all());
     }
 
+    public function testUnion()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $twoCopy = m::mock(Model::class);
+        $twoCopy->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(3);
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$twoCopy, $three]);
+        $union = $c1->union($c2);
+
+        $this->assertEquals(new Collection([$one, $two, $three]), $union);
+        $this->assertNotContains($twoCopy, $union);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
This PR adds an union method override to Eloquent collections to correctly form an union based on model keys.