### PR TITLE
[12.x]: Create Model Helpers

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 use function Illuminate\Support\enum_value;
+use function Illuminate\Support\is_model;
 
 class Authorize
 {
@@ -73,7 +74,7 @@ class Authorize
         }
 
         return (new Collection($models))
-            ->map(fn ($model) => $model instanceof Model ? $model : $this->getModel($request, $model))
+            ->map(fn ($model) => is_model($model) ? $model : $this->getModel($request, $model))
             ->all();
     }
 

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -8,6 +8,10 @@ if (! function_exists('Illuminate\Support\is_model')) {
     /**
      * Determine if the given value is a model.
      *
+     * @internal
+     *
+     * @template TModel
+     *
      * @param  TModel  $model
      * @return bool
      */
@@ -21,17 +25,21 @@ if (! function_exists('Illuminate\Support\model_key')) {
     /**
      * Return the key for the given model.
      *
+     * @internal
+     *
+     * @template TModel
+     *
      * @param  TModel  $model
-     * @param  TDefault|callable(TModel): TDefault  $default
-     * @return ($model is empty ? TDefault : mixed)
+     * @param  callable(TModel): mixed  $callback
+     * @return mixed
      */
-    function model_key($model, $default = null)
+    function model_key($model, $callback = null)
     {
-        return match (true) {
-            is_model($model) => $model->getKey(),
+        if (is_model($model)) {
+            return $model->getKey();
+        }
 
-            default => $model ?? value($default, $model),
-        };
+        return with($model, $callback);
     }
 }
 

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -2,6 +2,21 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Database\Eloquent\Model;
+
+if (! function_exists('Illuminate\Support\is_model')) {
+    /**
+     * Determine if the given value is a model.
+     *
+     * @param  TModel  $model
+     * @return bool
+     */
+    function is_model($model)
+    {
+        return $model instanceof Model;
+    }
+}
+
 if (! function_exists('Illuminate\Support\model_key')) {
     /**
      * Return the key for the given model.
@@ -13,9 +28,9 @@ if (! function_exists('Illuminate\Support\model_key')) {
     function model_key($model, $default = null)
     {
         return match (true) {
-            $model instanceof \Illuminate\Database\Eloquent\Model => $model->getKey(),
+            is_model($model) => $model->getKey(),
 
-            default => $value ?? value($default),
+            default => $model ?? value($default, $model),
         };
     }
 }

--- a/src/Illuminate/Collections/functions.php
+++ b/src/Illuminate/Collections/functions.php
@@ -2,6 +2,24 @@
 
 namespace Illuminate\Support;
 
+if (! function_exists('Illuminate\Support\model_key')) {
+    /**
+     * Return the key for the given model.
+     *
+     * @param  TModel  $model
+     * @param  TDefault|callable(TModel): TDefault  $default
+     * @return ($model is empty ? TDefault : mixed)
+     */
+    function model_key($model, $default = null)
+    {
+        return match (true) {
+            $model instanceof \Illuminate\Database\Eloquent\Model => $model->getKey(),
+
+            default => $value ?? value($default),
+        };
+    }
+}
+
 if (! function_exists('Illuminate\Support\enum_value')) {
     /**
      * Return a scalar value for the given value that might be an enum.

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -8,6 +8,8 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection as BaseCollection;
 
+use function Illuminate\Support\is_model;
+
 class BroadcastableModelEventOccurred implements ShouldBroadcast
 {
     use InteractsWithSockets, SerializesModels;
@@ -78,7 +80,7 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
             : $this->channels;
 
         return (new BaseCollection($channels))
-            ->map(fn ($channel) => $channel instanceof Model ? new PrivateChannel($channel) : $channel)
+            ->map(fn ($channel) => is_model($channel) ? new PrivateChannel($channel) : $channel)
             ->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -23,6 +23,8 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
 use ReflectionMethod;
 
+use function Illuminate\Support\model_key;
+
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
  *
@@ -275,9 +277,7 @@ class Builder implements BuilderContract
      */
     public function whereKey($id)
     {
-        if ($id instanceof Model) {
-            $id = $id->getKey();
-        }
+        $id = model_key($id);
 
         if (is_array($id) || $id instanceof Arrayable) {
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
@@ -304,9 +304,7 @@ class Builder implements BuilderContract
      */
     public function whereKeyNot($id)
     {
-        if ($id instanceof Model) {
-            $id = $id->getKey();
-        }
+        $id = model_key($id);
 
         if (is_array($id) || $id instanceof Arrayable) {
             if (in_array($this->model->getKeyType(), ['int', 'integer'])) {
@@ -334,9 +332,9 @@ class Builder implements BuilderContract
     public function except($models)
     {
         return $this->whereKeyNot(
-            $models instanceof Model
-                ? $models->getKey()
-                : Collection::wrap($models)->modelKeys()
+            model_key($models, function ($models) {
+                return Collection::wrap($models)->modelKeys();
+            })
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -11,6 +11,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use LogicException;
 
+use function Illuminate\Support\is_model;
+use function Illuminate\Support\model_key;
+
 /**
  * @template TKey of array-key
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -32,9 +35,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function find($key, $default = null)
     {
-        if ($key instanceof Model) {
-            $key = $key->getKey();
-        }
+        $key = model_key($key);
 
         if ($key instanceof Arrayable) {
             $key = $key->toArray();
@@ -358,7 +359,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return parent::contains(...func_get_args());
         }
 
-        if ($key instanceof Model) {
+        if (is_model($key)) {
             return parent::contains(fn ($model) => $model->is($key));
         }
 
@@ -417,7 +418,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn ($item) => ! is_model($item)) ? $result->toBase() : $result;
     }
 
     /**
@@ -435,7 +436,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::mapWithKeys($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn ($item) => ! is_model($item)) ? $result->toBase() : $result;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -23,6 +23,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\is_model;
+
 trait HasRelationships
 {
     /**
@@ -184,7 +186,7 @@ trait HasRelationships
             return;
         }
 
-        if ($models instanceof Model) {
+        if (is_model($models)) {
             $models = [$models];
         }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -19,6 +19,8 @@ use Throwable;
 use UnitEnum;
 
 use function Illuminate\Support\enum_value;
+use function Illuminate\Support\is_model;
+use function Illuminate\Support\model_key;
 
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
@@ -317,7 +319,7 @@ abstract class Factory
 
         $results = $this->make($attributes, $parent);
 
-        if ($results instanceof Model) {
+        if (is_model($results)) {
             $this->store(new Collection([$results]));
 
             $this->callAfterCreating(new Collection([$results]), $parent);
@@ -555,11 +557,9 @@ abstract class Factory
                 } elseif ($attribute instanceof self) {
                     $attribute = $this->getRandomRecycledModel($attribute->modelName())?->getKey()
                         ?? $attribute->recycle($this->recycle)->create()->getKey();
-                } elseif ($attribute instanceof Model) {
-                    $attribute = $attribute->getKey();
                 }
 
-                return $attribute;
+                return model_key($attribute);
             })
             ->map(function ($attribute, $key) use (&$definition, $evaluateRelations) {
                 if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
@@ -732,7 +732,7 @@ abstract class Factory
             'recycle' => $this->recycle
                 ->flatten()
                 ->merge(
-                    Collection::wrap($model instanceof Model ? func_get_args() : $model)
+                    Collection::wrap(is_model($model) ? func_get_args() : $model)
                         ->flatten()
                 )->groupBy(fn ($model) => get_class($model)),
         ]);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -34,6 +34,7 @@ use ReflectionMethod;
 use Stringable;
 
 use function Illuminate\Support\enum_value;
+use function Illuminate\Support\is_model;
 
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
 {
@@ -2266,7 +2267,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             $field = $relationship->getRelated()->qualifyColumn($field);
         }
 
-        return $relationship instanceof Model
+        return is_model($relationship)
             ? $relationship->resolveRouteBindingQuery($relationship, $value, $field)
             : $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 use function Illuminate\Support\enum_value;
+use function Illuminate\Support\is_model;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -184,11 +185,11 @@ class BelongsTo extends Relation
      */
     public function associate($model)
     {
-        $ownerKey = $model instanceof Model ? $model->getAttribute($this->ownerKey) : $model;
+        $ownerKey = is_model($model) ? $model->getAttribute($this->ownerKey) : $model;
 
         $this->child->setAttribute($this->foreignKey, $ownerKey);
 
-        if ($model instanceof Model) {
+        if (is_model($model)) {
             $this->child->setRelation($this->relationName, $model);
         } else {
             $this->child->unsetRelation($this->relationName);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -17,6 +17,8 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
+use function Illuminate\Support\is_model;
+
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
@@ -189,7 +191,7 @@ class BelongsToMany extends Relation
 
         $model = new $table;
 
-        if (! $model instanceof Model) {
+        if (! is_model($model)) {
             return $table;
         }
 
@@ -706,7 +708,7 @@ class BelongsToMany extends Relation
      */
     public function find($id, $columns = ['*'])
     {
-        if (! $id instanceof Model && (is_array($id) || $id instanceof Arrayable)) {
+        if (! is_model($id) && (is_array($id) || $id instanceof Arrayable)) {
             return $this->findMany($id, $columns);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Collection as BaseCollection;
 
+use function Illuminate\Support\is_model;
+
 trait InteractsWithPivotTable
 {
     /**
@@ -616,7 +618,7 @@ trait InteractsWithPivotTable
      */
     protected function parseIds($value)
     {
-        if ($value instanceof Model) {
+        if (is_model($value)) {
             return [$value->{$this->relatedKey}];
         }
 
@@ -626,7 +628,7 @@ trait InteractsWithPivotTable
 
         if ($value instanceof BaseCollection || is_array($value)) {
             return (new BaseCollection($value))
-                ->map(fn ($item) => $item instanceof Model ? $item->{$this->relatedKey} : $item)
+                ->map(fn ($item) => is_model($item) ? $item->{$this->relatedKey} : $item)
                 ->all();
         }
 
@@ -641,7 +643,7 @@ trait InteractsWithPivotTable
      */
     protected function parseId($value)
     {
-        return $value instanceof Model ? $value->{$this->relatedKey} : $value;
+        return is_model($value) ? $value->{$this->relatedKey} : $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\is_model;
+
 trait SupportsInverseRelations
 {
     /**
@@ -97,7 +99,7 @@ trait SupportsInverseRelations
         $parent ??= $this->getParent();
 
         foreach ($models as $model) {
-            $model instanceof Model && $this->applyInverseRelationToModel($model, $parent);
+            is_model($model) && $this->applyInverseRelationToModel($model, $parent);
         }
 
         return $models;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
+use function Illuminate\Support\is_model;
+
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
@@ -234,18 +236,18 @@ class MorphTo extends BelongsTo
     #[\Override]
     public function associate($model)
     {
-        if ($model instanceof Model) {
+        if (is_model($model)) {
             $foreignKey = $this->ownerKey && $model->{$this->ownerKey}
                 ? $this->ownerKey
                 : $model->getKeyName();
         }
 
         $this->parent->setAttribute(
-            $this->foreignKey, $model instanceof Model ? $model->{$foreignKey} : null
+            $this->foreignKey, is_model($model) ? $model->{$foreignKey} : null
         );
 
         $this->parent->setAttribute(
-            $this->morphType, $model instanceof Model ? $model->getMorphClass() : null
+            $this->morphType, is_model($model) ? $model->getMorphClass() : null
         );
 
         return $this->parent->setRelation($this->relationName, $model);

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Exceptions\Renderer;
 
 use Closure;
 use Composer\Autoload\ClassLoader;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
+use function Illuminate\Support\is_model;
+
 class Exception
 {
     /**
@@ -240,7 +242,7 @@ class Exception
         $parameters = $this->request()->route()?->parameters();
 
         return $parameters ? json_encode(array_map(
-            fn ($value) => $value instanceof Model ? $value->withoutRelations() : $value,
+            fn ($value) => is_model($value) ? $value->withoutRelations() : $value,
             $parameters
         ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) : null;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -13,6 +13,8 @@ use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
 
+use function Illuminate\Support\is_model;
+
 trait InteractsWithDatabase
 {
     /**
@@ -33,7 +35,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if ($table instanceof Model) {
+        if (is_model($table)) {
             $data = [
                 $table->getKeyName() => $table->getKey(),
                 ...$data,
@@ -65,7 +67,7 @@ trait InteractsWithDatabase
             return $this;
         }
 
-        if ($table instanceof Model) {
+        if (is_model($table)) {
             $data = [
                 $table->getKeyName() => $table->getKey(),
                 ...$data,
@@ -254,7 +256,7 @@ trait InteractsWithDatabase
      */
     protected function isSoftDeletableModel($model)
     {
-        return $model instanceof Model && $model::isSoftDeletable();
+        return is_model($model) && $model::isSoftDeletable();
     }
 
     /**
@@ -305,7 +307,7 @@ trait InteractsWithDatabase
      */
     protected function getTable($table)
     {
-        if ($table instanceof Model) {
+        if (is_model($table)) {
             return $table->getTable();
         }
 
@@ -320,7 +322,7 @@ trait InteractsWithDatabase
      */
     protected function getTableConnection($table)
     {
-        if ($table instanceof Model) {
+        if (is_model($table)) {
             return $table->getConnectionName();
         }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -4,6 +4,8 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 
+use function Illuminate\Support\is_model;
+
 trait InteractsWithFlashData
 {
     /**
@@ -15,7 +17,7 @@ trait InteractsWithFlashData
      */
     public function old($key = null, $default = null)
     {
-        $default = $default instanceof Model ? $default->getAttribute($key) : $default;
+        $default = is_model($default) ? $default->getAttribute($key) : $default;
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
-
 use function Illuminate\Support\is_model;
 
 trait InteractsWithFlashData

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
+use function Illuminate\Support\is_model;
+
 class ResourceResponse implements Responsable
 {
     /**
@@ -119,7 +121,7 @@ class ResourceResponse implements Responsable
      */
     protected function calculateStatus()
     {
-        return $this->resource->resource instanceof Model &&
+        return is_model($this->resource->resource) &&
                $this->resource->resource->wasRecentlyCreated ? 201 : 200;
     }
 }

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Resources\Json;
 
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 use function Illuminate\Support\is_model;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -16,6 +16,8 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Throwable;
 
+use function Illuminate\Support\is_model;
+
 class NotificationSender
 {
     use Localizable;
@@ -294,7 +296,7 @@ class NotificationSender
     protected function formatNotifiables($notifiables)
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
-            return $notifiables instanceof Model
+            return is_model($notifiables)
                 ? new EloquentCollection([$notifiables])
                 : [$notifiables];
         }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -5,7 +5,6 @@ namespace Illuminate\Notifications;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -12,6 +12,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 
+use function Illuminate\Support\is_model;
+
 class SendQueuedNotifications implements ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
@@ -100,7 +102,7 @@ class SendQueuedNotifications implements ShouldQueue
     {
         if ($notifiables instanceof Collection) {
             return $notifiables;
-        } elseif ($notifiables instanceof Model) {
+        } elseif (is_model($notifiables)) {
             return EloquentCollection::wrap($notifiables);
         }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Traits\TransformsToResourceCollection;
 use Stringable;
 use Traversable;
 
+use function Illuminate\Support\is_model;
+
 /**
  * @template TKey of array-key
  *
@@ -218,7 +220,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
                     $item = $item->resource;
                 }
 
-                if ($item instanceof Model &&
+                if (is_model($item) &&
                     ! is_null($parameter = $this->getPivotParameterForItem($item, $parameterName))) {
                     return $parameter;
                 } elseif ($item instanceof ArrayAccess || is_array($item)) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -32,6 +32,8 @@ use stdClass;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+use function Illuminate\Support\is_model;
+
 /**
  * @mixin \Illuminate\Routing\RouteRegistrar
  */
@@ -923,7 +925,7 @@ class Router implements BindingRegistrar, RegistrarContract
 
         if ($response instanceof PsrResponseInterface) {
             $response = (new HttpFoundationFactory)->createResponse($response);
-        } elseif ($response instanceof Model && $response->wasRecentlyCreated) {
+        } elseif (is_model($response) && $response->wasRecentlyCreated) {
             $response = new JsonResponse($response, 201);
         } elseif ($response instanceof Stringable) {
             $response = new Response($response->__toString(), 200, ['Content-Type' => 'text/html']);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -14,6 +14,8 @@ use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 
+use function Illuminate\Support\is_model;
+
 if (! function_exists('append_config')) {
     /**
      * Assign high numeric IDs to a config item to force appending.
@@ -60,7 +62,7 @@ if (! function_exists('blank')) {
             return false;
         }
 
-        if ($value instanceof Model) {
+        if (is_model($value)) {
             return false;
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+use function Illuminate\Support\is_model;
+
 /**
  * @template TResponse of \Symfony\Component\HttpFoundation\Response
  *
@@ -1282,7 +1284,7 @@ class TestResponse implements ArrayAccess
             PHPUnit::withResponse($this)->assertTrue(Arr::has($this->original->gatherData(), $key), "Failed asserting that the data contains the key [{$key}].");
         } elseif ($value instanceof Closure) {
             PHPUnit::withResponse($this)->assertTrue($value($actual), "Failed asserting that the value at [{$key}] fulfills the expectations defined by the closure.");
-        } elseif ($value instanceof Model) {
+        } elseif (is_model($value)) {
             PHPUnit::withResponse($this)->assertTrue($value->is($actual), "Failed asserting that the model at [{$key}] matches the given model.");
         } elseif ($value instanceof EloquentCollection) {
             PHPUnit::withResponse($this)->assertInstanceOf(EloquentCollection::class, $actual);

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\MessageBag;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -4,7 +4,6 @@ namespace Illuminate\Testing;
 
 use Closure;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -12,6 +12,8 @@ use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\View\View;
 use Stringable;
 
+use function Illuminate\Support\is_model;
+
 class TestView implements Stringable
 {
     use Macroable;
@@ -58,7 +60,7 @@ class TestView implements Stringable
             PHPUnit::assertTrue(Arr::has($this->view->gatherData(), $key));
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value(Arr::get($this->view->gatherData(), $key)));
-        } elseif ($value instanceof Model) {
+        } elseif (is_model($value)) {
             PHPUnit::assertTrue($value->is(Arr::get($this->view->gatherData(), $key)));
         } elseif ($value instanceof EloquentCollection) {
             $actual = Arr::get($this->view->gatherData(), $key);

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
 use Stringable;
 
+use function Illuminate\Support\is_model;
+
 class Unique implements Stringable
 {
     use Conditionable, DatabaseRule;
@@ -33,7 +35,7 @@ class Unique implements Stringable
      */
     public function ignore($id, $idColumn = null)
     {
-        if ($id instanceof Model) {
+        if (is_model($id)) {
             return $this->ignoreModel($id, $idColumn);
         }
 


### PR DESCRIPTION
- Adds two helpers: `model_key()` to fetch a model’s primary key and `is_model()` to check if a value is an Eloquent model.
- Replaces scattered `$model->getKey()` and `instanceof Model` checks with these helpers across collections, factories, notifications, and testing utilities.
- Gives us a single place to tweak how model keys are resolved, so queries, scopes, and serialization stay consistent.