### PR TITLE
[12.x] Add `setSeederRootClass` seeder in the app

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\App;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -91,7 +92,7 @@ class SeedCommand extends Command
             $class = 'Database\\Seeders\\'.$class;
         }
 
-        if ($class === 'Database\\Seeders\\DatabaseSeeder' &&
+        if ($class === App::seederRootClass() &&
             ! class_exists($class)) {
             $class = 'DatabaseSeeder';
         }
@@ -133,7 +134,7 @@ class SeedCommand extends Command
     protected function getOptions()
     {
         return [
-            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', App::seederRootClass()],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -174,6 +174,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $environmentPath;
 
     /**
+     * The root class name of the database seeder.
+     */
+    protected string $seederRootClass = 'Database\\Seeders\\DatabaseSeeder';
+
+    /**
      * The environment file to load during bootstrapping.
      *
      * @var string
@@ -1715,5 +1720,36 @@ class Application extends Container implements ApplicationContract, CachesConfig
         }
 
         throw new RuntimeException('Unable to detect application namespace.');
+    }
+
+    /**
+     * Set the root class for the database seeders.
+     *
+     * @param  string  $class
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setSeederRootClass(string $class): void
+    {
+        if (! class_exists($class)) {
+            throw new \InvalidArgumentException("The seeder root class [$class] does not exist");
+        }
+
+        if (! is_subclass_of($class, \Illuminate\Database\Seeder::class)) {
+            throw new \InvalidArgumentException("The seeder root class [$class] must be a subclass of Illuminate\\Database\\Seeder");
+        }
+
+        $this->seederRootClass = $class;
+    }
+
+    /**
+     * Get the root class for the database seeders.
+     *
+     * @return string
+     */
+    public function seederRootClass(): string
+    {
+        return $this->seederRootClass;
     }
 }

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -28,6 +28,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Foundation\Application usePublicPath(string $path)
  * @method static string storagePath(string $path = '')
  * @method static \Illuminate\Foundation\Application useStoragePath(string $path)
+ * @method static string seederRootClass()
+ * @method static \Illuminate\Foundation\Application setSeederRootClass(string $path)
  * @method static string resourcePath(string $path = '')
  * @method static string viewPath(string $path = '')
  * @method static string joinPaths(string $basePath, string $path = '')

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Testing\Assert;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +23,13 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class SeedCommandTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Facade::setFacadeApplication(new Application);
+    }
+
     public function testHandle()
     {
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Tests\Foundation\fixtures\CustomDatabaseSeeder;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -608,6 +609,33 @@ class FoundationApplicationTest extends TestCase
         } catch (HttpException $exception) {
             $this->assertSame(['X-FOO' => 'BAR'], $exception->getHeaders());
         }
+    }
+
+    public function testSetSeederRootClass()
+    {
+        $app = new Application;
+        $this->assertSame('Database\\Seeders\\DatabaseSeeder', $app->seederRootClass());
+
+        $app->setSeederRootClass(CustomDatabaseSeeder::class);
+        $this->assertSame(CustomDatabaseSeeder::class, $app->seederRootClass());
+    }
+
+    public function testCannotSetInvalidSeederRootClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seeder root class [stdClass] must be a subclass of Illuminate\Database\Seeder');
+
+        $app = new Application;
+        $app->setSeederRootClass(\stdClass::class);
+    }
+
+    public function testCannotSetNonExistentSeederRootClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The seeder root class [NonExistentClass] does not exist');
+
+        $app = new Application;
+        $app->setSeederRootClass('NonExistentClass');
     }
 }
 

--- a/tests/Foundation/fixtures/CustomDatabaseSeeder.php
+++ b/tests/Foundation/fixtures/CustomDatabaseSeeder.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Foundation\fixtures;
+
+use Illuminate\Database\Seeder;
+
+class CustomDatabaseSeeder extends Seeder
+{
+}


### PR DESCRIPTION
This PR adds the `setSeederRootClass` method to Laravel's `Application` class, allowing developers to specify a custom path for the root seeder class. This feature provides the ability to configure the base location of seeders, similar to how Laravel currently allows the migration path to be customized.

### Details

- **New methods:** `setSeederRootClass($path)` and `seederRootClass()`
- Enables setting a custom path for the root seeder class.
- Useful for projects that require a more modular structure or want to organize seeders outside the default location.
- Since Laravel already supports custom migration paths, it makes sense to offer the same flexibility for seeders.
- The `SeedCommand` now relies on the configured seeder root path instead of a hardcoded default.

### Motivation

This change gives developers greater control over code organization, letting them adapt Laravel to their project's needs and maintain consistency in how migration and seeder paths are configured.

### Example usage

```php
$app->setSeederRootClass(MyCustomSeeder::class);
```

---

Feedback and suggestions are welcome!
