### PR TITLE
[12.x] Allow sub-array notation in arrays validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1222,6 +1222,7 @@ class Validator implements ValidatorContract
             ->mapWithKeys(function ($value, $key) {
                 return [str_replace('\.', '__dot__'.static::$placeholderHash, $key) => $value];
             })
+            ->dot()
             ->toArray();
 
         $this->initialRules = $rules;

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -71,6 +71,17 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated());
     }
 
+    public function testValidatedMethodReturnsTheValidatedDataNestedWildcardArrayRules()
+    {
+        $payload = ['nested' => [['bar' => 'baz', 'with' => 'extras'], ['bar' => 'baz2', 'with' => 'extras']]];
+
+        $request = $this->createRequest($payload, FoundationTestFormRequestNestedWildcardArrayStub::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated());
+    }
+
     public function testValidatedMethodNotValidateTwice()
     {
         $payload = ['name' => 'specified', 'with' => 'extras'];
@@ -376,6 +387,25 @@ class FoundationTestFormRequestNestedArrayStub extends FormRequest
     public function rules()
     {
         return ['nested.*.bar' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestNestedWildcardArrayStub extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'nested' => [
+                '*' => [
+                    'bar' => 'required',
+                ],
+            ],
+        ];
     }
 
     public function authorize()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR allows to use the sub-array notation, in addition to the dot notation.
For example, instead of this:
```php
class NestedArrayRequest extends FormRequest
{
    public function rules()
    {
        return [
            'nested.*.bar' => 'required',
            'nested.*.baz' => 'required'
        ];
    }
}
```
We can now do this:
```php
class SubArrayRequest extends FormRequest
{
    public function rules()
    {
        return [
            'nested' => [
                '*' => [
                    'bar' => 'required',
                    'baz' => 'required',
                ],
            ],
        ];
    }
}
```

Usefull when the sub-array has many sub-fields.

Of course, the nested notation still works.

If this PR is OK, [I also created a PR to improve the Laravel documentation](https://github.com/laravel/docs/pull/10902).