### PR TITLE
Remove unused parameter from defineEnvironmentWouldThrowsPDOException method

### DIFF
--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -636,7 +636,7 @@ class QueryBuilderTest extends DatabaseTestCase
         ], DB::table('posts')->pluck('title', 'content')->toArray());
     }
 
-    protected function defineEnvironmentWouldThrowsPDOException($app)
+    protected function defineEnvironmentWouldThrowsPDOException()
     {
         $this->afterApplicationCreated(function () {
             if (in_array($this->driver, ['pgsql', 'sqlsrv'])) {


### PR DESCRIPTION
Remove unused `$app` parameter from the `defineEnvironmentWouldThrowsPDOException` method in `QueryBuilderTest.php`.

**Changes:**
- Removed unused `$app` parameter from `defineEnvironmentWouldThrowsPDOException()` method

**Why this change:**
The parameter is not used within the method body. This follows Laravel's code quality standards by removing unnecessary parameters, similar to other recent cleanup efforts in the framework.

**Testing:**
- Existing tests continue to pass as the method functionality remains unchanged
- The method signature change doesn't affect the `#[DefineEnvironment('defineEnvironmentWouldThrowsPDOException')]` attribute usage