### PR TITLE
[12.x] Rename NamedScope to Scope

### DIFF
--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Attributes\Scope as NamedScope;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Model;
 
 class EloquentModelScopeTest extends DatabaseTestCase
@@ -37,7 +37,7 @@ class TestScopeModel1 extends Model
         return $builder;
     }
 
-    #[NamedScope]
+    #[Scope]
     protected function existsAsWell(Builder $builder)
     {
         return $builder;

--- a/tests/Integration/Database/EloquentNamedScopeAttributeTest.php
+++ b/tests/Integration/Database/EloquentNamedScopeAttributeTest.php
@@ -21,7 +21,7 @@ class EloquentNamedScopeAttributeTest extends TestCase
         );
     }
 
-    #[DataProvider('namedScopeDataProvider')]
+    #[DataProvider('scopeDataProvider')]
     public function test_it_can_query_named_scoped_from_the_query_builder(string $methodName)
     {
         $query = Fixtures\NamedScopeUser::query()->{$methodName}(true);
@@ -29,7 +29,7 @@ class EloquentNamedScopeAttributeTest extends TestCase
         $this->assertSame($this->query, $query->toRawSql());
     }
 
-    #[DataProvider('namedScopeDataProvider')]
+    #[DataProvider('scopeDataProvider')]
     public function test_it_can_query_named_scoped_from_static_query(string $methodName)
     {
         $query = Fixtures\NamedScopeUser::{$methodName}(true);
@@ -37,7 +37,7 @@ class EloquentNamedScopeAttributeTest extends TestCase
         $this->assertSame($this->query, $query->toRawSql());
     }
 
-    public static function namedScopeDataProvider(): array
+    public static function scopeDataProvider(): array
     {
         return [
             'scope with return' => ['verified'],

--- a/tests/Integration/Database/Fixtures/NamedScopeUser.php
+++ b/tests/Integration/Database/Fixtures/NamedScopeUser.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\Fixtures;
 
-use Illuminate\Database\Eloquent\Attributes\Scope as NamedScope;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 class NamedScopeUser extends User
@@ -17,7 +17,7 @@ class NamedScopeUser extends User
         ];
     }
 
-    #[NamedScope]
+    #[Scope]
     protected function verified(Builder $builder, bool $email = true)
     {
         return $builder->when(
@@ -27,7 +27,7 @@ class NamedScopeUser extends User
         );
     }
 
-    #[NamedScope]
+    #[Scope]
     protected function verifiedWithoutReturn(Builder $builder, bool $email = true)
     {
         $this->verified($builder, $email);


### PR DESCRIPTION
Description
---
In PR #54450 we changed the name of the attribute from **NamedScope** to **Scope**.