### PR TITLE
[12.x] Add processFileUsing() method to AwsS3V3Adapter for temporary local processing of remote files and get() and path() overrides

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -63,12 +63,13 @@ class AwsS3V3Adapter extends FilesystemAdapter
     public function get($path)
     {
         if (str_ends_with($path, '.zip')) {
-            Storage::disk('local')->writeStream(
+            $localDisk = new Filesystem;
+            $localDisk->put(
                 $path,
                 $this->readStream($path)
             );
 
-            return Storage::disk('local')->get($path);
+            return $localDisk->get($path);
         }
 
         return parent::get($path);
@@ -77,12 +78,13 @@ class AwsS3V3Adapter extends FilesystemAdapter
     public function path($path)
     {
         if (str_ends_with($path, '.zip')) {
-            Storage::disk('local')->writeStream(
+            $localDisk = new Filesystem;
+            $localDisk->put(
                 $path,
                 $this->readStream($path)
             );
 
-            return Storage::disk('local')->path($path);
+            return $path;
         }
 
         return parent::path($path);

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Filesystem;
 
 use Aws\S3\S3Client;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Conditionable;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
@@ -96,20 +97,18 @@ class AwsS3V3Adapter extends FilesystemAdapter
     public function processFileUsing($path, $closure, ?string $disk = null)
     {
         $isZip = str_ends_with($path, '.zip');
-        $localPath = null;
         if ($isZip) {
-            Storage::disk('local')->writeStream(
+            $localDisk = new Filesystem();
+            $localDisk->put(
                 $path,
                 $this->readStream($path)
             );
-
-            $localPath = Storage::disk('local')->path($path);
         }
         try {
-            return $closure($localPath ?? $path);
+            return $closure($path);
         } finally {
             if ($isZip) {
-                Storage::disk('local')->delete($path);
+                $localDisk->delete($path);
             }
         }
     }

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -21,6 +21,11 @@ class AwsS3V3Adapter extends FilesystemAdapter
 
     /**
      * Create a new AwsS3V3FilesystemAdapter instance.
+     *
+     * @param  \League\Flysystem\FilesystemOperator  $driver
+     * @param  \League\Flysystem\FilesystemAdapter  $adapter
+     * @param  array  $config
+     * @param  \Aws\S3\S3Client  $client
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config, S3Client $client)
     {
@@ -124,6 +129,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
      * @return string
      */
     public function temporaryUrl($path, $expiration, array $options = [])
@@ -152,6 +158,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
      * @return array
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Filesystem;
 
 use Aws\S3\S3Client;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Conditionable;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
@@ -22,11 +21,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
 
     /**
      * Create a new AwsS3V3FilesystemAdapter instance.
-     *
-     * @param  \League\Flysystem\FilesystemOperator  $driver
-     * @param  \League\Flysystem\FilesystemAdapter  $adapter
-     * @param  array  $config
-     * @param  \Aws\S3\S3Client  $client
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config, S3Client $client)
     {
@@ -98,7 +92,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
     {
         $isZip = str_ends_with($path, '.zip');
         if ($isZip) {
-            $localDisk = new Filesystem();
+            $localDisk = new Filesystem;
             $localDisk->put(
                 $path,
                 $this->readStream($path)
@@ -128,7 +122,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return string
      */
     public function temporaryUrl($path, $expiration, array $options = [])
@@ -157,7 +150,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return array
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -1039,7 +1039,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function processFileUsing(string $path, Closure $closure, ?string $disk = null)
     {
         if ($disk) {
-            return Storage::disk($disk)->processFile($path, $closure);
+            return Storage::disk($disk)->processFileUsing($path, $closure);
         }
 
         return $closure($this->path($path));

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -1032,7 +1032,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * .
+     * This method accepts a closure to process the given Path.
      *
      * @return mixed
      */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Http\File;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -93,10 +94,6 @@ class FilesystemAdapter implements CloudFilesystemContract
 
     /**
      * Create a new filesystem adapter instance.
-     *
-     * @param  \League\Flysystem\FilesystemOperator  $driver
-     * @param  \League\Flysystem\FilesystemAdapter  $adapter
-     * @param  array  $config
      */
     public function __construct(FilesystemOperator $driver, FlysystemAdapter $adapter, array $config = [])
     {
@@ -314,7 +311,6 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array  $headers
      * @param  string|null  $disposition
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
@@ -349,10 +345,8 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Create a streamed download response for a given file.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function serve(Request $request, $path, $name = null, array $headers = [])
@@ -367,7 +361,6 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function download($path, $name = null, array $headers = [])
@@ -798,7 +791,6 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return string
      *
      * @throws \RuntimeException
@@ -823,7 +815,6 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  \DateTimeInterface  $expiration
-     * @param  array  $options
      * @return array
      *
      * @throws \RuntimeException
@@ -1023,7 +1014,6 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Define a custom callback that generates file download responses.
      *
-     * @param  \Closure  $callback
      * @return void
      */
     public function serveUsing(Closure $callback)
@@ -1034,7 +1024,6 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Define a custom temporary URL builder callback.
      *
-     * @param  \Closure  $callback
      * @return void
      */
     public function buildTemporaryUrlsUsing(Closure $callback)
@@ -1043,9 +1032,21 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * Determine if Flysystem exceptions should be thrown.
+     * .
      *
-     * @return bool
+     * @return mixed
+     */
+    public function processFileUsing(string $path, Closure $closure, ?string $disk = null)
+    {
+        if ($disk) {
+            return Storage::disk($disk)->processFile($path, $closure);
+        }
+
+        return $closure($this->path($path));
+    }
+
+    /**
+     * Determine if Flysystem exceptions should be thrown.
      */
     protected function throwsExceptions(): bool
     {
@@ -1067,8 +1068,6 @@ class FilesystemAdapter implements CloudFilesystemContract
 
     /**
      * Determine if Flysystem exceptions should be reported.
-     *
-     * @return bool
      */
     protected function shouldReport(): bool
     {

--- a/tests/Filesystem/AwsS3V3AdapterTest.php
+++ b/tests/Filesystem/AwsS3V3AdapterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use Illuminate\Filesystem\AwsS3V3Adapter;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Foundation\Application;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class AwsS3V3AdapterTest extends TestCase
+{
+    private $tempDir;
+
+    private $filesystem;
+
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = __DIR__.'/tmp';
+        $this->filesystem = new Filesystem(
+            $this->adapter = new LocalFilesystemAdapter($this->tempDir)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = new Filesystem(
+            $this->adapter = new LocalFilesystemAdapter(dirname($this->tempDir))
+        );
+        $filesystem->deleteDirectory(basename($this->tempDir));
+        m::close();
+
+        unset($this->tempDir, $this->filesystem, $this->adapter);
+    }
+
+    public function test_process_file_using_callback_returns_expected_values_for_s3_adapter_with_zip_file()
+    {
+        $filesystem = new FilesystemManager(new Application);
+
+        $filesystemAdapter = $filesystem->createS3Driver([
+            'region' => 'us-west-1',
+            'bucket' => 'laravel',
+        ]);
+
+        $receivedPath = null;
+
+        $result = $filesystemAdapter->processFileUsing('archive.zip', function ($path) use (&$receivedPath) {
+            $receivedPath = $path;
+
+            return 'processed-zip';
+        });
+
+        $this->assertSame('processed-zip', $result);
+
+        $this->assertNotNull($receivedPath);
+        $this->assertStringEndsWith('archive.zip', $receivedPath);
+    }
+
+    public function test_get_copies_zip_file_from_s3_to_local_and_returns_contents()
+    {
+        /** @var AwsS3V3Adapter|m\MockInterface $adapter */
+        $adapter = m::mock(AwsS3V3Adapter::class)->makePartial();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'zip-contents');
+        rewind($stream);
+
+        $adapter->shouldReceive('readStream')
+            ->once()
+            ->with('archive.zip')
+            ->andReturn($stream);
+
+        $adapter->shouldReceive('get')->passthru()->byDefault();
+
+        $result = $adapter->get('archive.zip');
+
+        $this->assertSame('zip-contents', $result);
+    }
+
+    public function test_get_falls_back_to_parent_get_for_non_zip_files()
+    {
+        /** @var AwsS3V3Adapter|m\MockInterface $adapter */
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $adapter = $this->createConfiguredMock(AwsS3V3Adapter::class, [
+            'get' => $filesystemAdapter->get('file.txt'),
+        ]);
+
+        $this->assertNull($adapter->get('file.txt'));
+    }
+
+    public function test_path_copies_zip_file_from_s3_to_local_and_returns_original_path()
+    {
+        /** @var AwsS3V3Adapter|m\MockInterface $adapter */
+        $adapter = m::mock(AwsS3V3Adapter::class)->makePartial();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'zip-contents');
+        rewind($stream);
+
+        $adapter->shouldReceive('readStream')
+            ->once()
+            ->with('archive.zip')
+            ->andReturn($stream);
+
+        $adapter->shouldReceive('path')->passthru()->byDefault();
+
+        $result = $adapter->path('archive.zip');
+
+        $this->assertSame('archive.zip', $result);
+    }
+
+    public function test_path_falls_back_to_parent_path_for_non_zip_files()
+    {
+        $filesystem = new Filesystem(
+            $this->adapter = new LocalFilesystemAdapter($this->tempDir)
+        );
+
+        $filesystemAdapter = new FilesystemAdapter($filesystem, $this->adapter, [
+            'root' => $this->tempDir.DIRECTORY_SEPARATOR,
+        ]);
+
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $this->assertEquals(
+            $this->tempDir.DIRECTORY_SEPARATOR.'file.txt',
+            $filesystemAdapter->path('file.txt')
+        );
+    }
+}

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -26,7 +26,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FilesystemAdapterTest extends TestCase
 {
     private $tempDir;
+
     private $filesystem;
+
     private $adapter;
 
     protected function setUp(): void
@@ -48,7 +50,7 @@ class FilesystemAdapterTest extends TestCase
         unset($this->tempDir, $this->filesystem, $this->adapter);
     }
 
-    public function testResponse()
+    public function test_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -63,7 +65,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('inline; filename=file.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testMimeTypeIsNotCalledAlreadyProvidedToResponse()
+    public function test_mime_type_is_not_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -75,7 +77,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testSizeIsNotCalledAlreadyProvidedToResponse()
+    public function test_size_is_not_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -87,7 +89,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testFallbackNameCalledAlreadyProvidedToResponse()
+    public function test_fallback_name_called_already_provided_to_response()
     {
         $this->filesystem->write('file.txt', 'Hello World');
 
@@ -101,7 +103,7 @@ class FilesystemAdapterTest extends TestCase
         ]);
     }
 
-    public function testDownload()
+    public function test_download()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -110,7 +112,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=hello.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadNonAsciiFilename()
+    public function test_download_non_ascii_filename()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -119,7 +121,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame("attachment; filename=privet.txt; filename*=utf-8''%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.txt", $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadNonAsciiEmptyFilename()
+    public function test_download_non_ascii_empty_filename()
     {
         $this->filesystem->write('привет.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -128,7 +130,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=privet.txt; filename*=utf-8\'\'%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testDownloadPercentInFilename()
+    public function test_download_percent_in_filename()
     {
         $this->filesystem->write('Hello%World.txt', 'Hello World');
         $files = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -137,7 +139,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('attachment; filename=HelloWorld.txt; filename*=utf-8\'\'Hello%25World.txt', $response->headers->get('content-disposition'));
     }
 
-    public function testExists()
+    public function test_exists()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -145,27 +147,27 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->fileExists('file.txt'));
     }
 
-    public function testMissing()
+    public function test_missing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->missing('file.txt'));
         $this->assertTrue($filesystemAdapter->fileMissing('file.txt'));
     }
 
-    public function testDirectoryExists()
+    public function test_directory_exists()
     {
         $this->filesystem->write('/foo/bar/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryExists('/foo/bar'));
     }
 
-    public function testDirectoryMissing()
+    public function test_directory_missing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryMissing('/foo/bar'));
     }
 
-    public function testPath()
+    public function test_path()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
@@ -174,48 +176,48 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
-    public function testGet()
+    public function test_get()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertSame('Hello World', $filesystemAdapter->get('file.txt'));
     }
 
-    public function testGetFileNotFound()
+    public function test_get_file_not_found()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->get('file.txt'));
     }
 
-    public function testJsonReturnsDecodedJsonData()
+    public function test_json_returns_decoded_json_data()
     {
         $this->filesystem->write('file.json', '{"foo": "bar"}');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertSame(['foo' => 'bar'], $filesystemAdapter->json('file.json'));
     }
 
-    public function testJsonReturnsNullIfJsonDataIsInvalid()
+    public function test_json_returns_null_if_json_data_is_invalid()
     {
         $this->filesystem->write('file.json', '{"foo":');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->json('file.json'));
     }
 
