### PR TITLE
[12.x] build a fluent `Uri` object for the current URL

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -48,6 +48,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Get a URI instance of the URL for the current request.
+     */
+    public static function current(): static
+    {
+        return new static(call_user_func(static::$urlGeneratorResolver)->current());
+    }
+
+    /**
      * Get a URI instance of an absolute URL for the given path.
      */
     public static function to(string $path): static

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -10,7 +10,7 @@ class SupportUriTest extends TestCase
 {
     public function test_can_build_special_urls()
     {
-        Uri::setUrlGeneratorResolver(fn() => new CustomUrlGeneratorResolver);
+        Uri::setUrlGeneratorResolver(fn () => new CustomUrlGeneratorResolver);
 
         $this->assertEquals('https://laravel.com/current', Uri::current()->value());
         $this->assertEquals('https://laravel.com/to', Uri::to('')->value());

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -2,11 +2,24 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Support\Uri;
 use PHPUnit\Framework\TestCase;
 
 class SupportUriTest extends TestCase
 {
+    public function test_can_build_special_urls()
+    {
+        Uri::setUrlGeneratorResolver(fn() => new CustomUrlGeneratorResolver);
+
+        $this->assertEquals('https://laravel.com/current', Uri::current()->value());
+        $this->assertEquals('https://laravel.com/to', Uri::to('')->value());
+        $this->assertEquals('https://laravel.com/route', Uri::route('')->value());
+        $this->assertEquals('https://laravel.com/signed-route', Uri::signedRoute('')->value());
+        $this->assertEquals('https://laravel.com/signed-route', Uri::temporarySignedRoute('', '')->value());
+        $this->assertEquals('https://laravel.com/action', Uri::action('')->value());
+    }
+
     public function test_basic_uri_interactions()
     {
         $uri = Uri::of($originalUri = 'https://laravel.com/docs/installation');
@@ -230,5 +243,68 @@ class SupportUriTest extends TestCase
         $uri = new Uri('https://laravel.com/');
 
         $this->assertSame('https://laravel.com/foobar', (string) $uri->myMacro());
+    }
+}
+
+class CustomUrlGeneratorResolver implements UrlGenerator
+{
+    public function current()
+    {
+        return 'https://laravel.com/current';
+    }
+
+    public function previous($fallback = false)
+    {
+        // TODO: Implement previous() method.
+    }
+
+    public function to($path, $extra = [], $secure = null)
+    {
+        return 'https://laravel.com/to';
+    }
+
+    public function secure($path, $parameters = [])
+    {
+        // TODO: Implement secure() method.
+    }
+
+    public function asset($path, $secure = null)
+    {
+        // TODO: Implement asset() method.
+    }
+
+    public function route($name, $parameters = [], $absolute = true)
+    {
+        return 'https://laravel.com/route';
+    }
+
+    public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true)
+    {
+        return 'https://laravel.com/signed-route';
+    }
+
+    public function temporarySignedRoute($name, $expiration, $parameters = [], $absolute = true)
+    {
+        return 'https://laravel.com/temporary-signed-route';
+    }
+
+    public function query($path, $query = [], $extra = [], $secure = null)
+    {
+        // TODO: Implement query() method.
+    }
+
+    public function action($action, $parameters = [], $absolute = true)
+    {
+        return 'https://laravel.com/action';
+    }
+
+    public function getRootControllerNamespace()
+    {
+        // TODO: Implement getRootControllerNamespace() method.
+    }
+
+    public function setRootControllerNamespace($rootNamespace)
+    {
+        // TODO: Implement setRootControllerNamespace() method.
     }
 }


### PR DESCRIPTION
similar to `route()`, `to()`, `action()` and others, this is a helper method to generate a fluent `Uri` object for the current request's URL.

added some basic tests to make sure these helpers were all instantiating correctly. our `CustomUrlGeneratorResolver` fakes generating the desired URLs.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
