### PR TITLE
[12.x] Use MariaDB idiomatic `json_value()`

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -53,4 +53,17 @@ class MariaDbGrammar extends MySqlGrammar
     {
         return false;
     }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
+
+        return 'json_value('.$field.$path.')';
+    }
 }

--- a/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MariaDbGrammar.php
@@ -51,4 +51,17 @@ class MariaDbGrammar extends MySqlGrammar
             $column->srid ? ' ref_system_id='.$column->srid : ''
         );
     }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($value);
+
+        return 'json_value('.$field.$path.')';
+    }
 }

--- a/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaGrammarTest.php
@@ -1435,7 +1435,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))))", $statements[0]);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_value(`my_json_column`, '$.\"some_attribute\"')))", $statements[0]);
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
@@ -1448,7 +1448,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))))", $statements[0]);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_value(`my_json_column`, '$.\"some_attribute\".\"nested\"')))", $statements[0]);
     }
 
     public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
@@ -1463,7 +1463,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("create table `users` (`my_json_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"foo\"[0][1]'))))", $statements[0]);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) as (json_value(`my_json_column`, '$.\"foo\"[0][1]')))", $statements[0]);
     }
 
     public function testCreateTableWithStoredAsColumn()
@@ -1494,7 +1494,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\"'))) stored)", $statements[0]);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_value(`my_json_column`, '$.\"some_attribute\"')) stored)", $statements[0]);
 
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->andReturn(null);
@@ -1507,7 +1507,7 @@ class DatabaseMariaDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))) stored)", $statements[0]);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_value(`my_json_column`, '$.\"some_attribute\".\"nested\"')) stored)", $statements[0]);
     }
 
     public function testDropDatabaseIfExists()

--- a/tests/Integration/Database/MariaDb/JsonLikeTest.php
+++ b/tests/Integration/Database/MariaDb/JsonLikeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MariaDb;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresPhpExtension('pdo_mysql')]
+class JsonLikeTest extends MariaDbTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->json('data');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('tasks');
+    }
+
+    public function testJsonLikeWithEmoji()
+    {
+        // Test that LIKE queries work correctly with emojis in JSON fields
+        // This verifies that json_value() handles emojis correctly (unlike json_unquote)
+        DB::table('tasks')->insert([
+            ['data' => '{"status":"Building started 🔨"}'],
+            ['data' => '{"status":"Tests passed ✅"}'],
+            ['data' => '{"status":"Deployment complete 🌎"}'],
+        ]);
+
+        // Search for records containing the hammer emoji
+        $buildCount = DB::table('tasks')
+            ->where('data->status', 'like', '%🔨%')
+            ->count();
+        $this->assertSame(1, $buildCount, 'Should find 1 record with hammer emoji');
+
+        // Search for records containing "Tests" with emoji
+        $testsCount = DB::table('tasks')
+            ->where('data->status', 'like', '%Tests%')
+            ->count();
+        $this->assertSame(1, $testsCount, 'Should find 1 record with "Tests"');
+
+        // Search for records containing rocket emoji
+        $deployCount = DB::table('tasks')
+            ->where('data->status', 'like', '%🌎%')
+            ->count();
+        $this->assertSame(1, $deployCount, 'Should find 1 record with globe emoji');
+
+        // Verify we can find text before emoji
+        $completeCount = DB::table('tasks')
+            ->where('data->status', 'like', '%complete%')
+            ->count();
+        $this->assertSame(1, $completeCount, 'Should find 1 record with "complete" before emoji');
+    }
+}


### PR DESCRIPTION
The pattern `json_unquote(json_extract(field, path))` to extract JSON values in a query has a couple of issues:

1. Until recent versions of MariaDB, `json_unquote` did not handle emoji: https://jira.mariadb.org/browse/MDEV-21124
2. The returned value from `json_unquote` has _binary_ collation (regardless of collation in the underlying schema)

From the linked MariaDB issue: 

> While it is common to use MySQL's `JSON_UNQUOTE(JSON_EXTRACT())` combination, MariaDB additionally offers `JSON_VALUE` function to basically perform the same task.

The change I propose is to use the idiomatic `json_value` function for MariaDB connections. 

Makes it possible to do `like` matching with emojis.

Related issue: #45901