### PR TITLE
[12.x] Add nullish check methods to `Str` facade

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2100,4 +2100,48 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+
+    /**
+     * Determines if a string is null or contains no characters.
+     *
+     * @param  string|null  $string
+     * @return bool
+     */
+    public static function nullOrEmpty($string)
+    {
+        return $string === null || $string === '';
+    }
+
+    /**
+     * Determines if a string is null or contains only whitespace characters.
+     *
+     * @param  string|null  $string
+     * @return bool
+     */
+    public static function nullOrWhitespace($string)
+    {
+        return static::nullOrEmpty($string) || trim($string) === '';
+    }
+
+    /**
+     * Determines if a string is not null and contains characters.
+     *
+     * @param  string|null  $string
+     * @return bool
+     */
+    public static function notNullOrEmpty($string)
+    {
+        return ! static::nullOrEmpty($string);
+    }
+
+    /**
+     * Determines if a string is not null and does not contain only whitespace characters.
+     *
+     * @param  string|null  $string
+     * @return bool
+     */
+    public static function notNullOrWhitespace($string)
+    {
+        return ! static::nullOrWhitespace($string);
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2120,7 +2120,7 @@ class Str
      */
     public static function nullOrWhitespace($string)
     {
-        return static::nullOrEmpty($string) || trim($string) === '';
+        return $string === null || trim($string) === '';
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1905,6 +1905,114 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    #[DataProvider('nullOrEmptyProvider')]
+    public function testNullOrEmpty($value, $expected)
+    {
+        $this->assertEquals($expected, Str::nullOrEmpty($value));
+    }
+
+    #[DataProvider('notNullOrEmptyProvider')]
+    public function testNotNullOrEmpty($value, $expected)
+    {
+        $this->assertEquals($expected, Str::notNullOrEmpty($value));
+    }
+
+    #[DataProvider('nullOrWhitespaceProvider')]
+    public function testNullOrWhitespace($value, $expected)
+    {
+        $this->assertEquals($expected, Str::nullOrWhitespace($value));
+    }
+
+    #[DataProvider('notNullOrWhitespaceProvider')]
+    public function testNotNullOrWhitespace($value, $expected)
+    {
+        $this->assertEquals($expected, Str::notNullOrWhitespace($value));
+    }
+
+    public static function nullOrEmptyProvider()
+    {
+        return [
+            'null value' => [null, true],
+            'empty string' => ['', true],
+            'single space' => [' ', false],
+            'multiple spaces' => ['   ', false],
+            'tab character' => ["\t", false],
+            'newline character' => ["\n", false],
+            'zero string' => ['0', false],
+            'simple text' => ['hello', false],
+            'text with spaces' => ['hello world', false],
+            'single character' => ['a', false],
+            'number string' => ['123', false],
+            'special characters' => ['!@#$', false],
+        ];
+    }
+
+    public static function notNullOrEmptyProvider()
+    {
+        return [
+            'null value' => [null, false],
+            'empty string' => ['', false],
+            'single space' => [' ', true],
+            'multiple spaces' => ['   ', true],
+            'tab character' => ["\t", true],
+            'newline character' => ["\n", true],
+            'zero string' => ['0', true],
+            'simple text' => ['hello', true],
+            'text with spaces' => ['hello world', true],
+            'single character' => ['a', true],
+            'number string' => ['123', true],
+            'special characters' => ['!@#$', true],
+        ];
+    }
+
+    public static function nullOrWhitespaceProvider()
+    {
+        return [
+            'null value' => [null, true],
+            'empty string' => ['', true],
+            'single space' => [' ', true],
+            'multiple spaces' => ['   ', true],
+            'tab character' => ["\t", true],
+            'newline character' => ["\n", true],
+            'carriage return' => ["\r", true],
+            'mixed whitespace' => [" \t\n\r ", true],
+            'zero string' => ['0', false],
+            'simple text' => ['hello', false],
+            'text with spaces' => ['hello world', false],
+            'text with leading space' => [' hello', false],
+            'text with trailing space' => ['hello ', false],
+            'text with surrounding spaces' => [' hello ', false],
+            'single character' => ['a', false],
+            'number string' => ['123', false],
+            'special characters' => ['!@#$', false],
+            'whitespace with period' => [' . ', false],
+        ];
+    }
+
+    public static function notNullOrWhitespaceProvider()
+    {
+        return [
+            'null value' => [null, false],
+            'empty string' => ['', false],
+            'single space' => [' ', false],
+            'multiple spaces' => ['   ', false],
+            'tab character' => ["\t", false],
+            'newline character' => ["\n", false],
+            'carriage return' => ["\r", false],
+            'mixed whitespace' => [" \t\n\r ", false],
+            'zero string' => ['0', true],
+            'simple text' => ['hello', true],
+            'text with spaces' => ['hello world', true],
+            'text with leading space' => [' hello', true],
+            'text with trailing space' => ['hello ', true],
+            'text with surrounding spaces' => [' hello ', true],
+            'single character' => ['a', true],
+            'number string' => ['123', true],
+            'special characters' => ['!@#$', true],
+            'whitespace with period' => [' . ', true],
+        ];
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In an ode to .NET, the `string.IsNullOrEmpty()` and `string.IsNullOrWhitespace()` functions I've always found helpful and thought they could be useful for the masses using Laravel. I usually add these to my own Laravel projects in some for of helper method, but thought it was be nice to have these officially as part of the `Str` facade.

I find it fairly useful for high PHPStan levels that enforce strict null checks/empty checks for strings rather than truthy/falsy assertions. For those of us weirdos using it near max level, we could centralize those checks to the `Str` facade rather than the various flavors of `is_null()`, `empty()`, `=== null`, `=== ''`, etc.