### PR TITLE
[12.x] Cache the result of `configurationIsCached()`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1302,7 +1302,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function configurationIsCached()
     {
-        return is_file($this->getCachedConfigPath());
+        if ($this->bound('config_loaded_from_cache')) {
+            return (bool) $this->make('config_loaded_from_cache');
+        }
+
+        return $this->instance('config_loaded_from_cache', is_file($this->getCachedConfigPath()));
     }
 
     /**


### PR DESCRIPTION
Reduces file_exists() calls. This is called repeatedly in the codebase, like when merging the configuration values in a service provider.

I think it might even be safe to store as an instance property in the Application class, but figured I would just leverage the existing app instances to not have to worry about flushing/resetting state.

For reference: this instance value is already set inside of [LoadConfiguration](https://github.com/laravel/framework/blob/1751d2c33250211883fb8097c5c4598baaba3ab4/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php#L30).