### PR TITLE
[12.x] Update `Route::middleware` to accept null

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -121,6 +121,8 @@ class RouteRegistrar
         }
 
         if ($key === 'middleware') {
+            $value = array_filter(Arr::wrap($value));
+
             foreach ($value as $index => $middleware) {
                 $value[$index] = (string) $middleware;
             }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -127,6 +127,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame(['one', 'two'], $this->getRoute()->middleware());
     }
 
+    public function testMiddlewareAsNull()
+    {
+        $this->router->middleware(null)->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertSame([], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware(null);
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertSame([], $this->getRoute()->middleware());
+    }
+
     public function testWithoutMiddlewareRegistration()
     {
         $this->router->middleware(['one', 'two'])->get('users', function () {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`Route::middleware` method's PHPDoc says it accepts null. However, it throws the following exception when null is passed as middleware.

<img width="862" height="121" alt="CleanShot 2025-10-18 at 21 30 57" src="https://github.com/user-attachments/assets/ec478eef-0a2f-41e8-ab8c-e7202bc2438c" />


Because of this, when we conditionally apply a middleware, we need to fallback to an empty array.

```php
Route::middleware(when(app()->isProduction(), MyMiddleware::class, []))
```

This PR fixes the issue by filtering out falsy values before registering middlewares.