### PR TITLE
[13.x] chore: make Facade::getFacadeAccessor() abstract

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -215,13 +215,8 @@ abstract class Facade
      * Get the registered name of the component.
      *
      * @return string
-     *
-     * @throws \RuntimeException
      */
-    protected static function getFacadeAccessor()
-    {
-        throw new RuntimeException('Facade does not implement getFacadeAccessor method.');
-    }
+    abstract protected static function getFacadeAccessor();
 
     /**
      * Resolve the facade root instance from the container.


### PR DESCRIPTION
This is cleaner than throwing an exception and it prevents users from having to use `/** @throws void */` annotations above child implementations of Facade to prevent phpstan warnings.

Thanks!