### PR TITLE
[12.x] Introduce `WithCachedRoutes` testing trait

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1322,9 +1322,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return ($this->bound('routes.cached')
-                && $this->make('routes.cached') === true)
-            || $this['files']->exists($this->getCachedRoutesPath());
+        return ($this->bound('routes.cached') && $this->make('routes.cached') === true) ||
+            $this['files']->exists($this->getCachedRoutesPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1322,9 +1322,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return ($this->bound('routes.cached') &&
-            $this->make('routes.cached') === true) ||
-        $this['files']->exists($this->getCachedRoutesPath());
+        return ($this->bound('routes.cached')
+                && $this->make('routes.cached') === true)
+            || $this['files']->exists($this->getCachedRoutesPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1322,7 +1322,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return $this['files']->exists($this->getCachedRoutesPath());
+        return ($this->bound('routes.cached') &&
+            $this->make('routes.cached') === true) ||
+        $this['files']->exists($this->getCachedRoutesPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -53,7 +53,6 @@ class RouteServiceProvider extends ServiceProvider
         $this->booted(function () {
             $this->setRootControllerNamespace();
 
-            //
             if ($this->routesAreCached()) {
                 $this->loadCachedRoutes();
             } else {

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -53,6 +53,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->booted(function () {
             $this->setRootControllerNamespace();
 
+            //
             if ($this->routesAreCached()) {
                 $this->loadCachedRoutes();
             } else {

--- a/src/Illuminate/Foundation/Testing/CachedState.php
+++ b/src/Illuminate/Foundation/Testing/CachedState.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+class CachedState
+{
+    public static array $cachedRoutes;
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,7 +29,7 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        if (in_array(WithCachedRoutes::class, class_uses_recursive(self::class)) && isset(CachedState::$cachedRoutes)) {
+        if (isset(CachedState::$cachedRoutes) && in_array(WithCachedRoutes::class, class_uses_recursive(self::class))) {
             $app->booting(fn () => $this->markRoutesCached($app));
         }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,6 +29,10 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
+        if (in_array(WithCachedRoutes::class, class_uses_recursive(self::class)) && isset(CachedState::$cachedRoutes)) {
+            $app->booting(fn () => $this->markRoutesCached($app));
+        }
+
         $app->make(Kernel::class)->bootstrap();
 
         return $app;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,7 +29,7 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        if (isset(CachedState::$cachedRoutes) && in_array(WithCachedRoutes::class, class_uses_recursive(self::class))) {
+        if (isset(CachedState::$cachedRoutes) && in_array(WithCachedRoutes::class, class_uses_recursive(static::class))) {
             $app->booting(fn () => $this->markRoutesCached($app));
         }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -29,7 +29,8 @@ abstract class TestCase extends BaseTestCase
     {
         $app = require Application::inferBasePath().'/bootstrap/app.php';
 
-        if (isset(CachedState::$cachedRoutes) && in_array(WithCachedRoutes::class, class_uses_recursive(static::class))) {
+        if (isset(CachedState::$cachedRoutes) &&
+            in_array(WithCachedRoutes::class, class_uses_recursive(static::class))) {
             $app->booting(fn () => $this->markRoutesCached($app));
         }
 

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -26,11 +26,20 @@ trait WithCachedRoutes
         $this->markRoutesCached($this->app);
     }
 
+    /**
+     * Reset the route service provider so it's not defaulting to loading cached routes.
+     * Helpful if some of the tests in the suite apply this trait while others do not.
+     *
+     * @return void
+     */
     protected function tearDownWithCachedRoutes(): void
     {
         RouteServiceProvider::loadCachedRoutesUsing(null);
     }
 
+    /**
+     * Inform the container to treat routes as cached.
+     */
     protected function markRoutesCached(Application $app): void
     {
         $app->instance('routes.cached', true);

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
 
 trait WithCachedRoutes
 {
-    protected static array $cachedRoutes = [];
+    protected static array $cachedRoutes;
 
     protected function setUpWithCachedRoutes(): void
     {

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -14,12 +14,12 @@ trait WithCachedRoutes
      */
     protected function setUpWithCachedRoutes(): void
     {
-        // If we haven't stored the cached routes yet, then let's store them
-        // once so we can use them in the remaining tests.
         if ((CachedState::$cachedRoutes ?? null) === null) {
             $routes = $this->app['router']->getRoutes();
+
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
+
             CachedState::$cachedRoutes = $routes->compile();
         }
 
@@ -28,7 +28,8 @@ trait WithCachedRoutes
 
     /**
      * Reset the route service provider so it's not defaulting to loading cached routes.
-     * Helpful if some of the tests in the suite apply this trait while others do not.
+     *
+     * This is helpful if some of the tests in the suite apply this trait while others do not.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+
+trait WithCachedRoutes
+{
+    protected static array $cachedRoutes = [];
+
+    protected function setUpWithCachedRoutes(): void
+    {
+        $this->app->instance('routes.cached', true);
+
+        if ((self::$cachedRoutes ?? null) === null) {
+            $routes = $this->app['router']->getRoutes();
+            $routes->refreshNameLookups();
+            $routes->refreshActionLookups();
+            self::$cachedRoutes = $routes;
+        }
+
+        RouteServiceProvider::loadCachedRoutesUsing(
+            static fn () => app('router')->setCompiledRoutes(self::$cachedRoutes)
+        );
+    }
+
+    protected function tearDownWithCachedRoutes(): void
+    {
+        RouteServiceProvider::loadCachedRoutesUsing(null);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -14,7 +14,7 @@ trait WithCachedRoutes
             $routes = $this->app['router']->getRoutes();
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
-            self::$cachedRoutes = $routes;
+            self::$cachedRoutes = $routes->compile();
         }
 
         $this->app->instance('routes.cached', true);

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -10,14 +10,14 @@ trait WithCachedRoutes
 
     protected function setUpWithCachedRoutes(): void
     {
-        $this->app->instance('routes.cached', true);
-
         if ((self::$cachedRoutes ?? null) === null) {
             $routes = $this->app['router']->getRoutes();
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
             self::$cachedRoutes = $routes;
         }
+
+        $this->app->instance('routes.cached', true);
 
         RouteServiceProvider::loadCachedRoutesUsing(
             static fn () => app('router')->setCompiledRoutes(self::$cachedRoutes)

--- a/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedRoutes.php
@@ -2,30 +2,42 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
 
 trait WithCachedRoutes
 {
-    protected static array $cachedRoutes;
-
+    /**
+     * After creating the routes once, we can cache them for the remaining tests.
+     *
+     * @return void
+     */
     protected function setUpWithCachedRoutes(): void
     {
-        if ((self::$cachedRoutes ?? null) === null) {
+        // If we haven't stored the cached routes yet, then let's store them
+        // once so we can use them in the remaining tests.
+        if ((CachedState::$cachedRoutes ?? null) === null) {
             $routes = $this->app['router']->getRoutes();
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
-            self::$cachedRoutes = $routes->compile();
+            CachedState::$cachedRoutes = $routes->compile();
         }
 
-        $this->app->instance('routes.cached', true);
-
-        RouteServiceProvider::loadCachedRoutesUsing(
-            static fn () => app('router')->setCompiledRoutes(self::$cachedRoutes)
-        );
+        $this->markRoutesCached($this->app);
     }
 
     protected function tearDownWithCachedRoutes(): void
     {
         RouteServiceProvider::loadCachedRoutesUsing(null);
     }
+
+    protected function markRoutesCached(Application $app): void
+    {
+        $app->instance('routes.cached', true);
+
+        RouteServiceProvider::loadCachedRoutesUsing(
+            static fn () => app('router')->setCompiledRoutes(CachedState::$cachedRoutes)
+        );
+    }
+
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -9,7 +9,6 @@ use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Support\ServiceProvider;
 use Mockery as m;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -621,7 +620,8 @@ class FoundationApplicationTest extends TestCase
     public function test_routes_are_not_cached_by_instance_falls_back_to_file()
     {
         $app = new Application();
-        $files = new class {
+        $files = new class
+        {
             public string $pathRequested;
             public function exists(string $path): bool
             {

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Support\ServiceProvider;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -608,6 +609,30 @@ class FoundationApplicationTest extends TestCase
         } catch (HttpException $exception) {
             $this->assertSame(['X-FOO' => 'BAR'], $exception->getHeaders());
         }
+    }
+
+    public function test_routes_are_cached()
+    {
+        $app = new Application();
+        $app->instance('routes.cached', true);
+        $this->assertTrue($app->routesAreCached());
+    }
+
+    public function test_routes_are_not_cached_by_instance_falls_back_to_file()
+    {
+        $app = new Application();
+        $files = new class {
+            public string $pathRequested;
+            public function exists(string $path): bool
+            {
+                $this->pathRequested = $path;
+                return false;
+            }
+        };
+        $app->instance('files', $files);
+
+        $this->assertFalse($app->routesAreCached());
+        $this->assertStringContainsString('routes-v7.php', $files->pathRequested);
     }
 }
 


### PR DESCRIPTION
I joined a team with a modular monolith. There are 8000+ tests, the majority of which extend from Laravel's `Illuminate\Foundation\Testing\TestCase`. By the nature of the modular monolith, there are many, many routes files, as each domain has one or more files for route definitions.

Leveraging the profiler in Herd and running the test suite, I noticed that we were spending a ton of cumulative time on the `ServiceProvider@loadRoutesFrom()` method. This is due to reading from disk.

Even if we were to cache the routes via `php artisan route:cache --env=testing`, we would still be reading from disk on every test. It also presents a problem, as it's possible the cached routes would differ from local vs testing environment, and it creates the overhead of developers having to remember to run the cache command.

## The(?) Solution
A new testing trait called `WithCachedRoutes`. This stores the routes as a static property within a `Testing\CachedState` object during test setup, and then subsequent tests do not need to read from disk.

### Potential pitfalls
* This completely ignores if the user has cached routes via the normal command. I don't consider this terribly risky, as the likelihood is much higher that they have generated a route cache before making a change to their, leading to tests breaking anyways.
* If a test overrides the `setUp()` method and tests some kind of static property/constant that changes how routes get defined, this will carry over into subsequent tests. I would _imagine_ that this is an incredibly rare case, and the user can just remove the trait from that test case. Good documentation about the feature will mitigate this.

## Follow ups
I think a logical next step is to cache the configuration as well.

## Benchmarks
This is mostly anecdotal, but for our test suite which reports 18,981 tests:

* normally: 07:52.903
* **WithCachedRoutes**: 05:41.584
