### PR TITLE
[12.x] Use separate lock directory to prevent key collisions in file cache

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -55,7 +55,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
-            'lock_path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/locks'),
         ],
 
         'memcached' => [

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -216,10 +216,12 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
+        $locksDir = $this->lockDirectory ?? ($this->directory.'/locks');
+
+        $this->ensureCacheDirectoryExists($locksDir);
 
         return new FileLock(
-            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
+            new static($this->files, $locksDir, $this->filePermission),
             $name,
             $seconds,
             $owner


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/57455

### Fix: file cache lock collision with identical keys

- Prevents collisions between file cache entries and locks when using the same key.
- Locks now use a separate directory by default, consistent with Redis/DB behavior.
- Adds a test to verify `Cache::remember()` returns the cached value when a lock exists with the same key.