### PR TITLE
[12.x] Add SQS FIFO and fair queue messageGroup() method support

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -262,7 +262,7 @@ class Mailable implements MailableContract, Renderable
      */
     protected function newQueuedJob()
     {
-        $messageGroup = $this->messageGroup ?? null;
+        $messageGroup = $this->messageGroup ?? (method_exists($this, 'messageGroup') ? $this->messageGroup() : null);
 
         /** @phpstan-ignore callable.nonNativeMethod (false positive since method_exists guard is used) */
         $deduplicator = $this->deduplicator ?? (method_exists($this, 'deduplicationId') ? $this->deduplicationId(...) : null);

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -247,7 +247,7 @@ class NotificationSender
                     $delay = $notification->withDelay($notifiable, $channel) ?? null;
                 }
 
-                $messageGroup = $notification->messageGroup ?? null;
+                $messageGroup = $notification->messageGroup ?? (method_exists($notification, 'messageGroup') ? $notification->messageGroup() : null);
 
                 if (method_exists($notification, 'withMessageGroups')) {
                     $messageGroup = $notification->withMessageGroups($notifiable, $channel) ?? null;

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -242,7 +242,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $messageGroupId = null;
 
         if ($isObject) {
-            $messageGroupId = transform($job->messageGroup ?? null, $transformToString);
+            $messageGroupId = transform($job->messageGroup ?? (method_exists($job, 'messageGroup') ? $job->messageGroup() : null), $transformToString);
         } elseif ($isFifo) {
             $messageGroupId = transform($queue, $transformToString);
         }

--- a/tests/Queue/Fixtures/FakeSqsJobWithMessageGroup.php
+++ b/tests/Queue/Fixtures/FakeSqsJobWithMessageGroup.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Queue\Fixtures;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class FakeSqsJobWithMessageGroup implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        //
+    }
+
+    /**
+     * Message group method called by SqsQueue.
+     *
+     * @return string
+     */
+    public function messageGroup(): string
+    {
+        return 'group-1';
+    }
+}


### PR DESCRIPTION
This is a follow up to the previous PR https://github.com/laravel/framework/pull/57187 that extended SQS FIFO and fair queue support to mailables, notifications, and event listeners. This PR adds support for defining a `messageGroup` method on the job classes instead of requiring the use of the `onGroup()` method at time of dispatch. See discussion on previous PR [starting here](https://github.com/laravel/framework/pull/57187#issuecomment-3351418174).

### Summary

Normal jobs, mailables, and notifications are actively dispatched by the user and have the ability to call `onGroup()` at the time of dispatch. However, event listeners are not dispatched by the user. They are predefined ahead of time (with class methods), and then dispatching the event triggers the listener. There is nowhere for the user to call `onGroup()` for a class-based event listener.

Due to this, there was an inconsistency where event listeners supported a `messageGroup()` method on the class, but all the other job types required calling `onGroup()` at the time of dispatch.

To help add some consistency, this PR adds support for defining a `messageGroup()` method on the other job types, as well. This also allows the message group logic to remain encapsulated inside of the job and not need to be provided by the dispatching logic.

### Notes

- The `messageGroup()` method does not take any parameters.

- The value of the `$messageGroup` property takes precedence over the `messageGroup()` method. This allows the dispatcher to still call `onGroup()` and have that value used instead of the `messageGroup()` method.

- For notifications, the new `messageGroup()` method support is in addition to the existing support for the `withMessageGroups($notifiable, $channel)` method, which takes the notifiable and channel in as parameters to determine the message group.

Please let me know if you need me to make any changes or have any questions.