### PR TITLE
Add clickable file reference for thrown exception

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -113,38 +113,40 @@ class Exception
      */
     public function frames()
     {
-        $classMap = once(fn () => array_map(function ($path) {
-            return (string) realpath($path);
-        }, array_values(ClassLoader::getRegisteredLoaders())[0]->getClassMap()));
+        return once(function () {
+            $classMap = array_map(function ($path) {
+                return (string) realpath($path);
+            }, array_values(ClassLoader::getRegisteredLoaders())[0]->getClassMap());
 
-        $trace = array_values(array_filter(
-            $this->exception->getTrace(), fn ($trace) => isset($trace['file']),
-        ));
+            $trace = array_values(array_filter(
+                $this->exception->getTrace(), fn ($trace) => isset($trace['file']),
+            ));
 
-        if (($trace[1]['class'] ?? '') === HandleExceptions::class) {
-            array_shift($trace);
-            array_shift($trace);
-        }
-
-        $frames = [];
-        $previousFrame = null;
-
-        foreach (array_reverse($trace) as $frameData) {
-            $frame = new Frame($this->exception, $classMap, $frameData, $this->basePath, $previousFrame);
-            $frames[] = $frame;
-            $previousFrame = $frame;
-        }
-
-        $frames = array_reverse($frames);
-
-        foreach ($frames as $frame) {
-            if (! $frame->isFromVendor()) {
-                $frame->markAsMain();
-                break;
+            if (($trace[1]['class'] ?? '') === HandleExceptions::class) {
+                array_shift($trace);
+                array_shift($trace);
             }
-        }
 
-        return new Collection($frames);
+            $frames = [];
+            $previousFrame = null;
+
+            foreach (array_reverse($trace) as $frameData) {
+                $frame = new Frame($this->exception, $classMap, $frameData, $this->basePath, $previousFrame);
+                $frames[] = $frame;
+                $previousFrame = $frame;
+            }
+
+            $frames = array_reverse($frames);
+
+            foreach ($frames as $frame) {
+                if (! $frame->isFromVendor()) {
+                    $frame->markAsMain();
+                    break;
+                }
+            }
+
+            return new Collection($frames);
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/header.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/header.blade.php
@@ -3,6 +3,7 @@
 <div class="flex flex-col pt-8 sm:pt-16 overflow-x-auto">
     <div class="flex flex-col gap-5 mb-8">
         <h1 class="text-3xl font-semibold text-neutral-950 dark:text-white">{{ $exception->class() }}</h1>
+        <x-laravel-exceptions-renderer::file-with-line :frame="$exception->frames()->first()" class="-mt-3 text-xs" />
         <p class="text-xl font-light text-neutral-800 dark:text-neutral-300">
             {{ $exception->message() }}
         </p>


### PR DESCRIPTION
As an OG PHP developer, my brain is trained to parse the exception for a file reference and line number. I was surprised not the see it in the new exception page.

While this does exist on the page, it can be "below the fold". In addition, that file reference is discerned from the stack trace and may not match the "thrown" exception.

This PR adds a clickable file reference for the "thrown" exception. I'm no designer. But I tried to follow the styling found on the rest of the page, while not introducing clutter.

<img width="1798" height="552" alt="Screenshot 2025-10-15 at 12 32 56 PM" src="https://github.com/user-attachments/assets/ab440b92-cf03-4099-a8a8-6764e3d7e258" />

---

This also includes an optimization to memoize the exception frames calculation using `once()`. This is a relatively expensive operation and this method was already called from multiple components. I've done so in an atomic commit, so it is easily reverted with: `git revert 35a2fa0`
