### PR TITLE
[12.26] Fix Arr::dot() to convert empty arrays to null

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -172,6 +172,11 @@ class Arr
                 if (is_array($value) && ! empty($value)) {
                     $flatten($value, $newKey.'.');
                 } else {
+
+                    if (is_array($value) && empty($value)) {
+                        $value = null;
+                    }
+
                     $results[$newKey] = $value;
                 }
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -217,10 +217,10 @@ class SupportArrTest extends TestCase
         $this->assertSame([], $array);
 
         $array = Arr::dot(['foo' => []]);
-        $this->assertSame(['foo' => []], $array);
+        $this->assertSame(['foo' => null], $array);
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
-        $this->assertSame(['foo.bar' => []], $array);
+        $this->assertSame(['foo.bar' => null], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertSame(['name' => 'taylor', 'languages.php' => true], $array);
@@ -243,7 +243,7 @@ class SupportArrTest extends TestCase
         $array = Arr::dot(['foo' => 'bar', 'empty_array' => [], 'user' => ['name' => 'Taylor'], 'key' => 'value']);
         $this->assertSame([
             'foo' => 'bar',
-            'empty_array' => [],
+            'empty_array' => null,
             'user.name' => 'Taylor',
             'key' => 'value',
         ], $array);


### PR DESCRIPTION
This PR updates the `Arr::dot()` method to convert empty arrays to `null` when flattening multi-dimensional arrays. The tests have been updated to reflect this behavior.

### Before

```php
Arr::dot(['foo' => []]);
// ['foo' => []]
```

### After

```php
Arr::dot(['foo' => []]);
// ['foo' => null]
```

Converting empty arrays to null makes the output more consistent for serialization, database storage, and logging.

Fixes #57305
