### PR TITLE
[12.x] Docblock mismatch in QueueFailedOver constructor

### DIFF
--- a/src/Illuminate/Queue/Events/QueueFailedOver.php
+++ b/src/Illuminate/Queue/Events/QueueFailedOver.php
@@ -10,7 +10,8 @@ class QueueFailedOver
      * Create a new event instance.
      *
      * @param  string  $connectionName  The queue connection that failed.
-     * @param  \Closure|string|object  $job  The job instance.
+     * @param This needs to be updated...
+     * @param We need another line for $exception...
      */
     public function __construct(
         public ?string $connectionName,


### PR DESCRIPTION
Description
---
The constructor's docblock currently lists parameters that don't match the actual signature.

I'm opening this PR to highlight the mismatch so the maintainers can decide the correct parameter descriptions and types.