### PR TITLE
[12.x] Pass exception to `QueueFailedOver` event

### DIFF
--- a/src/Illuminate/Queue/Events/QueueFailedOver.php
+++ b/src/Illuminate/Queue/Events/QueueFailedOver.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Queue\Events;
 
+use Throwable;
+
 class QueueFailedOver
 {
     /**
@@ -13,6 +15,7 @@ class QueueFailedOver
     public function __construct(
         public ?string $connectionName,
         public mixed $command,
+        public Throwable $exception,
     ) {
     }
 }

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -95,7 +95,7 @@ class FailoverQueue extends Queue implements QueueContract
             } catch (Throwable $e) {
                 $lastException = $e;
 
-                $this->events->dispatch(new QueueFailedOver($connection, $job));
+                $this->events->dispatch(new QueueFailedOver($connection, $job, $e));
             }
         }
 
@@ -143,7 +143,7 @@ class FailoverQueue extends Queue implements QueueContract
             } catch (Throwable $e) {
                 $lastException = $e;
 
-                $this->events->dispatch(new QueueFailedOver($connection, $job));
+                $this->events->dispatch(new QueueFailedOver($connection, $job, $e));
             }
         }
 


### PR DESCRIPTION
This PR updates the `QueueFailedOver` event to include the exception that caused the failover, similar to the `CacheFailedOver` event.