### PR TITLE
[12.x] Add previousRouteName method to retrieve the previous route name

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -21,6 +21,7 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Events\Routing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
@@ -1324,6 +1325,16 @@ class Router implements BindingRegistrar, RegistrarContract
     public function currentRouteName()
     {
         return $this->current() ? $this->current()->getName() : null;
+    }
+
+    /**
+     * Get the previous route name.
+     *
+     * @return string|null
+     */
+    public function previousRouteName()
+    {
+        return Session::previousRoute();
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -19,9 +19,9 @@ use Illuminate\Routing\Events\PreparingResponse;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Events\Routing;
+use Illuminate\Session\Store;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
@@ -1334,7 +1334,9 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function previousRouteName()
     {
-        return Session::previousRoute();
+        $store = app(Store::class);
+
+        return method_exists($store, 'previousRoute') ? $store->previousRoute() : null;
     }
 
     /**


### PR DESCRIPTION
Since we already have `currentRouteName` in Router, it seems reasonable to include `previousRouteName` as well. and the new `previousRoute` in Session makes this easy.