### PR TITLE
[12.x] Use displayName() for custom job identification

### DIFF
--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -29,8 +29,6 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
      */
     public function __construct($event)
     {
-        $this->uniqueId = get_class($event);
-
         if (method_exists($event, 'uniqueId')) {
             $this->uniqueId .= $event->uniqueId();
         } elseif (property_exists($event, 'uniqueId')) {

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -69,6 +69,10 @@ class UniqueLock
             ? $job->uniqueId()
             : ($job->uniqueId ?? '');
 
-        return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;
+        $jobType = method_exists($job, 'jobTypeIdentifier')
+            ? $job->jobTypeIdentifier()
+            : get_class($job);
+
+        return 'laravel_unique_job:'.$jobType.':'.$uniqueId;
     }
 }

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -69,10 +69,10 @@ class UniqueLock
             ? $job->uniqueId()
             : ($job->uniqueId ?? '');
 
-        $jobType = method_exists($job, 'jobTypeIdentifier')
-            ? $job->jobTypeIdentifier()
+        $jobName = method_exists($job, 'displayName')
+            ? $job->displayName()
             : get_class($job);
 
-        return 'laravel_unique_job:'.$jobType.':'.$uniqueId;
+        return 'laravel_unique_job:'.$jobName.':'.$uniqueId;
     }
 }

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -256,7 +256,11 @@ class ThrottlesExceptions
             return $this->prefix.$job->job->uuid();
         }
 
-        return $this->prefix.hash('xxh128', get_class($job));
+        $jobType = method_exists($job, 'jobTypeIdentifier')
+            ? $job->jobTypeIdentifier()
+            : get_class($job);
+
+        return $this->prefix.hash('xxh128', $jobType);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -256,11 +256,11 @@ class ThrottlesExceptions
             return $this->prefix.$job->job->uuid();
         }
 
-        $jobType = method_exists($job, 'jobTypeIdentifier')
-            ? $job->jobTypeIdentifier()
+        $jobName = method_exists($job, 'displayName')
+            ? $job->displayName()
             : get_class($job);
 
-        return $this->prefix.hash('xxh128', $jobType);
+        return $this->prefix.hash('xxh128', $jobName);
     }
 
     /**

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -154,8 +154,14 @@ class WithoutOverlapping
      */
     public function getLockKey($job)
     {
-        return $this->shareKey
-            ? $this->prefix.$this->key
-            : $this->prefix.get_class($job).':'.$this->key;
+        if ($this->shareKey) {
+            return $this->prefix.$this->key;
+        }
+
+        $jobType = method_exists($job, 'jobTypeIdentifier')
+            ? $job->jobTypeIdentifier()
+            : get_class($job);
+
+        return $this->prefix.$jobType.':'.$this->key;
     }
 }

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -158,10 +158,10 @@ class WithoutOverlapping
             return $this->prefix.$this->key;
         }
 
-        $jobType = method_exists($job, 'jobTypeIdentifier')
-            ? $job->jobTypeIdentifier()
+        $jobName = method_exists($job, 'displayName')
+            ? $job->displayName()
             : get_class($job);
 
-        return $this->prefix.$jobType.':'.$this->key;
+        return $this->prefix.$jobName.':'.$this->key;
     }
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -75,7 +75,35 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.':'.TestEventUnique::class;
+        $lockKey = 'laravel_unique_job:'.TestEventUnique::class.':';
+        $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
+    }
+
+    public function testUniqueEventsCanBeBroadcastWithUniqueIdFromProperty()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventUniqueWithIdProperty);
+
+        Bus::assertNotDispatched(UniqueBroadcastEvent::class);
+        Queue::assertPushed(UniqueBroadcastEvent::class);
+
+        $lockKey = 'laravel_unique_job:'.TestEventUniqueWithIdProperty::class.':unique-id-property';
+        $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
+    }
+
+    public function testUniqueEventsCanBeBroadcastWithUniqueIdFromMethod()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventUniqueWithIdMethod);
+
+        Bus::assertNotDispatched(UniqueBroadcastEvent::class);
+        Queue::assertPushed(UniqueBroadcastEvent::class);
+
+        $lockKey = 'laravel_unique_job:'.TestEventUniqueWithIdMethod::class.':unique-id-method';
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 
@@ -176,6 +204,16 @@ class TestEventUnique implements ShouldBroadcast, ShouldBeUnique
     {
         //
     }
+}
+
+class TestEventUniqueWithIdProperty extends TestEventUnique
+{
+    public string $uniqueId = 'unique-id-property';
+}
+
+class TestEventUniqueWithIdMethod extends TestEventUnique
+{
+    public string $uniqueId = 'unique-id-method';
 }
 
 class TestEventRescue implements ShouldBroadcast, ShouldRescue

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Queue;
 use Exception;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
@@ -344,6 +345,85 @@ class ThrottlesExceptionsTest extends TestCase
 
         $middleware->report(fn () => false);
         $middleware->handle($job, $next);
