### PR TITLE
[12.x] `Factory@insert()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -425,7 +425,7 @@ abstract class Factory
                 return $this->state($attributes)->make([], $parent);
             }
 
-            if ($this->count === null) { //
+            if ($this->count === null) {
                 return tap($this->makeInstance($parent), function ($instance) {
                     $this->callAfterMaking(new Collection([$instance]));
                 });
@@ -448,7 +448,7 @@ abstract class Factory
     }
 
     /**
-     * Insert the records (in bulk) but do not return them.
+     * Insert the records in bulk. No model events are emitted.
      *
      * @param  array<string, mixed>  $attributes
      * @param  Model|null  $parent
@@ -457,7 +457,7 @@ abstract class Factory
     public function insert(array $attributes = [], ?Model $parent = null): void
     {
         $made = $this->make($attributes, $parent);
-        $madeCollection = $made instanceof Collection ? $made : new Collection([$made]);
+        $madeCollection = $made instanceof Collection ? $made : $this->newModel()->newCollection([$made]);
 
         $model = $madeCollection->first();
         if (isset($this->connection)) {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -448,7 +448,7 @@ abstract class Factory
     }
 
     /**
-     * Insert the records in bulk. No model events are emitted.
+     * Insert the model records in bulk. No model events are emitted.
      *
      * @param  array<string, mixed>  $attributes
      * @param  Model|null  $parent
@@ -457,15 +457,22 @@ abstract class Factory
     public function insert(array $attributes = [], ?Model $parent = null): void
     {
         $made = $this->make($attributes, $parent);
-        $madeCollection = $made instanceof Collection ? $made : $this->newModel()->newCollection([$made]);
+
+        $madeCollection = $made instanceof Collection 
+            ? $made 
+            : $this->newModel()->newCollection([$made]);
 
         $model = $madeCollection->first();
+
         if (isset($this->connection)) {
             $model->setConnection($this->connection);
         }
+
         $query = $model->newQueryWithoutScopes();
 
-        $query->fillAndInsert($madeCollection->withoutAppends()->toArray());
+        $query->fillAndInsert(
+            $madeCollection->withoutAppends()->toArray()
+        );
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -982,6 +982,12 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertEquals('other body', FactoryTestComment::first()->body);
     }
 
+    public function test_factory_can_insert()
+    {
+        (new FactoryTestPostFactory())->count(5)->state(['title' => 'hello'])->insert();
+        $this->assertEquals(5, ($comments = FactoryTestPost::query()->get())->count());
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -9,6 +9,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\CrossJoinSequence;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -984,8 +985,19 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_factory_can_insert()
     {
-        (new FactoryTestPostFactory())->count(5)->state(['title' => 'hello'])->insert();
-        $this->assertEquals(5, ($comments = FactoryTestPost::query()->get())->count());
+        (new FactoryTestPostFactory())
+            ->count(5)
+            ->recycle([
+                (new FactoryTestUserFactory())->create(['name' => Name::Taylor]),
+                (new FactoryTestUserFactory())->create(['name' => Name::Shad, 'created_at' => now()])
+            ])
+            ->state(['title' => 'hello'])
+            ->insert();
+        $this->assertCount(5, $posts = FactoryTestPost::query()->where('title', 'hello')->get());
+        $this->assertEquals(strtoupper($posts[0]->user->name), $posts[0]->upper_case_name);
+        $this->assertEquals(2, ($users = FactoryTestUser::query()->get())->count());
+        $this->assertCount(1, $users->where('name', 'shaedrich'));
+        $this->assertCount(1, $users->where('name', 'totwell'));
     }
 
     /**
@@ -1077,6 +1089,13 @@ class FactoryTestPost extends Eloquent
     use SoftDeletes;
 
     protected $table = 'posts';
+
+    protected $appends = ['upper_case_name'];
+
+    public function upperCaseName(): Attribute
+    {
+        return Attribute::get(fn ($attr) => Str::upper($this->user->name));
+    }
 
     public function user()
     {
@@ -1198,4 +1217,10 @@ class FactoryTestUseFactoryAttributeFactory extends Factory
 class FactoryTestUseFactoryAttribute extends Eloquent
 {
     use HasFactory;
+}
+
+enum Name: string
+{
+    case Taylor = 'totwell';
+    case Shad = 'shaedrich';
 }


### PR DESCRIPTION
It's really, really easy to write inefficient tests by leveraging `Order::factory()->count(100)->create()` not realizing that it's going to run 100 inserts. I just fixed this in a number of tests this week.

Here we add a `Factory@insert()` method that allows performing a mass insert of models.

Note that this does not return anything (it's akin to the Eloquent model's insert() method), and similarly does not emit Model events. This is only really useful if you need to insert lot of some model in your database, but don't actually need those models handy in the test. Think of testing pagination or how a resource returns a count.