### PR TITLE
Update return type of pool method to include Throwable

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -884,7 +884,7 @@ class PendingRequest
      * Send a pool of asynchronous requests concurrently.
      *
      * @param  callable  $callback
-     * @return array<array-key, \Illuminate\Http\Client\Response>
+     * @return array<array-key, \Illuminate\Http\Client\Response|\Throwable>
      */
     public function pool(callable $callback)
     {


### PR DESCRIPTION

This pull request makes a minor update to the docblock of the `pool` method in `PendingRequest.php` to clarify that the returned array can contain both `Response` and `Throwable` objects. This improves the accuracy of the documentation for developers using this method.

- Updated the docblock return type for the `pool` method in `PendingRequest.php` to indicate it may return `Response` or `Throwable` objects.