### PR TITLE
[12.x] Refactor the setTrustedProxyIpAddresses() method

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -68,15 +68,17 @@ class TrustProxies
     {
         $trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
 
+        $host = $request->host();
+
         if (is_null($trustedIps) &&
             (laravel_cloud() ||
-             str_ends_with($request->host(), '.on-forge.com') ||
-             str_ends_with($request->host(), '.on-vapor.com'))) {
+             str_ends_with($host, '.on-forge.com') ||
+             str_ends_with($host, '.on-vapor.com'))) {
             $trustedIps = '*';
         }
 
-        if (str_ends_with($request->host(), '.on-forge.com') ||
-            str_ends_with($request->host(), '.on-vapor.com')) {
+        if (str_ends_with($host, '.on-forge.com') ||
+            str_ends_with($host, '.on-vapor.com')) {
             $request->headers->remove('X-Forwarded-Host');
         }
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -70,15 +70,14 @@ class TrustProxies
 
         $host = $request->host();
 
-        if (is_null($trustedIps) &&
-            (laravel_cloud() ||
-             str_ends_with($host, '.on-forge.com') ||
-             str_ends_with($host, '.on-vapor.com'))) {
+        $isForgeOrVapor = str_ends_with($host, '.on-forge.com') ||
+            str_ends_with($host, '.on-vapor.com');
+
+        if (is_null($trustedIps) && (laravel_cloud() || $isForgeOrVapor)) {
             $trustedIps = '*';
         }
 
-        if (str_ends_with($host, '.on-forge.com') ||
-            str_ends_with($host, '.on-vapor.com')) {
+        if ($isForgeOrVapor) {
             $request->headers->remove('X-Forwarded-Host');
         }
 


### PR DESCRIPTION
Description
---
This PR avoid redundant calls and simplify checks by:

- Storing `$request->host()` in a local `$host` variable instead of calling it multiple times.
- Replacing repeated `str_ends_with($host, '.on-forge.com') || str_ends_with($host, '.on-vapor.com')` checks with a single `$isForgeOrVapor` variable.

This reduces duplication and makes the intent of the code clearer without changing its behavior.