### PR TITLE
[12.x]: Support for custom date_format and filename_format in daily log

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -70,6 +70,8 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
+            'date_format' => env('LOG_DAILY_DATE_FORMAT', 'Y-m-d'),
+            'filename_format' => env('LOG_DAILY_FILENAME_FORMAT', '{filename}-{date}'),
             'replace_placeholders' => true,
         ],
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -323,7 +323,9 @@ class LogManager implements LoggerInterface
         return new Monolog($this->parseChannel($config), [
             $this->prepareHandler(new RotatingFileHandler(
                 $config['path'], $config['days'] ?? 7, $this->level($config),
-                $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false
+                $config['bubble'] ?? true, $config['permission'] ?? null, $config['locking'] ?? false,
+                $config['date_format'] ?? RotatingFileHandler::FILE_PER_DAY,
+                $config['filename_format'] ?? '{filename}-{date}'
             ), $config),
         ], $config['replace_placeholders'] ?? false ? [new PsrLogMessageProcessor()] : []);
     }


### PR DESCRIPTION
## Summary

This PR adds support for customizing the `date_format` and `filename_format` in the daily log driver by allowing these configurations to be passed through the logging configuration.

## Changes

- Added support for `date_format` configuration option in the daily log driver
- Added support for `filename_format` configuration option in the daily log driver
- Maintained backward compatibility by providing default values

## Motivation

This enhancement allows developers to have more control over their log file naming and rotation behavior, which is particularly useful in environments with specific logging requirements or when integrating with log management systems.

Additionally, when developers prefer to __retain all logs without rotation__, organizing files into nested date-based directories can make long-term log storage and browsing far more manageable and efficient.

## Examples

You can now define custom formats for daily logs in your `config/logging.php`:

```php
'channels' => [
    'daily' => [
        'driver' => 'daily',
        'path' => storage_path('logs/laravel.log'),
        'level' => 'debug',
        'days' => 14,
        'date_format' => 'Y/m/d',
        'filename_format' => '{filename}-{date}',
    ],
],
```

## Example outputs

Configuration | Generated log file path
-- | --
date_format = 'Y/m/d' | storage/logs/laravel/2025/10/23.log
date_format = 'Y-m/d', filename_format = '{date}-{filename}' | storage/logs/2025-10/23-laravel.log

## Additional Notes

Since this feature may result in nested directory structures (depending on the chosen date_format), please note that Monolog currently does not automatically remove empty directories when rotating log files.
As a result, the log file might be deleted while its parent directories remain.

A [PR](https://github.com/Seldaek/monolog/pull/2000) has already been submitted to Monolog to address this, and I am hoping that it will automatically clean up empty directories in future releases.
