### PR TITLE
[12.x] Add validation for password_hash() failure in hashers

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -66,6 +66,10 @@ class ArgonHasher extends AbstractHasher implements HasherContract
                 'time_cost' => $this->time($options),
                 'threads' => $this->threads($options),
             ]);
+
+            if ($hash === false) {
+                throw new RuntimeException('Argon2 hashing failed.');
+            }
         } catch (Error) {
             throw new RuntimeException('Argon2 hashing not supported.');
         }

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -61,6 +61,10 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             $hash = password_hash($value, PASSWORD_BCRYPT, [
                 'cost' => $this->cost($options),
             ]);
+
+            if ($hash === false) {
+                throw new RuntimeException('Bcrypt hashing failed.');
+            }
         } catch (Error) {
             throw new RuntimeException('Bcrypt hashing not supported.');
         }


### PR DESCRIPTION
 The `password_hash()` function can return `false` on failure (invalid
  parameters, memory exhaustion, etc.), but the `make()` methods in both
  `BcryptHasher` and `ArgonHasher` only caught `Error` exceptions and didn't
   validate the return value. This creates:

  1. **Type safety violation**: Method signature indicates `@return string`
  but could return `false`
  2. **Security risk**: If `false` is stored as a hash, it could lead to
  authentication issues
  3. **Silent failures**: Failures would go unnoticed until unexpected
  behavior occurs

  ## Changes

  **BcryptHasher.php:65-67**
  ```php
  if ($hash === false) {
      throw new RuntimeException('Bcrypt hashing failed.');
  }

  ArgonHasher.php:70-72
  if ($hash === false) {
      throw new RuntimeException('Argon2 hashing failed.');
  }