### PR TITLE
[12.x] Fix email rule helper message

### DIFF
--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -186,10 +186,6 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     {
         $this->messages = [];
 
-        if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
-            return false;
-        }
-
         $validator = Validator::make(
             $this->data,
             [$attribute => $this->buildValidationRules()],

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -37,13 +37,13 @@ class ValidationEmailRuleTest extends TestCase
         $this->fails(
             Email::default(),
             12345,
-            [Email::class]
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->fails(
             Rule::email(),
             12345,
-            [Email::class]
+            ['The '.self::ATTRIBUTE_REPLACED.' must be a valid email address.']
         );
 
         $this->passes(


### PR DESCRIPTION
When using the `Rule::email` helper, if you validate a non-string you end up with the class name as the validation message since no messages get set in the rule. I did see the test was expecting that, but without a mention in the docs of needing `Email::class => '...',` in your validation file to use the helper I assumed it was unintentional (or there used to be something converting the class string that was lost).

Since the email validator it falls back to will fail on a non-string anyway I removed the check and let it get replaced with the invalid validation message.

```
% composer create-project laravel/laravel test-app
% cd test-app/
% php artisan tinker
> Validator::make(['email_address' => 'test@example.com'], ['email_address' => \Illuminate\Validation\Rule::email()])->errors()->toArray()
= []

> Validator::make(['email_address' => 'not-an-email'], ['email_address' => \Illuminate\Validation\Rule::email()])->errors()->toArray()
= [
    "email_address" => [
      "The email address field must be a valid email address.",
    ],
  ]

> Validator::make(['email_address' => 123], ['email_address' => \Illuminate\Validation\Rule::email()])->errors()->toArray()
= [
    "email_address" => [
      "Illuminate\Validation\Rules\Email",
    ],
  ]

> Validator::make(['email_address' => ['not-a-string']], ['email_address' => \Illuminate\Validation\Rule::email()])->errors()->toArray()
= [
    "email_address" => [
      "Illuminate\Validation\Rules\Email",
    ],
  ]
```