### PR TITLE
Fix S3 adapter to use correct path separator and update related tests

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -6,6 +6,7 @@ use Aws\S3\S3Client;
 use Illuminate\Support\Traits\Conditionable;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
 use League\Flysystem\FilesystemOperator;
+use League\Flysystem\PathPrefixer;
 
 class AwsS3V3Adapter extends FilesystemAdapter
 {
@@ -20,15 +21,19 @@ class AwsS3V3Adapter extends FilesystemAdapter
 
     /**
      * Create a new AwsS3V3FilesystemAdapter instance.
-     *
-     * @param  \League\Flysystem\FilesystemOperator  $driver
-     * @param  \League\Flysystem\FilesystemAdapter  $adapter
-     * @param  array  $config
-     * @param  \Aws\S3\S3Client  $client
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config, S3Client $client)
     {
         parent::__construct($driver, $adapter, $config);
+
+        // We override the prefixer for the S3 Adapter, because S3 only accepts
+        // the normal / as a separator. On Windows, this causes errors because the
+        // directory separator \\ is used.
+        $this->prefixer = new PathPrefixer($config['root'] ?? '', '/');
+
+        if (isset($config['prefix'])) {
+            $this->prefixer = new PathPrefixer($this->prefixer->prefixPath($config['prefix']), '/');
+        }
 
         $this->client = $client;
     }
@@ -70,7 +75,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return string
      */
     public function temporaryUrl($path, $expiration, array $options = [])
@@ -99,7 +103,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return array
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -26,7 +26,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FilesystemAdapterTest extends TestCase
 {
     private $tempDir;
+
     private $filesystem;
+
     private $adapter;
 
     protected function setUp(): void
@@ -48,7 +50,7 @@ class FilesystemAdapterTest extends TestCase
         unset($this->tempDir, $this->filesystem, $this->adapter);
     }
 
-    public function testResponse()
+    public function test_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -63,7 +65,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('inline; filename=file.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testMimeTypeIsNotCalledAlreadyProvidedToResponse()
+    public function test_mime_type_is_not_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -75,7 +77,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testSizeIsNotCalledAlreadyProvidedToResponse()
+    public function test_size_is_not_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -87,7 +89,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testFallbackNameCalledAlreadyProvidedToResponse()
+    public function test_fallback_name_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -101,7 +103,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testDownload()
+    public function test_download()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -110,7 +112,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=hello.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadNonAsciiFilename()
+    public function test_download_non_ascii_filename()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -119,7 +121,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame("attachment; filename=privet.txt; filename*=utf-8''%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.txt", $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadNonAsciiEmptyFilename()
+    public function test_download_non_ascii_empty_filename()
     {
         $this->filesystem->write('привет.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -128,7 +130,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=privet.txt; filename*=utf-8\'\'%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadPercentInFilename()
+    public function test_download_percent_in_filename()
     {
         $this->filesystem->write('Hello%World.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -137,7 +139,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=HelloWorld.txt; filename*=utf-8\'\'Hello%25World.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testExists()
+    public function test_exists()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -145,27 +147,27 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->fileExists('file.txt'));
     }
 
-    public function testMissing()
+    public function test_missing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->missing('file.txt'));
         $this->assertTrue($filesystemAdapter->fileMissing('file.txt'));
     }
 
-    public function testDirectoryExists()
+    public function test_directory_exists()
     {
         $this->filesystem->write('/foo/bar/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryExists('/foo/bar'));
     }
 
-    public function testDirectoryMissing()
+    public function test_directory_missing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryMissing('/foo/bar'));
     }
 
-    public function testPath()
+    public function test_path()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
@@ -174,48 +176,48 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
-    public function testGet()
+    public function test_get()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertSame('Hello World', $filesystemAdapter->get('file.txt'));
     }
 
-    public function testGetFileNotFound()
+    public function test_get_file_not_found()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->get('file.txt'));
     }
 
