### PR TITLE
Only replace first basePath occurrence in dump source href

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Concerns;
 
+use Illuminate\Support\Str;
 use Throwable;
 
 trait ResolvesDumpSource
@@ -169,7 +170,7 @@ trait ResolvesDumpSource
             : ($this->editorHrefs[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
 
         if ($basePath = $editor['base_path'] ?? false) {
-            $file = str_replace($this->basePath, $basePath, $file);
+            $file = Str::replaceStart($this->basePath, $basePath, $file);
         }
 
         return str_replace(

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -254,6 +254,17 @@ class HtmlDumperTest extends TestCase
             'vscode://file//my-docker-work-directory/app/my-file:1',
             $href,
         );
+
+        // When base path appears elsewhere in the file path
+        $config->set('app.editor', ['name' => 'vscode', 'base_path' => '/my-docker-work-directory']);
+        $href = (fn () => $this->resolveSourceHref(
+            '/my-work-directory/storage/my-work-directory/my-file',
+            10,
+        ))->call($dumper);
+        $this->assertSame(
+            'vscode://file//my-docker-work-directory/storage/my-work-directory/my-file:10',
+            $href,
+        );
     }
 
     protected function dump($value)


### PR DESCRIPTION
With a custom value for `config('app.editor.base_path')`, you can essentially map a local path (inside a docker container in my case) to a path that exists on the dev's machine so they can open it in their editor. However, with the existing code, if my base path in the container is, say, `/app`, and the path I'm trying to get the source href to has that path duplicated, like with `/app/app/Models/User.php`, I'll end up with both instances of the base path mapped over to the custom base path (e.g., `/my-project/my-project/Models/User.php` if `config('app.editor.base_path')` is `/my-project`).
This PR just makes the path replacement more limited to avoid that issue.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
