### PR TITLE
Fix url->previousPath() returning url when referer different from app.url

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -182,9 +182,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function previousPath($fallback = false)
     {
-        $previousPath = str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
-
-        return $previousPath === '' ? '/' : $previousPath;
+        return parse_url($this->previous($fallback), PHP_URL_PATH) ?: '/';
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/57456

Sent to master, as it could technically be breaking change if people relied on the buggy/security behaviour and original feature was added 3 years ago in: https://github.com/laravel/framework/pull/41661
