### PR TITLE
[12.x] fix data_has empty check

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -44,7 +44,7 @@ if (! function_exists('data_has')) {
      */
     function data_has($target, $key): bool
     {
-        if (empty($key)) {
+        if (is_null($key) || $key === []) {
             return false;
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -225,6 +225,7 @@ class SupportHelpersTest extends TestCase
         $dottedArray = ['users' => ['first.name' => 'Taylor', 'middle.name' => null]];
         $arrayAccess = new SupportTestArrayAccess(['price' => 56, 'user' => new SupportTestArrayAccess(['name' => 'John']), 'email' => null]);
         $sameKeyMultiLevel = (object) ['name' => 'Taylor', 'company' => ['name' => 'Laravel']];
+        $plainArray = [1, 2, 3];
 
         $this->assertTrue(data_has($object, 'users.name.0'));
         $this->assertTrue(data_has($array, '0.users.0.name'));
@@ -244,6 +245,13 @@ class SupportHelpersTest extends TestCase
         $this->assertTrue(data_has($sameKeyMultiLevel, 'name'));
         $this->assertTrue(data_has($sameKeyMultiLevel, 'company.name'));
         $this->assertFalse(data_has($sameKeyMultiLevel, 'foo.name'));
+        $this->assertTrue(data_has($plainArray, 0));
+        $this->assertTrue(data_has($plainArray, '0'));
+        $this->assertFalse(data_has($plainArray, 4));
+        $this->assertFalse(data_has($plainArray, '4'));
+        $this->assertFalse(data_has($plainArray, ''));
+        $this->assertFalse(data_has($plainArray, []));
+        $this->assertFalse(data_has($plainArray, null));
     }
 
     public function testDataGet()


### PR DESCRIPTION
Continuation of #57580

As noted by @decadence in their comment https://github.com/laravel/framework/pull/57580#issuecomment-3466388987

> This function returns false for valid `0` key or I'm missing something? For example:
> 
> ```php
> $array = [1, 2, 3];
> 
> data_has($array, "0"); // wrong false
> ```

That is due to `empty($target)` evaluating to true if the `$key` is a string equal to `'0'`.

This PR:

- Fixes the test for an empty key
- Adds more assertions to the `data_has` test case

Thanks @decadence 
