### PR TITLE
Support specifying namespace to generate classes in

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -321,7 +321,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     {
         try {
             return $this->resolvePathForClass($name);
-        } catch (RuntimeException $e) {
+        } catch (RuntimeException) {
             return $this->laravel['path.base'].'/'.str_replace('\\', '/', $name).'.php';
         }
     }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -350,7 +350,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         // Sort by namespace depth (deepest first)
-        uksort($namespaceRoots, fn ($a, $b) => Str::substrCount($b, '\\') <=> Str::substrCount($a, '\\');
+        uksort($namespaceRoots, fn ($a, $b) => Str::substrCount($b, '\\') <=> Str::substrCount($a, '\\'));
 
         foreach ($namespaceRoots as $prefix => $paths) {
             if (! Str::startsWith($class, $prefix)) {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -338,11 +338,11 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         // Collect valid PSR-4 and PSR-0 namespace mappings
         foreach (ClassLoader::getRegisteredLoaders() as $loader) {
             foreach ([$loader->getPrefixesPsr4(), $loader->getPrefixes()] as $prefixes) {
-                foreach ($prefixes as $ns => $paths) {
+                foreach ($prefixes as $namespace => $paths) {
                     foreach ($paths as $path) {
                         $real = realpath($path);
                         if ($real !== false) {
-                            $namespaceRoots[rtrim($ns, '\\')][] = $real;
+                            $namespaceRoots[rtrim($namespace, '\\')][] = $real;
                         }
                     }
                 }
@@ -350,12 +350,10 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         }
 
         // Sort by namespace depth (deepest first)
-        uksort($namespaceRoots, fn($a, $b) =>
-            Str::substrCount($b, '\\') <=> Str::substrCount($a, '\\')
-        );
+        uksort($namespaceRoots, fn ($a, $b) => Str::substrCount($b, '\\') <=> Str::substrCount($a, '\\');
 
         foreach ($namespaceRoots as $prefix => $paths) {
-            if (!Str::startsWith($class, $prefix)) {
+            if (! Str::startsWith($class, $prefix)) {
                 continue;
             }
 
@@ -510,7 +508,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      */
     protected function rootNamespace()
     {
-        if (!empty($this->rootNamespace)) {
+        if (! empty($this->rootNamespace)) {
             return $this->rootNamespace;
         }
 
@@ -519,7 +517,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
             $in = text(
                 label: 'What namespace would you like to generate the '.$this->type.' in?',
                 placeholder: 'App',
-                validate: fn ($value) => empty($value) ? "The in option is required when the application namespace is empty." : null,
+                validate: fn ($value) => empty($value) ? 'The in option is required when the application namespace is empty.' : null,
             );
         }
 

--- a/tests/Integration/Generators/TestCase.php
+++ b/tests/Integration/Generators/TestCase.php
@@ -16,7 +16,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         foreach (ClassLoader::getRegisteredLoaders() as $loader) {
             $loader->addPsr4('App\\', [default_skeleton_path('app')]);
         }
-        
         parent::setUp();
     }
 }

--- a/tests/Integration/Generators/TestCase.php
+++ b/tests/Integration/Generators/TestCase.php
@@ -5,18 +5,18 @@ namespace Illuminate\Tests\Integration\Generators;
 use Composer\Autoload\ClassLoader;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 
+use function Orchestra\Testbench\default_skeleton_path;
+
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use InteractsWithPublishedFiles;
 
     protected function setUp(): void
     {
-        parent::setUp();
-
-        // Register the App namespace with Composer's autoloader for the testbench laravel app
-        $appPath = $this->app->path();
         foreach (ClassLoader::getRegisteredLoaders() as $loader) {
-            $loader->addPsr4('App\\', [$appPath]);
+            $loader->addPsr4('App\\', [default_skeleton_path('app')]);
         }
+        
+        parent::setUp();
     }
 }

--- a/tests/Integration/Generators/TestCase.php
+++ b/tests/Integration/Generators/TestCase.php
@@ -2,9 +2,21 @@
 
 namespace Illuminate\Tests\Integration\Generators;
 
+use Composer\Autoload\ClassLoader;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use InteractsWithPublishedFiles;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Register the App namespace with Composer's autoloader for the testbench laravel app
+        $appPath = $this->app->path();
+        foreach (ClassLoader::getRegisteredLoaders() as $loader) {
+            $loader->addPsr4('App\\', [$appPath]);
+        }
+    }
 }


### PR DESCRIPTION
This both fixes an infinite loop caused when the application namespace is an empty string (as it is in a domain-driven codebase like Winter CMS as there is no "root" namespace for the application) while also adding support for the --in option originally proposed in https://github.com/laravel/framework/pull/48571 by @innocenzi. 

This PR takes it a step further to resolve the correct path for real namespaces so that namespaces outside of root namespace (which may or may not actually exist) can also be written to.