### PR TITLE
feat: added detailed about for cache failover driver

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -200,7 +200,7 @@ class AboutCommand extends Command
                         json: fn () => $secondary->all(),
                     ), $json);
                 }
-                
+
                 return $cacheStore;
             },
             'Database' => config('database.default'),

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -188,7 +188,21 @@ class AboutCommand extends Command
 
         static::addToSection('Drivers', fn () => array_filter([
             'Broadcasting' => config('broadcasting.default'),
-            'Cache' => config('cache.default'),
+            'Cache' => function ($json) {
+                $cacheStore = config('cache.default');
+
+                if (config('cache.stores.'.$cacheStore.'.driver') === 'failover') {
+                    $secondary = new Collection(config('cache.stores.'.$cacheStore.'.stores'));
+
+                    return value(static::format(
+                        value: $cacheStore,
+                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: fn () => $secondary->all(),
+                    ), $json);
+                }
+                
+                return $cacheStore;
+            },
             'Database' => config('database.default'),
             'Logs' => function ($json) {
                 $logChannel = config('logging.default');


### PR DESCRIPTION
This pull request updates the way cache driver information is displayed in the `AboutCommand`. The main improvement is that it now provides more detailed information when the cache driver is set to `failover`, showing both the primary store and its secondary stores.

**Improvements to cache driver reporting:**

* Enhanced the `'Cache'` entry in the `Drivers` section to display the primary cache store and its secondary stores when the cache driver is set to `failover`, improving visibility into cache configuration.

Before:

<img width="1187" height="168" alt="image" src="https://github.com/user-attachments/assets/92b0f084-99ff-410d-af14-3e7916b87bc7" />

After:

<img width="1240" height="168" alt="image" src="https://github.com/user-attachments/assets/5a2f5706-6743-45d8-b471-e7d5bb6854b0" />

