### PR TITLE
[12.x] Add `Env::integer()` and `env_int()` helper for typed integer environment access

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -106,6 +106,27 @@ class Env
     }
 
     /**
+     * Get the integer value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return int
+     */
+    public static function integer(string $key, mixed $default = null): int
+    {
+        $value = self::get($key, $default);
+
+        if (! is_numeric($value)) {
+            throw new RuntimeException(sprintf(
+                'Environment variable [%s] must be integer, got %s instead.',
+                $key, gettype($value)
+            ));
+        }
+
+        return (int) $value;
+    }
+
+    /**
      * Get the value of a required environment variable.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -152,6 +152,20 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('env_int')) {
+    /**
+     * Gets the integer value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return int
+     */
+    function env_int(string $key, mixed $default = null): int
+    {
+        return Env::integer($key, $default);
+    }
+}
+
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1226,6 +1226,15 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('x"null"x', env('foo'));
     }
 
+    public function testEnvInteger()
+    {
+        $_SERVER['foo'] = 1234;
+        $this->assertIsInt(env_int('foo'));
+        $this->assertIsInt(Env::integer('foo'));
+        $this->assertSame(1234, env_int('foo'));
+        $this->assertSame(1234, Env::integer('foo'));
+    }
+
     public function testWriteArrayOfEnvVariablesToFile()
     {
         $filesystem = new Filesystem;


### PR DESCRIPTION
## Summary

This PR introduces a new method, `Env::integer()`, and a corresponding global helper, `env_int()`, to retrieve environment variables as strictly typed integers.
It adds safer and more expressive access to numeric environment variables (e.g., `REDIS_PORT`, `SESSION_LIFETIME`).

## Benefits

- **Type Safety**: Prevents accidental coercion of `null`, `false` values into `0` when casting using `(int)`.
- **Backward Compatibility**: Existing code using `env()` or `Env::get()` continues to work unchanged.

## Why?

The `Env` class already provides internal casting for boolean-like and null-like values. However, numeric values were not explicitly handled and developers often need to cast them manually.

## Example Usage

```php
$redis_port = env_int('REDIS_PORT', 6379);
$session_lifetime = Env::integer('SESSION_LIFETIME', 120); 
```

