### PR TITLE
[12.x] Add Blade @​verified Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -50,6 +50,31 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-verified statements into valid PHP.
+     *
+     * @param  string|null  $guard
+     * @return string
+     */
+    protected function compileVerified($guard = null)
+    {
+        $guard = is_null($guard) ? '()' : $guard;
+
+        return "<?php if(auth()->guard{$guard}->check() ".
+            "&& auth()->guard{$guard}->user() instanceof \\Illuminate\\Contracts\\Auth\\MustVerifyEmail ".
+            "&& auth()->guard{$guard}->user()->hasVerifiedEmail()): ?>";
+    }
+
+    /**
+     * Compile the end-verified statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndVerified()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the env statements into valid PHP.
      *
      * @param  string  $environments

--- a/tests/View/Blade/BladeIfVerifiedStatementsTest.php
+++ b/tests/View/Blade/BladeIfVerifiedStatementsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfVerifiedStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@verified("api")
+verified
+@endverified';
+        $expected = '<?php if(auth()->guard("api")->check() && auth()->guard("api")->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && auth()->guard("api")->user()->hasVerifiedEmail()): ?>
+verified
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPlainIfStatementsAreCompiled()
+    {
+        $string = '@verified
+verified
+@endverified';
+        $expected = '<?php if(auth()->guard()->check() && auth()->guard()->user() instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && auth()->guard()->user()->hasVerifiedEmail()): ?>
+verified
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Was surprised this didn’t exist already.

Adds a `@verified` Blade directive to determine whether a user has verified their email address or not.

Like the `@auth` directive, you can specify a guard name:

```blade
@verified('web')
    <p>Authenticated using web guard with verified email address.</p>
@endverified
```

Or you can omit the guard name and it will use the default:

```blade
@verified
    <p>Authenticated using default guard with verified email address.</p>
@endverified
```

Like the `@auth` directive, you can combine it with `@else` statements:

```blade
@verified
    <p>Authenticated using default guard with verified email address.</p>
@else
    <p>Either guest, or have not verified email address yet.</p>
@endverified
```

Supporting tests have also been added.