### PR TITLE
[12.x] Refactor: remove (int)

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -166,7 +166,7 @@ class Response implements ArrayAccess, Stringable
      */
     public function status()
     {
-        return (int) $this->response->getStatusCode();
+        return $this->response->getStatusCode();
     }
 
     /**


### PR DESCRIPTION
Response is instance of `\Psr\Http\Message\ResponseInterface` and `getStatusCode` method has return type int.
so, (int) is unnecessary