### PR TITLE
[12.x] Use `ReplacesAttributes::replaceWhileKeepingCase()` also for imploded parameters

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -930,11 +930,12 @@ trait ReplacesAttributes
 
         $replacements = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(function (callable $fn) use($placeholder, $mapping, $wordSeparators) {
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(function (callable $fn) use ($placeholder, $mapping, $wordSeparators) {
                 $parameter = $mapping[$placeholder];
                 if (is_array($parameter) && array_is_list($parameter) && array_key_exists($placeholder, $wordSeparators)) {
                     $parameter = implode($wordSeparators[$placeholder], $parameter);
                 }
+
                 return $fn($parameter, $placeholder);
             }, [...$fn, $ucwordsReplacement])],
             [],

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -912,17 +912,17 @@ trait ReplacesAttributes
     private function replaceWhileKeepingCase(string $message, array $mapping): string
     {
         $fn = [
-           Str::lower(...),
-           Str::upper(...),
-           //fn (string $placeholder, ?string $parameter = null) => ucwords($parameter ?? $placeholder, $parameter !== null ? ($wordSeparators[$placeholder] ?? ' ') : ' '),
-           fn (string $placeholder, ?string $parameter = null) => $parameter !== null && array_key_exists($placeholder, $wordSeparators)
-               ? ucwords($parameter ?? $placeholder, $wordSeparators[$placeholder])
-               : ucfirst($parameter ?? $placeholder),
+            Str::lower(...),
+            Str::upper(...),
+            //fn (string $placeholder, ?string $parameter = null) => ucwords($parameter ?? $placeholder, $parameter !== null ? ($wordSeparators[$placeholder] ?? ' ') : ' '),
+            fn (string $placeholder, ?string $parameter = null) => $parameter !== null && array_key_exists($placeholder, $wordSeparators)
+                ? ucwords($parameter ?? $placeholder, $wordSeparators[$placeholder])
+                : ucfirst($parameter ?? $placeholder),
         ];
 
         $cases = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':' . $fn($placeholder), $fn)],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), $fn)],
             [],
         );
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -910,7 +910,7 @@ trait ReplacesAttributes
      * @param  array<string, string>  $mapping
      * @param  array<string, string>  $wordSeparators
      */
-    private function replaceWhileKeepingCase(string $message, array $mapping, $wordSeparators = []): string
+    private function replaceWhileKeepingCase(string $message, array $mapping, array $wordSeparators = []): string
     {
         $fn = [
             Str::lower(...),

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -929,7 +929,7 @@ trait ReplacesAttributes
 
         $replacements = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => $fn($placeholder, $mapping[$placeholder]), $fn)],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => $fn($mapping[$placeholder], $placeholder), $fn)],
             [],
         );
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -930,7 +930,13 @@ trait ReplacesAttributes
 
         $replacements = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => $fn($mapping[$placeholder], $placeholder), [...$fn, $ucwordsReplacement])],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(function (callable $fn) use($placeholder, $mapping, $wordSeparators) {
+                $parameter = $mapping[$placeholder];
+                if (is_array($parameter) && array_is_list($parameter) && array_key_exists($placeholder, $wordSeparators)) {
+                    $parameter = implode($wordSeparators[$placeholder], $parameter);
+                }
+                return $fn($parameter, $placeholder);
+            }, [...$fn, $ucwordsReplacement])],
             [],
         );
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -916,20 +916,21 @@ trait ReplacesAttributes
             Str::lower(...),
             Str::upper(...),
             //fn (string $placeholder, ?string $parameter = null) => ucwords($parameter ?? $placeholder, $parameter !== null ? ($wordSeparators[$placeholder] ?? ' ') : ' '),
-            fn (string $placeholder, ?string $parameter = null) => $parameter !== null && array_key_exists($placeholder, $wordSeparators)
-                ? ucwords($parameter, $wordSeparators[$placeholder])
-                : ucfirst($parameter ?? $placeholder),
         ];
+        
+        $ucwordsReplacement = fn (string $parameter, string $placeholder) => array_key_exists($placeholder, $wordSeparators)
+                ? ucwords($placeholder, $wordSeparators[$placeholder])
+                : ucfirst($parameter);
 
         $cases = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), $fn)],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => ':'.$fn($placeholder), [...$fn, ucfirst(...)])],
             [],
         );
 
         $replacements = array_reduce(
             array_keys($mapping),
-            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => $fn($mapping[$placeholder], $placeholder), $fn)],
+            fn (array $carry, string $placeholder) => [...$carry, ...array_map(fn (callable $fn) => $fn($mapping[$placeholder], $placeholder), [...$fn, $ucwordsReplacement])],
             [],
         );
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -908,15 +908,16 @@ trait ReplacesAttributes
      * Replace the given string while maintaining different casing variants.
      *
      * @param  array<string, string>  $mapping
+     * @param  array<string, string>  $wordSeparators
      */
