### PR TITLE
[12.x] Add environment information to json output of schedule:list command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -67,9 +67,7 @@ class ScheduleListCommand extends Command
 
         $events = $this->sortEvents($events, $timezone);
 
-        $this->option('json')
-            ? $this->displayJson($events, $timezone)
-            : $this->displayForCli($events, $timezone);
+        $this->display($events, $timezone);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -107,6 +107,7 @@ class ScheduleListCommand extends Command
                 'timezone' => $timezone->getName(),
                 'has_mutex' => $event->mutex->exists($event),
                 'repeat_seconds' => $event->isRepeatable() ? $event->repeatSeconds : null,
+                'environments' => $event->environments,
             ];
         })->values()->toJson());
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -133,8 +133,8 @@ class ScheduleListCommandTest extends TestCase
         $this->assertCount(1, $data);
 
         $this->assertIsArray($data[0]['environments']);
-        $this->assertContains($data[0]['environments']);
-        $this->assertContains(environment, $data[0]['environments']);
+        $this->assertNotEmpty($data[0]['environments']);
+        $this->assertContains($environment, $data[0]['environments']);
     }
 
     public function testDisplayScheduleWithSortAsJson()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -122,7 +122,7 @@ class ScheduleListCommandTest extends TestCase
     public function testDisplayScheduleAsJsonWithSpecificEnvironment()
     {
         $environment = 'production';
-        $this->schedule->command(FooCommand::class)->quarterly()->environments(environment);
+        $this->schedule->command(FooCommand::class)->quarterly()->environments($environment);
 
         $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, ['--json' => true]);
         $output = Artisan::output();

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -103,6 +103,8 @@ class ScheduleListCommandTest extends TestCase
         $this->assertStringContainsString('2023-04-01 00:00:00', $data[0]['next_due_date']);
         $this->assertSame('3 months from now', $data[0]['next_due_date_human']);
         $this->assertFalse($data[0]['has_mutex']);
+        $this->assertIsArray($data[0]['environments']);
+        $this->assertEmpty($data[0]['environments']);
 
         $this->assertSame('* * * * *', $data[2]['expression']);
         $this->assertSame('php artisan foobar a='.ProcessUtils::escapeArgument('b'), $data[2]['command']);
@@ -115,6 +117,24 @@ class ScheduleListCommandTest extends TestCase
 
         $this->assertStringContainsString('Closure at:', $data[8]['command']);
         $this->assertStringContainsString('ScheduleListCommandTest.php', $data[8]['command']);
+    }
+
+    public function testDisplayScheduleAsJsonWithSpecificEnvironment()
+    {
+        $environment = 'production';
+        $this->schedule->command(FooCommand::class)->quarterly()->environments(environment);
+
+        $this->withoutMockingConsoleOutput()->artisan(ScheduleListCommand::class, ['--json' => true]);
+        $output = Artisan::output();
+
+        $this->assertJson($output);
+        $data = json_decode($output, true);
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+
+        $this->assertIsArray($data[0]['environments']);
+        $this->assertContains($data[0]['environments']);
+        $this->assertContains(environment, $data[0]['environments']);
     }
 
     public function testDisplayScheduleWithSortAsJson()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This adds the environment information for scheduled commands/jobs etc. to the json output.

It would make sense of outputting the environments with the default verbose output as well. If that is of interest please tell me.
