### PR TITLE
[12.x] Add missing separators to `Stringable::ucwords`

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1110,6 +1110,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Capitalize the first character of each word in a string.
      *
+     * @param  string  $separators
      * @return static
      */
     public function ucwords($separators = " \t\r\n\f\v")

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1112,9 +1112,9 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      *
      * @return static
      */
-    public function ucwords()
+    public function ucwords($separators = " \t\r\n\f\v")
     {
-        return new static(Str::ucwords($this->value));
+        return new static(Str::ucwords($this->value, $separators));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -180,6 +180,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Taylor Otwell', (string) $this->stringable('Taylor Otwell')->words(3));
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Laravel', (string) $this->stringable('laravel')->ucwords());
+        $this->assertSame('Laravel Framework', (string) $this->stringable('laravel framework')->ucwords());
+        $this->assertSame('Laravel-Framework', (string) $this->stringable('laravel-framework')->ucwords('-'));
+        $this->assertSame('Мама', (string) $this->stringable('мама')->ucwords());
+        $this->assertSame('Мама Мыла Раму', (string) $this->stringable('мама мыла раму')->ucwords());
+        $this->assertSame('JJ Watt', (string) $this->stringable('JJ watt')->ucwords());
+    }
+
     public function testUnless()
     {
         $this->assertSame('unless false', (string) $this->stringable('unless')->unless(false, function ($stringable, $value) {


### PR DESCRIPTION
This PR add missing separators to `Stringable::ucwords` introduced in https://github.com/laravel/framework/pull/57581 that allow custom separators when chaining.

Use case: 
```php
Str::of('LARAVEL-Framework')->lower()->ucwords('-'); // Laravel-Framework
```

I added related tests to StringableTest