-    private function replaceWhileKeepingCase(string $message, array $mapping): string
+    private function replaceWhileKeepingCase(string $message, array $mapping, $wordSeparators = []): string
     {
         $fn = [
             Str::lower(...),
             Str::upper(...),
             //fn (string $placeholder, ?string $parameter = null) => ucwords($parameter ?? $placeholder, $parameter !== null ? ($wordSeparators[$placeholder] ?? ' ') : ' '),
             fn (string $placeholder, ?string $parameter = null) => $parameter !== null && array_key_exists($placeholder, $wordSeparators)
-                ? ucwords($parameter ?? $placeholder, $wordSeparators[$placeholder])
+                ? ucwords($parameter, $wordSeparators[$placeholder])
                 : ucfirst($parameter ?? $placeholder),
         ];
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -919,7 +919,7 @@ trait ReplacesAttributes
         ];
 
         $ucwordsReplacement = fn (string $parameter, string $placeholder) => array_key_exists($placeholder, $wordSeparators)
-                ? ucwords($placeholder, $wordSeparators[$placeholder])
+                ? ucwords($parameter, $wordSeparators[$placeholder])
                 : ucfirst($parameter);
 
         $cases = array_reduce(

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -241,7 +241,7 @@ trait ReplacesAttributes
      */
     protected function replaceMissingWith($message, $attribute, $rule, $parameters)
     {
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['values' => $this->getAttributeList($parameters)],
             ['values' => ' / '],
@@ -291,7 +291,7 @@ trait ReplacesAttributes
             $parameter = $this->getDisplayableValue($attribute, $parameter);
         }
 
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['values' => $this->getAttributeList($parameters)],
             ['values' => ', '],
@@ -423,7 +423,7 @@ trait ReplacesAttributes
      */
     protected function replacePresentWith($message, $attribute, $rule, $parameters)
     {
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['values' => $this->getAttributeList($parameters)],
             ['values' => ' / '],
@@ -455,7 +455,7 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
     {
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['values' => $this->getAttributeList($parameters)],
             ['values' => ' / '],
@@ -641,7 +641,7 @@ trait ReplacesAttributes
             $values[] = $this->getDisplayableValue($parameters[0], $value);
         }
 
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['other' => $other, 'values' => $values],
             ['values' => ', '],
@@ -715,7 +715,7 @@ trait ReplacesAttributes
      */
     protected function replaceProhibits($message, $attribute, $rule, $parameters)
     {
-        return $this->replaceKeepCase(
+        return $this->replaceWhileKeepingCase(
             $message,
             ['other' => $this->getAttributeList($parameters)],
             ['other' => ' / '],

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -917,7 +917,7 @@ trait ReplacesAttributes
             Str::upper(...),
             //fn (string $placeholder, ?string $parameter = null) => ucwords($parameter ?? $placeholder, $parameter !== null ? ($wordSeparators[$placeholder] ?? ' ') : ' '),
         ];
-        
+
         $ucwordsReplacement = fn (string $parameter, string $placeholder) => array_key_exists($placeholder, $wordSeparators)
                 ? ucwords($placeholder, $wordSeparators[$placeholder])
                 : ucfirst($parameter);

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -293,7 +293,7 @@ trait ReplacesAttributes
 
         return $this->replaceWhileKeepingCase(
             $message,
-            ['values' => $this->getAttributeList($parameters)],
+            ['values' => $parameters],
             ['values' => ', '],
         );
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -816,12 +816,12 @@ class ValidationValidatorTest extends TestCase
         // in:foo,bar,...
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
-        $trans->addLines(['validation.values.type.5' => 'Short'], 'en');
-        $trans->addLines(['validation.values.type.300' => 'Long'], 'en');
+        $trans->addLines(['validation.values.type.5' => 'short'], 'en');
+        $trans->addLines(['validation.values.type.300' => 'long'], 'en');
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in short, long.', $v->messages()->first('type'));
 
         // date_equals:tomorrow
         $trans = $this->getIlluminateArrayTranslator();
@@ -837,30 +837,30 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
         $customValues = [
             'type' => [
-                '5' => 'Short',
-                '300' => 'Long',
+                '5' => 'short',
+                '300' => 'long',
             ],
         ];
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $v->addCustomValues($customValues);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in short, long.', $v->messages()->first('type'));
 
         // set custom values by setter
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.in' => ':attribute must be included in :values.'], 'en');
         $customValues = [
             'type' => [
-                '5' => 'Short',
-                '300' => 'Long',
+                '5' => 'short',
+                '300' => 'long',
             ],
         ];
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $v->setValueNames($customValues);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in short, long.', $v->messages()->first('type'));
     }
 
     public function testDisplayableAttributesAreReplacedInCustomReplacers()


### PR DESCRIPTION
Follow-up to #57564

As suggested in https://github.com/laravel/framework/pull/57564#issuecomment-3458111299

Now all case-sensitive replacements use `replaceWhileKeepingCase()` method

The benefits from the original PR become even more valuable with this one:
> ✅ Improves readability by making the methods more compact without the "internal logic" in each of them
> ✅ Improves maintainability by having a single source of truth/failure
> ✅ Makes adapting this in new methods quite easy