### PR TITLE
[12.x] Add database dump with data + load

### DIFF
--- a/src/Illuminate/Database/Console/DbDumpCommand.php
+++ b/src/Illuminate/Database/Console/DbDumpCommand.php
@@ -44,7 +44,7 @@ class DbDumpCommand extends Command
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $this->schemaState($connection)->dump(
-            $connection, $path = $this->path($connection), true
+            $connection, $path = $this->path($connection)
         );
 
         $dispatcher->dispatch(new DatabaseDumped($connection, $path));
@@ -63,6 +63,7 @@ class DbDumpCommand extends Command
     protected function schemaState(Connection $connection)
     {
         return $connection->getSchemaState()
+            ->withData()
             ->handleOutputUsing(function ($type, $buffer) {
                 $this->output->write($buffer);
             });

--- a/src/Illuminate/Database/Console/DbDumpCommand.php
+++ b/src/Illuminate/Database/Console/DbDumpCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Events\DatabaseDumped;
+use Illuminate\Database\Events\MigrationsPruned;
+use Illuminate\Database\Events\SchemaDumped;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'db:dump')]
+class DbDumpCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'db:dump
+                {--database= : The database connection to use}
+                {--path= : The path where the schema dump file should be stored}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dump the given database schema and data';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
+    {
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $this->schemaState($connection)->dump(
+            $connection, $path = $this->path($connection), true
+        );
+
+        $dispatcher->dispatch(new DatabaseDumped($connection, $path));
+
+        $info = 'Database dumped';
+
+        $this->components->info($info.' successfully to ' . $path);
+    }
+
+    /**
+     * Create a schema state instance for the given connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return mixed
+     */
+    protected function schemaState(Connection $connection)
+    {
+        return $connection->getSchemaState()
+            ->handleOutputUsing(function ($type, $buffer) {
+                $this->output->write($buffer);
+            });
+    }
+
+    /**
+     * Get the path that the dump should be written to.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     */
+    protected function path(Connection $connection)
+    {
+        return tap($this->option('path') ?: storage_path($connection->getName() . '-' . date("Ymdhis").'.sql'), function ($path) {
+            (new Filesystem)->ensureDirectoryExists(dirname($path));
+        });
+    }
+}

--- a/src/Illuminate/Database/Console/DbDumpCommand.php
+++ b/src/Illuminate/Database/Console/DbDumpCommand.php
@@ -7,10 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\DatabaseDumped;
-use Illuminate\Database\Events\MigrationsPruned;
-use Illuminate\Database\Events\SchemaDumped;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:dump')]
@@ -51,7 +48,7 @@ class DbDumpCommand extends Command
 
         $info = 'Database dumped';
 
-        $this->components->info($info.' successfully to ' . $path);
+        $this->components->info($info.' successfully to '.$path);
     }
 
     /**
@@ -76,7 +73,7 @@ class DbDumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: storage_path($connection->getName() . '-' . date("Ymdhis").'.sql'), function ($path) {
+        return tap($this->option('path') ?: storage_path($connection->getName().'-'.date("Ymdhis").'.sql'), function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Console/DbDumpCommand.php
+++ b/src/Illuminate/Database/Console/DbDumpCommand.php
@@ -73,7 +73,7 @@ class DbDumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: storage_path($connection->getName().'-'.date("Ymdhis").'.sql'), function ($path) {
+        return tap($this->option('path') ?: storage_path($connection->getName().'-'.date('Ymdhis').'.sql'), function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Console/DbLoadCommand.php
+++ b/src/Illuminate/Database/Console/DbLoadCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Events\DatabaseDumped;
+use Illuminate\Database\Events\MigrationsPruned;
+use Illuminate\Database\Events\SchemaDumped;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'db:load')]
+class DbLoadCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'db:load
+                {--database= : The database connection to use}
+                {--path= : The path where the schema dump file is stored}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Load the databse dump into the give database';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
+    {
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $path = $this->input->getOption('path') ?: $this->ask('Path to the schema dump file');
+        $this->schemaState($connection)->load($path);
+
+        $dispatcher->dispatch(new DatabaseDumped($connection, $path));
+
+        $info = 'Database loaded';
+
+        $this->components->info($info.' successfully in database ' . $database);
+    }
+
+    /**
+     * Create a schema state instance for the given connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return mixed
+     */
+    protected function schemaState(Connection $connection)
+    {
+        return $connection->getSchemaState()
+            ->handleOutputUsing(function ($type, $buffer) {
+                $this->output->write($buffer);
+            });
+    }
+}

--- a/src/Illuminate/Database/Console/DbLoadCommand.php
+++ b/src/Illuminate/Database/Console/DbLoadCommand.php
@@ -9,9 +9,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\DatabaseLoaded;
-use Illuminate\Database\Events\MigrationsPruned;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:load')]
@@ -67,7 +64,7 @@ class DbLoadCommand extends Command
 
         $info = 'Database loaded';
 
