### PR TITLE
[12.x] Http::batch - fix issue that non valid URL not triggering catch hook

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -72,7 +72,7 @@ class Batch
     /**
      * The callback to run after a request from the batch fails.
      *
-     * @var (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException): void)|null
+     * @var (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException|\Illuminate\Http\Client\ConnectionException): void)|null
      */
     protected $catchCallback = null;
 
@@ -171,7 +171,7 @@ class Batch
     /**
      * Register a callback to run after a request from the batch fails.
      *
-     * @param  (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException): void)  $callback
+     * @param  (\Closure($this, int|string, \Illuminate\Http\Response|\Illuminate\Http\Client\RequestException|\Illuminate\Http\Client\ConnectionException): void)  $callback
      * @return Batch
      */
     public function catch(Closure $callback): self
@@ -247,8 +247,11 @@ class Batch
                         return $result;
                     }
 
-                    if (($result instanceof Response && $result->failed()) ||
-                        $result instanceof RequestException) {
+                    if (
+                        ($result instanceof Response && $result->failed()) ||
+                        $result instanceof RequestException ||
+                        $result instanceof ConnectionException
+                    ) {
                         $this->incrementFailedRequests();
 
                         if ($this->catchCallback !== null) {
@@ -261,7 +264,7 @@ class Batch
                 'rejected' => function ($reason, $key) {
                     $this->decrementPendingRequests();
 
-                    if ($reason instanceof RequestException) {
+                    if ($reason instanceof RequestException || $reason instanceof ConnectionException) {
                         $this->incrementFailedRequests();
 
                         if ($this->catchCallback !== null) {


### PR DESCRIPTION
## Overview

I was talking with @christophrumpel on X and he showed me that calling a non-valid URL was not triggering the `catch` hook of the `Http::batch`

```php
Http::batch(fn (Batch $batch) => [
    $batch->get('https://laravel.com'),
    $batch->get('https://laravell.comn'),
])->catch(function (Batch $batch, int|string $key, Response|RequestException $response) {
    dump('error');
})->send();
```

## Fix

I saw that instead of a `\Illuminate\Http\Client\RequestException` in these cases it throws a `\Illuminate\Http\Client\ConnectionException`, so I added this check, and also updated the `catch` hook to handle this

```php
Http::batch(fn (Batch $batch) => [
    $batch->get('https://laravel.com'),
    $batch->get('https://laravell.comn'),
])->catch(function (Batch $batch, int|string $key, Response|RequestException|ConnectionException $response) {
    dump('error');
})->send();
```