### PR TITLE
[12.x] Remove unnecessary imports from BackgroundQueue and DeferredQueue.

### DIFF
--- a/src/Illuminate/Queue/BackgroundQueue.php
+++ b/src/Illuminate/Queue/BackgroundQueue.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Contracts\Queue\Job;
 use Illuminate\Support\Facades\Concurrency;
 
 class BackgroundQueue extends SyncQueue

--- a/src/Illuminate/Queue/DeferredQueue.php
+++ b/src/Illuminate/Queue/DeferredQueue.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Contracts\Queue\Job;
-
 class DeferredQueue extends SyncQueue
 {
     /**


### PR DESCRIPTION
`Illuminate\Contracts\Queue\Job` is unused here. So we needn't to import it.
