### PR TITLE
Fix: handle ParseError in hasEvenNumberOfParentheses when Xdebug triggers malformed expression

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -618,26 +618,33 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string  $expression
      * @return bool
      */
+    /**
+     * Determine if the given expression has an even number of parentheses.
+     */
     protected function hasEvenNumberOfParentheses(string $expression)
     {
-        $tokens = token_get_all('<?php '.$expression);
+        try {
+            $tokens = token_get_all('<?php '.$expression);
+        } catch (\ParseError) {
+            // Gracefully handle malformed expressions (e.g., Xdebug interference)
+            return false;
+        }
 
         if (Arr::last($tokens) !== ')') {
             return false;
         }
 
         $opening = 0;
-        $closing = 0;
 
         foreach ($tokens as $token) {
-            if ($token == ')') {
-                $closing++;
-            } elseif ($token == '(') {
+            if ($token === '(') {
                 $opening++;
+            } elseif ($token === ')') {
+                $opening--;
             }
         }
 
-        return $opening === $closing;
+        return $opening === 0;
     }
 
     /**


### PR DESCRIPTION
### Summary
When Xdebug is enabled, `token_get_all()` may throw a `ParseError` for incomplete or malformed Blade expressions.
This causes tests or runtime Blade compilation to crash with:
```
ParseError: Unclosed '(' in BladeCompiler.php:623
```
### Fix
Added a `try/catch (\ParseError)` block around `token_get_all()` in 
`Illuminate\View\Compilers\BladeCompiler::hasEvenNumberOfParentheses`.

If a parse error occurs, the method now gracefully returns `false` instead of crashing.

### Impact
Prevents test suite and runtime crashes under Xdebug  
Keeps behavior identical for valid expressions  
No breaking changes, PSR-12 and Pint-compliant

### Related issue
Fixes #57472

