### PR TITLE
[12.x] Emit underlying store name in cache events when using failover

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -257,7 +257,7 @@ class CacheManager implements FactoryContract
             $this,
             $this->app->make(DispatcherContract::class),
             $config['stores']
-        ));
+        ), ['events' => false, ...$config]);
     }
 
     /**

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -195,10 +195,10 @@ class FailoverStore extends TaggableStore implements LockProvider
     /**
      * Get the cache store for the given store name.
      *
-     * @return \Illuminate\Contracts\Cache\Store
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function store(string $store)
     {
-        return $this->cache->store($store)->getStore();
+        return $this->cache->store($store);
     }
 }


### PR DESCRIPTION
When using the failover cache, currently the cache events have a null `storeName`:

```php
Event::listen([
    CacheHit::class,
    CacheMissed::class,
], dump(...));

Cache::store('failover')->remember('time', 10, fn () => now()->toDateTimeString());


Illuminate\Cache\Events\CacheHit {
  +storeName: null
  +key: "time"
  +tags: []
  +value: "2025-10-23 06:11:09"
}
```

This is because the failover config is not currently passed to the `Illuminate\Cache\Respository` instance.

However, if we were to just pass the config, then the events would have the name `failover`, which I don't think is ideal:

```php
Illuminate\Cache\Events\CacheHit {
  +storeName: "failover"
  +key: "time"
  +tags: []
  +value: "2025-10-23 06:14:18"
}
```

Instead, this PR disables events for the repository that wraps the `FailoverStore` store, and modifies it to call the underlying repositories, instead of the underlying stores, so that cache events are emitted with the underlying store name:

```php
Illuminate\Cache\Events\CacheHit {
  +storeName: "database"
  +key: "time"
  +tags: []
  +value: "2025-10-23 06:16:30"
}
```

This is similar to the `MemoizedStore` which also disables events for itself, and calls the underlying repository, rather than the underlying store.