### PR TITLE
[12.x] Update docblock to reflect non-nullable parameter

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2916,7 +2916,7 @@ class Builder implements BuilderContract
     /**
      * Add descending "reorder" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string|null  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string $column
      * @return $this
      */
     public function reorderDesc($column)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2916,7 +2916,7 @@ class Builder implements BuilderContract
     /**
      * Add descending "reorder" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
      */
     public function reorderDesc($column)


### PR DESCRIPTION
Based on the feedback received in #57354, it was determined that the value of `$column` should not be `null`. Therefore, the docblock should also be updated accordingly.