### PR TITLE
[12.x] Remove unused catch variable in Job::fail()

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -199,7 +199,7 @@ abstract class Job
 
             try {
                 $batchRepository->rollBack();
-            } catch (Throwable $e) {
+            } catch (Throwable) {
                 // ...
             }
         }


### PR DESCRIPTION
This PR removes an unused exception variable in a catch block that only contains a comment.

**Changes:**
- Removes unused `$e` parameter from catch block in `Job::fail()` method
- Uses PHP 8.0+ syntax to omit the variable name when the caught exception is not used

**Benefits:**
- Cleaner code following modern PHP practices
- Eliminates unused variable warnings in static analysis tools
- Consistent with similar changes in Laravel framework (see #57617)

**Testing:**
- Existing tests continue to pass
- No functional changes to exception handling behavior