### PR TITLE
[12.x] add SQLite support for whereNotMorphedTo method

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -56,11 +56,7 @@ class SQLiteGrammar extends Grammar
             $column = $this->wrap($where['column']);
             $value = $this->parameter($where['value']);
 
-            if (is_null($where['value'])) {
-                return "{$column} IS NULL";
-            }
-
-            return "{$column} = {$value}";
+            return "{$column} IS {$value}";
         }
 
         return parent::whereBasic($query, $where);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -44,6 +44,29 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a basic where clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBasic(Builder $query, $where)
+    {
+        if ($where['operator'] === '<=>') {
+            $column = $this->wrap($where['column']);
+            $value = $this->parameter($where['value']);
+
+            if (is_null($where['value'])) {
+                return "{$column} IS NULL";
+            }
+
+            return "{$column} = {$value}";
+        }
+
+        return parent::whereBasic($query, $where);
+    }
+
+    /**
      * Compile a "where like" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2166,7 +2166,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $model->whereNotMorphedTo('morph', $relatedModel);
 
         $this->assertStringNotContainsString('<=>', $builder->toSql());
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not (("eloquent_builder_test_model_parent_stubs"."morph_type" = ? and "eloquent_builder_test_model_parent_stubs"."morph_id" in (?)))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not (("eloquent_builder_test_model_parent_stubs"."morph_type" IS ? and "eloquent_builder_test_model_parent_stubs"."morph_id" in (?)))', $builder->toSql());
         $this->assertEquals([$relatedModel->getMorphClass(), $relatedModel->getKey()], $builder->getBindings());
     }
 
@@ -2178,7 +2178,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $model->whereNotMorphedTo('morph', EloquentBuilderTestModelCloseRelatedStub::class);
 
         $this->assertStringNotContainsString('<=>', $builder->toSql());
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not "eloquent_builder_test_model_parent_stubs"."morph_type" = ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not "eloquent_builder_test_model_parent_stubs"."morph_type" IS ?', $builder->toSql());
         $this->assertEquals([EloquentBuilderTestModelCloseRelatedStub::class], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2155,6 +2155,33 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', EloquentBuilderTestModelCloseRelatedStub::class], $builder->getBindings());
     }
 
+    public function testWhereNotMorphedToWithSQLite()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $relatedModel = new EloquentBuilderTestModelCloseRelatedStub;
+        $relatedModel->id = 1;
+
+        $builder = $model->whereNotMorphedTo('morph', $relatedModel);
+
+        $this->assertStringNotContainsString('<=>', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not (("eloquent_builder_test_model_parent_stubs"."morph_type" = ? and "eloquent_builder_test_model_parent_stubs"."morph_id" in (?)))', $builder->toSql());
+        $this->assertEquals([$relatedModel->getMorphClass(), $relatedModel->getKey()], $builder->getBindings());
+    }
+
+    public function testWhereNotMorphedToClassWithSQLite()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $builder = $model->whereNotMorphedTo('morph', EloquentBuilderTestModelCloseRelatedStub::class);
+
+        $this->assertStringNotContainsString('<=>', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not "eloquent_builder_test_model_parent_stubs"."morph_type" = ?', $builder->toSql());
+        $this->assertEquals([EloquentBuilderTestModelCloseRelatedStub::class], $builder->getBindings());
+    }
+
     public function testWhereMorphedToAlias()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
Fixes SQLite compatibility for `whereNotMorphedTo` by converting MySQL's `<=>` operator to SQLite-compatible syntax in `SQLiteGrammar`.

- Override `whereBasic` in `SQLiteGrammar` to handle `<=>` operator
- Add SQLite-specific tests

Fixes #57594