### PR TITLE
Correct indentation in inline component generation

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -102,9 +102,12 @@ class ComponentMakeCommand extends GeneratorCommand
     protected function buildClass($name)
     {
         if ($this->option('inline')) {
+            $indent = '            '; // 12 spaces
+            $quote = Inspiring::quotes()->random();
+
             return str_replace(
                 ['DummyView', '{{ view }}'],
-                "<<<'blade'\n<div>\n    <!-- ".Inspiring::quotes()->random()." -->\n</div>\nblade",
+                "<<<'blade'\n{$indent}<div>\n{$indent}    <!-- {$quote} -->\n{$indent}</div>\n{$indent}blade;",
                 parent::buildClass($name)
             );
         }

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -107,7 +107,7 @@ class ComponentMakeCommand extends GeneratorCommand
 
             return str_replace(
                 ['DummyView', '{{ view }}'],
-                "<<<'blade'\n{$indent}<div>\n{$indent}    <!-- {$quote} -->\n{$indent}</div>\n{$indent}blade;",
+                "<<<'blade'\n{$indent}<div>\n{$indent}    <!-- {$quote} -->\n{$indent}</div>\n{$indent}blade",
                 parent::buildClass($name)
             );
         }

--- a/tests/Integration/Generators/ComponentMakeCommandTest.php
+++ b/tests/Integration/Generators/ComponentMakeCommandTest.php
@@ -45,6 +45,20 @@ class ComponentMakeCommandTest extends TestCase
         $this->assertFilenameNotExists('resources/views/components/foo.blade.php');
     }
 
+    public function testItGeneratesInlineComponentWithCorrectHeredocIndentation()
+    {
+        $this->artisan('make:component', ['name' => 'Foo', '--inline' => true]);
+
+        $this->assertFilenameExists('app/View/Components/Foo.php');
+
+        $this->assertFileContains([
+            '            <div>',
+            '                <!--',
+            '            </div>',
+            '            blade',
+        ], 'app/View/Components/Foo.php');
+    }
+
     public function testItCanGenerateComponentFileWithTest()
     {
         $this->artisan('make:component', ['name' => 'Foo', '--test' => true])


### PR DESCRIPTION
## Description
This PR fixes the indentation issue in inline Blade component generation. Previously, the generated inline components had improper indentation in the `render()` method's heredoc syntax.

## Before
```php
public function render(): View|Closure|string
{
    return <<<'blade'
<div>
    <!-- Nothing worth having comes easy. - Theodore Roosevelt -->
</div>
blade;
}
```

## After
```php
public function render(): View|Closure|string
{
    return <<<'blade'
        <div>
            <!-- Nothing worth having comes easy. - Theodore Roosevelt -->
        </div>
        blade;
}