### PR TITLE
[12.x] Add whereDateBetween and orWhereDateBetween methods to Query B…

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1456,6 +1456,46 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a basic where between clause specifically for date ranges.
+     *
+     * @param  string  $column
+     * @param  array  $range
+     * @param  bool  $inclusiveTime
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function whereDateBetween($column, array $range, bool $inclusiveTime = true)
+    {
+        [$start, $end] = $range;
+
+        if ($inclusiveTime) {
+            $start = \Illuminate\Support\Carbon::parse($start)->startOfDay();
+            $end = \Illuminate\Support\Carbon::parse($end)->endOfDay();
+        }
+
+        return $this->whereBetween($column, [$start, $end]);
+    }
+
+    /**
+     * Add an "or where" clause for date ranges.
+     *
+     * @param  string  $column
+     * @param  array  $range
+     * @param  bool  $inclusiveTime
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function orWhereDateBetween($column, array $range, bool $inclusiveTime = true)
+    {
+        [$start, $end] = $range;
+
+        if ($inclusiveTime) {
+            $start = \Illuminate\Support\Carbon::parse($start)->startOfDay();
+            $end = \Illuminate\Support\Carbon::parse($end)->endOfDay();
+        }
+
+        return $this->orWhereBetween($column, [$start, $end]);
+    }
+
+    /**
      * Add a where not between statement using columns to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -341,9 +341,10 @@ class PendingCommand
      *
      * @param  array<int, string|array<int, string>>|Collection<int, string|array<int, string>>  $headers
      * @param  array<int, array<int, string>>|Collection<int, array<int, string>>|null  $rows
-     * @return $this
      *
      * @phpstan-param ($rows is null ? list<list<string>>|Collection<int, list<string>> : list<string|list<string>>|Collection<int, string|list<string>>) $headers
+     *
+     * @return $this
      */
     public function expectsPromptsTable(array|Collection $headers, array|Collection|null $rows)
     {

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -68,7 +68,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
+            {
             };
         }
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -71,7 +71,8 @@ class BusPendingBatchTest extends TestCase
 
         $container = new Container;
 
