### PR TITLE
`stringify` method in `Number` helper and improvement perforamance of `trim` method in `Number`.

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -339,7 +339,22 @@ class Number
      */
     public static function trim(int|float $number)
     {
-        return json_decode(json_encode($number));
+        if ($number == 0) {
+            return 0;
+        }
+
+        if (is_int($number) || (is_float($number) && stripos(strval($number), 'E') !== false)) {
+            return $number;
+        }
+
+        $strNumber = strval($number);
+        $result = rtrim(rtrim($strNumber, '0'), '.');
+
+        if (stripos($result, '.') !== false) {
+            return (float) $result;
+        }
+
+        return (int) $result;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -370,4 +370,43 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
+
+    public function testStringify()
+    {
+        $this->assertSame('12300000000.0', Number::stringify(1.23e10));
+        $this->assertSame('150000.0', Number::stringify(1.5e5));
+        $this->assertSame('250.0', Number::stringify('2.5e2'));
+
+        $this->assertSame('0.0000123', Number::stringify(1.23e-5));
+        $this->assertSame('0.00000000056', Number::stringify(5.6e-10));
+        $this->assertSame('0.00000001', Number::stringify(1e-8));
+
+        $this->assertSame('-123000.0', Number::stringify(-1.23e5));
+        $this->assertSame('-0.00456', Number::stringify(-4.56e-3));
+
+        $this->assertSame('123', Number::stringify(123));
+        $this->assertSame('123.456', Number::stringify(123.456));
+        $this->assertSame('9.0', Number::stringify(9.0));
+        $this->assertSame('0', Number::stringify(0));
+
+        $this->assertSame('1.0', Number::stringify('1e0'));
+        $this->assertSame('1.0', Number::stringify('1.0e0'));
+        $this->assertSame('0.0', Number::stringify('0.0e0'));
+        $this->assertSame('0.0', Number::stringify('0e0'));
+
+        $this->assertSame('0.00000001', Number::stringify('1.00e-8'));
+        $this->assertSame('123000000000000000000000000000000000000000000000000.0', Number::stringify('1.23e50'));
+        $this->assertSame('0.0000000000000000000000000000000000000000000000000123', Number::stringify('1.23e-50'));
+
+        // underflow numbers
+        $this->assertSame('0.0', Number::stringify(1.5e-400));
+        $this->assertSame('0.0', Number::stringify(15e-400));
+
+        $this->assertSame('INF', Number::stringify(15e400));
+        $this->assertSame('-INF', Number::stringify(-15e400));
+
+        $this->assertSame('INF', Number::stringify(INF));
+        $this->assertSame('-INF', Number::stringify(-INF));
+        $this->assertSame('NAN', Number::stringify(NAN));
+    }
 }

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -334,6 +334,12 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+        $this->assertSame(1.33e60, Number::trim(1.33e60));
+        $this->assertSame(1.80e-24, Number::trim(1.80e-24));
+        $this->assertSame(0, Number::trim(0.0));
+        $this->assertSame(0.1, Number::trim(0.10));
+        $this->assertSame(-0.184, Number::trim(-0.18400));
+        $this->assertSame(0.064501, Number::trim(0.0645010));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
In this pull request, two changes have occurred:

## The `stringify` method in the `Illuminate\Support\Number` helper:
This method converts all numbers, including those in scientific notation, to strings with high precision. A common issue when working with bcmath functions is the `argument is not well-formed` error. This method can be helpful in converting numbers to strings for performing precise calculations with bcmath/gmp.

## Refactoring and performance improvement of the `trim` method in the `Illuminate\Support\Number` helper:
Although no specific change in functionality has occurred, the new changes make the code more explicit. Additionally, some numbers were not covered in the tests, which have now been covered in the changes of this pull request.