### PR TITLE
[12.x] Fix incorrect docblock

### DIFF
--- a/src/Illuminate/Queue/Events/QueueFailedOver.php
+++ b/src/Illuminate/Queue/Events/QueueFailedOver.php
@@ -8,7 +8,7 @@ class QueueFailedOver
      * Create a new event instance.
      *
      * @param  string  $connectionName  The queue connection that failed.
-     * @param  \Closure|string|object  $job  The job instance.
+     * @param  mixed  $command  The command that was being processed.
      */
     public function __construct(
         public ?string $connectionName,


### PR DESCRIPTION
Description
---
The docblock referenced a `$job` parameter with types `\Closure|string|object`, but the constructor actually defines a `$command` parameter of type `mixed`.

This PR updates the docblock to reflect the constructor's parameters and types.

Note
---
- I'm not entirely sure about the accuracy of the new description for `$command`.
- This entire class was newly introduced in: #57341.