### PR TITLE
[12.x] Allow dispatch helpers to accept class-string jobs

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -456,6 +456,8 @@ if (! function_exists('dispatch')) {
      */
     function dispatch($job): PendingDispatch|PendingClosureDispatch
     {
+        $job = is_string($job) ? Container::getInstance()->make($job) : $job;
+
         return $job instanceof Closure
             ? new PendingClosureDispatch(CallQueuedClosure::create($job))
             : new PendingDispatch($job);
@@ -474,6 +476,8 @@ if (! function_exists('dispatch_sync')) {
      */
     function dispatch_sync($job, $handler = null)
     {
+        $job = is_string($job) ? Container::getInstance()->make($job) : $job;
+
         return app(Dispatcher::class)->dispatchSync($job, $handler);
     }
 }

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -218,6 +218,9 @@ class JobDispatchingTest extends QueueTestCase
     public function testJobCanBeDispatchedByClassString()
     {
         dispatch(ClassStringDispatchableJob::class);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
         $this->assertTrue(ClassStringDispatchableJob::$ran);
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -215,6 +215,18 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertTrue(Job::$ran);
     }
 
+    public function testJobCanBeDispatchedByClassString()
+    {
+        dispatch(ClassStringDispatchableJob::class);
+        $this->assertTrue(ClassStringDispatchableJob::$ran);
+    }
+
+    public function testJobCanBeDispatchedSyncUsingClassString()
+    {
+        dispatch_sync(ClassStringDispatchableJob::class);
+        $this->assertTrue(ClassStringDispatchableJob::$ran);
+    }
+
     /**
      * Helpers.
      */
@@ -246,6 +258,20 @@ class Job implements ShouldQueue
     public function replaceValue($value)
     {
         static::$value = $value;
+    }
+}
+
+class ClassStringDispatchableJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function __construct() {}
+
+    public function handle()
+    {
+        static::$ran = true;
     }
 }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -221,7 +221,7 @@ class JobDispatchingTest extends QueueTestCase
         $this->assertTrue(ClassStringDispatchableJob::$ran);
     }
 
-    public function testJobCanBeDispatchedSyncUsingClassString()
+    public function testJobCanBeDispatchedSyncByClassString()
     {
         dispatch_sync(ClassStringDispatchableJob::class);
         $this->assertTrue(ClassStringDispatchableJob::$ran);
@@ -267,7 +267,9 @@ class ClassStringDispatchableJob implements ShouldQueue
 
     public static $ran = false;
 
-    public function __construct() {}
+    public function __construct()
+    {
+    }
 
     public function handle()
     {


### PR DESCRIPTION
## Summary

This PR enhances the global job dispatch helpers `dispatch()` and `dispatch_sync()` to support class-string jobs that can be resolved from the container.

## Benefits

- Consistent with Laravel’s existing class-string resolution patterns (e.g., `Schedule::job(TestJob::class)`)
- Backward compatible
- Improves readability and developer experience.

## Example

```php
dispatch(App\Jobs\TestJob::class);
dispatch_sync(App\Jobs\TestJob::class);
```
