### PR TITLE
[12.x] Add ability to default the mailable and notification queues

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -190,6 +190,13 @@ class Mailable implements MailableContract, Renderable
     public static $viewDataCallback;
 
     /**
+     * The name of the default queue that should be used when queued.
+     *
+     * @var string|null
+     */
+    public static $defaultQueue;
+
+    /**
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Factory|\Illuminate\Contracts\Mail\Mailer  $mailer
@@ -230,7 +237,7 @@ class Mailable implements MailableContract, Renderable
 
         $connection = property_exists($this, 'connection') ? $this->connection : null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = (property_exists($this, 'queue') ? $this->queue : null) ?? static::$defaultQueue;
 
         return $queue->connection($connection)->pushOn(
             $queueName ?: null, $this->newQueuedJob()
@@ -248,7 +255,7 @@ class Mailable implements MailableContract, Renderable
     {
         $connection = property_exists($this, 'connection') ? $this->connection : null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = (property_exists($this, 'queue') ? $this->queue : null) ?? static::$defaultQueue;
 
         return $queue->connection($connection)->laterOn(
             $queueName ?: null, $delay, $this->newQueuedJob()

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -23,6 +23,13 @@ class Notification
     public $locale;
 
     /**
+     * The name of the default queue that should be used when queued.
+     *
+     * @var string|null
+     */
+    public static $defaultQueue;
+
+    /**
      * Get the channels the event should broadcast on.
      *
      * @return array

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -235,7 +235,7 @@ class NotificationSender
                     $connection = $notification->viaConnections()[$channel] ?? null;
                 }
 
-                $queue = $notification->queue;
+                $queue = $notification->queue ?? Notification::$defaultQueue;
 
                 if (method_exists($notification, 'viaQueues')) {
                     $queue = $notification->viaQueues()[$channel] ?? null;


### PR DESCRIPTION
The other day I was trying to find a nice way to make all my Mailables go to one queue, and Notifications to go to another. 

Which, got me thinking rather than creating new base classes to extend them for all my mail / notifications classes- and then using `onQueue` / settings the `queue` property,  I thought it could be nice to have this as a static property so it can be setup in the service provider and defaulted.

This also means if anyone creates a new Mailable, or Notification in my application - there's no ability to forget to extend the base class (as there isnt one!) 

This means we can do something like the below and not worry about the queue as it'll default to what we set: 
` Mail::to($user->email)->queue(new X); ` 
`Notification::send($users, new InvoicePaid($invoice));`

I don't think this is a breaking change, as it's null by default so continues on as normal if its not set. 

Let me know if there's any adjustments needed / a better way 🫡 

Something like this may also work for Jobs, and could sit in a config - but one step at a time.

TLDR: 

We can do this to default all our notification / mailable queues as a one off in the provider:

```

Notification::$defaultQueue = 'notifications' 
Mailable::$defaultQueue = 'mail'

```