### PR TITLE
[12.x] Remove unused closure parameters in DatabaseServiceProvider

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -76,15 +76,15 @@ class DatabaseServiceProvider extends ServiceProvider
             return $app['db']->connection()->getSchemaBuilder();
         });
 
-        $this->app->singleton('db.transactions', function ($app) {
+        $this->app->singleton('db.transactions', function () {
             return new DatabaseTransactionsManager;
         });
 
-        $this->app->singleton(ConcurrencyErrorDetectorContract::class, function ($app) {
+        $this->app->singleton(ConcurrencyErrorDetectorContract::class, function () {
             return new ConcurrencyErrorDetector;
         });
 
-        $this->app->singleton(LostConnectionDetectorContract::class, function ($app) {
+        $this->app->singleton(LostConnectionDetectorContract::class, function () {
             return new LostConnectionDetector;
         });
     }


### PR DESCRIPTION
This PR removes unused `$app` parameters from closures that don't use the application container instance.

**Changes:**
- `db.transactions` singleton: Remove unused `$app` parameter
- `ConcurrencyErrorDetectorContract` singleton: Remove unused `$app` parameter  
- `LostConnectionDetectorContract` singleton: Remove unused `$app` parameter

**Benefits:**
- Cleaner code that clearly shows when container access is not needed
- Eliminates unused parameter warnings in static analysis tools
- More explicit about closure dependencies
- Consistent with Laravel's coding standards

**Rationale:**
These closures only instantiate classes without dependencies (`DatabaseTransactionsManager`, `ConcurrencyErrorDetector`, `LostConnectionDetector`), so they don't need access to the application container.

**Testing:**
- All existing tests continue to pass
- No functional changes to service registration
- Services are still properly registered as singletons

**Before:**
```php
$this->app->singleton('db.transactions', function ($app) {
    return new DatabaseTransactionsManager;
});
```

**After:**
```php
$this->app->singleton('db.transactions', function () {
    return new DatabaseTransactionsManager;
});
```