### PR TITLE
feat: Add exclude functionality to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -43,6 +43,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $additional = [];
 
     /**
+     * The attributes to exclude from the resource array.
+     *
+     * @var array
+     */
+    protected array $excludes = [];
+
+    /**
      * The "data" wrapper that should be applied.
      *
      * @var string|null
@@ -121,7 +128,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             $data = $data->jsonSerialize();
         }
 
-        return $this->filter((array) $data);
+        return $this->applyExcludes($this->filter((array) $data));
     }
 
     /**
@@ -196,6 +203,38 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
 
         return $this;
     }
+    /**
+     * Exclude one or more attributes from the resource array.
+     *
+     * Supports dot notation for nested arrays.
+     *
+     * @param  string|array  $fields
+     * @return static
+     */
+    public function except(string|array $fields): static
+    {
+        $this->excludes = array_merge($this->excludes, (array) $fields);
+
+        return $this;
+    }
+
+    /**
+     * Remove excluded attributes from the resolved data.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    protected function applyExcludes(array $data): array
+    {
+        if (! empty($this->excludes)) {
+            foreach ($this->excludes as $field) {
+                data_forget($data, $field);
+            }
+        }
+
+        return $data;
+    }
+
 
     /**
      * Get the JSON serialization options that should be applied to the resource response.
@@ -273,4 +312,4 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     {
         return $this->resolve(Container::getInstance()->make('request'));
     }
-}
+} 


### PR DESCRIPTION
- Introduced a new protected property `$excludes` to hold attributes to be excluded from the resource array.
- Added the `except` method to allow exclusion of specified attributes, supporting dot notation for nested arrays.
- Implemented `applyExcludes` method to remove excluded attributes from the resolved data before returning it.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
####  Example
```php
return (new UserResource($user))
    ->except(['password', 'profile.ssn']);