### PR TITLE
[12.x] Add `request` shorthand method for creating pending requests

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -495,6 +495,16 @@ class Factory
     }
 
     /**
+     * Begin building a new pending request instance.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function request()
+    {
+        return $this->createPendingRequest();
+    }
+
+    /**
      * Create a new pending request instance for this factory.
      *
      * @return \Illuminate\Http\Client\PendingRequest

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -26,6 +26,7 @@ use Illuminate\Http\Client\Factory;
  * @method static void assertSequencesAreEmpty()
  * @method static \Illuminate\Support\Collection recorded(\Closure|callable $callback = null)
  * @method static \Illuminate\Http\Client\PendingRequest createPendingRequest()
+ * @method static \Illuminate\Http\Client\PendingRequest request()
  * @method static \Illuminate\Contracts\Events\Dispatcher|null getDispatcher()
  * @method static array getGlobalMiddleware()
  * @method static void macro(string $name, object|callable $macro)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -81,6 +81,21 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->ok());
     }
 
+    public function testRequestConvenienceMethodCreatesPendingRequest()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', HttpResponse::HTTP_NO_CONTENT),
+        ]);
+
+        $pendingRequest = $this->factory->request();
+
+        $this->assertInstanceOf(PendingRequest::class, $pendingRequest);
+
+        $response = $pendingRequest->get('http://laravel.com');
+
+        $this->assertTrue($response->noContent());
+    }
+
     public function testCreatedRequest()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR introduces an `Http::request()` entry point that mirrors the way Eloquent exposes `Model::query()`, enabling developers to fluently build HTTP requests across multiple lines while keeping the pending request instance around for reuse.

The change is purely ergonomic and optional, so existing code paths remain untouched.

## Motivation

- Keep a configured pending request builder in scope, just like `Model::query()` allows staging a database query before execution.
- Offer a shorter, more readable alternative to `Http::createPendingRequest()` so multi-line chains look consistent with the rest of the framework.
- Improve DX by aligning the HTTP facade vocabulary with existing Laravel patterns, which makes fluent chaining feel familiar and aesthetically cleaner.
- No behavioural changes: `request()` delegates to the existing `createPendingRequest()` implementation.
