### PR TITLE
[12.x] Add warning when server workers cannot be respected

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -104,6 +104,8 @@ class ServeCommand extends Command
             if ($workers > 1 &&
                 ! $this->option('no-reload') &&
                 ! (int) env('LARAVEL_SAIL', 0)) {
+                $this->components->warn('Unable to respect the `PHP_CLI_SERVER_WORKERS` environment variable without the `--no-reload` flag. Only creating a single server.');
+
                 return false;
             }
 


### PR DESCRIPTION
When using `php artisan serve` with `PHP_CLI_SERVER_WORKERS`, the `--no-reload` flag must also be provided, otherwise the value is ignored (https://github.com/laravel/framework/pull/54606).

Right now, there is no indicator to the user that the environment variable is being ignored and is a tough one to track down without doing some source diving.

We now output a warning to help you get back on track.

## Without the flag

<img width="1362" height="362" alt="Screenshot 2025-10-22 at 14 29 57" src="https://github.com/user-attachments/assets/a6ce5214-c067-4938-bbfc-fecb5bec65e7" />

## With the flag

<img width="773" height="273" alt="Screenshot 2025-10-22 at 14 30 09" src="https://github.com/user-attachments/assets/d85e5f31-37d2-4f23-a122-5dda0b01d7fe" />
