### PR TITLE
[12.x] Add support for Pulsar editor in ResolvesDumpSource

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -23,6 +23,7 @@ trait ResolvesDumpSource
         'netbeans' => 'netbeans://open/?f={file}:{line}',
         'nova' => 'nova://core/open/file?filename={file}&line={line}',
         'phpstorm' => 'phpstorm://open?file={file}&line={line}',
+        'pulsar' => 'pulsar://open?file={file}&line={line}',
         'sublime' => 'subl://open?url=file://{file}&line={line}',
         'textmate' => 'txmt://open?url=file://{file}&line={line}',
         'trae' => 'trae://file/{file}:{line}',


### PR DESCRIPTION
This PR adds support for [Pulsar](https://pulsar-edit.dev) in ResolvesDumpSource for the exception page.

Pulsar is the community-driven successor to Atom editor and uses the same URL scheme pattern as other supported editors.