### PR TITLE
Don't call Model::toArray() to get attributes for factory insert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,7 @@ abstract class Factory
         $query = $model->newQueryWithoutScopes();
 
         $query->fillAndInsert(
-            $madeCollection->withoutAppends()->toArray()
+            $madeCollection->map(fn (Model $model) => $model->getAttributes())->all()
         );
     }
 


### PR DESCRIPTION
#57600 introduced an `insert` method for the Eloquent model factory.

I don't think it should call `Model::toArray()` to collect the model attributes for insertion. For multiple reasons, one of them being `toArray()` will also include any loaded relations.

I think calling `Model::getAttributesForInsert()` instead would be preferred, but since this method is protected and only calls `Model::getAttributes()`, I chose the latter. I think it might be better to make `getAttributesForInsert()` public if there's no objection to that.