### PR TITLE
Add request->all() to InteractsWithInput input() function

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -110,7 +110,7 @@ trait InteractsWithInput
     public function input($key = null, $default = null)
     {
         return data_get(
-            $this->getInputSource()->all() + $this->query->all(), $key, $default
+            $this->getInputSource()->all() + $this->query->all() + $this->request->all(), $key, $default
         );
     }
 


### PR DESCRIPTION
Add request->all() to InteractsWithInput input() function When there is a POST API with query params and the CONTENT_TYPE is Json, we are missing the query param in the input() function. its available only on $request->request->all()

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
