### PR TITLE
[12.x] add `allDirectories()` method to `Filesytem`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -623,6 +623,19 @@ class Filesystem
     }
 
     /**
+     * Get all the directories within a given directory (recursive).
+     *
+     * @return \Symfony\Component\Finder\SplFileInfo[]
+     */
+    public function allDirectories(string $directory): array
+    {
+        return iterator_to_array(
+            Finder::create()->in($directory)->directories()->sortByName(),
+            false,
+        );
+    }
+
+    /**
      * Ensure a directory exists.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -625,14 +625,17 @@ class Filesystem
     /**
      * Get all the directories within a given directory (recursive).
      *
-     * @return \Symfony\Component\Finder\SplFileInfo[]
+     * @return array
      */
     public function allDirectories(string $directory): array
     {
-        return iterator_to_array(
-            Finder::create()->in($directory)->directories()->sortByName(),
-            false,
-        );
+        $directories = [];
+
+        foreach (Finder::create()->in($directory)->directories()->sortByName() as $dir) {
+            $directories[] = $dir->getPathname();
+        }
+
+        return $directories;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -42,7 +42,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\Finder\SplFileInfo[] files(string $directory, bool $hidden = false)
  * @method static \Symfony\Component\Finder\SplFileInfo[] allFiles(string $directory, bool $hidden = false)
  * @method static array directories(string $directory)
- * @method static \Symfony\Component\Finder\SplFileInfo[] allDirectories(string $directory)
+ * @method static array allDirectories(string $directory)
  * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
  * @method static bool makeDirectory(string $path, int $mode = 0755, bool $recursive = false, bool $force = false)
  * @method static bool moveDirectory(string $from, string $to, bool $overwrite = false)

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -42,6 +42,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\Finder\SplFileInfo[] files(string $directory, bool $hidden = false)
  * @method static \Symfony\Component\Finder\SplFileInfo[] allFiles(string $directory, bool $hidden = false)
  * @method static array directories(string $directory)
+ * @method static \Symfony\Component\Finder\SplFileInfo[] allDirectories(string $directory)
  * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
  * @method static bool makeDirectory(string $path, int $mode = 0755, bool $recursive = false, bool $force = false)
  * @method static bool moveDirectory(string $from, string $to, bool $overwrite = false)

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -534,14 +534,10 @@ class FilesystemTest extends TestCase
 
         $directories = (new Filesystem)->allDirectories(self::$tempDir);
 
-        $this->assertContainsOnlyInstancesOf(SplFileInfo::class, $directories);
-
-        $mappedDirectories = array_map(fn ($item) => $item->getPathname(), $directories);
-
-        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'film', $mappedDirectories);
-        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music', $mappedDirectories);
-        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'rock', $mappedDirectories);
-        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'blues', $mappedDirectories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'film', $directories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music', $directories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'rock', $directories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'blues', $directories);
     }
 
     public function testMakeDirectory()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -525,6 +525,25 @@ class FilesystemTest extends TestCase
         $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music', $directories);
     }
 
+    public function testAllDirectoriesFindsDirectories()
+    {
+        mkdir(self::$tempDir.'/film');
+        mkdir(self::$tempDir.'/music');
+        mkdir(self::$tempDir.'/music/rock');
+        mkdir(self::$tempDir.'/music/blues');
+
+        $directories = (new Filesystem)->allDirectories(self::$tempDir);
+
+        $this->assertContainsOnlyInstancesOf(SplFileInfo::class, $directories);
+
+        $mappedDirectories = array_map(fn($item) => $item->getPathname(), $directories);
+
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'film', $mappedDirectories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music', $mappedDirectories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'rock', $mappedDirectories);
+        $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music'.DIRECTORY_SEPARATOR.'blues', $mappedDirectories);
+    }
+
     public function testMakeDirectory()
     {
         $files = new Filesystem;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -536,7 +536,7 @@ class FilesystemTest extends TestCase
 
         $this->assertContainsOnlyInstancesOf(SplFileInfo::class, $directories);
 
-        $mappedDirectories = array_map(fn($item) => $item->getPathname(), $directories);
+        $mappedDirectories = array_map(fn ($item) => $item->getPathname(), $directories);
 
         $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'film', $mappedDirectories);
         $this->assertContains(self::$tempDir.DIRECTORY_SEPARATOR.'music', $mappedDirectories);


### PR DESCRIPTION
we already have `files()`, `allFiles()`, and `directories()`, so this method completes the set and allows us to recursively get all directories within a given path.

both `files()` and `allFiles()` return an array of `SplFileInfo` objects, while `directories()` maps the results to the path name and returns an array of strings.  I was torn between wanting to be consistent with the `directories()` method here, but also wanting to return the full object to allow the calling code to decide what it needed. Ideally all 4 methods would return an array of `SplFileInfo` objects, but that would be a BC.  I landed on providing the objects back, but open to suggestions.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
