### PR TITLE
[12.x] Add lastId parameter to chunkById methods for improved chunking

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -141,11 +141,12 @@ trait BuildsQueries
      * @param  callable(\Illuminate\Support\Collection<int, TValue>, int): mixed  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null)
+    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
-        return $this->orderedChunkById($count, $callback, $column, $alias, descending: true);
+        return $this->orderedChunkById($count, $callback, $column, $alias, true, $lastId);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -126,11 +126,12 @@ trait BuildsQueries
      * @param  callable(\Illuminate\Support\Collection<int, TValue>, int): mixed  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = null, $alias = null)
+    public function chunkById($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
-        return $this->orderedChunkById($count, $callback, $column, $alias);
+        return $this->orderedChunkById($count, $callback, $column, $alias, false, $lastId);
     }
 
     /**
@@ -155,15 +156,15 @@ trait BuildsQueries
      * @param  string|null  $column
      * @param  string|null  $alias
      * @param  bool  $descending
+     * @param  mixed  $lastId
      * @return bool
      *
      * @throws \RuntimeException
      */
-    public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
+    public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false, $lastId = null)
     {
         $column ??= $this->defaultKeyName();
         $alias ??= $column;
-        $lastId = null;
         $skip = $this->getOffset();
         $remaining = $this->getLimit();
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1034,11 +1034,12 @@ class BelongsToMany extends Relation
      * @param  callable  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = null, $alias = null)
+    public function chunkById($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
-        return $this->orderedChunkById($count, $callback, $column, $alias);
+        return $this->orderedChunkById($count, $callback, $column, $alias, false, $lastId);
     }
 
     /**
@@ -1083,9 +1084,10 @@ class BelongsToMany extends Relation
      * @param  string|null  $column
      * @param  string|null  $alias
      * @param  bool  $descending
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false)
+    public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false, $lastId = null)
     {
         $column ??= $this->getRelated()->qualifyColumn(
             $this->getRelatedKeyName()
@@ -1097,7 +1099,7 @@ class BelongsToMany extends Relation
             $this->hydratePivotRelation($results->all());
 
             return $callback($results, $page);
-        }, $column, $alias, $descending);
+        }, $column, $alias, $descending, $lastId);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1049,11 +1049,12 @@ class BelongsToMany extends Relation
      * @param  callable  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null)
+    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
-        return $this->orderedChunkById($count, $callback, $column, $alias, descending: true);
+        return $this->orderedChunkById($count, $callback, $column, $alias, true, $lastId);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -544,15 +544,16 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  callable  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = null, $alias = null)
+    public function chunkById($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
         $column ??= $this->getRelated()->getQualifiedKeyName();
 
         $alias ??= $this->getRelated()->getKeyName();
 
-        return $this->prepareQueryBuilder()->chunkById($count, $callback, $column, $alias);
+        return $this->prepareQueryBuilder()->chunkById($count, $callback, $column, $alias, $lastId);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -563,15 +563,16 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  callable  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
+     * @param  mixed  $lastId
      * @return bool
      */
-    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null)
+    public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null, $lastId = null)
     {
         $column ??= $this->getRelated()->getQualifiedKeyName();
 
         $alias ??= $this->getRelated()->getKeyName();
 
-        return $this->prepareQueryBuilder()->chunkByIdDesc($count, $callback, $column, $alias);
+        return $this->prepareQueryBuilder()->chunkByIdDesc($count, $callback, $column, $alias, $lastId);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -109,16 +109,17 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         $user = BelongsToManyChunkByIdTestTestUser::query()->first();
         $i = 0;
 
-        // Start chunking from ID 2 (descending), so it should skip ID 3 and start from ID 2
+        // Start chunking from ID 3 (descending), so it should skip ID 3 and start from ID 2
+        // We pass lastId=3 so forPageBeforeId uses "where id < 3", which gives us ID 2 and ID 1
         $user->articles()->chunkByIdDesc(1, function (Collection $collection) use (&$i) {
             $i++;
-            // First chunk should start from ID 2
+            // First chunk should start from ID 2 (descending order, so highest ID < 3)
             if ($i === 1) {
                 $this->assertEquals(2, $collection->first()->id);
             } else {
                 $this->assertEquals(1, $collection->first()->id);
             }
-        }, null, null, 2);
+        }, null, null, 3);
 
         // Should process 2 chunks (ID 2 and ID 1), skipping ID 3
         $this->assertSame(2, $i);

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -80,6 +80,28 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         $this->assertSame(3, $i);
     }
 
