### PR TITLE
feat: add when directive to blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -38,6 +38,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesStyles,
         Concerns\CompilesTranslations,
         Concerns\CompilesUseStatements,
+        Concerns\CompilesWhen,
         ReflectsClosures;
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesWhen.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesWhen.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesWhen
+{
+    /**
+     * Compile the "@when" directive into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileWhen($expression)
+    {
+        return "<?php echo when{$expression}; ?>";
+    }
+}

--- a/tests/View/Blade/BladeWhenTest.php
+++ b/tests/View/Blade/BladeWhenTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeWhenTest extends AbstractBladeTestCase
+{
+    public function testWhenIsCompiled()
+    {
+        $this->assertSame('<?php echo when($var1, $var2, $var3); ?>', $this->compiler->compileString('@when($var1, $var2, $var3)'));
+    }
+}


### PR DESCRIPTION
This PR introduces a new Blade directive `@when`, which compiles to the when() helper for concise conditional rendering.

Before:
```blade
<button {{ when($shouldPoll, 'wire:poll.5s="updateData"') }}>Submit</button>
```

After:
```blade
<button @when($shouldPoll, 'wire:poll.5s="updateData"')>Submit</button>
```
