### PR TITLE
[12.x] Add helper bind for binding arguments to callable

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1101,3 +1101,18 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('bind')) {
+    /**
+     * For binding arguments to method
+     *
+     * @template TReturn
+     * @param  callable(mixed...): TReturn  $callable
+     * @param  mixed...  $args
+     * @return callable(mixed): TReturn
+     */
+    function bind(callable $callable, mixed ...$args): Closure
+    {
+        return static fn (mixed $arg) => $callable($arg, ...$args);
+    }
+}


### PR DESCRIPTION
### Problem
1. I would like to use a "map" with a short circuit record, but the key is passed as the second argument and this is not always convenient. 
```php
collect(['1', '4'])->map(intval(...))->dd();
// 1, 0
```
2. I would like to pass a closure with the specified arguments to the "map". 
```php
collect(['laravel-framework', 'symfony-framework'])->map(substr(...))->dd();
//  "laravel-framework", "ymfony-framework"
```
### Solution
The new helper "bind" solves these problems succinctly and locanically.
1.
```php
collect(['1', '4'])->map(bind(intval(...)))->dd();
// 1, 4
```
2.
```php
collect(['laravel-framework', 'symfony-framework'])->map(bind(substr(...), 0, -10))->dd();
//  "laravel", "symfony"
```