### PR TITLE
[12.x] Add the real method to facades.

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -202,6 +202,22 @@ abstract class Facade
     }
 
     /**
+     * If the facade instance is currently faked, switch to the real implementation again.
+     *
+     * @return void
+     */
+    public static function real()
+    {
+        if (static::isFake()) {
+            $name = static::getFacadeAccessor();
+
+            static::clearResolvedInstance($name);
+
+            static::$app?->forgetInstance($name);
+        }
+    }
+
+    /**
      * Get the root object behind the facade.
      *
      * @return mixed

--- a/tests/Integration/Support/FacadesTest.php
+++ b/tests/Integration/Support/FacadesTest.php
@@ -4,9 +4,15 @@ namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Auth\AuthManager;
 use Illuminate\Foundation\Application;
+use Illuminate\Notifications\ChannelManager;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
+use Illuminate\Support\Testing\Fakes\QueueFake;
 use Orchestra\Testbench\TestCase;
 use ReflectionClass;
 
@@ -58,5 +64,23 @@ class FacadesTest extends TestCase
             $reflection = new ReflectionClass($alias);
             $this->assertSame($abstract, $reflection->getName());
         }
+    }
+
+    public function testRealMethod()
+    {
+        Notification::fake();
+        $this->assertInstanceOf(NotificationFake::class, Notification::getFacadeRoot());
+
+        Notification::real();
+        $this->assertInstanceOf(ChannelManager::class, Notification::getFacadeRoot());
+
+        Notification::fake();
+        $this->assertInstanceOf(NotificationFake::class, Notification::getFacadeRoot());
+
+        Queue::fake();
+        $this->assertInstanceOf(QueueFake::class, Queue::getFacadeRoot());
+
+        Queue::real();
+        $this->assertInstanceOf(QueueManager::class, Queue::getFacadeRoot());
     }
 }


### PR DESCRIPTION
This is inspired by [this thread](https://laracasts.com/discuss/channels/laravel/remove-fake-notifications) in Laracasts.

Lets say we use the `fake` method of facades in the `setup` or `beforeEach` method of test cases, planning to fake the implementation for almost all test cases, excepts a handful of those that need not to. In those few test cases, it can be a bit of a pain to go back to the real implementation.

This method will make reverting seamless.