### PR TITLE
[12.x] Use UnitEnum not both

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -312,7 +312,7 @@ class RateLimiter
     /**
      * Resolve the rate limiter name.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return string
      */
     private function resolveLimiterName($name): string

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -41,7 +41,7 @@ class RateLimiter
     /**
      * Register a named limiter configuration.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @param  \Closure  $callback
      * @return $this
      */
@@ -57,7 +57,7 @@ class RateLimiter
     /**
      * Get the given named rate limiter.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return \Closure|null
      */
     public function limiter($name)

--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -28,7 +28,7 @@ class Bind
      * Create a new attribute instance.
      *
      * @param  class-string  $concrete
-     * @param  non-empty-array<int, \BackedEnum|\UnitEnum|non-empty-string>|non-empty-string|\UnitEnum  $environments
+     * @param  non-empty-array<int, \UnitEnum|non-empty-string>|non-empty-string|\UnitEnum  $environments
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -42,7 +42,7 @@ class RateLimited
     /**
      * Create a new middleware instance.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $limiterName
+     * @param  \UnitEnum|string  $limiterName
      */
     public function __construct($limiterName)
     {

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Cache\RateLimiter for(\BackedEnum|\UnitEnum|string $name, \Closure $callback)
- * @method static \Closure|null limiter(\BackedEnum|\UnitEnum|string $name)
+ * @method static \Illuminate\Cache\RateLimiter for(\UnitEnum|string $name, \Closure $callback)
+ * @method static \Closure|null limiter(\UnitEnum|string $name)
  * @method static mixed attempt(string $key, int $maxAttempts, \Closure $callback, \DateTimeInterface|\DateInterval|int $decaySeconds = 60)
  * @method static bool tooManyAttempts(string $key, int $maxAttempts)
  * @method static int hit(string $key, \DateTimeInterface|\DateInterval|int $decaySeconds = 60)

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -114,7 +114,7 @@ class Rule
     /**
      * Get an in rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\In
      */
     public static function in($values)
@@ -129,7 +129,7 @@ class Rule
     /**
      * Get a not_in rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\NotIn
      */
     public static function notIn($values)
@@ -263,7 +263,7 @@ class Rule
     /**
      * Get a contains rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\Contains
      */
     public static function contains($values)
@@ -278,7 +278,7 @@ class Rule
     /**
      * Get a "does not contain" rule builder instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      * @return \Illuminate\Validation\Rules\DoesntContain
      */
     public static function doesntContain($values)

--- a/src/Illuminate/Validation/Rules/Contains.php
+++ b/src/Illuminate/Validation/Rules/Contains.php
@@ -19,7 +19,7 @@ class Contains implements Stringable
     /**
      * Create a new contains rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      */
     public function __construct($values)
     {

--- a/src/Illuminate/Validation/Rules/DoesntContain.php
+++ b/src/Illuminate/Validation/Rules/DoesntContain.php
@@ -19,7 +19,7 @@ class DoesntContain implements Stringable
     /**
      * Create a new doesntContain rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      */
     public function __construct($values)
     {

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -26,7 +26,7 @@ class In implements Stringable
     /**
      * Create a new in rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      */
     public function __construct($values)
     {

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -26,7 +26,7 @@ class NotIn implements Stringable
     /**
      * Create a new "not in" rule instance.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable|\BackedEnum|\UnitEnum|array|string  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|\UnitEnum|array|string  $values
      */
     public function __construct($values)
     {


### PR DESCRIPTION
Description
---
As suggested (and approved) in: https://github.com/laravel/framework/pull/57190#discussion_r2384189817 we should not use both **BackedEnum** and **UnitEnum**. Through a quick GitHub search I found these instances.