### PR TITLE
[12.x] Add confirmation prompts to cache commands

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
@@ -13,12 +14,15 @@ use Throwable;
 #[AsCommand(name: 'config:cache')]
 class ConfigCacheCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'config:cache';
+    protected $signature = 'config:cache
+                    {--force : Force the operation to run when in production}';
 
     /**
      * The console command description.
@@ -55,6 +59,10 @@ class ConfigCacheCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $this->callSilent('config:clear');
 
         $config = $this->getFreshConfiguration();

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -3,18 +3,22 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'event:cache')]
 class EventCacheCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'event:cache';
+    protected $signature = 'event:cache
+                    {--force : Force the operation to run when in production}';
 
     /**
      * The console command description.
@@ -30,6 +34,10 @@ class EventCacheCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $this->callSilent('event:clear');
 
         file_put_contents(

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
@@ -11,12 +12,15 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'route:cache')]
 class RouteCacheCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'route:cache';
+    protected $signature = 'route:cache
+                    {--force : Force the operation to run when in production}';
 
     /**
      * The console command description.
@@ -51,6 +55,10 @@ class RouteCacheCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $this->callSilent('route:clear');
 
         $routes = $this->getFreshApplicationRoutes();

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,12 +13,15 @@ use Symfony\Component\Finder\SplFileInfo;
 #[AsCommand(name: 'view:cache')]
 class ViewCacheCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'view:cache';
+    protected $signature = 'view:cache
+                    {--force : Force the operation to run when in production}';
 
     /**
      * The console command description.
@@ -33,6 +37,10 @@ class ViewCacheCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $this->callSilent('view:clear');
 
         $this->paths()->each(function ($path) {


### PR DESCRIPTION
## Description

This PR adds confirmation prompts to cache commands (`config:cache`, `route:cache`, `view:cache`, and `event:cache`) to prevent accidental cache regeneration in production environments.

## Motivation

Cache commands can silently break applications in production if there are serialization issues or configuration errors. Currently, these commands execute immediately without any warning or confirmation, which poses a risk when run in production environments.

## Changes

- Added `ConfirmableTrait` to `ConfigCacheCommand`, `RouteCacheCommand`, `ViewCacheCommand`, and `EventCacheCommand`
- Added `--force` option to all cache commands to bypass confirmation prompts
- Converted `$name` property to `$signature` to support command options
- Added `confirmToProceed()` check before cache operations execute

## Behavior

**In production environments:**
- Commands now display an alert: "Application In Production"
- Prompts user: "Are you sure you want to run this command?"
- User can confirm (Yes) or cancel (No)
- If cancelled, displays "Command cancelled" and exits

**In development/testing environments:**
- No change in behavior - commands execute immediately without prompts

**In CI/CD pipelines:**
- Use `--force` flag to bypass prompts: `php artisan config:cache --force`

## Examples

```bash
# Production environment - will prompt for confirmation
APP_ENV=production php artisan config:cache

# Production environment - skip confirmation with --force
APP_ENV=production php artisan config:cache --force

# Development environment - no prompt (existing behavior)
php artisan config:cache