+    }
+
+    public function testUsesJobClassNameForCacheKey()
+    {
+        $rateLimiter = $this->mock(RateLimiter::class);
+
+        $job = new class
+        {
+            public $released = false;
+
+            public function release()
+            {
+                $this->released = true;
+
+                return $this;
+            }
+        };
+
+        $expectedKey = 'laravel_throttles_exceptions:'.hash('xxh128', get_class($job));
+
+        $rateLimiter->shouldReceive('tooManyAttempts')
+            ->once()
+            ->with($expectedKey, 10)
+            ->andReturn(false);
+
+        $rateLimiter->shouldReceive('hit')
+            ->once()
+            ->with($expectedKey, 600);
+
+        $next = function ($job) {
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptions();
+        $middleware->handle($job, $next);
+
+        $this->assertTrue($job->released);
+    }
+
+    public function testUsesJobTypeIdentifierForCacheKeyWhenAvailable()
+    {
+        $rateLimiter = $this->mock(RateLimiter::class);
+
+        $job = new class
+        {
+            public $released = false;
+
+            public function release()
+            {
+                $this->released = true;
+
+                return $this;
+            }
+
+            public function jobTypeIdentifier(): string
+            {
+                return 'App\\Actions\\ThrottlesExceptionsTestAction';
+            }
+        };
+
+        $expectedKey = 'laravel_throttles_exceptions:'.hash('xxh128', 'App\\Actions\\ThrottlesExceptionsTestAction');
+
+        $rateLimiter->shouldReceive('tooManyAttempts')
+            ->once()
+            ->with($expectedKey, 10)
+            ->andReturn(false);
+
+        $rateLimiter->shouldReceive('hit')
+            ->once()
+            ->with($expectedKey, 600);
+
+        $next = function ($job) {
+            throw new RuntimeException('Whoops!');
+        };
+
+        $middleware = new ThrottlesExceptions();
+        $middleware->handle($job, $next);
+
+        $this->assertTrue($job->released);
     }
 }
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -384,7 +384,7 @@ class ThrottlesExceptionsTest extends TestCase
         $this->assertTrue($job->released);
     }
 
-    public function testUsesJobTypeIdentifierForCacheKeyWhenAvailable()
+    public function testUsesDisplayNameForCacheKeyWhenAvailable()
     {
         $rateLimiter = $this->mock(RateLimiter::class);
 
@@ -399,7 +399,7 @@ class ThrottlesExceptionsTest extends TestCase
                 return $this;
             }
 
-            public function jobTypeIdentifier(): string
+            public function displayName(): string
             {
                 return 'App\\Actions\\ThrottlesExceptionsTestAction';
             }

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -171,24 +171,24 @@ class UniqueJobTest extends QueueTestCase
         return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job)).':';
     }
 
-    public function testLockUsesJobTypeIdentifierWhenAvailable()
+    public function testLockUsesDisplayNameWhenAvailable()
     {
         Bus::fake();
 
         $lockKey = 'laravel_unique_job:App\\Actions\\UniqueTestAction:';
 
-        dispatch(new UniqueTestJobWithJobTypeIdentifier);
+        dispatch(new UniqueTestJobWithDisplayName);
         $this->runQueueWorkerCommand(['--once' => true]);
-        Bus::assertDispatched(UniqueTestJobWithJobTypeIdentifier::class);
+        Bus::assertDispatched(UniqueTestJobWithDisplayName::class);
 
         $this->assertFalse(
             $this->app->get(Cache::class)->lock($lockKey, 10)->get()
         );
 
-        Bus::assertDispatchedTimes(UniqueTestJobWithJobTypeIdentifier::class);
-        dispatch(new UniqueTestJobWithJobTypeIdentifier);
+        Bus::assertDispatchedTimes(UniqueTestJobWithDisplayName::class);
+        dispatch(new UniqueTestJobWithDisplayName);
         $this->runQueueWorkerCommand(['--once' => true]);
-        Bus::assertDispatchedTimes(UniqueTestJobWithJobTypeIdentifier::class);
+        Bus::assertDispatchedTimes(UniqueTestJobWithDisplayName::class);
 
         $this->assertFalse(
             $this->app->get(Cache::class)->lock($lockKey, 10)->get()
@@ -211,19 +211,19 @@ class UniqueJobTest extends QueueTestCase
         );
     }
 
-    public function testUniqueLockCreatesKeyWithJobTypeIdentifierWhenAvailable()
+    public function testUniqueLockCreatesKeyWithDisplayNameWhenAvailable()
     {
         $this->assertEquals(
             'laravel_unique_job:App\\Actions\\UniqueTestAction:unique-id-2',
-            UniqueLock::getKey(new UniqueIdTestJobWithJobTypeIdentifier)
+            UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );
     }
 
-    public function testUniqueLockCreatesKeyWithIdAndJobTypeIdentifierWhenAvailable()
+    public function testUniqueLockCreatesKeyWithIdAndDisplayNameWhenAvailable()
     {
         $this->assertEquals(
             'laravel_unique_job:App\\Actions\\UniqueTestAction:unique-id-2',
-            UniqueLock::getKey(new UniqueIdTestJobWithJobTypeIdentifier)
+            UniqueLock::getKey(new UniqueIdTestJobWithDisplayName)
         );
     }
 }
