### PR TITLE
Prevent TypeError in validateDigits when attribute value is an array

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -721,8 +721,9 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'digits');
 
-        return (is_numeric($value) || is_string($value)) && ! preg_match('/[^0-9]/', $value)
-                    && strlen((string) $value) == $parameters[0];
+        return (is_numeric($value) || is_string($value)) && 
+            ! preg_match('/[^0-9]/', $value) && 
+            strlen((string) $value) == $parameters[0];
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -721,7 +721,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'digits');
 
-        return ! preg_match('/[^0-9]/', $value)
+        return (is_numeric($value) || is_string($value)) && ! preg_match('/[^0-9]/', $value)
                     && strlen((string) $value) == $parameters[0];
     }
 


### PR DESCRIPTION
This pull request fixes an issue where the validateDigits method throws a TypeError when the validated attribute value is an array instead of a string.

Previously:
```php
preg_match('/^\d{'.$parameters[0].'}$/', $value);
```
would throw:
```
preg_match(): Argument #2 ($subject) must be of type string, array given
```

Now, the method ensures that the value is a string before running the validation, preventing framework-level exceptions and keeping behavior consistent with other validation rules.

Example case:
```php
$request->validate([
    'code' => 'digits:4',
]);
```
If the request accidentally sends `code[]`, Laravel will now gracefully handle the invalid type instead of throwing an error.

Impact:
This change improves robustness of the validation system by preventing a framework exception and instead treating the case as a simple validation failure.
