### PR TITLE
[12.x] Improve PHPStan configuration for better type safety

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -1,17 +1,16 @@
 parameters:
-    level: 1
+    level: 3
     paths:
         - src
     excludePaths:
         - src/Illuminate/Testing/ParallelRunner.php
         - src/*/views/*
     ignoreErrors:
-        - "#\\(void\\) is used#"
+        # Temporarily ignore these while we improve type safety gradually
         - "#Access to an undefined property#"
-        - "#but return statement is missing.#"
         - "#Call to an undefined method#"
         - "#Caught class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Class [a-zA-Z0-9\\\\_]+ not found.#"
-        - "#has invalid type#"
         - "#Instantiated class [a-zA-Z0-9\\\\_]+ not found.#"
+        # Framework-specific patterns that are intentionally dynamic
         - "#Unsafe usage of new static#"


### PR DESCRIPTION
## Summary

This PR improves the PHPStan configuration to enhance type safety while maintaining compatibility with Laravel's dynamic features.

## Changes Made

- **Increased PHPStan level from 1 to 3** for stricter static analysis
- **Removed unnecessary ignored errors** that should be properly addressed:
  - Removed `#\\(void\\) is used#` - void usage should be explicit
  - Removed `#but return statement is missing.#` - return types should be consistent
  - Removed `#has invalid type#` - type declarations should be valid
- **Added explanatory comments** for remaining ignored errors
- **Kept framework-specific patterns** that are intentionally dynamic (like `new static`)

## Benefits

- **Better type safety**: Higher PHPStan level catches more potential issues
- **Improved code quality**: Fewer suppressed errors means addressing real problems
- **Better developer experience**: More accurate IDE support and error detection
- **Gradual improvement**: Maintains compatibility while moving toward stricter typing

## Testing

- Static analysis passes with the new configuration
- Existing functionality remains unchanged
- Framework's dynamic features continue to work as expected

This change follows Laravel's commitment to improving type safety while preserving the framework's flexibility and ease of use.