### PR TITLE
[12.x] Queue tests for Redis Cluster missing QUEUE_CONNECTION

### DIFF
--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -175,6 +175,7 @@ jobs:
           REDIS_CLIENT: ${{ matrix.client }}
           REDIS_CLUSTER_HOSTS_AND_PORTS: 127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002
           REDIS_QUEUE: '{default}'
+          QUEUE_CONNECTION: redis
 
   beanstalkd:
     runs-on: ubuntu-24.04

--- a/.github/workflows/queues.yml
+++ b/.github/workflows/queues.yml
@@ -169,6 +169,18 @@ jobs:
           redis-server --daemonize yes --port 7002 --appendonly yes --cluster-enabled yes --cluster-config-file nodes-7002.conf
           redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0 --cluster-yes
 
+      - name: Check Redis Cluster is ready
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 5
+          max_attempts: 5
+          retry_wait_seconds: 5
+          retry_on: error
+          command: |
+            redis-cli -c -h 127.0.0.1 -p 7000 cluster info | grep "cluster_state:ok"
+            redis-cli -c -h 127.0.0.1 -p 7001 cluster info | grep "cluster_state:ok"
+            redis-cli -c -h 127.0.0.1 -p 7002 cluster info | grep "cluster_state:ok"
+
       - name: Execute tests
         run: vendor/bin/phpunit tests/Integration/Queue
         env:

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -416,6 +416,10 @@ class JobChainingTest extends QueueTestCase
             $this->assertEquals(
                 ['c1', 'c2', 'b1', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results
             );
+        } else {
+            $this->assertEquals(
+                ['c1', 'c2', 'b1', 'b2', 'b3', 'b4', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'c3'], JobRunRecorder::$results
+            );
         }
 
         $this->assertCount(11, JobRunRecorder::$results);
@@ -444,6 +448,10 @@ class JobChainingTest extends QueueTestCase
         if ($this->getQueueDriver() === 'sync') {
             $this->assertEquals(
                 ['c1', 'c2', 'bc1', 'bc2', 'b1', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results
+            );
+        } else {
+            $this->assertEquals(
+                ['c1', 'c2', 'bc1', 'b1', 'b2', 'b3', 'b4', 'bc2', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'c3'], JobRunRecorder::$results
             );
         }
 
@@ -477,6 +485,10 @@ class JobChainingTest extends QueueTestCase
         if ($this->getQueueDriver() === 'sync') {
             $this->assertEquals(
                 ['c1', 'c2', 'bc1', 'bc2', 'bb1', 'bb2', 'b1', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'b2', 'b3', 'b4', 'c3'], JobRunRecorder::$results
+            );
+        } else {
+            $this->assertEquals(
+                ['c1', 'c2', 'bc1', 'b1', 'b2', 'b3', 'b4', 'bc2', 'b2-0', 'b2-1', 'b2-2', 'b2-3', 'bb1', 'bb2', 'c3'], JobRunRecorder::$results
             );
         }
 

--- a/tests/Integration/Queue/QueueTestCase.php
+++ b/tests/Integration/Queue/QueueTestCase.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Orchestra\Testbench\TestCase;
 
 abstract class QueueTestCase extends TestCase
 {
-    use DatabaseMigrations;
+    use DatabaseMigrations, InteractsWithRedis;
 
     /**
      * The current database driver.
@@ -25,6 +26,24 @@ abstract class QueueTestCase extends TestCase
     protected function defineEnvironment($app)
     {
         $this->driver = $app['config']->get('queue.default', 'sync');
+    }
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->afterApplicationCreated(function () {
+            if ($this->getQueueDriver() === 'redis') {
+                $this->setUpRedis();
+            }
+        });
+
+        $this->beforeApplicationDestroyed(function () {
+            if ($this->getQueueDriver() === 'redis') {
+                $this->tearDownRedis();
+            }
+        });
+
+        parent::setUp();
     }
 
     /**


### PR DESCRIPTION
Suddenly found out that QUEUE_CONNECTION is not set for Redis Cluster queue integration tests. This leads to using of default connection (sync) in some tests and not really testing integration where it should.

This PR fixes this issue, and adds calling setUpRedis in QueueTestCase to properly setup Redis Cluster connection.

It also adds jobs order asserts for non-sync queues in JobChainingTest for better behaviour coverage.

Sometimes Redis Cluster was not ready to serve requests at the start of test (previously this problem was not seen, because first tests in list really used sync driver and did not communicated with Redis). Added action to check if cluster is ready before starting tests.