### PR TITLE
warn missing events in cache when running `php artisan event:list`

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -270,6 +270,13 @@ class EventListCommand extends Command
         $cachePath = base_path('bootstrap/cache/events.php');
 
         if (! file_exists($cachePath)) {
+            $tempPath = sys_get_temp_dir().'/events.php';
+            if (file_exists($tempPath)) {
+                $cachePath = $tempPath;
+            }
+        }
+
+        if (! file_exists($cachePath)) {
             $this->warn('Event cache not found. Run `php artisan event:cache` to build it.');
 
             return;

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -271,6 +271,7 @@ class EventListCommand extends Command
 
         if (! file_exists($cachePath)) {
             $this->warn('Event cache not found. Run `php artisan event:cache` to build it.');
+
             return;
         }
 
@@ -292,5 +293,4 @@ class EventListCommand extends Command
             $this->line('Run `php artisan event:clear` to refresh the event cache.');
         }
     }
-
 }

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -263,10 +263,14 @@ class EventListCommand extends Command
 
     protected function warnIfEventMissingInCache(Collection $events): void
     {
+        if ($this->option('json')) {
+            return;
+        }
+
         $cachePath = base_path('bootstrap/cache/events.php');
 
         if (! file_exists($cachePath)) {
-            $this->warn("Event cache not found. Run `php artisan event:cache` to build it.");
+            $this->warn('Event cache not found. Run `php artisan event:cache` to build it.');
             return;
         }
 
@@ -281,11 +285,11 @@ class EventListCommand extends Command
         }
 
         if (! empty($missing)) {
-            $this->warn("⚠️ The following events are registered in EventServiceProvider but missing in cache:");
+            $this->warn('⚠️ The following events are registered in EventServiceProvider but missing in cache:');
             foreach ($missing as $event) {
                 $this->line("  - {$event}");
             }
-            $this->line("Run `php artisan event:clear` to refresh the event cache.");
+            $this->line('Run `php artisan event:clear` to refresh the event cache.');
         }
     }
 

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
 
 class EventListCommandTest extends TestCase

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -134,7 +134,6 @@ class EventListCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -22,7 +22,7 @@ class EventListCommandTest extends TestCase
         $this->dispatcher = new Dispatcher();
         EventListCommand::resolveEventsUsing(fn () => $this->dispatcher);
 
-        $this->tempCachePath = sys_get_temp_dir() . '/events.php';
+        $this->tempCachePath = sys_get_temp_dir().'/events.php';
         $this->mockBasePath();
     }
 

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -20,7 +20,7 @@ class EventListCommandTest extends TestCase
 
         $this->dispatcher = new Dispatcher();
         EventListCommand::resolveEventsUsing(fn () => $this->dispatcher);
-        $this->tempCachePath = sys_get_temp_dir() . '/events.php';
+        $this->tempCachePath = sys_get_temp_dir().'/events.php';
     }
 
     public function testDisplayEmptyList()

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -13,6 +13,7 @@ use Orchestra\Testbench\TestCase;
 class EventListCommandTest extends TestCase
 {
     public $dispatcher;
+
     protected $tempCachePath;
 
     protected function setUp(): void
@@ -119,17 +120,13 @@ class EventListCommandTest extends TestCase
         $this->assertStringNotContainsString('ExampleSubscriberEventName', $output);
     }
 
-    // -------------------------------
-    // Event cache warning tests
-    // -------------------------------
-
     public function testWarnsWhenEventMissingInCache(): void
     {
         if (file_exists($this->tempCachePath)) {
             unlink($this->tempCachePath);
         }
 
-        Event::listen('FakeEvent', fn () => '');
+        $this->dispatcher->listen('FakeEvent', fn () => '');
 
         $this->artisan(EventListCommand::class)
             ->expectsOutputToContain('Event cache not found. Run `php artisan event:cache` to build it.')
@@ -140,7 +137,7 @@ class EventListCommandTest extends TestCase
     {
         file_put_contents($this->tempCachePath, '<?php return ["SomeOtherEvent" => []];');
 
-        Event::listen('FakeEvent', fn () => '');
+        $this->dispatcher->listen('FakeEvent', fn () => '');
 
         $this->artisan(EventListCommand::class)
             ->expectsOutputToContain('⚠️ The following events are registered in EventServiceProvider but missing in cache:')


### PR DESCRIPTION
Add warning for missing events in cache in event:list

This PR adds a warning to php artisan event:list when events are missing in the cached events file (bootstrap/cache/events.php).

Changes:

Warns if the cache file is missing.

Lists events that are registered in EventServiceProvider but missing in cache.

Updates EventListCommand::handle() to call warnIfEventMissingInCache().

Adds unit tests covering missing cache file and missing events.

Adds a note in Event Caching documentation.

Example output:

Event cache not found. Run `php artisan event:cache` to build it.

⚠️ The following events are registered in EventServiceProvider but missing in cache:
  - FlightReserveBound
Run `php artisan event:clear` to refresh the event cache.


Tests:

testWarnsWhenEventMissingInCache()
testWarnsForEventsMissingInCache()