### PR TITLE
[12.x] Validator default attributes formatter

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -305,7 +305,9 @@ trait FormatsMessages
                 : $attribute;
         }
 
-        return str_replace('_', ' ', Str::snake($attribute));
+        return ($formatter = $this->defaultAttributesFormatter)
+            ? $formatter($attribute)
+            : str_replace('_', ' ', Str::snake($attribute));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1481,7 +1481,7 @@ class Validator implements ValidatorContract
     /**
      * Set the callback used to format attributes.
      *
-     * @param callable|null $formatter
+     * @param  callable|null $formatter
      * @return $this
      */
     public function setDefaultAttributesFormatter(?callable $formatter = null)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1481,7 +1481,7 @@ class Validator implements ValidatorContract
     /**
      * Set the callback used to format attributes.
      *
-     * @param  callable|null $formatter
+     * @param  callable|null  $formatter
      * @return $this
      */
     public function setDefaultAttributesFormatter(?callable $formatter = null)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -104,11 +104,18 @@ class Validator implements ValidatorContract
     protected $implicitAttributes = [];
 
     /**
-     * The callback that should be used to format the attribute.
+     * The callback that should be used to format implicit attributes.
      *
      * @var callable|null
      */
     protected $implicitAttributesFormatter;
+
+    /**
+     * The callback that should be used to format attributes.
+     *
+     * @var callable|null
+     */
+    protected $defaultAttributesFormatter;
 
     /**
      * The cached data for the "distinct" rule.
@@ -1467,6 +1474,19 @@ class Validator implements ValidatorContract
     public function addCustomAttributes(array $attributes)
     {
         $this->customAttributes = array_merge($this->customAttributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Set the callback used to format attributes.
+     *
+     * @param callable|null $formatter
+     * @return $this
+     */
+    public function setDefaultAttributesFormatter(?callable $formatter = null)
+    {
+        $this->defaultAttributesFormatter = $formatter;
 
         return $this;
     }

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -87,6 +87,20 @@ class ValidatorTest extends DatabaseTestCase
         $this->assertSame('name at line 1 must be a string!', $validator->getMessageBag()->all()[0]);
     }
 
+    public function testDefaultAttributeFormatting(): void
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $translator->addLines(['validation.required' => 'The :attribute field is required.'], 'en');
+        $validator = new Validator($translator, [], ['someAttribute' => 'required']);
+        $validator->setDefaultAttributesFormatter(function ($attribute) {
+            return Str::upper(Str::snake($attribute));
+        });
+
+        $validator->passes();
+
+        $this->assertSame('The SOME_ATTRIBUTE field is required.', $validator->getMessageBag()->all()[0]);
+    }
+
     protected function getValidator(array $data, array $rules)
     {
         $translator = new Translator(new ArrayLoader, 'en');


### PR DESCRIPTION
This PR adds `setDefaultAttributesFormatter` to allow for control over how attribute names are formatted in cases where the default `str_replace('_', ' ', Str::snake($attribute))` logic is not desired.

This allows for something like:

```php
Validator::make([], ['data.someAttribute' => 'required'])
    ->setDefaultAttributesFormatter(fn($attribute) => $attribute)
    ->validate()
```

Which would produce:
```
The data.someAttribute field is required.
```

Instead of:
```
The data.some attribute field is required.
```

This doesn't break existing behavior because it only applies when a `defaultAttributesFormatter` has been set on the validator.