### PR TITLE
Add Collection Methods to AnonymousResourceCollection

### DIFF
--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Resources\Json;
 
+use Illuminate\Support\Arr;
+
 class AnonymousResourceCollection extends ResourceCollection
 {
     /**
@@ -29,5 +31,79 @@ class AnonymousResourceCollection extends ResourceCollection
         $this->collects = $collects;
 
         parent::__construct($resource);
+    }
+
+    /**
+     * Resolve all resources and return as a Collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function toCollection()
+    {
+        return $this->collection->map(function ($resource) {
+            return $resource->resolve(request());
+        });
+    }
+
+    /**
+     * Apply only() to each item in the collection.
+     *
+     * @param  array|string  $keys
+     * @return array
+     */
+    public function only($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+        return $this->toCollection()->map(function ($item) use ($keys) {
+            return Arr::only($item, $keys);
+        })->values()->all();
+    }
+
+    /**
+     * Apply except() to each item in the collection.
+     *
+     * @param  array|string  $keys
+     * @return array
+     */
+    public function except($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+        return $this->toCollection()->map(function ($item) use ($keys) {
+            return Arr::except($item, $keys);
+        })->values()->all();
+    }
+
+    /**
+     * Filter the collection.
+     *
+     * @param  callable|null  $callback
+     * @return array
+     */
+    public function filter($callback = null)
+    {
+        return $this->toCollection()->filter($callback)->values()->all();
+    }
+
+    /**
+     * Map over the collection.
+     *
+     * @param  callable  $callback
+     * @return array
+     */
+    public function map($callback)
+    {
+        return $this->toCollection()->map($callback)->values()->all();
+    }
+
+    /**
+     * Pluck values from the collection.
+     *
+     * @param  string|int  $value
+     * @param  string|int|null  $key
+     * @return array
+     */
+    public function pluck($value, $key = null)
+    {
+        return $this->toCollection()->pluck($value, $key)->all();
     }
 }


### PR DESCRIPTION
### Summary
This PR adds convenient collection manipulation methods to `AnonymousResourceCollection`, allowing developers to transform and filter resource collections after resolution without having to manually call `toArray()` or `toCollection()` first.

### Changes

**New `toCollection()` method:**
- Resolves all resources in the collection and returns them as a Laravel Collection
- Provides a foundation for the other collection manipulation methods

**New collection methods:**
- **`only($keys)`** - Extract only the specified keys from each resource
- **`except($keys)`** - Exclude the specified keys from each resource  
- **`filter($callback)`** - Filter resources using a callback
- **`map($callback)`** - Transform each resource using a callback
- **`pluck($value, $key)`** - Extract a single column from the collection

### Motivation
Currently, developers need to convert resource collections to arrays or collections manually before applying transformations. These methods provide a more fluent API for common operations directly on the resource collection.

Let's say I have a `UserResource` and I do not want to return the `created_at` for some routes, here are some examples on why I created this PR.

I know `map` and `filter` are generally done at the Model level when running the sql queries, but I did not want to exclude them. 

```php
<?php

declare(strict_types=1);

namespace App\Http\Resources;

use App\Models\User;
use Illuminate\Http\Request;
use Illuminate\Http\Resources\Json\JsonResource;
use Illuminate\Support\Str;

/** @mixin User */
final class UserResource extends JsonResource
{
    /**
     * Transform the resource collection into an array.
     *
     * @return array<int|string, mixed>
     */
    public function toArray(Request $request): array
    {
        return [
            'id' => $this->id,
            'name' => ucwords($this->name),
            'email' => Str::lower($this->email),
            'active' => $this->active,
            'created_at' => $this->created_at->toDateTimeString(),
        ];
    }
}
```

### Old Usage (Before This PR)
```php
// Getting only specific fields - verbose and repetitive
$collection = UserResource::collection($users)->toArray(request());
$filtered = collect($collection)->map(function ($user) {
    return Arr::only($user, ['id', 'name', 'email']);
})->values()->all();

// Excluding fields - multiple steps required
$collection = UserResource::collection($users)->toArray(request());
$filtered = collect($collection)->map(function ($user) {
    return Arr::except($user, ['created_at']);
})->values()->all();

// Filtering - need to manually resolve and convert
$collection = UserResource::collection($users)->toArray(request());
$filtered = collect($collection)->filter(fn($user) => $user['active'])->values()->all();

// Mapping - cumbersome process
$collection = UserResource::collection($users)->toArray(request());
$mapped = collect($collection)->map(fn($user) => array_merge($user, ['computed' => true]))->values()->all();

// Plucking - requires multiple conversions
$collection = UserResource::collection($users)->toArray(request());
$emails = collect($collection)->pluck('email', 'id')->all();
```

### New Usage (After This PR)
```php
// Get only specific fields from all resources
UserResource::collection($users)->only(['id', 'name', 'email']);

// Exclude sensitive fields
UserResource::collection($users)->except(['created_at']);

// Filter resources
UserResource::collection($users)->filter(fn($user) => $user['active']);

// Transform resources
UserResource::collection($users)->map(fn($user) => array_merge($user, ['computed' => true]));

// Pluck specific values
UserResource::collection($users)->pluck('email', 'id');
```

### Notes
- All methods resolve resources using the current request context
- Array keys are reset with `values()` where appropriate to maintain consistent indexing
- Methods accept both array and variadic arguments (e.g., `only(['id', 'name'])` or `only('id', 'name')`)

---