### PR TITLE
[12.x] Add missing @throws annotations to Database Connection class

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1101,6 +1101,8 @@ class Connection implements ConnectionInterface
      * @param  string|float|int|bool|null  $value
      * @param  bool  $binary
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function escape($value, $binary = false)
     {
@@ -1154,6 +1156,8 @@ class Connection implements ConnectionInterface
      *
      * @param  string  $value
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function escapeBinary($value)
     {


### PR DESCRIPTION
This PR adds missing `@throws` annotations to the Database Connection class methods that throw exceptions but were missing proper documentation.

## Changes Made

- **`escape()` method**: Added `@throws \RuntimeException` annotation
- **`escapeBinary()` method**: Added `@throws \RuntimeException` annotation

## Why This Matters

These methods throw `RuntimeException` when the PDO connection is not available, but were missing the proper `@throws` annotations in their docblocks. This improvement:

- Enhances IDE support and autocomplete functionality
- Improves static analysis capabilities (PHPStan, Psalm, etc.)
- Provides better documentation for developers using these methods
- Maintains consistency with Laravel's documentation standards
- Helps developers understand when these methods might fail and handle exceptions appropriately

## Implementation Details

Both methods check for PDO availability and throw `RuntimeException` with descriptive messages when the connection is not available:
- `escape()`: Throws when trying to escape values without a PDO connection
- `escapeBinary()`: Throws when trying to escape binary data without a PDO connection

## Testing

No functional changes were made - only documentation improvements. The existing test suite should continue to pass without modification.