### PR TITLE
[12.x] Null coalesce and `fn` in `RateLimiter::attempt()`

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -108,13 +108,9 @@ class RateLimiter
             return false;
         }
 
-        if (is_null($result = $callback())) {
-            $result = true;
-        }
+        $result = $callback() ?? true;
 
-        return tap($result, function () use ($key, $decaySeconds) {
-            $this->hit($key, $decaySeconds);
-        });
+        return tap($result, fn() => $this->hit($key, $decaySeconds));
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -110,7 +110,7 @@ class RateLimiter
 
         $result = $callback() ?? true;
 
-        return tap($result, fn() => $this->hit($key, $decaySeconds));
+        return tap($result, fn () => $this->hit($key, $decaySeconds));
     }
 
     /**


### PR DESCRIPTION
- Null coalesce felt simpler to follow than an assignment within `is_null()`
- Short function avoids needing to `use`, and is more consistent with other class methods