### PR TITLE
[12.x] Add `Numerable` helper class in addition to `Stringable`

### DIFF
--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -166,6 +166,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Http\Request|mixed whenMissing(string $key, callable $callback, callable|null $default = null)
  * @method static \Illuminate\Support\Stringable str(string $key, mixed $default = null)
  * @method static \Illuminate\Support\Stringable string(string $key, mixed $default = null)
+ * @method static \Illuminate\Support\Numberable number(string $key, mixed $default = null)
  * @method static bool boolean(string|null $key = null, bool $default = false)
  * @method static int integer(string $key, int $default = 0)
  * @method static float float(string $key, float $default = 0)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -369,7 +369,7 @@ class Number
      *
      * @param  int|float  $number
      * @param  non-negative-int  $precision
-     * @param  int  $mode
+     * @param  value-of<PHP_ROUND_*>  $mode
      * @return float
      */
     public static function round(int|float $number, int $precision = 0, int $mode = PHP_ROUND_HALF_UP): float

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -27,7 +27,7 @@ class Number
     /**
      * Get a new numberable object from the given number.
      *
-     * @param  int|float|string  $number
+     * @param  int|float|numeric-string  $number
      * @return \Illuminate\Support\Numberable
      */
     public static function of($number)

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,6 +25,17 @@ class Number
     protected static $currency = 'USD';
 
     /**
+     * Get a new numberable object from the given number.
+     *
+     * @param  int|float|string  $number
+     * @return \Illuminate\Support\Numberable
+     */
+    public static function of($number)
+    {
+        return new Numberable($number);
+    }
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -340,6 +351,205 @@ class Number
     public static function trim(int|float $number)
     {
         return json_decode(json_encode($number));
+    }
+
+    /**
+     * Return the absolute value of the given number.
+     *
+     * @param  int|float  $number
+     * @return int|float
+     */
+    public static function abs(int|float $number)
+    {
+        return abs($number);
+    }
+
+    /**
+     * Round the given number to the specified precision.
+     *
+     * @param  int|float  $number
+     * @param  int  $precision
+     * @param  int  $mode
+     * @return float
+     */
+    public static function round(int|float $number, int $precision = 0, int $mode = PHP_ROUND_HALF_UP): float
+    {
+        return round($number, $precision, $mode);
+    }
+
+    /**
+     * Round the given number up to the nearest integer.
+     *
+     * @param  int|float  $number
+     * @return float
+     */
+    public static function ceil(int|float $number): float
+    {
+        return ceil($number);
+    }
+
+    /**
+     * Round the given number down to the nearest integer.
+     *
+     * @param  int|float  $number
+     * @return float
+     */
+    public static function floor(int|float $number): float
+    {
+        return floor($number);
+    }
+
+    /**
+     * Determine if the given number is even.
+     *
+     * @param  int  $number
+     * @return bool
+     */
+    public static function isEven(int $number): bool
+    {
+        return $number % 2 === 0;
+    }
+
+    /**
+     * Determine if the given number is odd.
+     *
+     * @param  int  $number
+     * @return bool
+     */
+    public static function isOdd(int $number): bool
+    {
+        return $number % 2 !== 0;
+    }
+
+    /**
+     * Determine if the given number is prime.
+     *
+     * @param  int  $number
+     * @return bool
+     */
+    public static function isPrime(int $number): bool
+    {
+        if ($number <= 1) {
+            return false;
+        }
+
+        if ($number <= 3) {
+            return true;
+        }
+
+        if ($number % 2 === 0 || $number % 3 === 0) {
+            return false;
+        }
+
+        for ($i = 5; $i * $i <= $number; $i += 6) {
+            if ($number % $i === 0 || $number % ($i + 2) === 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Raise the given number to the specified power.
+     *
+     * @param  int|float  $base
+     * @param  int|float  $exponent
+     * @return int|float
+     */
+    public static function power(int|float $base, int|float $exponent): int|float
+    {
+        return pow($base, $exponent);
+    }
+
+    /**
+     * Calculate the square root of the given number.
+     *
+     * @param  int|float  $number
+     * @return float
+     */
+    public static function sqrt(int|float $number): float
+    {
+        return sqrt($number);
+    }
+
+    /**
+     * Calculate the factorial of the given number.
+     *
+     * @param  int  $number
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function factorial(int $number): int
+    {
+        if ($number < 0) {
+            throw new \InvalidArgumentException('Factorial is not defined for negative numbers.');
+        }
+
+        if ($number === 0 || $number === 1) {
+            return 1;
+        }
+
+        $result = 1;
+        for ($i = 2; $i <= $number; $i++) {
+            $result *= $i;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Calculate the greatest common divisor of two numbers.
+     *
+     * @param  int  $a
+     * @param  int  $b
+     * @return int
+     */
+    public static function gcd(int $a, int $b): int
+    {
+        $a = abs($a);
+        $b = abs($b);
+
+        while ($b !== 0) {
+            $temp = $b;
+            $b = $a % $b;
+            $a = $temp;
+        }
+
+        return $a;
+    }
+
+    /**
+     * Calculate the least common multiple of two numbers.
+     *
+     * @param  int  $a
+     * @param  int  $b
+     * @return int
+     */
+    public static function lcm(int $a, int $b): int
+    {
+        if ($a === 0 || $b === 0) {
+            return 0;
+        }
+
+        return abs($a * $b) / static::gcd($a, $b);
+    }
+
+    /**
+     * Check if the given number is a perfect square.
+     *
+     * @param  int  $number
+     * @return bool
+     */
+    public static function isPerfectSquare(int $number): bool
+    {
+        if ($number < 0) {
+            return false;
+        }
+
+        $sqrt = (int) sqrt($number);
+        return $sqrt * $sqrt === $number;
     }
 
     /**

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -368,7 +368,7 @@ class Number
      * Round the given number to the specified precision.
      *
      * @param  int|float  $number
-     * @param  int  $precision
+     * @param  non-negative-int  $precision
      * @param  int  $mode
      * @return float
      */

--- a/src/Illuminate/Support/Numberable.php
+++ b/src/Illuminate/Support/Numberable.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Dumpable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+use InvalidArgumentException;
+use JsonSerializable;
+
+class Numberable implements JsonSerializable
+{
+    use Conditionable, Dumpable, Macroable, Tappable;
+
+    /**
+     * The underlying numeric value.
+     *
+     * @var int|float
+     */
+    protected $value;
+
+    /**
+     * Create a new instance of the class.
+     *
+     * @param  int|float|string  $value
+     */
+    public function __construct($value = 0)
+    {
+        $this->value = is_string($value) ? $this->parseValue($value) : $value;
+    }
+
+    /**
+     * Parse a string value to int or float.
+     *
+     * @param  string  $value
+     * @return int|float
+     */
+    protected function parseValue(string $value): int|float
+    {
+        if (is_numeric($value)) {
+            return str_contains($value, '.') ? (float) $value : (int) $value;
+        }
+
+        throw new InvalidArgumentException("Invalid numeric value: {$value}");
+    }
+
+    /**
+     * Return the absolute value of the number.
+     *
+     * @return static
+     */
+    public function abs()
+    {
+        return new static(Number::abs($this->value));
+    }
+
+    /**
+     * Round the number to the specified precision.
+     *
+     * @param  int  $precision
+     * @param  int  $mode
+     * @return static
+     */
+    public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP)
+    {
+        return new static(Number::round($this->value, $precision, $mode));
+    }
+
+    /**
+     * Round the number up to the nearest integer.
+     *
+     * @return static
+     */
+    public function ceil()
+    {
+        return new static(Number::ceil($this->value));
+    }
+
+    /**
+     * Round the number down to the nearest integer.
+     *
+     * @return static
+     */
+    public function floor()
+    {
+        return new static(Number::floor($this->value));
+    }
+
+    /**
+     * Clamp the number between the given minimum and maximum.
+     *
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @return static
+     */
+    public function clamp(int|float $min, int|float $max)
+    {
+        return new static(Number::clamp($this->value, $min, $max));
+    }
+
+    /**
+     * Raise the number to the specified power.
+     *
+     * @param  int|float  $exponent
+     * @return static
+     */
+    public function power(int|float $exponent)
+    {
+        return new static(Number::power($this->value, $exponent));
+    }
+
+    /**
+     * Calculate the square root of the number.
+     *
+     * @return static
+     */
+    public function sqrt()
+    {
+        return new static(Number::sqrt($this->value));
+    }
+
+    /**
+     * Remove any trailing zero digits after the decimal point.
+     *
+     * @return static
+     */
+    public function trim()
+    {
+        return new static(Number::trim($this->value));
+    }
+
+    /**
+     * Determine if the number is even.
+     *
+     * @return bool
+     */
+    public function isEven(): bool
+    {
+        return Number::isEven((int) $this->value);
+    }
+
+    /**
+     * Determine if the number is odd.
+     *
+     * @return bool
+     */
+    public function isOdd(): bool
+    {
+        return Number::isOdd((int) $this->value);
+    }
+
+    /**
+     * Determine if the number is prime.
+     *
+     * @return bool
+     */
+    public function isPrime(): bool
+    {
+        return Number::isPrime((int) $this->value);
+    }
+
+    /**
+     * Check if the number is a perfect square.
+     *
+     * @return bool
+     */
+    public function isPerfectSquare(): bool
+    {
+        return Number::isPerfectSquare((int) $this->value);
+    }
+
+    /**
+     * Calculate the factorial of the number.
+     *
+     * @return static
+     */
+    public function factorial()
+    {
+        return new static(Number::factorial((int) $this->value));
+    }
+
+    /**
+     * Calculate the greatest common divisor with another number.
+     *
+     * @param  int  $other
+     * @return static
+     */
+    public function gcd(int $other)
+    {
+        return new static(Number::gcd((int) $this->value, $other));
+    }
+
+    /**
+     * Calculate the least common multiple with another number.
+     *
+     * @param  int  $other
+     * @return static
+     */
+    public function lcm(int $other)
+    {
+        return new static(Number::lcm((int) $this->value, $other));
+    }
+
+    /**
+     * Format the number according to the current locale.
+     *
+     * @param  int|null  $precision
+     * @param  int|null  $maxPrecision
+     * @param  string|null  $locale
+     * @return string|false
+     */
+    public function format(?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
+    {
+        return Number::format($this->value, $precision, $maxPrecision, $locale);
+    }
+
+    /**
+     * Spell out the number in the given locale.
+     *
+     * @param  string|null  $locale
+     * @param  int|null  $after
+     * @param  int|null  $until
+     * @return string
+     */
+    public function spell(?string $locale = null, ?int $after = null, ?int $until = null)
+    {
+        return Number::spell($this->value, $locale, $after, $until);
+    }
+
+    /**
+     * Convert the number to ordinal form.
+     *
+     * @param  string|null  $locale
+     * @return string
+     */
+    public function ordinal(?string $locale = null)
+    {
+        return Number::ordinal($this->value, $locale);
+    }
+
+    /**
+     * Spell out the number in ordinal form.
+     *
+     * @param  string|null  $locale
+     * @return string
+     */
+    public function spellOrdinal(?string $locale = null)
+    {
+        return Number::spellOrdinal($this->value, $locale);
+    }
+
+    /**
+     * Convert the number to its percentage equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @param  string|null  $locale
+     * @return string|false
+     */
+    public function percentage(int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
+    {
+        return Number::percentage($this->value, $precision, $maxPrecision, $locale);
+    }
+
+    /**
+     * Convert the number to its currency equivalent.
+     *
+     * @param  string  $in
+     * @param  string|null  $locale
+     * @param  int|null  $precision
+     * @return string|false
+     */
+    public function currency(string $in = '', ?string $locale = null, ?int $precision = null)
+    {
+        return Number::currency($this->value, $in, $locale, $precision);
+    }
+
+    /**
+     * Convert the number to its file size equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string
+     */
+    public function fileSize(int $precision = 0, ?int $maxPrecision = null)
+    {
+        return Number::fileSize($this->value, $precision, $maxPrecision);
+    }
+
+    /**
+     * Convert the number to its human-readable equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return string|false
+     */
+    public function forHumans(int $precision = 0, ?int $maxPrecision = null)
+    {
+        return Number::forHumans($this->value, $precision, $maxPrecision);
+    }
+
+    /**
+     * Convert the number to its abbreviated equivalent.
+     *
+     * @param  int  $precision
+     * @param  int|null  $maxPrecision
+     * @return bool|string
+     */
+    public function abbreviate(int $precision = 0, ?int $maxPrecision = null)
+    {
+        return Number::abbreviate($this->value, $precision, $maxPrecision);
+    }
+
+    /**
+     * Add another number to this number.
+     *
+     * @param  int|float  $value
+     * @return static
+     */
+    public function add(int|float $value)
+    {
+        return new static($this->value + $value);
+    }
+
+    /**
+     * Subtract another number from this number.
+     *
+     * @param  int|float  $value
+     * @return static
+     */
+    public function subtract(int|float $value)
+    {
+        return new static($this->value - $value);
+    }
+
+    /**
+     * Multiply this number by another number.
+     *
+     * @param  int|float  $value
+     * @return static
+     */
+    public function multiply(int|float $value)
+    {
+        return new static($this->value * $value);
+    }
+
+    /**
+     * Divide this number by another number.
+     *
+     * @param  int|float  $value
+     * @return static
+     */
+    public function divide(int|float $value)
+    {
+        return new static($this->value / $value);
+    }
+
+    /**
+     * Get the modulus of this number.
+     *
+     * @param  int|float  $value
+     * @return static
+     */
+    public function modulus(int|float $value)
+    {
+        return new static($this->value % $value);
+    }
+
+    /**
+     * Check if this number is equal to another number.
+     *
+     * @param  int|float  $value
+     * @return bool
+     */
+    public function equals(int|float $value): bool
+    {
+        return $this->value === $value;
+    }
+
+    /**
+     * Check if this number is greater than another number.
+     *
+     * @param  int|float  $value
+     * @return bool
+     */
+    public function greaterThan(int|float $value): bool
+    {
+        return $this->value > $value;
+    }
+
+    /**
+     * Check if this number is greater than or equal to another number.
+     *
+     * @param  int|float  $value
+     * @return bool
+     */
+    public function greaterThanOrEqual(int|float $value): bool
+    {
+        return $this->value >= $value;
+    }
+
+    /**
+     * Check if this number is less than another number.
+     *
+     * @param  int|float  $value
+     * @return bool
+     */
+    public function lessThan(int|float $value): bool
+    {
+        return $this->value < $value;
+    }
+
+    /**
+     * Check if this number is less than or equal to another number.
+     *
+     * @param  int|float  $value
+     * @return bool
+     */
+    public function lessThanOrEqual(int|float $value): bool
+    {
+        return $this->value <= $value;
+    }
+
+    /**
+     * Check if this number is between two other numbers.
+     *
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @return bool
+     */
+    public function between(int|float $min, int|float $max): bool
+    {
+        return $this->value >= $min && $this->value <= $max;
+    }
+
+    /**
+     * Get the underlying numeric value.
+     *
+     * @return int|float
+     */
+    public function value(): int|float
+    {
+        return $this->value;
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return int|float
+     */
+    public function jsonSerialize(): int|float
+    {
+        return $this->value;
+    }
+
+    /**
+     * Convert the number to its string representation.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Numberable;
 use Illuminate\Support\Str;
 use stdClass;
 
@@ -244,6 +245,28 @@ trait InteractsWithData
     public function string($key, $default = null)
     {
         return Str::of($this->data($key, $default));
+    }
+
+    /**
+     * Retrieve data from the instance as a Numberable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Numberable
+     */
+    public function number($key, $default = null)
+    {
+        $value = $this->data($key, $default);
+
+        // Handle null, empty strings, arrays, objects, and non-numeric strings gracefully
+        if (is_null($value) ||
+            is_array($value) ||
+            is_object($value) ||
+            (is_string($value) && (trim($value) === '' || !is_numeric($value)))) {
+            return new Numberable(0);
+        }
+
+        return new Numberable($value);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Number;
+use Illuminate\Support\Numberable;
 use Illuminate\Support\Once;
 use Illuminate\Support\Onceable;
 use Illuminate\Support\Optional;
@@ -368,6 +370,34 @@ if (! function_exists('str')) {
         }
 
         return new SupportStringable($string);
+    }
+}
+
+if (! function_exists('number')) {
+    /**
+     * Get a new numberable object from the given number.
+     *
+     * @param  int|float|string|null  $number
+     * @return ($number is null ? object : \Illuminate\Support\Numberable)
+     */
+    function number($number = null)
+    {
+        if (func_num_args() === 0) {
+            return new class
+            {
+                public function __call($method, $parameters)
+                {
+                    return Number::$method(...$parameters);
+                }
+
+                public function __toString()
+                {
+                    return '0';
+                }
+            };
+        }
+
+        return new Numberable($number);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Env;
+use Illuminate\Support\Numberable;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Stringable;
@@ -788,6 +789,26 @@ class SupportHelpersTest extends TestCase
         $strAccessor = str();
         $this->assertTrue((new ReflectionClass($strAccessor))->isAnonymous());
         $this->assertSame((string) $strAccessor, '');
+    }
+
+    public function testNumber()
+    {
+        $numberable = number(42);
+
+        $this->assertInstanceOf(Numberable::class, $numberable);
+        $this->assertSame(42, $numberable->value());
+
+        $numberable = number(42.5);
+        $this->assertInstanceOf(Numberable::class, $numberable);
+        $this->assertSame(42.5, $numberable->value());
+
+        $numberAccessor = number();
+        $this->assertTrue((new ReflectionClass($numberAccessor))->isAnonymous());
+        $this->assertSame($numberAccessor->format(1234), '1,234');
+
+        $numberAccessor = number();
+        $this->assertTrue((new ReflectionClass($numberAccessor))->isAnonymous());
+        $this->assertSame((string) $numberAccessor, '0');
     }
 
     public function testTap()

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -370,4 +370,195 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
+
+    public function testAbs()
+    {
+        $this->assertSame(5, Number::abs(5));
+        $this->assertSame(5, Number::abs(-5));
+        $this->assertSame(0, Number::abs(0));
+        $this->assertSame(3.14, Number::abs(3.14));
+        $this->assertSame(3.14, Number::abs(-3.14));
+        $this->assertSame(0.0, Number::abs(0.0));
+    }
+
+    public function testRound()
+    {
+        $this->assertSame(3.0, Number::round(3.14159));
+        $this->assertSame(3.14, Number::round(3.14159, 2));
+        $this->assertSame(3.142, Number::round(3.14159, 3));
+        $this->assertSame(3.0, Number::round(2.5));
+        $this->assertSame(4.0, Number::round(3.5));
+        $this->assertSame(-3.0, Number::round(-2.5));
+        $this->assertSame(-4.0, Number::round(-3.5));
+        $this->assertSame(2.0, Number::round(2.5, 0, PHP_ROUND_HALF_DOWN));
+    }
+
+    public function testCeil()
+    {
+        $this->assertSame(4.0, Number::ceil(3.14159));
+        $this->assertSame(3.0, Number::ceil(3.0));
+        $this->assertSame(-3.0, Number::ceil(-3.14159));
+        $this->assertSame(-3.0, Number::ceil(-3.0));
+        $this->assertSame(1.0, Number::ceil(0.1));
+        $this->assertSame(0.0, Number::ceil(0.0));
+    }
+
+    public function testFloor()
+    {
+        $this->assertSame(3.0, Number::floor(3.14159));
+        $this->assertSame(3.0, Number::floor(3.0));
+        $this->assertSame(-4.0, Number::floor(-3.14159));
+        $this->assertSame(-3.0, Number::floor(-3.0));
+        $this->assertSame(0.0, Number::floor(0.9));
+        $this->assertSame(0.0, Number::floor(0.0));
+    }
+
+    public function testIsEven()
+    {
+        $this->assertTrue(Number::isEven(0));
+        $this->assertTrue(Number::isEven(2));
+        $this->assertTrue(Number::isEven(4));
+        $this->assertTrue(Number::isEven(-2));
+        $this->assertTrue(Number::isEven(-4));
+        $this->assertFalse(Number::isEven(1));
+        $this->assertFalse(Number::isEven(3));
+        $this->assertFalse(Number::isEven(-1));
+        $this->assertFalse(Number::isEven(-3));
+    }
+
+    public function testIsOdd()
+    {
+        $this->assertFalse(Number::isOdd(0));
+        $this->assertFalse(Number::isOdd(2));
+        $this->assertFalse(Number::isOdd(4));
+        $this->assertFalse(Number::isOdd(-2));
+        $this->assertFalse(Number::isOdd(-4));
+        $this->assertTrue(Number::isOdd(1));
+        $this->assertTrue(Number::isOdd(3));
+        $this->assertTrue(Number::isOdd(-1));
+        $this->assertTrue(Number::isOdd(-3));
+    }
+
+    public function testIsPrime()
+    {
+        $this->assertFalse(Number::isPrime(-1));
+        $this->assertFalse(Number::isPrime(0));
+        $this->assertFalse(Number::isPrime(1));
+        $this->assertTrue(Number::isPrime(2));
+        $this->assertTrue(Number::isPrime(3));
+        $this->assertFalse(Number::isPrime(4));
+        $this->assertTrue(Number::isPrime(5));
+        $this->assertFalse(Number::isPrime(6));
+        $this->assertTrue(Number::isPrime(7));
+        $this->assertFalse(Number::isPrime(8));
+        $this->assertFalse(Number::isPrime(9));
+        $this->assertFalse(Number::isPrime(10));
+        $this->assertTrue(Number::isPrime(11));
+        $this->assertTrue(Number::isPrime(13));
+        $this->assertTrue(Number::isPrime(17));
+        $this->assertTrue(Number::isPrime(19));
+        $this->assertFalse(Number::isPrime(25));
+        $this->assertFalse(Number::isPrime(100));
+        $this->assertTrue(Number::isPrime(101));
+    }
+
+    public function testPower()
+    {
+        $this->assertSame(1, Number::power(2, 0));
+        $this->assertSame(2, Number::power(2, 1));
+        $this->assertSame(4, Number::power(2, 2));
+        $this->assertSame(8, Number::power(2, 3));
+        $this->assertSame(0.5, Number::power(2, -1));
+        $this->assertSame(0.25, Number::power(2, -2));
+        $this->assertSame(9, Number::power(3, 2));
+        $this->assertSame(27, Number::power(3, 3));
+        $this->assertSame(2.25, Number::power(1.5, 2));
+    }
+
+    public function testSqrt()
+    {
+        $this->assertSame(2.0, Number::sqrt(4));
+        $this->assertSame(3.0, Number::sqrt(9));
+        $this->assertSame(4.0, Number::sqrt(16));
+        $this->assertSame(5.0, Number::sqrt(25));
+        $this->assertEqualsWithDelta(3.16227766, Number::sqrt(10), 0.00000001);
+        $this->assertSame(0.0, Number::sqrt(0));
+        $this->assertSame(1.0, Number::sqrt(1));
+    }
+
+    public function testFactorial()
+    {
+        $this->assertSame(1, Number::factorial(0));
+        $this->assertSame(1, Number::factorial(1));
+        $this->assertSame(2, Number::factorial(2));
+        $this->assertSame(6, Number::factorial(3));
+        $this->assertSame(24, Number::factorial(4));
+        $this->assertSame(120, Number::factorial(5));
+        $this->assertSame(720, Number::factorial(6));
+        $this->assertSame(5040, Number::factorial(7));
+        $this->assertSame(40320, Number::factorial(8));
+        $this->assertSame(362880, Number::factorial(9));
+        $this->assertSame(3628800, Number::factorial(10));
+    }
+
+    public function testFactorialThrowsExceptionForNegativeNumbers()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Factorial is not defined for negative numbers.');
+
+        Number::factorial(-1);
+    }
+
+    public function testGcd()
+    {
+        $this->assertSame(1, Number::gcd(17, 13));
+        $this->assertSame(6, Number::gcd(18, 24));
+        $this->assertSame(15, Number::gcd(45, 60));
+        $this->assertSame(12, Number::gcd(48, 60));
+        $this->assertSame(7, Number::gcd(49, 14));
+        $this->assertSame(5, Number::gcd(-10, 15));
+        $this->assertSame(3, Number::gcd(-9, -12));
+        $this->assertSame(8, Number::gcd(0, 8));
+        $this->assertSame(5, Number::gcd(5, 0));
+    }
+
+    public function testLcm()
+    {
+        $this->assertSame(15, Number::lcm(3, 5));
+        $this->assertSame(12, Number::lcm(4, 6));
+        $this->assertSame(36, Number::lcm(9, 12));
+        $this->assertSame(30, Number::lcm(10, 15));
+        $this->assertSame(42, Number::lcm(6, 14));
+        $this->assertSame(20, Number::lcm(-4, 10));
+        $this->assertSame(24, Number::lcm(-6, -8));
+        $this->assertSame(0, Number::lcm(0, 5));
+        $this->assertSame(0, Number::lcm(7, 0));
+    }
+
+    public function testIsPerfectSquare()
+    {
+        $this->assertTrue(Number::isPerfectSquare(0));
+        $this->assertTrue(Number::isPerfectSquare(1));
+        $this->assertTrue(Number::isPerfectSquare(4));
+        $this->assertTrue(Number::isPerfectSquare(9));
+        $this->assertTrue(Number::isPerfectSquare(16));
+        $this->assertTrue(Number::isPerfectSquare(25));
+        $this->assertTrue(Number::isPerfectSquare(36));
+        $this->assertTrue(Number::isPerfectSquare(49));
+        $this->assertTrue(Number::isPerfectSquare(64));
+        $this->assertTrue(Number::isPerfectSquare(81));
+        $this->assertTrue(Number::isPerfectSquare(100));
+
+        $this->assertFalse(Number::isPerfectSquare(2));
+        $this->assertFalse(Number::isPerfectSquare(3));
+        $this->assertFalse(Number::isPerfectSquare(5));
+        $this->assertFalse(Number::isPerfectSquare(6));
+        $this->assertFalse(Number::isPerfectSquare(7));
+        $this->assertFalse(Number::isPerfectSquare(8));
+        $this->assertFalse(Number::isPerfectSquare(10));
+        $this->assertFalse(Number::isPerfectSquare(15));
+        $this->assertFalse(Number::isPerfectSquare(24));
+        $this->assertFalse(Number::isPerfectSquare(-4));
+        $this->assertFalse(Number::isPerfectSquare(-9));
+    }
 }

--- a/tests/Support/SupportNumberableTest.php
+++ b/tests/Support/SupportNumberableTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Number;
+use Illuminate\Support\Numberable;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumberableTest extends TestCase
+{
+    /**
+     * @param  int|float|string  $number
+     * @return \Illuminate\Support\Numberable
+     */
+    protected function numberable($number = 0)
+    {
+        return new Numberable($number);
+    }
+
+    public function testCreation()
+    {
+        $this->assertSame(42, $this->numberable(42)->value());
+        $this->assertSame(42.5, $this->numberable(42.5)->value());
+        $this->assertSame(42, $this->numberable('42')->value());
+        $this->assertSame(42.5, $this->numberable('42.5')->value());
+        $this->assertSame(0, $this->numberable()->value());
+    }
+
+    public function testCreationWithInvalidString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid numeric value: not-a-number');
+
+        $this->numberable('not-a-number');
+    }
+
+    public function testNumberOf()
+    {
+        $this->assertInstanceOf(Numberable::class, Number::of(42));
+        $this->assertSame(42, Number::of(42)->value());
+    }
+
+    public function testAbs()
+    {
+        $this->assertSame(5, $this->numberable(-5)->abs()->value());
+        $this->assertSame(5, $this->numberable(5)->abs()->value());
+        $this->assertSame(0, $this->numberable(0)->abs()->value());
+    }
+
+    public function testRound()
+    {
+        $this->assertSame(3.0, $this->numberable(3.14159)->round()->value());
+        $this->assertSame(3.14, $this->numberable(3.14159)->round(2)->value());
+        $this->assertSame(3.142, $this->numberable(3.14159)->round(3)->value());
+    }
+
+    public function testCeil()
+    {
+        $this->assertSame(4.0, $this->numberable(3.14159)->ceil()->value());
+        $this->assertSame(3.0, $this->numberable(3.0)->ceil()->value());
+        $this->assertSame(-3.0, $this->numberable(-3.14159)->ceil()->value());
+    }
+
+    public function testFloor()
+    {
+        $this->assertSame(3.0, $this->numberable(3.14159)->floor()->value());
+        $this->assertSame(3.0, $this->numberable(3.0)->floor()->value());
+        $this->assertSame(-4.0, $this->numberable(-3.14159)->floor()->value());
+    }
+
+    public function testClamp()
+    {
+        $this->assertSame(2, $this->numberable(1)->clamp(2, 3)->value());
+        $this->assertSame(3, $this->numberable(5)->clamp(2, 3)->value());
+        $this->assertSame(5, $this->numberable(5)->clamp(1, 10)->value());
+    }
+
+    public function testPower()
+    {
+        $this->assertSame(8, $this->numberable(2)->power(3)->value());
+        $this->assertSame(9, $this->numberable(3)->power(2)->value());
+        $this->assertSame(1, $this->numberable(5)->power(0)->value());
+    }
+
+    public function testSqrt()
+    {
+        $this->assertSame(2.0, $this->numberable(4)->sqrt()->value());
+        $this->assertSame(3.0, $this->numberable(9)->sqrt()->value());
+        $this->assertSame(5.0, $this->numberable(25)->sqrt()->value());
+    }
+
+    public function testTrim()
+    {
+        $this->assertSame(12, $this->numberable(12.0)->trim()->value());
+        $this->assertSame(12.3, $this->numberable(12.30)->trim()->value());
+    }
+
+    public function testIsEven()
+    {
+        $this->assertTrue($this->numberable(0)->isEven());
+        $this->assertTrue($this->numberable(2)->isEven());
+        $this->assertTrue($this->numberable(4)->isEven());
+        $this->assertFalse($this->numberable(1)->isEven());
+        $this->assertFalse($this->numberable(3)->isEven());
+    }
+
+    public function testIsOdd()
+    {
+        $this->assertTrue($this->numberable(1)->isOdd());
+        $this->assertTrue($this->numberable(3)->isOdd());
+        $this->assertTrue($this->numberable(5)->isOdd());
+        $this->assertFalse($this->numberable(0)->isOdd());
+        $this->assertFalse($this->numberable(2)->isOdd());
+    }
+
+    public function testIsPrime()
+    {
+        $this->assertFalse($this->numberable(0)->isPrime());
+        $this->assertFalse($this->numberable(1)->isPrime());
+        $this->assertTrue($this->numberable(2)->isPrime());
+        $this->assertTrue($this->numberable(3)->isPrime());
+        $this->assertFalse($this->numberable(4)->isPrime());
+        $this->assertTrue($this->numberable(5)->isPrime());
+        $this->assertTrue($this->numberable(17)->isPrime());
+        $this->assertFalse($this->numberable(25)->isPrime());
+    }
+
+    public function testIsPerfectSquare()
+    {
+        $this->assertTrue($this->numberable(0)->isPerfectSquare());
+        $this->assertTrue($this->numberable(1)->isPerfectSquare());
+        $this->assertTrue($this->numberable(4)->isPerfectSquare());
+        $this->assertTrue($this->numberable(9)->isPerfectSquare());
+        $this->assertTrue($this->numberable(16)->isPerfectSquare());
+        $this->assertFalse($this->numberable(2)->isPerfectSquare());
+        $this->assertFalse($this->numberable(3)->isPerfectSquare());
+        $this->assertFalse($this->numberable(5)->isPerfectSquare());
+    }
+
+    public function testFactorial()
+    {
+        $this->assertSame(1, $this->numberable(0)->factorial()->value());
+        $this->assertSame(1, $this->numberable(1)->factorial()->value());
+        $this->assertSame(2, $this->numberable(2)->factorial()->value());
+        $this->assertSame(6, $this->numberable(3)->factorial()->value());
+        $this->assertSame(24, $this->numberable(4)->factorial()->value());
+        $this->assertSame(120, $this->numberable(5)->factorial()->value());
+    }
+
+    public function testGcd()
+    {
+        $this->assertSame(6, $this->numberable(18)->gcd(24)->value());
+        $this->assertSame(1, $this->numberable(17)->gcd(13)->value());
+        $this->assertSame(15, $this->numberable(45)->gcd(60)->value());
+    }
+
+    public function testLcm()
+    {
+        $this->assertSame(12, $this->numberable(4)->lcm(6)->value());
+        $this->assertSame(15, $this->numberable(3)->lcm(5)->value());
+        $this->assertSame(36, $this->numberable(9)->lcm(12)->value());
+    }
+
+    public function testArithmeticOperations()
+    {
+        $this->assertSame(7, $this->numberable(5)->add(2)->value());
+        $this->assertSame(3, $this->numberable(5)->subtract(2)->value());
+        $this->assertSame(10, $this->numberable(5)->multiply(2)->value());
+        $this->assertSame(2.5, $this->numberable(5)->divide(2)->value());
+        $this->assertSame(1, $this->numberable(5)->modulus(2)->value());
+    }
+
+    public function testComparisonMethods()
+    {
+        $this->assertTrue($this->numberable(5)->equals(5));
+        $this->assertFalse($this->numberable(5)->equals(4));
+
+        $this->assertTrue($this->numberable(5)->greaterThan(4));
+        $this->assertFalse($this->numberable(5)->greaterThan(6));
+
+        $this->assertTrue($this->numberable(5)->greaterThanOrEqual(5));
+        $this->assertTrue($this->numberable(5)->greaterThanOrEqual(4));
+        $this->assertFalse($this->numberable(5)->greaterThanOrEqual(6));
+
+        $this->assertTrue($this->numberable(5)->lessThan(6));
+        $this->assertFalse($this->numberable(5)->lessThan(4));
+
+        $this->assertTrue($this->numberable(5)->lessThanOrEqual(5));
+        $this->assertTrue($this->numberable(5)->lessThanOrEqual(6));
+        $this->assertFalse($this->numberable(5)->lessThanOrEqual(4));
+
+        $this->assertTrue($this->numberable(5)->between(4, 6));
+        $this->assertTrue($this->numberable(5)->between(5, 5));
+        $this->assertFalse($this->numberable(5)->between(6, 8));
+    }
+
+    public function testChaining()
+    {
+        $result = $this->numberable(10)
+            ->add(5)
+            ->multiply(2)
+            ->subtract(10)
+            ->divide(2);
+
+        $this->assertSame(10, $result->value());
+    }
+
+    public function testFormat()
+    {
+        $this->assertSame('1,234', $this->numberable(1234)->format());
+        $this->assertSame('1,234.56', $this->numberable(1234.56)->format(2));
+    }
+
+    public function testSpell()
+    {
+        $this->assertSame('ten', $this->numberable(10)->spell());
+        $this->assertSame('one point two', $this->numberable(1.2)->spell());
+    }
+
+    public function testOrdinal()
+    {
+        $this->assertSame('1st', $this->numberable(1)->ordinal());
+        $this->assertSame('2nd', $this->numberable(2)->ordinal());
+        $this->assertSame('3rd', $this->numberable(3)->ordinal());
+    }
+
+    public function testForHumans()
+    {
+        $this->assertSame('1 thousand', $this->numberable(1000)->forHumans());
+        $this->assertSame('1 million', $this->numberable(1000000)->forHumans());
+    }
+
+    public function testAbbreviate()
+    {
+        $this->assertSame('1K', $this->numberable(1000)->abbreviate());
+        $this->assertSame('1M', $this->numberable(1000000)->abbreviate());
+    }
+
+    public function testFileSize()
+    {
+        $this->assertSame('1 KB', $this->numberable(1024)->fileSize());
+        $this->assertSame('1 MB', $this->numberable(1024 * 1024)->fileSize());
+    }
+
+    public function testPercentage()
+    {
+        $this->assertSame('50%', $this->numberable(50)->percentage());
+        $this->assertSame('50.00%', $this->numberable(50)->percentage(2));
+    }
+
+    public function testCurrency()
+    {
+        $this->assertSame('$100.00', $this->numberable(100)->currency());
+        $this->assertSame('€100.00', $this->numberable(100)->currency('EUR'));
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('42', (string) $this->numberable(42));
+        $this->assertSame('42.5', (string) $this->numberable(42.5));
+    }
+
+    public function testJsonSerialize()
+    {
+        $this->assertSame(42, $this->numberable(42)->jsonSerialize());
+        $this->assertSame(42.5, $this->numberable(42.5)->jsonSerialize());
+    }
+
+    public function testNumberHelperFunction()
+    {
+        $this->assertInstanceOf(Numberable::class, number(42));
+        $this->assertSame(42, number(42)->value());
+
+        // Test static accessor when called without arguments
+        $staticAccessor = number();
+        $this->assertSame('1,234', $staticAccessor->format(1234));
+        $this->assertSame('0', (string) $staticAccessor);
+    }
+}


### PR DESCRIPTION
# Enhanced Number Helper for Laravel

This PR adds mathematical methods to Laravel's `Number` class and introduces fluent number operations to mimic the approach taken when using the `Stringable` class and fluent helper.

## What's New

### Number Class Methods
Added 13 new methods to `Illuminate\Support\Number`:
- `abs()`, `round()`, `ceil()`, `floor()`
- `power()`, `sqrt()`, `factorial()`
- `isEven()`, `isOdd()`, `isPrime()`, `isPerfectSquare()`
- `gcd()`, `lcm()`
- `Number::of()` factory method

### Fluent Interface
New `Numberable` class for method chaining:
```php
number(10)->add(5)->multiply(2)->format(); // "30"
$request->number('price')->multiply(1.08)->currency(); // "$10.80"
```

### Request Integration
Added `$request->number()` method with dot notation support:
```php
$price = $request->number('item.price')->value();
$weight = $request->number('product.details.weight')->format();
```

### Global Helper
Added `number()` helper function:
```php
number(42)->power(2); // Fluent interface
number()->format(1234); // Static methods
```

## Files Changed
- `Number.php` - Added 13 mathematical methods
- `Numberable.php` (new) - Fluent wrapper class
- `helpers.php` - Added number() helper
- `InteractsWithData.php` - Added number() method

## Usage Examples
```php
// Basic operations
Number::abs(-5); // 5
Number::isPrime(17); // true

// Fluent chaining
number(100)
    ->multiply(0.08)
    ->round(2)
    ->currency(); // "$8.00"

// Request data
$total = $request->number('quantity')
    ->multiply($request->number('price')->value())
    ->format();
```

## Backward Compatibility
✅ Fully backward compatible - only adds new functionality