### PR TITLE
[13.x] Make Arr::dot() convert empty arrays to null

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -172,7 +172,7 @@ class Arr
                 if (is_array($value) && ! empty($value)) {
                     $flatten($value, $newKey.'.');
                 } else {
-                    $results[$newKey] = $value;
+                    $results[$newKey] = is_array($value) ? null : $value;
                 }
             }
         };

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -217,10 +217,10 @@ class SupportArrTest extends TestCase
         $this->assertSame([], $array);
 
         $array = Arr::dot(['foo' => []]);
-        $this->assertSame(['foo' => []], $array);
+        $this->assertSame(['foo' => null], $array);
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
-        $this->assertSame(['foo.bar' => []], $array);
+        $this->assertSame(['foo.bar' => null], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertSame(['name' => 'taylor', 'languages.php' => true], $array);
@@ -243,7 +243,7 @@ class SupportArrTest extends TestCase
         $array = Arr::dot(['foo' => 'bar', 'empty_array' => [], 'user' => ['name' => 'Taylor'], 'key' => 'value']);
         $this->assertSame([
             'foo' => 'bar',
-            'empty_array' => [],
+            'empty_array' => null,
             'user.name' => 'Taylor',
             'key' => 'value',
         ], $array);


### PR DESCRIPTION
### Make Arr::dot() convert empty arrays to null

This PR updates `Arr::dot()` so that empty arrays are converted to `null` when flattening nested structures.

**Before:**

```php
 $results[$newKey] = $value;
```

**After:**

```php
$results[$newKey] = is_array($value) ? null : $value;
```

This improvement ensures `Arr::dot()` produces truly flattened arrays and provides more consistent behavior for serialization, diffing, and database operations.

**Note:**
As [[Taylor Otwell](https://github.com/taylorotwell)] mentioned in [#57307 (comment)](https://github.com/laravel/framework/pull/57307#issuecomment-3381397868), this fix won’t be merged on a patch release, So made the PR to the master for **Laravel 13**.

**Fixes:** #57305

