### PR TITLE
Feature/where collation

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2431,6 +2431,38 @@ class Builder implements BuilderContract
         return $this->whereNone($columns, $operator, $value, 'or');
     }
 
+
+    /**
+     * @param string $column
+     * @param string $operator
+     * @param $value
+     * @param string $collation
+     * @param string $charset
+     * @return $this
+     */
+    public function whereCollation(
+        string $column,
+        string $operator = '=',
+               $value = null,
+        string $collation = 'utf8mb4_unicode_ci',
+        string $charset = 'utf8mb4'
+    ): Builder
+    {
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_]+$/', $charset) || !preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
+            throw new InvalidArgumentException('Invalid charset or collation name.');
+        }
+
+        return $this->whereRaw(
+            "CONVERT(`{$column}` USING {$charset}) COLLATE {$collation} {$operator} ?",
+            [$value]
+        );
+    }
+
     /**
      * Add a "group by" clause to the query.
      *

--- a/tests/Database/DatabaseWhereCollationTest.php
+++ b/tests/Database/DatabaseWhereCollationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Database;
+
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\TestCase;
+
+class DatabaseWhereCollationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('CREATE TEMPORARY TABLE _test_collation (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_cs,
+            url VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+        )');
+
+        DB::table('_test_collation')->insert([
+            ['name' => 'simple', 'url' => 'https://example.com'],
+            ['name' => 'سلام', 'url' => 'https://example.com/fa'],
+        ]);
+    }
+
+    public function test_where_collation_can_match_ascii_value()
+    {
+        $record = DB::table('_test_collation')
+            ->whereCollation('name', 'simple')
+            ->first();
+
+        $this->assertNotNull($record);
+        $this->assertEquals('https://example.com', $record->url);
+    }
+
+    public function test_where_collation_can_match_unicode_value()
+    {
+        $record = DB::table('_test_collation')
+            ->whereCollation('name', '=', 'سلام')
+            ->first();
+
+        $this->assertNotNull($record);
+        $this->assertEquals('https://example.com/fa', $record->url);
+    }
+
+    public function test_invalid_collation_name_throws_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DB::table('_test_collation')->whereCollation('name', '=', 'test', 'utf8mb4; DROP TABLE users;', 'utf8mb4');
+    }
+}


### PR DESCRIPTION
Feature: Add whereCollation() to Query Builder

Problem

When comparing columns with different collations (e.g., latin1_general_ci vs utf8mb4_unicode_ci),
MySQL throws "Illegal mix of collations" errors.

Solution

Added a new whereCollation() method to the Query Builder to allow explicit charset and collation conversion.

Example
DB::table('users')->whereCollation('name', '=', 'سلام');
DB::table('users')->whereCollation('name', 'John');

Benefits

Prevents collation mismatch errors

Keeps syntax clean and expressive

Fully backward compatible
