### PR TITLE
[12.x] Add windowPaginate() for single-query pagination

### DIFF
--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -96,6 +96,161 @@ class EloquentPaginateTest extends DatabaseTestCase
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
+
+    public function testPaginateUsingWindowBasicFunctionality()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::paginateUsingWindow(15);
+
+        $this->assertCount(15, $paginator);
+        $this->assertEquals(50, $paginator->total());
+        $this->assertEquals(4, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+    }
+
+    public function testPaginateUsingWindowWithCustomColumns()
+    {
+        for ($i = 1; $i <= 30; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::paginateUsingWindow(10, ['id', 'title']);
+
+        $this->assertCount(10, $paginator);
+        $this->assertEquals(30, $paginator->total());
+        $this->assertEquals(3, $paginator->lastPage());
+
+        // Verify only specified columns are returned (plus total_count is removed)
+        $firstItem = $paginator->items()[0];
+        $this->assertTrue(isset($firstItem->id));
+        $this->assertTrue(isset($firstItem->title));
+        $this->assertFalse(property_exists($firstItem, 'created_at'));
+        $this->assertFalse(property_exists($firstItem, 'total_count'));
+    }
+
+    public function testPaginateUsingWindowWithStringColumn()
+    {
+        for ($i = 1; $i <= 25; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::paginateUsingWindow(10, 'title');
+
+        $this->assertCount(10, $paginator);
+        $this->assertEquals(25, $paginator->total());
+
+        $firstItem = $paginator->items()[0];
+        $this->assertTrue(isset($firstItem->title));
+        $this->assertFalse(property_exists($firstItem, 'total_count'));
+    }
+
+    public function testPaginateUsingWindowWithSpecificPage()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::paginateUsingWindow(15, ['*'], 'page', 2);
+
+        $this->assertCount(15, $paginator);
+        $this->assertEquals(50, $paginator->total());
+        $this->assertEquals(2, $paginator->currentPage());
+        $this->assertEquals(4, $paginator->lastPage());
+    }
+
+    public function testPaginateUsingWindowWithEmptyResults()
+    {
+        $paginator = Post::where('id', '<', 0)->paginateUsingWindow(15);
+
+        $this->assertCount(0, $paginator);
+        $this->assertEquals(0, $paginator->total());
+        $this->assertEquals(1, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+    }
+
+    public function testPaginateUsingWindowWithWhereCondition()
+    {
+        for ($i = 1; $i <= 30; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::where('id', '>', 10)->paginateUsingWindow(10);
+
+        $this->assertCount(10, $paginator);
+        $this->assertEquals(20, $paginator->total());
+        $this->assertEquals(2, $paginator->lastPage());
+    }
+
+    public function testPaginateUsingWindowWithOrderBy()
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        $paginator = Post::orderBy('id', 'desc')->paginateUsingWindow(5);
+
+        $this->assertCount(5, $paginator);
+        $this->assertEquals(20, $paginator->total());
+
+        $items = $paginator->items();
+        $this->assertEquals(20, $items[0]->id);
+        $this->assertEquals(19, $items[1]->id);
+    }
+
+    public function testPaginateUsingWindowWithJoin()
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $user = User::create();
+            for ($j = 1; $j <= 4; $j++) {
+                Post::create([
+                    'title' => 'Title '.$i.'-'.$j,
+                    'user_id' => $user->id,
+                ]);
+            }
+        }
+
+        $paginator = Post::join('users', 'posts.user_id', '=', 'users.id')
+            ->paginateUsingWindow(10, ['posts.*', 'users.id as user_id']);
+
+        $this->assertCount(10, $paginator);
+        $this->assertEquals(20, $paginator->total());
+        $this->assertEquals(2, $paginator->lastPage());
+    }
+
+    public function testPaginateUsingWindowPerformanceComparison()
+    {
+        // Create a larger dataset to test performance benefit
+        for ($i = 1; $i <= 100; $i++) {
+            Post::create([
+                'title' => 'Title '.$i,
+            ]);
+        }
+
+        // Test that both methods return the same results
+        $standardPaginator = Post::paginate(20);
+        $windowPaginator = Post::paginateUsingWindow(20);
+
+        $this->assertEquals($standardPaginator->total(), $windowPaginator->total());
+        $this->assertEquals($standardPaginator->lastPage(), $windowPaginator->lastPage());
+        $this->assertEquals($standardPaginator->currentPage(), $windowPaginator->currentPage());
+        $this->assertCount(20, $standardPaginator);
+        $this->assertCount(20, $windowPaginator);
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
### What does this PR do?

Adds a new `windowPaginate()` method to Eloquent Builder that uses
SQL window functions (COUNT(*) OVER()) to fetch the total count
and page results in a single query.

### Benefits

- Reduces the need for a separate COUNT() query.
- Faster for large datasets.

### Example Usage

$users = User::query()->windowPaginate(15);