### PR TITLE
[12.x] Namespace file cache lock keys

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -55,7 +55,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
-            'lock_path' => storage_path('framework/cache/locks'),
+            'lock_path' => storage_path('framework/cache/data'),
         ],
 
         'memcached' => [

--- a/config/cache.php
+++ b/config/cache.php
@@ -55,7 +55,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
-            'lock_path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/locks'),
         ],
 
         'memcached' => [

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -216,10 +216,12 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
+        $locksDir = $this->lockDirectory ?? ($this->directory.'/locks');
+
+        $this->ensureCacheDirectoryExists($locksDir);
 
         return new FileLock(
-            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
+            new static($this->files, $locksDir, $this->filePermission),
             $name,
             $seconds,
             $owner

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -218,7 +218,7 @@ class FileStore implements Store, LockProvider
     {
         $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
 
-        $lockName = "illuminate:cache:lock:{$name}";
+        $lockName = "{$name}:file-store-lock";
 
         return new FileLock(
             new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -216,13 +216,15 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $locksDir = $this->lockDirectory ?? ($this->directory.'/locks');
+        $locksDir = $this->lockDirectory ?? $this->directory;
 
         $this->ensureCacheDirectoryExists($locksDir);
 
+        $lockName = "illuminate:cache:lock:{$name}";
+
         return new FileLock(
             new static($this->files, $locksDir, $this->filePermission),
-            $name,
+            $lockName,
             $seconds,
             $owner
         );

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -216,14 +216,12 @@ class FileStore implements Store, LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        $locksDir = $this->lockDirectory ?? $this->directory;
-
-        $this->ensureCacheDirectoryExists($locksDir);
+        $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
 
         $lockName = "illuminate:cache:lock:{$name}";
 
         return new FileLock(
-            new static($this->files, $locksDir, $this->filePermission),
+            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
             $lockName,
             $seconds,
             $owner

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -218,11 +218,9 @@ class FileStore implements Store, LockProvider
     {
         $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
 
-        $lockName = "{$name}:file-store-lock";
-
         return new FileLock(
             new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
-            $lockName,
+            "file-store-lock:{$name}",
             $seconds,
             $owner
         );

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Sleep;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
+use Throwable;
 
 #[WithConfig('cache.default', 'file')]
 class FileCacheLockTest extends TestCase
@@ -15,6 +16,9 @@ class FileCacheLockTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->app['config']->set('cache.default', 'file');
+        $this->app['config']->set('cache.stores.file.lock_path', storage_path('framework/cache/locks'));
 
         // flush lock from previous tests
         Cache::lock('foo')->forceRelease();
@@ -100,6 +104,18 @@ class FileCacheLockTest extends TestCase
         $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
+    public function testCacheRememberReturnsValueWhenLockWithSameKeyExists()
+    {
+        $lock = Cache::lock('my-key', 5);
+        $this->assertTrue($lock->get());
+
+        $value = Cache::remember('my-key', 60, fn () => 'expected-value');
+
+        $this->assertSame('expected-value', $value);
+
+        $lock->release();
+    }
+
     public function testOtherOwnerDoesNotOwnLockAfterRestore()
     {
         $firstLock = Cache::lock('foo', 10);
@@ -122,5 +138,15 @@ class FileCacheLockTest extends TestCase
         // try to get lock and hit block timeout
         $this->expectException(LockTimeoutException::class);
         Cache::lock('foo', 10)->block(5);
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            Cache::lock('foo')->forceRelease();
+        } catch (Throwable) {
+        }
+
+        parent::tearDown();
     }
 }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -17,9 +17,6 @@ class FileCacheLockTest extends TestCase
     {
         parent::setUp();
 
-        $this->app['config']->set('cache.default', 'file');
-        $this->app['config']->set('cache.stores.file.lock_path', storage_path('framework/cache/locks'));
-
         // flush lock from previous tests
         Cache::lock('foo')->forceRelease();
     }


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/57455

Prevent collisions between file cache entries and cache locks when using the same key by namespacing file lock keys