### PR TITLE
[12.x] Remove redundant cache->store() calls from CacheCommandMutex class

### DIFF
--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -80,7 +80,7 @@ class CacheCommandMutex implements CommandMutex
             });
         }
 
-        return $this->cache->store($this->store)->has($this->commandMutexName($command));
+        return $store->has($this->commandMutexName($command));
     }
 
     /**
@@ -97,7 +97,7 @@ class CacheCommandMutex implements CommandMutex
             return $store->getStore()->lock($this->commandMutexName($command))->forceRelease();
         }
 
-        return $this->cache->store($this->store)->forget($this->commandMutexName($command));
+        return $store->forget($this->commandMutexName($command));
     }
 
     /**


### PR DESCRIPTION
The CacheCommandMutex class has `exists` and `forget` methods. They both defines `$store` as a top block variable. So we can use `$store` through the whole methods instead of calling cache->store() again in the end within the return statement.

Please take a look at the `exists` method for more details!

```php
    public function exists($command)
    {
        $store = $this->cache->store($this->store);

        // Do something.

        // before
        return $this->cache->store($this->store)->has($this->commandMutexName($command));

        // after
        return $store->has($this->commandMutexName($command));
    }
```