### PR TITLE
Add new `Str::unique` function

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1128,6 +1128,19 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Ensure the string is unique, calling the fallback
+     * if the test fails. If no fallback is provided, a
+     * failed test will be appended by a random string.
+     *
+     * @param  (\Closure(Stringable): string|Stringable|null)|string|null  $fallback
+     * @return static
+     */
+    public function unique(string $table, string $column = 'id', mixed $fallback = null, ?string $connection = null, bool $throw = true, int $maxAttempts = 5)
+    {
+        return new static(Str::unique($this->value, $table, $column, $fallback, $connection, $throw, $maxAttempts));
+    }
+
+    /**
      * Execute the given callback if the string contains a given substring.
      *
      * @param  string|iterable<string>  $needles


### PR DESCRIPTION
This PR introduces a `unique` helper for `Stringable` strings, inspired by Laravel's `Rule::unique`. Its goal is to provide a fluent, reusable way to ensure that a generated string (like a slug) is unique in a given database table and modifying(fluently or automatically) it if fails the uniqueness test, reducing repetitive code for common patterns like slug generation.

**Problem**

Consider a forum where topics need slugs for SEO. Titles may not be unique, but slugs must be. A typical implementation requires manually checking the database and appending a random string if a conflict exists through a reusable trait or macro:

```php
protected static function bootHasSlug(): void
{
    static::creating(function (Topic $topic): void {
        $slug = Str::slug($topic->name);
        $slugExists = $topic->newModelQuery()->where('slug', $slug)->exists();

        $topic->forceFill([
            'slug' => Str::of($slug)
                ->when($slugExists, fn (Stringable $str) => $str->append('-')->append(Str::random(8)))
                ->slug()
                ->toString(),
        ]);
    });
}
```

**Solution**

With the `unique` helper, the above logic reduces to:

```php
protected static function bootHasSlug(): void
{
    static::creating(function (Topic $topic): void {
        $topic->forceFill([
            'slug' => Str::of($topic->name)
                ->slug()
                ->unique('topics', 'slug')
                ->toString(),
        ]);
    });
}
```

**Key Features**

- **Fluent API**: Works seamlessly with `Stringable` chains.
- **Fallback Handling**: Optionally pass a callback or string to customize what happens if a duplicate is found.
- **Random Append**: Defaults to appending a random string if no fallback is provided.
- **Null-Friendly**: Returning `null` from the fallback leaves the string unchanged.

**Use Cases**

- Slug generation
- Custom username/handles
- File names
- Importing/syncing external data
- Testing/seeding data
- Multi-tenant scenarios

```php
Str::of('This Should Be Unique')
  ->slug()
  ->unique('topics', 'slug')
  ->toString(),

// Output: this-should-be-unique-a6jaFakfn
```

```php 
Str::of('This Should Be Unique')
  ->slug()
  ->unique('topics', 'slug', fn (Stringable $string) => $string->append('-some-new-text'))
  ->toString(),

// Output: this-should-be-unique-some-new-text
```

```php
Str::of('This Should Be Unique')
  ->slug()
  ->unique('topics', 'slug', 'this-returned-instead')
  ->toString(),

// Output: this-returned-instead
```

```php
Str::of('This Should Be Unique')
  ->slug()
  ->unique('topics', 'slug', fn () => null)
  ->toString(),

// Output: this-should-be-unique
```