### PR TITLE
[12.x] Revert lowercasing validation message placeholders

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -938,7 +938,7 @@ trait ReplacesAttributes
      */
     private function replaceWhileKeepingCase(string $message, array $mapping): string
     {
-        $fn = [Str::lower(...), Str::upper(...), Str::ucfirst(...)];
+        $fn = [fn ($v) => $v, Str::upper(...), Str::ucfirst(...)];
 
         $cases = array_reduce(
             array_keys($mapping),

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Validation;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Validation;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
@@ -639,6 +640,12 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('The foo field must be accepted when BAR is AAA.', $v->messages()->first('foo'));
 
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.accepted_if' => 'The :attribute field must be accepted when :other is :value.'], 'en');
+        $v = new Validator($trans, ['foo' => 'no', 'bar' => 'aAa'], ['foo' => 'accepted_if:bar,aAa']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The foo field must be accepted when bar is aAa.', $v->messages()->first('foo'));
+
         // in_array
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.in_array' => 'The value of :attribute does not exist in :Other.'], 'en');
@@ -715,6 +722,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertSame('The last field is required unless FIRST is in TAYLOR, SVEN.', $v->messages()->first('last'));
 
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en');
+        $v = new Validator($trans, ['firstName' => 'dAyle', 'lastName' => ''], ['lastName' => 'RequiredUnless:firstName,tAylor,sVen']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The last name field is required unless first name is in tAylor, sVen.', $v->messages()->first('lastName'));
+
         // required_with
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required_with' => 'The :attribute field is required when :Values is present.'], 'en');
@@ -753,6 +766,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:http,https']);
         $this->assertFalse($v->passes());
         $this->assertSame('The url must start with one of the following values HTTP, HTTPS', $v->messages()->first('url'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.starts_with' => 'The :attribute must start with one of the following values :values'], 'en');
+        $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:hTtp,hTtps']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The url must start with one of the following values hTtp, hTtps', $v->messages()->first('url'));
     }
 
     public function testInputIsReplacedByItsDisplayableValue()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -18,7 +18,6 @@ use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;


### PR DESCRIPTION
This PR reverts the minor breaking change around placeholder capitalization reported in [https://github.com/laravel/framework/issues/57678](https://github.com/laravel/framework/issues/57678). The issue was that certain placeholder values were explicitly lowercased, whereas previously they were not. This PR restores the prior behavior and keeps things consistent again with `:attribute`, which does not explicitly lowercase.

Example
```php
$trans->addLines(['validation.accepted_if' => 'The :attribute field must be accepted when :other is :value.'], 'en');
$v = new Validator($trans, ['foo' => 'no', 'bar' => 'aAa'], ['foo' => 'accepted_if:bar,aAa']);
echo $v->messages()->first('foo');

// Currently (after the breaking change):
// The foo field must be accepted when bar is aaa.

// Previously (expected behavior):
// The foo field must be accepted when bar is aAa.
```

The change was introduced in [https://github.com/laravel/framework/pull/57564](https://github.com/laravel/framework/pull/57564) and already pointed out by [https://github.com/laravel/framework/pull/57564#issuecomment-3457631210](https://github.com/laravel/framework/pull/57564#issuecomment-3457631210).
Several attempts to fix this have already been made ([https://github.com/laravel/framework/pull/57679](https://github.com/laravel/framework/pull/57679), [https://github.com/laravel/framework/pull/57686](https://github.com/laravel/framework/pull/57686)). This PR simply removes the `Str::lower(...)` call. It focuses on reverting the breaking change and introducing test cases to ensure future correctness. Others are welcome to open further PRs for refactoring if deemed necessary.

I've gone through each rule and manually checked if the lowercasing change affected them:

* accepted_if:
  `:other` — no; field name is converted to snake_case, so explicit lowercasing has no additional effect
  `:value` — yes

* same, in_array, prohibits:
  `:other` — no; field name is converted to snake_case

* missing_with, required_with, present_with:
  `:values` — no; field names are converted to snake_case

* required_unless, starts_with:
  no — does not use `replaceWhileKeepingCase`, which introduced the change (test cases still added for completeness)

For all the listed rules above there are unique method implementations inside `ReplacesAttributes`. Methods for other rules just call one of the above rules' methods (e.g., `replaceRequiredIf` calls `replaceAcceptedIf`). This is also why, in my initial PR [https://github.com/laravel/framework/pull/57556](https://github.com/laravel/framework/pull/57556), I only added test cases for the rules above, as they cover the remaining delegated rules as well.