### PR TITLE
Add isTesting environment check method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -778,6 +778,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the application is in the testing environment.
+     *
+     * @return bool
+     */
+    public function isTesting()
+    {
+        return $this['env'] === 'testing';
+    }
+
+    /**
      * Detect the application's current environment.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -52,7 +52,7 @@ class HandleExceptions
 
         register_shutdown_function($this->forwardsTo('handleShutdown'));
 
-        if (! $app->isTesting()) {
+        if (! $app->environment('testing')) {
             ini_set('display_errors', 'Off');
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -52,7 +52,7 @@ class HandleExceptions
 
         register_shutdown_function($this->forwardsTo('handleShutdown'));
 
-        if (! $app->environment('testing')) {
+        if (! $app->isTesting()) {
             ini_set('display_errors', 'Off');
         }
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -232,6 +232,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($local->isLocal());
         $this->assertFalse($local->isProduction());
         $this->assertFalse($local->runningUnitTests());
+        $this->assertFalse($local->isTesting());
 
         $production = new Application;
         $production['env'] = 'production';
@@ -239,6 +240,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($production->isProduction());
         $this->assertFalse($production->isLocal());
         $this->assertFalse($production->runningUnitTests());
+        $this->assertFalse($production->isTesting());
 
         $testing = new Application;
         $testing['env'] = 'testing';
@@ -246,6 +248,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($testing->runningUnitTests());
         $this->assertFalse($testing->isLocal());
         $this->assertFalse($testing->isProduction());
+        $this->assertTrue($testing->isTesting());
     }
 
     public function testDebugHelper()


### PR DESCRIPTION
This PR adds an `isTesting()` convenience method for checking if the app is in the testing environment (similar to the existing `isLocal()` and `isProduction()` methods).  It's also not prone to typos, unlike `app()->environment('testing')`.