### PR TITLE
[12.x] allow disabling the mapping to the path name

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -606,14 +606,14 @@ class Filesystem
      * Get all of the directories within a given directory.
      *
      * @param  string  $directory
-     * @return array
+     * @return ($map is true ? array<string> : array<\Symfony\Component\Finder\SplFileInfo>)
      */
-    public function directories($directory, array|string|int $depth = 0)
+    public function directories($directory, array|string|int $depth = 0, bool $map = true)
     {
         $directories = [];
 
         foreach (Finder::create()->in($directory)->directories()->depth($depth)->sortByName() as $dir) {
-            $directories[] = $dir->getPathname();
+            $directories[] = $map ? $dir->getPathname() : $dir;
         }
 
         return $directories;
@@ -622,11 +622,11 @@ class Filesystem
     /**
      * Get all the directories within a given directory (recursive).
      *
-     * @return array
+     * @return ($map is true ? array<string> : array<\Symfony\Component\Finder\SplFileInfo>)
      */
-    public function allDirectories(string $directory): array
+    public function allDirectories(string $directory, bool $map = true): array
     {
-        return $this->directories($directory, []);
+        return $this->directories($directory, [], $map);
     }
 
     /**


### PR DESCRIPTION
it can often be helpful to get an `SplFileInfo` object back rather than only the string path name.  I think ideally we would get rid of the mapping by default, but this code has been around for so long it'd be a huge BC.

I think the next best thing is providing an optional parameter to allow the calling code to disable the mapping.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
