### PR TITLE
[12.x] Add --no-down flag to make:migration command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -19,6 +19,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
     protected $signature = 'make:migration {name : The name of the migration}
         {--create= : The table to be created}
         {--table= : The table to migrate}
+        {--no-down : Do not add the down method to the migration}
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
         {--fullpath : Output the full path of the migration (Deprecated)}';
@@ -76,6 +77,8 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 
         $create = $this->input->getOption('create') ?: false;
 
+        $noDown = $this->input->getOption('no-down') ?: false;
+
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
         // to pass a table name into this option as a short-cut for creating.
@@ -95,7 +98,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $table, $create, $noDown);
     }
 
     /**
@@ -104,12 +107,13 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      * @param  string  $name
      * @param  string  $table
      * @param  bool  $create
+     * @param  bool  $noDown
      * @return void
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $table, $create, $noDown = false)
     {
         $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $noDown
         );
 
         if (windows_os()) {

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -49,18 +49,19 @@ class MigrationCreator
      * @param  string  $path
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $noDown
      * @return string
      *
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $noDown = false)
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($table, $create, $noDown);
 
         $path = $this->getPath($name, $path);
 
@@ -107,23 +108,26 @@ class MigrationCreator
      *
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  bool  $noDown
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($table, $create, $noDown = false)
     {
         if (is_null($table)) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration')
                 ? $customPath
-                : $this->stubPath().'/migration.stub';
+                : $this->stubPath().'/migration';
         } elseif ($create) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create.stub')
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create')
                 ? $customPath
-                : $this->stubPath().'/migration.create.stub';
+                : $this->stubPath().'/migration.create';
         } else {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update.stub')
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update')
                 ? $customPath
-                : $this->stubPath().'/migration.update.stub';
+                : $this->stubPath().'/migration.update';
         }
+
+        $stub .= $noDown ? '.nodown.stub' : '.stub';
 
         return $this->files->get($stub);
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -113,21 +113,21 @@ class MigrationCreator
      */
     protected function getStub($table, $create, $noDown = false)
     {
-        if (is_null($table)) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration')
-                ? $customPath
-                : $this->stubPath().'/migration';
-        } elseif ($create) {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create')
-                ? $customPath
-                : $this->stubPath().'/migration.create';
-        } else {
-            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update')
-                ? $customPath
-                : $this->stubPath().'/migration.update';
-        }
+        $stubSuffix =  $noDown ? '.nodown.stub' : '.stub';
 
-        $stub .= $noDown ? '.nodown.stub' : '.stub';
+        if (is_null($table)) {
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration'.$stubSuffix)
+                ? $customPath
+                : $this->stubPath().'/migration'.$stubSuffix;
+        } elseif ($create) {
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.create'.$stubSuffix)
+                ? $customPath
+                : $this->stubPath().'/migration.create'.$stubSuffix;
+        } else {
+            $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.update'.$stubSuffix)
+                ? $customPath
+                : $this->stubPath().'/migration.update'.$stubSuffix;
+        }
 
         return $this->files->get($stub);
     }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -113,7 +113,7 @@ class MigrationCreator
      */
     protected function getStub($table, $create, $noDown = false)
     {
-        $stubSuffix =  $noDown ? '.nodown.stub' : '.stub';
+        $stubSuffix = $noDown ? '.nodown.stub' : '.stub';
 
         if (is_null($table)) {
             $stub = $this->files->exists($customPath = $this->customStubPath.'/migration'.$stubSuffix)

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.nodown.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.nodown.stub
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+};

--- a/src/Illuminate/Database/Migrations/stubs/migration.nodown.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.nodown.stub
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+    }
+};

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.nodown.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.nodown.stub
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -44,7 +44,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -60,7 +60,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
@@ -76,7 +76,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
@@ -92,7 +92,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+            ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, false)
             ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
@@ -108,9 +108,25 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+            ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, false)
             ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
+    public function testNoDownFlagIsPassedToMigrationCreator()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()
+            ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, true)
+            ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
+
+        $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users', '--no-down' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
This PR adds a new `--no-down` flag to the `make:migration` command that enables the possibility of creating migrations without the `down` method.