### PR TITLE
[12.x] Fix potential memory leak risk in `Arr::dot()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -169,19 +169,15 @@ class Arr
     {
         $results = [];
 
-        $flatten = function ($data, $prefix) use (&$results, &$flatten): void {
-            foreach ($data as $key => $value) {
-                $newKey = $prefix.$key;
+        foreach ($array as $key => $value) {
+            $newKey = $prepend.$key;
 
-                if (is_array($value) && ! empty($value)) {
-                    $flatten($value, $newKey.'.');
-                } else {
-                    $results[$newKey] = $value;
-                }
+            if (is_array($value) && ! empty($value)) {
+                $results += static::dot($value, $newKey.'.');
+            } else {
+                $results[$newKey] = $value;
             }
-        };
-
-        $flatten($array, $prepend);
+        }
 
         return $results;
     }


### PR DESCRIPTION
# Description
Because `$flatten` references itself repeatedly, `$flatten` is not garbage-collected in time after the function finishes executing (normally the variables inside the function are garbage-collected as soon as the function finishes executing).

Although `$flatten` is eventually GC'd, this process lasts for a while, during which time memory increases with the number of requests, leading developers who are working in Swoole or Octane mode to believe that their program has a memory leak.

This PR solves this problem by replacing the `$flatten` variable with a recursive call to `Arr::dot()`.

Since `Arr::dot()` is very heavily used in the framework, I thought it was necessary to address this issue in order to avoid this unnecessary misunderstanding, thanks!

# Expected results
The memory used is the same for each request.

# Actual results
As the number of requests increases, so does the memory.

# Steps To Reproduce

1. Add the following routes to the `routes/api.php` file.
    ```php
    Route::get('test', function () {
        for ($i = 0; $i < 10; $i++) {
            Arr::dot(['foo' => [10 => 100]]);
        }
    });
    ```
2. Execute `php artisan octane:start` in the console to start the program.
3. Make multiple requests to `http://127.0.0.1:8000/api/test` using `curl` or your browser.
4. Observe the output on the console to see how much memory is used for each request.
    <img width="848" height="341" alt="image" src="https://github.com/user-attachments/assets/c1831b8b-44c2-405d-a593-f25c39b0a653" />