### PR TITLE
[12.x] allow passing custom "depth" to `files()` and `directories()`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -582,10 +582,10 @@ class Filesystem
      * @param  bool  $hidden
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function files($directory, $hidden = false)
+    public function files($directory, $hidden = false, string|int|array $depth = 0)
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0)->sortByName(),
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth($depth)->sortByName(),
             false
         );
     }
@@ -599,10 +599,7 @@ class Filesystem
      */
     public function allFiles($directory, $hidden = false)
     {
-        return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->sortByName(),
-            false
-        );
+        return $this->files($directory, $hidden, []);
     }
 
     /**
@@ -611,11 +608,11 @@ class Filesystem
      * @param  string  $directory
      * @return array
      */
-    public function directories($directory)
+    public function directories($directory, string|int|array $depth = 0)
     {
         $directories = [];
 
-        foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
+        foreach (Finder::create()->in($directory)->directories()->depth($depth)->sortByName() as $dir) {
             $directories[] = $dir->getPathname();
         }
 
@@ -629,13 +626,7 @@ class Filesystem
      */
     public function allDirectories(string $directory): array
     {
-        $directories = [];
-
-        foreach (Finder::create()->in($directory)->directories()->sortByName() as $dir) {
-            $directories[] = $dir->getPathname();
-        }
-
-        return $directories;
+        return $this->directories($directory, []);
     }
 
     /**


### PR DESCRIPTION
this change serves 2 purposes:

- it allows the calling code to pass in an optional custom depth for more control over the desired output.
- it allows refactoring and deduplication of the `allFiles()` and `allDirectories()` methods to defer to the `files()` and `directories()` methods, respectively.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