-    public function testMimeTypeNotDetected()
+    public function test_mime_type_not_detected()
     {
         $this->filesystem->write('unknown.mime-type', '');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertFalse($filesystemAdapter->mimeType('unknown.mime-type'));
     }
 
-    public function testPut()
+    public function test_put()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->put('file.txt', 'Something inside');
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Something inside');
     }
 
-    public function testPrepend()
+    public function test_prepend()
     {
         file_put_contents($this->tempDir.'/file.txt', 'World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -223,7 +225,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'World');
     }
 
-    public function testAppend()
+    public function test_append()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello ');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -231,7 +233,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello '.PHP_EOL.'Moon');
     }
 
-    public function testDelete()
+    public function test_delete()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -239,13 +241,13 @@ class FilesystemAdapterTest extends TestCase
         Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
     }
 
-    public function testDeleteReturnsTrueWhenFileNotFound()
+    public function test_delete_returns_true_when_file_not_found()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->delete('file.txt'));
     }
 
-    public function testCopy()
+    public function test_copy()
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');
@@ -261,7 +263,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testMove()
+    public function test_move()
     {
         $data = '33232';
         mkdir($this->tempDir.'/foo');
@@ -276,7 +278,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));
     }
 
-    public function testStream()
+    public function test_stream()
     {
         $this->filesystem->write('file.txt', $original_content = 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
@@ -285,7 +287,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($original_content, $filesystemAdapter->get('copy.txt'));
     }
 
-    public function testStreamBetweenFilesystems()
+    public function test_stream_between_filesystems()
     {
         $secondFilesystem = new Filesystem(new LocalFilesystemAdapter($this->tempDir.'/second'));
         $this->filesystem->write('file.txt', $original_content = 'Hello World');
@@ -296,7 +298,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($original_content, $secondFilesystemAdapter->get('copy.txt'));
     }
 
-    public function testStreamToExistingFileOverwrites()
+    public function test_stream_to_existing_file_overwrites()
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $this->filesystem->write('existing.txt', 'Dear Kate');
@@ -306,20 +308,20 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->read('existing.txt'));
     }
 
