### PR TITLE
[12.x] Follow up improvements to #57557

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2583,7 +2583,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
     protected function getPropertiesForSerialization(): array
     {
-        if (version_compare(PHP_VERSION, '8.4.0') < 0) {
+        if (version_compare(PHP_VERSION, '8.4.0', '<')) {
             return array_keys(get_object_vars($this));
         }
 


### PR DESCRIPTION
Follow up to https://github.com/laravel/framework/pull/57557 as discussed in the comments.

Approach **does not** change compared to 57557. But in 8.4 we get an advantage because:

- No unnecessary `get_object_vars()` call; avoids duplicate work.
- Collects desired keys instead of having a call to `unset()` for each undesired property.
- No unnecessary `array_keys()` call

Makes it slightly faster (~25%) and a bit cleaner. Nothing massive, but things add up. 
Since it's a fresh feature it doesn't hurt to squeeze what we can.

Addtionally:

- Extracted to method to make it overwritable as requested in https://github.com/laravel/framework/pull/57557#issuecomment-3466316842