### PR TITLE
Feature/eloquent composite keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -6,7 +6,6 @@ use BadMethodCallException;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
-use InvalidArgumentException;
 use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
@@ -21,6 +20,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionMethod;
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -344,7 +344,7 @@ class Builder implements BuilderContract
         $keyNames = $this->model->getKeyName();
 
         // Single composite key: ['order_id' => 1, 'product_id' => 5]
-        if ($this->isAssociativeArray($keyValues)) {
+        if (! array_is_list($keyValues)) {
             foreach ($keyNames as $index => $keyName) {
                 if (! array_key_exists($keyName, $keyValues)) {
                     throw new InvalidArgumentException(
@@ -371,21 +371,6 @@ class Builder implements BuilderContract
         });
 
         return $this;
-    }
-
-    /**
-     * Determine if an array is associative.
-     *
-     * @param  array  $array
-     * @return bool
-     */
-    protected function isAssociativeArray(array $array)
-    {
-        if ([] === $array) {
-            return false;
-        }
-
-        return array_keys($array) !== range(0, count($array) - 1);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2092,7 +2092,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         if ($this->hasCompositeKey()) {
             return array_map(
-                fn ($key) => $this->qualifyColumn($key),
+                $this->qualifyColumn(...),
                 $this->primaryKey
             );
         }

--- a/tests/Integration/Database/EloquentCompositeKeyTest.php
+++ b/tests/Integration/Database/EloquentCompositeKeyTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use LogicException;
+
+class EloquentCompositeKeyTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('composite_key_models', function (Blueprint $table) {
+            $table->unsignedBigInteger('order_id');
+            $table->unsignedBigInteger('product_id');
+            $table->integer('quantity')->default(1);
+            $table->string('notes')->nullable();
+            $table->timestamps();
+
+            $table->primary(['order_id', 'product_id']);
+        });
+    }
+
+    public function testHasCompositeKey()
+    {
+        $model = new CompositeKeyModel;
+
+        $this->assertTrue($model->hasCompositeKey());
+        $this->assertEquals(['order_id', 'product_id'], $model->getKeyName());
+    }
+
+    public function testGetKeyReturnsArrayForCompositeKey()
+    {
+        $model = new CompositeKeyModel;
+        $model->order_id = 1;
+        $model->product_id = 5;
+        $model->quantity = 10;
+
+        $this->assertEquals(['order_id' => 1, 'product_id' => 5], $model->getKey());
+    }
+
+    public function testGetQualifiedKeyNameReturnsArray()
+    {
+        $model = new CompositeKeyModel;
+
+        $qualifiedKeys = $model->getQualifiedKeyName();
+
+        $this->assertIsArray($qualifiedKeys);
+        $this->assertEquals([
+            'composite_key_models.order_id',
+            'composite_key_models.product_id',
+        ], $qualifiedKeys);
+    }
+
+    public function testCreateWithCompositeKey()
+    {
+        $model = CompositeKeyModel::create([
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+            'notes' => 'Test item',
+        ]);
+
+        $this->assertNotNull($model);
+        $this->assertEquals(1, $model->order_id);
+        $this->assertEquals(5, $model->product_id);
+        $this->assertEquals(10, $model->quantity);
+        $this->assertEquals('Test item', $model->notes);
+
+        $this->assertDatabaseHas('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+            'notes' => 'Test item',
+        ]);
+    }
+
+    public function testFindWithCompositeKey()
+    {
+        CompositeKeyModel::create([
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+        ]);
+
+        $found = CompositeKeyModel::find(['order_id' => 1, 'product_id' => 5]);
+
+        $this->assertNotNull($found);
+        $this->assertEquals(1, $found->order_id);
+        $this->assertEquals(5, $found->product_id);
+        $this->assertEquals(10, $found->quantity);
+    }
+
+    public function testFindReturnsNullWhenNotFound()
+    {
+        $found = CompositeKeyModel::find(['order_id' => 999, 'product_id' => 999]);
+
+        $this->assertNull($found);
+    }
+
+    public function testFindOrFailWithCompositeKey()
+    {
+        CompositeKeyModel::create([
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+        ]);
+
+        $found = CompositeKeyModel::findOrFail(['order_id' => 1, 'product_id' => 5]);
+
+        $this->assertNotNull($found);
+        $this->assertEquals(1, $found->order_id);
+        $this->assertEquals(5, $found->product_id);
+    }
+
+    public function testFindOrFailThrowsExceptionWhenNotFound()
+    {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+        CompositeKeyModel::findOrFail(['order_id' => 999, 'product_id' => 999]);
+    }
+
+    public function testFindManyWithCompositeKeys()
+    {
+        CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+        CompositeKeyModel::create(['order_id' => 2, 'product_id' => 3, 'quantity' => 20]);
+        CompositeKeyModel::create(['order_id' => 3, 'product_id' => 7, 'quantity' => 30]);
+
+        $found = CompositeKeyModel::findMany([
+            ['order_id' => 1, 'product_id' => 5],
+            ['order_id' => 3, 'product_id' => 7],
+        ]);
+
+        $this->assertCount(2, $found);
+        $this->assertEquals(10, $found->firstWhere('order_id', 1)->quantity);
+        $this->assertEquals(30, $found->firstWhere('order_id', 3)->quantity);
+    }
+
+    public function testUpdateWithCompositeKey()
+    {
+        $model = CompositeKeyModel::create([
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+            'notes' => 'Original',
+        ]);
+
+        $model->quantity = 20;
+        $model->notes = 'Updated';
+        $model->save();
+
+        $this->assertDatabaseHas('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 20,
+            'notes' => 'Updated',
+        ]);
+
+        $this->assertDatabaseMissing('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 5,
+            'notes' => 'Original',
+        ]);
+    }
+
+    public function testDeleteWithCompositeKey()
+    {
+        $model = CompositeKeyModel::create([
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 10,
+        ]);
+
+        $model->delete();
+
+        $this->assertDatabaseMissing('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 5,
+        ]);
+    }
+
+    public function testWhereKeyWithCompositeKey()
+    {
+        CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+        CompositeKeyModel::create(['order_id' => 2, 'product_id' => 3, 'quantity' => 20]);
+
+        $found = CompositeKeyModel::whereKey(['order_id' => 1, 'product_id' => 5])->first();
+
+        $this->assertNotNull($found);
+        $this->assertEquals(10, $found->quantity);
+    }
+
+    public function testWhereKeyNotWithCompositeKey()
+    {
+        CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+        CompositeKeyModel::create(['order_id' => 2, 'product_id' => 3, 'quantity' => 20]);
+
+        $found = CompositeKeyModel::whereKeyNot(['order_id' => 1, 'product_id' => 5])->get();
+
+        $this->assertCount(1, $found);
+        $this->assertEquals(20, $found->first()->quantity);
+    }
+
+    public function testCompositeKeyCannotBeAutoIncrementing()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Composite primary keys cannot be auto-incrementing.');
+
+        $model = new InvalidCompositeKeyModel;
+        $model->order_id = 1;
+        $model->product_id = 5;
+        $model->save();
+    }
+
+    public function testWhereKeyThrowsExceptionForMissingKeyComponent()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing value for composite key component: product_id');
+
+        CompositeKeyModel::whereKey(['order_id' => 1])->get();
+    }
+
+    public function testUpdateChangesOnlySpecifiedModel()
+    {
+        CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+        CompositeKeyModel::create(['order_id' => 1, 'product_id' => 6, 'quantity' => 20]);
+
+        $model = CompositeKeyModel::find(['order_id' => 1, 'product_id' => 5]);
+        $model->quantity = 100;
+        $model->save();
+
+        $this->assertDatabaseHas('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 5,
+            'quantity' => 100,
+        ]);
+
+        $this->assertDatabaseHas('composite_key_models', [
+            'order_id' => 1,
+            'product_id' => 6,
+            'quantity' => 20,
+        ]);
+    }
+
+    public function testFreshRetrievesCorrectModel()
+    {
+        $model = CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+
+        CompositeKeyModel::where('order_id', 1)
+            ->where('product_id', 5)
+            ->update(['quantity' => 50]);
+
+        $fresh = $model->fresh();
+
+        $this->assertEquals(50, $fresh->quantity);
+    }
+
+    public function testRefreshUpdatesModel()
+    {
+        $model = CompositeKeyModel::create(['order_id' => 1, 'product_id' => 5, 'quantity' => 10]);
+
+        CompositeKeyModel::where('order_id', 1)
+            ->where('product_id', 5)
+            ->update(['quantity' => 50]);
+
+        $model->refresh();
+
+        $this->assertEquals(50, $model->quantity);
+    }
+}
+
+class CompositeKeyModel extends Model
+{
+    protected $table = 'composite_key_models';
+
+    protected $primaryKey = ['order_id', 'product_id'];
+
+    public $incrementing = false;
+
+    protected $guarded = [];
+}
+
+class InvalidCompositeKeyModel extends Model
+{
+    protected $table = 'composite_key_models';
+
+    protected $primaryKey = ['order_id', 'product_id'];
+
+    // Intentionally left as true to test validation
+    public $incrementing = true;
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
## Native Composite Primary Key Support for Eloquent ORM

### Summary

This PR implements comprehensive support for **composite (multi-column) primary keys** in Laravel's Eloquent ORM, enabling developers to work seamlessly with tables that use multiple columns as their primary key.

### Motivation

Many enterprise and normalized database schemas use composite primary keys for:
- **Junction tables** (e.g., `order_items` with `order_id` + `product_id`)
- **Multi-tenant systems** (e.g., `tenant_id` + `id`)
- **Versioned records** (e.g., `document_id` + `version`)
- **Legacy database integration** where composite keys are already established

Currently, developers must use workarounds or third-party packages like `awobaz/compoships`, which only support relationships but not full CRUD operations.

### Changes

#### Core Model Changes (`Illuminate\Database\Eloquent\Model`)

**1. Enhanced Property Types**
```php
// Before: string only
protected $primaryKey = 'id';

// After: string or array
protected $primaryKey = 'id'; // or ['order_id', 'product_id']
protected $keyType = 'int';    // or ['int', 'int']
2. New Methods
hasCompositeKey() - Detects if model uses composite keys
3. Enhanced Methods
getKey() - Returns array for composite keys: ['order_id' => 1, 'product_id' => 5]
getKeyName() - Returns array of key names for composite keys
getQualifiedKeyName() - Returns array of qualified key names
setKeysForSaveQuery() - Applies multiple WHERE clauses for updates/deletes
getKeyForSaveQuery() - Accepts optional key parameter
performInsert() - Validates composite keys cannot be auto-incrementing
Builder Changes (Illuminate\Database\Eloquent\Builder)
1. Enhanced Methods
whereKey() - Detects composite keys and delegates to specialized handler
2. New Methods
whereCompositeKey() - Handles composite key WHERE clauses
Single key: ['order_id' => 1, 'product_id' => 5]
Multiple keys: [['order_id' => 1, 'product_id' => 5], ['order_id' => 2, 'product_id' => 3]]
isAssociativeArray() - Helper to distinguish single vs multiple composite keys
Usage
Model Definition
use Illuminate\Database\Eloquent\Model;

class OrderItem extends Model
{
    // Define composite primary key
    protected $primaryKey = ['order_id', 'product_id'];
    
    // Composite keys cannot auto-increment
    public $incrementing = false;
    
    // Optional: specify types for each key
    protected $keyType = ['int', 'int']; // or just 'int' for all
}
Migration (Already Supported!)
Schema::create('order_items', function (Blueprint $table) {
    $table->unsignedBigInteger('order_id');
    $table->unsignedBigInteger('product_id');
    $table->integer('quantity');
    $table->timestamps();
    
    // Composite primary key (Blueprint already supports this)
    $table->primary(['order_id', 'product_id']);
    
    $table->foreign('order_id')->references('id')->on('orders');
    $table->foreign('product_id')->references('id')->on('products');
});
CRUD Operations
// CREATE
$item = OrderItem::create([
    'order_id' => 1,
    'product_id' => 5,
    'quantity' => 10
]);

// READ - Find by composite key
$item = OrderItem::find(['order_id' => 1, 'product_id' => 5]);

$item = OrderItem::findOrFail(['order_id' => 1, 'product_id' => 5]);

$items = OrderItem::findMany([
    ['order_id' => 1, 'product_id' => 5],
    ['order_id' => 2, 'product_id' => 3]
]);

// UPDATE
$item = OrderItem::find(['order_id' => 1, 'product_id' => 5]);
$item->quantity = 20;
$item->save(); // Executes: UPDATE ... WHERE order_id = 1 AND product_id = 5

// DELETE
$item->delete(); // Executes: DELETE ... WHERE order_id = 1 AND product_id = 5
Query Builder
// Single composite key lookup
$item = OrderItem::whereKey(['order_id' => 1, 'product_id' => 5])->first();

// Multiple composite keys (whereIn equivalent)
$items = OrderItem::whereKey([
    ['order_id' => 1, 'product_id' => 5],
    ['order_id' => 2, 'product_id' => 3]
])->get();

// Exclusion
$items = OrderItem::whereKeyNot(['order_id' => 1, 'product_id' => 5])->get();

// Get key values
$keys = $item->getKey(); 
// Returns: ['order_id' => 1, 'product_id' => 5]
Technical Implementation
Detection Strategy
Composite keys are detected using a simple type check:
public function hasCompositeKey()
{
    return is_array($this->primaryKey);
}
This provides zero overhead for existing single-key models.
Query Building
For composite keys, WHERE clauses are constructed using multiple conditions:
// Single composite key
WHERE order_id = 1 AND product_id = 5

// Multiple composite keys
WHERE (order_id = 1 AND product_id = 5) 
   OR (order_id = 2 AND product_id = 3)