### PR TITLE
[12.x] Add whereCollation() query builder method with tests

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2432,6 +2432,36 @@ class Builder implements BuilderContract
     }
 
     /**
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  $value
+     * @param  string  $collation
+     * @param  string  $charset
+     * @return  $this
+     */
+    public function whereCollation(
+        string $column,
+        string $operator = '=',
+               $value = null,
+        string $collation = 'utf8mb4_unicode_ci',
+        string $charset = 'utf8mb4'
+    ): Builder {
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if (! preg_match('/^[a-zA-Z0-9_]+$/', $charset) || ! preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
+            throw new InvalidArgumentException('Invalid charset or collation name.');
+        }
+
+        return $this->whereRaw(
+            "CONVERT(`{$column}` USING {$charset}) COLLATE {$collation} {$operator} ?",
+            [$value]
+        );
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|\Illuminate\Contracts\Database\Query\Expression|string  ...$groups

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2432,12 +2432,12 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param  string  $column
-     * @param  string  $operator
-     * @param  $value
-     * @param  string  $collation
-     * @param  string  $charset
+     * Add a where clause with explicit charset and collation.
+     *
+     * @param  mixed  $value  The value to compare against
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function whereCollation(
         string $column,
@@ -2451,8 +2451,12 @@ class Builder implements BuilderContract
             $operator = '=';
         }
 
-        if (! preg_match('/^[a-zA-Z0-9_]+$/', $charset) || ! preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
-            throw new InvalidArgumentException('Invalid charset or collation name.');
+        if (!preg_match('/^[a-zA-Z0-9_]+$/', $charset)) {
+            throw new InvalidArgumentException("Invalid charset name: {$charset}");
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
+            throw new InvalidArgumentException("Invalid collation name: {$collation}");
         }
 
         return $this->whereRaw(

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2437,7 +2437,7 @@ class Builder implements BuilderContract
      * @param  $value
      * @param  string  $collation
      * @param  string  $charset
-     * @return  $this
+     * @return $this
      */
     public function whereCollation(
         string $column,

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2451,11 +2451,11 @@ class Builder implements BuilderContract
             $operator = '=';
         }
 
-        if (!preg_match('/^[a-zA-Z0-9_]+$/', $charset)) {
+        if (! preg_match('/^[a-zA-Z0-9_]+$/', $charset)) {
             throw new InvalidArgumentException("Invalid charset name: {$charset}");
         }
 
-        if (!preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
+        if (! preg_match('/^[a-zA-Z0-9_]+$/', str_replace('_', '', $collation))) {
             throw new InvalidArgumentException("Invalid collation name: {$collation}");
         }
 

--- a/tests/Database/DatabaseWhereCollationTest.php
+++ b/tests/Database/DatabaseWhereCollationTest.php
@@ -65,7 +65,6 @@ class DatabaseWhereCollationTest extends TestCase
         DB::table('_test_collation')->whereCollation('name', '=', 'test', 'invalid_collation', 'utf8mb4');
     }
 
-
     protected function tearDown(): void
     {
         try {

--- a/tests/Database/DatabaseWhereCollationTest.php
+++ b/tests/Database/DatabaseWhereCollationTest.php
@@ -49,18 +49,22 @@ class DatabaseWhereCollationTest extends TestCase
         $this->assertEquals('https://example.com/fa', $record->url);
     }
 
+    public function test_invalid_charset_name_throws_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid charset name');
+
+        DB::table('_test_collation')->whereCollation('name', '=', 'test', 'utf8mb4', 'invalid-charset');
+    }
+
     public function test_invalid_collation_name_throws_exception()
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid collation name');
 
-        DB::table('_test_collation')->whereCollation(
-            'name',
-            '=',
-            'test',
-            'utf8mb4; DROP TABLE users;',
-            'utf8mb4'
-        );
+        DB::table('_test_collation')->whereCollation('name', '=', 'test', 'invalid_collation', 'utf8mb4');
     }
+
 
     protected function tearDown(): void
     {

--- a/tests/Database/DatabaseWhereCollationTest.php
+++ b/tests/Database/DatabaseWhereCollationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use InvalidArgumentException;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\TestCase;
+
+class DatabaseWhereCollationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('CREATE TEMPORARY TABLE _test_collation (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_cs,
+            url VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+        )');
+
+        DB::table('_test_collation')->insert([
+            ['name' => 'simple', 'url' => 'https://example.com'],
+            ['name' => 'سلام', 'url' => 'https://example.com/fa'],
+        ]);
+    }
+
+    public function test_where_collation_can_match_ascii_value()
+    {
+        $record = DB::table('_test_collation')
+            ->whereCollation('name', 'simple')
+            ->first();
+
+        $this->assertNotNull($record);
+        $this->assertEquals('https://example.com', $record->url);
+    }
+
+    public function test_where_collation_can_match_unicode_value()
+    {
+        $record = DB::table('_test_collation')
+            ->whereCollation('name', '=', 'سلام')
+            ->first();
+
+        $this->assertNotNull($record);
+        $this->assertEquals('https://example.com/fa', $record->url);
+    }
+
+    public function test_invalid_collation_name_throws_exception()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        DB::table('_test_collation')->whereCollation(
+            'name',
+            '=',
+            'test',
+            'utf8mb4; DROP TABLE users;',
+            'utf8mb4'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        DB::statement('DROP TEMPORARY TABLE IF EXISTS _test_collation');
+    }
+}

--- a/tests/Database/DatabaseWhereCollationTest.php
+++ b/tests/Database/DatabaseWhereCollationTest.php
@@ -2,15 +2,20 @@
 
 namespace Illuminate\Tests\Database;
 
-use InvalidArgumentException;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\TestCase;
+use InvalidArgumentException;
 
 class DatabaseWhereCollationTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (DB::getDriverName() === 'sqlite') {
+            $this->markTestSkipped('Collation tests require MySQL or MariaDB.');
+        }
 
         DB::statement('CREATE TEMPORARY TABLE _test_collation (
             id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -59,8 +64,14 @@ class DatabaseWhereCollationTest extends TestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('DROP TEMPORARY TABLE IF EXISTS _test_collation');
+        }
 
-        DB::statement('DROP TEMPORARY TABLE IF EXISTS _test_collation');
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
     }
+
 }


### PR DESCRIPTION

This introduces a new `whereCollation()` method to the query builder, allowing developers to explicitly compare string columns using a specific charset and collation.

Example:
    DB::table('users')->whereCollation('name', '=', 'Ali', 'utf8mb4_unicode_ci');

The method internally uses `CONVERT(... USING ...) COLLATE ...` to perform comparisons under the given collation, and validates charset and collation names to prevent SQL injection.

A new test suite `DatabaseWhereCollationTest` ensures:
- ASCII and Unicode matching behavior
- Invalid charset/collation handling
- Proper collation conversion on temporary tables
