### PR TITLE
[12.x] Fix passing countable to Number::format()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -996,6 +996,10 @@ class Str
      */
     public static function plural($value, $count = 2, $prependCount = false)
     {
+        if (is_countable($count)) {
+            $count = count($count);
+        }
+
         return ($prependCount ? Number::format($count).' ' : '').Pluralizer::plural($value, $count);
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1873,7 +1873,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laracon', Str::plural('Laracon', [2025]));
 
         $this->assertSame('Laracons', Str::plural('Laracon', 3));
-        $this->assertSame('Laracons', Str::plural('Laracon', [2024, 2025));
+        $this->assertSame('Laracons', Str::plural('Laracon', [2024, 2025]));
 
         $this->assertSame('1 Laracon', Str::plural('Laracon', 1, prependCount: true));
         $this->assertSame('1 Laracon', Str::plural('Laracon', [2025], prependCount: true));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1870,8 +1870,16 @@ class SupportStrTest extends TestCase
     public function testPlural(): void
     {
         $this->assertSame('Laracon', Str::plural('Laracon', 1));
+        $this->assertSame('Laracon', Str::plural('Laracon', [2025]));
+
         $this->assertSame('Laracons', Str::plural('Laracon', 3));
+        $this->assertSame('Laracons', Str::plural('Laracon', [2024, 2025));
+
+        $this->assertSame('1 Laracon', Str::plural('Laracon', 1, prependCount: true));
+        $this->assertSame('1 Laracon', Str::plural('Laracon', [2025], prependCount: true));
+
         $this->assertSame('1,000 Laracons', Str::plural('Laracon', 1000, prependCount: true));
+        $this->assertSame('2 Laracons', Str::plural('Laracon', [2024, 2025], prependCount: true));
     }
 
     public function testPluralPascal(): void


### PR DESCRIPTION
`Str::plural()` accepts a countable as value. Recently #56802 introduced a call to `Number::format()`, but this method does not accept a countable.