### PR TITLE
Deferred queue

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -80,7 +80,7 @@ return [
             'driver' => 'failover',
             'connections' => [
                 'database',
-                'sync',
+                'deferred',
             ],
         ],
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -72,6 +72,18 @@ return [
             'after_commit' => false,
         ],
 
+        'deferred' => [
+            'driver' => 'deferred',
+        ],
+
+        'failover' => [
+            'driver' => 'failover',
+            'connections' => [
+                'database',
+                'sync',
+            ],
+        ],
+
     ],
 
     /*

--- a/src/Illuminate/Queue/Connectors/DeferredConnector.php
+++ b/src/Illuminate/Queue/Connectors/DeferredConnector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Connectors;
+
+use Illuminate\Queue\DeferredQueue;
+
+class DeferredConnector implements ConnectorInterface
+{
+    /**
+     * Establish a queue connection.
+     *
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        return new DeferredQueue($config['after_commit'] ?? null);
+    }
+}

--- a/src/Illuminate/Queue/DeferredQueue.php
+++ b/src/Illuminate/Queue/DeferredQueue.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Contracts\Queue\Job;
+
+class DeferredQueue extends SyncQueue
+{
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $job
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        return \Illuminate\Support\defer(fn () => parent::push($job, $data, $queue));
+    }
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Connectors\DatabaseConnector;
+use Illuminate\Queue\Connectors\DeferredConnector;
 use Illuminate\Queue\Connectors\FailoverConnector;
 use Illuminate\Queue\Connectors\NullConnector;
 use Illuminate\Queue\Connectors\RedisConnector;
@@ -104,7 +105,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function registerConnectors($manager)
     {
-        foreach (['Null', 'Sync', 'Failover', 'Database', 'Redis', 'Beanstalkd', 'Sqs'] as $connector) {
+        foreach (['Null', 'Sync', 'Deferred', 'Failover', 'Database', 'Redis', 'Beanstalkd', 'Sqs'] as $connector) {
             $this->{"register{$connector}Connector"}($manager);
         }
     }
@@ -132,6 +133,19 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         $manager->addConnector('sync', function () {
             return new SyncConnector;
+        });
+    }
+
+    /**
+     * Register the Deferred queue connector.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    protected function registerDeferredConnector($manager)
+    {
+        $manager->addConnector('deferred', function () {
+            return new DeferredConnector;
         });
     }
 


### PR DESCRIPTION
Very similar to sync queue, but [deferred](https://laravel.com/docs/12.x/helpers#deferred-functions). Potentially useful for `failover` queues.