### PR TITLE
implement missing docblock comments across codebase

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,6 +64,9 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  array|null  $default
      * @return array
      *
      * @throws \InvalidArgumentException


### PR DESCRIPTION
Missing docblock add

```
    /**
     * Get an array item from an array using "dot" notation.
     *
     * @return array
     *
     * @throws \InvalidArgumentException
     */
    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null)
    {
        $value = Arr::get($array, $key, $default);

        if (! is_array($value)) {
            throw new InvalidArgumentException(
                sprintf('Array value for key [%s] must be an array, %s found.', $key, gettype($value))
            );
        }

        return $value;
    }
```
to 

```
    /**
     * Get an array item from an array using "dot" notation.
     *
     * @param  \ArrayAccess|array  $array
     * @param  string|int|null  $key
     * @param  array|null  $default
     * @return array
     *
     * @throws \InvalidArgumentException
     */
    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null)
    {
        $value = Arr::get($array, $key, $default);

        if (! is_array($value)) {
            throw new InvalidArgumentException(
                sprintf('Array value for key [%s] must be an array, %s found.', $key, gettype($value))
            );
        }

        return $value;
    }
```
