### PR TITLE
[12.x] type hint the `directory` parameter

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -578,11 +578,10 @@ class Filesystem
     /**
      * Get an array of all files in a directory.
      *
-     * @param  string  $directory
      * @param  bool  $hidden
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function files($directory, $hidden = false, array|string|int $depth = 0)
+    public function files(string|array $directory, $hidden = false, array|string|int $depth = 0)
     {
         return iterator_to_array(
             Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth($depth)->sortByName(),
@@ -593,11 +592,10 @@ class Filesystem
     /**
      * Get all of the files from the given directory (recursive).
      *
-     * @param  string  $directory
      * @param  bool  $hidden
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function allFiles($directory, $hidden = false)
+    public function allFiles(string|array $directory, $hidden = false)
     {
         return $this->files($directory, $hidden, []);
     }
@@ -605,10 +603,9 @@ class Filesystem
     /**
      * Get all of the directories within a given directory.
      *
-     * @param  string  $directory
      * @return array
      */
-    public function directories($directory, array|string|int $depth = 0)
+    public function directories(string|array $directory, array|string|int $depth = 0)
     {
         $directories = [];
 
@@ -624,7 +621,7 @@ class Filesystem
      *
      * @return array
      */
-    public function allDirectories(string $directory): array
+    public function allDirectories(string|array $directory): array
     {
         return $this->directories($directory, []);
     }


### PR DESCRIPTION
the parameter is being directly passed to the Symfony `Finder::in()` method, which strictly type hints its parameter as `string|array`. this means we can safely match the type hint in our method signature because if the calling code had been previously passing something other than an array or string, it would have been failing. this change merely moves the failure up a level to the Laravel code.

this also more correctly documents the code as accepting both strings and arrays, as our previous docblock only suggested that strings would work.

we'll remove the now unnecessary docblock.

unfortunately we cannot do the same for the boolean `hidden` parameter because we are effectively casting all values passed in via the `!` to a boolean.

https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Finder/Finder.php#L635

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
