### PR TITLE
Carry `--force` to `make:test` for generators with `--test`

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -40,6 +40,7 @@ trait CreatesMatchingTest
             'name' => (new Stringable($path))->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
             '--phpunit' => $this->option('phpunit'),
+            '--force' => $this->hasOption('force') && $this->option('force'),
         ]) == 0;
     }
 }


### PR DESCRIPTION
This PR fixes that tests aren't regenerated when a generator is used with both `--test` and `--force` and the tests already exist.