### PR TITLE
allow precognitive requests to use wildcards with array validations (#57437)

### DIFF
--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -18,7 +18,7 @@ trait CanBePrecognitive
             return $rules;
         }
 
-        $validateOnly = array_filter(explode(',', $this->header('Precognition-Validate-Only')));
+        $validateOnly = explode(',', $this->header('Precognition-Validate-Only'));
 
         return (new Collection($rules))
             ->filter(fn ($rule, $attribute) => $this->shouldValidatePrecognitiveAttribute($attribute, $validateOnly))

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -18,9 +18,20 @@ trait CanBePrecognitive
             return $rules;
         }
 
+        $validateOnly = explode(',', $this->header('Precognition-Validate-Only'));
+        $validateOnlyPatterns = (new Collection($validateOnly))
+            ->map(fn ($pattern) => '/^'.str_replace('\*', '\d+', preg_quote($pattern, '/')).'$/');
+
         return (new Collection($rules))
-            ->only(explode(',', $this->header('Precognition-Validate-Only')))
-            ->all();
+            ->filter(function ($rule, $ruleKey) use ($validateOnlyPatterns) {
+                foreach ($validateOnlyPatterns as $pattern) {
+                    if (preg_match($pattern, $ruleKey)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            })->all();
     }
 
     /**

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -537,6 +537,8 @@ class PrecognitionTest extends TestCase
 
         $response->assertUnprocessable();
         $response->assertHeaderMissing('Precognition-Success');
+        $response->assertJsonMissing(['errors' => ['email' => []]]);
+        $response->assertJsonMissing(['errors' => ['name' => []]]);
         $response->assertJsonPath('errors', [
             'user.name' => ['The user.name field must be a string.'],
         ]);


### PR DESCRIPTION
This PR is a proposal to resolve #57437.

With this change, users can specify a wildcard to trigger all validation rules for an array field when using precognitive requests. Before the change the user had to specify all array validation rules manually in the `Precognition-Validate-Only` header. Now wildcards can specified to cover all array entries.

```
// Before
Precognition-Validate-Only: nested_array,nested_array.0.title,nested_array.1.title,nested_array.2.title
Precognition-Validate-Only: raw_array,raw_array.0,raw_array.1,raw_array.2

// After
Precognition-Validate-Only: nested_array,nested_array.*.title
Precognition-Validate-Only: raw_array,raw_array.*
```

PS. This is my first PR for Laravel so please forgive me mistakes. I appreciate any feedback :)