### PR TITLE
fix: correctly handle route parameters with defaults and binding keys

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -201,7 +201,7 @@ class RouteUrlGenerator
                 $bindingField = $route->bindingFieldFor($name);
                 $defaultParameterKey = $bindingField ? "$name:$bindingField" : $name;
 
-                if (! isset($this->defaultParameters[$defaultParameterKey]) && ! isset($optionalParameters[$name])) {
+                if (! isset($this->defaultParameters[$defaultParameterKey]) && ! isset($this->defaultParameters[$name]) && ! isset($optionalParameters[$name])) {
                     // No named parameter or default value for a required parameter, try to match to positional parameter below...
                     array_push($requiredRouteParametersWithoutDefaultsOrNamedParameters, $name);
                 }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -284,8 +284,12 @@ class RouteUrlGenerator
             $bindingField = $route->bindingFieldFor($key);
             $defaultParameterKey = $bindingField ? "$key:$bindingField" : $key;
 
-            if ($value === '' && isset($this->defaultParameters[$defaultParameterKey])) {
-                $namedParameters[$key] = $this->defaultParameters[$defaultParameterKey];
+            $defaultParameter = $this->defaultParameters[$defaultParameterKey]
+                ?? $this->defaultParameters[$key]
+                ?? null;
+
+            if ($value === '' && isset($defaultParameter)) {
+                $namedParameters[$key] = $defaultParameter;
             }
         }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2014,13 +2014,12 @@ class RoutingUrlGeneratorTest extends TestCase
         /**
          * Test case 1: Route with optional parameter with binding field.
          */
-        $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show', fn () => '']);
-        $routes->add($route);
-
-        // Set up defaults
         $url->defaults([
             'team' => 'example-team',
         ]);
+
+        $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show', fn () => '']);
+        $routes->add($route);
 
         // Test with positional parameters
         $this->assertSame(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2059,7 +2059,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 3: Route with multiple parameters with binding fields
+         * Test case 3: Route with multiple parameters with binding fields.
          */
         $url->defaults([
             'team' => 'example-team',

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2012,7 +2012,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 1: Route with optional parameter with binding field
+         * Test case 1: Route with optional parameter with binding field.
          */
         $route = new Route(['GET'], '{team:slug?}/posts/{post}', ['as' => 'posts.show', fn () => '']);
         $routes->add($route);
@@ -2041,7 +2041,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 2: Route with required parameter with binding field
+         * Test case 2: Route with required parameter with binding field.
          */
         $route = new Route(['GET'], '{team:slug}/posts/{post}', ['as' => 'posts.show.required', fn () => '']);
         $routes->add($route);
@@ -2083,7 +2083,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 4: Route with mixed parameter types (some with defaults, some without)
+         * Test case 4: Route with mixed parameter types (some with defaults, some without).
          */
         $route = new Route(['GET'], '{team:slug?}/posts/{post}/comments/{comment}', ['as' => 'comments.show', fn () => '']);
         $routes->add($route);
@@ -2101,7 +2101,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 5: Route with only binding field default (no regular parameter default)
+         * Test case 5: Route with only binding field default (no regular parameter default).
          */
         $url->defaults([
             'team:slug' => 'example-team',
@@ -2123,7 +2123,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 6: Route with only regular parameter default (no binding field default)
+         * Test case 6: Route with only regular parameter default (no binding field default).
          */
         $url->defaults([
             'team' => 'example-team',
@@ -2145,7 +2145,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         /**
-         * Test case 7: Route without any defaults to ensure existing functionality works
+         * Test case 7: Route without any defaults to ensure existing functionality works.
          */
         $route = new Route(['GET'], '{team:slug}/posts/{post}', ['as' => 'posts.show.no-defaults', fn () => '']);
         $routes->add($route);


### PR DESCRIPTION
Note: The description and example have been updated to avoid confusion.

---

**Description:**
This PR fixes an issue where `URL::defaults()` combined with route parameters (including model key binding fields) causes positional parameter misalignment when generating URLs with `route()` call.

**Problem:**
When a route defines a parameter with a key binding (e.g., `{team:slug}`) and a default is set using only the parameter name (e.g., `URL::defaults(['team' => 'example-team']);`), the default does not correctly align with the bound field (slug).
As a result, calling `route()` with positional or named parameters can incorrectly assign values, producing an empty query string like `<URL>?team=` instead of the expected URL.


**Reference:** [#56604](https://github.com/laravel/framework/issues/56604)

**Solution:**
Added a check for both named parameters and key binding fields to correctly align route parameters when generating URLs.

**Example (Updated):**
```php
// Route with model key binding
Route::get('{team:slug}/projects/{project}', [ProjectController::class, 'show'])
    ->name('projects.show');

// Middleware sets default team
URL::defaults(['team' => 'example-team']);

// Case 1: Route call with positional parameter
route('projects.show', 123);

// ❌ Before
// http://laravel.test/example-team/projects/123?team=

// ✅ After
// http://laravel.test/example-team/projects/123

// Case 2: Route call only with named parameters
route('projects.show', ['project' => 123])

// ❌ Before
http://laravel.test/example-team/projects/123?team=

// ✅ After
http://laravel.test/example-team/projects/123

```