### PR TITLE
Fix Collection unique() to handle numeric strings correctly

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1771,8 +1771,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function unique($key = null, $strict = false)
     {
-        if (is_null($key) && $strict === false) {
-            return new static(array_unique($this->items, SORT_REGULAR));
+        if ($key === null && $strict === false) {
+            foreach ($this->items as $item) {
+                if (! is_scalar($item) && $item !== null) {
+                    return new static(array_unique($this->items, SORT_REGULAR));
+                }
+            }
+
+            return new static(array_unique($this->items));
         }
 
         $callback = $this->valueRetriever($key);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1695,6 +1695,9 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([[1, 2], [1, 2], [2, 3], [3, 4], [2, 3]]);
         $this->assertEquals([[1, 2], [2, 3], [3, 4]], $c->unique()->values()->all());
+
+        $c = new $collection(['+100', '100', '1100']);
+        $this->assertEquals(['+100', '100', '1100'], $c->unique()->values()->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
Fixes bug where `SORT_REGULAR` correctly deduplicates _numeric strings_ when a `+` prefix is present, causing mass confusion and hysteria, in a world where "unique" is meant to mean "unlike anything else" haha.

## The Bug

You can see the wild behavior of `SORT_REGULAR` here: [https://3v4l.org/UTnXH#v8.4.14](https://3v4l.org/UTnXH#v8.4.14)

This affects phone numbers in E.164 format -- and likely other important things forever lost in the universe.

Taylor, if you've read this far, thank you for being an amazing human being!

The PHP docs note the default sort behavior of `array_unique` is effectively strict eg. `(string) $elem1 === (string) $elem2 `. The PHP docs also note that "array_unique() is not intended to work on multidimensional arrays." However, `SORT_REGULAR` breaks from this documented behavior, and essentially provides a loose comparison that can be used with multi-dimensional arrays. 

Ultimately, I feel `Collection::unique()` should effectively align with the default behavior of `array_unique()` when the array passed to the `Collection` is not multidimensional. This is my attempt to do just that, in a BC and performant manner. I'll leave the proper multidimensional array unique function to the PHP gods.

## The Fix

Checks if the collection contains complex types (arrays/objects) requiring `SORT_REGULAR`. If the Collection is one of scalar values, it will use the faster and more accurate `array_unique()`.

## Performance

- ~1.4x overall speedup (19,000 iterations)
- ~5.9x faster for numeric strings
- Same speed for arrays/objects

Benchmark: https://gist.github.com/jmarble/3e7960efba8fef8814686d0f0db07bbf

## References

- See: php/php-src#4801 
- Open issue in PHP docs: php/doc-en#1463
- Related to: 48a53be4418d6d0f8eee443e272158f1d2af832b
