### PR TITLE
fix: allow instantiation of Stringable with no argument

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -79,7 +79,7 @@ class Str
      * @param  string  $string
      * @return \Illuminate\Support\Stringable
      */
-    public static function of($string)
+    public static function of($string = '')
     {
         return new Stringable($string);
     }


### PR DESCRIPTION
This pull request makes a small change to the `Str` class in the `src/Illuminate/Support/Str.php` file. The change updates the `of` method to accept an optional string parameter, defaulting to an empty string if none is provided.

As of now: 
This works

<img width="1310" height="217" alt="image" src="https://github.com/user-attachments/assets/87bd7ae4-4902-467b-9ea1-efb45f0477b2" />

This doesn't

<img width="1424" height="232" alt="image" src="https://github.com/user-attachments/assets/37b3de03-0e7d-4564-a6cf-0ad177b77c68" />
