### PR TITLE
Fix VSCode not recognising FormRequest functions

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/** @mixin \Illuminate\Http\Request */
 class {{ class }} extends FormRequest
 {
     /**


### PR DESCRIPTION
VSCode does not recognise some functions in a FormRequest (e.g. `$this->has('some-var')`), adding `/** @mixin \Illuminate\Http\Request */` to the `request.stub` means that all FormRequests generated from `php artisan make:request` will have all auto completion and function recognition working correctly in VSCode.

Before 
<img width="380" height="303" alt="image" src="https://github.com/user-attachments/assets/95887a54-6233-4d2e-beb9-739ea2b63dc8" />

After
<img width="393" height="279" alt="image" src="https://github.com/user-attachments/assets/7ce6aaac-ec71-4f70-9dd3-cd7b7f1ff1ac" />
