### PR TITLE
[12.x] Improved boolean handling in Blade component attributes 

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -495,10 +495,10 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            if ($key === $value) {
+            if($key === $value) {
                 $string .= ' '.$key;
             } else {
-                $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+                $string .= ' ' . $key . '="' . str_replace('"', '\\"', trim($value)) . '"';
             }
         }
 

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -495,7 +495,11 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            if ($key === $value) {
+                $string .= ' '.$key;
+            } else {
+                $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            }
         }
 
         return trim($string);

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -495,10 +495,10 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 $value = $key === 'x-data' || str_starts_with($key, 'wire:') ? '' : $key;
             }
 
-            if($key === $value) {
+            if ($key === $value) {
                 $string .= ' '.$key;
             } else {
-                $string .= ' ' . $key . '="' . str_replace('"', '\\"', trim($value)) . '"';
+                $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
             }
         }
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -53,8 +53,8 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-empty-string' => '',
         ]);
 
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
+        $this->assertSame('test-string="ok" test-true test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
 
         $bag = (new ComponentAttributeBag)
             ->merge([
@@ -74,7 +74,7 @@ class ViewComponentAttributeBagTest extends TestCase
                 'test-empty-string' => '',
             ]);
 
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
 
         $bag = (new ComponentAttributeBag)
             ->merge([
@@ -151,7 +151,7 @@ class ViewComponentAttributeBagTest extends TestCase
             'x-data' => true,
         ]);
 
-        $this->assertSame('required="required" x-data=""', (string) $bag);
+        $this->assertSame('required x-data=""', (string) $bag);
     }
 
     public function testItMakesAnExceptionForLivewireWireAttributes()


### PR DESCRIPTION
How it is rendered now is **not** against the spec, but being verbose also does not add any extra value.

<img width="1523" height="459" alt="image" src="https://github.com/user-attachments/assets/20904c6b-6459-4ec3-b8ca-3d732de77480" />

~~This is strictly speaking not breaking. But since it depends on #57467 I targeted master. Reason for change https://github.com/laravel/framework/pull/57235#issuecomment-3425564153~~

~~Edit: phpdoc changes are unrelated; GH actions, not from me.~~
