### PR TITLE
feat: allow defining withQuery in config/auth.php

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -78,7 +78,13 @@ trait CreatesUserProviders
      */
     protected function createEloquentProvider($config)
     {
-        return new EloquentUserProvider($this->app['hash'], $config['model']);
+        $provider = new EloquentUserProvider($this->app['hash'], $config['model']);
+
+        if (isset($config['with'])) {
+            $provider->withQuery($config['with']);
+        }
+
+        return $provider;
     }
 
     /**

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -337,6 +337,21 @@ class AuthenticationTest extends TestCase
 
         $this->assertInstanceOf(MyDispatcherLessCustomGuardStub::class, $this->app['auth']->guard('myGuard'));
     }
+
+    public function testAttachesWithQueryFromConfigToEloquentUserProvider()
+    {
+        $called = false;
+
+        $this->app['config']->set([
+            'auth.providers.users.with' => function () use (&$called) {
+                $called = true;
+            },
+        ]);
+
+        $this->app['auth']->loginUsingId(1);
+
+        $this->assertTrue($called);
+    }
 }
 
 class MyCustomGuardStub


### PR DESCRIPTION
## Motivation

There are some time you might want to customize the query for getting auth users when using EloquentUserProvider.

This includes disabling global scope.

For a concrete example, let's say we have an Admin/User model where you added a global scope to filter out certain criteria by default e.g (unsubscribed, not admin, internal/external).

Authenticating with users matching this criteria (for a reason) will not work.

Right now, there are 2 ways you can do this:

**Method 1**: Create a new provider that extends EloquentUserProvider and override methods slightly

```php
class AdminEloquentUserProvider extends EloquentUserProvider
{
    public function retrieveById($identifier)
    {
        $model = $this->createModel();

        // allow superadmin that are excluded by default to login
        return $this->newModelQuery($model)
            ->withoutGlobalScope('not-superadmin'') // This is the only change
            ->where($model->getAuthIdentifierName(), $identifier)
            ->first();
    }

    // do the same for the other methods
    // or you can set a value for $this->queryCallback (more on to this later)
}
```

then register it in a service provider:

```php
Auth::provider('my-provider'', function() {
  // args omitted for brevity
  return new AdminEloquentUserProvider();
})
```

and lastly, use it in your config/auth:

```
'providers' => [
    'admins' => [
        'driver' => 'my-provider',
    ]
]
```


**Method 2**: Create a new model just for logging in

```php
class Admin extends Authenticatable
{
    protected static function booted()
    {
        // By default, exclude superadmins.
        // This is a special case account.
        static::addGlobalScope('not-superadmin', function (Builder $builder) {
            $builder->whereRelation('role', 'name', '!=', Role::SUPERADMIN);
        });
    }
}

class AuthAdmin extends Admin
{
    protected static function booted()
    {
        // empty to avoid attaching global scope
    }
}
```

then use it in your config/auth:

```php
'providers' => [
    'admins' => [
        'driver' => 'eloquent',
        'model' => AuthAdmin::class,
    ]
]
```

## Solution

Upon digging, I discovered [withQuery()](https://github.com/laravel/framework/blob/v12.37.0/src/Illuminate/Auth/EloquentUserProvider.php#L273) method from EloquentUserProvider which does the exact thing in a shorter way.

With this, you can simply just do:

```php
'providers' => [
    'admins' => [
        'driver' => 'eloquent',
        'model' => Admin::class,
        'with' => function (Builder $builder) {
            $builder->disableGlobalScope('not-superadmin')
        }
    ]
]
```

It may also be useful for defining multiple guard with the same model:

```php
'guards' => [
    'customer' => [
        'driver'   => 'session',
        'provider' => 'customers',
    ],

    'admin' => [
        'driver'   => 'session',
        'provider' => 'admins',
    ],
],

'providers' => [
    'customers' => [
        'driver' => 'eloquent',
        'model' => User::class,
        'with' => function (Builder $builder) {
            $builder->where('is_admin', false)
        }
    ],

    'admins' => [
        'driver' => 'eloquent',
        'model' => User::class,
        'with' => function (Builder $builder) {
            $builder->where('is_admin', true)
        }
    ]
]
```

## Relevant issues

- https://laravel.io/forum/07-16-2016-laravel-authentication-without-global-scope
- https://laracasts.com/discuss/channels/laravel/ignore-global-scopes-for-auth
- https://github.com/laravel/framework/issues/37027
- https://www.yellowduck.be/posts/ignoring-global-scopes-during-auth-in-laravel
- https://stackoverflow.com/questions/38266296/laravel-authentication-without-global-scope
