### PR TITLE
[12.x] Remove methods related to the Macroable trait in the doc block of the Notification facade.

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -33,10 +33,6 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static bool hasSent(mixed $notifiable, string $notification)
  * @method static \Illuminate\Support\Testing\Fakes\NotificationFake serializeAndRestore(bool $serializeAndRestore = true)
  * @method static array sentNotifications()
- * @method static void macro(string $name, object|callable $macro)
- * @method static void mixin(object $mixin, bool $replace = true)
- * @method static bool hasMacro(string $name)
- * @method static void flushMacros()
  *
  * @see \Illuminate\Notifications\ChannelManager
  * @see \Illuminate\Support\Testing\Fakes\NotificationFake


### PR DESCRIPTION
I attempt to run `Notification::macro('test', fn () => 'test test')` And the following error happen:

```php
Exception  Call to undefined method Illuminate\Notifications\Channels\MailChannel::macro().

Error 

Call to undefined method Illuminate\Notifications\Channels\MailChannel::macro()

at vendor/laravel/framework/src/Illuminate/Support/Manager.php:186
   182▕      * @return mixed
   183▕      */
   184▕     public function __call($method, $parameters)
   185▕     {
➜186▕         return $this->driver()->$method(...$parameters);
   187▕     }
   188▕ }
   189▕
```

This makes sense. The `ChannelManager` is not macroable and none of the built-in channels (`BroadcastChannel`, `DatabaseChannel`, `MailChannel`) are. So we can safely remove methods related to the `Macroable` trait in the doc block of the `Notification` facade.