### PR TITLE
Use container to resolve PendingBatch and PendingChain for dispatch

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -151,7 +151,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function batch($jobs)
     {
-        return new PendingBatch($this->container, Collection::wrap($jobs));
+        return $this->container->make(PendingBatch::class, [$this->container, Collection::wrap($jobs)]);
     }
 
     /**
@@ -165,7 +165,7 @@ class Dispatcher implements QueueingDispatcher
         $jobs = Collection::wrap($jobs);
         $jobs = ChainedBatch::prepareNestedBatches($jobs);
 
-        return new PendingChain($jobs->shift(), $jobs->toArray());
+        return $this->container->make(PendingChain::class, [$jobs->shift(), $jobs->toArray()]);
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/issues/57402

The `Illuminate\Bus\Dispatcher` class initiate the `PendingBatch` and `PendingChain` instances directly, instead of using the container to resolve them.

This makes impossible to extend and swap these classes.

Practical example:

- Having a multi-tenanted application, where each tenant has it's own queue (to mitigate noisy neighbour problem).
- It is possible to define a dynamic, tenant-aware queue for individual jobs, it is not easily possible to do for batches and chains.
- The developer has to specify the `->onQueue()` modifier for every instance of batches and chains, which can be unnecessarily verbose.
- If the framework would let the developer to re-bind the `PendingBatch` and/or `PendingChain` instances, the dynamic queue resolution could be easily done in one place - inside the tenant aware 
descendant class.
