### PR TITLE
[12.x] Move duplicated logic to separate method to be reusable

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -939,7 +939,7 @@ trait ReplacesAttributes
         $fn = [Str::lower(...), Str::upper(...), Str::ucfirst(...)];
         $cases = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':' . $fn($placeholder), $fn)],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), $fn)],
             [],
         );
         $replacements = array_reduce(

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -947,6 +947,7 @@ trait ReplacesAttributes
             fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],
             [],
         );
+
         return str_replace($cases, $replacements, $message);
     }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -22,7 +22,7 @@ trait ReplacesAttributes
 
         $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
 
-        return $this->replaceKeepCase($message, ['other' => $parameters[0], 'value' => $parameters[1]]);
+        return $this->replaceWhileKeepingCase($message, ['other' => $parameters[0], 'value' => $parameters[1]]);
     }
 
     /**
@@ -333,7 +333,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return $this->replaceKeepCase($message, ['other' => $value]);
+        return $this->replaceWhileKeepingCase($message, ['other' => $value]);
     }
 
     /**
@@ -621,7 +621,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return $this->replaceKeepCase($message, ['other' => $value]);
+        return $this->replaceWhileKeepingCase($message, ['other' => $value]);
     }
 
     /**
@@ -762,7 +762,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return $this->replaceKeepCase($message, ['other' => $value]);
+        return $this->replaceWhileKeepingCase($message, ['other' => $value]);
     }
 
     /**
@@ -932,16 +932,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace the given string while maintaining different casing variants.
+     *
      * @param  array<string, string>  $mapping
      */
-    private function replaceKeepCase(string $message, array $mapping): string
+    private function replaceWhileKeepingCase(string $message, array $mapping): string
     {
         $fn = [Str::lower(...), Str::upper(...), Str::ucfirst(...)];
+
         $cases = array_reduce(
             array_keys($mapping),
             fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), $fn)],
             [],
         );
+
         $replacements = array_reduce(
             array_values($mapping),
             fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -934,7 +934,7 @@ trait ReplacesAttributes
     /**
      * @param  array<string, string>  $mapping
      */
-    private function function replaceKeepCase(string $message, array $mapping): string
+    private function replaceKeepCase(string $message, array $mapping): string
     {
     	$fn = [ Str::lower(...), Str::upper(...), Str::ucfirst(...) ];
     	$cases = array_reduce(

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -936,17 +936,17 @@ trait ReplacesAttributes
      */
     private function replaceKeepCase(string $message, array $mapping): string
     {
-    	$fn = [ Str::lower(...), Str::upper(...), Str::ucfirst(...) ];
-    	$cases = array_reduce(
-    	    array_keys($mapping),
-    	    fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':' . $fn($placeholder), $fn)],
-    	    [],
+        $fn = [Str::lower(...), Str::upper(...), Str::ucfirst(...)];
+        $cases = array_reduce(
+            array_keys($mapping),
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':' . $fn($placeholder), $fn)],
+            [],
         );
-    	$replacements = array_reduce(
-    	    array_values($mapping),
-    	    fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],
-    	    [],
+        $replacements = array_reduce(
+            array_values($mapping),
+            fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],
+            [],
         );
-    	return str_replace($cases, $replacements, $message);
+        return str_replace($cases, $replacements, $message);
     }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -22,11 +22,7 @@ trait ReplacesAttributes
 
         $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
 
-        return str_replace(
-            [':other', ':OTHER', ':Other', ':value', ':VALUE', ':Value'],
-            [$parameters[0], Str::upper($parameters[0]), Str::ucfirst($parameters[0]), $parameters[1], Str::upper($parameters[1]), Str::ucfirst($parameters[1])],
-            $message
-        );
+        return $this->replaceKeepCase($message, ['other' => $parameters[0], 'value' => $parameters[1]]);
     }
 
     /**
@@ -337,11 +333,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return str_replace(
-            [':other', ':OTHER', ':Other'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
-            $message
-        );
+        return $this->replaceKeepCase($message, ['other' => $value]);
     }
 
     /**
@@ -629,11 +621,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return str_replace(
-            [':other', ':OTHER', ':Other'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
-            $message
-        );
+        return $this->replaceKeepCase($message, ['other' => $value]);
     }
 
     /**
@@ -774,11 +762,7 @@ trait ReplacesAttributes
     {
         $value = $this->getDisplayableAttribute($parameters[0]);
 
-        return str_replace(
-            [':other', ':OTHER', ':Other'],
-            [$value, Str::upper($value), Str::ucfirst($value)],
-            $message
-        );
+        return $this->replaceKeepCase($message, ['other' => $value]);
     }
 
     /**
@@ -945,5 +929,24 @@ trait ReplacesAttributes
     protected function replaceDoesntContain($message, $attribute, $rule, $parameters)
     {
         return $this->replaceIn($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * @param  array<string, string>  $mapping
+     */
+    private function function replaceKeepCase(string $message, array $mapping): string
+    {
+    	$fn = [ Str::lower(...), Str::upper(...), Str::ucfirst(...) ];
+    	$cases = array_reduce(
+    	    array_keys($mapping),
+    	    fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':' . $fn($placeholder), $fn)],
+    	    [],
+        );
+    	$replacements = array_reduce(
+    	    array_values($mapping),
+    	    fn (array $carry, string $parameter) => [...$carry, ...array_map(fn (callable $fn) => $fn($parameter), $fn)],
+    	    [],
+        );
+    	return str_replace($cases, $replacements, $message);
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/pull/57556#discussion_r2467233764

✅ Improves readability by making the methods more compact without the "internal logic" in each of them
✅ Improves maintainability by having a single source of truth/failure
✅ Makes adapting this in new methods quite easy