### PR TITLE
[12.x] Remove return void from Http\Client\Batch's constructor

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -116,8 +116,6 @@ class Batch
 
     /**
      * Create a new request batch instance.
-     *
-     * @return void
      */
     public function __construct(?Factory $factory = null)
     {


### PR DESCRIPTION
`@return void` was removed from class constructors' docblocks framework-wise in PR #55076.

There seems to have been an oversight on the PR that introduced the `Illuminate\Http\Client\Batch` class, which included that param in that class constructor's docblock.

This PR:

- Removes the `@return void` docblock from the `Illuminate\Http\Client\Batch` class constructor docblock.
