### PR TITLE
[12.x] Fix `GeneratorCommand` missing `possibleModels()` method

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -243,6 +243,18 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     }
 
     /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     *
+     * @deprecated 12.38.0 Use `findAvailableModels()` method instead.
+     */
+    protected function possibleModels()
+    {
+        return $this->findAvailableModels();
+    }
+
+    /**
      * Get a list of possible event names.
      *
      * @return array<int, string>


### PR DESCRIPTION
Regression issue introduced via #57671

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
