### PR TITLE
[12.x] Add support for query-level comments

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -263,6 +263,13 @@ class Builder implements BuilderContract
     public $useWritePdo = false;
 
     /**
+     * The comment to be added to the query.
+     *
+     * @var string
+     */
+    public $comment;
+
+    /**
      * Create a new query builder instance.
      */
     public function __construct(
@@ -4441,6 +4448,19 @@ class Builder implements BuilderContract
                 $clone->bindings[$type] = [];
             }
         });
+    }
+
+    /**
+     * Add a comment to the query
+     *
+     * @param  string  $comment
+     * @return $this
+     */
+    public function comment($comment)
+    {
+        $this->comment = $comment;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4451,7 +4451,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a comment to the query
+     * Add a comment to the query.
      *
      * @param  string  $comment
      * @return $this

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -416,11 +416,12 @@ class MySqlGrammar extends Grammar
      * @param  string  $table
      * @param  string  $columns
      * @param  string  $where
+     * @param  string  $comment
      * @return string
      */
-    protected function compileUpdateWithoutJoins(Builder $query, $table, $columns, $where)
+    protected function compileUpdateWithoutJoins(Builder $query, $table, $columns, $where, $comment)
     {
-        $sql = parent::compileUpdateWithoutJoins($query, $table, $columns, $where);
+        $sql = parent::compileUpdateWithoutJoins($query, $table, $columns, $where, $comment);
 
         if (! empty($query->orders)) {
             $sql .= ' '.$this->compileOrders($query, $query->orders);
@@ -459,11 +460,12 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $table
      * @param  string  $where
+     * @param  string  $comment
      * @return string
      */
-    protected function compileDeleteWithoutJoins(Builder $query, $table, $where)
+    protected function compileDeleteWithoutJoins(Builder $query, $table, $where, $comment)
     {
-        $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
+        $sql = parent::compileDeleteWithoutJoins($query, $table, $where, $comment);
 
         // When using MySQL, delete statements may contain order by statements and limits
         // so we will compile both of those here. Once we have finished compiling this

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -274,11 +274,12 @@ class SqlServerGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $table
      * @param  string  $where
+     * @param  string  $comment
      * @return string
      */
-    protected function compileDeleteWithoutJoins(Builder $query, $table, $where)
+    protected function compileDeleteWithoutJoins(Builder $query, $table, $where, $comment)
     {
-        $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
+        $sql = parent::compileDeleteWithoutJoins($query, $table, $where, $comment);
 
         return ! is_null($query->limit) && $query->limit > 0 && $query->offset <= 0
             ? Str::replaceFirst('delete', 'delete top ('.$query->limit.')', $sql)
@@ -393,15 +394,16 @@ class SqlServerGrammar extends Grammar
      * @param  string  $table
      * @param  string  $columns
      * @param  string  $where
+     * @param  string  $comment
      * @return string
      */
-    protected function compileUpdateWithJoins(Builder $query, $table, $columns, $where)
+    protected function compileUpdateWithJoins(Builder $query, $table, $columns, $where, $comment)
     {
         $alias = last(explode(' as ', $table));
 
         $joins = $this->compileJoins($query, $query->joins);
 
-        return "update {$alias} set {$columns} from {$table} {$joins} {$where}";
+        return "update {$alias} set {$columns} from {$table} {$joins} {$where} {$comment}";
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7092,6 +7092,34 @@ SQL;
         $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toRawSql());
     }
 
+    public function testAddingCommentToSelects()
+    {
+        $builder = $this->getBuilder();
+        $builder->comment('This is a comment')->from('users');
+        $this->assertSame('select * from "users" /* This is a comment */', $builder->toSql());
+    }
+
+    public function testAddingCommentToInserts()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) /* This is a comment */', ['foo']);
+        $builder->comment('This is a comment')->from('users')->insert(['email' => 'foo']);
+    }
+
+    public function testAddingCommentToUpdates()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "id" = ? /* This is a comment */', ['foo', 'bar', 1]);
+        $builder->comment('This is a comment')->from('users')->where('id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
+    }
+
+    public function testAddingCommentToDeletes()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "email" = ? /* This is a comment */', ['foo']);
+        $builder->comment('This is a comment')->from('users')->where('email', '=', 'foo')->delete();
+    }
+
     protected function getConnection(string $prefix = '')
     {
         $connection = m::mock(Connection::class);


### PR DESCRIPTION
This PR adds a new method to the database query builder class: `comment()`, which enables a user-defined comment string to be appended to the end of a query. 

For example, executing `DB::from('users)->comment('Getting all users')->get();` generates the following query:

```sql
select * from users /* Getting all users */
```

## Why?

Too many times, while looking at running queries in a specific database instance, I wanted to have a quick way to know where a given query is being executed. I thought that a simple comment could allow for that little extra context on where it's running, much like code comments.

I honestly don't know if all other database engines strip away these comments, but the one I use the most (MySQL) seems to show this information when running `show full processlist`.

## Docs

If this PR gets merged, I'll open a PR to update the docs.