### PR TITLE
Adding tests ensuring `action()` returns first route for overlapping routes

### DIFF
--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -571,6 +571,39 @@ class CompiledRouteCollectionTest extends TestCase
         ], $this->collection()->getRoutesByMethod());
     }
 
+    public function testActionUrlGenerationChoosesFirstMatchingRouteWithCompiledRoutes()
+    {
+        $this->routeCollection->add($this->newRoute('GET', '{resource}/attachable/{field}', [
+            'controller' => 'MyController',
+        ]));
+
+        $this->routeCollection->add($this->newRoute('GET', '{resource}/{resourceId}/attachable/{field}', [
+            'controller' => 'MyController',
+        ]));
+
+        $routes = $this->collection();
+
+        $url = app('url');
+        $url->setRoutes($routes);
+
+        $result = $url->action('MyController', [
+            'resource' => 'posts',
+            'resourceId' => 1,
+            'field' => 'category',
+            'foo' => 'bar',
+        ]);
+
+        $this->assertStringEndsWith('/posts/attachable/category?resourceId=1&foo=bar', $result);
+
+        $result = $url->action('MyController', [
+            'resource' => 'posts',
+            'field' => 'category',
+            'foo' => 'bar',
+        ]);
+
+        $this->assertStringEndsWith('/posts/attachable/category?foo=bar', $result);
+    }
+
     /**
      * Create a new Route object.
      *

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2026,7 +2026,7 @@ class RoutingUrlGeneratorTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->assertSame('http://www.foo.com/posts/attachable/category?resourceId=1&foo=bar', $result,);
+        $this->assertSame('http://www.foo.com/posts/attachable/category?resourceId=1&foo=bar', $result);
 
         $result = $url->action('MyController', [
             'resource' => 'posts',


### PR DESCRIPTION
Resolves #57312

[As per previous tests](https://github.com/laravel/framework/pull/54050), the first route should always be used in case of overlapping routes

This PR only adds testing, ensuring the first route is returned via `action()` to be consistent