### PR TITLE
[12.x] Do not assume `Str::uuid()` returns `Stringable`

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -111,7 +111,7 @@ class NotificationSender
             }
 
             $this->withLocale($this->preferredLocale($notifiable, $notification), function () use ($viaChannels, $notifiable, $original) {
-                $notificationId = Str::uuid()->toString();
+                $notificationId = (string) Str::uuid();
 
                 foreach ((array) $viaChannels as $channel) {
                     if (! ($notifiable instanceof AnonymousNotifiable && $channel === 'database')) {
@@ -216,7 +216,7 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            $notificationId = Str::uuid()->toString();
+            $notificationId = (string) Str::uuid();
 
             foreach ((array) $original->via($notifiable) as $channel) {
                 $notification = clone $original;

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -314,7 +314,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
 
         foreach ($notifiables as $notifiable) {
             if (! $notification->id) {
-                $notification->id = Str::uuid()->toString();
+                $notification->id = (string) Str::uuid();
             }
 
             $notifiableChannels = $channels ?: $notification->via($notifiable);


### PR DESCRIPTION
To close https://github.com/laravel/framework/issues/57328

Most of the places within the app use `(string) Str::uuid()`. While there are now typehints on `Str::createUuidUsing()`, they are just docblocks and cannot be strictly enforced.

Now users who want to leverage NotificationFake in conjunction with `Str::createUuidsUsing(fn () => 'dis-my-uuid-tho')` can.