### PR TITLE
Only merge cached casts for accessed attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1904,8 +1904,8 @@ trait HasAttributes
     protected function mergeAttributesFromClassCasts(?string $onlyMergeCachedCastsForThisKey = null)
     {
         foreach ($this->classCastCache as $key => $value) {
-            if(!is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
-                continue;
+            if (! is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
+                 continue;
             }
             
             $caster = $this->resolveCasterClass($key);
@@ -1927,8 +1927,8 @@ trait HasAttributes
     protected function mergeAttributesFromAttributeCasts(?string $onlyMergeCachedCastsForThisKey = null)
     {
         foreach ($this->attributeCastCache as $key => $value) {
-            if(!is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
-                continue;
+            if (! is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
+                 continue;
             }
             $attribute = $this->{Str::camel($key)}();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1947,7 +1947,7 @@ trait HasAttributes
     protected function mergeAttributesFromAttributeCasts()
     {
         foreach ($this->attributeCastCache as $key => $value) {
-           $this->mergeAttributeFromAttributeCasts($key);
+            $this->mergeAttributeFromAttributeCasts($key);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1929,7 +1929,12 @@ trait HasAttributes
         }
     }
 
-    private function mergeAttributeFromClassCasts(string $key): void
+    /**
+     * Merge the cast class attribute back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributeFromClassCasts(string $key): void
     {
         if (! isset($this->classCastCache[$key])) {
             return;
@@ -1959,7 +1964,12 @@ trait HasAttributes
         }
     }
 
-    private function mergeAttributeFromAttributeCasts(string $key): void
+    /**
+     * Merge the cast class attribute back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributeFromAttributeCasts(string $key): void
     {
         if (! isset($this->attributeCastCache[$key])) {
             return;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -537,7 +537,7 @@ trait HasAttributes
      */
     protected function getAttributeFromArray($key)
     {
-        return $this->getAttributes()[$key] ?? null;
+        return $this->getAttributes($key)[$key] ?? null;
     }
 
     /**
@@ -1890,10 +1890,10 @@ trait HasAttributes
      *
      * @return void
      */
-    protected function mergeAttributesFromCachedCasts()
+    protected function mergeAttributesFromCachedCasts(?string $onlyMergeCachedCastsForThisKey = null)
     {
-        $this->mergeAttributesFromClassCasts();
-        $this->mergeAttributesFromAttributeCasts();
+        $this->mergeAttributesFromClassCasts($onlyMergeCachedCastsForThisKey);
+        $this->mergeAttributesFromAttributeCasts($onlyMergeCachedCastsForThisKey);
     }
 
     /**
@@ -1901,9 +1901,13 @@ trait HasAttributes
      *
      * @return void
      */
-    protected function mergeAttributesFromClassCasts()
+    protected function mergeAttributesFromClassCasts(?string $onlyMergeCachedCastsForThisKey = null)
     {
         foreach ($this->classCastCache as $key => $value) {
+            if(!is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
+                continue;
+            }
+            
             $caster = $this->resolveCasterClass($key);
 
             $this->attributes = array_merge(
@@ -1920,9 +1924,12 @@ trait HasAttributes
      *
      * @return void
      */
-    protected function mergeAttributesFromAttributeCasts()
+    protected function mergeAttributesFromAttributeCasts(?string $onlyMergeCachedCastsForThisKey = null)
     {
         foreach ($this->attributeCastCache as $key => $value) {
+            if(!is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
+                continue;
+            }
             $attribute = $this->{Str::camel($key)}();
 
             if ($attribute->get && ! $attribute->set) {
@@ -1959,9 +1966,9 @@ trait HasAttributes
      *
      * @return array<string, mixed>
      */
-    public function getAttributes()
+    public function getAttributes(?string $onlyMergeCachedCastsForThisKey = null)
     {
-        $this->mergeAttributesFromCachedCasts();
+        $this->mergeAttributesFromCachedCasts($onlyMergeCachedCastsForThisKey);
 
         return $this->attributes;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1907,7 +1907,6 @@ trait HasAttributes
             if (! is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
                 continue;
             }
-            
             $caster = $this->resolveCasterClass($key);
 
             $this->attributes = array_merge(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1905,7 +1905,7 @@ trait HasAttributes
     {
         foreach ($this->classCastCache as $key => $value) {
             if (! is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
-                 continue;
+                continue;
             }
             
             $caster = $this->resolveCasterClass($key);
@@ -1928,7 +1928,7 @@ trait HasAttributes
     {
         foreach ($this->attributeCastCache as $key => $value) {
             if (! is_null($onlyMergeCachedCastsForThisKey) && $key !== $onlyMergeCachedCastsForThisKey) {
-                 continue;
+                continue;
             }
             $attribute = $this->{Str::camel($key)}();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -712,6 +712,8 @@ trait HasAttributes
      */
     protected function mutateAttribute($key, $value)
     {
+        $this->mergeAttributesFromCachedCasts();
+
         return $this->{'get'.Str::studly($key).'Attribute'}($value);
     }
 
@@ -727,6 +729,8 @@ trait HasAttributes
         if (array_key_exists($key, $this->attributeCastCache)) {
             return $this->attributeCastCache[$key];
         }
+
+        $this->mergeAttributesFromCachedCasts();
 
         $attribute = $this->{Str::camel($key)}();
 
@@ -1159,6 +1163,8 @@ trait HasAttributes
      */
     protected function setMutatedAttributeValue($key, $value)
     {
+        $this->mergeAttributesFromCachedCasts();
+
         return $this->{'set'.Str::studly($key).'Attribute'}($value);
     }
 
@@ -1171,6 +1177,8 @@ trait HasAttributes
      */
     protected function setAttributeMarkedMutatedAttributeValue($key, $value)
     {
+        $this->mergeAttributesFromCachedCasts();
+
         $attribute = $this->{Str::camel($key)}();
 
         $callback = $attribute->set ?: function ($value) use ($key) {

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -330,7 +330,6 @@ class TestEloquentModelWithCustomCast extends Model
         'anniversary_on_without_object_caching' => DateTimezoneCasterWithoutObjectCaching::class.':America/New_York',
     ];
 
-
     /**
      * A computed attribute that depends on another casted attribute.
      *

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -287,6 +287,16 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $model->undefined_cast_column = 'Glāžšķūņu rūķīši';
     }
+
+    public function testMutatorCanDependOnAnotherCastedAttribute()
+    {
+        $model = new TestEloquentModelWithCustomCast([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My Childhood House',
+        ]);
+        $model->address->lineOne = 'Changed St.';
+        $this->assertSame('Changed St. (My Childhood House)', $model->address_string);
+    }
 }
 
 class TestEloquentModelWithCustomCast extends Model
@@ -319,6 +329,27 @@ class TestEloquentModelWithCustomCast extends Model
         'anniversary_on_with_object_caching' => DateTimezoneCasterWithObjectCaching::class.':America/New_York',
         'anniversary_on_without_object_caching' => DateTimezoneCasterWithoutObjectCaching::class.':America/New_York',
     ];
+
+
+    /**
+     * A computed attribute that depends on another casted attribute.
+     *
+     * This simulates a mutator that uses the value of a casted property.
+     */
+    protected function addressString(): \Illuminate\Database\Eloquent\Casts\Attribute
+    {
+        return \Illuminate\Database\Eloquent\Casts\Attribute::get(function () {
+            $address = $this->address;
+
+            // If mergeAttributesFromClassCasts() hasn't prepared casts properly,
+            // this could be an array instead of an Address instance.
+            if (! $address instanceof Address) {
+                throw new \RuntimeException('Address was not cast before mutator access.');
+            }
+
+            return "{$address->lineOne} ({$address->lineTwo})";
+        });
+    }
 }
 
 class HashCaster implements CastsInboundAttributes

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -306,7 +306,6 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         ]);
 
         $model->dob->addDay();
-        
         $this->assertSame('2000-11-12 11:11:00', $model->tob);
     }
 }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -306,6 +306,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         ]);
 
         $model->dob->addDay();
+        
         $this->assertSame('2000-11-12 11:11:00', $model->tob);
     }
 }

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -189,7 +189,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('{"key1":"value1"}')
             ->andReturn('encrypted-secret-collection-string-1');
         $this->encrypter->expects('encryptString')
-            ->times(10)
+            ->times(9)
             ->with('{"key1":"value1","key2":"value2"}')
             ->andReturn('encrypted-secret-collection-string-2');
         $this->encrypter->expects('decryptString')
@@ -239,7 +239,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('[{"key1":"value1"}]')
             ->andReturn('encrypted-secret-collection-string-1');
         $this->encrypter->expects('encryptString')
-            ->times(12)
+            ->times(11)
             ->with('[{"key1":"value1"},{"key2":"value2"}]')
             ->andReturn('encrypted-secret-collection-string-2');
         $this->encrypter->expects('decryptString')
@@ -295,7 +295,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('encrypted-secret-array-string-1')
             ->andReturn('{"key1":"value1"}');
         $this->encrypter->expects('encryptString')
-            ->times(10)
+            ->times(9)
             ->with('{"key1":"value1","key2":"value2"}')
             ->andReturn('encrypted-secret-array-string-2');
         $this->encrypter->expects('decryptString')


### PR DESCRIPTION
This is a PoC for the issues discussed in https://github.com/laravel/framework/discussions/31778

One major performance hog that I noticed in my laravel jobs is the fact that all model attributes that have a cast and were already accessed are serialized everytime any attribute of the model is accessed. This happens in HasAttributes.php in the method mergeAttributesFromClassCasts.

Here is an example:

```
$user = User::first();
$someCastedAttribute = $user->some_casted_attribute;
$id = $user->id; // <-- this line triggers mergeAttributesFromClassCasts which causes a serialization of some_casted_attribute
```

This behavior is very expensive if the casted attributes are large objects. (e.g. an instantiated class from a large json column). 

Let's assume $user->some_casted_attribute holds a class with 100kB of loaded data

```
for($i = 0; $i < 1000; $i++) {
    $id = $user->id;
}
```
This loop will cause 1000 calls to json_encode($this->some_casted_attribute) which effectively encodes a total of 100MB of data, even though some_casted_attribute is never used in the loop.

My PR includes a PoC that makes sure that only the attribute that is really accessed via getAttribute is serialized. This is optional behavior that I added to mergeAttributesFromClassCasts and it will behave as it used to for all other places in the codebase that access it.

The linked github discussion includes further suggestions how to reduce the calls for places like isDirty checks, but I decided to stick to the highest ROI change with the lowest chance of negative side effects in this PR.

Tests are passing and I cannot think of a way how this would break something, but I am happy to get confirmation that the approach is sound and that I am not overlooking some edge case or reason why we would actually want to serialize all casted attributes even when we just access id.

My benchmarks showed a huge improvement for my workloads. Before the change my code spent over 80% of the total execution time in mergeAttributesFromClassCasts. With the change this reduced <20% for most cases (still high, but definitely an improvement, that will save significant server costs). Disclaimer: My workload actually contains large json columns (10-100kB).

The screenshot lists some of my jobs which have a high execution time % spent in mergeAttributesFromClassCasts with the time spent before and after this proposed change.

<img width="138" height="388" alt="image" src="https://github.com/user-attachments/assets/3ee3d213-6936-446f-a32d-df56edafa78d" />
