### PR TITLE
[13.x] Improved empty and whitespace-only string handling in Blade component attributes

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -511,11 +511,22 @@ class ComponentAttributeBag implements ArrayAccess, IteratorAggregate, JsonSeria
                 continue;
             }
 
+            // Empty "alt" explicitly marks an image as decorative; empty "value" and "data-*"
+            // are valid. For everything else we don't want to render the attribute at all.
+            if (!in_array($key, ['alt', 'value']) && !str_starts_with($key, 'data') && (is_string($value) && trim($value) === '')) {
+                continue;
+            }
+
             if ($value === true) {
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            // Same as above. We want everything but data and value to be trimmed
+            $value = !str_starts_with($key, 'data') && $key !== 'value'
+                ? trim($value)
+                : $value;
+
+            $string .= ' '.$key.'="'.str_replace('"', '\\"', $value).'"';
         }
 
         return trim($string);

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -51,10 +51,15 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-0' => 0,
             'test-0-string' => '0',
             'test-empty-string' => '',
+            'test-whitespace-string' => ' ',
+            'data-test-empty-string' => '',
+            'data-test-whitespace-string' => ' ',
+            'value' => ' ',
+            'alt' => '',
         ]);
 
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" data-test-empty-string="" data-test-whitespace-string=" " value=" " alt=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" data-test-empty-string="" data-test-whitespace-string=" " value=" " alt=""', (string) $bag->merge());
 
         $bag = (new ComponentAttributeBag)
             ->merge([
@@ -72,9 +77,14 @@ class ViewComponentAttributeBagTest extends TestCase
                 'test-0' => 0,
                 'test-0-string' => '0',
                 'test-empty-string' => '',
+                'test-whitespace-string' => ' ',
+                'data-test-empty-string' => '',
+                'data-test-whitespace-string' => ' ',
+                'value' => ' ',
+                'alt' => '',
             ]);
 
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" data-test-empty-string="" data-test-whitespace-string=" " value=" " alt=""', (string) $bag);
 
         $bag = (new ComponentAttributeBag)
             ->merge([


### PR DESCRIPTION
Closes #57463
Related #31994

```blade
 @php($foo = "")
 <x-link :title="$foo">Blub</x-link>
```

```html
<a {{ $attributes }}>Blub</a>
```

renders as

```html
<a title>Blub</a>
``` 

which is wrong. Title isn't a boolean attribute. It should be 

```html
<a>Blub</a>
``` 

We only ever want to have empty strings or whitespace-only strings in these situations:
- `alt`
- `value`
- `data-*`

Never for `title`, `rel`, `placeholder`, `class` etc.

Everything in our #57235 supi dupi mega thread points to that we want Laravel data attributes to be somewhat aligned with what Vue does (cc @timacdonald). So, if we want that, we should start here. Though, Vue doesn't allow `:title="item.value"` so the exceptions I added only make sense but Vue doesn't have them. That said, given how Blade component attributes work, I believe we surely don't want to introduce a whole new defaults-concept in #57235, but mirror what we already have in Blade component attributes. Not sure if Tim agrees, but I believe consistency within the framework is more important than what Vue does (this is mainly about boolean behaviour) . So, if this is merged we have one thing less to worry about in the other PR.