### PR TITLE
[11.x] Avoid duplicate chain catch when nested batch fails on sync queue

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -188,9 +188,7 @@ class Batch implements Arrayable, JsonSerializable
         $queueConnection = $this->queue->connection($this->options['connection'] ?? null);
 
         if ($queueConnection instanceof SyncQueue) {
-            $this->repository->transaction(function () use ($count) {
-                $this->repository->incrementTotalJobs($this->id, $count);
-            });
+            $this->repository->incrementTotalJobs($this->id, $count);
 
             try {
                 $queueConnection->bulk(

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -201,10 +201,10 @@ class Batch implements Arrayable, JsonSerializable
             } catch (Throwable $e) {
             }
         } else {
-            $this->repository->transaction(function () use ($jobs, $count) {
+            $this->repository->transaction(function () use ($jobs, $count, $queueConnection) {
                 $this->repository->incrementTotalJobs($this->id, $count);
 
-                $this->queue->connection($this->options['connection'] ?? null)->bulk(
+                $queueConnection->bulk(
                     $jobs->all(),
                     $data = '',
                     $this->options['queue'] ?? null


### PR DESCRIPTION
Prevents `Bus::chain(...)->catch(...)` from being invoked twice when a `Bus::batch(...)` inside the chain fails on the `sync` queue. Batch catch runs once; chain catch runs once.

As described in [#55077](https://github.com/laravel/framework/issues/55077), nested batches inside chains on the `sync` queue caused:
- Chain catch to run twice (once via injected batch catch, once via chain).
- Batch catch to run inside a DB transaction, rolling back its side effects on `sync`.