### PR TITLE
[12.x] Feature: get models from a request array

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Support\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use stdClass;
 
 use function Illuminate\Support\enum_value;
@@ -358,6 +360,26 @@ trait InteractsWithData
     protected function isBackedEnum($enumClass)
     {
         return enum_exists($enumClass) && method_exists($enumClass, 'tryFrom');
+    }
+
+    /**
+     * Retrieve data from the instance as a collection of models.
+     *
+     * @param  string  $key
+     * @param  class-string  $modelClass
+     * @return Collection<Model>
+     *
+     * @throws InvalidArgumentException
+     */
+    public function models($key, $modelClass)
+    {
+        if (! in_array(Model::class, class_parents($modelClass))) {
+            throw new InvalidArgumentException('Model class should be a child of Illuminate\Database\Eloquent\Model');
+        }
+
+        $routeKeyName = (new $modelClass)->getRouteKeyName();
+
+        return $modelClass::whereIn($routeKeyName, $this->array($key))->get();
     }
 
     /**


### PR DESCRIPTION
It happens quite a lot that I need to have a collection of models that are send in via an array in a form. For example when I am selecting the persons I need to assign a meal to. In my controller I often write this code:

```php
$persons = Person::whereIn('uuid', $request->array('persons'))->get();
 ```

Since we have nice helpers to return Collections or Enums, I would like to suggest to add the `models` method to the requests. It make the code a little bit nicer, like we try to do every single day.

With this pull request, we can get our collection of models that match the given model identifiers with like this:
```php
$persons = $request->models('persons', Person::class);
 ```

It checks if the given class is a child of the `Illuminate\Database\Eloquent\Model` class. Otherwise it throws an exception.