-    public function testReadStreamNonExistentFileReturnsNull()
+    public function test_read_stream_non_existent_file_returns_null()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertNull($filesystemAdapter->readStream('nonexistent.txt'));
     }
 
-    public function testStreamInvalidResourceThrows()
+    public function test_stream_invalid_resource_throws()
     {
         $this->expectException(InvalidArgumentException::class);
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->writeStream('file.txt', 'foo bar');
     }
 
-    public function testPutWithStreamInterface()
+    public function test_put_with_stream_interface()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'some-data');
 
@@ -332,7 +334,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('some-data', $filesystemAdapter->get('bar.txt'));
     }
 
-    public function testPutFileAs()
+    public function test_put_file_as()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -356,7 +358,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileAsWithAbsoluteFilePath()
+    public function test_put_file_as_with_absolute_file_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -367,7 +369,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
-    public function testPutFileAsWithoutPath()
+    public function test_put_file_as_without_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -378,7 +380,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
-    public function testPutFile()
+    public function test_put_file()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -400,7 +402,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileWithAbsoluteFilePath()
+    public function test_put_file_with_absolute_file_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -418,7 +420,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testPutFileWithoutPath()
+    public function test_put_file_without_path()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
@@ -430,7 +432,7 @@ class FilesystemAdapterTest extends TestCase
     }
 
     #[RequiresPhpExtension('ftp')]
