### PR TITLE
[12.x] Add `withTrashedRelations()` to automatically eager load deleted related models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -215,7 +215,6 @@ class Builder implements BuilderContract
      * Register many new global scopes.
      *
      * @param  array  $scopes
-     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
      * @return $this
      */
     public function withGlobalScopes(array $scopes)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -280,7 +280,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Register scopes that related model queries should inherit.
+     * Register scopes that related model eager loading queries should inherit.
      *
      * @param  array  $scopes
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -982,7 +982,7 @@ class Builder implements BuilderContract
         $relation->addEagerConstraints($models);
 
         // Run this before the callback so if the user wanted to they can override it.
-        if (!empty($this->inheritedScopes)) {
+        if (! empty($this->inheritedScopes)) {
             $relation
                 ->withGlobalScopes($this->inheritedScopes['keep'] ?? [])
                 ->withoutGlobalScopes($this->inheritedScopes['remove'] ?? [])

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -205,6 +205,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Register many new global scopes.
+     *
+     * @param  array  $scopes
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @return $this
+     */
+    public function withGlobalScopes(array $scopes)
+    {
+        foreach ($scopes as $identifier => $scope) {
+            $this->withGlobalScope($identifier, $scope);
+        }
+
+        return $this;
+    }
+
+    /**
      * Remove a registered global scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -138,6 +138,13 @@ class Builder implements BuilderContract
     ];
 
     /**
+     * Indicate if the related models should inherit the scopes from the parent.
+     *
+     * @var bool
+     */
+    protected $inheritScopes = false;
+
+    /**
      * Applied global scopes.
      *
      * @var array
@@ -956,6 +963,14 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
+        // Run this before the callback so if the user wanted to they can overwrite it.
+        if ($this->inheritScopes) {
+            $relation
+                ->withGlobalScopes($this->scopes)
+                ->withoutGlobalScopes($this->removedScopes)
+                ->inheritScopes();
+        }
+
         $constraints($relation);
 
         // Once we have the results, we just match those back up to their parent models
@@ -1515,6 +1530,18 @@ class Builder implements BuilderContract
     public function onDelete(Closure $callback)
     {
         $this->onDelete = $callback;
+    }
+
+    /**
+     * Apply current scopes to all relationships.
+     *
+     * @return $this
+     */
+    public function inheritScopes()
+    {
+        $this->inheritScopes = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -138,21 +138,21 @@ class Builder implements BuilderContract
     ];
 
     /**
-     * Applied global scopes.
+     * The applied global scopes.
      *
      * @var array
      */
     protected $scopes = [];
 
     /**
-     * Removed global scopes.
+     * The removed global scopes.
      *
      * @var array
      */
     protected $removedScopes = [];
 
     /**
-     * Inherited global scopes.
+     * The inherited global scopes.
      *
      * @var array
      */
@@ -280,7 +280,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Register scopes that related models should inherit.
+     * Register scopes that related model queries should inherit.
      *
      * @param  array  $scopes
      * @return $this
@@ -981,7 +981,6 @@ class Builder implements BuilderContract
 
         $relation->addEagerConstraints($models);
 
-        // Run this before the callback so if the user wanted to they can override it.
         if (! empty($this->inheritedScopes)) {
             $relation
                 ->withGlobalScopes($this->inheritedScopes['keep'] ?? [])

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -136,7 +136,7 @@ class SoftDeletingScope implements Scope
     protected function addWithTrashedRelations(Builder $builder)
     {
         $builder->macro('withTrashedRelations', function (Builder $builder) {
-            return $builder->withTrashed()->inheritScopes();
+            return $builder->withTrashed()->inheritScopes(remove: [$this]);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var string[]
      */
-    protected $extensions = ['Restore', 'RestoreOrCreate', 'CreateOrRestore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+    protected $extensions = ['Restore', 'RestoreOrCreate', 'CreateOrRestore', 'WithTrashed', 'WithTrashedRelations', 'WithoutTrashed', 'OnlyTrashed'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -124,6 +124,19 @@ class SoftDeletingScope implements Scope
             }
 
             return $builder->withoutGlobalScope($this);
+        });
+    }
+
+    /**
+     * Add the with-trashed relationships extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<*>  $builder
+     * @return void
+     */
+    protected function addWithTrashedRelations(Builder $builder)
+    {
+        $builder->macro('withTrashedRelations', function (Builder $builder) {
+            return $builder->withTrashed()->inheritScopes();
         });
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -864,10 +864,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setEagerLoads(['orders' => function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
-        $builder->withGlobalScope('test_scope', function ($query) {
+        $scope = function ($query) {
             $query->where('active', 1);
-        });
-        $builder->inheritScopes();
+        };
+        $builder->withGlobalScope('test_scope', $scope);
+        $builder->inheritScopes(['test_scope' => $scope]);
 
         $relation = m::mock(stdClass::class);
         $relation->shouldReceive('addEagerConstraints')->once()->with(['models']);

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -124,7 +124,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $callback = $builder->getMacro('withTrashedRelations');
         $givenBuilder = m::mock(EloquentBuilder::class);
         $givenBuilder->shouldReceive('withTrashed')->once()->andReturn($givenBuilder);
-        $givenBuilder->shouldReceive('inheritScopes')->once()->andReturn($givenBuilder);
+        $givenBuilder->shouldReceive('inheritScopes')->once()->with([], [$scope])->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -112,6 +112,24 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $this->assertEquals($givenBuilder, $result);
     }
 
+    public function testWithTrashedRelationsExtension()
+    {
+        $builder = new EloquentBuilder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            m::mock(Grammar::class),
+            m::mock(Processor::class)
+        ));
+        $scope = m::mock(SoftDeletingScope::class.'[remove]');
+        $scope->extend($builder);
+        $callback = $builder->getMacro('withTrashedRelations');
+        $givenBuilder = m::mock(EloquentBuilder::class);
+        $givenBuilder->shouldReceive('withTrashed')->once()->andReturn($givenBuilder);
+        $givenBuilder->shouldReceive('inheritScopes')->once()->andReturn($givenBuilder);
+        $result = $callback($givenBuilder);
+
+        $this->assertEquals($givenBuilder, $result);
+    }
+
     public function testOnlyTrashedExtension()
     {
         $builder = new EloquentBuilder(new BaseBuilder(


### PR DESCRIPTION
## Problem

When you have several related models that have all been trashed, it can be tricky and verbose to load these along with your original model. 

Let's use a blog for this example, which we can expect to have the model structure of User -> Post -> Comment. Now let's say our blog allows us to archive users along with any content they've created. That's all pretty basic Eloquent, until you need to add a way to still show archived users _and_ their content. 

The assumption would be to do something like this:

```php
use App\Models\User;

User::limit(10)
    ->with('posts.comments')
    ->withTrashed()
    ->get();
```

However if we look at the queries that ran we'll quickly see why your blog is still missing some content:

```sql
select * from `users`
select * from `posts` where `posts`.`id` in (...) and `posts`.`deleted_at` is null
select * from `comments` where `comments`.`id` in (...) and `comments`.`deleted_at` is null
```

The method only removed the global scope for the model we queried and not any relations. 

A solution for this would be to add constraints to your eager loaded models:

```php
use App\Models\User;

User::limit(10)
    ->with([
        'posts' => fn ($query) => $query->withTrashed(),
        'posts.comments' => fn ($query) => $query->withTrashed(),
    ])
    ->withTrashed()
    ->get();
```

If we check the queries again, everything is now scoped correctly:

```sql
select * from `users`
select * from `posts` where `posts`.`id` in (...)
select * from `comments` where `comments`.`id` in (...)
```

As you can see, those `with()` constraints will quickly get out of hand on larger models or a more complicated query.

## Solution

```diff
use App\Models\User;

User::limit(10)
    ->with('posts.comments')
-   ->withTrashed()
+   ->withTrashedRelations()
    ->get();
```

This new method will automatically remove the trashed scope on all eager loaded models, just like we did with the manual constraints, but without the bloat. If we check our query again, everything is still scoped correctly!

```sql
select * from `users`
select * from `posts` where `posts`.`id` in (...)
select * from `comments` where `comments`.`id` in (...)
```

Now I'm not discounting that you could just scope this on the model relationship, but for scenarios like this you generally want the default behaviour throughout the application, and to override it in smaller doses.

## Notes

After much trial and error this seemed the best approach I could find that avoided a breaking change (based on the many ways relationships can be loaded) but I'm open to suggestions! There's also the possibility to repeat this for `onlyTrashed()` - I just wasn't sure if it would be wanted.

Currently this doesn't work with [lazy](https://laravel.com/docs/12.x/eloquent-relationships#lazy-eager-loading) or [automatic](https://laravel.com/docs/12.x/eloquent-relationships#automatic-eager-loading) eager loading, but if there's interest in this first step I'm happy to investigate further. 

The problem I see with both of those is we don't have access to the original query because they happen once the data is collected - unless we introduce a new method like `loadWithTrashed()` or wrap it in a static callback like with event muting:

```php
User::withTrashedRelations(function () {
    //
});
```

This implementation isn't limited to just soft deletes though, it could be used for a number of other things as it allows you to ensure any eager-loaded nested relation uses the same scope as the parent.