### PR TITLE
[12.x] ChainedBatch keeps queue and connection of wrapped batch

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -46,6 +46,7 @@ class ChainedBatch implements ShouldQueue
 
         $this->name = $batch->name;
         $this->options = $batch->options;
+
         $this->queue = $batch->queue();
         $this->connection = $batch->connection();
     }

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -46,6 +46,8 @@ class ChainedBatch implements ShouldQueue
 
         $this->name = $batch->name;
         $this->options = $batch->options;
+        $this->queue = $batch->queue();
+        $this->connection = $batch->connection();
     }
 
     /**

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -398,19 +398,20 @@ class JobChainingTest extends QueueTestCase
 
     public function testBatchInChainUsesCorrectQueue()
     {
+        $otherQueue = $this->getQueueDriver() === 'redis' ? '{other}' : 'other';
         Bus::chain([
-            (new JobChainingNamedTestJob('c1'))->onQueue('other'),
-            (new JobChainingNamedTestJob('c2'))->onQueue('other'),
+            (new JobChainingNamedTestJob('c1'))->onQueue($otherQueue),
+            (new JobChainingNamedTestJob('c2'))->onQueue($otherQueue),
             Bus::batch([
                 new JobChainingTestBatchedJob('b1'),
                 new JobChainingTestBatchedJob('b2'),
                 new JobChainingTestBatchedJob('b3'),
                 new JobChainingTestBatchedJob('b4'),
-            ])->onQueue('other'),
-            (new JobChainingNamedTestJob('c3'))->onQueue('other'),
+            ])->onQueue($otherQueue),
+            (new JobChainingNamedTestJob('c3'))->onQueue($otherQueue),
         ])->dispatch();
 
-        $this->runQueueWorkerCommand(['--queue' => 'other', '--stop-when-empty' => true]);
+        $this->runQueueWorkerCommand(['--queue' => $otherQueue, '--stop-when-empty' => true]);
 
         $this->assertEquals(['c1', 'c2', 'b1', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results);
     }


### PR DESCRIPTION
Currently ChainedBatch do not use queue and connection of wrapped PendingBatch. When it creates new batch in src/Illuminate/Bus/ChainedBatch.php:86, connection and queue of original batch is lost.

Currenctly, if we have code
```
        Bus::chain([
            Bus::batch([
                new ProcessPodcast(1),
                new ProcessPodcast(2),
            ])->onQueue('other'),
            (new ProcessPodcast(3))->onQueue('other'),
        ])->dispatch();
```
Job 3 will be dispatched to queue `other`, but Jobs 1 and 2 will be dispatched to queue `default`, even it is explicitly defined to use other queue.

In this PR chainedBatch takes queue and connection from wrapped batch, so later, when converted back to pending batch, it has same queue and connection as before.

Example of tests failing before fix https://github.com/laravel/framework/actions/runs/19057979725