### PR TITLE
[12.x] Accept string bindings in give attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Give.php
+++ b/src/Illuminate/Container/Attributes/Give.php
@@ -12,9 +12,7 @@ class Give implements ContextualAttribute
     /**
      * Provide a concrete class implementation for dependency injection.
      *
-     * @template T
-     *
-     * @param  class-string<T>  $class
+     * @param  string  $class
      * @param  array|null  $params
      */
     public function __construct(


### PR DESCRIPTION
I like to use a named binding from a container. This works properly, but PHPStan is complaining.
The property type of container make method accepts strings