-        $this->components->info($info.' successfully in database ' . $database);
+        $this->components->info($info.' successfully in database '.$database);
     }
 
     /**

--- a/src/Illuminate/Database/Console/DbLoadCommand.php
+++ b/src/Illuminate/Database/Console/DbLoadCommand.php
@@ -64,7 +64,7 @@ class DbLoadCommand extends Command
 
         $info = 'Database loaded';
 
-        $this->components->info($info.' successfully in database '.$database);
+        $this->components->info($info.' successfully in database '.$connection->getDatabaseName());
     }
 
     /**

--- a/src/Illuminate/Database/Events/DatabaseDumped.php
+++ b/src/Illuminate/Database/Events/DatabaseDumped.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class DatabaseDumped
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The path to the schema dump.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $path
+     */
+    public function __construct($connection, $path)
+    {
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+        $this->path = $path;
+    }
+}

--- a/src/Illuminate/Database/Events/DatabaseLoaded.php
+++ b/src/Illuminate/Database/Events/DatabaseLoaded.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class DatabaseLoaded
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The path to the schema dump.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $path
+     */
+    public function __construct($connection, $path)
+    {
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+        $this->path = $path;
+    }
+}

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -16,18 +16,20 @@ class MySqlSchemaState extends SchemaState
      * @param  string  $path
      * @return void
      */
-    public function dump(Connection $connection, $path)
+    public function dump(Connection $connection, $path, $withData = false)
     {
         $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" --no-data'
+            $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" ' . ($withData ? '' : '--no-data')
         ), $this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));
 
-        $this->removeAutoIncrementingState($path);
+        if (!$withData) {
+            $this->removeAutoIncrementingState($path);
 
-        if ($this->hasMigrationTable()) {
-            $this->appendMigrationData($path);
+            if ($this->hasMigrationTable()) {
+                $this->appendMigrationData($path);
+            }
         }
     }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -29,7 +29,7 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_PATH' => $path,
         ]));
 
-        if (!$this->hasData()) {
+        if (! $this->hasData()) {
             $this->removeAutoIncrementingState($path);
 
             if ($this->hasMigrationTable()) {

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -16,11 +16,18 @@ class PostgresSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
+        $dumpCommand = $this->baseDumpCommand();
+        if ($this->hasData()) {
+            $dumpCommand .= ' --column-inserts';
+        } else {
+            $dumpCommand .= ' ---schema-only';
+        }
+
         $commands = new Collection([
-            $this->baseDumpCommand().' --schema-only > '.$path,
+            $dumpCommand.' > '.$path,
         ]);
 
-        if ($this->hasMigrationTable()) {
+        if (! $this->hasData() && $this->hasMigrationTable()) {
             $commands->push($this->baseDumpCommand().' -t '.$this->getMigrationTable().' --data-only >> '.$path);
         }
 

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -30,6 +30,13 @@ abstract class SchemaState
     protected $migrationTable = 'migrations';
 
     /**
+     * Indicates if the dumper should include data.
+     *
+     * @var bool
+     */
+    protected $data = false;
+
+    /**
      * The process factory callback.
      *
      * @var callable
@@ -122,6 +129,29 @@ abstract class SchemaState
     public function withMigrationTable(string $table)
     {
         $this->migrationTable = $table;
+
+        return $this;
+    }
+
+    /**
+     * Check if the dumper should include data.
+     *
+     * @return bool
+     */
+    public function hasData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Indicate that the dumper should include data.
+     *
+     * @param bool $data
+     * @return $this
+     */
+    public function withData(bool $data = true)
+    {
+        $this->data = $data;
 
         return $this;
     }

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -146,7 +146,7 @@ abstract class SchemaState
     /**
      * Indicate that the dumper should include data.
      *
-     * @param bool $data
+     * @param  bool  $data
      * @return $this
      */
     public function withData(bool $data = true)

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -35,6 +35,8 @@ class SqliteSchemaState extends SchemaState
             if ($this->hasMigrationTable()) {
                 $this->appendMigrationData($path);
             }
+        } else {
+            $this->files->put($path, $process->getOutput());
         }
     }
 

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -27,7 +27,7 @@ class SqliteSchemaState extends SchemaState
                 //
             ]));
 
-        if (!$this->hasData()) {
+        if (! $this->hasData()) {
             $migrations = preg_replace('/CREATE TABLE sqlite_.+?\);[\r\n]+/is', '', $process->getOutput());
 
             $this->files->put($path, $migrations.PHP_EOL);

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Console\Signals;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
+use Illuminate\Database\Console\DbDumpCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
@@ -126,6 +127,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigClear' => ConfigClearCommand::class,
         'ConfigShow' => ConfigShowCommand::class,
         'Db' => DbCommand::class,
+        'DbDump' => DbDumpCommand::class,
         'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -19,6 +19,7 @@ use Illuminate\Console\Signals;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
 use Illuminate\Database\Console\DbDumpCommand;
+use Illuminate\Database\Console\DbLoadCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
@@ -128,6 +129,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigShow' => ConfigShowCommand::class,
         'Db' => DbCommand::class,
         'DbDump' => DbDumpCommand::class,
+        'DbLoad' => DbLoadCommand::class,
         'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,


### PR DESCRIPTION
The code is mostly in place, but we only dump schema now. We could extend this to include data, so we can just do `php artisan db:dump` and dump the entire database.
Optionally we could then create `db:load <file>` to quickly import an entire file.

Status: work in progress. I think most drivers are similar, just an optional flag to include data or not.