### PR TITLE
[13.x] Always cast something as fluent if column is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsFluent.php
@@ -20,7 +20,7 @@ class AsFluent implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($value) ? new Fluent(Json::decode($value)) : null;
+                return new Fluent(Json::decode($value ?? '[]'));
             }
 
             public function set($model, $key, $value, $attributes)


### PR DESCRIPTION
This is a resubmission of PR #56540, previously closed as a breaking change for Laravel 12.x. Proposing for Laravel 13.

**Problem:**

The `AsFluent` cast returns `null` when a database column is null, requiring null checks:
```php
$user->preferences->get('theme'); // Crashes if preferences is null
$user->preferences?->get('theme'); // Current workaround - seems out of character for "Fluent"
```

**Solution:**

Always return a Fluent instance, even when the column is null:
```php
$user->preferences->get('theme'); // Works safely, returns null if empty
```

This is especially useful for JSON columns in MySQL where default values cannot be set at the database level.

**Breaking Change:**

Code that explicitly checks for `null` to determine if a column was set will break. Acceptable for a major version release.