### PR TITLE
[12.x] try another way to activate Broadcast routes

### DIFF
--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -161,6 +161,14 @@ class BroadcastingInstallCommand extends Command
                 'commands: __DIR__.\'/../routes/console.php\','.PHP_EOL.'        channels: __DIR__.\'/../routes/channels.php\',',
                 $appBootstrapPath,
             );
+        } elseif (str_contains($content, '->withRouting(')) {
+            (new Filesystem)->replaceInFile(
+                '->withRouting(',
+                '->withRouting('.PHP_EOL.'        channels: __DIR__.\'/../routes/channels.php\',',
+                $appBootstrapPath,
+            );
+        } else {
+            $this->components->error('Unable to activate broadcast routes. Please activate them manually in your '.$appBootstrapPath.' file.');
         }
     }
 

--- a/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
+++ b/src/Illuminate/Foundation/Console/BroadcastingInstallCommand.php
@@ -168,7 +168,7 @@ class BroadcastingInstallCommand extends Command
                 $appBootstrapPath,
             );
         } else {
-            $this->components->error('Unable to activate broadcast routes. Please activate them manually in your '.$appBootstrapPath.' file.');
+            $this->components->error('Unable to register broadcast routes. Please register them manually in ['.$appBootstrapPath.'].');
         }
     }
 


### PR DESCRIPTION
this command currently has 2 conditions it checks to try and activate the "channels" file in your `/bootstrap/app.php`.  while this may cover a good chunk of users, it fails if the `commands:` named argument has been removed from the file.

this change adds an additional check to look for the `->withRouting()` method call, which has a *very* high likelyhood of being in the file. placing it after the "commands" named argument is ideal because it maintains named argument order, but this is a good fallback.

_if even this additional check fails_, it now returns an error message to the user telling them they need to manually activate the broadcast routes in their `/bootstrap/app.php` file. this will helpfully avoid confusion if the automatic enabling fails.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
