### PR TITLE
[12.x] Fix: use trim before check empty string

### DIFF
--- a/src/Illuminate/Bus/DynamoBatchRepository.php
+++ b/src/Illuminate/Bus/DynamoBatchRepository.php
@@ -119,7 +119,7 @@ class DynamoBatchRepository implements BatchRepository
      */
     public function find(string $batchId)
     {
-        if ($batchId === '') {
+        if (trim($batchId) === '') {
             return null;
         }
 


### PR DESCRIPTION
Currently, if a string with spaces is given, the code will be executed.
That's why I set trim to not accept empty strings that only contain spaces.