### PR TITLE
[12.x] Clean the toSymfonyRouteCollection method

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -202,18 +202,18 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     {
         $symfonyRoutes = new SymfonyRouteCollection;
 
-        $routes = $this->getRoutes();
+        $fallback = [];
 
-        foreach ($routes as $route) {
-            if (! $route->isFallback) {
-                $symfonyRoutes = $this->addToSymfonyRoutesCollection($symfonyRoutes, $route);
+        foreach ($this->getRoutes() as $route) {
+            if ($route->isFallback) {
+                $fallback[] = $route;
+            } else {
+                $this->addToSymfonyRoutesCollection($symfonyRoutes, $route);
             }
         }
 
-        foreach ($routes as $route) {
-            if ($route->isFallback) {
-                $symfonyRoutes = $this->addToSymfonyRoutesCollection($symfonyRoutes, $route);
-            }
+        foreach ($fallback as $route) {
+            $this->addToSymfonyRoutesCollection($symfonyRoutes, $route);
         }
 
         return $symfonyRoutes;


### PR DESCRIPTION
There are 2 small things I suggest in this PR.

- Instead of going through all routes twice, we can use an extra variable that holds fallback routes. It reduces loops and if statements. Adding a little space here gains a bit of speed.

- The `$symfonyRoutes` variable is an object, so it's passed by reference. We needn't to re-assign it every time the `addToSymfonyRoutesCollection` is called.