### PR TITLE
NotPwnedVerifier will no longer silently report StrayRequestException during testing

### DIFF
--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Exception;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
+use Illuminate\Http\Client\StrayRequestException;
 use Illuminate\Support\Stringable;
 
 class NotPwnedVerifier implements UncompromisedVerifier
@@ -88,6 +89,8 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ])->timeout($this->timeout)->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
+        } catch (StrayRequestException $e) {
+            throw $e;
         } catch (Exception $e) {
             report($e);
         }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\StrayRequestException;
 use Illuminate\Validation\NotPwnedVerifier;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -142,5 +143,20 @@ class ValidationNotPwnedVerifierTest extends TestCase
         ]));
 
         unset($container[ExceptionHandler::class]);
+    }
+
+    public function testStrayRequestExceptionIsThrown()
+    {
+        $this->expectException(StrayRequestException::class);
+
+        $httpFactory = new HttpFactory;
+        $httpFactory->preventStrayRequests();
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        $verifier->verify([
+            'value' => 'password',
+            'threshold' => 0,
+        ]);
     }
 }


### PR DESCRIPTION
When testing code that is using `Password::uncompromised()` with `Http::preventStrayRequests()` a test will not fail when there is not a matching fake. This is due to a `try/catch` catching the `StrayRequestException`, and not bubbling it upwards.


To replicate this:
- Create a FormRequest with a `Password::uncompromised()`
- Create a post route, and controller that uses this FormRequest
- Create a test for this endpoint with `Http::preventStrayRequests()`
- Run test, it will pass but leave an exception in the `laravel.log` file