### PR TITLE
[12.x] Add Response Helper methods

### DIFF
--- a/src/Illuminate/Http/Concerns/ResponseHelpers.php
+++ b/src/Illuminate/Http/Concerns/ResponseHelpers.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Http\Concerns;
+
+use Illuminate\Http\Response;
+
+trait ResponseHelpers
+{
+    public static function ok(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_OK, $headers);
+    }
+
+    public static function created(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_CREATED, $headers);
+    }
+
+    public static function accepted(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_ACCEPTED, $headers);
+    }
+
+    public static function noContent(array $headers = []): static
+    {
+        return new static(status: Response::HTTP_NO_CONTENT, headers: $headers);
+    }
+
+    public static function movePermanently(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_MOVED_PERMANENTLY, $headers);
+    }
+
+    public static function found(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_FOUND, $headers);
+    }
+
+    public static function notModified(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_NOT_MODIFIED, $headers);
+    }
+
+    public static function temporaryRedirect(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_TEMPORARY_REDIRECT, $headers);
+    }
+
+    public static function permanentRedirect(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_PERMANENTLY_REDIRECT, $headers);
+    }
+
+    public static function badRequest(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_BAD_REQUEST, $headers);
+    }
+
+    public static function unauthorized(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_UNAUTHORIZED, $headers);
+    }
+
+    public static function paymentRequired(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_PAYMENT_REQUIRED, $headers);
+    }
+
+    public static function forbidden(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_FORBIDDEN, $headers);
+    }
+
+    public static function notFound(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_NOT_FOUND, $headers);
+    }
+
+    public static function methodNotAllowed(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_METHOD_NOT_ALLOWED, $headers);
+    }
+
+    public static function notAcceptable(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_NOT_ACCEPTABLE, $headers);
+    }
+
+    public static function requestTimeout(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_REQUEST_TIMEOUT, $headers);
+    }
+
+    public static function conflict(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_CONFLICT, $headers);
+    }
+
+    public static function gone(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_GONE, $headers);
+    }
+
+    public static function unsupportedMediaType(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $headers);
+    }
+
+    public static function unprocessableEntity(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_UNPROCESSABLE_ENTITY, $headers);
+    }
+
+    public static function tooManyRequests(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_TOO_MANY_REQUESTS, $headers);
+    }
+
+    public static function internalServerError(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_INTERNAL_SERVER_ERROR, $headers);
+    }
+
+    public static function serviceUnavailable(mixed $data = [], array $headers = []): static
+    {
+        return new static($data, Response::HTTP_SERVICE_UNAVAILABLE, $headers);
+    }
+}

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\Concerns\ResponseHelpers;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -14,7 +15,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends SymfonyResponse
 {
-    use ResponseTrait, Macroable {
+    use ResponseHelpers, ResponseTrait, Macroable {
         Macroable::__call as macroCall;
     }
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -230,6 +230,150 @@ class HttpResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $response->doesNotExist('bar');
     }
+
+    public function testOkHelper()
+    {
+        $response = Response::ok();
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testCreatedHelper()
+    {
+        $response = Response::created();
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public function testAcceptedHelper()
+    {
+        $response = Response::accepted();
+        $this->assertSame(202, $response->getStatusCode());
+    }
+
+    public function testNoContentHelper()
+    {
+        $response = Response::noContent();
+        $this->assertSame(204, $response->getStatusCode());
+    }
+
+    public function testMovePermanentlyHelper()
+    {
+        $response = Response::movePermanently();
+        $this->assertSame(301, $response->getStatusCode());
+    }
+
+    public function testFoundHelper()
+    {
+        $response = Response::found();
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testNotModifiedHelper()
+    {
+        $response = Response::notModified();
+        $this->assertSame(304, $response->getStatusCode());
+    }
+
+    public function testTemporaryRedirectHelper()
+    {
+        $response = Response::temporaryRedirect();
+        $this->assertSame(307, $response->getStatusCode());
+    }
+
+    public function testPermanentRedirectHelper()
+    {
+        $response = Response::permanentRedirect();
+        $this->assertSame(308, $response->getStatusCode());
+    }
+
+    public function testBadRequestHelper()
+    {
+        $response = Response::badRequest();
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
+    public function testUnauthorizedHelper()
+    {
+        $response = Response::unauthorized();
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testPaymentRequiredHelper()
+    {
+        $response = Response::paymentRequired();
+        $this->assertSame(402, $response->getStatusCode());
+    }
+
+    public function testForbiddenHelper()
+    {
+        $response = Response::forbidden();
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testNotFoundHelper()
+    {
+        $response = Response::notFound();
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testMethodNotAllowedHelper()
+    {
+        $response = Response::methodNotAllowed();
+        $this->assertSame(405, $response->getStatusCode());
+    }
+
+    public function testNotAcceptableHelper()
+    {
+        $response = Response::notAcceptable();
+        $this->assertSame(406, $response->getStatusCode());
+    }
+
+    public function testRequestTimeoutHelper()
+    {
+        $response = Response::requestTimeout();
+        $this->assertSame(408, $response->getStatusCode());
+    }
+
+    public function testConflictHelper()
+    {
+        $response = Response::conflict();
+        $this->assertSame(409, $response->getStatusCode());
+    }
+
+    public function testGoneHelper()
+    {
+        $response = Response::gone();
+        $this->assertSame(410, $response->getStatusCode());
+    }
+
+    public function testUnsupportedMediaTypeHelper()
+    {
+        $response = Response::unsupportedMediaType();
+        $this->assertSame(415, $response->getStatusCode());
+    }
+
+    public function testUnprocessableEntityHelper()
+    {
+        $response = Response::unprocessableEntity();
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testTooManyRequestsHelper()
+    {
+        $response = Response::tooManyRequests();
+        $this->assertSame(429, $response->getStatusCode());
+    }
+
+    public function testInternalServerErrorHelper()
+    {
+        $response = Response::internalServerError();
+        $this->assertSame(500, $response->getStatusCode());
+    }
+
+    public function testServiceUnavailableHelper()
+    {
+        $response = Response::serviceUnavailable();
+        $this->assertSame(503, $response->getStatusCode());
+    }
 }
 
 class ArrayableStub implements Arrayable


### PR DESCRIPTION
## Overview

This PR adds response helper methods for the status codes that we have helper assertions on `src/Illuminate/Testing/Concerns/AssertStatusCodes`.

## Why

This is a `QoL` improvement where we can return responses with the wanted status code by calling any of the helper methods.

## Examples

```php
// Instead of this
return new Response($data, 200, $headers);


// Or this
return response($data, 200, $headers);


// We can do this:
return Response::ok($data, $headers); // 200

return Response::created($data, $headers); // 201

return Response::noContent(); // 204

return Response::notFound(); // 404

return Response::internalServerError(); // 500
```