-    public function testJsonReturnsDecodedJsonData()
+    public function test_json_returns_decoded_json_data()
     {
         $this->filesystem->write('file.json', '{"foo": "bar"}');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
     }
 
-    public function testJsonReturnsNullIfJsonDataIsInvalid()
+    public function test_json_returns_null_if_json_data_is_invalid()
     {
         $this->filesystem->write('file.json', '{"foo":');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
-    public function testMimeTypeNotDetected()
+    public function test_mime_type_not_detected()
     {
         $this->filesystem->write('unknown.mime-type', '');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertFalse($filesystemAdapter->mimeType('unknown.mime-type'));
     }
 
-    public function testPut()
+    public function test_put()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->put('file.txt', 'Something inside');
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something inside');
     }
 
-    public function testPrepend()
+    public function test_prepend()
     {
         file_put_contents($this->tempDir.'/file.txt', 'World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -223,7 +225,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'World');
     }
 
-    public function testAppend()
+    public function test_append()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello ');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -231,7 +233,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'Moon');
     }
 
-    public function testDelete()
+    public function test_delete()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -239,13 +241,13 @@ class FilesystemAdapterTest extends TestCase
         Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
     }
 
-    public function testDeleteReturnsTrueWhenFileNotFound()
+    public function test_delete_returns_true_when_file_not_found()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->delete('file.txt'));
     }
 
-    public function testCopy()
+    public function test_copy()
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');
@@ -261,7 +263,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testMove()
+    public function test_move()
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');
@@ -276,7 +278,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testStream()
+    public function test_stream()
     {
         $this->filesystem->write('file.txt', $original_content = 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -285,7 +287,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($original_content, $filesystemAdapter->get('copy.txt'));
     }
 
-    public function testStreamBetweenFilesystems()
+    public function test_stream_between_filesystems()
     {
         $secondFilesystem = new Filesystem(new LocalFilesystemAdapter($this->tempDir.'/second'));
         $this->filesystem->write('file.txt', $original_content = 'Hello World');
@@ -296,7 +298,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($original_content, $secondFilesystemAdapter->get('copy.txt'));
     }
 
-    public function testStreamToExistingFileOverwrites()
+    public function test_stream_to_existing_file_overwrites()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $this->filesystem->write('existing.txt', 'Dear Kate');
@@ -306,20 +308,20 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->read('existing.txt'));
     }
 
-    public function testReadStreamNonExistentFileReturnsNull()
+    public function test_read_stream_non_existent_file_returns_null()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->readStream('nonexistent.txt'));
     }
 
-    public function testStreamInvalidResourceThrows()
+    public function test_stream_invalid_resource_throws()
     {
         $this->expectException(InvalidArgumentException::class);
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->writeStream('file.txt', 'foo bar');
     }
 
-    public function testPutWithStreamInterface()
+    public function test_put_with_stream_interface()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'some-data');
 
@@ -332,7 +334,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('some-data', $filesystemAdapter->get('bar.txt'));
     }
 
-    public function testPutFileAs()
+    public function test_put_file_as()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -356,7 +358,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileAsWithAbsoluteFilePath()
+    public function test_put_file_as_with_absolute_file_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -367,7 +369,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
-    public function testPutFileAsWithoutPath()
+    public function test_put_file_as_without_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -378,7 +380,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
-    public function testPutFile()
+    public function test_put_file()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -400,7 +402,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileWithAbsoluteFilePath()
+    public function test_put_file_with_absolute_file_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -418,7 +420,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileWithoutPath()
+    public function test_put_file_without_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -430,7 +432,7 @@ class FilesystemAdapterTest extends TestCase
     }
 
     #[RequiresPhpExtension('ftp')]
-    public function testCreateFtpDriver()
+    public function test_create_ftp_driver()
     {
         $filesystem = new FilesystemManager(new Application);
 
@@ -449,7 +451,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('admin', $config['username']);
     }
 
