### PR TITLE
[12.x] Add `json_response` helper method

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -24,6 +24,7 @@ use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Log\Context\Repository as ContextRepository;
@@ -540,6 +541,22 @@ if (! function_exists('info')) {
     function info($message, $context = []): void
     {
         app('log')->info($message, $context);
+    }
+}
+
+if (! function_exists('json')) {
+    /**
+     * @param  mixed  $data
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  array  $options
+     * @return JsonResponse
+     */
+    function json($data = [], $status = 200, array $headers = [], $options = 0): JsonResponse
+    {
+        $factory = app(ResponseFactory::class);
+
+        return $factory->json($data, $status, $headers, $options);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -544,7 +544,7 @@ if (! function_exists('info')) {
     }
 }
 
-if (! function_exists('json')) {
+if (! function_exists('json_response')) {
     /**
      * @param  mixed  $data
      * @param  int  $status
@@ -552,7 +552,7 @@ if (! function_exists('json')) {
      * @param  array  $options
      * @return JsonResponse
      */
-    function json($data = [], $status = 200, array $headers = [], $options = 0): JsonResponse
+    function json_response($data = [], $status = 200, array $headers = [], $options = 0): JsonResponse
     {
         $factory = app(ResponseFactory::class);
 

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -28,4 +28,24 @@ class ResponseTest extends TestCase
 
         $this->get('/response');
     }
+
+    public function testJsonResponseHelper(): void
+    {
+        $response = json(['message' => 'Hello World']);
+        $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
+        $this->assertEquals(200, $response->status());
+        $this->assertEquals(['message' => 'Hello World'], $response->getData(true));
+
+        $response = json(['error' => 'Not Found'], 404);
+        $this->assertEquals(404, $response->status());
+        $this->assertEquals(['error' => 'Not Found'], $response->getData(true));
+
+        $response = json(['data' => 'test'], 200, ['X-Custom-Header' => 'TestValue']);
+        $this->assertEquals('TestValue', $response->headers->get('X-Custom-Header'));
+
+        $data = ['url' => 'https://example.com/test'];
+        $response = json($data, 200, [], JSON_UNESCAPED_SLASHES);
+        $this->assertStringNotContainsString('\/', $response->getContent());
+        $this->assertStringContainsString('https://example.com/test', $response->getContent());
+    }
 }

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -31,20 +31,20 @@ class ResponseTest extends TestCase
 
     public function testJsonResponseHelper(): void
     {
-        $response = json(['message' => 'Hello World']);
+        $response = json_response(['message' => 'Hello World']);
         $this->assertInstanceOf(\Illuminate\Http\JsonResponse::class, $response);
         $this->assertEquals(200, $response->status());
         $this->assertEquals(['message' => 'Hello World'], $response->getData(true));
 
-        $response = json(['error' => 'Not Found'], 404);
+        $response = json_response(['error' => 'Not Found'], 404);
         $this->assertEquals(404, $response->status());
         $this->assertEquals(['error' => 'Not Found'], $response->getData(true));
 
-        $response = json(['data' => 'test'], 200, ['X-Custom-Header' => 'TestValue']);
+        $response = json_response(['data' => 'test'], 200, ['X-Custom-Header' => 'TestValue']);
         $this->assertEquals('TestValue', $response->headers->get('X-Custom-Header'));
 
         $data = ['url' => 'https://example.com/test'];
-        $response = json($data, 200, [], JSON_UNESCAPED_SLASHES);
+        $response = json_response($data, 200, [], JSON_UNESCAPED_SLASHES);
         $this->assertStringNotContainsString('\/', $response->getContent());
         $this->assertStringContainsString('https://example.com/test', $response->getContent());
     }


### PR DESCRIPTION
This is just a QoL improvement where we can use this:

```php
public function index(): JsonResponse
{
    return json_response($data);
}
```

Instead of this:

```php
public function index(): JsonResponse
{
    return response()->json($data);
}