### PR TITLE
[12.x] Fix: Correctly fallback to notification's connection/queue when using viaConnections/viaQueues

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -232,7 +232,7 @@ class NotificationSender
                 $connection = $notification->connection;
 
                 if (method_exists($notification, 'viaConnections')) {
-                    $connection = $notification->viaConnections()[$channel] ?? null;
+                    $connection = $notification->viaConnections()[$channel] ?? $connection;
                 }
 
                 $queue = $notification->queue;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -238,7 +238,7 @@ class NotificationSender
                 $queue = $notification->queue;
 
                 if (method_exists($notification, 'viaQueues')) {
-                    $queue = $notification->viaQueues()[$channel] ?? null;
+                    $queue = $notification->viaQueues()[$channel] ?? $queue;
                 }
 
                 $delay = $notification->delay;

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -43,6 +43,31 @@ class NotificationSenderTest extends TestCase
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia);
     }
 
+    public function testItCanSendQueuedNotificationsWithAnArrayVia()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'dummy' && $job->channels === ['database'] && $job->connection === 'redis';
+            });
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'dummy' && $job->channels === ['mail'] && $job->connection === 'redis';
+            });
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyQueuedNotificationWithArrayVia);
+    }
+
     public function testItCanSendNotificationsWithAnEmptyStringVia()
     {
         $notifiable = new AnonymousNotifiable;
@@ -128,12 +153,12 @@ class NotificationSenderTest extends TestCase
         $bus->shouldReceive('dispatch')
             ->once()
             ->withArgs(function ($job) {
-                return $job->connection === 'sync' && $job->channels === ['database'];
+                return $job->connection === 'sync' && $job->channels === ['database'] && $job->queue === 'dummy';
             });
         $bus->shouldReceive('dispatch')
             ->once()
             ->withArgs(function ($job) {
-                return $job->connection === null && $job->channels === ['mail'];
+                return $job->connection === 'redis' && $job->channels === ['mail'] && $job->queue === 'dummy';
             });
 
         $events = m::mock(EventDispatcher::class);
@@ -142,6 +167,31 @@ class NotificationSenderTest extends TestCase
         $sender = new NotificationSender($manager, $bus, $events);
 
         $sender->send($notifiable, new DummyNotificationWithViaConnections);
+    }
+
+    public function testItCanSendQueuedWithViaQueuesNotifications()
+    {
+        $notifiable = new AnonymousNotifiable;
+        $manager = m::mock(ChannelManager::class);
+        $manager->shouldReceive('getContainer')->andReturn(app());
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'dummy' && $job->channels === ['database'] && $job->connection === 'redis';
+            });
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->queue === 'admin_notifications' && $job->channels === ['mail'] && $job->connection === 'redis';
+            });
+
+        $events = m::mock(EventDispatcher::class);
+        $events->shouldReceive('listen')->once();
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyNotificationWithViaQueues);
     }
 
     public function testNotificationFailedSentWithoutHttpTransportException()
@@ -184,6 +234,28 @@ class DummyQueuedNotificationWithStringVia extends Notification implements Shoul
     }
 }
 
+class DummyQueuedNotificationWithArrayVia extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
+    }
+
+    /**
+     * Get the notification channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+}
+
 class DummyNotificationWithEmptyStringVia extends Notification
 {
     use Queueable;
@@ -220,6 +292,12 @@ class DummyNotificationWithViaConnections extends Notification implements Should
 {
     use Queueable;
 
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
+    }
+
     public function via($notifiable)
     {
         return ['mail', 'database'];
@@ -229,6 +307,29 @@ class DummyNotificationWithViaConnections extends Notification implements Should
     {
         return [
             'database' => 'sync',
+        ];
+    }
+}
+
+class DummyNotificationWithViaQueues extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->connection = 'redis';
+        $this->queue = 'dummy';
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail', 'database'];
+    }
+
+    public function viaQueues()
+    {
+        return [
+            'mail' => 'admin_notifications',
         ];
     }
 }


### PR DESCRIPTION
**The Problem:**

When a `ShouldQueue` notification is dispatched:
* By default, without `viaQueues()` or `viaConnections()` methods, all channels correctly utilize the notification's own `$connection` and `$queue` properties (e.g., `'redis'` and `'admin_notifications'`) as their queue/connection settings.
* However, if we define `viaQueues()` or `viaConnections()` to customize settings for **only some** channels, the channels that are *not* customized incorrectly bypass the notification's own default properties and fall back directly to the application's **global default** queue/connection settings.


**Example Scenario:**

* **App Defaults:** `QUEUE_CONNECTION=sync`, Default Queue: `base_queue`
* **Notification Class Settings:** `$connection = 'redis'`, `$queue = 'admin_notifications'`

 ```php
class AdminNotification extends Notification implements ShouldQueue
{
    use Queueable;

    public function __construct()
    {
        $this->connection = 'redis';
        $this->queue = 'admin_notifications';
    }
    
    public function via($notifiable)
    {
        return ['mail', 'database'];
    }
    
    public function viaQueues(): array
    {
        return ['mail' => 'mail_urgent'];
    }
    
    public function viaConnections()
    {
        return ['mail' => 'sqs'];
    }
```

* **Incorrect Behavior (Before Fix):**
    * `mail` channel: Uses `sqs` connection, `mail_urgent` queue. (Correct)
    * `database` channel: Uses the **`database`** connection (Global Default) and the **`base_queue`** queue (Global Default). (**INCORRECT**) It should have used the notification's defaults (`redis` / `admin_notifications`).

**The Fix:**

This PR modifies the queue resolution logic. For channels not explicitly defined in `viaQueues()` or `viaConnections()`, Laravel will now first check and use the notification's own `$queue` or `$connection` properties. It will only fallback to the application's global defaults if the notification's properties are also unset.

* **Correct Behavior (After Fix):**
    * `mail` channel: Uses `redis` connection, `mail_urgent` queue. (Correct)
    * `database` channel: Uses the **`redis`** connection (Notification Default) and the **`admin_notifications`** queue (Notification Default). (**CORRECT**)