### PR TITLE
[12.x] Update hashing verification tests

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -103,7 +103,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }
 
-        return parent::check($value, $hashedValue, $options);
+        return password_verify($value, $hashedValue);
     }
 
     /**

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -88,7 +88,7 @@ class BcryptHasher extends AbstractHasher implements HasherContract
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 
-        return parent::check($value, $hashedValue, $options);
+        return password_verify($value, $hashedValue);
     }
 
     /**

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -94,6 +94,7 @@ class HasherTest extends TestCase
     public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This password does not use the Bcrypt algorithm.');
 
         $argonHasher = new ArgonHasher(['verify' => true]);
         $argonHashed = $argonHasher->make('password');
@@ -104,6 +105,7 @@ class HasherTest extends TestCase
     public function testBasicArgon2iVerification()
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This password does not use the Argon2i algorithm.');
 
         $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');
@@ -114,6 +116,7 @@ class HasherTest extends TestCase
     public function testBasicArgon2idVerification()
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This password does not use the Argon2id algorithm.');
 
         $bcryptHasher = new BcryptHasher(['verify' => true]);
         $bcryptHashed = $bcryptHasher->make('password');


### PR DESCRIPTION
I suggest checking exception messages here to ensure they are thrown by the `check` methods, not by others.
