### PR TITLE
[12.x] Add default `null` parameter to `reorderDesc()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2919,7 +2919,7 @@ class Builder implements BuilderContract
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
      * @return $this
      */
-    public function reorderDesc($column)
+    public function reorderDesc($column = null)
     {
         return $this->reorder($column, 'desc');
     }


### PR DESCRIPTION
This makes `reorderDesc()` consistent with `reorder()` by allowing it to be called without arguments.