### PR TITLE
Avoid PHP 8.2+ null deprecation in hasher check

### DIFF
--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -18,14 +18,14 @@ abstract class AbstractHasher
     /**
      * Check the given plain value against a hash.
      *
-     * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $value
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      */
     public function check(#[\SensitiveParameter] $value, $hashedValue, array $options = [])
     {
-        if (is_null($hashedValue) || strlen($hashedValue) === 0) {
+        if (!is_string($value) || $value === '' || !is_string($hashedValue) || $hashedValue === '') {
             return false;
         }
 


### PR DESCRIPTION
This PR updates the `Illuminate\Hashing\AbstractHasher::check()` method to prevent PHP 8.2+ from throwing a deprecation warning when null or non-string values are passed to `password_verify()`.

In PHP 8.2 and later, passing `null` to functions that expect `string` parameters (like `password_verify()`) is deprecated. Under some authentication edge cases, `$value` or `$hashedValue` can be `null` before validation, which triggers this warning.