### PR TITLE
feat: added detailed about for queue failover driver

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -223,7 +223,21 @@ class AboutCommand extends Command
             },
             'Mail' => config('mail.default'),
             'Octane' => config('octane.server'),
-            'Queue' => config('queue.default'),
+            'Queue' => function ($json) {
+                $queueConnection = config('queue.default');
+
+                if (config('queue.connections.'.$queueConnection.'.driver') === 'failover') {
+                    $secondary = new Collection(config('queue.connections.'.$queueConnection.'.connections'));
+
+                    return value(static::format(
+                        value: $queueConnection,
+                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: fn () => $secondary->all(),
+                    ), $json);
+                }
+
+                return $queueConnection;
+            },
             'Scout' => config('scout.driver'),
             'Session' => config('session.driver'),
         ]));


### PR DESCRIPTION
This pull request updates the way queue connection information is displayed in the `AboutCommand` output. Specifically, it enhances the reporting for queue connections that use the `failover` driver by showing both the primary and secondary connections.

Improvements to queue connection reporting:

* Modified the `Queue` entry in `gatherApplicationInformation()` in `src/Illuminate/Foundation/Console/AboutCommand.php` to display both the main and secondary connections when the `failover` driver is used, providing clearer visibility into queue configuration.

Before:

<img width="1222" height="161" alt="image" src="https://github.com/user-attachments/assets/791ac1b2-dac6-4ee1-a0e5-ffde56840620" />

After:

<img width="1195" height="170" alt="image" src="https://github.com/user-attachments/assets/25c0c531-c392-4345-95f9-79807bdaed14" />
