### PR TITLE
[12.x] Stop double prefixing S3 filesystem paths

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -6,7 +6,6 @@ use Aws\S3\S3Client;
 use Illuminate\Support\Traits\Conditionable;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
 use League\Flysystem\FilesystemOperator;
-use League\Flysystem\PathPrefixer;
 
 class AwsS3V3Adapter extends FilesystemAdapter
 {

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -29,13 +29,11 @@ class AwsS3V3Adapter extends FilesystemAdapter
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config, S3Client $client)
     {
+        $config['directory_separator'] = '/';
+
         parent::__construct($driver, $adapter, $config);
 
         $this->client = $client;
-
-        $this->prefixer = isset($config['prefix'])
-            ? new PathPrefixer($this->prefixer->prefixPath($config['prefix']), '/')
-            : new PathPrefixer($config['root'] ?? '', '/');
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -752,4 +752,19 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('730bed78bccf58c2cfe44c29b71e5e6b', $filesystemAdapter->checksum('path.txt'));
         $this->assertEquals('a5c3556d', $filesystemAdapter->checksum('path.txt', ['checksum_algo' => 'crc32']));
     }
+
+    public function testUsesRightSeperatorForS3AdapterWithoutDoublePrefixing()
+    {
+        $filesystem = new FilesystemManager(new Application);
+        $filesystemAdapter = $filesystem->createS3Driver([
+            'region' => 'us-west-1',
+            'bucket' => 'laravel',
+            'root' => 'my-root',
+            'prefix' => 'someprefix',
+            'directory_separator' => '\\',
+        ]);
+
+        $path = $filesystemAdapter->path('different');
+        $this->assertEquals('my-root/someprefix/different', $path);
+    }
 }


### PR DESCRIPTION
To close: https://github.com/laravel/framework/issues/57523

The prefix is getting applied twice in the current implementation: once in construction of FilesystemAdapter and once in construction of AwsS3V3Adapter.

To me, the simplest solution is to just set the `directory_separator` property to a Unix-slash before calling the FilesystemAdapter.