### PR TITLE
[12.x] always use the `operator` argument for `version_compare()`

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -145,7 +145,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
 
         $version = $config['version'] ?? $connection->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if (version_compare($version, '8.0.11') >= 0) {
+        if (version_compare($version, '8.0.11', '>=')) {
             return 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2597,7 +2597,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $keys = get_object_vars($this);
 
-        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
+        if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
             foreach ((new ReflectionClass($this))->getProperties() as $property) {
                 if ($property->hasHooks()) {
                     unset($keys[$property->getName()]);

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -135,7 +135,7 @@ class MySqlGrammar extends Grammar
     {
         $version = $query->getConnection()->getServerVersion();
 
-        return ! $query->getConnection()->isMaria() && version_compare($version, '8.0.11') < 0;
+        return ! $query->getConnection()->isMaria() && version_compare($version, '8.0.11', '<');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -228,7 +228,7 @@ class SQLiteGrammar extends Grammar
     {
         $version = $query->getConnection()->getServerVersion();
 
-        if (version_compare($version, '3.25.0') >= 0) {
+        if (version_compare($version, '3.25.0', '>=')) {
             return parent::compileGroupLimit($query);
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -27,7 +27,7 @@ class SQLiteConnection extends Connection
      */
     protected function executeBeginTransactionStatement()
     {
-        if (version_compare(PHP_VERSION, '8.4.0') >= 0) {
+        if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
             $mode = $this->getConfig('transaction_mode') ?? 'DEFERRED';
 
             $this->getPdo()->exec("BEGIN {$mode} TRANSACTION");


### PR DESCRIPTION
`version_compare()` can be called without a 3rd argument, and return a -1|0|1, or with a 3rd argument and return a boolean.  we currently use this function 28 times in the framework:

- 23 with the 3rd argument
- 5 without the 3rd argument

this commit standardizes our calls to ***always*** use the 3rd argument and return a boolean, which has a couple benefits:

- consistency
- slight readability improvement rather than magic numbers (subjective I guess)
- defensive against operator precedence issues

https://www.php.net/manual/en/function.version-compare.php

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
