### PR TITLE
[12.x] Add support for colon-prefixed attributes (:attr) in Blade

### DIFF
--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -214,6 +214,18 @@ class BladeTest extends TestCase
         $this->assertSame('<a href="#">default slot</a>', trim($content));
     }
 
+    public function test_colon_attributes_are_compiled(): void
+    {
+        $content = Blade::render('<img :src="$logo" :alt="$title" :class="$class">');
+
+        $this->assertSame('<img src="{{ $logo }}" alt="{{ $title }}" class="{{ $class }}">', trim($content));
+
+        // Test with function calls
+        $content = Blade::render('<a :href="route(\'home\')">Home</a>');
+
+        $this->assertSame('<a href="{{ route(\'home\') }}">Home</a>', trim($content));
+    }
+
     public function testViewCacheCommandHandlesConfiguredBladeExtensions()
     {
         View::addExtension('sh', 'blade');


### PR DESCRIPTION
This PR adds a feature to Blade that allows colon-prefixed HTML attributes
to automatically echo PHP expressions, similar to Blade Component bindings:

Example:
    `<img :src="$logo" :alt="$title">`

Compiles to:
    `<img src="{{ $logo }}" alt="{{ $title }}">`

This works for all HTML elements and attributes.