### PR TITLE
Add wait time option to queue:retry and queue:retry-batch command

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -22,7 +22,8 @@ class RetryCommand extends Command
     protected $signature = 'queue:retry
                             {id?* : The ID of the failed job or "all" to retry all jobs}
                             {--queue= : Retry all of the failed jobs for the specified queue}
-                            {--range=* : Range of job IDs (numeric) to be retried (e.g. 1-5)}';
+                            {--range=* : Range of job IDs (numeric) to be retried (e.g. 1-5)}
+                            {--wait= : Execution wait time in seconds (applicable for multiple jobs)}';
 
     /**
      * The console command description.
@@ -38,6 +39,7 @@ class RetryCommand extends Command
      */
     public function handle()
     {
+        $waitTime = (int) $this->option('wait');
         $jobsFound = count($ids = $this->getJobIds()) > 0;
 
         if ($jobsFound) {
@@ -55,6 +57,10 @@ class RetryCommand extends Command
                 $this->components->task($id, fn () => $this->retryJob($job));
 
                 $this->laravel['queue.failer']->forget($id);
+
+                if ($waitTime > 0 && $jobsFound > 1) {
+                    sleep($waitTime);
+                }
             }
         }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -68,7 +68,6 @@ class RetryCommand extends Command
         $jobsFound ? $this->newLine() : $this->components->info('No retryable jobs found.');
     }
 
-
     /**
      * Get the job IDs to be retried.
      *

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -40,7 +40,8 @@ class RetryCommand extends Command
     public function handle()
     {
         $waitTime = (int) $this->option('wait');
-        $jobsFound = count($ids = $this->getJobIds()) > 0;
+        $jobsCounter = count($ids = $this->getJobIds());
+        $jobsFound = $jobsCounter > 0;
 
         if ($jobsFound) {
             $this->components->info('Pushing failed queue jobs back onto the queue.');
@@ -58,7 +59,7 @@ class RetryCommand extends Command
 
                 $this->laravel['queue.failer']->forget($id);
 
-                if ($waitTime > 0 && $jobsFound > 1) {
+                if ($waitTime > 0 && $jobsCounter > 1) {
                     sleep($waitTime);
                 }
             }
@@ -66,6 +67,7 @@ class RetryCommand extends Command
 
         $jobsFound ? $this->newLine() : $this->components->info('No retryable jobs found.');
     }
+
 
     /**
      * Get the job IDs to be retried.


### PR DESCRIPTION
Add wait time option to queue:retry and queue:retry-batch command.

Benefit: Implementing this feature would allow users to manage large volumes of retries gracefully, preventing the system from becoming overloaded or resource-saturated during the process.