-    public function testCreateFtpDriver()
+    public function test_create_ftp_driver()
     {
         $filesystem = new FilesystemManager(new Application);
 
@@ -449,7 +451,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('admin', $config['username']);
     }
 
-    public function testMacroable()
+    public function test_macroable()
     {
         $this->filesystem->write('foo.txt', 'Hello World');
 
@@ -461,7 +463,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
     }
 
-    public function testTemporaryUrlWithCustomCallback()
+    public function test_temporary_url_with_custom_callback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
@@ -479,7 +481,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testThrowExceptionsForGet()
+    public function test_throw_exceptions_for_get()
     {
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
@@ -494,7 +496,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForReadStream()
+    public function test_throw_exceptions_for_read_stream()
     {
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
@@ -509,7 +511,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForPut()
+    public function test_throw_exceptions_for_put()
     {
         $this->filesystem->write('foo.txt', 'Hello World');
 
@@ -530,7 +532,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testThrowExceptionsForMimeType()
+    public function test_throw_exceptions_for_mime_type()
     {
         $this->filesystem->write('unknown.mime-type', '');
 
@@ -547,7 +549,7 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    public function testReportExceptionsForGet()
+    public function test_report_exceptions_for_get()
     {
         $container = Container::getInstance();
 
@@ -575,7 +577,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForReadStream()
+    public function test_report_exceptions_for_read_stream()
     {
         $container = Container::getInstance();
 
@@ -603,7 +605,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForPut()
+    public function test_report_exceptions_for_put()
     {
         $container = Container::getInstance();
 
@@ -637,7 +639,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testReportExceptionsForMimeType()
+    public function test_report_exceptions_for_mime_type()
     {
         $container = Container::getInstance();
 
@@ -667,7 +669,7 @@ class FilesystemAdapterTest extends TestCase
         }
     }
 
-    public function testGetAllFiles()
+    public function test_get_all_files()
     {
         $this->filesystem->write('body.txt', 'Hello World');
         $this->filesystem->write('file1.txt', 'Hello World');
@@ -679,7 +681,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame($filesystemAdapter->files(), ['body.txt', 'existing.txt', 'file.txt', 'file1.txt']);
     }
 
-    public function testProvidesTemporaryUrls()
+    public function test_provides_temporary_urls()
     {
         $localAdapter = new class($this->tempDir) extends LocalFilesystemAdapter
         {
@@ -693,7 +695,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testProvidesTemporaryUrlsWithCustomCallback()
+    public function test_provides_temporary_urls_with_custom_callback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
@@ -704,7 +706,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testProvidesTemporaryUrlsForS3Adapter()
+    public function test_provides_temporary_urls_for_s3_adapter()
     {
         $filesystem = new FilesystemManager(new Application);
         $filesystemAdapter = $filesystem->createS3Driver([
@@ -715,7 +717,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testUsesRightSeperatorForS3Adapter()
+    public function test_uses_right_seperator_for_s3_adapter()
     {
         $filesystem = new FilesystemManager(new Application);
         $filesystemAdapter = $filesystem->createS3Driver([
@@ -730,21 +732,21 @@ class FilesystemAdapterTest extends TestCase
         $this->assertStringNotContainsString('\\', $path);
     }
 
-    public function testProvidesTemporaryUrlsForAdapterWithoutTemporaryUrlSupport()
+    public function test_provides_temporary_urls_for_adapter_without_temporary_url_support()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
         $this->assertFalse($filesystemAdapter->providesTemporaryUrls());
     }
 
-    public function testPrefixesUrls()
+    public function test_prefixes_urls()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['url' => 'https://example.org/', 'prefix' => 'images']);
 
         $this->assertEquals('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
     }
 
-    public function testGetChecksum()
+    public function test_get_checksum()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $filesystemAdapter->write('path.txt', 'contents of file');
@@ -753,7 +755,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('a5c3556d', $filesystemAdapter->checksum('path.txt', ['checksum_algo' => 'crc32']));
     }
 
-    public function testUsesRightSeperatorForS3AdapterWithoutDoublePrefixing()
+    public function test_uses_right_seperator_for_s3_adapter_without_double_prefixing()
     {
         $filesystem = new FilesystemManager(new Application);
         $filesystemAdapter = $filesystem->createS3Driver([
@@ -768,7 +770,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('my-root/someprefix/different', $path);
     }
 
-    public function testProcessFileUsingCallbackReceivesPathAndReturnsValue()
+    public function test_process_file_using_callback_receives_path_and_returns_value()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
 
@@ -784,7 +786,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('mypath', $receivedPath);
     }
 
-    public function testProcessFileUsingCallbackReturnsExpectedValuesForS3Adapter()
+    public function test_process_file_using_callback_returns_expected_values_for_s3_adapter()
     {
         $filesystem = new FilesystemManager(new Application);
 
@@ -805,7 +807,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('mypath', $receivedPath);
     }
 
-    public function testProcessFileUsingCallbackReturnsExpectedValuesForS3AdapterWithZipFile()
+    public function test_process_file_using_callback_returns_expected_values_for_s3_adapter_with_zip_file()
     {
         $filesystem = new FilesystemManager(new Application);
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -824,10 +824,8 @@ class FilesystemAdapterTest extends TestCase
             return 'processed-zip';
         });
 
-        // Rückgabewert des Callbacks wird korrekt durchgereicht
         $this->assertSame('processed-zip', $result);
 
-        // Callback wurde mit einem Pfad auf eine ZIP-Datei aufgerufen
         $this->assertNotNull($receivedPath);
         $this->assertStringEndsWith('archive.zip', $receivedPath);
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -806,27 +806,4 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('myotherpath', $result);
         $this->assertSame('mypath', $receivedPath);
     }
-
-    public function test_process_file_using_callback_returns_expected_values_for_s3_adapter_with_zip_file()
-    {
-        $filesystem = new FilesystemManager(new Application);
-
-        $filesystemAdapter = $filesystem->createS3Driver([
-            'region' => 'us-west-1',
-            'bucket' => 'laravel',
-        ]);
-
-        $receivedPath = null;
-
-        $result = $filesystemAdapter->processFileUsing('archive.zip', function ($path) use (&$receivedPath) {
-            $receivedPath = $path;
-
-            return 'processed-zip';
-        });
-
-        $this->assertSame('processed-zip', $result);
-
-        $this->assertNotNull($receivedPath);
-        $this->assertStringEndsWith('archive.zip', $receivedPath);
-    }
 }


### PR DESCRIPTION
## Description

This PR adds a new `processFileUsing()` method to the `AwsS3V3Adapter` that enables safe and temporary local processing of remote files (for example, ZIP archives) stored on S3 or any S3-compatible storage system.

When working with tools like PHP’s `ZipArchive`, a local file path is required — however, S3 streams cannot be passed directly.  
The new `processFileUsing()` method provides a clean and framework-integrated solution to handle this scenario efficiently.

In addition, the S3 adapter now provides ZIP-aware overrides for `get()` and `path()` so that ZIP files stored on S3 can be transparently copied to local storage before being read or used with APIs that expect a local filesystem path.

---

## How it works

### `processFileUsing()`

- If the given file path ends with `.zip`, the adapter:
  1. Reads the file stream from S3.
  2. Writes it temporarily to the `local` disk.
  3. Passes the **local file path** to the provided callback.
  4. Deletes the temporary file after the callback finishes (even if an exception occurs).

- For all other file types, the callback simply receives the original path.

This pattern allows developers to work with real local files when necessary, while automatically cleaning up any temporary data.

### ZIP handling for `get()` and `path()` on S3

- When calling `get()` for a path ending in `.zip` on the S3 adapter:
  - The file is streamed from S3 and written to local storage.
  - `get()` then returns the contents of the local copy instead of reading directly from S3.

- When calling `path()` for a path ending in `.zip` on the S3 adapter:
  - The file is likewise streamed from S3 and mirrored to local storage.
  - `path()` returns a path that can be used with APIs (such as `ZipArchive`) that require a local filesystem path.

For non-ZIP files, both `get()` and `path()` keep their existing behavior and delegate to the parent implementation.

---

## Example usage

```php
// Processing a ZIP file using a local path
Storage::disk('s3')->getAdapter()->processFileUsing('releases/package.zip', function (string $localPath) {
    $zip = new ZipArchive();
    if ($zip->open($localPath) === true) {
        for ($i = 0; $i < $zip->numFiles; $i++) {
            Log::info($zip->getNameIndex($i));
        }
        $zip->close();
    }
});

// Reading a ZIP file via get() – content is served from a local copy
$contents = Storage::disk('s3')->get('releases/package.zip');

// Obtaining a filesystem path for a ZIP file – path points to the local copy
$localPath = Storage::disk('s3')->path('releases/package.zip');

// The returned $localPath can safely be used with ZipArchive::open()
$zip = new ZipArchive();
if ($zip->open($localPath) === true) {
    // …
    $zip->close();
}