### PR TITLE
Fix FormRequest passedValidation data sync issue

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -33,6 +33,12 @@ trait ValidatesWhenResolvedTrait
         }
 
         $this->passedValidation();
+
+        // Sync the validator data with the current request data after passedValidation()
+        // in case the request data was modified (e.g., via replace() or merge())
+        if (method_exists($this, 'validationData')) {
+            $instance->setData($this->validationData());
+        }
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -129,6 +129,15 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
+    public function testPassedValidationDataIsReflectedInValidatedMethod()
+    {
+        $request = $this->createRequest([], FoundationTestFormRequestHooks::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Adam'], $request->validated());
+    }
+
     public function testValidatedMethodReturnsOnlyRequestedValidatedData()
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);


### PR DESCRIPTION
**Problem:**
When `replace()` or `merge()` methods are called in `passedValidation()`, the changes were not reflected in the `validated()` method because the validator instance held a copy of the original data.

**Root Cause:**
The validation flow in `ValidatesWhenResolvedTrait::validateResolved()` creates the validator instance before calling `passedValidation()`. When `passedValidation()` modifies the request data using `replace()` or `merge()`, the validator still has the old data, so `validated()` returns the original data instead of the modified data.

**Solution:**
After `passedValidation()` is called, sync the validator's data with the current request data using `setData()`. This ensures that any modifications made to the request data in `passedValidation()` are properly reflected in `validated()`.

**Changes:**
- Modified `ValidatesWhenResolvedTrait::validateResolved()` to sync validator data after `passedValidation()`
- Added a test case to verify the fix works correctly
- The fix is backward compatible and only affects cases where data is modified in `passedValidation()`

**Testing:**
- Added `testPassedValidationDataIsReflectedInValidatedMethod()` test case
- Existing tests continue to pass
- The fix uses the existing `validationData()` method to get current data and `setData()` to update the validator

**Fixes:** #57659