### PR TITLE
[12.x] Refactor the duplicate code by extracting it into a reusable method.

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -69,6 +69,19 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Add a route to the name lookup table if it has a name.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     */
+    protected function addToNameLookup($route)
+    {
+        if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
+            $this->nameList[$name] = $route;
+        }
+    }
+
+    /**
      * Add the route to any look-up tables if necessary.
      *
      * @param  \Illuminate\Routing\Route  $route
@@ -79,9 +92,7 @@ class RouteCollection extends AbstractRouteCollection
         // If the route has a name, we will add it to the name look-up table, so that we
         // will quickly be able to find the route associated with a name and not have
         // to iterate through every route every time we need to find a named route.
-        if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
-            $this->nameList[$name] = $route;
-        }
+        $this->addToNameLookup($route);
 
         // When the route is routing to a controller we will also store the action that
         // is used by the route. This will let us reverse route to controllers while
@@ -139,9 +150,7 @@ class RouteCollection extends AbstractRouteCollection
         $this->nameList = [];
 
         foreach ($this->allRoutes as $route) {
-            if (($name = $route->getName()) && ! $this->inNameLookup($name)) {
-                $this->nameList[$name] = $route;
-            }
+            $this->addToNameLookup($route);
         }
     }
 


### PR DESCRIPTION
**Summary**

This PR refactors repetitive logic in the `Illuminate\Routing\RouteCollection` class related to populating the `$nameList` lookup array. Previously, both `refreshNameLookups()` and `addLookups()` contained duplicated code for checking and assigning named routes to the lookup table.

✅ Improvements included in this PR:

* Extracted name lookup logic into a dedicated `addToNameLookup()` method.
* `refreshNameLookups()` now delegates to the new helper method.
* Maintains existing behavior with zero breaking changes.
* Supports better readability, extensibility, and single-responsibility adherence.

**Why?**

This cleanup:

* Removes redundancy in the name lookup initialization logic.
* Makes route registration code more maintainable.
* Helps future customization or enhancements to named routing.

**Before**

Logic duplicated inside both:

* `addLookups()`
* `refreshNameLookups()`

**After**

Single clean implementation:

* `addLookups()` → calls `addToNameLookup()`
* `refreshNameLookups()` → calls `addToNameLookup()` during iteration
* Ensures consistent behavior

**Tests**

No functional modifications, so no new tests were required. All existing route tests already pass with these changes.