### PR TITLE
Feature/json schema improvements

### DIFF
--- a/src/Illuminate/JsonSchema/Types/StringType.php
+++ b/src/Illuminate/JsonSchema/Types/StringType.php
@@ -20,6 +20,11 @@ class StringType extends Type
     protected ?string $pattern = null;
 
     /**
+     * The format of the string.
+     */
+    protected ?string $format = null;
+
+    /**
      * Set the minimum length (inclusive).
      */
     public function min(int $value): static
@@ -45,6 +50,18 @@ class StringType extends Type
     public function pattern(string $value): static
     {
         $this->pattern = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the format of the string.
+     *
+     * {@link https://json-schema.org/understanding-json-schema/reference/type#built-in-formats}
+     */
+    public function format(string $value): static
+    {
+        $this->format = $value;
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -90,7 +90,7 @@ abstract class Type extends JsonSchema
      */
     public function enum(string|array $values): static
     {
-        if(is_string($values)) {
+        if (is_string($values)) {
             $values = array_column($values::cases(), 'value');
         }
 

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -86,10 +86,14 @@ abstract class Type extends JsonSchema
     /**
      * Restrict the value to one of the provided enumerated values.
      *
-     * @param  array<int, mixed>  $values
+     * @param  class-string<\BackedEnum>|array<int, mixed>  $values
      */
-    public function enum(array $values): static
+    public function enum(string|array $values): static
     {
+        if(is_string($values)) {
+            $values = array_column($values::cases(), 'value');
+        }
+
         // Keep order and allow complex values (arrays/objects) without forcing uniqueness...
         $this->enum = array_values($values);
 

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -93,8 +93,8 @@ abstract class Type extends JsonSchema
     public function enum(string|array $values): static
     {
         if (is_string($values)) {
-            if(!is_subclass_of($values, BackedEnum::class)) {
-                throw new InvalidArgumentException("The provided class must be a BackedEnum.");
+            if (! is_subclass_of($values, BackedEnum::class)) {
+                throw new InvalidArgumentException('The provided class must be a BackedEnum.');
             }
 
             $values = array_column($values::cases(), 'value');

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -90,7 +90,7 @@ abstract class Type extends JsonSchema
      *
      * @param  class-string<\BackedEnum>|array<int, mixed>  $values
      */
-    public function enum(string|array $values): static
+    public function enum(array|string $values): static
     {
         if (is_string($values)) {
             if (! is_subclass_of($values, BackedEnum::class)) {
@@ -100,7 +100,7 @@ abstract class Type extends JsonSchema
             $values = array_column($values::cases(), 'value');
         }
 
-        // Keep order and allow complex values (arrays/objects) without forcing uniqueness...
+        // Keep order and allow complex values (arrays / objects) without forcing uniqueness...
         $this->enum = array_values($values);
 
         return $this;

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\JsonSchema\Types;
 
+use BackedEnum;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Serializer;
+use InvalidArgumentException;
 
 abstract class Type extends JsonSchema
 {
@@ -91,6 +93,10 @@ abstract class Type extends JsonSchema
     public function enum(string|array $values): static
     {
         if (is_string($values)) {
+            if(!is_subclass_of($values, BackedEnum::class)) {
+                throw new InvalidArgumentException("The provided class must be a BackedEnum.");
+            }
+
             $values = array_column($values::cases(), 'value');
         }
 

--- a/tests/JsonSchema/Fixtures/Enums/IntBackedEnum.php
+++ b/tests/JsonSchema/Fixtures/Enums/IntBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema\Fixtures\Enums;
+
+enum IntBackedEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}

--- a/tests/JsonSchema/Fixtures/Enums/StringBackedEnum.php
+++ b/tests/JsonSchema/Fixtures/Enums/StringBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema\Fixtures\Enums;
+
+enum StringBackedEnum: string
+{
+    case One = 'one';
+    case Two = 'two';
+}

--- a/tests/JsonSchema/Fixtures/Enums/UnitEnum.php
+++ b/tests/JsonSchema/Fixtures/Enums/UnitEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\JsonSchema\Fixtures\Enums;
+
+enum UnitEnum
+{
+    case One;
+    case Two;
+}

--- a/tests/JsonSchema/StringTypeTest.php
+++ b/tests/JsonSchema/StringTypeTest.php
@@ -39,6 +39,17 @@ class StringTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_sets_format()
+    {
+        $type = (new StringType)->default('foo')->format('date');
+
+        $this->assertEquals([
+            'type' => 'string',
+            'default' => 'foo',
+            'format' => 'date',
+        ], $type->toArray());
+    }
+
     public function test_it_sets_enum()
     {
         $type = (new StringType)->enum(['draft', 'published']);

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\JsonSchema;
 
 use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Tests\JsonSchema\Fixtures\Enums\IntBackedEnum;
+use Illuminate\Tests\JsonSchema\Fixtures\Enums\StringBackedEnum;
 use Opis\JsonSchema\Resolvers\SchemaResolver;
 use Opis\JsonSchema\SchemaLoader;
 use Opis\JsonSchema\Validator;
@@ -118,6 +120,7 @@ class TypeTest extends TestCase
             [JsonSchema::string()->min(1)->max(3), 'a'], // boundary at min
             [JsonSchema::string()->pattern('^[A-Z]{2}[0-9]{2}$'), 'AB12'], // complex pattern
             [JsonSchema::string()->enum(['', 'x', 'y']), ''], // enum including empty string
+            [JsonSchema::string()->enum(StringBackedEnum::class), 'one'], // string backed enum cases
             [JsonSchema::string()->nullable(), null],
             [JsonSchema::string()->nullable(false), ''],
 
@@ -132,6 +135,7 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(10), 9], // below max
             [JsonSchema::integer()->min(1)->max(3), 3], // boundary at max
             [JsonSchema::integer()->enum([0, -1, 5]), 0], // enum with zero
+            [JsonSchema::integer()->enum(IntBackedEnum::class), 1], // integer backed enum cases
             [JsonSchema::integer()->default(0), 0], // default value
             [JsonSchema::integer()->nullable(), null],
             [JsonSchema::integer()->nullable(false), 0],
@@ -265,6 +269,7 @@ class TypeTest extends TestCase
             [JsonSchema::string()->max(0), 'a'], // too long for zero max
             [JsonSchema::string()->pattern('^[a]+$'), 'ab'], // pattern mismatch
             [JsonSchema::string()->enum(['a', 'b']), 'A'], // case sensitive mismatch
+            [JsonSchema::string()->enum(StringBackedEnum::class), 'three'], // string backed enum cases mismatch
             [JsonSchema::string(), null], // null not allowed
             [JsonSchema::string()->nullable(false), null], // not nullable
 
@@ -279,6 +284,7 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(0), 1], // above max boundary
             [JsonSchema::integer(), 3.14], // not an integer
             [JsonSchema::integer()->enum([1, 2]), 2.5], // not in enum and not an integer
+            [JsonSchema::integer()->enum(IntBackedEnum::class), 3], // integer backed enum cases mismatch
             [JsonSchema::integer()->default(1), null], // wrong type
             [JsonSchema::integer()->nullable(false), null], // not nullable
 

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -5,12 +5,15 @@ namespace Illuminate\Tests\JsonSchema;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Tests\JsonSchema\Fixtures\Enums\IntBackedEnum;
 use Illuminate\Tests\JsonSchema\Fixtures\Enums\StringBackedEnum;
+use Illuminate\Tests\JsonSchema\Fixtures\Enums\UnitEnum;
+use InvalidArgumentException;
 use Opis\JsonSchema\Resolvers\SchemaResolver;
 use Opis\JsonSchema\SchemaLoader;
 use Opis\JsonSchema\Validator;
 use Opis\Uri\Uri;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Stringable;
 
 class TypeTest extends TestCase
@@ -102,6 +105,33 @@ class TypeTest extends TestCase
         ]);
 
         $this->assertInstanceOf(JsonSchema::class, $schema);
+    }
+
+    public function test_throws_with_invalid_enum_string(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionCode(0);
+
+        JsonSchema::string()->enum('NonExistentEnumClass');
+    }
+
+    public function test_throws_with_not_an_enum_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionCode(0);
+
+        JsonSchema::string()->enum(stdClass::class);
+    }
+
+    public function test_throws_with_unit_enum_class(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided class must be a BackedEnum.');
+        $this->expectExceptionCode(0);
+
+        JsonSchema::string()->enum(UnitEnum::class);
     }
 
     public static function validSchemasProvider(): array


### PR DESCRIPTION
Improve the current JSON schema implementation by the following:

1. Add support for passing a backed enum to Type's enum method.  
   Before:
   ```php
   $schema->string('oneof')->enum(['a', 'b', 'c']);
   ```
   After:
   ```php
   enum Options: string
   {
     case A = 'a';
     case B = 'b';
     case C = 'c';
   }

   $schema->string('oneof')->enum(Options::class);
   ```
2. Add missing `format` for StringType.
   New:
   ```php
   $schema->string('somedate')->format('date');
   ```

I didn't create an issue beforehand since I deemed those additions so minor.

The improved enum handling just makes sense looking at how Laravel supports this in various other places.  
The missing format was added primarily to improve `laravel/mcp`.  
Ref.: https://modelcontextprotocol.io/docs/learn/server-concepts#how-tools-work

Tests have been added.

Cheers,
Anticom