### PR TITLE
Fix php8.2 Deprecation warnings for strpos/preg_match/mb_strwidth in extractQueryString/extractQueryString/limit

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -674,6 +674,10 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
+        if ($path === null) {
+            return false;
+        }
+
         if (! preg_match('~^(#|//|https?://|(mailto|tel|sms):)~', $path)) {
             return filter_var($path, FILTER_VALIDATE_URL) !== false;
         }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -608,7 +608,10 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function extractQueryString($path)
     {
-        if (($queryPosition = strpos($path, '?')) !== false) {
+        if (
+            $path !== null
+            && ($queryPosition = strpos($path, '?')) !== false
+        ) {
             return [
                 substr($path, 0, $queryPosition),
                 substr($path, $queryPosition),

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -721,6 +721,10 @@ class Str
      */
     public static function limit($value, $limit = 100, $end = '...', $preserveWords = false)
     {
+        if ($value === null) {
+            return $value;
+        }
+
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -56,6 +56,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar?baz=boom', ['baz' => null]));
         $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&zal=bee', $url->query('foo/bar?foo=bar', ['zal' => 'bee'], ['baz'], true));
         $this->assertSame('http://www.foo.com/foo/bar?baz[0]=boom&baz[1]=bam&baz[2]=bim', urldecode($url->query('foo/bar', ['baz' => ['boom', 'bam', 'bim']])));
+        $this->assertSame('http://www.foo.com', urldecode($url->query(null)));
     }
 
     public function testAssetGeneration()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -2001,6 +2001,17 @@ class RoutingUrlGeneratorTest extends TestCase
             $url->route('tenantPostUserOptionalMethod', ['concreteTenant', 'concretePost', 'concreteUser', 'concreteMethod']),
         );
     }
+
+    public function testIsValidUrlPathIsNull()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('https://www.foo.com/')
+        );
+
+        $this->assertSame(false, $url->isValidUrl(null));
+    }
+
 }
 
 class RoutableInterfaceStub implements UrlRoutable

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -766,6 +766,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6, preserveWords: true));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', true));
+
+        $this->assertSame(null, Str::limit(null));
     }
 
     public function testLength()


### PR DESCRIPTION
Hello,

We log php deprecation warnings of our Laravel app in Sentry.
These fixes benefit us that we don't recive them anymore.
As soon as PHP removes this functionality in the next version, a fix will be needed.

My code does not introduce any side effects. (hopefully)
If i missed somthing please contact me.

Thanks!
Timothy Elias