### PR TITLE
[12.x] Add Str::isSlug() and Stringable::isSlug() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -688,6 +688,24 @@ class Str
     }
 
     /**
+     * Determine if a given string is a valid slug.
+     *
+     * A valid slug may contain lowercase letters, numbers, and single hyphens,
+     * and cannot begin or end with a hyphen.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isSlug($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $value) === 1;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -424,6 +424,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the given string is a valid slug.
+     *
+     * @return bool
+     */
+    public function isSlug()
+    {
+        return Str::isSlug($this->value);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1867,6 +1867,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo baZ baz bar', $result);
     }
 
+    public function testItCanDetectValidSlugs(): void
+    {
+        $this->assertTrue(Str::isSlug('hello-world'));
+        $this->assertTrue(Str::isSlug('my-slug-123'));
+        $this->assertFalse(Str::isSlug('Hello World'));
+        $this->assertFalse(Str::isSlug('-slug'));
+        $this->assertFalse(Str::isSlug('slug-'));
+        $this->assertFalse(Str::isSlug('slug--test'));
+    }
+
+    public function testStringableIsSlug(): void
+    {
+        $this->assertTrue(str('valid-slug')->isSlug());
+        $this->assertFalse(str('Not A Slug')->isSlug());
+    }
+
     public function testPlural(): void
     {
         $this->assertSame('Laracon', Str::plural('Laracon', 1));


### PR DESCRIPTION
This PR adds a new helper to determine whether a given string is a valid, URL-friendly slug.

### Motivation
Laravel already offers `Str::slug()` to generate slugs, but there is no built-in way to validate them. This helper:
- Improves readability vs. custom regex in each project
- Encourages consistency across apps and packages
- Complements the existing is* helpers in Str

### Implementation
New methods:
- `Illuminate\Support\Str::isSlug(string $value): bool`
- `Illuminate\Support\Stringable::isSlug(): bool`

Validation rule (ASCII lowercase, digits, single hyphens, no leading/trailing hyphen, no double hyphens):
`^[a-z0-9]+(?:-[a-z0-9]+)*$`

#### Examples
```php
use Illuminate\Support\Str;

Str::isSlug('hello-world');   // true
Str::isSlug('my-slug-123');   // true
Str::isSlug('Hello World');   // false
Str::isSlug('-slug');         // false
Str::isSlug('slug-');         // false
Str::isSlug('slug--test');    // false

str('valid-slug')->isSlug();  // true
str('Not A Slug')->isSlug();  // false
```

### Tests
Added assertions in `tests/Support/SupportStrTest.php`:
- Valid slugs (lowercase letters, digits, single hyphens)
- Invalid cases (uppercase, spaces, leading/trailing/multiple hyphens)
- Stringable behavior

#### Examples
```php
public function testItCanDetectValidSlugs(): void
{
    $this->assertTrue(Str::isSlug('hello-world'));
    $this->assertTrue(Str::isSlug('my-slug-123'));
    $this->assertFalse(Str::isSlug('Hello World'));
    $this->assertFalse(Str::isSlug('-slug'));
    $this->assertFalse(Str::isSlug('slug-'));
    $this->assertFalse(Str::isSlug('slug--test'));
}

public function testStringableIsSlug(): void
{
    $this->assertTrue(str('valid-slug')->isSlug());
    $this->assertFalse(str('Not A Slug')->isSlug());
}
```

### Backwards Compatibility
- Fully backward compatible
- No new dependencies
- Naming/style consistent with existing `Str::is*()` helpers
- All existing tests pass

### Example Usage in Validation
```php
$request->validate([
    'slug' => [
        'required',
        function ($attribute, $value, $fail) {
            if (! Str::isSlug($value)) {
                $fail("The {$attribute} must be a valid slug.");
            }
        },
    ],
]);
```

### Notes
- Focuses on the common ASCII slug convention used by `Str::slug()` with `-` as the separator.
- If broader i18n slug validation is desired in the future, this API can be extended without breaking changes.
