### PR TITLE
[12.x] Fix the docblock of the BroadcastManager::purge method.

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -465,7 +465,7 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Disconnect the given disk and remove from local cache.
+     * Disconnect the given driver / connection and remove it from local cache.
      *
      * @param  string|null  $name
      * @return void


### PR DESCRIPTION
The current description in the docblock of the `BroadcastManager::purge` isn't correct.

> Disconnect the given disk and remove from local cache.

I guessed it was accidentally copied from the `FilesystemManager::purge` method. So, I change it to:

> Disconnect the given driver / connection and remove it from local cache.