### PR TITLE
[12.x] Test configurationIsCached

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -29,8 +29,7 @@ class RegisterProviders
      */
     public function bootstrap(Application $app)
     {
-        if (! $app->bound('config_loaded_from_cache') ||
-            $app->make('config_loaded_from_cache') === false) {
+        if (! $app->configurationIsCached()) {
             $this->mergeAdditionalProviders($app);
         }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -677,10 +677,11 @@ class FoundationApplicationTest extends TestCase
         $this->assertFalse($app->configurationIsCached());
 
         // A config cache file exists.
-        $app = new class extends Application {
+        $app = new class extends Application
+        {
             public function getCachedConfigPath()
             {
-                return __DIR__ . '/fixtures/cache/config.php';
+                return __DIR__.'/fixtures/cache/config.php';
             }
         };
 

--- a/tests/Foundation/fixtures/cache/config.php
+++ b/tests/Foundation/fixtures/cache/config.php
@@ -1,7 +1,7 @@
 <?php
 
-return array(
-    'app' => array(
+return [
+    'app' => [
         'name' => 'Laravel',
-    ),
-);
+    ],
+];

--- a/tests/Foundation/fixtures/cache/config.php
+++ b/tests/Foundation/fixtures/cache/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+    'app' => array(
+        'name' => 'Laravel',
+    ),
+);


### PR DESCRIPTION
The application `configurationIsCached` method is currently controlled by 2 factors:
- The "config_loaded_from_cache" abstract is bound to the container or not.
- A config cache file (usually bootstrap/cache/config.php) exists or not.

Therefore, I added some small tests here to prevent unexpected breaking changes later if any.

### a config cache file does not exist

- If "config_loaded_from_cache" is not bound to the container, `configurationIsCached` returns `false` and "config_loaded_from_cache" is implicitly set as `false`
- If "config_loaded_from_cache" is bound to the container as `true`, `configurationIsCached` returns `true`.
- If "config_loaded_from_cache" is bound to the container as `false`, `configurationIsCached` returns `false`.

### a config cache file exist

- If "config_loaded_from_cache" is not bound to the container, `configurationIsCached` returns `true` and "config_loaded_from_cache" is implicitly set as `true`
- If "config_loaded_from_cache" is bound to the container as `false`, `configurationIsCached` returns `false`.


### Plus

inside the `RegisterProviders` class, instead of accessing `config_loaded_from_cache` directly, using `configurationIsCached` is more consistent because:
- `config_loaded_from_cache` should be called with a "setter" in order to change the config cache state.

```php
$app->instance('config_loaded_from_cache', true);
```

- `configurationIsCached` should be called with a "getter" in order to check the config cache state.

```php
$app->configurationIsCached();
```