### PR TITLE
refactor: remove unused parameter in ArtisanServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -409,7 +409,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigPublishCommand()
     {
-        $this->app->singleton(ConfigPublishCommand::class, function ($app) {
+        $this->app->singleton(ConfigPublishCommand::class, function () {
             return new ConfigPublishCommand;
         });
     }


### PR DESCRIPTION
This PR removes unused `$app` parameter from closure that doesn't use the application container instance.

#### Changes:

- **ConfigPublishCommand singleton**: Remove unused $app parameter

#### Benefits:

- Cleaner code that clearly shows when container access is not needed
- Eliminates unused parameter warnings in static analysis tools
- Consistent with Laravel's coding standards

#### Testing:

- All existing tests continue to pass
- No functional changes to service registration
- Service is still properly registered as singleton

#### Before:

```php
$this->app->singleton(ConfigPublishCommand::class, function ($app) {
    return new ConfigPublishCommand;
});
```

#### After:

```php
$this->app->singleton(ConfigPublishCommand::class, function () {
    return new ConfigPublishCommand;
});
```
