### PR TITLE
Revert "[12.x] Fix setting request exception truncating doesn't work on HTTP layer when configured inside `bootstrap/app.php`"

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -14,14 +14,7 @@ class RequestException extends HttpClientException
     public $response;
 
     /**
-     * The current truncation length for the exception message.
-     *
-     * @var int|false
-     */
-    public $truncateExceptionsAt;
-
-    /**
-     * The global truncation length for the exception message.
+     * The truncation length for the exception message.
      *
      * @var int|false
      */
@@ -31,13 +24,10 @@ class RequestException extends HttpClientException
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response
-     * @param  int|false|null  $truncateExceptionsAt
      */
-    public function __construct(Response $response, $truncateExceptionsAt = null)
+    public function __construct(Response $response)
     {
-        parent::__construct("HTTP request returned status code {$response->status()}", $response->status());
-
-        $this->truncateExceptionsAt = $truncateExceptionsAt;
+        parent::__construct($this->prepareMessage($response), $response->status());
 
         $this->response = $response;
     }
@@ -76,18 +66,17 @@ class RequestException extends HttpClientException
     /**
      * Prepare the exception message.
      *
-     * @return void
+     * @param  \Illuminate\Http\Client\Response  $response
+     * @return string
      */
-    public function report(): void
+    protected function prepareMessage(Response $response)
     {
-        $truncateExceptionsAt = $this->truncateExceptionsAt ?? static::$truncateAt;
+        $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = $truncateExceptionsAt
-            ? Message::bodySummary($this->response->toPsrResponse(), $truncateExceptionsAt)
-            : Message::toString($this->response->toPsrResponse());
+        $summary = static::$truncateAt
+            ? Message::bodySummary($response->toPsrResponse(), static::$truncateAt)
+            : Message::toString($response->toPsrResponse());
 
-        if (! is_null($summary)) {
-            $this->message .= ":\n{$summary}\n";
-        }
+        return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }
 }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -304,7 +304,19 @@ class Response implements ArrayAccess, Stringable
     public function toException()
     {
         if ($this->failed()) {
-            return new RequestException($this, $this->truncateExceptionsAt);
+            $originalTruncateAt = RequestException::$truncateAt;
+
+            try {
+                if ($this->truncateExceptionsAt !== null) {
+                    $this->truncateExceptionsAt === false
+                        ? RequestException::dontTruncate()
+                        : RequestException::truncateAt($this->truncateExceptionsAt);
+                }
+
+                return new RequestException($this);
+            } finally {
+                RequestException::$truncateAt = $originalTruncateAt;
+            }
         }
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1301,10 +1301,9 @@ class HttpClientTest extends TestCase
                 'message' => 'The Request can not be completed',
             ],
         ];
-
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
+        throw new RequestException(new Response($response));
     }
 
     public function testRequestExceptionTruncatedSummary()
@@ -1320,7 +1319,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
+        throw new RequestException(new Response($response));
     }
 
     public function testRequestExceptionWithoutTruncatedSummary()
@@ -1338,7 +1337,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
+        throw new RequestException(new Response($response));
     }
 
     public function testRequestExceptionWithCustomTruncatedSummary()
@@ -1356,7 +1355,7 @@ class HttpClientTest extends TestCase
         ];
         $response = new Psr7Response(403, [], json_encode($error));
 
-        throw tap(new RequestException(new Response($response)), fn ($exception) => $exception->report());
+        throw new RequestException(new Response($response));
     }
 
     public function testRequestLevelTruncationLevelOnRequestException()
@@ -1373,8 +1372,6 @@ class HttpClientTest extends TestCase
         } catch (RequestException $e) {
             $exception = $e;
         }
-
-        $exception->report();
 
         $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
@@ -1397,8 +1394,6 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
-        $exception->report();
-
         $this->assertEquals("HTTP request returned status code 403:\nHTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\n\r\n[\"error\"]\n", $exception->getMessage());
 
         $this->assertEquals(60, RequestException::$truncateAt);
@@ -1419,8 +1414,6 @@ class HttpClientTest extends TestCase
             $exception = $e;
         }
 
-        $exception->report();
-
         $this->assertEquals("HTTP request returned status code 403:\n[\"e (truncated...)\n", $exception->getMessage());
 
         $this->assertFalse(RequestException::$truncateAt);
@@ -1434,8 +1427,6 @@ class HttpClientTest extends TestCase
         ]);
 
         $exception = $this->factory->async()->throw()->truncateExceptionsAt(4)->get('http://foo.com/json')->wait();
-
-        $exception->report();
 
         $this->assertInstanceOf(RequestException::class, $exception);
         $this->assertEquals("HTTP request returned status code 403:\n[\"er (truncated...)\n", $exception->getMessage());


### PR DESCRIPTION
Reverts laravel/framework#57759

PR to update the documentation with ~~correct~~ working example: https://github.com/laravel/docs/pull/10912