### PR TITLE
[12.x] EnumerateValues::value() support and return negative values if exists #54910

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -340,7 +340,10 @@ trait EnumeratesValues
      */
     public function value($key, $default = null)
     {
-        if ($value = $this->firstWhere($key)) {
+        $value = $this->first();
+        if ($value && Arr::exists($value, $key)) {
+            return data_get($value, $key);
+        } elseif ($value = $this->firstWhere($key)) {
             return data_get($value, $key, $default);
         }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -341,6 +341,7 @@ trait EnumeratesValues
     public function value($key, $default = null)
     {
         $value = $this->first();
+
         if ($value && Arr::exists($value, $key)) {
             return data_get($value, $key);
         } elseif ($value = $this->firstWhere($key)) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1183,6 +1183,26 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testValueWithNegativeValue($collection)
+    {
+        $c = new $collection([['id' => 1, 'balance' => 0], ['id' => 2, 'balance' => 200]]);
+
+        $this->assertEquals(0, $c->value('balance'));
+
+        $c = new $collection([['id' => 1, 'balance' => ''], ['id' => 2, 'balance' => 200]]);
+
+        $this->assertEquals('', $c->value('balance'));
+
+        $c = new $collection([['id' => 1, 'balance' => null], ['id' => 2, 'balance' => 200]]);
+
+        $this->assertEquals(null, $c->value('balance'));
+
+        $c = new $collection([['id' => 1], ['id' => 2, 'balance' => 200]]);
+
+        $this->assertEquals(200, $c->value('balance'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testBetween($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
Another one from [The value collection method shouldn't consider 0 as null #54910](https://github.com/laravel/framework/issues/54910)