### PR TITLE
[12.x] Fix: use trim before check empty and return type in doc block

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -590,13 +590,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string  $replace
      * @param  string  $subject
      * @param  int  $offset
-     * @return array
+     * @return array|string
      */
     protected function replaceFirstStatement($search, $replace, $subject, $offset)
     {
         $search = (string) $search;
 
-        if ($search === '') {
+        if (trim($search) === '') {
             return $subject;
         }
 


### PR DESCRIPTION
continuation of #57583