@@ -305,22 +305,22 @@ class UniqueIdTestJob extends UniqueTestJob
     }
 }
 
-class UniqueTestJobWithJobTypeIdentifier extends UniqueTestJob
+class UniqueTestJobWithDisplayName extends UniqueTestJob
 {
-    public function jobTypeIdentifier(): string
+    public function displayName(): string
     {
         return 'App\\Actions\\UniqueTestAction';
     }
 }
 
-class UniqueIdTestJobWithJobTypeIdentifier extends UniqueTestJob
+class UniqueIdTestJobWithDisplayName extends UniqueTestJob
 {
     public function uniqueId(): string
     {
         return 'unique-id-2';
     }
 
-    public function jobTypeIdentifier(): string
+    public function displayName(): string
     {
         return 'App\\Actions\\UniqueTestAction';
     }

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -152,9 +152,9 @@ class WithoutOverlappingJobsTest extends QueueTestCase
         );
     }
 
-    public function testGetLockUsesJobTypeIdentifier()
+    public function testGetLockUsesDisplayName()
     {
-        $job = new OverlappingTestJobWithJobTypeIdentifier;
+        $job = new OverlappingTestJobWithDisplayName;
 
         $this->assertSame(
             'laravel-queue-overlap:App\\Actions\\WithoutOverlappingTestAction:key',
@@ -247,9 +247,9 @@ class OverlappingTestJobWithSharedKeyTwo
     }
 }
 
-class OverlappingTestJobWithJobTypeIdentifier extends OverlappingTestJob
+class OverlappingTestJobWithDisplayName extends OverlappingTestJob
 {
-    public function jobTypeIdentifier(): string
+    public function displayName(): string
     {
         return 'App\\Actions\\WithoutOverlappingTestAction';
     }

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -151,6 +151,31 @@ class WithoutOverlappingJobsTest extends QueueTestCase
             (new WithoutOverlapping('key'))->withPrefix('prefix:')->shared()->getLockKey($job)
         );
     }
+
+    public function testGetLockUsesJobTypeIdentifier()
+    {
+        $job = new OverlappingTestJobWithJobTypeIdentifier;
+
+        $this->assertSame(
+            'laravel-queue-overlap:App\\Actions\\WithoutOverlappingTestAction:key',
+            (new WithoutOverlapping('key'))->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'laravel-queue-overlap:key',
+            (new WithoutOverlapping('key'))->shared()->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:App\\Actions\\WithoutOverlappingTestAction:key',
+            (new WithoutOverlapping('key'))->withPrefix('prefix:')->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:key',
+            (new WithoutOverlapping('key'))->withPrefix('prefix:')->shared()->getLockKey($job)
+        );
+    }
 }
 
 class OverlappingTestJob
@@ -219,5 +244,13 @@ class OverlappingTestJobWithSharedKeyTwo
     public function middleware()
     {
         return [(new WithoutOverlapping)->shared()];
+    }
+}
+
+class OverlappingTestJobWithJobTypeIdentifier extends OverlappingTestJob
+{
+    public function jobTypeIdentifier(): string
+    {
+        return 'App\\Actions\\WithoutOverlappingTestAction';
     }
 }


### PR DESCRIPTION
## Problem

The queue system uses `get_class($job)` to identify jobs for:
- Unique job locks (`UniqueLock::getKey()`)
- Exception throttling (`ThrottlesExceptions::getKey()`)
- Overlap prevention (`WithoutOverlapping::getLockKey()`)

This doesn't support job wrapper patterns where multiple actions use the same wrapper class. This affects popular packages:
- [lorisleiva/laravel-actions](https://github.com/lorisleiva/laravel-actions) (6.0M installs)
- [spatie/laravel-queueable-action](https://github.com/spatie/laravel-queueable-action) (2.7M installs)

Since all actions share the same wrapper class name, they incorrectly share the same lock/cache keys.

## Solution
Add an optional `jobTypeIdentifier()` method that jobs can implement to provide a custom identifier as an alternative to `get_class()`.

**Before:**

```php
// UniqueLock.php line 72
return 'laravel_unique_job:'.get_class($job).':'.$uniqueId;
```

**After:**

```php
$jobType = method_exists($job, 'jobTypeIdentifier')
    ? $job->jobTypeIdentifier()
    : get_class($job);

return 'laravel_unique_job:'.$jobType.':'.$uniqueId;
```

Wrapper packages can then implement:
```php
class ActionJob implements ShouldQueue
{
    public function __construct(
        protected string $actionClass,
        protected array $parameters = []
    ) {}

    public function jobTypeIdentifier(): string
    {
        return $this->actionClass; // Return wrapped action class
    }
}
```

## Changes

Applied the same pattern to all three identification points:
- `src/Illuminate/Bus/UniqueLock.php`
- `src/Illuminate/Queue/Middleware/ThrottlesExceptions.php`
- `src/Illuminate/Queue/Middleware/WithoutOverlapping.php`

Tests added for both default (`get_class()`) and custom identifier behavior.

## Backward Compatibility

✅ Fully backward compatible, existing jobs continue using `get_class()` as before.
