### PR TITLE
[12.x]Feature: add sum method on Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1225,8 +1225,8 @@ class Arr
     }
 
     /**
-     * @param  array $value
-     * @param  string|callable|null $callback
+     * @param  array  $value
+     * @param  string|callable|null  $callback
      * @return float|int
      */
     public static function sum($value, $callback = null)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1223,4 +1223,26 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * @param  array $value
+     * @param  string|callable|null $callback
+     * @return float|int
+     */
+    public static function sum($value, $callback = null)
+    {
+        if ($callback) {
+            $sum = 0;
+
+            foreach ($value as $key => $item) {
+                $sum += is_callable($callback)
+                    ? $callback($item, $key)
+                    : (float) data_get($item, $callback);
+            }
+
+            return $sum;
+        }
+
+        return array_sum(array_filter(static::flatten($value), 'is_numeric'));
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1828,7 +1828,7 @@ class SupportArrTest extends TestCase
         ];
         $this->assertEquals(450, Arr::sum($data, 'price'), 'Failed on key-based sum');
 
-        $sum = Arr::sum($data, fn($item) => $item['price'] * $item['qty']);
+        $sum = Arr::sum($data, fn ($item) => $item['price'] * $item['qty']);
         $this->assertEquals(850, $sum, 'Failed on callable sum');
 
         $data = [1, 'a', 3, null, '5', [], false];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1812,4 +1812,31 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testSum()
+    {
+        $data = [1, 2, 3, 4, 5];
+        $this->assertEquals(15, Arr::sum($data), 'Failed on simple numeric array');
+
+        $data = [1, [2, 3], [4, [5, 6]]];
+        $this->assertEquals(21, Arr::sum($data), 'Failed on nested arrays');
+
+        $data = [
+            ['price' => 100, 'qty' => 2],
+            ['price' => 200, 'qty' => 1],
+            ['price' => 150, 'qty' => 3],
+        ];
+        $this->assertEquals(450, Arr::sum($data, 'price'), 'Failed on key-based sum');
+
+        $sum = Arr::sum($data, fn($item) => $item['price'] * $item['qty']);
+        $this->assertEquals(850, $sum, 'Failed on callable sum');
+
+        $data = [1, 'a', 3, null, '5', [], false];
+        $this->assertEquals(9, Arr::sum($data), 'Failed on mixed types');
+
+        $this->assertEquals(0, Arr::sum([]), 'Failed on empty array');
+
+        $data = ['a', null, false, [], 'hello'];
+        $this->assertEquals(0, Arr::sum($data), 'Failed on non-numeric-only array');
+    }
 }


### PR DESCRIPTION
This PR introduces a new static method `Arr::sum()` to the Arr class.
It provides an easy way to calculate the sum of array values — including nested arrays —
and supports summing by a specific key or a custom callable (similar to `Collection::sum()`).