### PR TITLE
[12.x] Fix http client pending request throw-throwIf call order

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -736,7 +736,7 @@ class PendingRequest
             $this->throwIfCallback = $condition;
         }
 
-        return $condition ? $this->throw(func_get_args()[1] ?? null) : $this;
+        return $condition ? $this->throw(func_get_args()[1] ?? $this->throwCallback ?? null) : $this;
     }
 
     /**


### PR DESCRIPTION
## Calling throwIf() before throw()
```php
...
->throwIf(fn () => true)
->throw(fn ($req) => throw new CustomException(...))
```

Throws CustomException as expected.

## Calling throw() before throwIf()
```php
...
->throw(fn ($req) => throw new CustomException(...))
->throwIf(fn () => true)
```

Should throw CustomException, throws RequestException instead.