### PR TITLE
[12.x] Add defer method to HTTP batch

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -7,6 +7,9 @@ use Closure;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Utils;
+use Illuminate\Support\Defer\DeferredCallback;
+
+use function Illuminate\Support\defer;
 
 /**
  * @mixin \Illuminate\Http\Client\Factory
@@ -205,6 +208,16 @@ class Batch
         $this->finallyCallback = $callback;
 
         return $this;
+    }
+
+    /**
+     * Defer the batch to run in the background after the current task has finished.
+     *
+     * @return \Illuminate\Support\Defer\DeferredCallback
+     */
+    public function defer(): DeferredCallback
+    {
+        return defer(fn () => $this->send());
     }
 
     /**


### PR DESCRIPTION
This adds a `defer()` method to `Http::batch` following the same pattern used in `Concurrency::defer`.

```php
Http::batch(fn (Batch $batch) => [
    $batch->get('https://example.com/endpoint-1'),
    $batch->get('https://example.com/endpoint-2'),
])->before(function (Batch $batch) {
    // The batch has been created but no requests have been initialized...
})->progress(function (Batch $batch, int|string $key, Response $response) {
    // An individual request has completed successfully...
})->then(function (Batch $batch, array $results) {
    // All requests completed successfully...
})->catch(function (Batch $batch, int|string $key, Response|RequestException $response) {
    // First batch request failure detected...
})->finally(function (Batch $batch, array $results) {
    // The batch has finished executing...
})->defer();
```

This can be handy when we don't need the results, but we want to trigger actions with the hooks, so this can be done without affecting the performance and the response that we need to send back to the users.