### PR TITLE
[12.x] Add uniqueStrings() method to collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1789,6 +1789,33 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Return only unique items from the collection array using string comparison.
+     *
+     * @param  (callable(TValue, TKey): string)|string|null  $key
+     * @return static
+     */
+    public function uniqueStrings($key = null)
+    {
+        if (is_null($key)) {
+            return new static(array_unique($this->items, SORT_STRING));
+        }
+
+        $callback = $this->valueRetriever($key);
+
+        $exists = [];
+
+        return $this->reject(function ($item, $key) use ($callback, &$exists) {
+            $id = $callback($item, $key);
+
+            if (isset($exists[$id])) {
+                return true;
+            }
+
+            $exists[$id] = true;
+        });
+    }
+
+    /**
      * Reset the keys on the underlying array.
      *
      * @return static<int, TValue>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1761,6 +1761,31 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Return only unique items from the collection array using string comparison.
+     *
+     * @param  (callable(TValue, TKey): string)|string|null  $key
+     * @return static<TKey, TValue>
+     */
+    public function uniqueStrings($key = null)
+    {
+        $callback = $this->valueRetriever($key);
+
+        return new static(function () use ($callback) {
+            $exists = [];
+
+            foreach ($this as $key => $item) {
+                $id = $callback($item, $key);
+
+                if (! isset($exists[$id])) {
+                    yield $key => $item;
+
+                    $exists[$id] = true;
+                }
+            }
+        });
+    }
+
+    /**
      * Reset the keys on the underlying array.
      *
      * @return static<int, TValue>

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1761,6 +1761,163 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testUniqueStrings($collection)
+    {
+        $c = new $collection(['Hello', 'World', 'World', 'Hello']);
+        $this->assertEquals(['Hello', 'World'], $c->uniqueStrings()->all());
+
+        $c = new $collection(['user@example.com', 'admin@example.com', 'user@example.com']);
+        $this->assertEquals(['user@example.com', 'admin@example.com'], $c->uniqueStrings()->all());
+
+        $c = new $collection(['SKU-001', 'SKU-002', 'SKU-001', 'SKU-003']);
+        $this->assertEquals(['SKU-001', 'SKU-002', 'SKU-003'], $c->uniqueStrings()->values()->all());
+
+        $c = new $collection(['5', '10', '5', '3A', '5', '5']);
+        $this->assertEquals(['5', '10', '3A'], $c->uniqueStrings()->values()->all());
+
+        $c = new $collection([
+            'a' => 'foo',
+            'b' => 'bar',
+            'c' => 'foo',
+            'd' => 'baz',
+        ]);
+        $this->assertEquals([
+            'a' => 'foo',
+            'b' => 'bar',
+            'd' => 'baz',
+        ], $c->uniqueStrings()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testUniqueStringsWithKey($collection)
+    {
+        $c = new $collection([
+            1 => ['id' => 1, 'email' => 'taylor@example.com', 'name' => 'Taylor'],
+            2 => ['id' => 2, 'email' => 'abigail@example.com', 'name' => 'Abigail'],
+            3 => ['id' => 3, 'email' => 'taylor@example.com', 'name' => 'Taylor Otwell'],
+            4 => ['id' => 4, 'email' => 'jess@example.com', 'name' => 'Jess'],
+        ]);
+
+        $this->assertEquals([
+            1 => ['id' => 1, 'email' => 'taylor@example.com', 'name' => 'Taylor'],
+            2 => ['id' => 2, 'email' => 'abigail@example.com', 'name' => 'Abigail'],
+            4 => ['id' => 4, 'email' => 'jess@example.com', 'name' => 'Jess'],
+        ], $c->uniqueStrings('email')->all());
+
+        $c = new $collection([
+            ['user' => ['email' => 'foo@example.com']],
+            ['user' => ['email' => 'bar@example.com']],
+            ['user' => ['email' => 'foo@example.com']],
+        ]);
+
+        $result = $c->uniqueStrings('user.email')->values()->all();
+        $this->assertCount(2, $result);
+        $this->assertEquals('foo@example.com', $result[0]['user']['email']);
+        $this->assertEquals('bar@example.com', $result[1]['user']['email']);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testUniqueStringsWithCallback($collection)
+    {
+        $c = new $collection([
+            1 => ['id' => 1, 'sku' => 'SKU-001', 'name' => 'Product 1'],
+            2 => ['id' => 2, 'sku' => 'SKU-002', 'name' => 'Product 2'],
+            3 => ['id' => 3, 'sku' => 'SKU-001', 'name' => 'Product 1 Duplicate'],
+            4 => ['id' => 4, 'sku' => 'SKU-003', 'name' => 'Product 3'],
+        ]);
+
+        // Dedupe by SKU using closure
+        $this->assertEquals([
+            1 => ['id' => 1, 'sku' => 'SKU-001', 'name' => 'Product 1'],
+            2 => ['id' => 2, 'sku' => 'SKU-002', 'name' => 'Product 2'],
+            4 => ['id' => 4, 'sku' => 'SKU-003', 'name' => 'Product 3'],
+        ], $c->uniqueStrings(function ($item) {
+            return $item['sku'];
+        })->all());
+
+        // Concatenating multiple fields
+        $c = new $collection([
+            ['first' => 'Taylor', 'last' => 'Otwell'],
+            ['first' => 'Abigail', 'last' => 'Otwell'],
+            ['first' => 'Taylor', 'last' => 'Otwell'],
+            ['first' => 'Taylor', 'last' => 'Swift'],
+        ]);
+
+        $this->assertEquals([
+            ['first' => 'Taylor', 'last' => 'Otwell'],
+            ['first' => 'Abigail', 'last' => 'Otwell'],
+            ['first' => 'Taylor', 'last' => 'Swift'],
+        ], $c->uniqueStrings(function ($item) {
+            return $item['first'].$item['last'];
+        })->values()->all());
+
+        // With key parameter in closure
+        $c = new $collection([
+            'a' => ['code' => 'A1'],
+            'b' => ['code' => 'B2'],
+            'c' => ['code' => 'A1'],
+            'd' => ['code' => 'D4'],
+        ]);
+
+        $result = $c->uniqueStrings(function ($item, $key) {
+            return $item['code'];
+        })->all();
+
+        $this->assertCount(3, $result);
+        $this->assertArrayHasKey('a', $result);
+        $this->assertArrayHasKey('b', $result);
+        $this->assertArrayHasKey('d', $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testUniqueStringsPreservesKeys($collection)
+    {
+        // Numeric keys
+        $c = new $collection([
+            10 => 'apple',
+            20 => 'banana',
+            30 => 'apple',
+            40 => 'cherry',
+        ]);
+
+        $result = $c->uniqueStrings()->all();
+        $this->assertEquals([
+            10 => 'apple',
+            20 => 'banana',
+            40 => 'cherry',
+        ], $result);
+
+        // String keys
+        $c = new $collection([
+            'first' => 'foo',
+            'second' => 'bar',
+            'third' => 'foo',
+            'fourth' => 'baz',
+        ]);
+
+        $result = $c->uniqueStrings()->all();
+        $this->assertEquals([
+            'first' => 'foo',
+            'second' => 'bar',
+            'fourth' => 'baz',
+        ], $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testUniqueStringsEmptyCollection($collection)
+    {
+        $c = new $collection([]);
+        $this->assertEquals([], $c->uniqueStrings()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testUniqueStringsSingleItem($collection)
+    {
+        $c = new $collection(['only-one']);
+        $this->assertEquals(['only-one'], $c->uniqueStrings()->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCollapse($collection)
     {
         // Normal case: a two-dimensional array with different elements


### PR DESCRIPTION
Adds `uniqueStrings()` method to `Collection` and `LazyCollection` for optimized string deduplication.

Provides 5-245x performance improvement over `unique()` by using `array_unique(SORT_STRING)` and `isset()` hash lookups. Supports keys, closures, and nested properties.

```php
collect(['5', '10', '5', '3A'])->uniqueStrings(); // ['5', '10', '3A']
collect($users)->uniqueStrings('email');
collect($products)->uniqueStrings(fn($p) => $p->sku);
collect($posts)->uniqueStrings('author.email'); // nested relationships
```

Also avoids `SORT_REGULAR` instability: https://github.com/php/php-src/issues/20262

## Benchmark

Small datasets (10 items):   1-5x faster
Large datasets (10K items):  21-38x faster (up to 293x vs uniqueStrict!)

Benchmark results: https://gist.github.com/jmarble/e4bcecb63e021d48c8246dde1400ad3c
Benchmark source code: https://gist.github.com/jmarble/57746453e7a1e9cbf77c8bc2812e5e1c


