### PR TITLE
[12.x] Remove unused foreach value variables

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -912,7 +912,7 @@ class Connection implements ConnectionInterface
      */
     public function allowQueryDurationHandlersToRunAgain()
     {
-        foreach ($this->queryDurationHandlers as $key => $queryDurationHandler) {
+        foreach (array_keys($this->queryDurationHandlers) as $key) {
             $this->queryDurationHandlers[$key]['has_run'] = false;
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -295,7 +295,7 @@ abstract class HasOneOrMany extends Relation
             $values = [$values];
         }
 
-        foreach ($values as $key => $value) {
+        foreach (array_keys($values) as $key) {
             $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -120,7 +120,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
             $values = [$values];
         }
 
-        foreach ($values as $key => $value) {
+        foreach (array_keys($values) as $key) {
             $values[$key][$this->getMorphType()] = $this->getMorphClass();
         }
 


### PR DESCRIPTION
This PR removes unused value variables in foreach loops where only the key is needed, improving code clarity and performance.

**Changes:**
- `Connection::allowQueryDurationHandlersToRunAgain()`: Use `array_keys()` instead of unused `$queryDurationHandler` variable
- `MorphOneOrMany::upsert()`: Use `array_keys()` instead of unused `$value` variable  
- `HasOneOrMany::upsert()`: Use `array_keys()` instead of unused `$value` variable

**Benefits:**
- Cleaner, more readable code that clearly shows intent
- Slight performance improvement by avoiding unnecessary variable assignment
- Eliminates unused variable warnings in static analysis tools
- More explicit about only needing array keys

**Testing:**
- All existing tests continue to pass
- No functional changes to the logic, only optimization of variable usage

**Before:**
```php
foreach ($values as $key => $value) {
    $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
}
```

**After:**
```php
foreach (array_keys($values) as $key) {
    $values[$key][$this->getForeignKeyName()] = $this->getParentKey();
}
```