### PR TITLE
[12.x] Refactor: use `orderByDesc()` 

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -62,8 +62,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $query = $this->table()->where('batch', '>=', '1');
 
-        return $query->orderBy('batch', 'desc')
-            ->orderBy('migration', 'desc')
+        return $query->orderByDesc('batch')
+            ->orderByDesc('migration')
             ->limit($steps)
             ->get()
             ->all();
@@ -79,7 +79,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         return $this->table()
             ->where('batch', $batch)
-            ->orderBy('migration', 'desc')
+            ->orderByDesc('migration')
             ->get()
             ->all();
     }
@@ -93,7 +93,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $query = $this->table()->where('batch', $this->getLastBatchNumber());
 
-        return $query->orderBy('migration', 'desc')->get()->all();
+        return $query->orderByDesc('migration')->get()->all();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2723,7 +2723,7 @@ class Builder implements BuilderContract
      */
     public function latest($column = 'created_at')
     {
-        return $this->orderBy($column, 'desc');
+        return $this->orderByDesc($column);
     }
 
     /**
@@ -2866,7 +2866,7 @@ class Builder implements BuilderContract
             $this->where($column, '<', $lastId);
         }
 
-        return $this->orderBy($column, 'desc')
+        return $this->orderByDesc($column)
             ->limit($perPage);
     }
 

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -73,7 +73,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
     {
         return $this->getTable()
             ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
-            ->orderBy('id', 'desc')
+            ->orderByDesc('id')
             ->pluck('id')
             ->all();
     }
@@ -85,7 +85,7 @@ class DatabaseFailedJobProvider implements CountableFailedJobProvider, FailedJob
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+        return $this->getTable()->orderByDesc('id')->get()->all();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -76,7 +76,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
     {
         return $this->getTable()
             ->when(! is_null($queue), fn ($query) => $query->where('queue', $queue))
-            ->orderBy('id', 'desc')
+            ->orderByDesc('id')
             ->pluck('uuid')
             ->all();
     }
@@ -88,7 +88,7 @@ class DatabaseUuidFailedJobProvider implements CountableFailedJobProvider, Faile
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->map(function ($record) {
+        return $this->getTable()->orderByDesc('id')->get()->map(function ($record) {
             $record->id = $record->uuid;
             unset($record->uuid);
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -44,7 +44,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
-        $query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
+        $query->shouldReceive('orderByDesc')->once()->with('migration')->andReturn($query);
         $query->shouldReceive('get')->once()->andReturn(new Collection(['foo']));
         $query->shouldReceive('useWritePdo')->once()->andReturn($query);
 


### PR DESCRIPTION
This PR refactors all instances of `$this->orderBy(..., 'desc')` to use the more expressive `$this->orderByDesc(...)` method from query builder.
