### PR TITLE
[12.x]: Add `getBindingMap` method

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use PDOException;
@@ -105,5 +106,20 @@ class QueryException extends PDOException
     public function getBindings()
     {
         return $this->bindings;
+    }
+
+    /**
+     * Get a collection of keys and their corresponding bindings.
+     *
+     * @return Collection
+     */
+    public function getBindingMap(): Collection
+    {
+        return Str::of($this->getSql())
+            ->after('(')
+            ->before(')')
+            ->replace('"', '')
+            ->explode(', ')
+            ->combine($this->getBindings());
     }
 }


### PR DESCRIPTION
On the QueryException when you run ->getBindings() you only get the values, and when you look at the sql you can see the keys. However, when you have many columns to insert and one of them fails, it is harder to figure out what is the value for the key in the exception. This attempts to help with that. It's a new independent feature, so won't break anything.
