### PR TITLE
[12.x] Add missing app key generation button to exception page

### DIFF
--- a/src/Illuminate/Foundation/Http/Controllers/KeyGenerationController.php
+++ b/src/Illuminate/Foundation/Http/Controllers/KeyGenerationController.php
@@ -12,21 +12,13 @@ use Throwable;
 class KeyGenerationController extends Controller
 {
     /**
-     * The application implementation.
-     *
-     * @var \Illuminate\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * Create a new controller instance.
      *
      * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
-    public function __construct(Application $app)
+    public function __construct(protected Application $app)
     {
-        $this->app = $app;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Controllers/KeyGenerationController.php
+++ b/src/Illuminate/Foundation/Http/Controllers/KeyGenerationController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Controllers;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Throwable;
+
+class KeyGenerationController extends Controller
+{
+    /**
+     * The application implementation.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Generate a new application key.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     *
+     * @throws \Throwable
+     */
+    public function generate(Request $request): JsonResponse
+    {
+        if (! $this->app->hasDebugModeEnabled()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Key generation is only available in debug mode.',
+            ], JsonResponse::HTTP_FORBIDDEN);
+        }
+
+        try {
+            $key = $this->generateRandomKey();
+
+            if (! $this->setKeyInEnvironmentFile($key)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Unable to set application key. Ensure the .env file is writable.',
+                ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+            }
+
+            $this->app['config']['app.key'] = $key;
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Application key set successfully.',
+            ]);
+        } catch (Throwable $e) {
+            report($e);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'An error occurred while generating the application key.',
+            ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Generate a random key for the application.
+     *
+     * @return string
+     */
+    protected function generateRandomKey()
+    {
+        return 'base64:'.base64_encode(
+            Encrypter::generateKey($this->app['config']['app.cipher'])
+        );
+    }
+
+    /**
+     * Set the application key in the environment file.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function setKeyInEnvironmentFile($key)
+    {
+        $path = $this->app->environmentFilePath();
+
+        if (! is_file($path) || ! is_writable($path)) {
+            return false;
+        }
+
+        $replaced = preg_replace(
+            $this->keyReplacementPattern(),
+            'APP_KEY='.$key,
+            $input = file_get_contents($path)
+        );
+
+        if ($replaced === $input || $replaced === null) {
+            return false;
+        }
+
+        file_put_contents($path, $replaced);
+
+        return true;
+    }
+
+    /**
+     * Get a regex pattern that will match env APP_KEY with any random key.
+     *
+     * @return string
+     */
+    protected function keyReplacementPattern()
+    {
+        $escaped = preg_quote('='.$this->app['config']['app.key'], '/');
+
+        return "/^APP_KEY{$escaped}/m";
+    }
+}

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -76,6 +76,8 @@ class FoundationServiceProvider extends AggregateServiceProvider
                 $this->app->make(Dispatcher::class)
             );
         }
