### PR TITLE
[12.x] bump symfony/http-foundation to ^7.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/console": "^7.2.0",
         "symfony/error-handler": "^7.2.0",
         "symfony/finder": "^7.2.0",
-        "symfony/http-foundation": "^7.2.0",
+        "symfony/http-foundation": "^7.3.7",
         "symfony/http-kernel": "^7.2.0",
         "symfony/mailer": "^7.2.0",
         "symfony/mime": "^7.2.0",


### PR DESCRIPTION
A CVE has been reported yesterday for `symfony/http-foundation`.

More information: https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass
