### PR TITLE
[12.x] Add `shouldRun()` method to Seeder

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -33,16 +33,6 @@ abstract class Seeder
     protected static $called = [];
 
     /**
-     * Determine if this seeder should run.
-     *
-     * @return bool
-     */
-    public function shouldRun(): bool
-    {
-        return true;
-    }
-
-    /**
      * Run the given seeder class.
      *
      * @param  array|string  $class
@@ -152,6 +142,16 @@ abstract class Seeder
         }
 
         return $instance;
+    }
+
+    /**
+     * Determine if this seeder should run.
+     *
+     * @return bool
+     */
+    public function shouldRun(): bool
+    {
+        return true;
     }
 
     /**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -33,6 +33,16 @@ abstract class Seeder
     protected static $called = [];
 
     /**
+     * Determine if this seeder should run.
+     *
+     * @return bool
+     */
+    public function shouldRun(): bool
+    {
+        return true;
+    }
+
+    /**
      * Run the given seeder class.
      *
      * @param  array|string  $class
@@ -46,6 +56,10 @@ abstract class Seeder
 
         foreach ($classes as $class) {
             $seeder = $this->resolve($class);
+
+            if (! $seeder->shouldRun()) {
+                continue;
+            }
 
             $name = get_class($seeder);
 

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -45,7 +45,20 @@ class DatabaseSeederTest extends TestCase
         $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
+        $child->shouldReceive('shouldRun')->once()->andReturn(true);
         $child->shouldReceive('__invoke')->once();
+
+        $seeder->call('ClassName');
+    }
+
+    public function testCallShouldntRun()
+    {
+        $seeder = new TestSeeder;
+        $seeder->setContainer($container = m::mock(Container::class));
+        $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock(Seeder::class));
+        $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
+        $child->shouldReceive('shouldRun')->once()->andReturn(false);
+        $child->shouldNotReceive('__invoke');
 
         $seeder->call('ClassName');
     }


### PR DESCRIPTION
Adds a `shouldRun()` method to the Seeder.php abstract class which gives it a similar ability as the `shouldRun()` method in the Migration.php abstract class.

Resolves https://github.com/laravel/framework/discussions/52708#discussion-7160846

Questions:

- should we log any output that the seeder was skipped?
