### PR TITLE
[12.x] Add ucwords to Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1831,18 +1831,16 @@ class Str
      * Capitalize the first character of each word in a string.
      *
      * @param  string  $string
-     * @param  string  $delimiter
+     * @param  string  $separators
      * @return string
      */
-    public static function ucwords($string, $delimiter = ' ')
+    public static function ucwords($string, $separators = " \t\r\n\f\v")
     {
-        $words = explode($delimiter, $string);
+        $pattern = '/(^|['.preg_quote($separators, '/').'])(\p{Ll})/u';
 
-        foreach ($words as &$word) {
-            $word = static::ucfirst($word);
-        }
-
-        return implode($delimiter, $words);
+        return preg_replace_callback($pattern, function ($matches) {
+            return $matches[1].mb_strtoupper($matches[2]);
+        }, $string);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1828,6 +1828,24 @@ class Str
     }
 
     /**
+     * Capitalize the first character of each word in a string.
+     *
+     * @param  string  $string
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function ucwords($string, $delimiter = ' ')
+    {
+        $words = explode($delimiter, $string);
+
+        foreach ($words as &$word) {
+            $word = static::ucfirst($word);
+        }
+
+        return implode($delimiter, $words);
+    }
+
+    /**
      * Split a string into pieces by uppercase characters.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1108,6 +1108,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Capitalize the first character of each word in a string.
+     *
+     * @return static
+     */
+    public function ucwords()
+    {
+        return new static(Str::ucwords($this->value));
+    }
+
+    /**
      * Split a string by uppercase characters.
      *
      * @return \Illuminate\Support\Collection<int, string>

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1295,8 +1295,10 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('Laravel', Str::ucwords('laravel'));
         $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
+        $this->assertSame('Laravel-Framework', Str::ucwords('laravel-framework', '-'));
         $this->assertSame('Мама', Str::ucwords('мама'));
         $this->assertSame('Мама Мыла Раму', Str::ucwords('мама мыла раму'));
+        $this->assertSame('JJ Watt', Str::ucwords('JJ watt'));
     }
 
     public function testUcsplit()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1291,6 +1291,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Laravel', Str::ucwords('laravel'));
+        $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
+        $this->assertSame('Мама', Str::ucwords('мама'));
+        $this->assertSame('Мама Мыла Раму', Str::ucwords('мама мыла раму'));
+    }
+
     public function testUcsplit()
     {
         $this->assertSame(['Laravel_p_h_p_framework'], Str::ucsplit('Laravel_p_h_p_framework'));


### PR DESCRIPTION
When transforming a name in a request, I'm currently doing the following:

`$name = ucwords($this->string('name')->trim()->squish()->value());`

After this change, we'll be able to:

`$name = $this->string('name')->trim()->squish()->ucwords()->value();`


Maybe it's worth noting that I was using `->title()` instead of `ucwords`, but it undesirably changes names like "JJ watt" to "Jj Watt" when I'd rather preserve "JJ".