### PR TITLE
[12.x] Add missing @throws annotations to Encrypter class

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -302,6 +302,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @param  string  $tag
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Encryption\DecryptException
      */
     protected function ensureTagIsValid($tag)
     {
@@ -359,6 +361,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @param  array  $keys
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     public function previousKeys(array $keys)
     {


### PR DESCRIPTION
This PR adds missing `@throws` annotations to the Encrypter class methods that throw exceptions but were missing proper documentation.

## Changes Made

- **`ensureTagIsValid()` method**: Added `@throws \Illuminate\Contracts\Encryption\DecryptException` annotation
- **`previousKeys()` method**: Added `@throws \RuntimeException` annotation

## Why This Matters

These methods throw exceptions in their implementation but were missing the proper `@throws` annotations in their docblocks. This improvement:

- Enhances IDE support and autocomplete functionality
- Improves static analysis capabilities (PHPStan, Psalm, etc.)
- Provides better documentation for developers using these methods
- Maintains consistency with Laravel's documentation standards

## Testing

No functional changes were made - only documentation improvements. The existing test suite should continue to pass without modification.