### PR TITLE
[12.x] Support Enum for Manager

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -50,21 +50,21 @@ abstract class Manager
     /**
      * Get the default driver name.
      *
-     * @return string|null
+     * @return \UnitEnum|string|null
      */
     abstract public function getDefaultDriver();
 
     /**
      * Get a driver instance.
      *
-     * @param  string|null  $driver
+     * @param  \UnitEnum|string|null  $driver
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
     public function driver($driver = null)
     {
-        $driver = $driver ?: $this->getDefaultDriver();
+        $driver = enum_value($driver ?: $this->getDefaultDriver());
 
         if (is_null($driver)) {
             throw new InvalidArgumentException(sprintf(
@@ -118,13 +118,13 @@ abstract class Manager
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string  $driver
+     * @param  \UnitEnum|string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
+        $this->customCreators[enum_value($driver)] = $callback;
 
         return $this;
     }


### PR DESCRIPTION
Hi team,

From our projects, we love the `Manager` abstract and use it a lot. Since the Manager hasn't supported Enum for driver names, this PR adds support for the Enum for that - and of course, no breaking changes.

This will increase DX, of course. As of now, we have to explicitly do `$enum->value` or use `public const string` (IMO not so cool)

This will also enable Laravel to provide its own Enum for drivers instead of raw strings (easier for new devs to find out supported drivers)

If this gets accepted, I'll tackle the `MultipleInstanceManager` next.

Thanks.