### PR TITLE
[12.x] Add dd() to Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -295,6 +295,18 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Render the mailable into a view and display it, then halt execution.
+     *
+     * @throws \ReflectionException
+     */
+    public function dd()
+    {
+        header('Content-Type: text/html; charset=UTF-8');
+        echo $this->render();
+        exit(1);
+    }
+
+    /**
      * Build the view for the message.
      *
      * @return array|string


### PR DESCRIPTION
This mirrors the behavior of returning a `Mailable` from a controller or route, but not all mail is sent from controllers.

Developers can now preview mail directly from any context, like services, without sending it.