### PR TITLE
Feat: add mailers detail for failover or roundrobin

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -221,7 +221,21 @@ class AboutCommand extends Command
 
                 return $logs;
             },
-            'Mail' => config('mail.default'),
+            'Mail' => function ($json) {
+                $mailMailer = config('mail.default');
+
+                if (in_array(config('mail.mailers.'.$mailMailer.'.driver'), ['failover', 'roundrobin'])) {
+                    $secondary = new Collection(config('mail.mailers.'.$mailMailer.'.mailers'));
+
+                    return value(static::format(
+                        value: $mailMailer,
+                        console: fn ($value) => '<fg=yellow;options=bold>'.$value.'</> <fg=gray;options=bold>/</> '.$secondary->implode(', '),
+                        json: fn () => $secondary->all(),
+                    ), $json);
+                }
+
+                return $mailMailer;
+            },
             'Octane' => config('octane.server'),
             'Queue' => function ($json) {
                 $queueConnection = config('queue.default');

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -224,7 +224,7 @@ class AboutCommand extends Command
             'Mail' => function ($json) {
                 $mailMailer = config('mail.default');
 
-                if (in_array(config('mail.mailers.'.$mailMailer.'.driver'), ['failover', 'roundrobin'])) {
+                if (in_array(config('mail.mailers.'.$mailMailer.'.transport'), ['failover', 'roundrobin'])) {
                     $secondary = new Collection(config('mail.mailers.'.$mailMailer.'.mailers'));
 
                     return value(static::format(


### PR DESCRIPTION
This pull request updates how mail configuration information is displayed in the `gatherApplicationInformation` method of `AboutCommand.php`. The main change is to provide more detailed output when the mail transport uses either `failover` or `roundrobin`, showing secondary mailers in addition to the default mailer.

Mail configuration output improvements:

* Enhanced the `Mail` entry to display secondary mailers when the transport is set to `failover` or `roundrobin`, using a formatted output for console and JSON modes. (`src/Illuminate/Foundation/Console/AboutCommand.php`, [src/Illuminate/Foundation/Console/AboutCommand.phpL224-R238](diffhunk://#diff-50e224ec9caef764eaff244ea0aa2d9c847501dbd600ebe865a3c57b7c5753fcL224-R238))

Before:

failover
<img width="1221" height="166" alt="image" src="https://github.com/user-attachments/assets/b5cc46ec-cea1-4f24-8a8d-8c5a7ceabfe2" />

roundrobin
<img width="1173" height="157" alt="image" src="https://github.com/user-attachments/assets/3677dc70-88ea-4514-8939-dc0be2453d0b" />

After:
failover
<img width="1195" height="162" alt="image" src="https://github.com/user-attachments/assets/3429cfa8-cbb4-43fe-88ca-ace308617472" />
roundrobin
<img width="1185" height="163" alt="image" src="https://github.com/user-attachments/assets/0e005d95-5831-428e-9478-8b9b8f6aaf59" />
