### PR TITLE
Add to_english_numbers helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -523,3 +523,21 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('to_english_numbers')) {
+    /**
+     * Converting Persian/Arabic digits to English
+     * @param  mixed  $value
+     * @return string
+     */
+    function to_english_numbers($value): string
+    {
+        return strtr($value, [
+            '۰' => '0', '۱' => '1', '۲' => '2', '۳' => '3', '۴' => '4',
+            '۵' => '5', '۶' => '6', '۷' => '7', '۸' => '8', '۹' => '9',
+            '٠' => '0', '١' => '1', '٢' => '2', '٣' => '3', '٤' => '4',
+            '٥' => '5', '٦' => '6', '٧' => '7', '٨' => '8', '٩' => '9',
+        ]);
+    }
+}
+

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1572,6 +1572,13 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testToEnglishNumbersConvertsPersianAndArabicDigits()
+    {
+        $this->assertEquals('123', to_english_numbers('۱۲۳'));
+        $this->assertEquals('456', to_english_numbers('٤٥٦'));
+    }
+
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Many Laravel developers working with Persian or Arabic inputs often need to normalize user-entered numeric values (for example, phone numbers or amounts) before storing or using that numbers. Having this as a built-in helper improves developer experience and prevents code duplication across projects.

All tests are included and passing.