### PR TITLE
Failover cache

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -27,7 +27,8 @@ return [
     | same cache driver to group types of items stored in your caches.
     |
     | Supported drivers: "array", "database", "file", "memcached",
-    |                    "redis", "dynamodb", "octane", "null"
+    |                    "redis", "dynamodb", "octane",
+    |                    "failover", "null"
     |
     */
 
@@ -93,6 +94,14 @@ return [
 
         'octane' => [
             'driver' => 'octane',
+        ],
+
+        'failover' => [
+            'driver' => 'failover',
+            'stores' => [
+                'database',
+                'array',
+            ],
         ],
 
     ],

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -253,7 +253,11 @@ class CacheManager implements FactoryContract
      */
     protected function createFailoverDriver(array $config)
     {
-        return $this->repository(new FailoverStore($this, $config['stores']));
+        return $this->repository(new FailoverStore(
+            $this,
+            $this->app->make(DispatcherContract::class),
+            $config['stores']
+        ));
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -246,6 +246,17 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Create an instance of the failover cache driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Cache\Repository
+     */
+    protected function createFailoverDriver(array $config)
+    {
+        return $this->repository(new FailoverStore($this, $config['stores']));
+    }
+
+    /**
      * Create an instance of the file cache driver.
      *
      * @param  array  $config

--- a/src/Illuminate/Cache/Events/CacheFailedOver.php
+++ b/src/Illuminate/Cache/Events/CacheFailedOver.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache\Events;
 
+use Throwable;
+
 class CacheFailedOver
 {
     /**
@@ -11,6 +13,7 @@ class CacheFailedOver
      */
     public function __construct(
         public ?string $storeName,
+        public Throwable $exception,
     ) {
     }
 }

--- a/src/Illuminate/Cache/Events/CacheFailedOver.php
+++ b/src/Illuminate/Cache/Events/CacheFailedOver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheFailedOver
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $storeName  The name of the cache store that failed.
+     */
+    public function __construct(
+        public ?string $storeName,
+    ) {
+    }
+}

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -185,7 +185,7 @@ class FailoverStore extends TaggableStore implements LockProvider
             } catch (Throwable $e) {
                 $lastException = $e;
 
-                $this->events->dispatch(new CacheFailedOver($store));
+                $this->events->dispatch(new CacheFailedOver($store, $e));
             }
         }
 

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -16,7 +16,9 @@ class FailoverStore extends TaggableStore implements LockProvider
     public function __construct(
         protected CacheManager $cache,
         protected Dispatcher $events,
-        protected array $stores) {}
+        protected array $stores)
+    {
+    }
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Support\InteractsWithTime;
+use Memcached;
+use ReflectionMethod;
+use Throwable;
+
+class FailoverStore extends TaggableStore implements LockProvider
+{
+    /**
+     * Create a new failover store.
+     *
+     * @param  \Illuminate\Cache\CacheManager  $cache
+     * @param  array $stores
+     */
+    public function __construct(protected CacheManager $cache, protected array $stores)
+    {
+    }
+
+    /**
+     * Retrieve an item from the cache by key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        foreach ($this->stores as $store) {
+            try {
+                return $this->store($store)->get($key);
+            } catch (Throwable $e) {
+                $lastException = $e;
+
+                $this->events->dispatch(new CacheFailedOver($store));
+            }
+        }
+
+        throw $lastException ?? new \RuntimeException('No available connections to push the job.');
+    }
+
+    /**
+     * Retrieve multiple items from the cache by key.
+     *
+     * Items not found in the cache will have a null value.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function many(array $keys)
+    {
+        $prefixedKeys = array_map(function ($key) {
+            return $this->prefix.$key;
+        }, $keys);
+
+        if ($this->onVersionThree) {
+            $values = $this->memcached->getMulti($prefixedKeys, Memcached::GET_PRESERVE_ORDER);
+        } else {
+            $null = null;
+
+            $values = $this->memcached->getMulti($prefixedKeys, $null, Memcached::GET_PRESERVE_ORDER);
+        }
+
+        if ($this->memcached->getResultCode() != 0) {
+            return array_fill_keys($keys, null);
+        }
+
+        return array_combine($keys, $values);
+    }
+
+    /**
+     * Store an item in the cache for a given number of seconds.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function put($key, $value, $seconds)
+    {
+        return $this->memcached->set(
+            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+        );
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of seconds.
+     *
+     * @param  array  $values
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function putMany(array $values, $seconds)
+    {
+        $prefixedValues = [];
+
+        foreach ($values as $key => $value) {
+            $prefixedValues[$this->prefix.$key] = $value;
+        }
+
+        return $this->memcached->setMulti(
+            $prefixedValues, $this->calculateExpiration($seconds)
+        );
+    }
+
+    /**
+     * Store an item in the cache if the key doesn't exist.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function add($key, $value, $seconds)
+    {
+        return $this->memcached->add(
+            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+        );
+    }
+
+    /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|false
+     */
+    public function increment($key, $value = 1)
+    {
+        return $this->memcached->increment($this->prefix.$key, $value);
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|false
+     */
+    public function decrement($key, $value = 1)
+    {
+        return $this->memcached->decrement($this->prefix.$key, $value);
+    }
+
+    /**
+     * Store an item in the cache indefinitely.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function forever($key, $value)
+    {
+        return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new MemcachedLock($this->memcached, $this->prefix.$name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
+    }
+
+    /**
+     * Remove an item from the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forget($key)
+    {
+        return $this->memcached->delete($this->prefix.$key);
+    }
+
+    /**
+     * Remove all items from the cache.
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        return $this->memcached->flush();
+    }
+
+    /**
+     * Get the cache store for the given store name.
+     *
+     * @param  string  $store
+     * @return \Illuminate\Contracts\Cache\Store
+     */
+    protected function store(string $store)
+    {
+        return $this->cache->store($store)->getStore();
+    }
+}

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -187,7 +187,7 @@ class FailoverStore extends TaggableStore implements LockProvider
             }
         }
 
-        throw $lastException ?? new RuntimeException('All failover cache connections failed.');
+        throw $lastException ?? new RuntimeException('All failover cache stores failed.');
     }
 
     /**


### PR DESCRIPTION
Similar to queue failover, this implements cache failover. If a cache operation fails, the next cache store in the failover list will be used. The `CacheFailedOver` event is dispatched on failover.

In the `config/cache.php` configuration file:

```php
'failover' => [
    'driver' => 'failover',
    'stores' => [
        'redis',
        'database',
        'array',
    ],
],
```

Then, use the cache normally:

```php
return Cache::get('name');
```