### PR TITLE
[12.x] improve `Connection@listen()` docblock

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1048,7 +1048,7 @@ class Connection implements ConnectionInterface
     /**
      * Register a database query listener with the connection.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(\Illuminate\Database\Events\QueryExecuted)  $callback
      * @return void
      */
     public function listen(Closure $callback)


### PR DESCRIPTION
I had to jump into the method definition the other day to see what typehint I needed on my closure. Figured this would save other folks a few seconds.