### PR TITLE
Fix validate integer php doc type annotation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array{0: 'strict'}  $parameters
+     * @param array<int, string> $parameters
      * @return bool
      */
     public function validateInteger($attribute, $value, array $parameters = [])

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<int, string>  $parameters
+     * @param  array{0?: 'strict'}  $parameters
      * @return bool
      */
     public function validateInteger($attribute, $value, array $parameters = [])

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param array<int, string> $parameters
+     * @param  array<int, string> $parameters
      * @return bool
      */
     public function validateInteger($attribute, $value, array $parameters = [])

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1553,7 +1553,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array<int, string> $parameters
+     * @param  array<int, string>  $parameters
      * @return bool
      */
     public function validateInteger($attribute, $value, array $parameters = [])


### PR DESCRIPTION
## Fix PHPDoc type annotation for validateInteger parameters

This PR fixes a PHPStan error caused by the PHPDoc type annotation added in #56503 for the `validateInteger()` method's `$parameters` argument.

### Problem

The PHPDoc type `array{0: 'strict'}` requires the first element to always be present and be the string `'strict'`. However, the `$parameters` argument defaults to an empty array `[]`, which causes a PHPStan type mismatch error when the method is called without the strict option.
```php
/**
 * @param  array{0: 'strict'}  $parameters  // ❌ Requires element 0 to exist
 */
public function validateInteger($attribute, $value, array $parameters = [])
{
    if (($parameters[0] ?? null) === 'strict') {
        return is_int($value);
    }
    return filter_var($value, FILTER_VALIDATE_INT) !== false;
}
```

### Solution

Changed the PHPDoc type to `array<int, string>` to properly reflect that:
- The array can be empty (default case)
- When provided, it contains string values at integer keys
- This aligns with other validation rule parameter types in the codebase
```php
/**
 * @param  array<int, string>  $parameters  // ✅ Allows empty array
 */
```

### Benefits
- Eliminates PHPStan errors for projects using strict type checking
- Maintains backward compatibility with existing code
- Consistent with parameter type definitions in other validation methods