### PR TITLE
[12.x] Refactor: remove collect and replace new Collection()

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -73,7 +73,7 @@ class EventListCommand extends Command
         $data = $events->map(function ($listeners, $event) {
             return [
                 'event' => strip_tags($this->appendEventInterfaces($event)),
-                'listeners' => collect($listeners)->map(fn ($listener) => strip_tags($listener))->values()->all(),
+                'listeners' => (new Collection($listeners))->map(fn ($listener) => strip_tags($listener))->values()->all(),
             ];
         })->values();
 

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Broadcasting;
 
+use _PHPStan_8996d3948\olvlvl\ComposerAttributeCollector\Collection;
 use Exception;
 use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
@@ -132,7 +133,7 @@ class TestBroadcastEvent
 
     public function __construct()
     {
-        $this->collection = collect(['foo' => 'bar']);
+        $this->collection = new \Illuminate\Support\Collection(['foo' => 'bar']);
     }
 
     public function broadcastOn()

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Broadcasting;
 
-use _PHPStan_8996d3948\olvlvl\ComposerAttributeCollector\Collection;
 use Exception;
 use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Broadcasting\InteractsWithBroadcasting;
 use Illuminate\Contracts\Broadcasting\Broadcaster;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -133,7 +133,7 @@ class TestBroadcastEvent
 
     public function __construct()
     {
-        $this->collection = new \Illuminate\Support\Collection(['foo' => 'bar']);
+        $this->collection = new Collection(['foo' => 'bar']);
     }
 
     public function broadcastOn()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -408,10 +408,10 @@ class HttpClientTest extends TestCase
         $response = $this->factory->get('http://foo.com/api');
 
         $this->assertInstanceOf(Collection::class, $response->collect());
-        $this->assertEquals(collect(['result' => ['foo' => 'bar']]), $response->collect());
-        $this->assertEquals(collect(['foo' => 'bar']), $response->collect('result'));
-        $this->assertEquals(collect(['bar']), $response->collect('result.foo'));
-        $this->assertEquals(collect(), $response->collect('missing_key'));
+        $this->assertEquals(new Collection(['result' => ['foo' => 'bar']]), $response->collect());
+        $this->assertEquals(new Collection(['foo' => 'bar']), $response->collect('result'));
+        $this->assertEquals(new Collection(['bar']), $response->collect('result.foo'));
+        $this->assertEquals(new Collection(), $response->collect('missing_key'));
     }
 
     public function testResponseCanBeReturnedAsFluent()
@@ -2343,7 +2343,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 500),
         ]);
 
-        $whenAttempts = collect();
+        $whenAttempts = new Collection();
 
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
@@ -2384,7 +2384,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 500),
         ]);
 
-        $whenAttempts = collect();
+        $whenAttempts = new Collection();
 
         [$response] = $this->factory->pool(fn ($pool) => [
             $pool->retry(2, 1000, function ($exception) use ($whenAttempts) {
@@ -3027,7 +3027,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $hitThrowCallback = collect();
+        $hitThrowCallback = new Collection();
 
         [$exception] = $this->factory->pool(fn ($pool) => [
             $pool->throwIf(function ($response) {
@@ -3056,7 +3056,7 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
-        $hitThrowCallback = collect();
+        $hitThrowCallback = new Collection();
 
         [$response] = $this->factory->pool(fn ($pool) => [
             $pool->throwIf(function ($response) {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -14,7 +14,7 @@ class Users implements Arrayable
     }
 }
 
-$collection = collect([new User]);
+$collection = new Collection([new User]);
 $arrayable = new Users;
 /** @var iterable<int, int> $iterable */
 $iterable = [1];


### PR DESCRIPTION
To avoid extra call stack, `collect` was replaced with `new Collection`