+    public function testBelongsToChunkByIdWithLastId()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+        $i = 0;
+
+        // Start chunking from ID 1, so it should skip ID 1 and start from ID 2
+        $user->articles()->chunkById(1, function (Collection $collection) use (&$i) {
+            $i++;
+            // First chunk should start from ID 2
+            if ($i === 1) {
+                $this->assertEquals(2, $collection->first()->id);
+            } else {
+                $this->assertEquals(3, $collection->first()->id);
+            }
+        }, null, null, 1);
+
+        // Should process 2 chunks (ID 2 and ID 3), skipping ID 1
+        $this->assertSame(2, $i);
+    }
+
     /**
      * Tear down the database schema.
      *

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -102,6 +102,28 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
         $this->assertSame(2, $i);
     }
 
+    public function testBelongsToChunkByIdDescWithLastId()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+        $i = 0;
+
+        // Start chunking from ID 2 (descending), so it should skip ID 3 and start from ID 2
+        $user->articles()->chunkByIdDesc(1, function (Collection $collection) use (&$i) {
+            $i++;
+            // First chunk should start from ID 2
+            if ($i === 1) {
+                $this->assertEquals(2, $collection->first()->id);
+            } else {
+                $this->assertEquals(1, $collection->first()->id);
+            }
+        }, null, null, 2);
+
+        // Should process 2 chunks (ID 2 and ID 1), skipping ID 3
+        $this->assertSame(2, $i);
+    }
+
     /**
      * Tear down the database schema.
      *

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -363,6 +363,34 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertEquals(6, $count);
     }
 
+    public function testChunkByIdWithLastId()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $i = 0;
+        $count = 0;
+        $processedIds = [];
+
+        // Start from a specific ID (e.g., 2)
+        $country->posts()->chunkById(2, function ($collection) use (&$i, &$count, &$processedIds) {
+            $i++;
+            $count += $collection->count();
+            foreach ($collection as $post) {
+                $processedIds[] = $post->id;
+            }
+        }, null, null, 2);
+
+        // Should process posts starting from ID 2
+        $this->assertGreaterThan(0, $i);
+        $this->assertGreaterThan(0, $count);
+        // All processed IDs should be greater than 2
+        foreach ($processedIds as $id) {
+            $this->assertGreaterThan(2, $id);
+        }
+    }
+
     public function testCursorReturnsCorrectModels()
     {
         $this->seedData();

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -391,6 +391,34 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         }
     }
 
+    public function testChunkByIdDescWithLastId()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $i = 0;
+        $count = 0;
+        $processedIds = [];
+
+        // Start from a specific ID (e.g., 5) in descending order
+        $country->posts()->chunkByIdDesc(2, function ($collection) use (&$i, &$count, &$processedIds) {
+            $i++;
+            $count += $collection->count();
+            foreach ($collection as $post) {
+                $processedIds[] = $post->id;
+            }
+        }, null, null, 5);
+
+        // Should process posts starting from ID 5 going down
+        $this->assertGreaterThan(0, $i);
+        $this->assertGreaterThan(0, $count);
+        // All processed IDs should be less than 5
+        foreach ($processedIds as $id) {
+            $this->assertLessThan(5, $id);
+        }
+    }
+
     public function testCursorReturnsCorrectModels()
     {
         $this->seedData();

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -981,6 +981,25 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
     }
 
+    public function testChunkByIdWithLastId()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'user1@example.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'user2@example.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'user3@example.com']);
+        EloquentTestUser::create(['id' => 4, 'email' => 'user4@example.com']);
+
+        $processedIds = [];
+
+        // Start from ID 2, so should process IDs 2, 3, 4 (skipping 1)
+        EloquentTestUser::query()->chunkById(2, function ($users) use (&$processedIds) {
+            foreach ($users as $user) {
+                $processedIds[] = $user->id;
+            }
+        }, null, null, 1);
+
+        $this->assertEquals([2, 3, 4], $processedIds);
+    }
+
     public function testPluck()
     {
         EloquentTestUser::insert([

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1000,6 +1000,25 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals([2, 3, 4], $processedIds);
     }
 
+    public function testChunkByIdDescWithLastId()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'user1@example.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'user2@example.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'user3@example.com']);
+        EloquentTestUser::create(['id' => 4, 'email' => 'user4@example.com']);
+
+        $processedIds = [];
+
+        // Start from ID 3 (descending), so should process IDs 2, 1 (skipping 4 and 3)
+        EloquentTestUser::query()->chunkByIdDesc(2, function ($users) use (&$processedIds) {
+            foreach ($users as $user) {
+                $processedIds[] = $user->id;
+            }
+        }, null, null, 3);
+
+        $this->assertEquals([2, 1], $processedIds);
+    }
+
     public function testPluck()
     {
         EloquentTestUser::insert([

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5646,6 +5646,66 @@ SQL;
         }, 'someIdField');
     }
 
+    public function testChunkByIdWithLastId()
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
+
+        $chunk1 = collect([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
+        $chunk2 = collect([]);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 5, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
+
+        $callbackAssertor = m::mock(stdClass::class);
+        $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
+        $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
+
+        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+            $callbackAssertor->doSomething($results);
+        }, 'someIdField', null, 5);
+    }
+
+    public function testChunkByIdWithLastIdOnArrays()
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
+
+        $chunk1 = collect([['someIdField' => 10], ['someIdField' => 11]]);
+        $chunk2 = collect([]);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 5, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
+
+        $callbackAssertor = m::mock(stdClass::class);
+        $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
+        $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
+
+        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+            $callbackAssertor->doSomething($results);
+        }, 'someIdField', null, 5);
+    }
+
+    public function testChunkByIdWithLastIdAndAlias()
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
+
+        $chunk1 = collect([(object) ['table_id' => 10], (object) ['table_id' => 11]]);
+        $chunk2 = collect([]);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 5, 'table.id')->andReturnSelf();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'table.id')->andReturnSelf();
+        $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
+
+        $callbackAssertor = m::mock(stdClass::class);
+        $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
+        $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
+
+        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+            $callbackAssertor->doSomething($results);
+        }, 'table.id', 'table_id', 5);
+    }
+
     public function testPaginate()
     {
         $perPage = 16;


### PR DESCRIPTION
# Implementation Plan: Add `$lastId` Parameter to `chunkById` Method

## Overview
This plan outlines the implementation of a new optional `$lastId` parameter for the `chunkById` method in Laravel Framework. This enhancement will allow users to specify a starting point for chunking operations, enabling use cases such as resuming interrupted chunking processes or skipping already processed records.

## Problem Statement
Currently, the `chunkById` method always starts from the beginning (with `$lastId = null`). There's no way to resume chunking from a specific ID, which can be useful when:
- A chunking process was interrupted and needs to be resumed
- You want to skip records that have already been processed
- You need to process records starting from a specific ID

## Proposed Solution
Add an optional `$lastId` parameter to the `chunkById` method signature. When provided, the chunking will start from the specified ID instead of starting from the beginning.

## Implementation Details

### 1. Core Query Builder (`BuildsQueries.php`)
**File**: `src/Illuminate/Database/Concerns/BuildsQueries.php`

**Current Implementation**:
- `chunkById()` calls `orderedChunkById()` without the `$lastId` parameter
- `orderedChunkById()` initializes `$lastId = null` on line 166

**Changes**:
- Add `$lastId = null` parameter to `chunkById()` method signature (5th parameter)
- Pass `$lastId` to `orderedChunkById()` (must also pass `false` for `$descending` since it's the 5th param)
- Add `$lastId = null` parameter to `orderedChunkById()` method signature (6th parameter)
- Change line 166 from `$lastId = null;` to use the provided parameter instead

**New Signatures**:
```php
public function chunkById($count, callable $callback, $column = null, $alias = null, $lastId = null)
public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false, $lastId = null)
```

**Implementation Logic**:
- `chunkById()` will call: `$this->orderedChunkById($count, $callback, $column, $alias, false, $lastId)`
- `orderedChunkById()` will use the provided `$lastId` parameter instead of always initializing to `null`

### 2. Core Query Builder - Descending (`BuildsQueries.php`)
**File**: `src/Illuminate/Database/Concerns/BuildsQueries.php`

**Additional Changes for `chunkByIdDesc()`**:
- Add `$lastId = null` parameter to `chunkByIdDesc()` method signature (5th parameter)
- Pass `$lastId` to `orderedChunkById()` (must also pass `true` for `$descending` since it's the 5th param)

**New Signature**:
```php
public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null, $lastId = null)
```

### 3. BelongsToMany Relation (`BelongsToMany.php`)
**File**: `src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php`

**Current Implementation**:
- `chunkById()` calls `orderedChunkById()` without `$lastId` parameter
- `chunkByIdDesc()` calls `orderedChunkById()` without `$lastId` parameter
- `orderedChunkById()` calls `prepareQueryBuilder()->orderedChunkById()` without `$lastId` parameter

**Changes**:
- Add `$lastId = null` parameter to `chunkById()` method signature (5th parameter)
- Pass `$lastId` to `orderedChunkById()` (must also pass `false` for `$descending` since it's the 5th param)
- Add `$lastId = null` parameter to `chunkByIdDesc()` method signature (5th parameter)
- Pass `$lastId` to `orderedChunkById()` (must also pass `true` for `$descending` since it's the 5th param)
- Add `$lastId = null` parameter to `orderedChunkById()` method signature (6th parameter)
- Pass `$lastId` to `prepareQueryBuilder()->orderedChunkById()` (must also pass `$descending` since it's the 5th param)
- Update PHPDoc to document the new parameter

**New Signatures**:
```php
public function chunkById($count, callable $callback, $column = null, $alias = null, $lastId = null)
public function chunkByIdDesc($count, callable $callback, $column = null, $alias = null, $lastId = null)
public function orderedChunkById($count, callable $callback, $column = null, $alias = null, $descending = false, $lastId = null)
```

### 4. HasOneOrManyThrough Relation (`HasOneOrManyThrough.php`)
**File**: `src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php`

**Note**: `HasManyThrough` extends `HasOneOrManyThrough`, so we update the parent class.

**Current Implementation**:
- `chunkById()` directly calls `prepareQueryBuilder()->chunkById()` without `$lastId` parameter
- `chunkByIdDesc()` directly calls `prepareQueryBuilder()->chunkByIdDesc()` without `$lastId` parameter

**Changes**:
- Add `$lastId = null` parameter to `chunkById()` method signature (5th parameter)
- Pass `$lastId` to `prepareQueryBuilder()->chunkById()`
- Add `$lastId = null` parameter to `chunkByIdDesc()` method signature (5th parameter)
- Pass `$lastId` to `prepareQueryBuilder()->chunkByIdDesc()`
- Update PHPDoc to document the new parameter

## Testing Strategy

### Test Cases to Add/Update

#### 1. Query Builder Tests (`DatabaseQueryBuilderTest.php`)
- ✅ **Test chunkById with lastId parameter** - Verify that chunking starts from the provided ID
- ✅ **Test chunkById without lastId (backwards compatibility)** - Ensure existing behavior still works
- ✅ **Test chunkById with lastId on arrays** - Test with array results
- ✅ **Test chunkById with lastId using alias** - Test with custom column alias
- ✅ **Test chunkByIdDesc with lastId parameter** - Verify that descending chunking starts from the provided ID

#### 2. Eloquent Builder Tests (`DatabaseEloquentBuilderTest.php`)
- ✅ **Test chunkById with lastId on Eloquent models** - Verify it works with Eloquent collections
- ✅ **Test chunkById backwards compatibility** - Ensure existing tests still pass
- ✅ **Test chunkByIdDesc with lastId** - Verify descending chunking with lastId works

#### 3. Integration Tests
- ✅ **Test chunkById with lastId on relations** - Test with `BelongsToMany` and `HasManyThrough` relations
- ✅ **Test chunkById resumes correctly** - Verify that chunking can resume from a specific ID
- ✅ **Test chunkByIdDesc with lastId on relations** - Test descending chunking with lastId on relations

### Test Scenarios

1. **Basic functionality**: Chunk starts from the provided `$lastId`
2. **Default behavior**: When `$lastId` is not provided (or `null`), behavior matches current implementation
3. **Edge cases**: 
   - `$lastId` that doesn't exist in the dataset
   - `$lastId` at the end of the dataset
   - `$lastId` is the last item in a chunk
4. **Relation compatibility**: Works correctly with `BelongsToMany` and `HasManyThrough` relations

## Backwards Compatibility
✅ **Fully backwards compatible** - The `$lastId` parameter is optional and defaults to `null`, which matches the current behavior. All existing code will continue to work without modification.

## Usage Examples

### Before (Current)
```php
User::chunkById(100, function ($users) {
    // Process users starting from the beginning
});
```

### After (New)
```php
// Start from a specific ID (ascending order)
User::chunkById(100, function ($users) {
    // Process users
}, null, null, 1000);

// Resume from where we left off (ascending order)
$lastProcessedId = 5000;
User::chunkById(100, function ($users) {
    // Process users
}, null, null, $lastProcessedId);

// Start from a specific ID (descending order)
User::chunkByIdDesc(100, function ($users) {
    // Process users from highest ID downwards
}, null, null, 5000);

// Resume descending chunking from where we left off
$lastProcessedId = 1000;
User::chunkByIdDesc(100, function ($users) {
    // Process users
}, null, null, $lastProcessedId);
```

## Files Modified

1. ✅ `src/Illuminate/Database/Concerns/BuildsQueries.php` - Updated `chunkById()`, `chunkByIdDesc()`, and `orderedChunkById()` to accept and pass `$lastId`
2. ✅ `src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php` - Updated `chunkById()`, `chunkByIdDesc()`, and `orderedChunkById()` to accept and pass `$lastId`
3. ✅ `src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php` - Updated `chunkById()` and `chunkByIdDesc()` to accept and pass `$lastId` (covers HasManyThrough)
4. ✅ `tests/Database/DatabaseQueryBuilderTest.php` - Added 3 new test cases for `chunkById` with `lastId`, 1 for `chunkByIdDesc` with `lastId`
5. ✅ `tests/Database/DatabaseEloquentBuilderTest.php` - Added 1 new test case for `chunkById` with `lastId`, 1 for `chunkByIdDesc` with `lastId`
6. ✅ `tests/Database/DatabaseEloquentIntegrationTest.php` - Added integration test for `chunkById` with `lastId`, 1 for `chunkByIdDesc` with `lastId`
7. ✅ `tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php` - Added relation test for `chunkById` with `lastId`, 1 for `chunkByIdDesc` with `lastId`
8. ✅ `tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php` - Added relation test for `chunkById` with `lastId`, 1 for `chunkByIdDesc` with `lastId`

## Notes

- The implementation maintains full backwards compatibility
- The parameter is positioned at the end to minimize impact on existing code
- All relationship methods that override `chunkById` will need to be updated to pass through the parameter
- Tests should verify both the new functionality and backwards compatibility