### PR TITLE
[12.x] Cache result of `Application@routesAreCached()`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1326,8 +1326,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function routesAreCached()
     {
-        return ($this->bound('routes.cached') && $this->make('routes.cached') === true) ||
-            $this['files']->exists($this->getCachedRoutesPath());
+        if ($this->bound('routes.cached')) {
+            return (bool) $this->make('routes.cached');
+        }
+
+        return $this->instance('routes.cached', $this['files']->exists($this->getCachedRoutesPath()));
     }
 
     /**


### PR DESCRIPTION
This is a similar effort to the one found here: https://github.com/laravel/framework/pull/57665. We want to reduce file_exists checks where we know it's unlikely to change during a request