### PR TITLE
[13.x] enhancement/feat: add securityCheck parameter to previousPath method for optional security enhancement

### DIFF
--- a/tests/Routing/RoutingUrlGeneratorPreviousPathTest.php
+++ b/tests/Routing/RoutingUrlGeneratorPreviousPathTest.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\UrlGenerator;
+use PHPUnit\Framework\TestCase;
+
+class RoutingUrlGeneratorPreviousPathTest extends TestCase
+{
+    protected function getUrlGenerator($referer = null, $host = 'www.foo.com', $scheme = 'http')
+    {
+        $routes = new RouteCollection;
+
+        $request = Request::create("{$scheme}://{$host}/");
+
+        if ($referer) {
+            $request->headers->set('referer', $referer);
+        }
+
+        return new UrlGenerator($routes, $request);
+    }
+
+    public function testPreviousPathWithSameDomainUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/bar/baz?query=value');
+
+        $this->assertSame('/bar/baz', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainRootUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainUrlAndQueryString()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/products/123?category=electronics&sort=price');
+
+        $this->assertSame('/products/123', $url->previousPath());
+    }
+
+    public function testPreviousPathWithSameDomainUrlAndFragment()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/docs/api#authentication');
+
+        $this->assertSame('/docs/api#authentication', $url->previousPath());
+    }
+
+    // backward compatibility tests - non-secure mode (old behavior)
+    public function testPreviousPathBackwardCompatibilityWithCrossDomain()
+    {
+        $url = $this->getUrlGenerator('http://evil.com/malicious');
+
+        $this->assertSame('http://evil.com/malicious', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwardCompatibilityWithJavascriptSchemes()
+    {
+        $url = $this->getUrlGenerator('javascript:alert("xss")');
+
+        $this->assertSame('/javascript:alert("xss")', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwardCompatibilityWithDataSchemes()
+    {
+        $url = $this->getUrlGenerator('data:text/html,<script>alert("xss")</script>');
+
+        $this->assertSame('/data:text/html,<script>alert("xss")</script>', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwaCompatibilityWithDifferentSchemes()
+    {
+        $url = $this->getUrlGenerator('https://www.foo.com/secure/area', 'www.foo.com', 'http');
+
+        $this->assertSame('https://www.foo.com/secure/area', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwardCompatibilityWithSubdomains()
+    {
+        $url = $this->getUrlGenerator('http://sub.foo.com/malicious');
+
+        $this->assertSame('http://sub.foo.com/malicious', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwardCompatibilityWithDifferentPorts()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com:8080/admin', 'www.foo.com', 'http');
+
+        $this->assertSame(':8080/admin', $url->previousPath());
+    }
+
+    public function testPreviousPathBackwardCompatibilityWithExternalUrlAndFallback()
+    {
+        $url = $this->getUrlGenerator('https://evil.com/malicious');
+
+        $this->assertSame('https://evil.com/malicious', $url->previousPath('/dashboard'));
+    }
+
+    // secure mode tests - enhanced behavior with secure flag
+    public function testPreviousPathSecureModeWithSameDomainUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/bar/baz?secure=true');
+
+        $this->assertSame('/bar/baz', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithSameDomainUrlAndFragment()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/docs/api#authentication');
+
+        $this->assertSame('/docs/api', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithCrossDomain()
+    {
+        $url = $this->getUrlGenerator('http://evil.com/malicious');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithJavascriptSchemes()
+    {
+        $url = $this->getUrlGenerator('javascript:alert("xss")');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithDataSchemes()
+    {
+        $url = $this->getUrlGenerator('data:text/html,<script>alert("xss")</script>');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithFileSchemes()
+    {
+        $url = $this->getUrlGenerator('file:///etc/passwd');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeWithFallback()
+    {
+        $url = $this->getUrlGenerator('http://evil.com/malicious');
+
+        $this->assertSame('/home', $url->previousPath('/home', true));
+    }
+
+    public function testPreviousPathSecureModeBlocksExternalDomain()
+    {
+        $url = $this->getUrlGenerator('https://evil-site.com/malicious/path');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksExternalDomainWithAnyPaths()
+    {
+        $url = $this->getUrlGenerator('https://attacker.com/admin/users');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksDifferentScheme()
+    {
+        $url = $this->getUrlGenerator('https://www.foo.com/secure/area', 'www.foo.com', 'http');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeAllowsSameSchemeWithPaths()
+    {
+        $url = $this->getUrlGenerator('https://www.foo.com/secures/area', 'www.foo.com', 'https');
+
+        $this->assertSame('/secures/area', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksSubdomainAttack()
+    {
+        $url = $this->getUrlGenerator('http://sub.foo.com/malicious');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksDifferentPortBasedAttack()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com:8080/admin', 'www.foo.com', 'http');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeAllowsSameDomainWithSamePortUrl()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com:8080/allowed', 'www.foo.com:8080', 'http');
+
+        $this->assertSame('/allowed', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksDataUri()
+    {
+        $url = $this->getUrlGenerator('data:text/html,<script>alert("xss")</script>');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksJavascriptUri()
+    {
+        $url = $this->getUrlGenerator('javascript:alert("xss")');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeAllowsJavascriptUriIfOriginIsSame()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/javascript:alert("same-origin")', 'www.foo.com');
+
+        $this->assertSame('/javascript:alert("same-origin")', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeBlocksFileUri()
+    {
+        $url = $this->getUrlGenerator('file:///etc/passwd');
+
+        $this->assertSame('/', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathHandlesEmptyReferer()
+    {
+        $url = $this->getUrlGenerator('');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesNullReferer()
+    {
+        $url = $this->getUrlGenerator(null);
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathSecureModeWithFallbackForExternalUrl()
+    {
+        $url = $this->getUrlGenerator('https://evil.com/malicious');
+
+        $this->assertSame('/dashboard', $url->previousPath('/dashboard', true));
+    }
+
+    public function testPreviousPathSecureModeAllowsFileUriIfOriginIsSame()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/file:///etc/same');
+
+        $this->assertSame('/file:///etc/same', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathNormalizesTrailingSlashes()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path/to/resource/');
+
+        $this->assertSame('/path/to/resource', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesDeepNestedPaths()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/level1/level2/level3/level4/list');
+
+        $this->assertSame('/level1/level2/level3/level4/list', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesSpecialCharactersInPath()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path-with-dashes/under_scores/123');
+
+        $this->assertSame('/path-with-dashes/under_scores/123', $url->previousPath());
+    }
+
+    public function testPreviousPathSecureModeHandlesCaseInsensitiveHost()
+    {
+        $url = $this->getUrlGenerator('http://WWW.FOO.COM/path', 'www.foo.com');
+
+        $this->assertSame('/path', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathSecureModeHandlesCaseVariations()
+    {
+        $url = $this->getUrlGenerator('http://www.FOO.com/path', 'www.foo.com');
+
+        $this->assertSame('/path', $url->previousPath(false, true));
+    }
+
+    public function testPreviousPathHandlesUrlWithoutPath()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com');
+
+        $this->assertSame('/', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesComplexQueryString()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/search?q=php&framework=laravel&sort=popularity&page=34');
+
+        $this->assertSame('/search', $url->previousPath());
+    }
+
+    public function testPreviousPathHandlesEncodedCharacters()
+    {
+        $url = $this->getUrlGenerator('http://www.foo.com/path%20with%20spaces%20encoded/resource');
+
+        $this->assertSame('/path%20with%20spaces%20encoded/resource', $url->previousPath());
+    }
+
+    public function testIsSameOriginMethod()
+    {
+        $url = $this->getUrlGenerator();
+
+        $reflection = new \ReflectionClass($url);
+        $method = $reflection->getMethod('isSameOrigin');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(
+            $url,
+            ['host' => 'www.foo.com', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // different host
+        $this->assertFalse($method->invoke(
+            $url,
+            ['host' => 'evil.com', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // different scheme
+        $this->assertFalse($method->invoke(
+            $url,
+            ['host' => 'www.foo.com', 'scheme' => 'https'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+
+        // missing component
+        $this->assertFalse($method->invoke($url, false, ['host' => 'www.foo.com', 'scheme' => 'http']));
+        $this->assertFalse($method->invoke($url, ['host' => 'www.foo.com'], ['host' => 'www.foo.com', 'scheme' => 'http']));
+
+        // case insensitive
+        $this->assertTrue($method->invoke(
+            $url,
+            ['host' => 'WWW.FOO.COM', 'scheme' => 'http'],
+            ['host' => 'www.foo.com', 'scheme' => 'http']
+        ));
+    }
+}


### PR DESCRIPTION
### Optional `$securityCheck` parameter for the `previousPath()` method

This PR brings a **security enhancement** to the `previousPath()` method in `UrlGenerator` with better security check and origin validation, which resolves the issue [#57456](https://github.com/laravel/framework/issues/57456). 
This is an improved version of the PR [#57487](https://github.com/laravel/framework/pull/57487) - as @taylorotwell stated that this change can be a **breaking change** for some devs, so now I developed it as an **opt-in** feature with a new parameter `$securityCheck` and I am submitting this into the `master` branch as a a security enhancement/feature for the next major release **v13**. Details are below.

### Issue Summary

<img width="635" height="465" alt="Screenshot 2025-10-22 at 1 57 03 PM" src="https://github.com/user-attachments/assets/84eddb1f-2cd9-4fde-8635-4b3859ecb177" />

The `previousPath()` method is expected to return only the **path** of the previous URL (the doc SS attached for clarity). However, the existing implementation in `previousPath()` method returns the URL, when the request origin is different from the app origin. This happened because it extracted the path from the previous URL without checking that the request originated from the *same origin or not* and the path extracting logic *only worked for the same origin* requests. So, this was making applications open to potential security issues including:
- **Open redirect attacks** via external domains in the referrer header
- **XSS attacks** through dangerous URI schemes (`javascript:`, `data:` etc)
- **Protocol confusion attacks** using different schemes (http vs https) 

And considering these potential security implications of returning the full external URL, I brought this change as a **security enhancement** to provide developers with more control over the previous URL path.


### Solution in Brief

I have added a new parameter `$securityCheck` to the `previousPath()` method, which when set to `true`, will enable the security checks to *validate the origin of the previous URL* and also check if that URL path is dangerous or not. If the origin is different from the app origin or detects as dangerous, the method will return the fallback value or the root path (`/`) instead of the previous URL path.
And, if the parameter is set to `false` (which I kept as the `default` value), the method will work exactly as it did before, returning the previous URL path like before without any security checks, thus **bringing no change in the behavior**.

So, this implementation provides a **fully backward-compatible, and opt-in security enhancement** for the `previousPath()` method:

1. **Backward Compatibility**: The `previousPath()` method maintains the **existing/old behavior by default** - no breaking changes.
2. **Opt-in Security**: Added an optional `$securityCheck` parameter (`previousPath($fallback = false, $securityCheck = false)`)
3. **Enhanced Security Checks** (when enabled):
   - **Origin Validation**: Same-origin checking with host matching (case-insensitive), scheme consistency, and port validation
   - **Dangerous URL Detection**: Protection against malicious URI schemes (`javascript:`, `data:`, `file:`), when origin is different from the app origin.
   - **Updated URL Parsing**: Uses built-in `parse_url()` for reliability

### New Changes Benefits

- **Zero Breaking Changes**: Existing code continues to work exactly as before
- **Opt-in Security**: If developers want, they can choose when to enable security checks via the `$securityCheck` parameter
- **Comprehensive Protection**: When enabled, prevents open redirect vulnerabilities, XSS attacks, and protocol confusion attacks
- **Future-Proof**: Provides a migration path for future Laravel versions where security could become the default
- **Better DX**: Developers can rely on the method to get a more secure previous path, when they enable the security checks.

### Test Coverage

Added comprehensive tests covering both backward compatibility and security modes:

**Backward Compatibility Tests:**
- Existing behavior preserved for all current use cases
- External domains, different schemes, and dangerous URIs work as before in the default mode
- *No chance* of breaking changes for existing applications using the method

**Security Mode Tests:**
- Same-origin URL validation and external domain blocking
- Dangerous URI scheme detection (`javascript:`, `data:`,  `file:`)
- Port-based and protocol confusion attack prevention
- Empty/ null referrer handling and case-insensitive host validation
- Complex query strings, URL encoding, and special characters
- Fallback behavior verification and path extraction accuracy

### Implementation Details

As stated above, when the optional `$securityCheck` parameter is enabled by devs, then the method applies extra security validations while maintaining the same API contract.

**Usage Examples:**
```php
// Default behavior (backward compatible)
$path = $url->previousPath(); // securityCheck = false by default and the logic remains the same as before

// with security checks enabled
$path = $url->previousPath(fallback: '/', securityCheck: true);
```

**Note:** This change is designed for the **master branch (next major release)** to provide developers time to adopt the security enhancements. The opt-in approach ensures no immediate breaking changes while offering a clear migration path for enhanced security and better DX. Hope this helps the devs in their future projects. 

Let me know if you need any further clarification or tests from my side or if u have any suggestions to improve my approach. Thank you.