+
+        $this->registerKeyGenerationRoute();
     }
 
     /**
@@ -288,5 +290,24 @@ class FoundationServiceProvider extends AggregateServiceProvider
             MaintenanceModeContract::class,
             fn () => $this->app->make(MaintenanceModeManager::class)->driver()
         );
+    }
+
+    /**
+     * Register the key generation route for MissingAppKeyException.
+     *
+     * @return void
+     */
+    protected function registerKeyGenerationRoute()
+    {
+        if (! $this->app->hasDebugModeEnabled()) {
+            return;
+        }
+
+        $this->app->booted(function () {
+            $this->app->make('router')
+                ->post('/__laravel_generate_key', [\Illuminate\Foundation\Http\Controllers\KeyGenerationController::class, 'generate'])
+                ->middleware(['web', 'throttle:5,1'])
+                ->name('laravel.generate-key');
+        });
     }
 }

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php
@@ -1,0 +1,186 @@
+@props(['exception'])
+
+<div class="flex flex-col pt-8 sm:pt-16 overflow-x-auto">
+    <div class="flex flex-col gap-5 mb-8">
+        <h1 class="text-3xl font-semibold text-neutral-950 dark:text-white">{{ $exception->class() }}</h1>
+        <x-laravel-exceptions-renderer::file-with-line :frame="$exception->frames()->first()" class="-mt-3 text-xs" />
+        <p class="text-xl font-light text-neutral-800 dark:text-neutral-300">
+            {{ $exception->message() }}
+        </p>
+    </div>
+
+    <div class="flex items-start gap-2 mb-8 sm:mb-16">
+        <div class="bg-white dark:bg-white/[3%] border border-neutral-200 dark:border-white/10 divide-x divide-neutral-200 dark:divide-white/10 rounded-md shadow-xs flex items-center gap-0.5">
+            <div class="flex items-center gap-1.5 h-6 px-[6px] font-mono text-[13px]">
+                <span class="text-neutral-400 dark:text-neutral-500">LARAVEL</span>
+                <span class="text-neutral-500 dark:text-neutral-300">{{ app()->version() }}</span>
+            </div>
+            <div class="flex items-center gap-1.5 h-6 px-[6px] font-mono text-[13px]">
+                <span class="text-neutral-400 dark:text-neutral-500">PHP</span>
+                <span class="text-neutral-500 dark:text-neutral-300">{{ PHP_VERSION }}</span>
+            </div>
+        </div>
+        <x-laravel-exceptions-renderer::badge type="error">
+            <x-laravel-exceptions-renderer::icons.alert class="w-2.5 h-2.5" />
+            UNHANDLED
+        </x-laravel-exceptions-renderer::badge>
+        <x-laravel-exceptions-renderer::badge type="error" variant="solid">
+            CODE {{ $exception->code() }}
+        </x-laravel-exceptions-renderer::badge>
+    </div>
+
+    <div class="bg-blue-50 dark:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg p-6 mb-8">
+        <div class="flex items-start gap-3">
+            <div class="flex-shrink-0">
+                <x-laravel-exceptions-renderer::icons.info class="w-6 h-6 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div class="flex-1">
+                <h3 class="text-lg font-semibold text-blue-900 dark:text-blue-200 mb-2">
+                    Application Key Missing
+                </h3>
+                <p class="text-sm text-blue-800 dark:text-blue-300 mb-4">
+                    Your application needs an encryption key to function properly. You can generate one automatically by clicking the button below or run the command manually.
+                </p>
+                <div class="flex flex-wrap gap-3">
+                    <button
+                        type="button"
+                        onclick="generateAppKey()"
+                        class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white text-sm font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                        id="generate-key-btn"
+                        aria-label="Generate application key"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                        </svg>
+                        <span>Generate Application Key</span>
+                    </button>
+                    <button
+                        type="button"
+                        onclick="copyCommand()"
+                        class="inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-neutral-50 dark:bg-neutral-800 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-700 text-neutral-900 dark:text-neutral-100 text-sm font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-neutral-500 focus:ring-offset-2"
+                        aria-label="Copy command to clipboard"
+                    >
+                        <x-laravel-exceptions-renderer::icons.copy class="w-4 h-4" aria-hidden="true" />
+                        <span>Copy Command</span>
+                    </button>
+                </div>
+                <div id="status-message" class="mt-3 text-sm hidden" role="status" aria-live="polite"></div>
+            </div>
+        </div>
+    </div>
+
+    <x-laravel-exceptions-renderer::request-url :$exception :request="$exception->request()" class="relative z-50" />
+</div>
+
+<script>
+function generateAppKey() {
+    const btn = document.getElementById('generate-key-btn');
+    const statusDiv = document.getElementById('status-message');
+    const csrfToken = document.querySelector('meta[name="csrf-token"]');
+
+    if (!csrfToken) {
+        showStatus('CSRF token not found. Please refresh the page.', 'error');
+        return;
+    }
+
+    // Disable button and show loading state
+    btn.disabled = true;
+    btn.innerHTML = `
+        <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <span>Generating...</span>
+    `;
+
+    // Clear previous status
+    statusDiv.className = 'mt-3 text-sm hidden';
+
+    fetch('/__laravel_generate_key', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': csrfToken.getAttribute('content'),
+            'Accept': 'application/json'
+        },
+        credentials: 'same-origin'
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        return response.json();
+    })
+    .then(data => {
+        if (data.success) {
+            showStatus('Application key generated successfully! Reloading...', 'success');
+            setTimeout(() => window.location.reload(), 1500);
+        } else {
+            throw new Error(data.message || 'Failed to generate key');
+        }
+    })
+    .catch(error => {
+        showStatus(error.message, 'error');
+        resetButton();
+    });
+}
+
+function copyCommand() {
+    const command = 'php artisan key:generate';
+    const statusDiv = document.getElementById('status-message');
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(command)
+            .then(() => {
+                showStatus('Command copied to clipboard!', 'success');
+                setTimeout(() => {
+                    statusDiv.className = 'mt-3 text-sm hidden';
+                }, 2000);
+            })
+            .catch(() => {
+                showStatus('Failed to copy command. Please copy manually: ' + command, 'error');
+            });
+    } else {
+        // Fallback for older browsers
+        const textArea = document.createElement('textarea');
+        textArea.value = command;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.select();
+
+        try {
+            document.execCommand('copy');
+            showStatus('Command copied to clipboard!', 'success');
+            setTimeout(() => {
+                statusDiv.className = 'mt-3 text-sm hidden';
+            }, 2000);
+        } catch (err) {
+            showStatus('Failed to copy command. Please copy manually: ' + command, 'error');
+        } finally {
+            document.body.removeChild(textArea);
+        }
+    }
+}
+
+function showStatus(message, type) {
+    const statusDiv = document.getElementById('status-message');
+    const colorClass = type === 'success'
+        ? 'text-emerald-600 dark:text-emerald-400'
+        : 'text-rose-600 dark:text-rose-400';
+
+    statusDiv.className = `mt-3 text-sm ${colorClass}`;
+    statusDiv.textContent = message;
+}
+
+function resetButton() {
+    const btn = document.getElementById('generate-key-btn');
+    btn.disabled = false;
+    btn.innerHTML = `
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+        </svg>
+        <span>Generate Application Key</span>
+    `;
+}
+</script>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
@@ -6,7 +6,11 @@
     <x-laravel-exceptions-renderer::separator />
 
     <x-laravel-exceptions-renderer::section-container class="flex flex-col gap-8 py-0 sm:py-0">
