### PR TITLE
[12.x] Remove @return tag from constructor

### DIFF
--- a/src/Illuminate/Validation/Rules/ProhibitedIf.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedIf.php
@@ -19,7 +19,6 @@ class ProhibitedIf implements Stringable
      * Create a new prohibited validation rule based on a condition.
      *
      * @param  (\Closure(): bool)|bool  $condition
-     * @return void
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
In PR #55076, `@return void` was removed from constructor docblocks across the framework.
This PR removes the remaining instance and confirms that no others remain.