### PR TITLE
[12.x] Fix embedded image Content-ID inconsistency in cloned emails

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -350,8 +350,9 @@ class Message
                     return "cid:{$part->getContentId()}";
                 },
                 function ($data) use ($file) {
-                    $part = (new DataPart($data(), $file->as, $file->mime))->asInline();
-                    $this->message->addPart($part);
+                    $this->message->addPart(
+                        $part = $part = (new DataPart($data(), $file->as, $file->mime))->asInline()
+                    );
 
                     return "cid:{$part->getContentId()}";
                 }
@@ -359,9 +360,10 @@ class Message
         }
 
         $fileObject = new File($file);
-        $part = (new DataPart($fileObject, $fileObject->getFilename()))->asInline();
 
-        $this->message->addPart($part);
+        $this->message->addPart(
+            $part = (new DataPart($fileObject, $fileObject->getFilename()))->asInline()
+        );
 
         return "cid:{$part->getContentId()}";
     }

--- a/tests/Integration/Mail/Fixtures/embed-image.blade.php
+++ b/tests/Integration/Mail/Fixtures/embed-image.blade.php
@@ -1,0 +1,1 @@
+Embedded image: <img src="{{ $message->embed($image) }}" alt="Embedded test image" />

--- a/tests/Integration/Mail/Fixtures/embed.blade.php
+++ b/tests/Integration/Mail/Fixtures/embed.blade.php
@@ -1,1 +1,3 @@
+Embed file: {{ basename(__FILE__) }}
+
 Embed content: {{ $message->embed(__FILE__) }}

--- a/tests/Integration/Notifications/Fixtures/markdown.blade.php
+++ b/tests/Integration/Notifications/Fixtures/markdown.blade.php
@@ -1,1 +1,2 @@
+Embed file: {{ basename(__FILE__) }}
 Embed content: {{ $message->embed(__FILE__) }}

--- a/tests/Integration/Notifications/SendingMailableNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailableNotificationsTest.php
@@ -49,16 +49,24 @@ class SendingMailableNotificationsTest extends TestCase
 
         $user->notify(new MarkdownNotification());
 
-        $email = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->toString();
+        $message = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage();
+        $email = $message->toString();
+        $textBody = $message->getTextBody();
 
-        $cid = explode(' cid:', (new Stringable($email))->explode("\r\n")
+        $cid = explode(' cid:', (new Stringable($textBody))->explode("\n")
             ->filter(fn ($line) => str_contains($line, 'Embed content: cid:'))
             ->first())[1];
 
+        $filename = explode(' file: ', (new Stringable($textBody))->explode("\n")
+            ->filter(fn ($line) => str_contains($line, 'Embed file: '))
+            ->first())[1];
+
         $this->assertStringContainsString(<<<EOT
-        Content-Type: application/x-php; name=$cid\r
+        Content-Type: application/x-php; name=$filename\r
         Content-Transfer-Encoding: base64\r
-        Content-Disposition: inline; name=$cid; filename=$cid\r
+        Content-Disposition: inline; name=$filename;\r
+         filename=$filename\r
+        Content-ID: <$cid>\r
         EOT, $email);
     }
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -165,13 +165,14 @@ class MailMessageTest extends TestCase
         $cid = $this->message->embed($path);
 
         $this->assertStringStartsWith('cid:', $cid);
-        $name = Str::after($cid, 'cid:');
+        $contentId = Str::after($cid, 'cid:');
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();
         $this->assertSame('bar', $attachment->getBody());
-        $this->assertSame("Content-Type: image/jpeg; name={$name}", $headers[0]);
+        $this->assertSame($contentId, $attachment->getContentId());
+        $this->assertStringContainsString('Content-Type: image/jpeg', $headers[0]);
         $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
-        $this->assertSame("Content-Disposition: inline; name={$name}; filename={$name}", $headers[2]);
+        $this->assertStringContainsString('Content-Disposition: inline', $headers[2]);
 
         unlink($path);
     }
@@ -182,7 +183,9 @@ class MailMessageTest extends TestCase
 
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();
-        $this->assertSame('cid:foo.jpg', $cid);
+        $this->assertStringStartsWith('cid:', $cid);
+        $contentId = Str::after($cid, 'cid:');
+        $this->assertSame($contentId, $attachment->getContentId());
         $this->assertSame('bar', $attachment->getBody());
         $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
         $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
@@ -201,9 +204,11 @@ class MailMessageTest extends TestCase
             }
         });
 
-        $this->assertSame('cid:baz', $cid);
+        $this->assertStringStartsWith('cid:', $cid);
+        $contentId = Str::after($cid, 'cid:');
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
         $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame($contentId, $attachment->getContentId());
         $this->assertSame('bar', $attachment->getBody());
         $this->assertSame('Content-Type: image/png; name=baz', $headers[0]);
         $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
@@ -225,14 +230,14 @@ class MailMessageTest extends TestCase
         });
 
         $this->assertStringStartsWith('cid:', $cid);
-        $name = Str::after($cid, 'cid:');
-        $this->assertSame(16, mb_strlen($name));
+        $contentId = Str::after($cid, 'cid:');
         $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $this->assertSame($contentId, $attachment->getContentId());
         $headers = $attachment->getPreparedHeaders()->toArray();
         $this->assertSame('bar', $attachment->getBody());
-        $this->assertSame("Content-Type: image/jpeg; name={$name}", $headers[0]);
+        $this->assertStringContainsString('Content-Type: image/jpeg', $headers[0]);
         $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
-        $this->assertSame("Content-Disposition: inline; name={$name};\r\n filename={$name}", $headers[2]);
+        $this->assertStringContainsString('Content-Disposition: inline', $headers[2]);
 
         unlink($path);
     }


### PR DESCRIPTION
### Problem

When using failover mailer configurations (e.g., Mailgun → AWS SES), embedded
images in emails fail to display after the email object is cloned for retry.

The issue occurs because the Content-ID referenced in HTML (`<img src="cid:...">`)
and the Content-ID in the MIME attachment become inconsistent after cloning.

### Root Cause

Incorrect usage of the `DataPart` constructor in `embed()` and `embedData()` methods. The second parameter of `DataPart` is `filename`, not Content-ID. 
`DataPart` generates its own Content-ID automatically.

- [\Symfony\Component\Mime\Part\DataPart](https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/Mime/Part/DataPart.php#L32)
- [\Illuminate\Mail\Message](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Mail/Message.php#L368)

### Reproduction

I've isolated a unit test to simulate the failover clone scenario. To reproduce the issue, please check out commit 23b3783dad8f96f9d390b640d9ddb27b39dd2944.


### Apology and Context

I apologize for not including a reproduction test in my previous PR #57606. This PR adds a failing test case and the corresponding fix. 
Thank you for the patience and thorough review.
