### PR TITLE
[12.x] Fix stale in-memory SQLite connections after re-migration in RefreshDatabase

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -85,10 +85,29 @@ trait RefreshDatabase
 
             $this->app[Kernel::class]->setArtisan(null);
 
+            $this->updateInMemoryConnections();
+
             RefreshDatabaseState::$migrated = true;
         }
 
         $this->beginDatabaseTransaction();
+    }
+
+    /**
+     * Update stored in-memory PDO connections after migration.
+     *
+     * @return void
+     */
+    protected function updateInMemoryConnections()
+    {
+        $database = $this->app->make('db');
+
+        foreach ($this->connectionsToTransact() as $name) {
+            if ($this->usingInMemoryDatabase($name)) {
+                $connection = $database->connection($name);
+                RefreshDatabaseState::$inMemoryConnections[$name] = $connection->getPdo();
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -85,7 +85,7 @@ trait RefreshDatabase
 
             $this->app[Kernel::class]->setArtisan(null);
 
-            $this->updateInMemoryConnections();
+            $this->updateLocalCacheOfInMemoryDatabases();
 
             RefreshDatabaseState::$migrated = true;
         }
@@ -94,18 +94,17 @@ trait RefreshDatabase
     }
 
     /**
-     * Update stored in-memory PDO connections after migration.
+     * Update locally cached in-memory PDO connections after migration.
      *
      * @return void
      */
-    protected function updateInMemoryConnections()
+    protected function updateLocalCacheOfInMemoryDatabases()
     {
         $database = $this->app->make('db');
 
         foreach ($this->connectionsToTransact() as $name) {
             if ($this->usingInMemoryDatabase($name)) {
-                $connection = $database->connection($name);
-                RefreshDatabaseState::$inMemoryConnections[$name] = $connection->getPdo();
+                RefreshDatabaseState::$inMemoryConnections[$name] = $database->connection($name)->getPdo();
             }
         }
     }


### PR DESCRIPTION
## Problem
When using the `RefreshDatabase` trait with SQLite in-memory databases, tests can fail with "General error: 1 no such table" errors in subsequent test runs after a PDO connection is detected as closed.

This occurs when:
1. A test uses database transactions across multiple connections (e.g., `mysql` and `mysql_vandar`)
2. One connection closes or ends its transaction
3. Laravel detects the connection is not in a transaction and sets `RefreshDatabaseState::$migrated = false`
4. The next test triggers re-migration, creating new PDO connections
5. However, `RefreshDatabaseState::$inMemoryConnections` still references the old, closed connections
6. Subsequent tests fail because they're using stale PDO instances without the migrated schema

## Root Cause
In `RefreshDatabase::refreshTestDatabase()`, when `RefreshDatabaseState::$migrated` is false and migrations run again via `migrateDatabases()`, the method creates new database connections. However, the stored PDO references in `RefreshDatabaseState::$inMemoryConnections` are never updated to point to these new connections.

The check in `RefreshDatabase::beginDatabaseTransaction()`:
```php
if ($connection->getPdo() && ! $connection->getPdo()->inTransaction()) {
    RefreshDatabaseState::$migrated = false;
}
```
Correctly detects when migrations need to run again, but the re-migration process doesn't update the cached in-memory connection references.

## Solution
Call `updateInMemoryConnections()` immediately after `migrateDatabases()` to ensure `RefreshDatabaseState::$inMemoryConnections` always references the current, valid PDO instances.

## Changes
```php
protected function refreshTestDatabase()
{
    if (! RefreshDatabaseState::$migrated) {
        $this->migrateDatabases();
        $this->app[Kernel::class]->setArtisan(null);
        $this->updateInMemoryConnections(); // Added this line
        RefreshDatabaseState::$migrated = true;
    }

    $this->beginDatabaseTransaction();
}
```

This ensures that after re-migration, all subsequent tests reference the correct in-memory database connections with the proper schema.