### PR TITLE
Process queue jobs in background (Concurrently::defer())

### DIFF
--- a/src/Illuminate/Queue/BackgroundQueue.php
+++ b/src/Illuminate/Queue/BackgroundQueue.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Support\Facades\Concurrency;
+
+class BackgroundQueue extends SyncQueue
+{
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $job
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        Concurrency::driver('process')->defer(
+            fn () => \Illuminate\Support\Facades\Queue::connection('sync')->push($job, $data, $queue)
+        );
+    }
+}

--- a/src/Illuminate/Queue/Connectors/BackgroundConnector.php
+++ b/src/Illuminate/Queue/Connectors/BackgroundConnector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Connectors;
+
+use Illuminate\Queue\BackgroundQueue;
+
+class BackgroundConnector implements ConnectorInterface
+{
+    /**
+     * Establish a queue connection.
+     *
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        return new BackgroundQueue($config['after_commit'] ?? null);
+    }
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -6,6 +6,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Queue\Connectors\BackgroundConnector;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Connectors\DatabaseConnector;
 use Illuminate\Queue\Connectors\DeferredConnector;
@@ -105,7 +106,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function registerConnectors($manager)
     {
-        foreach (['Null', 'Sync', 'Deferred', 'Failover', 'Database', 'Redis', 'Beanstalkd', 'Sqs'] as $connector) {
+        foreach (['Null', 'Sync', 'Deferred', 'Background', 'Failover', 'Database', 'Redis', 'Beanstalkd', 'Sqs'] as $connector) {
             $this->{"register{$connector}Connector"}($manager);
         }
     }
@@ -146,6 +147,19 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         $manager->addConnector('deferred', function () {
             return new DeferredConnector;
+        });
+    }
+
+    /**
+     * Register the Background queue connector.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    protected function registerBackgroundConnector($manager)
+    {
+        $manager->addConnector('background', function () {
+            return new BackgroundConnector;
         });
     }
 


### PR DESCRIPTION
Similar to the `deferred` queue driver, this defers the jobs to the background, but uses `Concurrently::defer()` instead of the regular defer. This means the job will be serialized and ran from a PHP process, which might be more suitable for 'heavier'/longer requests.

Use cases would be similar to Concurrently::defer() but simplified as a Job.

Not sure about the name, because both methods are called defer(). I called it 'async' in a community package before, which is also not very clear.


