### PR TITLE
Normalize locale format in getPluralIndex method

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -109,6 +109,8 @@ class MessageSelector
      */
     public function getPluralIndex($locale, $number)
     {
+        $locale = str_replace('-', '_', $locale);
+        
         switch ($locale) {
             case 'az':
             case 'az_AZ':


### PR DESCRIPTION
The IETF standard for locales uses a hyphen (`-`) instead of an underscore (`_`).

This pull request makes it possible to translate strings (especially plurals) when the locale is something like `en-US` vs. `en_US`.
