### PR TITLE
[12.x] Ensure custom validation messages work for the File rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
@@ -103,10 +104,12 @@ trait FormatsMessages
 
         $keys = ["{$attribute}.{$lowerRule}", $lowerRule, $attribute];
 
-        $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
+        if (class_exists($lowerRule) && ! is_subclass_of($lowerRule, DataAwareRule::class)) {
+            $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
 
-        if (! in_array($shortRule, $keys)) {
-            $keys[] = $shortRule;
+            if (! in_array($shortRule, $keys, true)) {
+                $keys[] = $shortRule;
+            }
         }
 
         // First we will check for a custom message for an attribute specific rule

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -106,7 +106,7 @@ trait FormatsMessages
         if ($this->getAttributeType($attribute) !== 'file') {
             $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
 
-            if (! in_array($shortRule, $keys, true)) {
+            if (! in_array($shortRule, $keys)) {
                 $keys[] = $shortRule;
             }
         }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Validation\Concerns;
 
 use Closure;
-use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Number;
 use Illuminate\Support\Str;
@@ -104,7 +103,7 @@ trait FormatsMessages
 
         $keys = ["{$attribute}.{$lowerRule}", $lowerRule, $attribute];
 
-        if (class_exists($lowerRule) && ! is_subclass_of($lowerRule, DataAwareRule::class)) {
+        if ($this->getAttributeType($attribute) !== 'file') {
             $shortRule = "{$attribute}.".Str::snake(class_basename($lowerRule));
 
             if (! in_array($shortRule, $keys, true)) {

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -52,7 +52,8 @@ class FileValidationTest extends TestCase
         ], $validator->messages()->all());
     }
 
-    public function test_file_custom_validation_messages() {
+    public function test_file_custom_validation_messages()
+    {
 
         $validator = Validator::make(
             [

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -54,7 +54,6 @@ class FileValidationTest extends TestCase
 
     public function test_file_custom_validation_messages()
     {
-
         $validator = Validator::make(
             [
                 'one' => UploadedFile::fake()->create('photo', 1000),

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -51,4 +51,30 @@ class FileValidationTest extends TestCase
             0 => __('validation.mimetypes', ['attribute' => sprintf('files.%s', str_replace('_', ' ', $attribute)), 'values' => implode(', ', $mimes)]),
         ], $validator->messages()->all());
     }
+
+    public function test_file_custom_validation_messages() {
+
+        $validator = Validator::make(
+            [
+                'one' => UploadedFile::fake()->create('photo', 1000),
+                'two' => 'not-a-file',
+            ],
+            [
+                'one' => [File::default()->max(50)],
+                'two' => [File::default()->max(50)],
+            ],
+            [
+                'one.max' => 'File one is too large',
+                'one.file' => 'File one is not a file',
+                'two.max' => 'File two is too large',
+                'two.file' => 'File two is not a file',
+            ]);
+
+        $this->assertTrue($validator->fails());
+
+        $this->assertSame([
+            'File one is too large',
+            'File two is not a file',
+        ], $validator->messages()->all());
+    }
 }


### PR DESCRIPTION
When using the File rule with custom messages for multiple files in the same request, the wrong message can appear. The generic file message is shown instead of the sub-rule messages (max, size, etc.). - This appears to be introduced by my previous PR - https://github.com/laravel/framework/pull/57356

This PR resolves that and adds a test to prevent regression - I believe only File is affected because it wraps multiple sub-rules and has a default class-based file message. I've tried to same with Password, etc, and have been unable to get it to happen. 


The alternative- if this feels too narrow could be: 

```diff
-        if ($this->getAttributeType($attribute) !== 'file') {
+       if (class_exists($lowerRule) && ! is_subclass_of($lowerRule, DataAwareRule::class)) {
```

Any suggestions, please let me know 🫡  - Thanks!!

 