### PR TITLE
[12.x] Fix setting request exception truncating doesn't work on HTTP layer when configured inside `bootstrap/app.php`

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -27,7 +27,7 @@ class RequestException extends HttpClientException
      */
     public function __construct(Response $response)
     {
-        parent::__construct($this->prepareMessage($response), $response->status());
+        parent::__construct("HTTP request returned status code {$response->status()}", $response->status());
 
         $this->response = $response;
     }
@@ -66,17 +66,16 @@ class RequestException extends HttpClientException
     /**
      * Prepare the exception message.
      *
-     * @param  \Illuminate\Http\Client\Response  $response
-     * @return string
+     * @return void
      */
-    protected function prepareMessage(Response $response)
+    public function report(): void
     {
-        $message = "HTTP request returned status code {$response->status()}";
-
         $summary = static::$truncateAt
-            ? Message::bodySummary($response->toPsrResponse(), static::$truncateAt)
-            : Message::toString($response->toPsrResponse());
+            ? Message::bodySummary($this->response->toPsrResponse(), static::$truncateAt)
+            : Message::toString($this->response->toPsrResponse());
 
-        return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
+        $this->message = is_null($summary)
+            ? $this->message
+            : $this->message .= ":\n{$summary}\n";
     }
 }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -37,7 +37,7 @@ class RequestException extends HttpClientException
     {
         parent::__construct("HTTP request returned status code {$response->status()}", $response->status());
 
-        $this->truncateExceptionsAt = $truncateExceptionsAt ?? static::$truncateAt;
+        $this->truncateExceptionsAt = $truncateExceptionsAt;
 
         $this->response = $response;
     }
@@ -80,8 +80,10 @@ class RequestException extends HttpClientException
      */
     public function report(): void
     {
-        $summary = $this->truncateExceptionsAt
-            ? Message::bodySummary($this->response->toPsrResponse(), $this->truncateExceptionsAt)
+        $truncateExceptionsAt = $this->truncateExceptionsAt ?? static::$truncateAt;
+
+        $summary = $truncateExceptionsAt
+            ? Message::bodySummary($this->response->toPsrResponse(), $truncateExceptionsAt)
             : Message::toString($this->response->toPsrResponse());
 
         if (! is_null($summary)) {

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -304,19 +304,7 @@ class Response implements ArrayAccess, Stringable
     public function toException()
     {
         if ($this->failed()) {
-            $originalTruncateAt = RequestException::$truncateAt;
-
-            try {
-                if ($this->truncateExceptionsAt !== null) {
-                    $this->truncateExceptionsAt === false
-                        ? RequestException::dontTruncate()
-                        : RequestException::truncateAt($this->truncateExceptionsAt);
-                }
-
-                return new RequestException($this);
-            } finally {
-                RequestException::$truncateAt = $originalTruncateAt;
-            }
+            return new RequestException($this, $this->truncateExceptionsAt);
         }
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1301,9 +1301,10 @@ class HttpClientTest extends TestCase
                 'message' => 'The Request can not be completed',
             ],
         ];
+
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw new RequestException(new Response($response));
+        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
     }
 
     public function testRequestExceptionTruncatedSummary()
@@ -1319,7 +1320,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw new RequestException(new Response($response));
+        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
     }
 
     public function testRequestExceptionWithoutTruncatedSummary()
@@ -1337,7 +1338,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw new RequestException(new Response($response));
+        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
     }
 
     public function testRequestExceptionWithCustomTruncatedSummary()
@@ -1355,7 +1356,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw new RequestException(new Response($response));
+        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
     }
 
     public function testRequestLevelTruncationLevelOnRequestException()
@@ -1372,6 +1373,8 @@ class HttpClientTest extends TestCase
         } catch (RequestException $e) {
             $exception = $e;
         }
+
+        $exception->report();
 
         $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
@@ -1394,6 +1397,8 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
+        $exception->report();
+
         $this->assertEquals("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"error\"]\n", $exception->getMessage());
 
         $this->assertEquals(60, RequestException::$truncateAt);
@@ -1414,6 +1419,8 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
+        $exception->report();
+
         $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertFalse(RequestException::$truncateAt);
@@ -1427,6 +1434,8 @@ class HttpClientTest extends TestCase
         ]);
 
         $exception = $this->factory->async()->throw()->truncateExceptionsAt(4)->get('http://foo.com/json')->wait();
+
+        $exception->report();
 
         $this->assertInstanceOf(RequestException::class, $exception);
         $this->assertEquals("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());


### PR DESCRIPTION
fix #57601

`ApplicationBuilder::withExceptions($using)` method only resolves the `$using` callback after resolving `Illuminate\Foundation\Exceptions\Handler`. Therefore, any value set via `new RequestException($response)` will only consist of resolved  `prepareMessage()` value before `Handler`. 

Using `report()` method will solve the issue.


### After the changes

#### Default

<img width="1248" height="981" alt="CleanShot 2025-11-12 at 14 45 14" src="https://github.com/user-attachments/assets/f40f7c94-4b65-49d8-b305-2cbac8075211" />

#### Using `$exceptions->truncateRequestExceptionsAt(5);`

<img width="1248" height="981" alt="CleanShot 2025-11-12 at 14 44 49" src="https://github.com/user-attachments/assets/bb256756-579f-4024-99ad-218792df3cf2" />

#### Using `$exceptions->dontTruncateRequestExceptions();`

<img width="1248" height="981" alt="CleanShot 2025-11-12 at 14 45 24" src="https://github.com/user-attachments/assets/b6eaaed4-2690-41e1-a49d-b575f94782bc" />
