### PR TITLE
Simplify command registration by removing deferred kernel execution.

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -322,11 +322,9 @@ class ApplicationBuilder
             [$commands, $paths] = (new Collection($commands))->partition(fn ($command) => class_exists($command));
             [$routes, $paths] = $paths->partition(fn ($path) => is_file($path));
 
-            $this->app->booted(static function () use ($kernel, $commands, $paths, $routes) {
-                $kernel->addCommands($commands->all());
-                $kernel->addCommandPaths($paths->all());
-                $kernel->addCommandRoutePaths($routes->all());
-            });
+            $kernel->addCommands($commands->all());
+            $kernel->addCommandPaths($paths->all());
+            $kernel->addCommandRoutePaths($routes->all());
         });
 
         return $this;


### PR DESCRIPTION
PS:
I removed the callback booted to load console commands and changed it to a simple call, because when the booted method is called, the booted function in the Application class is called by calling it with a callback, and the booted constructor in the class has not yet been set to true, which will cause new commands created in the project to not be loaded.

The reason is that the load method in the Application class is called through the BootProviders class, and the BootProviders class contains an array of special providers for the Console Kernel, but this list of classes works when the bootstrap method in Console/Kernel is called, and calling the withConsole function with booted in the ApplicationBuilder becomes useless.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
