### PR TITLE
[12.x] `RequestException`: attempt to summarize message before reporting

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -32,7 +32,7 @@ class RequestException extends HttpClientException
      *
      * @var bool
      */
-    protected $hasBeenSummarized = false;
+    public $hasBeenSummarized = false;
 
     /**
      * Create a new exception instance.

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -90,8 +90,10 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = static::$truncateAt
-            ? Message::bodySummary($response->toPsrResponse(), static::$truncateAt)
+        $truncateExceptionsAt = $this->truncateExceptionsAt ?? static::$truncateAt;
+
+        $summary = is_int($truncateExceptionsAt)
+            ? Message::bodySummary($response->toPsrResponse(), $truncateExceptionsAt)
             : Message::toString($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message . ":\n{$summary}\n";

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -28,6 +28,13 @@ class RequestException extends HttpClientException
     public static $truncateAt = 120;
 
     /**
+     * Whether the response has been summarized in the message.
+     *
+     * @var bool
+     */
+    protected $hasBeenSummarized = false;
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response
@@ -80,6 +87,10 @@ class RequestException extends HttpClientException
      */
     public function report(): void
     {
+        if ($this->hasBeenSummarized) {
+            return;
+        }
+
         $truncateExceptionsAt = $this->truncateExceptionsAt ?? static::$truncateAt;
 
         $summary = $truncateExceptionsAt
@@ -89,5 +100,7 @@ class RequestException extends HttpClientException
         if (! is_null($summary)) {
             $this->message .= ":\n{$summary}\n";
         }
+
+        $this->hasBeenSummarized = true;
     }
 }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -16,7 +16,7 @@ class RequestException extends HttpClientException
     /**
      * The current truncation length for the exception message.
      *
-     * @var int|false
+     * @var int|false|null
      */
     public $truncateExceptionsAt;
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1469,7 +1469,7 @@ class HttpClientTest extends TestCase
         $exception->report();
         $exception->report();
 
-        $this->assertStringContainsString('{"error":{"code":403,"message":"The Request can not be completed"}}', $exception->getMessage());
+        $this->assertEquals(1, substr_count($exception->getMessage(), '{"error":{"code":403,"message":"The Request can not be completed"}}')); 
     }
 
     public function testOnErrorDoesntCallClosureOnInformational()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1452,6 +1452,26 @@ class HttpClientTest extends TestCase
         throw new RequestException(new Response($response));
     }
 
+    public function testReportingExceptionTwiceDoesNotIncludeSummaryTwice()
+    {
+        RequestException::dontTruncate();
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed',
+            ],
+        ];
+
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        $exception = new RequestException(new Response($response));
+        $exception->report();
+        $exception->report();
+
+        $this->assertStringContainsString('{"error":{"code":403,"message":"The Request can not be completed"}}', $exception->getMessage());
+    }
+
     public function testOnErrorDoesntCallClosureOnInformational()
     {
         $status = 0;


### PR DESCRIPTION
For applications that were logging the RequestException's error message (but not calling `report()`) or who were using `$exception->getMessage()` in some other way:

* `str_contains($requestException->getMessage(), 'not found')`
* `throw new ShippingException($requestException->getMessage(), previous: $requestException)`

For example, if an application had set `RequestException::dontTruncate()` inside of their AppServiceProvider instead of through the callback provided to `ApplicationBuilder@exceptions()`, they would have previously had the body of the response in hand. But now, a separate method needs to be called in order to build the message.

Additionally, it's possible a RequestException could be reported twice, and in so doing would build the summary twice.

---
The benefit to just reverting the change is that we don't need users to update their configuration to use the `ApplicationBuilder@registered()` callback instead of how it's been documented. (The `Exceptions@dontTruncateRequestExceptions()` and `Exceptions@truncateRequestExceptionsAt()` would remain in the code, tho do not function as expected). If the users DO switch to using the new callback described [in this docs PR](https://github.com/laravel/docs/pull/10912), they'll actually get the full body of the payload even without having to call `RequestException@report()`

The downside here is that when exceptions are reported, they'll generate the summary twice (once upon construction, once upon reporting).