### PR TITLE
[12.x] redirect response enforce same origin

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -162,27 +162,6 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Enforce the target to be the same origin as the request.
-     */
-    public function enforceSameOrigin(
-        string $fallback,
-        bool $validateScheme = true,
-        bool $validatePort = true,
-    ): static {
-        $target = Uri::of($this->targetUrl);
-        $current = Uri::of($this->request->getSchemeAndHttpHost());
-
-        if ($target->host() !== $current->host()
-            || ($validateScheme && $target->scheme() !== $current->scheme())
-            || ($validatePort && $target->port() !== $current->port())
-        ) {
-            $this->setTargetUrl($fallback);
-        }
-
-        return $this;
-    }
-
-    /**
      * Add a fragment identifier to the URL.
      *
      * @param  string  $fragment
@@ -202,6 +181,26 @@ class RedirectResponse extends BaseRedirectResponse
     public function withoutFragment()
     {
         return $this->setTargetUrl(Str::before($this->getTargetUrl(), '#'));
+    }
+
+    /**
+     * Enforce that the redirect target must have the same host as the current request.
+     */
+    public function enforceSameOrigin(
+        string $fallback,
+        bool $validateScheme = true,
+        bool $validatePort = true,
+    ): static {
+        $target = Uri::of($this->targetUrl);
+        $current = Uri::of($this->request->getSchemeAndHttpHost());
+
+        if ($target->host() !== $current->host() ||
+            ($validateScheme && $target->scheme() !== $current->scheme()) ||
+            ($validatePort && $target->port() !== $current->port())) {
+            $this->setTargetUrl($fallback);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use Illuminate\Support\ViewErrorBag;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
@@ -158,6 +159,27 @@ class RedirectResponse extends BaseRedirectResponse
         }
 
         return new MessageBag((array) $provider);
+    }
+
+    /**
+     * Enforce the target to be the same origin as the request.
+     */
+    public function enforceSameOrigin(
+        string $fallback,
+        bool   $validateScheme = true,
+        bool   $validatePort = true,
+    ): static {
+        $target = Uri::of($this->targetUrl);
+        $current = Uri::of($this->request->getSchemeAndHttpHost());
+
+        if ($target->host() !== $current->host()
+            || ($validateScheme && $target->scheme() !== $current->scheme())
+            || ($validatePort && $target->port() !== $current->port())
+        ) {
+            $this->setTargetUrl($fallback);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -166,8 +166,8 @@ class RedirectResponse extends BaseRedirectResponse
      */
     public function enforceSameOrigin(
         string $fallback,
-        bool   $validateScheme = true,
-        bool   $validatePort = true,
+        bool $validateScheme = true,
+        bool $validatePort = true,
     ): static {
         $target = Uri::of($this->targetUrl);
         $current = Uri::of($this->request->getSchemeAndHttpHost());

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -126,6 +126,15 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertSame('https://example.com/foo/bar', $response->getTargetUrl());
     }
 
+    public function testCanEnforceSameOriginWhenSameOriginAndCustomPort()
+    {
+        $response = new RedirectResponse('https://example.com:1/foo/bar');
+        $response->setRequest(Request::create('https://example.com:1/baz/buzz'));
+        $response->enforceSameOrigin('fallback');
+
+        $this->assertSame('https://example.com:1/foo/bar', $response->getTargetUrl());
+    }
+
     public function testCanEnforceSameOriginWhenNotSameScheme()
     {
         $response = new RedirectResponse('https://example.com/foo/bar');

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -117,6 +117,60 @@ class HttpRedirectResponseTest extends TestCase
         $response->withErrors($provider);
     }
 
+    public function testCanEnforceSameOriginWhenSameOrigin()
+    {
+        $response = new RedirectResponse('https://example.com/foo/bar');
+        $response->setRequest(Request::create('https://example.com/baz/buzz'));
+        $response->enforceSameOrigin('fallback');
+
+        $this->assertSame('https://example.com/foo/bar', $response->getTargetUrl());
+    }
+
+    public function testCanEnforceSameOriginWhenNotSameScheme()
+    {
+        $response = new RedirectResponse('https://example.com/foo/bar');
+        $response->setRequest(Request::create('http://example.com/baz/buzz'));
+        $response->enforceSameOrigin('fallback');
+
+        $this->assertSame('fallback', $response->getTargetUrl());
+    }
+
+    public function testCanEnforceSameOriginWhenNotSameHostname()
+    {
+        $response = new RedirectResponse('https://example.com/foo/bar');
+        $response->setRequest(Request::create('https://example2.com/baz/buzz'));
+        $response->enforceSameOrigin('fallback');
+
+        $this->assertSame('fallback', $response->getTargetUrl());
+    }
+
+    public function testCanEnforceSameOriginWhenNotSamePort()
+    {
+        $response = new RedirectResponse('https://example.com:1/foo/bar');
+        $response->setRequest(Request::create('https://example.com:2/baz/buzz'));
+        $response->enforceSameOrigin('fallback');
+
+        $this->assertSame('fallback', $response->getTargetUrl());
+    }
+
+    public function testCanEnforceSameOriginWhenNotSameSchemeAndSchemeValidationIsDisabled()
+    {
+        $response = new RedirectResponse('https://example.com/foo/bar');
+        $response->setRequest(Request::create('http://example.com/baz/buzz'));
+        $response->enforceSameOrigin('fallback', validateScheme: false);
+
+        $this->assertSame('https://example.com/foo/bar', $response->getTargetUrl());
+    }
+
+    public function testCanEnforceSameOriginWhenNotSamePortAndPortValidationIsDisabled()
+    {
+        $response = new RedirectResponse('https://example.com:1/foo/bar');
+        $response->setRequest(Request::create('https://example.com:2/baz/buzz'));
+        $response->enforceSameOrigin('fallback', validatePort: false);
+
+        $this->assertSame('https://example.com:1/foo/bar', $response->getTargetUrl());
+    }
+
     public function testSettersGettersOnRequest()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
it can be dangerous to allow user controlled data to determine a redirect target. this is something that could possibly be exploited when using something like the "referer" header to generate your target, like with our `back()` helper.  this new `enforceSameOrigin()` method forces the target URL to match the origin (scheme, host, and port) of the current request URL.

you _must_ provide a fallback (ideally an absolute URL) for if the check fails. optionally, you may disable scheme and/or port validation. you may not disable hostname validation, because honestly then what's the point?

ideally I would be able to use the `$this->request` property to directly access the scheme, host, and port, but because of how the `Request` object handles standard and non-standard ports differently than the `Uri` class, it's more reliable to turn them both into `Uri`s so we get consistent behavior to compare.

this implementation allows us to build our redirects in a composable way. We can chain on this method to any redirect response. It would likely mostly be used in conjunction with the `Redirector::back()` method, due to its use of the "referer" header. However, maybe you're using a user generated database entry like `Redirect::to($userDefinedTarget)` that you also wish limit to same origin.  This pattern gives full control.

```php
return redirect()
    ->back()
    ->enforceSameOrigin(route('dashboard'));
```

This was driven by a recent security audit my company did on our website. One of the findings, although deemed minor, was our use of the "referer" header for redirects. Our solution at the time was to remove any `back()` calls in favor of explicit routes. This feature would allow us to maintain "back" functionality while still preventing the attack vector.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
