### PR TITLE
[12.x] Feature/cache flexible forever

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -527,6 +527,23 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Retrieve an item from the cache by key, refreshing it in the background if it is stale, with a fixed "forever-like" higher ttl.
+     *
+     * @template TCacheValue
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
+     * @param  (callable(): TCacheValue)  $callback
+     * @param  array{ seconds?: int, owner?: string }|null  $lock
+     * @param  bool  $alwaysDefer
+     * @return TCacheValue
+     */
+    public function flexibleForever($key, $ttl, $callback, $lock = null, $alwaysDefer = false)
+    {
+        return $this->flexible($key, [$ttl, Carbon::now()->addYears(1000)], $callback, $lock, $alwaysDefer);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key


### PR DESCRIPTION
## Problem

As a developer I would like to be able to use `Cache::forever` with a flexible approach to trigger background refreshes.

By definition, `Cache::forever` never automatically refreshes the value unless manually handled via application logic.

## Proposal

We add a `flexibleForever` utility method to cache Repository which can serve stale values while triggering deferred refreshing (leveraging the new `Cache::flexible` method).

The new method exposes the same signature as `Cache::remember` while implementing a flexible version of `Cache::forever`
 
```php
public function flexibleForever($key, $refreshTtl, $callback, $lock = null, $alwaysDefer = false)
{
   return $this->flexible($key, [$refreshTtl, Carbon::now()->addYears(1000)], $callback, $lock, $alwaysDefer);
}
```

Of course the same result could be achieved at application level via registering a macro in `AppServiceProvider`

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        // [...]

        Cache::macro('flexibleForever', function (string $key, int $ttl, callable $generator) {
            return Cache::flexible($key, [$ttl, Carbon::now()->addYears(1000)], $generator);
        });
    }
}
```

or via simply calling `Cache::flexible` with a fixed, high upper ttl.