### PR TITLE
Update text color in minimal error view to ensure better accessibility

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/minimal.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/minimal.blade.php
@@ -20,11 +20,11 @@
         <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center sm:pt-0">
             <div class="max-w-xl mx-auto sm:px-6 lg:px-8">
                 <div class="flex items-center pt-8 sm:justify-start sm:pt-0">
-                    <div class="px-4 text-lg text-gray-500 border-r border-gray-400 tracking-wider">
+                    <div class="px-4 text-lg text-gray-600 dark:text-gray-300 border-r border-gray-400 tracking-wider">
                         @yield('code')
                     </div>
 
-                    <div class="ml-4 text-lg text-gray-500 uppercase tracking-wider">
+                    <div class="ml-4 text-lg text-gray-600 dark:text-gray-300 uppercase tracking-wider">
                         @yield('message')
                     </div>
                 </div>


### PR DESCRIPTION
This pull request makes a minor visual improvement to the error page template. The color of the error code and message text has been updated for better readability and dark mode support.

- Updated text color classes in `src/Illuminate/Foundation/Exceptions/views/minimal.blade.php` to use `text-gray-600` for light mode and `dark:text-gray-300` for dark mode, improving accessibility and visual consistency across themes.
- Ensured contrast ratios meet WCAG AAA accessibility standards, making the error page more readable for all users, including those with visual impairments.

While developing my own application, and writing tests to ensure it would be accessible for all users, I found that the standard HTTP error pages were having issues with the contrast of the text color and background color. 

Prior to these changes, when comparing the contrast ratios, it would be:
<img width="584" height="440" alt="Lightmode ratios with issues" src="https://github.com/user-attachments/assets/03d32967-e68c-441d-8249-d1c1e043d067" />
<img width="589" height="447" alt="Darkmode ratios with issues" src="https://github.com/user-attachments/assets/8ddf2a07-d8b0-4033-9e01-f9588290027a" />

After these changes, when comparing the contrast ratios, it will be:
<img width="583" height="438" alt="Lightmode ratios" src="https://github.com/user-attachments/assets/076b46d8-bc8d-48a7-b976-e707abd8dc61" />

<img width="594" height="451" alt="Darkmode ratios" src="https://github.com/user-attachments/assets/8d469d6a-a583-4c9a-b29e-ba29bb28bfe5" />
