### PR TITLE
[12.x] model:show command prompt for missing input with model suggestion

### DIFF
--- a/src/Illuminate/Console/Concerns/FindsAvailableModels.php
+++ b/src/Illuminate/Console/Concerns/FindsAvailableModels.php
@@ -5,14 +5,14 @@ namespace Illuminate\Console\Concerns;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
 
-trait InteractsWithModels
+trait FindsAvailableModels
 {
     /**
      * Get a list of possible model names.
      *
      * @return array<int, string>
      */
-    protected function possibleModels()
+    protected function findAvailableModels()
     {
         $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
 

--- a/src/Illuminate/Console/Concerns/InteractsWithModels.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithModels.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Support\Collection;
+use Symfony\Component\Finder\Finder;
+
+trait InteractsWithModels
+{
+    /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     */
+    protected function possibleModels()
+    {
+        $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
+
+        return (new Collection(Finder::create()->files()->depth(0)->in($modelPath)))
+            ->map(fn($file) => $file->getBasename('.php'))
+            ->sort()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Illuminate/Console/Concerns/InteractsWithModels.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithModels.php
@@ -17,7 +17,7 @@ trait InteractsWithModels
         $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
 
         return (new Collection(Finder::create()->files()->depth(0)->in($modelPath)))
-            ->map(fn($file) => $file->getBasename('.php'))
+            ->map(fn ($file) => $file->getBasename('.php'))
             ->sort()
             ->values()
             ->all();

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
-use Illuminate\Console\Concerns\InteractsWithModels;
+use Illuminate\Console\Concerns\FindsAvailableModels;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
@@ -13,7 +13,7 @@ use Symfony\Component\Finder\Finder;
 
 abstract class GeneratorCommand extends Command implements PromptsForMissingInput
 {
-    use InteractsWithModels;
+    use FindsAvailableModels;
 
     /**
      * The filesystem instance.

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\Concerns\InteractsWithModels;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
@@ -12,6 +13,8 @@ use Symfony\Component\Finder\Finder;
 
 abstract class GeneratorCommand extends Command implements PromptsForMissingInput
 {
+    use InteractsWithModels;
+
     /**
      * The filesystem instance.
      *
@@ -237,22 +240,6 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         return is_dir(app_path('Models'))
             ? $rootNamespace.'Models\\'.$model
             : $rootNamespace.$model;
-    }
-
-    /**
-     * Get a list of possible model names.
-     *
-     * @return array<int, string>
-     */
-    protected function possibleModels()
-    {
-        $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
-
-        return (new Collection(Finder::create()->files()->depth(0)->in($modelPath)))
-            ->map(fn ($file) => $file->getBasename('.php'))
-            ->sort()
-            ->values()
-            ->all();
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Console;
 
-use Illuminate\Console\Concerns\InteractsWithModels;
+use Illuminate\Console\Concerns\FindsAvailableModels;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\ModelInspector;
@@ -15,7 +15,7 @@ use function Laravel\Prompts\suggest;
 #[AsCommand(name: 'model:show')]
 class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMissingInput
 {
-    use InteractsWithModels;
+    use FindsAvailableModels;
 
     /**
      * The console command name.
@@ -226,7 +226,7 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
     protected function promptForMissingArgumentsUsing(): array
     {
         return [
-            'model' => fn (): string => suggest('Which model would you like to show?', $this->possibleModels()),
+            'model' => fn (): string => suggest('Which model would you like to show?', $this->findAvailableModels()),
         ];
     }
 }

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -2,15 +2,21 @@
 
 namespace Illuminate\Database\Console;
 
+use Illuminate\Console\Concerns\InteractsWithModels;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\ModelInspector;
 use Illuminate\Support\Collection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Laravel\Prompts\suggest;
+
 #[AsCommand(name: 'model:show')]
-class ShowModelCommand extends DatabaseInspectionCommand
+class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMissingInput
 {
+    use InteractsWithModels;
+
     /**
      * The console command name.
      *
@@ -210,5 +216,17 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         $this->newLine();
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            'model' => fn() => suggest('Which model would you like to show?', $this->possibleModels()),
+        ];
     }
 }

--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -221,12 +221,12 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array
+     * @return array<string, \Closure(): string>
      */
     protected function promptForMissingArgumentsUsing(): array
     {
         return [
-            'model' => fn() => suggest('Which model would you like to show?', $this->possibleModels()),
+            'model' => fn (): string => suggest('Which model would you like to show?', $this->possibleModels()),
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -158,8 +158,8 @@ class ObserverMakeCommand extends GeneratorCommand
         }
 
         $model = suggest(
-            'What model should this observer apply to? (Optional)',
-            $this->possibleModels(),
+            'What model should be observed? (Optional)',
+            $this->findAvailableModels(),
         );
 
         if ($model) {

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -218,7 +218,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $model = suggest(
             'What model should this policy apply to? (Optional)',
-            $this->possibleModels(),
+            $this->findAvailableModels(),
         );
 
         if ($model) {

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -328,7 +328,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         if (in_array($type, ['api', 'resource', 'singleton'])) {
             $model = suggest(
-                "What model should this $type controller be for? (Optional)",
+                "What model is this $type controller for? (Optional)",
                 $this->findAvailableModels()
             );
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -329,7 +329,7 @@ class ControllerMakeCommand extends GeneratorCommand
         if (in_array($type, ['api', 'resource', 'singleton'])) {
             $model = suggest(
                 "What model should this $type controller be for? (Optional)",
-                $this->possibleModels()
+                $this->findAvailableModels()
             );
 
             if ($model) {


### PR DESCRIPTION
Re-attempt on #56674

Abstracted `possibleModels` into `InteractsWithModels.php` trait.