### PR TITLE
[12.x] Fix/file cache lock collision

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -55,7 +55,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
-            'lock_path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/locks'),
         ],
 
         'memcached' => [

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -216,10 +216,12 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
+        $locksDir = $this->lockDirectory ?? ($this->directory.'/locks');
+
+        $this->ensureCacheDirectoryExists($locksDir);
 
         return new FileLock(
-            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
+            new static($this->files, $locksDir, $this->filePermission),
             $name,
             $seconds,
             $owner

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Sleep;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use Throwable;
 
 #[WithConfig('cache.default', 'file')]
 class FileCacheLockTest extends TestCase
@@ -15,6 +16,9 @@ class FileCacheLockTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->app['config']->set('cache.default', 'file');
+        $this->app['config']->set('cache.stores.file.lock_path', storage_path('framework/cache/locks'));
 
         // flush lock from previous tests
         Cache::lock('foo')->forceRelease();
@@ -100,6 +104,18 @@ class FileCacheLockTest extends TestCase
         $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
+    public function testCacheRememberReturnsValueWhenLockWithSameKeyExists()
+    {
+        $lock = Cache::lock('my-key', 5);
+        $this->assertTrue($lock->get());
+
+        $value = Cache::remember('my-key', 60, fn () => 'expected-value');
+
+        $this->assertSame('expected-value', $value);
+
+        $lock->release();
+    }
+
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
     {
         $firstLock = Cache::lock('foo', 10);
@@ -122,5 +138,15 @@ class FileCacheLockTest extends TestCase
         // try to get lock and hit block timeout
         $this->expectException(LockTimeoutException::class);
         Cache::lock('foo', 10)->block(5);
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            Cache::lock('foo')->forceRelease();
+        } catch (Throwable) {
+        }
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/57455

### Fix: file cache lock collision with identical keys

- Prevents collisions between file cache entries and locks when using the same key.
- Locks now use a separate directory by default, consistent with Redis/DB behavior.
- Adds a test to verify `Cache::remember()` returns the cached value when a lock exists with the same key.