### PR TITLE
[12.x] Refactor unreleased data_has helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -44,19 +44,23 @@ if (! function_exists('data_has')) {
      */
     function data_has($target, $key): bool
     {
-        if (Arr::accessible($target)) {
-            return Arr::has($target, $key);
+        if (empty($key)) {
+            return false;
         }
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        while ($property = array_shift($key)) {
-            if (property_exists($target, $property)) {
-                return $key ? data_has($target->{$property}, $key) : true;
+        foreach ($key as $segment) {
+            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
+                $target = $target[$segment];
+            } elseif (is_object($target) && property_exists($target, $segment)) {
+                $target = $target->{$segment};
+            } else {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -218,6 +218,34 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($object, object_get($object, '  '));
     }
 
+    public function testDataHas()
+    {
+        $object = (object) ['users' => ['name' => ['Taylor', 'Otwell']]];
+        $array = [(object) ['users' => [(object) ['name' => 'Taylor']]]];
+        $dottedArray = ['users' => ['first.name' => 'Taylor', 'middle.name' => null]];
+        $arrayAccess = new SupportTestArrayAccess(['price' => 56, 'user' => new SupportTestArrayAccess(['name' => 'John']), 'email' => null]);
+        $sameKeyMultiLevel = (object) ['name' => 'Taylor', 'company' => ['name' => 'Laravel']];
+
+        $this->assertTrue(data_has($object, 'users.name.0'));
+        $this->assertTrue(data_has($array, '0.users.0.name'));
+        $this->assertFalse(data_has($array, '0.users.3'));
+        $this->assertFalse(data_has($array, '0.users.3'));
+        $this->assertFalse(data_has($array, '0.users.3'));
+        $this->assertTrue(data_has($dottedArray, ['users', 'first.name']));
+        $this->assertTrue(data_has($dottedArray, ['users', 'middle.name']));
+        $this->assertFalse(data_has($dottedArray, ['users', 'last.name']));
+        $this->assertTrue(data_has($arrayAccess, 'price'));
+        $this->assertTrue(data_has($arrayAccess, 'user.name'));
+        $this->assertFalse(data_has($arrayAccess, 'foo'));
+        $this->assertFalse(data_has($arrayAccess, 'user.foo'));
+        $this->assertFalse(data_has($arrayAccess, 'foo'));
+        $this->assertFalse(data_has($arrayAccess, 'user.foo'));
+        $this->assertTrue(data_has($arrayAccess, 'email'));
+        $this->assertTrue(data_has($sameKeyMultiLevel, 'name'));
+        $this->assertTrue(data_has($sameKeyMultiLevel, 'company.name'));
+        $this->assertFalse(data_has($sameKeyMultiLevel, 'foo.name'));
+    }
+
     public function testDataGet()
     {
         $object = (object) ['users' => ['name' => ['Taylor', 'Otwell']]];


### PR DESCRIPTION
PR #57570 introduced the `data_has()` helper to aid fixing the `EnumerateValues::value()` implementation.

The new helper works for the purposes of that PR, but is misaligned with other sibilings helpers, such as `data_get()`.

For example, using the current implementation, all these assertions fail when then should pass:

```php
$this->assertTrue(data_has($object, 'users.name.0'));
$this->assertTrue(data_has($array, '0.users.0.name'));
$this->assertTrue(data_has($dottedArray, ['users', 'first.name']));
$this->assertTrue(data_has($dottedArray, ['users', 'middle.name']));
$this->assertFalse(data_has($sameKeyMultiLevel, 'foo.name'));
```

This assertions were adapted from the `data_get()` helper tests. 

The last one fails due to the current implementation using a while loop to search for a property segment existence.

This PR:

- Refactor the unreleased `data_has()` helper to behave more aligned with other sibling helpers.
  - Actually the logic is basically the same to traverse the `data_get()` helper\
  - The difference is that `data_has()` uses `property_exists()` and `data_get()` uses `isset()` to verify a object's property
- Add tests for the `data_has()` helper with assertions that would fail with the current implementation