### PR TITLE
Make trait LazilyRefreshDatabase handle multiple connections

### DIFF
--- a/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/LazilyRefreshDatabase.php
@@ -37,8 +37,11 @@ trait LazilyRefreshDatabase
             }
         };
 
-        $database->beforeStartingTransaction($callback);
-        $database->beforeExecuting($callback);
+        foreach ($this->connectionsToTransact() as $name) {
+            $connection = $database->connection($name);
+            $connection->beforeStartingTransaction($callback);
+            $connection->beforeExecuting($callback);
+        }
 
         $this->beforeApplicationDestroyed(function () {
             RefreshDatabaseState::$lazilyRefreshed = false;


### PR DESCRIPTION
Simply allow LazilyRefreshDatabase to support multiple db connections.
