### PR TITLE
Refactor jsonSerialize() method to use match expression

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -961,15 +961,12 @@ trait EnumeratesValues
     public function jsonSerialize(): array
     {
         return array_map(function ($value) {
-            if ($value instanceof JsonSerializable) {
-                return $value->jsonSerialize();
-            } elseif ($value instanceof Jsonable) {
-                return json_decode($value->toJson(), true);
-            } elseif ($value instanceof Arrayable) {
-                return $value->toArray();
-            }
-
-            return $value;
+            return match (true) {
+                $value instanceof JsonSerializable => $value->jsonSerialize(),
+                $value instanceof Jsonable => json_decode($value->toJson(), true),
+                $value instanceof Arrayable => $value->toArray(),
+                default => $value,
+            };
         }, $this->all());
     }
 


### PR DESCRIPTION
# Refactor jsonSerialize() method to use match expression

## Summary
Refactored the `jsonSerialize()` method in Collection class to use PHP 8's match expression for cleaner and more readable code.

## Changes
- Replaced if-elseif chain with match expression
- Improved code readability and maintainability
- No functional changes - behavior remains identical

## Before
```php
public function jsonSerialize(): array
{
    return array_map(function ($value) {
        if ($value instanceof JsonSerializable) {
            return $value->jsonSerialize();
        } elseif ($value instanceof Jsonable) {
            return json_decode($value->toJson(), true);
        } elseif ($value instanceof Arrayable) {
            return $value->toArray();
        }
        return $value;
    }, $this->all());
}
```

## After
```php
public function jsonSerialize(): array
{
    return array_map(function ($value) {
        return match (true) {
            $value instanceof JsonSerializable => $value->jsonSerialize(),
            $value instanceof Jsonable => json_decode($value->toJson(), true),
            $value instanceof Arrayable => $value->toArray(),
            default => $value,
        };
    }, $this->all());
}
```