### PR TITLE
Fix grammar in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -3,7 +3,7 @@ description: "Report something that's broken."
 body:
   - type: markdown
     attributes:
-      value: "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before submitting bug reports. If you notice improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
+      value: "Please read [our full contribution guide](https://laravel.com/docs/contributions#bug-reports) before submitting bug reports. If you notice an improper DocBlock, PHPStan, or IDE warnings while using Laravel, do not create a GitHub issue. Instead, please submit a pull request to fix the problem."
   - type: input
     attributes:
       label: Laravel Version


### PR DESCRIPTION
## Description

This PR fixes a minor grammar issue in the bug report template.

## Changes

- Changed "improper DocBlock" to "an improper DocBlock" in `.github/ISSUE_TEMPLATE/Bug_report.yml` for proper English grammar

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

No testing required for this documentation fix.

## Checklist

- [x] I have read the [contribution guidelines](https://laravel.com/docs/contributions)
- [x] My code follows the code style of this project
- [x] This change requires no documentation update
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] New and existing unit tests pass locally with my changes (N/A)