### PR TITLE
[12.x] Fix `WithCachedConfig` to work with parallel test runs

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends BaseTestCase
 
         if (isset(CachedState::$cachedConfig) &&
             isset($this->traitsUsedByTest[WithCachedConfig::class])) {
-            $this->markConfigCached($app);
+            $app->booting(fn () => $this->markConfigCached($app));
         }
 
         if (isset(CachedState::$cachedRoutes) &&

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends BaseTestCase
 
         if (isset(CachedState::$cachedConfig) &&
             isset($this->traitsUsedByTest[WithCachedConfig::class])) {
-            $app->booting(fn () => $this->markConfigCached($app));
+            fn () => $this->markConfigCached($app);
         }
 
         if (isset(CachedState::$cachedRoutes) &&

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends BaseTestCase
 
         if (isset(CachedState::$cachedConfig) &&
             isset($this->traitsUsedByTest[WithCachedConfig::class])) {
-            fn () => $this->markConfigCached($app);
+            $this->markConfigCached($app);
         }
 
         if (isset(CachedState::$cachedRoutes) &&

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -20,6 +20,13 @@ trait TestDatabases
     protected static $schemaIsUpToDate = false;
 
     /**
+     * The root database name prior to concatenating the token.
+     *
+     * @var null|string
+     */
+    protected static $originalDatabaseName = null;
+
+    /**
      * Boot a test database.
      *
      * @return void
@@ -186,6 +193,12 @@ trait TestDatabases
      */
     protected function testDatabase($database)
     {
+        if (! isset(self::$originalDatabaseName)) {
+            self::$originalDatabaseName = $database;
+        } else {
+            $database = self::$originalDatabaseName;
+        }
+
         $token = ParallelTesting::token();
 
         return "{$database}_test_{$token}";


### PR DESCRIPTION
I'll be honest, I'm not entirely sure why this has fixed the problem described here. https://github.com/laravel/framework/pull/57663#issuecomment-3528728561 I've stepped through this many times and I am still lost about what this change is preventing from happening. I can see it has something to do with caching the config before calling the parallel testing provider, but... yeah, I'm still a touch confused.

For whatever it's worth, I _thought_ that I wanted to set the application to cached before booting to avoid a disk read on LoadEnvironmentVariables, however, TIL that Env keeps a static instance of the environment variables stored. Turns out that wasn't necessary.

Thanks to @santigarcor for bringing this to my attention.