### PR TITLE
[12.x] Fixes for RedisCache with Redis Cluster

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 class RedisStore extends TaggableStore implements LockProvider
 {
     use RetrievesMultipleKeys {
+        many as private manyAlias;
         putMany as private putManyAlias;
     }
 
@@ -91,6 +92,12 @@ class RedisStore extends TaggableStore implements LockProvider
         $results = [];
 
         $connection = $this->connection();
+
+        // Cluster connections do not support reading multiple values if the keys hash differently...
+        if ($connection instanceof PhpRedisClusterConnection ||
+            $connection instanceof PredisClusterConnection) {
+            return $this->manyAlias($keys);
+        }
 
         $values = $connection->mget(array_map(function ($key) {
             return $this->prefix.$key;

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -79,11 +79,18 @@ class RedisTagSet extends TagSet
      */
     public function flushStaleEntries()
     {
-        $this->store->connection()->pipeline(function ($pipe) {
+        $flushStaleEntries = function ($pipe) {
             foreach ($this->tagIds() as $tagKey) {
                 $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
             }
-        });
+        };
+
+        $connection = $this->store->connection();
+        if ($connection instanceof PhpRedisConnection) {
+            $flushStaleEntries($connection);
+        } else {
+            $connection->pipeline($flushStaleEntries);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -193,8 +193,17 @@ class RedisTaggedCache extends TaggedCache
             ->map(fn (string $key) => $this->store->getPrefix().$key)
             ->chunk(1000);
 
+        $connection = $this->store->connection();
         foreach ($entries as $cacheKeys) {
-            $this->store->connection()->del(...$cacheKeys);
+            if ($connection instanceof PredisClusterConnection) {
+                $connection->pipeline(function ($connection) use ($cacheKeys) {
+                    foreach ($cacheKeys as $cacheKey) {
+                        $connection->del($cacheKey);
+                    }
+                });
+            } else {
+                $connection->del(...$cacheKeys);
+            }
         }
     }
 

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -22,4 +22,20 @@ class PredisClusterConnection extends PredisConnection
             $node->executeCommand(tap(new $command)->setArguments(func_get_args()));
         }
     }
+
+    /**
+     * Returns the keys that match a certain pattern.
+     *
+     * @param  string  $pattern
+     * @return array
+     */
+    public function keys(string $pattern)
+    {
+        $keys = [];
+        foreach ($this->client as $node) {
+            $keys[] = $node->keys($pattern);
+        }
+
+        return array_merge(...$keys);
+    }
 }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -32,7 +32,8 @@ class MemoizedStoreTest extends TestCase
         $this->setUpRedis();
 
         Config::set('cache.default', 'redis');
-        Redis::flushAll();
+        Redis::connection(Config::get('cache.stores.redis.connection'))->flushDb();
+        Redis::connection(Config::get('cache.stores.redis.lock_connection'))->flushDb();
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -13,8 +13,6 @@ use Illuminate\Cache\Events\RetrievingManyKeys;
 use Illuminate\Cache\Events\WritingKey;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -32,12 +30,6 @@ class MemoizedStoreTest extends TestCase
         parent::setUp();
 
         $this->setUpRedis();
-
-        $connection = $this->app['redis']->connection();
-        $this->markTestSkippedWhen(
-            $connection instanceof PhpRedisClusterConnection || $connection instanceof PredisClusterConnection,
-            'flushAll and many currently not supported for Redis Cluster connections',
-        );
 
         Config::set('cache.default', 'redis');
         Redis::flushAll();

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -6,9 +6,7 @@ use DateTime;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Sleep;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -23,12 +21,6 @@ class RedisStoreTest extends TestCase
     {
         $this->afterApplicationCreated(function () {
             $this->setUpRedis();
-
-            $connection = $this->app['redis']->connection();
-            $this->markTestSkippedWhen(
-                $connection instanceof PhpRedisClusterConnection || $connection instanceof PredisClusterConnection,
-                'RedisStore currently does not support tags, many and some other on Redis Cluster cluster connections',
-            );
         });
 
         $this->beforeApplicationDestroyed(function () {


### PR DESCRIPTION
Currently some functions of cache do not work well with Redis Cluster. This PR fixes them.

* Unskipped tests from https://github.com/laravel/framework/pull/57710
* RedisStore::many made to work with Redis Cluster same way putMany from https://github.com/laravel/framework/pull/53940 .
* RedisTagSet::flushStaleEntries does not call pipline for PhpRedisCluster
* RedisTaggedCache::flushValues deletes keys separately for PredisCluster
* PredisClusterConnection::keys - gathers keys over all nodes.
* replaced flushAll with flushDb in MemoizedStoreTest