-        <x-laravel-exceptions-renderer::header :$exception />
+        @if($exception->class() === 'Illuminate\Encryption\MissingAppKeyException')
+            <x-laravel-exceptions-renderer::missing-app-key-header :$exception />
+        @else
+            <x-laravel-exceptions-renderer::header :$exception />
+        @endif
     </x-laravel-exceptions-renderer::section-container>
 
     <x-laravel-exceptions-renderer::separator class="-mt-5 -z-10" />

--- a/tests/Foundation/Http/KeyGenerationControllerTest.php
+++ b/tests/Foundation/Http/KeyGenerationControllerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http;
+
+use Illuminate\Foundation\Http\Controllers\KeyGenerationController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Orchestra\Testbench\TestCase;
+
+class KeyGenerationControllerTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('app.cipher', 'AES-256-CBC');
+    }
+
+    public function test_returns_forbidden_when_debug_mode_is_disabled()
+    {
+        $this->app['config']->set('app.debug', false);
+
+        $controller = $this->app->make(KeyGenerationController::class);
+        $response = $controller->generate(new Request());
+
+        $this->assertEquals(JsonResponse::HTTP_FORBIDDEN, $response->getStatusCode());
+
+        $data = $response->getData(true);
+        $this->assertFalse($data['success']);
+        $this->assertEquals('Key generation is only available in debug mode.', $data['message']);
+    }
+
+    public function test_returns_error_when_env_file_is_not_writable()
+    {
+        $this->app['config']->set('app.debug', true);
+
+        // Use a non-existent path
+        $this->app->useEnvironmentPath(sys_get_temp_dir());
+        $this->app->loadEnvironmentFrom('.env.nonexistent');
+
+        $controller = $this->app->make(KeyGenerationController::class);
+        $response = $controller->generate(new Request());
+
+        $this->assertEquals(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+
+        $data = $response->getData(true);
+        $this->assertFalse($data['success']);
+        $this->assertStringContainsString('Unable to set application key', $data['message']);
+    }
+
+    public function test_generates_key_successfully_in_debug_mode()
+    {
+        $this->app['config']->set('app.debug', true);
+        $this->app['config']->set('app.key', '');
+
+        // Create a temporary environment file
+        $envPath = sys_get_temp_dir().'/'.uniqid('.env.testing.');
+        file_put_contents($envPath, "APP_NAME=Laravel\nAPP_KEY=\nAPP_DEBUG=true\n");
+
+        $this->app->useEnvironmentPath(dirname($envPath));
+        $this->app->loadEnvironmentFrom(basename($envPath));
+
+        try {
+            $controller = $this->app->make(KeyGenerationController::class);
+            $response = $controller->generate(new Request());
+
+            $this->assertEquals(JsonResponse::HTTP_OK, $response->getStatusCode());
+
+            $data = $response->getData(true);
+            $this->assertTrue($data['success']);
+            $this->assertEquals('Application key set successfully.', $data['message']);
+
+            // Verify the key was written to the file
+            $contents = file_get_contents($envPath);
+            $this->assertStringContainsString('APP_KEY=base64:', $contents);
+        } finally {
+            // Cleanup
+            if (file_exists($envPath)) {
+                unlink($envPath);
+            }
+        }
+    }
+
+    public function test_updates_config_after_generating_key()
+    {
+        $this->app['config']->set('app.debug', true);
+        $this->app['config']->set('app.key', '');
+
+        // Create a temporary environment file
+        $envPath = sys_get_temp_dir().'/'.uniqid('.env.testing.');
+        file_put_contents($envPath, "APP_NAME=Laravel\nAPP_KEY=\nAPP_DEBUG=true\n");
+
+        $this->app->useEnvironmentPath(dirname($envPath));
+        $this->app->loadEnvironmentFrom(basename($envPath));
+
+        try {
+            $originalKey = $this->app['config']['app.key'];
+
+            $controller = $this->app->make(KeyGenerationController::class);
+            $controller->generate(new Request());
+
+            $newKey = $this->app['config']['app.key'];
+
+            $this->assertNotEquals($originalKey, $newKey);
+            $this->assertStringStartsWith('base64:', $newKey);
+        } finally {
+            // Cleanup
+            if (file_exists($envPath)) {
+                unlink($envPath);
+            }
+        }
+    }
+
+    public function test_replaces_existing_key()
+    {
+        $this->app['config']->set('app.debug', true);
+
+        $existingKey = 'base64:'.base64_encode(random_bytes(32));
+        $this->app['config']->set('app.key', $existingKey);
+
+        // Create a temporary environment file with existing key
+        $envPath = sys_get_temp_dir().'/'.uniqid('.env.testing.');
+        file_put_contents($envPath, "APP_NAME=Laravel\nAPP_KEY={$existingKey}\nAPP_DEBUG=true\n");
+
+        $this->app->useEnvironmentPath(dirname($envPath));
+        $this->app->loadEnvironmentFrom(basename($envPath));
+
+        try {
+            $controller = $this->app->make(KeyGenerationController::class);
+            $response = $controller->generate(new Request());
+
+            $this->assertEquals(JsonResponse::HTTP_OK, $response->getStatusCode());
+
+            // Verify the key was replaced
+            $contents = file_get_contents($envPath);
+            $this->assertStringContainsString('APP_KEY=base64:', $contents);
+            $this->assertStringNotContainsString($existingKey, $contents);
+        } finally {
+            // Cleanup
+            if (file_exists($envPath)) {
+                unlink($envPath);
+            }
+        }
+    }
+
+    public function test_uses_same_key_replacement_pattern_as_key_generate_command()
+    {
+        $this->app['config']->set('app.debug', true);
+
+        $existingKey = 'base64:'.base64_encode(random_bytes(32));
+        $this->app['config']->set('app.key', $existingKey);
+
+        // Create env file with different formats
+        $envPath = sys_get_temp_dir().'/'.uniqid('.env.testing.');
+        file_put_contents($envPath, "APP_NAME=Laravel\nAPP_KEY={$existingKey}\nAPP_DEBUG=true\n");
+
+        $this->app->useEnvironmentPath(dirname($envPath));
+        $this->app->loadEnvironmentFrom(basename($envPath));
+
+        try {
+            $controller = $this->app->make(KeyGenerationController::class);
+            $response = $controller->generate(new Request());
+
+            $this->assertEquals(JsonResponse::HTTP_OK, $response->getStatusCode());
+
+            // Verify the pattern worked correctly
+            $contents = file_get_contents($envPath);
+            $lines = explode("\n", $contents);
+            $appKeyLine = array_filter($lines, fn ($line) => str_starts_with($line, 'APP_KEY='));
+
+            $this->assertCount(1, $appKeyLine, 'Should have exactly one APP_KEY line');
+        } finally {
+            // Cleanup
+            if (file_exists($envPath)) {
+                unlink($envPath);
+            }
+        }
+    }
+}

