### PR TITLE
bug extractFilesFromDataArray  Refactor file extraction logic in Make…

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -682,7 +682,10 @@ trait MakesHttpRequests
             }
 
             if (is_array($value)) {
-                $files[$key] = $this->extractFilesFromDataArray($value);
+                $temp = $this->extractFilesFromDataArray($value);
+                if ($temp) {
+                    $files[$key] = $temp;
+                }
 
                 $data[$key] = $value;
             }


### PR DESCRIPTION
…sHttpRequests

Recursive call to extractFilesFromDataArray. Only when there is a value can it be assigned; otherwise, all elements of the two-dimensional structure will be assigned.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
