### PR TITLE
[12.x] Ensure HTTP batch results are returned in the same order as requested

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -292,9 +292,10 @@ class Batch
 
         // Before returning the results, we must ensure that the results are sorted
         // in the same order as the requests were defined, respecting any custom
-        // key names that were assigned to the request using the "as" method.
+        // key names that were assigned to this request using the "as" method.
         uksort($results, function ($key1, $key2) {
-            return array_search($key1, array_keys($this->requests), true) <=> array_search($key2, array_keys($this->requests), true);
+            return array_search($key1, array_keys($this->requests), true) <=> 
+                   array_search($key2, array_keys($this->requests), true);
         });
 
         if (! $this->hasFailures() && $this->thenCallback !== null) {

--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -290,6 +290,13 @@ class Batch
             ]))->promise()->wait();
         }
 
+        // Before returning the results, we must ensure that the results are sorted
+        // in the same order as the requests were defined, respecting any custom
+        // key names that were assigned to the request using the "as" method.
+        uksort($results, function ($key1, $key2) {
+            return array_search($key1, array_keys($this->requests), true) <=> array_search($key2, array_keys($this->requests), true);
+        });
+
         if (! $this->hasFailures() && $this->thenCallback !== null) {
             call_user_func($this->thenCallback, $this, $results);
         }


### PR DESCRIPTION
When using the `Http::batch` method (#56946), the results are currently sorted in the order that the responses came back, rather than the order that the requests were defined:

```php
dump(Http::batch(fn (Batch $batch) => [
    $batch->get('https://httpbin.org/delay/3'),
    $batch->get('https://httpbin.org/delay/2'),
    $batch->get('https://httpbin.org/delay/1'),
])->send());

array:3 [
  2 => Illuminate\Http\Client\Response {#419}
  1 => Illuminate\Http\Client\Response {#374}
  0 => Illuminate\Http\Client\Response {#328}
]
```

While the keys are maintained, the results array is no longer a list, and the iterating order is likely unexpected.

This differs from the `Http::pool` method, which always returns the results in the same order:

```php
dump(Http::pool(fn (Pool $pool) => [
    $pool->get('https://httpbin.org/delay/3'),
    $pool->get('https://httpbin.org/delay/2'),
    $pool->get('https://httpbin.org/delay/1'),
]));

array:3 [
  0 => Illuminate\Http\Client\Response {#327}
  1 => Illuminate\Http\Client\Response {#373}
  2 => Illuminate\Http\Client\Response {#418}
]
```

This PR fixes this by sorting the results before they are returned, respecting any requests named with the `as` method.

I wasn't able to write a good test for this without hitting an external URL, because faked requests don't run async and always return in the correct order. I added a comment in lieu of a test.

I can confirm the following test passes (but would slow down the test suite and could be flaky):

```php
public function testBatchResultsAreReturnedInTheSameOrderAsRequested(): void
{
    $responses = $this->factory->batch(function (Batch $batch) {
        return [
            $batch->get('https://httpbin.org/delay/3'),
            $batch->get('https://httpbin.org/delay/2'),
            $batch->get('https://httpbin.org/delay/1'),
        ];
    })->send();

    $this->assertSame([0, 1, 2], array_keys($responses));
    $this->assertTrue(array_is_list($responses));

    $responses = $this->factory->batch(function (Batch $batch) {
        return [
            $batch->as('c')->get('https://httpbin.org/delay/3'),
            $batch->as('b')->get('https://httpbin.org/delay/2'),
            $batch->as('a')->get('https://httpbin.org/delay/1'),
        ];
    })->send();

    $this->assertSame(['c', 'b', 'a'], array_keys($responses));
}
```