### PR TITLE
[12.x] Make DumpCommand prohibitable 

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
@@ -15,6 +16,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'schema:dump')]
 class DumpCommand extends Command
 {
+    use Prohibitable;
+
     /**
      * The console command name.
      *
@@ -41,6 +44,10 @@ class DumpCommand extends Command
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
+        if ($this->isProhibited()) {
+            return Command::FAILURE;
+        }
+
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $this->schemaState($connection)->dump(

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
@@ -16,7 +17,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'schema:dump')]
 class DumpCommand extends Command
 {
-    use Prohibitable;
+    use ConfirmableTrait, Prohibitable;
 
     /**
      * The console command name.
@@ -44,7 +45,8 @@ class DumpCommand extends Command
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
-        if ($this->isProhibited()) {
+        if ($this->isProhibited() ||
+            ! $this->confirmToProceed()) {
             return Command::FAILURE;
         }
 


### PR DESCRIPTION
Many commands are already prohibitable, currently I do something along the lines of: 

```php
        $hosted = $this->app->environment(['jupiter','neptune']);

        SeedCommand::prohibit($hosted);
        // Loads of other custom commands I want to prohibit..
```

But, I can't do this for `DumpCommand` atm as it's not prohibitable.

If you use the `--prune` option the `schema:dump` command replaces your migration files with a single SQL schema dump of your database structure. It also deletes existing migration files. 

I would like the ability to prohibit it in production to prevent any workflow issues etc. 

I haven't added this to `prohibitDestructiveCommands` - so it can remain an opt in.

I haven't adjusted any tests, as couldn't find one for this class.

It could be worth adding this to more commands, but focusing on just this one for now.