--- a/tests/Foundation/View/MissingAppKeyHeaderComponentTest.php
+++ b/tests/Foundation/View/MissingAppKeyHeaderComponentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\View;
+
+use Orchestra\Testbench\TestCase;
+
+class MissingAppKeyHeaderComponentTest extends TestCase
+{
+    public function test_missing_app_key_header_component_file_exists()
+    {
+        $componentPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php';
+
+        $this->assertFileExists($componentPath);
+        $this->assertFileIsReadable($componentPath);
+    }
+
+    public function test_missing_app_key_header_component_contains_expected_elements()
+    {
+        $componentPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php';
+        $content = file_get_contents($componentPath);
+
+        // Check for key UI elements
+        $this->assertStringContainsString('@props([\'exception\'])', $content);
+        $this->assertStringContainsString('Application Key Missing', $content);
+        $this->assertStringContainsString('Generate Application Key', $content);
+        $this->assertStringContainsString('Copy Command', $content);
+        $this->assertStringContainsString('function generateAppKey()', $content);
+        $this->assertStringContainsString('function copyCommand()', $content);
+        $this->assertStringContainsString('/__laravel_generate_key', $content);
+    }
+
+    public function test_missing_app_key_header_component_has_proper_styling()
+    {
+        $componentPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php';
+        $content = file_get_contents($componentPath);
+
+        // Check for Tailwind classes
+        $this->assertStringContainsString('bg-blue-', $content);
+        $this->assertStringContainsString('dark:', $content);
+        $this->assertStringContainsString('rounded-md', $content);
+    }
+
+    public function test_missing_app_key_header_component_has_csrf_token_reference()
+    {
+        $componentPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/components/missing-app-key-header.blade.php';
+        $content = file_get_contents($componentPath);
+
+        $this->assertStringContainsString('X-CSRF-TOKEN', $content);
+        $this->assertStringContainsString('csrf-token', $content);
+    }
+
+    public function test_show_blade_template_uses_conditional_rendering()
+    {
+        $showPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php';
+        $content = file_get_contents($showPath);
+
+        $this->assertStringContainsString('Illuminate\Encryption\MissingAppKeyException', $content);
+        $this->assertStringContainsString('missing-app-key-header', $content);
+    }
+
+    public function test_layout_blade_template_includes_csrf_meta_tag()
+    {
+        $layoutPath = __DIR__.'/../../../src/Illuminate/Foundation/resources/exceptions/renderer/components/layout.blade.php';
+        $content = file_get_contents($layoutPath);
+
+        $this->assertStringContainsString('<meta name="csrf-token"', $content);
+        $this->assertStringContainsString('{{ csrf_token() }}', $content);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a convenient "Generate Application Key" button to Laravel's error page when encountering a `MissingAppKeyException`. This button allows developers to generate an application key with a single click directly from the error page, significantly improving the developer experience.

## Problem

Laravel's new error page design removed the automatic key generation functionality that was previously available when encountering a missing application key error. Developers now have to manually run `php artisan key:generate` in the terminal, which creates unnecessary friction during development and setup.

## Solution

This implementation adds back the functionality by:

- **HTTP Controller**: Created `KeyGenerationController` with a `generate()` method that follows Laravel's architectural patterns
- **Secure Route**: Added `/__laravel_generate_key` endpoint with `web` middleware and rate limiting (5 requests/minute)
- **Blade Component**: Created `missing-app-key-header.blade.php` component with AJAX functionality
- **Conditional Rendering**: Modified error page template to show the button only for `MissingAppKeyException`

## Security Features

- **Debug Mode Only**: Functionality only available when `APP_DEBUG=true`
- **Rate Limiting**: Throttled to 5 requests per minute to prevent abuse
- **CSRF Protection**: Uses Laravel's built-in CSRF token system
- **File Validation**: Validates that the `.env` file is writable before attempting to modify it

## Technical Implementation

- **Identical Logic**: Uses the exact same key generation and replacement logic as `KeyGenerateCommand`
- **Proper Error Handling**: Uses `report($e)` for logging and returns generic error messages
- **Comprehensive Tests**: 12 tests with 36 assertions covering all scenarios
- **No Breaking Changes**: Only affects `MissingAppKeyException`, other exceptions use standard header

## Testing

All tests pass with 100% success rate:
- Controller tests (6 tests, 17 assertions)
- Component tests (6 tests, 19 assertions)
- Code style validated with Pint
- No linting errors

## Backward Compatibility

✅ **No Breaking Changes**: All existing functionality remains unchanged
✅ **Conditional Rendering**: Only affects `MissingAppKeyException`
✅ **Debug Mode Only**: No impact on production applications
✅ **Fallback Available**: "Copy Command" button provides manual option

This feature restores a valuable developer experience improvement that was lost in the transition to the new error page design, making Laravel more accessible and user-friendly for developers of all skill levels.