### PR TITLE
Fix ScheduleRunCommandTest failure on Windows by using OS-specific success command

### DIFF
--- a/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php
@@ -132,7 +132,8 @@ class ScheduleRunCommandTest extends TestCase
 
         // Create a schedule and add the command that just performs an action without explicit exit
         $schedule = $this->app->make(Schedule::class);
-        $task = $schedule->exec('true')
+        $command = PHP_OS_FAMILY === 'Windows' ? 'cmd /c exit 0' : 'true';
+        $task = $schedule->exec($command)
             ->everyMinute();
 
         // Make sure it will run regardless of schedule


### PR DESCRIPTION
The test `test_command_with_no_explicit_return_does_not_trigger_event` in `tests/Integration/Console/Scheduling/ScheduleRunCommandTest.php` fails on Windows environments. This is because the shell command `'true'` is not natively available on Windows (it's a Unix-specific command that always exits with code 0). When executed on Windows, it results in a non-zero exit code, unexpectedly triggering the `ScheduledTaskFailed` event, which causes the assertion `Event::assertNotDispatched(ScheduledTaskFailed::class)` to fail.
This leads to the following error:

````
The unexpected [Illuminate\Console\Events\ScheduledTaskFailed] event was dispatched.
Failed asserting that actual size 1 matches expected size 0.
````

### Proposed Fix: 

This PR introduces an OS-specific check using `PHP_OS_FAMILY` to select the appropriate success command:

- On Windows: `'cmd /c exit 0'` (which reliably exits with code 0).
- On other OS (Unix-like): `'true'`.

This ensures the test behaves consistently across platforms without triggering the failure event on Windows.

### Testing:

- Tested on Windows 11 with PHP 8.4.11: The test now passes without dispatching the `ScheduledTaskFailed` event.
- All other tests in the suite remain unaffected.

### Related Issue:

- None yet. If needed, I can open an issue to discuss further.

This fix improves cross-platform compatibility for the test suite. Let me know if any adjustments are needed!
