### PR TITLE
[12.x] Adds simple key transformation to Collection and Arr helper.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1196,6 +1196,60 @@ class Arr
     }
 
     /**
+     * Executes a callback that transforms each key of the array.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @param  int  $maxDepth
+     * @return array|void
+     */
+    public static function mapKeys(array &$array, callable $callback, $maxDepth = 512)
+    {
+        if ($maxDepth <= 0) {
+            return $array;
+        }
+
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                static::mapKeys($array, $callback, $maxDepth - 1);
+            }
+
+            if (is_string($key)) {
+                $newKey = $callback($key);
+
+                if ($newKey !== $key) {
+                    $array[$newKey] = $array[$key];
+                    unset($array[$key]);
+                }
+            }
+        }
+
+        return $array;
+    }
+
+    /**
+     * Transforms each key of the array into "camelCase".
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function mapKeysToCamel(array $array)
+    {
+        return static::mapKeys($array, Str::camel(...));
+    }
+
+    /**
+     * Transforms each key of the array into "snake_case".
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function mapKeysToSnake(array $array)
+    {
+        return static::mapKeys($array, Str::snake(...));
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -877,6 +877,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Map each key in the collection using a callback.
+     *
+     * @template TNewKey of array-key
+     *
+     * @param  callable(TKey): TNewKey  $callback
+     * @return static<TNewKey, TValue>
+     */
+    public function mapKeys(callable $callback)
+    {
+        return new static(Arr::mapKeys($this->all(), $callback));
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.
@@ -1816,6 +1829,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function transform(callable $callback)
     {
         $this->items = $this->map($callback)->all();
+
+        return $this;
+    }
+
+    /**
+     * Transform each key in the collection using a callback.
+     *
+     * @param  callable(TKey): TKey  $callback
+     * @return $this
+     *
+     * @phpstan-this-out static<TKey, TValue>
+     */
+    public function transformKeys(callable $callback)
+    {
+        $this->items = Arr::mapKeys($this->all(), $callback);
 
         return $this;
     }

--- a/src/Illuminate/Support/HighOrderRescueProxy.php
+++ b/src/Illuminate/Support/HighOrderRescueProxy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Throwable;
+
+class HighOrderRescueProxy
+{
+    /**
+     * The target being tried.
+     *
+     * @var mixed
+     */
+    public $target;
+
+    /**
+     * The catch callback for the exception.
+     *
+     * @var (callable(\Throwable):void)|null
+     */
+    public $callback;
+
+    /**
+     * Create a new try proxy instance.
+     *
+     * @param  mixed  $target
+     * @param  (callable(\Throwable):void)|null  $callback
+     */
+    public function __construct($target, $callback)
+    {
+        $this->target = $target;
+        $this->callback = $callback;
+    }
+
+    /**
+     * Dynamically pass method calls to the target.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        try {
+            $this->target->{$method}(...$parameters);
+        } catch (Throwable $exception) {
+
+        }
+
+        return $this->target;
+    }
+}

--- a/src/Illuminate/Support/Traits/Rescueable.php
+++ b/src/Illuminate/Support/Traits/Rescueable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Rescueable
+{
+    /**
+     * Catch a potential exception and return a default value or the same instance.
+     *
+     * @template TValue
+     * @template TFallback
+     *
+     * @param  (callable(\Throwable): TFallback)|TFallback  $rescue
+     * @param  bool|callable(\Throwable): bool  $report
+     * @return $this
+     */
+    public function rescue($rescue = null, $report = true)
+    {
+        return tap($this, $callback)
+    }
+}

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1066,6 +1066,45 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'first-taylor', 'last' => 'last-'], $mapped);
     }
 
+    public function testMapKeys()
+    {
+        $array = [100, '200', 300, '400', 500];
+
+        $array = Arr::mapKeys($array, fn($key) => $key + 1);
+
+        $this->assertSame([1 => 100, 2 => '200', 3 => 300, 4 => '400', 5 => 500], $array);
+    }
+
+    public function testMapKeysToCamel()
+    {
+        $array = [
+            1 => 'foo',
+            'foo_bar' => 'bar',
+            'cuzCux' => 'baz',
+        ];
+
+        $this->assertSame([
+            '1' => 'foo',
+            'fooBar' => 'bar',
+            'cuzCux' => 'baz',
+        ], Arr::mapKeysToCamel($array));
+    }
+
+    public function testMapKeysToSnake()
+    {
+        $array = [
+            1 => 'foo',
+            'foo_bar' => 'bar',
+            'cuzCux' => 'baz',
+        ];
+
+        $this->assertSame([
+            '1' => 'foo',
+            'foo_bar' => 'bar',
+            'cuz_cux' => 'baz',
+        ], Arr::mapKeysToSnake($array));
+    }
+
     public function testMapWithKeys()
     {
         $data = [

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3478,6 +3478,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testTransformKeys()
+    {
+        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data = $data->mapKeys('strtoupper');
+        $this->assertSame(['FIRST' => 'taylor', 'LAST' => 'otwell'], $data->all());
+    }
+
     #[DataProvider('collectionClassProvider')]
     public function testGroupByAttribute($collection)
     {


### PR DESCRIPTION
# What?

Introduces a method to both base Collection and Arr helpers to _transform_ each array key using a callback. 

The main idea for this is to avoid extensive callbacks or using `mapWithKeys()` just to change the keys when these come from an endpoint that uses `camelCase` or `kebab-case` for its keys (since the convention on Laravel is to use `snake_case`)

The `Arr::mapKeys()` will return a new array with the new keys.

```php
use Illuminate\Support\Arr;

$array = [
    'first_name' => 'John',
    'is_admin' => false
];

$new = Arr::mapKeys($array, fn ($key) => Str::replace('_', '-'));

// [
//     'first-name' => 'John',
//     'is-admin' => false,
// ]
```

The `Collection::mapKeys()` will also do the same.

```php
use Illuminate\Support\Collection;use Illuminate\Support\Str;

$collection = Collection::make([
    'first_name' => 'John',
    'is_admin' => false
]);

$collection->mapKeys(fn ($key) => Str::replace('_', '-'));

// \Illuminate\Support\Collection([
//     'first-name' => 'John',
//     'is-admin' => false,
// ])
```

The main idea for this is to avoid extensive callbacks or using `mapWithKeys()` just to change the keys. Personally I like to use this to allow the developer to issue either an array of items or multiple parameters, like when these come from parsed JSON into an array without sort warranties, but also allow to translate each key for _frontend reasons_.

```php
use Illuminate\Support\Arr;
use Illuminate\Support\Str;

public function make(array|string $name, string $streetAddress = '', string $cityName = '')
{
    if (is_array($name)) {
        return $this->make(...Arr::mapKeys($name, Str::camel(...)))
    }
    
    // ...
}
```

With that, this PR also introduces `mapKeysToCamel` and `mapKeysToSnake` into the `Arr` helper to conveniently change the case of the array keys, which should be useful when using JSON values as parameters like the above example, or exposing an object as JSON when being serialized to an array.

```php
use Illuminate\Support\Arr;

public function make(array|string $name, string $streetAddress = '', string $cityName = '')
{
    if (is_array($name)) {
        return $this->make(...Arr::mapKeysToCamel($name))
    }
    
    // ...
}

public function toArray(): array
{
    return Arr::mapKeysToSnake(get_object_vars($this));
}
```