### PR TITLE
[12.X] add support for windsurf IDE in ResolvesDumpSource

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -27,6 +27,7 @@ trait ResolvesDumpSource
         'vscode-insiders' => 'vscode-insiders://file/{file}:{line}',
         'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/{file}:{line}',
         'vscode-remote' => 'vscode://vscode-remote/{file}:{line}',
+        'windsurf' => 'windsurf://file/{file}:{line}',
         'vscodium' => 'vscodium://file/{file}:{line}',
         'xdebug' => 'xdebug://{file}@{line}',
         'zed' => 'zed://file/{file}:{line}',

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -27,8 +27,8 @@ trait ResolvesDumpSource
         'vscode-insiders' => 'vscode-insiders://file/{file}:{line}',
         'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/{file}:{line}',
         'vscode-remote' => 'vscode://vscode-remote/{file}:{line}',
-        'windsurf' => 'windsurf://file/{file}:{line}',
         'vscodium' => 'vscodium://file/{file}:{line}',
+        'windsurf' => 'windsurf://file/{file}:{line}',
         'xdebug' => 'xdebug://{file}@{line}',
         'zed' => 'zed://file/{file}:{line}',
     ];


### PR DESCRIPTION
This PR Adds support for [Windsurf](https://windsurf.com) in ResolvesDumpSource for the exception page.
