### PR TITLE
[12.x] Fix: Correctly fallback to notification's connection/queue when using viaConnections/viaQueues

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -232,7 +232,7 @@ class NotificationSender
                 $connection = $notification->connection;
 
                 if (method_exists($notification, 'viaConnections')) {
-                    $connection = $notification->viaConnections()[$channel] ?? null;
+                    $connection = $notification->viaConnections()[$channel] ?? $connection;
                 }
 
                 $queue = $notification->queue;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -238,7 +238,7 @@ class NotificationSender
                 $queue = $notification->queue;
 
                 if (method_exists($notification, 'viaQueues')) {
-                    $queue = $notification->viaQueues()[$channel] ?? null;
+                    $queue = $notification->viaQueues()[$channel] ?? $queue;
                 }
 
                 $delay = $notification->delay;


### PR DESCRIPTION
When a notification uses viaConnections() or viaQueues(), Laravel behaves inconsistently.
If those methods are not defined, the notification uses its own default connection and queue.
But if they are defined and don’t include all channels, Laravel falls back to the global defaults instead of the notification’s defaults.