### PR TITLE
[12.x] Improve type annotations to `$depth` and `Filesystem::allDirectories()`

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -580,6 +580,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  bool  $hidden
+     * @param  string|int|string[]|int[]  $levels
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
     public function files($directory, $hidden = false, array|string|int $depth = 0)
@@ -606,6 +607,7 @@ class Filesystem
      * Get all of the directories within a given directory.
      *
      * @param  string  $directory
+     * @param  string|int|string[]|int[]  $levels
      * @return array
      */
     public function directories($directory, array|string|int $depth = 0)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -580,7 +580,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  bool  $hidden
-     * @param  string|int|string[]|int[]  $levels
+     * @param  string|int|string[]|int[]  $depth
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
     public function files($directory, $hidden = false, array|string|int $depth = 0)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -624,7 +624,7 @@ class Filesystem
     /**
      * Get all the directories within a given directory (recursive).
      *
-     * @return array
+     * @return string[]
      */
     public function allDirectories(string $directory): array
     {

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -607,7 +607,7 @@ class Filesystem
      * Get all of the directories within a given directory.
      *
      * @param  string  $directory
-     * @param  string|int|string[]|int[]  $levels
+     * @param  string|int|string[]|int[]  $depth
      * @return array
      */
     public function directories($directory, array|string|int $depth = 0)


### PR DESCRIPTION
Follow-up to #57573 ([Taken from Symfony](https://github.com/symfony/symfony/blob/070fb79e8a8167b27c5c9a47388997c6c634d0b7/src/Symfony/Component/Finder/Finder.php#L117C6-L117C103)) and #57565