### PR TITLE
[12.x] fix schedule list cli format in multibye locale

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -204,7 +204,7 @@ class ScheduleListCommand extends Command
         $hasMutex = $event->mutex->exists($event) ? 'Has Mutex › ' : '';
 
         $dots = str_repeat('.', max(
-            $terminalWidth - mb_strlen($expression.$repeatExpression.$command.$nextDueDateLabel.$nextDueDate.$hasMutex) - 8, 0
+            $terminalWidth - mb_strwidth($expression.$repeatExpression.$command.$nextDueDateLabel.$nextDueDate.$hasMutex) - 8, 0
         ));
 
         // Highlight the parameters...


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The problem

When APP_LOCALE is set to a multibyte language such as Chinese or Japanese, the CLI output incorrectly double-counts characters in the “next due” section.

![Screenshot 2025-10-13 at 2 32 25 PM](https://github.com/user-attachments/assets/e1bcbad4-30db-4a0c-bd0e-a613239ea7a7)

This fix ensures correct spacing for multibyte characters.

![Screenshot 2025-10-13 at 2 32 42 PM](https://github.com/user-attachments/assets/620b9dba-30d2-435c-a645-e1519976894a)
