### PR TITLE
refactor: utilize Collection's add()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1047,7 +1047,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function push(...$values)
     {
         foreach ($values as $value) {
-            $this->items[] = $value;
+            $this->add($value);
         }
 
         return $this;
@@ -1918,7 +1918,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function offsetSet($key, $value): void
     {
         if (is_null($key)) {
-            $this->items[] = $value;
+            $this->add($value);
         } else {
             $this->items[$key] = $value;
         }


### PR DESCRIPTION
This is a minor refactoring of adding items into a Collection. In methods like `push()` and `offsetSet()` the line:

```php
$this->items[] = $value;
```

is used. The same LOC of code is written twice when a method for it already exists: `add()`.