### PR TITLE
[12.x] Added Kiro editor support in `ResolvesDumpSource` 

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -16,6 +16,7 @@ trait ResolvesDumpSource
         'cursor' => 'cursor://file/{file}:{line}',
         'emacs' => 'emacs://open?url=file://{file}&line={line}',
         'idea' => 'idea://open?file={file}&line={line}',
+        'kiro' => 'kiro://file/{file}:{line}',
         'macvim' => 'mvim://open/?url=file://{file}&line={line}',
         'netbeans' => 'netbeans://open/?f={file}:{line}',
         'nova' => 'nova://core/open/file?filename={file}&line={line}',


### PR DESCRIPTION
In this PR, I added support for the [Kiro](https://kiro.dev/) editor in `ResolvesDumpSource`.  