### PR TITLE
fix: correctly handle route parameters with defaults and binding keys

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -284,8 +284,12 @@ class RouteUrlGenerator
             $bindingField = $route->bindingFieldFor($key);
             $defaultParameterKey = $bindingField ? "$key:$bindingField" : $key;
 
-            if ($value === '' && isset($this->defaultParameters[$defaultParameterKey])) {
-                $namedParameters[$key] = $this->defaultParameters[$defaultParameterKey];
+            $defaultParameter = $this->defaultParameters[$defaultParameterKey]
+                ?? $this->defaultParameters[$key]
+                ?? null;
+
+            if ($value === '' && isset($defaultParameter)) {
+                $namedParameters[$key] = $defaultParameter;
             }
         }
 


### PR DESCRIPTION
**Description:**
This PR fixes an issue where `URL::defaults()` combined with route parameters (including model key binding fields) causes positional parameter misalignment when generating URLs with `route()` call.

**Problem:**
When a route has a parameter in the URL, e.g., `{workspace:uuid?}`, and its value is set via `URL::defaults()` (without using the route key), calling `route()` with positional parameters for other route parameters can incorrectly assign the first positional parameter to the prefix parameter. This results in an empty query string like `?workspace=` instead of the intended URL.

**Reference:** [#56604](https://github.com/laravel/framework/issues/56604)

**Solution:**
Added the check for both named parameters and key binding fields.

**Example:**
```php
// Route with model key binding
Route::get('{workspace:uuid?}/customers/{customer}', [CustomerController::class, 'show'])
    ->name('customers.show');

// Middleware sets default workspace
URL::defaults(['workspace' => $workspace->uuid]);

// Route call with positional parameter
route('customers.show', $customer->id);

// ❌ Generates:
// http://laravel.test/7b1c3cbe-675e-43cc-aed6-55bc36e7f79a/customers/123?workspace=

// ✅ Should generate:
// http://laravel.test/7b1c3cbe-675e-43cc-aed6-55bc36e7f79a/customers/123
```