### PR TITLE
[12.x] Feature: add diff method to `Arr`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1233,4 +1233,16 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Get the values in the first array that are not present in the other given arrays.
+     *
+     * @param  array  $array
+     * @param  array  ...$arrays
+     * @return array
+     */
+    public static function diff(array $array, array ...$arrays)
+    {
+        return array_diff($array, ...$arrays);
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1812,4 +1812,69 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testReturnsItemsThatAreNotInTheSecondArray()
+    {
+        $result = Arr::diff(['a' => 1, 'b' => 2, 'c' => 3], ['b' => 2]);
+
+        $this->assertSame(['a' => 1, 'c' => 3], $result);
+    }
+
+    public function testReturnsEmptyArrayWhenAllValuesMatch()
+    {
+        $result = Arr::diff(['a' => 1, 'b' => 2], ['b' => 2, 'a' => 1]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testHandlesMultipleArraysForDifference()
+    {
+        $result = Arr::diff(
+            ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
+            ['b' => 2],
+            ['c' => 3, 'e' => 5]
+        );
+
+        $this->assertSame(['a' => 1, 'd' => 4], $result);
+    }
+
+    public function testPreservesOriginalKeys()
+    {
+        $result = Arr::diff(['x' => 10, 'y' => 20, 'z' => 30], ['y' => 20]);
+
+        $this->assertArrayHasKey('x', $result);
+        $this->assertArrayHasKey('z', $result);
+        $this->assertSame(['x' => 10, 'z' => 30], $result);
+    }
+
+    public function testReturnsOriginalArrayWhenOtherArraysAreEmpty()
+    {
+        $result = Arr::diff(['a' => 1, 'b' => 2], []);
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+    }
+
+    public function testReturnsEmptyArrayWhenFirstArrayIsEmpty()
+    {
+        $result = Arr::diff([], ['a' => 1, 'b' => 2]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testComparesValuesLooselyLikeArrayDiff()
+    {
+        $result = Arr::diff(['a' => '2', 'b' => 3], ['a' => 2]);
+
+        $this->assertSame(['b' => 3], $result);
+    }
+
+    public function testHandlesNestedArraysAsValuesWithoutFlattening()
+    {
+        $result = Arr::diff(
+            ['a' => [1, 2], 'b' => 2],
+            ['a' => [1, 2]]
+        );
+
+        $this->assertSame(['b' => 2], $result);
+    }
 }


### PR DESCRIPTION
This PR adds a new Arr::diff() method — a simple, expressive wrapper around PHP’s array_diff().