### PR TITLE
[12.x] Fix `DB::update()` with subqueries is not supported for all databases

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -442,6 +442,7 @@ class MySqlGrammar extends Grammar
      * @param  array  $values
      * @return array
      */
+    #[\Override]
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = (new Collection($values))

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -618,6 +618,7 @@ class PostgresGrammar extends Grammar
      * @param  array  $values
      * @return array
      */
+    #[\Override]
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = (new Collection($values))->map(function ($value, $column) {
@@ -627,6 +628,8 @@ class PostgresGrammar extends Grammar
         })->all();
 
         $cleanBindings = Arr::except($bindings, 'select');
+
+        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -384,6 +384,7 @@ class SQLiteGrammar extends Grammar
      * @param  array  $values
      * @return array
      */
+    #[\Override]
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $groups = $this->groupJsonColumnsForUpdate($values);
@@ -395,6 +396,8 @@ class SQLiteGrammar extends Grammar
             ->all();
 
         $cleanBindings = Arr::except($bindings, 'select');
+
+        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -453,9 +453,12 @@ class SqlServerGrammar extends Grammar
      * @param  array  $values
      * @return array
      */
+    #[\Override]
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $cleanBindings = Arr::except($bindings, 'select');
+
+        $values = Arr::flatten(array_map(fn ($value) => value($value), $values));
 
         return array_values(
             array_merge($values, Arr::flatten($cleanBindings))

--- a/tests/Integration/Database/QueryBuilderUpdateTest.php
+++ b/tests/Integration/Database/QueryBuilderUpdateTest.php
@@ -52,7 +52,7 @@ class QueryBuilderUpdateTest extends DatabaseTestCase
         var_dump(DB::table('example')->selectRaw('CONCAT(example.title, example.name)')::class);
 
         DB::table('example')->update([
-            'payload->fullname' => DB::table('example')->selectRaw('CONCAT(example.title, example.name)'),
+            'payload->fullname' => DB::table('example')->selectRaw('CONCAT(title, name)'),
         ]);
 
         $this->assertDatabaseHas('example', [

--- a/tests/Integration/Database/QueryBuilderUpdateTest.php
+++ b/tests/Integration/Database/QueryBuilderUpdateTest.php
@@ -52,7 +52,7 @@ class QueryBuilderUpdateTest extends DatabaseTestCase
         var_dump(DB::table('example')->selectRaw('CONCAT(example.title, example.name)')::class);
 
         DB::table('example')->update([
-            'payload->fullname' => DB::table('example')->selectRaw('CONCAT(example.title, example.name)')
+            'payload->fullname' => DB::table('example')->selectRaw('CONCAT(example.title, example.name)'),
         ]);
 
         $this->assertDatabaseHas('example', [


### PR DESCRIPTION
fix #57374 