### PR TITLE
fix phpdoc return of HasAttributes::getArrayAttributeWithValue

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1314,7 +1314,7 @@ trait HasAttributes
      * @param  string  $path
      * @param  string  $key
      * @param  mixed  $value
-     * @return $this
+     * @return array
      */
     protected function getArrayAttributeWithValue($path, $key, $value)
     {


### PR DESCRIPTION
Not much more to be said, the description is longer than the patch.  The code clearly returns `array` rather than `$this`.  Noticed this in one of my static typing experiments.