### PR TITLE
toEnglishFormat() / add number conversion helper

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -439,4 +439,15 @@ class Number
             throw new RuntimeException('The "intl" PHP extension is required to use the ['.$method.'] method.');
         }
     }
+    
+    /**
+     * Converting Persian/Arabic digits to English
+     * @param  mixed $value
+     * @return bool|float|int
+     */
+    public static function toEnglishFormat($value)
+    {
+        $numberFormatter = new NumberFormatter('ar-u-nu-latn', NumberFormatter::DECIMAL);
+        return $numberFormatter->parse($value);
+    }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -523,3 +523,21 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('to_english_numbers')) {
+    /**
+     * Converting Persian/Arabic digits to English
+     * @param  mixed  $value
+     * @return string
+     */
+    function to_english_numbers($value): string
+    {
+        return strtr($value, [
+            '۰' => '0', '۱' => '1', '۲' => '2', '۳' => '3', '۴' => '4',
+            '۵' => '5', '۶' => '6', '۷' => '7', '۸' => '8', '۹' => '9',
+            '٠' => '0', '١' => '1', '٢' => '2', '٣' => '3', '٤' => '4',
+            '٥' => '5', '٦' => '6', '٧' => '7', '٨' => '8', '٩' => '9',
+        ]);
+    }
+}
+

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -532,12 +532,7 @@ if (! function_exists('to_english_numbers')) {
      */
     function to_english_numbers($value): string
     {
-        return strtr($value, [
-            '۰' => '0', '۱' => '1', '۲' => '2', '۳' => '3', '۴' => '4',
-            '۵' => '5', '۶' => '6', '۷' => '7', '۸' => '8', '۹' => '9',
-            '٠' => '0', '١' => '1', '٢' => '2', '٣' => '3', '٤' => '4',
-            '٥' => '5', '٦' => '6', '٧' => '7', '٨' => '8', '٩' => '9',
-        ]);
+        return Number::toEnglishFormat($value);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1572,6 +1572,13 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testToEnglishNumbersConvertsPersianAndArabicDigits()
+    {
+        $this->assertEquals('123', to_english_numbers('۱۲۳'));
+        $this->assertEquals('456', to_english_numbers('٤٥٦'));
+    }
+
 }
 
 trait SupportTestTraitOne

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -370,4 +370,11 @@ class SupportNumberTest extends TestCase
         $this->assertSame(1234.56, Number::parseFloat('1.234,56', locale: 'de'));
         $this->assertSame(1234.56, Number::parseFloat('1 234,56', locale: 'fr'));
     }
+
+    #[RequiresPhpExtension('intl')]
+    public function testToEnglishFormat()
+    {
+        $this->assertEquals('123', Number::toEnglishFormat('۱۲۳'));
+        $this->assertEquals('456', Number::toEnglishFormat('٤٥٦'));
+    }
 }


### PR DESCRIPTION
Many Laravel developers working with Persian or Arabic inputs often need to normalize user-entered numeric values (for example, phone numbers or amounts) before validation or database storage. Having this as a built-in helper improves developer experience and prevents code duplication across projects.

All tests are included and passing.