### PR TITLE
Align trans helper return type with Translator contract

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -986,9 +986,9 @@ if (! function_exists('trans')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
-     * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : array|string)
+     * @return ($key is null ? \Illuminate\Contracts\Translation\Translator : mixed)
      */
-    function trans($key = null, $replace = [], $locale = null): Translator|array|string
+    function trans($key = null, $replace = [], $locale = null): mixed
     {
         if (is_null($key)) {
             return app('translator');

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -57,7 +57,7 @@ assertType('mixed', session('foo'));
 assertType('null', session(['foo' => 'bar']));
 
 assertType('Illuminate\Contracts\Translation\Translator', trans());
-assertType('array|string', trans('foo'));
+assertType('mixed', trans('foo'));
 
 assertType('Illuminate\Contracts\Validation\Factory', validator());
 assertType('Illuminate\Contracts\Validation\Validator', validator([]));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Summary
This change adjusts the return type of the translation helper to `mixed`, aligning it with the `\Illuminate\Contracts\Translation\Translator::get()` contract.

### Reason for Change

Currently, PHPStan reports an error in cases like:

```php
return new MailMessage()
    ->subject(trans('notifications.invite_user.subject'));
```

Error:
> phpstan: Parameter #1 $subject of method Illuminate\Notifications\Messages\SimpleMessage::subject() expects string, array|string given.

### Reference

From the framework source:

https://github.com/laravel/framework/blob/909102ce32569ad935cb03f89cd5dc2b81b2b67e/src/Illuminate/Contracts/Translation/Translator.php#L7-L15
