### PR TITLE
feat: support dynamic cache forget segments

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -100,7 +100,11 @@ class ApcStore extends TaggableStore
      */
     public function forget($key)
     {
-        return $this->apc->delete($this->prefix.$key);
+        if (str_contains($key, '{any}')) {
+            return $this->apc->deletePattern($this->prefix.str_replace('{any}', '(.*)', $key));
+        } else {
+            return $this->apc->delete($this->prefix.$key);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -66,6 +66,17 @@ class ApcWrapper
     }
 
     /**
+     * Remove an item from the cache with APCUIterator.
+     *
+     * @param  string  $pattern
+     * @return bool
+     */
+    public function deletePattern($pattern)
+    {
+        return apcu_delete(new \APCUIterator("/^$pattern$/"));
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return bool

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -166,6 +166,7 @@ class ArrayStore extends TaggableStore implements LockProvider
             $removed = array_map(
                 function ($item) {
                     unset($this->storage[$item]);
+
                     return true;
                 },
                 preg_grep('/^'.str_replace('{any}', '(.*)', $key).'$/', array_keys($this->storage))

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -162,13 +162,25 @@ class ArrayStore extends TaggableStore implements LockProvider
      */
     public function forget($key)
     {
-        if (array_key_exists($key, $this->storage)) {
-            unset($this->storage[$key]);
+        if (str_contains($key, '{any}')) {
+            $removed = array_map(
+                function ($item) {
+                    unset($this->storage[$item]);
+                    return true;
+                },
+                preg_grep('/^'.str_replace('{any}', '(.*)', $key).'$/', array_keys($this->storage))
+            );
 
-            return true;
+            return count($removed) > 0;
+        } else {
+            if (array_key_exists($key, $this->storage)) {
+                unset($this->storage[$key]);
+
+                return true;
+            }
+
+            return false;
         }
-
-        return false;
     }
 
     /**

--- a/src/Illuminate/Cache/SessionStore.php
+++ b/src/Illuminate/Cache/SessionStore.php
@@ -167,6 +167,7 @@ class SessionStore implements Store
             $removed = array_map(
                 function ($item) {
                     $this->session->forget($this->itemKey($item));
+
                     return true;
                 },
                 preg_grep('/^'.str_replace('{any}', '(.*)', $key).'$/', array_keys($this->session->get($this->key)))

--- a/src/Illuminate/Cache/SessionStore.php
+++ b/src/Illuminate/Cache/SessionStore.php
@@ -163,13 +163,25 @@ class SessionStore implements Store
      */
     public function forget($key)
     {
-        if ($this->session->exists($this->itemKey($key))) {
-            $this->session->forget($this->itemKey($key));
+        if (str_contains($key, '{any}')) {
+            $removed = array_map(
+                function ($item) {
+                    $this->session->forget($this->itemKey($item));
+                    return true;
+                },
+                preg_grep('/^'.str_replace('{any}', '(.*)', $key).'$/', array_keys($this->session->get($this->key)))
+            );
 
-            return true;
+            return count($removed) > 0;
+        } else {
+            if ($this->session->exists($this->itemKey($key))) {
+                $this->session->forget($this->itemKey($key));
+
+                return true;
+            }
+
+            return false;
         }
-
-        return false;
     }
 
     /**

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -124,6 +124,24 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testSingleDynamicSegmentForgetMethodProperlyCallsAPC()
+    {
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['deletePattern'])->getMock();
+        $apc->expects($this->once())->method('deletePattern')->with($this->equalTo('foo_(.*)'))->willReturn(true);
+        $store = new ApcStore($apc);
+        $result = $store->forget('foo_{any}');
+        $this->assertTrue($result);
+    }
+
+    public function testMultipleDynamicSegmentForgetMethodProperlyCallsAPC()
+    {
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['deletePattern'])->getMock();
+        $apc->expects($this->once())->method('deletePattern')->with($this->equalTo('foo_(.*)_bar_(.*)'))->willReturn(true);
+        $store = new ApcStore($apc);
+        $result = $store->forget('foo_{any}_bar_{any}');
+        $this->assertTrue($result);
+    }
+
     public function testFlushesCached()
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['flush'])->getMock();

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -162,6 +162,36 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($store->forget('foo'));
     }
 
+    public function testSingleDynamicSegmentItemsCanBeRemoved()
+    {
+        $store = new ArrayStore;
+        $store->put('foo', 'bar', 10);
+        $store->put('foo_1', 'bar', 10);
+        $store->put('foo_2', 'bar', 10);
+        $store->put('foo_3_bar_1', 'bar', 10);
+        $this->assertTrue($store->forget('foo_{any}'));
+        $this->assertNull($store->get('foo_1'));
+        $this->assertNull($store->get('foo_2'));
+        $this->assertNull($store->get('foo_3_bar_1'));
+        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertFalse($store->forget('foo_{any}'));
+    }
+
+    public function testMultipleDynamicSegmentItemsCanBeRemoved()
+    {
+        $store = new ArrayStore;
+        $store->put('foo', 'bar', 10);
+        $store->put('foo_1', 'bar', 10);
+        $store->put('foo_2', 'bar', 10);
+        $store->put('foo_3_bar_1', 'bar', 10);
+        $this->assertTrue($store->forget('foo_{any}_bar_{any}'));
+        $this->assertNull($store->get('foo_3_bar_1'));
+        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertEquals('bar', $store->get('foo_1'));
+        $this->assertEquals('bar', $store->get('foo_2'));
+        $this->assertFalse($store->forget('foo_{any}_bar_{any}'));
+    }
+
     public function testItemsCanBeFlushed()
     {
         $store = new ArrayStore;

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -129,10 +129,35 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('whereIn')->once()->with('key', ['prefixfoo', 'prefixilluminate:cache:flexible:created:foo'])->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixilluminate:cache:flexible:created:foo')->andReturn($table);
         $table->shouldReceive('delete')->once();
 
         $store->forget('foo');
+    }
+
+    public function testSingleDynamicSegmentItemsMayBeRemovedFromCache()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixfoo_%')->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixilluminate:cache:flexible:created:foo_%')->andReturn($table);
+        $table->shouldReceive('delete')->once();
+
+        $store->forget('foo_{any}');
+    }
+
+    public function testMultipleDynamicSegmentItemsMayBeRemovedFromCache()
+    {
+        $store = $this->getStore();
+        $table = m::mock(stdClass::class);
+        $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixfoo_%_bar_%')->andReturn($table);
+        $table->shouldReceive('orWhereLike')->once()->with('key', 'prefixilluminate:cache:flexible:created:foo_%_bar_%')->andReturn($table);
+        $table->shouldReceive('delete')->once();
+
+        $store->forget('foo_{any}_bar_{any}');
     }
 
     public function testItemsMayBeFlushedFromCache()

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -167,6 +167,36 @@ class CacheSessionStoreTest extends TestCase
         $this->assertFalse($store->forget('foo'));
     }
 
+    public function testSingleDynamicSegmentItemsCanBeRemoved()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'bar', 10);
+        $store->put('foo_1', 'bar', 10);
+        $store->put('foo_2', 'bar', 10);
+        $store->put('foo_3_bar_1', 'bar', 10);
+        $this->assertTrue($store->forget('foo_{any}'));
+        $this->assertNull($store->get('foo_1'));
+        $this->assertNull($store->get('foo_2'));
+        $this->assertNull($store->get('foo_3_bar_1'));
+        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertFalse($store->forget('foo_{any}'));
+    }
+
+    public function testMultipleDynamicSegmentItemsCanBeRemoved()
+    {
+        $store = new SessionStore(self::getSession());
+        $store->put('foo', 'bar', 10);
+        $store->put('foo_1', 'bar', 10);
+        $store->put('foo_2', 'bar', 10);
+        $store->put('foo_3_bar_1', 'bar', 10);
+        $this->assertTrue($store->forget('foo_{any}_bar_{any}'));
+        $this->assertNull($store->get('foo_3_bar_1'));
+        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertEquals('bar', $store->get('foo_1'));
+        $this->assertEquals('bar', $store->get('foo_2'));
+        $this->assertFalse($store->forget('foo_{any}_bar_{any}'));
+    }
+
     public function testItemsCanBeFlushed()
     {
         $store = new SessionStore(self::getSession());


### PR DESCRIPTION
### Suggestion

Currently `Cache::forget()` does not support dynamic segments or wildcards at all, making cache clearing a little bit cumbersome from Event Listeners, Events, Jobs, Queue and so on for specific cache items that use dynamic segments in the key. 
For Example, if you use IDs in cache keys like so:
```php
Cache::put("item_1", "someData");
Cache::put("item_2", "someData");
Cache::put("something_613", "someData");
Cache::put("important_999", "someData");
```
Then you must know keys in advance and do this, which limits to what could be done automatically:
```php
Cache::forget("item_1");
Cache::forget("item_2");
Cache::forget("something_613");
Cache::forget("important_999");
```


### Implementation & Examples
This PR adds wildcard support to `Array`, `Database`, `Session` & `Apcu` cache drivers (i was not able to fully test APCU though, it might need a little nudge in the right direction or a rollback)
Implementation itself might not be ideal, but the idea i feel is quite useful.
Soo with this PR addition remains the same as well as `Cache::forget` is backwards compatible, it adds `{any}` wildcard:
```php
Cache::forget("item_{any}");
```
This would delete all items with prefix "item_"
It can also be mixed like so:
```php
Cache::forget("item_{any}_someSubKey");
```
OR
```php
Cache::forget("item_{any}_anotherKey_{any}");
```
Items deleted would be "item_\*\_someSubKey" and "item_\*\_anotherKey\_\*" respectively.

Implementation uses regex and in addition to suggested `{any}` which is `(.*)` it could be expanded to also limit to numeric only with wildcard `{num}` which is `(\d*)`