### PR TITLE
Optimize Collection unique() strict mode for string-only collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1771,8 +1771,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function unique($key = null, $strict = false)
     {
-        if (is_null($key) && $strict === false) {
+        if ($key === null && $strict === false) {
             return new static(array_unique($this->items, SORT_REGULAR));
+        }
+
+        if ($key === null && $strict === true) {
+            $canUseFastPath = true;
+            foreach ($this->items as $item) {
+                if (! is_string($item)) {
+                    $canUseFastPath = false;
+                    break;
+                }
+            }
+
+            if ($canUseFastPath) {
+                return new static(array_unique($this->items, SORT_STRING));
+            }
         }
 
         $callback = $this->valueRetriever($key);


### PR DESCRIPTION
## Summary

This PR adds an **_exponential_ performance improvement** for `unique(null, true)` when the collection contains only strings.

**Tested on:**
- PHP 8.4.13
- Laravel 12.x

## Implementation

Added an optimization path for strict mode that detects string-only collections and uses native `array_unique()`.

## Backward Compatibility

**100% Backward Compatible**

- No changes to non-strict mode behavior
- Strict mode behavior unchanged (still uses strict comparison)
- Only adds performance optimization for string-only collections

## Performance Impact

See benchmark results here: [https://gist.github.com/jmarble/27faeeece7ac58edecbc2024e84f842d](https://gist.github.com/jmarble/27faeeece7ac58edecbc2024e84f842d)
Benchmark test code (thank you Claude!): [https://gist.github.com/jmarble/adf92aef31009652c8616c5b8d2966e9](https://gist.github.com/jmarble/adf92aef31009652c8616c5b8d2966e9)

### Real-world use cases that benefit:

```php
// Unit numbers, apartment codes
collect(['5', '10', '5', '3A', '5'])->unique(null, true);

// SKUs, product codes
collect(['SKU-001', 'SKU-002', 'SKU-001'])->unique(null, true);

// Email addresses
collect(['user@example.com', 'admin@example.com', 'user@example.com'])->unique(null, true);

// File paths
collect(['/path/to/file', '/path/to/other', '/path/to/file'])->unique(null, true);
```

## Why String-Only?

`SORT_STRING` converts all values to strings before comparison. This works perfectly for strict comparison when:
- All items are strings -> No type conversion needed
- Mixed types (int/string/bool) -> Would incorrectly merge `1` and `'1'`

The optimization automatically falls back to the existing implementation for mixed-type collections.


## No Breaking Changes

- Non-strict mode: Unchanged (uses `SORT_REGULAR` despite the sometimes unpredictable results)
- Strict mode with mixed types: Unchanged (uses reject + in_array)
- Strict mode with strings: **Optimized** (same behavior, faster execution)
