### PR TITLE
[12.x] Test `Factory@insert()` with hidden

### DIFF
--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -995,9 +995,21 @@ class DatabaseEloquentFactoryTest extends TestCase
             ->insert();
         $this->assertCount(5, $posts = FactoryTestPost::query()->where('title', 'hello')->get());
         $this->assertEquals(strtoupper($posts[0]->user->name), $posts[0]->upper_case_name);
-        $this->assertEquals(2, ($users = FactoryTestUser::query()->get())->count());
-        $this->assertCount(1, $users->where('name', 'shaedrich'));
+        $this->assertEquals(
+            2,
+            ($users = FactoryTestUser::query()->get())->count()
+        );
         $this->assertCount(1, $users->where('name', 'totwell'));
+        $this->assertCount(1, $users->where('name', 'shaedrich'));
+    }
+
+    public function test_factory_can_insert_with_hidden()
+    {
+        (new FactoryTestUserFactory())->forEachSequence(['name' => Name::Taylor, 'options' => 'abc'])->insert();
+        $user = DB::table('users')->sole();
+        $this->assertEquals('abc', $user->options);
+        $userModel = FactoryTestUser::query()->sole();
+        $this->assertEquals('abc', $userModel->options);
     }
 
     /**
@@ -1039,6 +1051,9 @@ class FactoryTestUser extends Eloquent
     use HasFactory;
 
     protected $table = 'users';
+    protected $hidden = ['options'];
+    protected $withCount = ['posts'];
+    protected $with = ['posts'];
 
     public function posts()
     {


### PR DESCRIPTION
Based on @tpetry's comment here https://github.com/laravel/framework/pull/57600#issuecomment-3507850514 I wanted to confirm this behavior. With a test, we can prevent regression.

It tests `$hidden`, `$withCount`, and `$with` properties on the model as well.