### PR TITLE
[12.x] Add recursive map helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -760,6 +760,45 @@ class Arr
     }
 
     /**
+     * Recursively run a map over each of the items in the array.
+     *
+     * @template TMapRecursiveValue
+     *
+     * @param  array|Arrayable|Enumerable|Traversable|Jsonable|JsonSerializable  $items
+     * @param  callable(mixed, string|int): TMapRecursiveValue  $callback
+     * @param  bool  $preserveKeys
+     * @return array
+     */
+    public static function mapRecursive($items, callable $callback, bool $preserveKeys = true)
+    {
+        $array = static::from($items);
+
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            if (static::arrayable($value)) {
+                $mappedValue = static::mapRecursive(static::from($value), $callback, $preserveKeys);
+            } elseif ($value instanceof Traversable) {
+                $mappedValue = static::mapRecursive(iterator_to_array($value), $callback, $preserveKeys);
+            } else {
+                try {
+                    $mappedValue = $callback($value, $key);
+                } catch (ArgumentCountError) {
+                    $mappedValue = $callback($value);
+                }
+            }
+
+            if ($preserveKeys) {
+                $result[$key] = $mappedValue;
+            } else {
+                $result[] = $mappedValue;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -810,6 +810,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Recursively run a map over each of the items.
+     *
+     * @template TMapRecursiveValue
+     *
+     * @param  callable(TValue, array-key): TMapRecursiveValue  $callback
+     * @param  bool  $preserveKeys
+     * @return static<array-key, mixed>
+     */
+    public function mapRecursive(callable $callback, bool $preserveKeys = true)
+    {
+        return new static(Arr::mapRecursive($this->items, $callback, $preserveKeys));
+    }
+
+    /**
      * Run a dictionary map over the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -997,6 +997,51 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['1-a-0', '2-b-1'], $result);
     }
 
+    public function testMapRecursive()
+    {
+        $data = [
+            'name' => '  Taylor ',
+            'tags' => [' php', 'Laravel '],
+            'profile' => [
+                'github' => ' taylorotwell ',
+                'team' => [
+                    'members' => [' Abby  ', ' Dayle '],
+                    'active' => true,
+                ],
+            ],
+            'meta' => null,
+        ];
+
+        $mapped = Arr::mapRecursive($data, function ($value) {
+            return is_string($value) ? trim($value) : $value;
+        });
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'tags' => ['php', 'Laravel'],
+            'profile' => [
+                'github' => 'taylorotwell',
+                'team' => [
+                    'members' => ['Abby', 'Dayle'],
+                    'active' => true,
+                ],
+            ],
+            'meta' => null,
+        ], $mapped);
+        $this->assertEquals('  Taylor ', $data['name']);
+        $this->assertEquals([' php', 'Laravel '], $data['tags']);
+    }
+
+    public function testMapRecursiveWithoutPreservingKeys()
+    {
+        $data = ['  foo  ', ['  bar  ', ' baz  '], ' qux '];
+
+        $mapped = Arr::mapRecursive($data, 'trim', false);
+
+        $this->assertEquals(['foo', ['bar', 'baz'], 'qux'], $mapped);
+        $this->assertEquals(['  foo  ', ['  bar  ', ' baz  '], ' qux '], $data);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3003,6 +3003,53 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testMapRecursive($collection)
+    {
+        $data = new $collection([
+            'name' => '  Taylor ',
+            'meta' => [
+                ['label' => '  foo ', 'value' => ' bar '],
+                ['label' => ' baz ', 'value' => ' qux '],
+            ],
+            'active' => true,
+        ]);
+
+        $mapped = $data->mapRecursive(function ($value) {
+            return is_string($value) ? trim($value) : $value;
+        });
+
+        $this->assertInstanceOf($collection, $mapped);
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'meta' => [
+                ['label' => 'foo', 'value' => 'bar'],
+                ['label' => 'baz', 'value' => 'qux'],
+            ],
+            'active' => true,
+        ], $mapped->all());
+        $this->assertEquals('  Taylor ', $data->get('name'));
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMapRecursiveWithoutPreservingKeys($collection)
+    {
+        $data = new $collection([
+            'first' => ['label' => ' foo '],
+            'second' => ['label' => ' bar '],
+        ]);
+
+        $mapped = $data->mapRecursive(function ($value) {
+            return is_string($value) ? trim($value) : $value;
+        }, false);
+
+        $this->assertInstanceOf($collection, $mapped);
+        $this->assertSame([
+            ['label' => 'foo'],
+            ['label' => 'bar'],
+        ], $mapped->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testMapSpread($collection)
     {
         $c = new $collection([[1, 'a'], [2, 'b']]);


### PR DESCRIPTION
This pull request introduces a new static method, mapRecursive, to extend Laravel’s array utilities. The method enables applying a callback function recursively across deeply nested data structures such as arrays, Arrayable, Enumerable, Traversable, Jsonable, and JsonSerializable objects.

Key Features

Recursive mapping: Handles multi-level data structures without manual flattening.
Broad compatibility: Supports Laravel’s common collection and arrayable interfaces, as well as native traversable types.
Flexible callback: Gracefully handles callbacks that accept either one or two parameters (value and key).
Optional key preservation: Allows preserving original keys or reindexing results.

Example Usage
```
$result = Arr::mapRecursive($data, function ($value, $key) {
    return is_string($value) ? Str::upper($value) : $value;
});
```

Benefits
Simplifies recursive transformations without additional loops.
Improves code readability for deeply nested array processing.
Extends Laravel’s array manipulation capabilities in a backward-compatible way.
