### PR TITLE
[12.x] Rename NamedScope to Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -875,7 +875,7 @@
 * [12.x] Added except() method to Model class for excluding attributes by [@vishal2931](https://github.com/vishal2931) in https://github.com/laravel/framework/pull/55072
 * [12.x] fix: add TPivotModel default and define pivot property in {Belongs,Morph}ToMany by [@calebdw](https://github.com/calebdw) in https://github.com/laravel/framework/pull/55086
 * [12.x] remove `@return` docblocks on constructors by [@browner12](https://github.com/browner12) in https://github.com/laravel/framework/pull/55076
-* [12.x] Add NamedScope attribute by [@shaedrich](https://github.com/shaedrich) in https://github.com/laravel/framework/pull/54450
+* [12.x] Add Scope attribute by [@shaedrich](https://github.com/shaedrich) in https://github.com/laravel/framework/pull/54450
 * [12.x] Improve syntax highlighting for stub type files by [@kayw-geek](https://github.com/kayw-geek) in https://github.com/laravel/framework/pull/55094
 * [12.x] Prefer `new Collection` over `Collection::make` by [@AhmedAlaa4611](https://github.com/AhmedAlaa4611) in https://github.com/laravel/framework/pull/55091
 * [12.x] Fix except() method to support casted values by [@vishal2931](https://github.com/vishal2931) in https://github.com/laravel/framework/pull/55124

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1533,7 +1533,7 @@ class Builder implements BuilderContract
             // Next we'll pass the scope callback to the callScope method which will take
             // care of grouping the "wheres" properly so the logical order doesn't get
             // messed up when adding scopes. Then we'll return back out the builder.
-            $builder = $builder->callScope(
+            $builder = $builder->callNamedScope(
                 $scope, Arr::wrap($parameters)
             );
         }
@@ -1615,10 +1615,10 @@ class Builder implements BuilderContract
      * @param  array  $parameters
      * @return mixed
      */
-    protected function callScope($scope, array $parameters = [])
+    protected function callNamedScope($scope, array $parameters = [])
     {
         return $this->callScope(function (...$parameters) use ($scope) {
-            return $this->model->callScope($scope, $parameters);
+            return $this->model->callNamedScope($scope, $parameters);
         }, $parameters);
     }
 
@@ -2228,7 +2228,7 @@ class Builder implements BuilderContract
         }
 
         if ($this->hasScope($method)) {
-            return $this->callScope($method, $parameters);
+            return $this->callNamedScope($method, $parameters);
         }
 
         if (in_array(strtolower($method), $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1507,9 +1507,9 @@ class Builder implements BuilderContract
      * @param  string  $scope
      * @return bool
      */
-    public function hasNamedScope($scope)
+    public function hasScope($scope)
     {
-        return $this->model && $this->model->hasNamedScope($scope);
+        return $this->model && $this->model->hasScope($scope);
     }
 
     /**
@@ -1533,7 +1533,7 @@ class Builder implements BuilderContract
             // Next we'll pass the scope callback to the callScope method which will take
             // care of grouping the "wheres" properly so the logical order doesn't get
             // messed up when adding scopes. Then we'll return back out the builder.
-            $builder = $builder->callNamedScope(
+            $builder = $builder->callScope(
                 $scope, Arr::wrap($parameters)
             );
         }
@@ -1615,10 +1615,10 @@ class Builder implements BuilderContract
      * @param  array  $parameters
      * @return mixed
      */
-    protected function callNamedScope($scope, array $parameters = [])
+    protected function callScope($scope, array $parameters = [])
     {
         return $this->callScope(function (...$parameters) use ($scope) {
-            return $this->model->callNamedScope($scope, $parameters);
+            return $this->model->callScope($scope, $parameters);
         }, $parameters);
     }
 
@@ -2227,8 +2227,8 @@ class Builder implements BuilderContract
             return $callable(...$parameters);
         }
 
-        if ($this->hasNamedScope($method)) {
-            return $this->callNamedScope($method, $parameters);
+        if ($this->hasScope($method)) {
+            return $this->callScope($method, $parameters);
         }
 
         if (in_array(strtolower($method), $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1735,7 +1735,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string  $scope
      * @return bool
      */
-    public function hasNamedScope($scope)
+    public function hasScope($scope)
     {
         return method_exists($this, 'scope'.ucfirst($scope)) ||
             static::isScopeMethodWithAttribute($scope);
@@ -1748,7 +1748,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $parameters
      * @return mixed
      */
-    public function callNamedScope($scope, array $parameters = [])
+    public function callScope($scope, array $parameters = [])
     {
         if ($this->isScopeMethodWithAttribute($scope)) {
             return $this->{$scope}(...$parameters);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1748,7 +1748,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $parameters
      * @return mixed
      */
-    public function callScope($scope, array $parameters = [])
+    public function callNamedScope($scope, array $parameters = [])
     {
         if ($this->isScopeMethodWithAttribute($scope)) {
             return $this->{$scope}(...$parameters);

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -29,10 +29,10 @@ class DatabaseEloquentLocalScopesTest extends TestCase
     {
         $model = new EloquentLocalScopesTestModel;
 
-        $this->assertTrue($model->hasNamedScope('active'));
-        $this->assertTrue($model->hasNamedScope('type'));
+        $this->assertTrue($model->hasScope('active'));
+        $this->assertTrue($model->hasScope('type'));
 
-        $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+        $this->assertFalse($model->hasScope('nonExistentLocalScope'));
     }
 
     public function testLocalScopeIsApplied()

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -12,21 +12,21 @@ class EloquentModelScopeTest extends DatabaseTestCase
     {
         $model = new TestScopeModel1;
 
-        $this->assertTrue($model->hasNamedScope('exists'));
+        $this->assertTrue($model->hasScope('exists'));
     }
 
     public function testModelDoesNotHaveScope()
     {
         $model = new TestScopeModel1;
 
-        $this->assertFalse($model->hasNamedScope('doesNotExist'));
+        $this->assertFalse($model->hasScope('doesNotExist'));
     }
 
     public function testModelHasAttributedScope()
     {
         $model = new TestScopeModel1;
 
-        $this->assertTrue($model->hasNamedScope('existsAsWell'));
+        $this->assertTrue($model->hasScope('existsAsWell'));
     }
 }
 

--- a/tests/Integration/Database/EloquentScopeAttributeTest.php
+++ b/tests/Integration/Database/EloquentScopeAttributeTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[WithMigration]
 class EloquentScopeAttributeTest extends TestCase
 {
-    protected $query = 'select * from "named_scope_users" where "email_verified_at" is not null';
+    protected $query = 'select * from "scope_users" where "email_verified_at" is not null';
 
     protected function setUp(): void
     {
@@ -22,7 +22,7 @@ class EloquentScopeAttributeTest extends TestCase
     }
 
     #[DataProvider('scopeDataProvider')]
-    public function test_it_can_query_named_scoped_from_the_query_builder(string $methodName)
+    public function test_it_can_query_scoped_from_the_query_builder(string $methodName)
     {
         $query = Fixtures\ScopeUser::query()->{$methodName}(true);
 
@@ -30,7 +30,7 @@ class EloquentScopeAttributeTest extends TestCase
     }
 
     #[DataProvider('scopeDataProvider')]
-    public function test_it_can_query_named_scoped_from_static_query(string $methodName)
+    public function test_it_can_query_scoped_from_static_query(string $methodName)
     {
         $query = Fixtures\ScopeUser::{$methodName}(true);
 

--- a/tests/Integration/Database/EloquentScopeAttributeTest.php
+++ b/tests/Integration/Database/EloquentScopeAttributeTest.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[WithMigration]
-class EloquentNamedScopeAttributeTest extends TestCase
+class EloquentScopeAttributeTest extends TestCase
 {
     protected $query = 'select * from "named_scope_users" where "email_verified_at" is not null';
 
@@ -24,7 +24,7 @@ class EloquentNamedScopeAttributeTest extends TestCase
     #[DataProvider('scopeDataProvider')]
     public function test_it_can_query_named_scoped_from_the_query_builder(string $methodName)
     {
-        $query = Fixtures\NamedScopeUser::query()->{$methodName}(true);
+        $query = Fixtures\ScopeUser::query()->{$methodName}(true);
 
         $this->assertSame($this->query, $query->toRawSql());
     }
@@ -32,7 +32,7 @@ class EloquentNamedScopeAttributeTest extends TestCase
     #[DataProvider('scopeDataProvider')]
     public function test_it_can_query_named_scoped_from_static_query(string $methodName)
     {
-        $query = Fixtures\NamedScopeUser::{$methodName}(true);
+        $query = Fixtures\ScopeUser::{$methodName}(true);
 
         $this->assertSame($this->query, $query->toRawSql());
     }

--- a/tests/Integration/Database/Fixtures/ScopeUser.php
+++ b/tests/Integration/Database/Fixtures/ScopeUser.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Integration\Database\Fixtures;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
-class NamedScopeUser extends User
+class ScopeUser extends User
 {
     /** {@inheritdoc} */
     #[\Override]


### PR DESCRIPTION
Continuation of: #57478

---

A quick GitHub search showed other instances of **NamedScope**.