-        $job = new class {
+        $job = new class
+        {
         };
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
@@ -226,7 +227,8 @@ class BusPendingBatchTest extends TestCase
 
     public function test_it_throws_exception_if_batched_job_is_not_batchable(): void
     {
-        $nonBatchableJob = new class {
+        $nonBatchableJob = new class
+        {
         };
 
         $this->expectException(RuntimeException::class);
@@ -242,7 +244,8 @@ class BusPendingBatchTest extends TestCase
         new PendingBatch(
             $container,
             new Collection(
-                [new PendingBatch($container, new Collection([new BatchableJob, new class {
+                [new PendingBatch($container, new Collection([new BatchableJob, new class
+                {
                 }]))]
             )
         );

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1109,9 +1109,7 @@ class WildcardConcrete implements WildcardOnlyInterface
 {
 }
 
-/*
- * The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
- */
+// The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
 #[Bind(FallbackConcrete::class)]
 #[Bind(ProdConcrete::class, environments: 'prod')]
 interface WildcardAndProdInterface

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -17,7 +17,8 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
     public function testCreateDatabase()
     {
         $connection = m::mock(Connection::class);
-        $grammar = new class($connection) extends Grammar {
+        $grammar = new class($connection) extends Grammar
+        {
         };
 
         $this->assertSame('create database "foo"', $grammar->compileCreateDatabase('foo'));
@@ -26,7 +27,8 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
     public function testDropDatabaseIfExists()
     {
         $connection = m::mock(Connection::class);
-        $grammar = new class($connection) extends Grammar {
+        $grammar = new class($connection) extends Grammar
+        {
         };
 
         $this->assertSame('drop database if exists "foo"', $grammar->compileDropDatabaseIfExists('foo'));

--- a/tests/Database/DatabaseEloquentInverseRelationTest.php
+++ b/tests/Database/DatabaseEloquentInverseRelationTest.php
@@ -288,7 +288,8 @@ class DatabaseEloquentInverseRelationTest extends TestCase
             [],
             new HasInverseRelationRelatedStub(),
             'foo',
-            new class() {
+            new class()
+            {
             },
             new HasInverseRelationRelatedStub(),
         ]);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1277,6 +1277,45 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "id" = ? or 1 not between "created_at" and "updated_at"', $builder->toSql());
     }
 
+    public function testWhereDateBetween()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')
+            ->from('users')
+            ->whereDateBetween('created_at', ['2025-10-01', '2025-10-05']);
+
+        $this->assertSame(
+            'select * from "users" where "created_at" between ? and ?',
+            $builder->toSql()
+        );
+
+        $this->assertCount(2, $builder->getBindings());
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $builder->getBindings()[0]);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $builder->getBindings()[1]);
+    }
+
+    public function testOrWhereDateBetween()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')
+            ->from('users')
+            ->where('id', '=', 1)
+            ->orWhereDateBetween('created_at', ['2025-10-01', '2025-10-05']);
+
+        $this->assertSame(
+            'select * from "users" where "id" = ? or "created_at" between ? and ?',
+            $builder->toSql()
+        );
+
+        $bindings = $builder->getBindings();
+        $this->assertEquals(3, count($bindings));
+        $this->assertEquals(1, $bindings[0]); // from `where('id', '=', 1)`
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $bindings[1]);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $bindings[2]);
+    }
+
     public function testBasicOrWheres()
     {
         $builder = $this->getBuilder();

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -248,10 +248,12 @@ class EncrypterTest extends TestCase
 
         return [
             [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
-            [['iv' => new class() {
+            [['iv' => new class()
+            {
             }, 'value' => '', 'mac' => '']],
             [['iv' => $validIv, 'value' => ['value_in_array'], 'mac' => '']],
-            [['iv' => $validIv, 'value' => new class() {
+            [['iv' => $validIv, 'value' => new class()
+            {
             }, 'mac' => '']],
             [['iv' => $validIv, 'value' => '', 'mac' => ['value_in_array']]],
             [['iv' => $validIv, 'value' => '', 'mac' => null]],

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -12,7 +12,8 @@ class JsonResourceTest extends TestCase
 {
     public function testJsonResourceNullAttributes()
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $model->setAttribute('relation_sum_column', null);
@@ -32,7 +33,8 @@ class JsonResourceTest extends TestCase
 
     public function testJsonResourceToJsonSucceedsWithPriorErrors(): void
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])
@@ -49,7 +51,8 @@ class JsonResourceTest extends TestCase
 
     public function testJsonResourceToPrettyPrint(): void
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
         $resource = m::mock(JsonResource::class, ['resource' => $model])

--- a/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedDirtyTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use Orchestra\Testbench\TestCase;
 
 class EloquentModelEncryptedDirtyTest extends TestCase

--- a/tests/JsonSchema/SerializerTest.php
+++ b/tests/JsonSchema/SerializerTest.php
@@ -13,7 +13,8 @@ class SerializerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unsupported [Illuminate\\JsonSchema\\Types\\Type@anonymous');
 
-        $type = new class extends Type {
+        $type = new class extends Type
+        {
             // anonymous type for triggering serializer failure
         };
 

--- a/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphCountTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorphCount('parentable', $relations));

--- a/tests/Pagination/CursorPaginatorLoadMorphTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorph('parentable', $relations));

--- a/tests/Pagination/PaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/PaginatorLoadMorphCountTest.php
@@ -19,7 +19,8 @@ class PaginatorLoadMorphCountTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractPaginator {
+        $p = (new class extends AbstractPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorphCount('parentable', $relations));

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -19,7 +19,8 @@ class PaginatorLoadMorphTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractPaginator {
+        $p = (new class extends AbstractPaginator
+        {
         })->setCollection($items);
 
         $this->assertSame($p, $p->loadMorph('parentable', $relations));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1588,7 +1588,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2483,10 +2483,12 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testImplodeModels($collection)
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
         $model->setAttribute('email', 'foo');
-        $modelTwo = new class extends Model {
+        $modelTwo = new class extends Model
+        {
         };
         $modelTwo->setAttribute('email', 'bar');
         $data = new $collection([$model, $modelTwo]);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1086,7 +1086,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class($v) extends ValidationException {
+        $exception = new class($v) extends ValidationException
+        {
         };
         $v->setException($exception);
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -822,10 +822,12 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
             }
         };
 
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
         };
 
-        $paginator = new class extends AbstractPaginator {
+        $paginator = new class extends AbstractPaginator
+        {
         };
 
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));


### PR DESCRIPTION
[12.x] Add whereDateBetween and orWhereDateBetween methods to Query Builder

This adds two new methods to the Query Builder: whereDateBetween() and
orWhereDateBetween().

These methods make it easier to filter records between two date values
while automatically normalizing the range to full-day boundaries using Carbon.
They provide a cleaner, more expressive alternative to manual whereBetween()
calls for date filtering.

Example:

    DB::table('users')
        ->whereDateBetween('created_at', ['2025-10-01', '2025-10-31'])
        ->get();
