### PR TITLE
[12.x] Respect SQS_PREFIX for SQS endpoint; add SQS_ENDPOINT support and tests

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -60,6 +60,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'endpoint' => env('SQS_ENDPOINT'),
             'after_commit' => false,
         ],
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -60,7 +60,6 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-            'endpoint' => env('SQS_ENDPOINT'),
             'after_commit' => false,
         ],
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -25,6 +25,18 @@ class SqsConnector implements ConnectorInterface
             }
         }
 
+        if (empty($config['endpoint']) && ! empty($config['prefix']) && filter_var($config['prefix'], FILTER_VALIDATE_URL)) {
+            $parts = parse_url($config['prefix']);
+
+            if ($parts !== false && isset($parts['scheme'], $parts['host'])) {
+                $endpoint = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+
+                if (! empty($endpoint)) {
+                    $config['endpoint'] = $endpoint;
+                }
+            }
+        }
+
         return new SqsQueue(
             new SqsClient(
                 Arr::except($config, ['token'])

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -30,10 +30,7 @@ class SqsConnector implements ConnectorInterface
 
             if ($parts !== false && isset($parts['scheme'], $parts['host'])) {
                 $endpoint = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
-
-                if (! empty($endpoint)) {
-                    $config['endpoint'] = $endpoint;
-                }
+                $config['endpoint'] = $endpoint;
             }
         }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -20,17 +20,19 @@ class SqsConnector implements ConnectorInterface
 
         if (! empty($config['key']) && ! empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret']);
+
             if (! empty($config['token'])) {
                 $config['credentials']['token'] = $config['token'];
             }
         }
 
-        if (empty($config['endpoint']) && ! empty($config['prefix']) && filter_var($config['prefix'], FILTER_VALIDATE_URL)) {
+        if (empty($config['endpoint']) &&
+            ! empty($config['prefix']) &&
+            filter_var($config['prefix'], FILTER_VALIDATE_URL)) {
             $parts = parse_url($config['prefix']);
 
             if ($parts !== false && isset($parts['scheme'], $parts['host'])) {
-                $endpoint = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
-                $config['endpoint'] = $endpoint;
+                $config['endpoint'] = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
             }
         }
 

--- a/tests/Queue/SqsConnectorTest.php
+++ b/tests/Queue/SqsConnectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Queue\Connectors\SqsConnector;
+use Illuminate\Queue\SqsQueue;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class SqsConnectorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testConnectDerivesEndpointFromPrefixUrl()
+    {
+        $prefix = 'http://elasticmq.local:9324/000000000000';
+        $expectedEndpoint = 'http://elasticmq.local:9324';
+
+        $overloaded = m::mock('overload:Aws\\Sqs\\SqsClient');
+        $overloaded->shouldReceive('__construct')->once()->with(m::on(function ($cfg) use ($expectedEndpoint) {
+            return isset($cfg['endpoint']) && $cfg['endpoint'] === $expectedEndpoint
+                && isset($cfg['region']) && is_string($cfg['region'])
+                && isset($cfg['version']) && $cfg['version'] === 'latest';
+        }));
+
+        $connector = new SqsConnector();
+
+        $queue = $connector->connect([
+            'driver' => 'sqs',
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'prefix' => $prefix,
+            'queue' => 'emails',
+            'region' => 'ap-southeast-2',
+        ]);
+
+        $this->assertInstanceOf(SqsQueue::class, $queue);
+    }
+}

--- a/tests/Queue/SqsConnectorTest.php
+++ b/tests/Queue/SqsConnectorTest.php
@@ -4,27 +4,14 @@ namespace Illuminate\Tests\Queue;
 
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\SqsQueue;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class SqsConnectorTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testConnectDerivesEndpointFromPrefixUrl()
     {
         $prefix = 'http://elasticmq.local:9324/000000000000';
         $expectedEndpoint = 'http://elasticmq.local:9324';
-
-        $overloaded = m::mock('overload:Aws\\Sqs\\SqsClient');
-        $overloaded->shouldReceive('__construct')->once()->with(m::on(function ($cfg) use ($expectedEndpoint) {
-            return isset($cfg['endpoint']) && $cfg['endpoint'] === $expectedEndpoint
-                && isset($cfg['region']) && is_string($cfg['region'])
-                && isset($cfg['version']) && $cfg['version'] === 'latest';
-        }));
 
         $connector = new SqsConnector();
 
@@ -38,5 +25,9 @@ class SqsConnectorTest extends TestCase
         ]);
 
         $this->assertInstanceOf(SqsQueue::class, $queue);
+
+        /** @var SqsQueue $queue */
+        $endpointUri = $queue->getSqs()->getEndpoint();
+        $this->assertSame($expectedEndpoint, (string) $endpointUri);
     }
 }


### PR DESCRIPTION
### Summary
- Respect custom SQS prefix/endpoint for local SQS emulators.
- Derive AWS SDK client `endpoint` from `SQS_PREFIX` when it’s a URL; add explicit `SQS_ENDPOINT` support.

Related issue [SqsConnector ignores custom prefix #55313](https://github.com/laravel/framework/issues/55313)