-    public function testMacroable()
+    public function test_macroable()
     {
         $this->filesystem->write('foo.txt', 'Hello World');
 
@@ -461,7 +463,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
     }
 
-    public function testTemporaryUrlWithCustomCallback()
+    public function test_temporary_url_with_custom_callback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
@@ -479,7 +481,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testThrowExceptionsForGet()
+    public function test_throw_exceptions_for_get()
     {
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
@@ -494,7 +496,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForReadStream()
+    public function test_throw_exceptions_for_read_stream()
     {
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
@@ -509,7 +511,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForPut()
+    public function test_throw_exceptions_for_put()
     {
         $this->filesystem->write('foo.txt', 'Hello World');
 
@@ -530,7 +532,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForMimeType()
+    public function test_throw_exceptions_for_mime_type()
     {
         $this->filesystem->write('unknown.mime-type', '');
 
@@ -547,7 +549,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testReportExceptionsForGet()
+    public function test_report_exceptions_for_get()
     {
         $container = Container::getInstance();
 
@@ -575,7 +577,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForReadStream()
+    public function test_report_exceptions_for_read_stream()
     {
         $container = Container::getInstance();
 
@@ -603,7 +605,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForPut()
+    public function test_report_exceptions_for_put()
     {
         $container = Container::getInstance();
 
@@ -637,7 +639,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForMimeType()
+    public function test_report_exceptions_for_mime_type()
     {
         $container = Container::getInstance();
 
@@ -667,7 +669,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testGetAllFiles()
+    public function test_get_all_files()
     {
         $this->filesystem->write('body.txt', 'Hello World');
         $this->filesystem->write('file1.txt', 'Hello World');
@@ -679,7 +681,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame($filesystemAdapter->files(), ['body.txt', 'existing.txt', 'file.txt', 'file1.txt']);
     }
 
-    public function testProvidesTemporaryUrls()
+    public function test_provides_temporary_urls()
     {
         $localAdapter = new class($this->tempDir) extends LocalFilesystemAdapter
         {
@@ -693,7 +695,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testProvidesTemporaryUrlsWithCustomCallback()
+    public function test_provides_temporary_urls_with_custom_callback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
@@ -704,7 +706,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testProvidesTemporaryUrlsForS3Adapter()
+    public function test_provides_temporary_urls_for_s3_adapter()
     {
         $filesystem = new FilesystemManager(new Application);
         $filesystemAdapter = $filesystem->createS3Driver([
@@ -715,21 +717,36 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testProvidesTemporaryUrlsForAdapterWithoutTemporaryUrlSupport()
+    public function test_uses_right_separator_for_s3_adapter_urls()
+    {
+        $filesystem = new FilesystemManager(new Application);
+        $filesystemAdapter = $filesystem->createS3Driver([
+            'region' => 'us-west-1',
+            'bucket' => 'laravel',
+            'root' => 'something',
+            'directory_separator' => '\\',
+        ]);
+
+        $path = $filesystemAdapter->path('different');
+        $this->assertStringContainsString('/', $path);
+        $this->assertStringNotContainsString('\\', $path);
+    }
+
+    public function test_provides_temporary_urls_for_adapter_without_temporary_url_support()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
         $this->assertFalse($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testPrefixesUrls()
+    public function test_prefixes_urls()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['url' => 'https://example.org/', 'prefix' => 'images']);
 
         $this->assertEquals('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
     }
 
-    public function testGetChecksum()
+    public function test_get_checksum()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->write('path.txt', 'contents of file');


### PR DESCRIPTION
In #55119 it was reported that when using the S3 adapter on Windows and setting a `root`, the `PathPrefixer` uses the OS's `DIRECTORY_SEPARATOR`, which on Windows is `\\`.

However, AWS only allows `/` as a separator, and most S3 implementations also do.

This PR overrides the `PathPrefixer` for the S3 Adapter to always use `/`.

I have added a test to make sure this behavior works, by manually setting the `directory_separator` config value in the test. This ensures that `/` is always used.

This should not break anything.