### PR TITLE
[12.x] Add `@filled` blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -426,4 +426,25 @@ trait CompilesConditionals
     {
         return '<?php $__env->stopPush(); endif; ?>';
     }
+
+    /**
+     * Compile the "filled" statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    public function compileFilled($expression)
+    {
+        return "<?php if (\Illuminate\Support\Arr::filled{$expression}): ?>";
+    }
+
+    /**
+     * Compile the "endfilled" statements into valid PHP.
+     *
+     * @return string
+     */
+    public function compileEndfilled()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -435,7 +435,7 @@ trait CompilesConditionals
      */
     public function compileFilled($expression)
     {
-        return "<?php if (\Illuminate\Support\Arr::filled{$expression}): ?>";
+        return "<?php if (filled{$expression}): ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeFilledStatementsTest.php
+++ b/tests/View/Blade/BladeFilledStatementsTest.php
@@ -9,7 +9,7 @@ class BladeFilledStatementsTest extends AbstractBladeTestCase
         $string = '@filled($var)
             <p>Filled</p>
         @endfilled';
-        $expected = '<?php if (\Illuminate\Support\Arr::filled($var)): ?>
+        $expected = '<?php if (filled($var)): ?>
             <p>Filled</p>
         <?php endif; ?>';
 
@@ -23,7 +23,7 @@ class BladeFilledStatementsTest extends AbstractBladeTestCase
         @else
             <p>Empty</p>
         @endfilled';
-        $expected = '<?php if (\Illuminate\Support\Arr::filled($var)): ?>
+        $expected = '<?php if (filled($var)): ?>
             <p>Filled</p>
         <?php else: ?>
             <p>Empty</p>

--- a/tests/View/Blade/BladeFilledStatementsTest.php
+++ b/tests/View/Blade/BladeFilledStatementsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeFilledStatementsTest extends AbstractBladeTestCase
+{
+    public function testFilledStatementsAreCompiled()
+    {
+        $string = '@filled($var)
+            <p>Filled</p>
+        @endfilled';
+        $expected = '<?php if (\Illuminate\Support\Arr::filled($var)): ?>
+            <p>Filled</p>
+        <?php endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testFilledStatementsWithElseAreCompiled()
+    {
+        $string = '@filled($var)
+            <p>Filled</p>
+        @else
+            <p>Empty</p>
+        @endfilled';
+        $expected = '<?php if (\Illuminate\Support\Arr::filled($var)): ?>
+            <p>Filled</p>
+        <?php else: ?>
+            <p>Empty</p>
+        <?php endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
This PR adds the `@filled` Blade directive, the logical counterpart to `@empty`.

It always felt a bit asymmetrical to have `@empty` but no `@filled`. We often have to write `@if (filled($users))`, and while that works, `@filled($users)` is just more expressive and improves template readability.

This implementation adds `compileFilled` and `compileEndfilled` to the `CompilesConditionals`. It compiles down to `<?php if (filled{$expression}): ?>`, so it uses the `filled()` helper and works correctly with collections, strings, etc.

**Usage:**

```blade
@filled($users)
    <p>Users are available.</p>
@else
    <p>No users found.</p>
@endfilled