### PR TITLE
Added Brackets editor support in ResolvesDumpSource

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -13,6 +13,7 @@ trait ResolvesDumpSource
      */
     protected $editorHrefs = [
         'atom' => 'atom://core/open/file?filename={file}&line={line}',
+        'brackets' => 'brackets://open?url=file://{file}&line={line}',
         'cursor' => 'cursor://file/{file}:{line}',
         'emacs' => 'emacs://open?url=file://{file}&line={line}',
         'fleet' => 'fleet://open?file={file}&line={line}',


### PR DESCRIPTION
Add support for [Brackets](https://brackets.io/) editor in ResolvesDumpSource. While [Brackets](https://brackets.io/) development has ceased, it remains in active use by many developers.