### PR TITLE
[12.x] Add concurrency control to Http::pool and Http::batch

### DIFF
--- a/src/Illuminate/Http/Client/Batch.php
+++ b/src/Illuminate/Http/Client/Batch.php
@@ -115,6 +115,13 @@ class Batch
     public $finishedAt = null;
 
     /**
+     * The maximum number of concurrent requests.
+     *
+     * @var int|null
+     */
+    protected $concurrencyLimit = null;
+
+    /**
      * Create a new request batch instance.
      */
     public function __construct(?Factory $factory = null)
@@ -209,6 +216,19 @@ class Batch
     }
 
     /**
+     * Set the maximum number of concurrent requests.
+     *
+     * @param  int  $limit
+     * @return Batch
+     */
+    public function concurrency(int $limit): self
+    {
+        $this->concurrencyLimit = $limit;
+
+        return $this;
+    }
+
+    /**
      * Defer the batch to run in the background after the current task has finished.
      *
      * @return \Illuminate\Support\Defer\DeferredCallback
@@ -244,7 +264,7 @@ class Batch
         }
 
         if (! empty($promises)) {
-            (new EachPromise($promises, [
+            $eachPromiseOptions = [
                 'fulfilled' => function ($result, $key) use (&$results) {
                     $results[$key] = $result;
 
@@ -285,7 +305,13 @@ class Batch
 
                     return $reason;
                 },
-            ]))->promise()->wait();
+            ];
+
+            if ($this->concurrencyLimit !== null) {
+                $eachPromiseOptions['concurrency'] = $this->concurrencyLimit;
+            }
+
+            (new EachPromise($promises, $eachPromiseOptions))->promise()->wait();
         }
 
         // Before returning the results, we must ensure that the results are sorted

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\UriTemplate\UriTemplate;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
@@ -884,17 +885,38 @@ class PendingRequest
      * Send a pool of asynchronous requests concurrently.
      *
      * @param  callable  $callback
+     * @param  int|null  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response>
      */
-    public function pool(callable $callback)
+    public function pool(callable $callback, ?int $concurrency = null)
     {
         $results = [];
 
         $requests = tap(new Pool($this->factory), $callback)->getRequests();
 
-        foreach ($requests as $key => $item) {
-            $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();
+        if ($concurrency === null) {
+            foreach ($requests as $key => $item) {
+                $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();
+            }
+
+            return $results;
         }
+
+        $promises = [];
+
+        foreach ($requests as $key => $item) {
+            $promises[$key] = $item instanceof static ? $item->getPromise() : $item;
+        }
+
+        (new EachPromise($promises, [
+            'concurrency' => $concurrency,
+            'fulfilled' => function ($result, $key) use (&$results) {
+                $results[$key] = $result;
+            },
+            'rejected' => function ($reason, $key) use (&$results) {
+                $results[$key] = $reason;
+            },
+        ]))->promise()->wait();
 
         return $results;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -909,13 +909,13 @@ class PendingRequest
         }
 
         (new EachPromise($promises, [
-            'concurrency' => $concurrency,
             'fulfilled' => function ($result, $key) use (&$results) {
                 $results[$key] = $result;
             },
             'rejected' => function ($reason, $key) use (&$results) {
                 $results[$key] = $reason;
             },
+            'concurrency' => $concurrency,
         ]))->promise()->wait();
 
         return $results;


### PR DESCRIPTION
This PR adds the ability to control how many concurrent HTTP requests the `Http::pool` and `Http::batch` can make.

## `Http::pool` Example

A new optional param should be passed in the `Http::pool` call:

```php
$responses = Http::pool(fn (Pool $pool) => [
    $pool->get('http://localhost/first'),
    $pool->get('http://localhost/second'),
    $pool->get('http://localhost/third'),
], 2); // Sets the pool to have at max 2 concurrent HTTP requests
```

## `Http::batch` Example

A new `->concurrency()` method can be called before calling the `->send()` or `->defer()` methods:

```php
$responses = Http::batch(fn (Batch $batch) => [
    $batch->as('first')->get('http://localhost/first'),
    $batch->as('second')->get('http://localhost/second'),
    $batch->as('third')->get('http://localhost/third'),
])->concurrency(2)->send(); // Sets the batch to have at max 2 concurrent HTTP requests
```