### PR TITLE
[12.x] Fix security vulnerability in previousPath() method, preventing from returning external URLs

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -192,6 +192,7 @@ class UrlGenerator implements UrlGeneratorContract
         // to prevent open redirect vulnerabilities
         if (! $referrer || $this->isDangerousUrl($referrer)) {
             $path = $fallback ? parse_url($this->to($fallback), PHP_URL_PATH) ?? '/' : '/';
+            
             return rtrim($path, '/') ?: '/';
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -188,6 +188,8 @@ class UrlGenerator implements UrlGeneratorContract
             $referrer = $this->getPreviousUrlFromSession();
         }
 
+        // checking the referrer against dangerous schemes (e.g., javascript:, data:, file: etc)
+        // to prevent open redirect vulnerabilities
         if (! $referrer || $this->isDangerousUrl($referrer)) {
             $path = $fallback ? parse_url($this->to($fallback), PHP_URL_PATH) ?? '/' : '/';
             return rtrim($path, '/') ?: '/';
@@ -198,6 +200,7 @@ class UrlGenerator implements UrlGeneratorContract
         $previousUrlComponents = parse_url($previous);
         $appUrlComponents = parse_url($this->to('/'));
 
+        // if the previous URL is not from the same origin, we will use the fallback or root URL
         if (! $this->isSameOrigin($previousUrlComponents, $appUrlComponents)) {
             $previous = $fallback ? $this->to($fallback) : $this->to('/');
         }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -192,7 +192,7 @@ class UrlGenerator implements UrlGeneratorContract
         // to prevent open redirect vulnerabilities
         if (! $referrer || $this->isDangerousUrl($referrer)) {
             $path = $fallback ? parse_url($this->to($fallback), PHP_URL_PATH) ?? '/' : '/';
-            
+
             return rtrim($path, '/') ?: '/';
         }
 

--- a/tests/Routing/RoutingUrlGeneratorPreviousPathTest.php
+++ b/tests/Routing/RoutingUrlGeneratorPreviousPathTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\UrlGenerator;
+use PHPUnit\Framework\TestCase;
+
+class RoutingUrlGeneratorPreviousPathTest extends TestCase
+{
+    protected function getUrlGenerator($referer = null, $host = 'www.foo.com', $scheme = 'http')
+    {
+        $routes = new RouteCollection;
+
+        $request = Request::create("{$scheme}://{$host}/");
+
+        if ($referer) {
+            $request->headers->set('referer', $referer);
+        }
+
+        return new UrlGenerator($routes, $request);
+    }
+
+    public function testPreviousPathWithSameDomainUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/bar/baz?query=value');
+
+        $this->assertSame('/bar/baz', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainRootUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainUrlAndQueryString()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/products/123?category=electronics&sort=price');
+
+        $this->assertSame('/products/123', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainUrlAndFragment()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/docs/api#authentication');
+
+        $this->assertSame('/docs/api', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksExternalDomain()
+    {
+        $url = $this->getUrlGenerator('https://evil-site.com/malicious/path');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksExternalDomainWithAnyPaths()
+    {
+        $url = $this->getUrlGenerator('https://attacker.com/admin/users');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksDifferentScheme()
+    {
+        $url = $this->getUrlGenerator('https://www.foo.com/secure/area', 'www.foo.com', 'http');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathAllowsSameSchemeWithPaths()
+    {
+        $url = $this->getUrlGenerator('https://www.foo.com/secures/area', 'www.foo.com', 'https');
+
+        $this->assertSame('/secures/area', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksSubdomainAttack()
+    {
+        $url = $this->getUrlGenerator('http://sub.foo.com/malicious');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksDifferentPortBasedAttack()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com:8080/admin', 'www.foo.com', 'http');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathAllowsSameDomainWithSamePortUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com:8080/allowed', 'www.foo.com:8080', 'http');
+
+        $this->assertSame('/allowed', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesEmptyReferer()
+    {
+        $url = $this->getUrlGenerator('');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesNullReferer()
+    {
+        $url = $this->getUrlGenerator(null);
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathWithFallbackForExternalUrl()
+    {
+        $url = $this->getUrlGenerator('https://evil.com/malicious');
+
+        $this->assertSame('/dashboard', $url->previousPath('/dashboard'));
+    }
+
+    public function testPreviousPathNormalizesTrailingSlashes()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path/to/resource/');
+
+        $this->assertSame('/path/to/resource', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesDeepNestedPaths()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/level1/level2/level3/level4/list');
+
+        $this->assertSame('/level1/level2/level3/level4/list', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesSpecialCharactersInPath()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path-with-dashes/under_scores/123');
+
+        $this->assertSame('/path-with-dashes/under_scores/123', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksDataUri()
+    {
+        $url = $this->getUrlGenerator('data:text/html,<script>alert("xss")</script>');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksJavascriptUri()
+    {
+        $url = $this->getUrlGenerator('javascript:alert("xss")');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathAllowsJavascriptUriIfOriginIsSame()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/javascript:alert("same-origin")', 'www.foo.com');
+
+        $this->assertSame('/javascript:alert("same-origin")', $url->previousPath());
+    }
+
+    public function testPreviousPathBlocksFileUri()
+    {
+        $url = $this->getUrlGenerator('file:///etc/passwd');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathAllowsFileUriIfOriginIsSame()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/file:///etc/same');
+
+        $this->assertSame('/file:///etc/same', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesCaseInsensitiveHost()
+    {
+        $url = $this->getUrlGenerator('http://WWW.FOO.COM/path', 'www.foo.com');
+
+        $this->assertSame('/path', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesCaseVariations()
+    {
+        $url = $this->getUrlGenerator('http://www.FOO.com/path', 'www.foo.com');
+
+        $this->assertSame('/path', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesUrlWithoutPath()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesComplexQueryString()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/search?q=php&framework=laravel&sort=popularity&page=34');
+
+        $this->assertSame('/search', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesEncodedCharacters()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path%20with%20spaces%20encoded/resource');
+
+        $this->assertSame('/path%20with%20spaces%20encoded/resource', $url->previousPath());
+    }
+
+    public function testIsSameOriginMethod()
+    {
+        $url = $this->getUrlGenerator();
+
+        $reflection = new \ReflectionClass($url);
+        $method = $reflection->getMethod('isSameOrigin');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($url,
+            ['host' => 'www.foo.com', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // different host
+        $this->assertFalse($method->invoke($url,
+            ['host' => 'evil.com', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // different scheme
+        $this->assertFalse($method->invoke($url,
+            ['host' => 'www.foo.com', 'scheme' => 'https'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // missing component
+        $this->assertFalse($method->invoke($url, false, ['host' => 'www.foo.com', 'scheme' => 'http']));
+        $this->assertFalse($method->invoke($url, ['host' => 'www.foo.com'], ['host' => 'www.foo.com', 'scheme' => 'http']));
+
+        // case insensitive
+        $this->assertTrue($method->invoke($url,
+            ['host' => 'WWW.FOO.COM', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+    }
+}


### PR DESCRIPTION
This PR improves and fixes the `previousPath()` method in `UrlGenerator` with better security and origin validation, which solves the issue [#57456](https://github.com/laravel/framework/issues/57456).

### Problem Summary

<img width="635" height="465" alt="Screenshot 2025-10-22 at 1 57 03 PM" src="https://github.com/user-attachments/assets/84eddb1f-2cd9-4fde-8635-4b3859ecb177" />

The `previousPath()` method is expected to return only the **path** of the previous URL (the doc SS attached for clarity). However, the existing implementation in `previousPath()` method had a security vulnerability where it returned a full external URL, when a malicious referrer header is sent. 
This happened because it extracted the path from the previous URL without validating that the request originated from the *same origin or not* and the path extracting logic *only worked for the same origin* requests. So, this was making applications vulnerable to security issues including:
- **Open redirect attacks** via external domains in the referrer header
- **XSS attacks** through dangerous URI schemes (`javascript:`, `data:` etc)
- **Protocol confusion attacks** using different schemes (http vs https)

### Solution
So, I solved this with - 

1. **Origin Validation**: Added error-proof same-origin checking in `previousPath()`, that validates Host matching (case-insensitive), Scheme consistency (http/https) and also Port validation.
2. **Dangerous URL Detection**: Also implemented protection against malicious URI schemes.
3. **Used built-in PHP function** (`parse_url()`) for reliability
4. **Fallback Handling**: Enhanced fallback behavior for invalid or malicious referrers ensuring a good DX overall.

### New Changes Benefits

- **Prevents open redirect vulnerabilities** by blocking external domain referrers
- **Eliminates XSS or port-based attack** with better URI detection and validation
- **Handles different origin requests gracefully** by returning fallback/root path
- **Maintains backward compatibility** while adding necessary fixes with security layers
- **Provides fallback accurately** for edge cases and malformed URL

### Test Coverage

Added comprehensive tests covering:

- Same-origin URL allowing and External domain blocking
- Dangerous or suspicious URI scheme detect, Port-based attack prevention
- Protocol confusion prevention and Empty or null referrer handling
- Case-insensitive host validation
- Complex query strings and URL encoding
- Deep nested paths and trailing slash normalization
- Query string, fragment and special characters handling
- Fallback behavior verification and Path extraction accuracy

The changes made are **fully backward compatible** - existing functionality remains unchanged for legitimate same-origin requests while fixing the logic to match the expected behavior of the `previousPath()` method and adding security protection that was needed. 
Even if a malicious referrer header is sent, it will return the fallback path or root path (e.g., `/`) instead of that external URL and thus handling this case silently and gracefully. 

**Note:** Why I think this change should be added into `12.x`? because it's a **security vulnerability**, not a feature. - The current behavior is not what is expected (the documentation also states that). Anyone relying on it is unknowingly *vulnerable*. The method name is `previousPath()` not `previousUrlOrPath()`.. so, current behavior also violates the naming contract.

So this is surely a correctness fix, not any new feature or bringing breaking change. What we can do is - 
- Clear change-log entry, marking it as as a security fix 
- Note in upgrade guide with necessary info about the change and how it works.

@taylorotwell, Kindly let me know if we want to add/update anything in the documentation related to this change. Or if you have any disagreement on my thoughts, please inform me what can be improved. Thank you.
