### PR TITLE
Query\Builder::aggregate() returns incorrect result when used with groupBy()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3609,6 +3609,8 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $columns
      * @return int<0, max>
+     *
+     * @throws \RuntimeException
      */
     public function count($columns = '*')
     {
@@ -3620,6 +3622,8 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function min($column)
     {
@@ -3631,6 +3635,8 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function max($column)
     {
@@ -3642,6 +3648,8 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function sum($column)
     {
@@ -3655,6 +3663,8 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function avg($column)
     {
@@ -3678,9 +3688,15 @@ class Builder implements BuilderContract
      * @param  string  $function
      * @param  array  $columns
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function aggregate($function, $columns = ['*'])
     {
+        if (! empty($this->groups)) {
+            throw new RuntimeException('Aggregate functions cannot be used with a GROUP BY clause.');
+        }
+
         $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
             ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
             ->setAggregate($function, $columns)
@@ -3697,6 +3713,8 @@ class Builder implements BuilderContract
      * @param  string  $function
      * @param  array  $columns
      * @return float|int
+     *
+     * @throws \RuntimeException
      */
     public function numericAggregate($function, $columns = ['*'])
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1910,6 +1910,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->count();
     }
 
+    public function testGroupByAggregate()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('getDatabaseName');
+        $builder->from('posts')->selectSub(function ($query) {
+            $query->from('videos')->select('count(*)')->whereColumn('posts.id', '=', 'videos.post_id');
+        }, 'videos_count')->groupBy('videos_count');
+        $builder->count();
+    }
+
     public function testSubSelectWhereIns()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Related: https://github.com/laravel/framework/discussions/57738



The `Illuminate\Database\Query\Builder::aggregate()` method (used by `count()`, `sum()`, `min()`, `max()`, `avg()`) **returns only the first row** when combined with `groupBy()`. This behavior is **incorrect**, **misleading**, and **inconsistent with SQL semantics**.

Users expect:
- `count()` → **number of groups**
- `sum()` → **sum of group totals**
- `min()` → **smallest group value**

But Laravel returns **only the first group's result**.

---

## Current (Buggy) Behavior

```php
Post::groupBy('post_category_id')->count();
```

### Generated SQL (Laravel)
```SQL
SELECT COUNT(*) AS aggregate 
FROM `posts` 
GROUP BY `post_category_id`;
```
```
+-----------+
| aggregate |
+-----------+
|         3 |
|       459 |
+-----------+
```
Laravel Returns 3  // Only first row — WRONG if user expects group count

User confusion:
“SQL shows 2 groups, but Laravel returns 3?” → Actually returns first group count, not total or group count.




### Steps To Reproduce

Example Data

```
-- Table: posts
+----+--------------------+---------+
| id | post_category_id   | title   |
+----+--------------------+---------+
|  1 |                  1 | Post A  |
|  2 |                  2 | Post B  |
|  3 |                  3 | Post C  |
+----+--------------------+---------+
```


```php
Post::groupBy('post_category_id')->count(); // returns 1
```