### PR TITLE
Add Queue Pause/Resume Feature

### DIFF
--- a/src/Illuminate/Contracts/Queue/Factory.php
+++ b/src/Illuminate/Contracts/Queue/Factory.php
@@ -11,4 +11,36 @@ interface Factory
      * @return \Illuminate\Contracts\Queue\Queue
      */
     public function connection($name = null);
+
+    /**
+     * Pause a queue by name.
+     *
+     * @param  string  $queue
+     * @param  int  $ttl
+     * @return void
+     */
+    public function pause($queue, $ttl = 86400);
+
+    /**
+     * Resume a paused queue by name.
+     *
+     * @param  string  $queue
+     * @return void
+     */
+    public function resume($queue);
+
+    /**
+     * Determine if a queue is paused.
+     *
+     * @param  string  $queue
+     * @return bool
+     */
+    public function isPaused($queue);
+
+    /**
+     * Get all paused queues.
+     *
+     * @return array
+     */
+    public function getPausedQueues();
 }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -97,9 +97,12 @@ use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
 use Illuminate\Queue\Console\ListenCommand as QueueListenCommand;
 use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
 use Illuminate\Queue\Console\MonitorCommand as QueueMonitorCommand;
+use Illuminate\Queue\Console\PauseCommand as QueuePauseCommand;
+use Illuminate\Queue\Console\PauseListCommand as QueuePauseListCommand;
 use Illuminate\Queue\Console\PruneBatchesCommand as QueuePruneBatchesCommand;
 use Illuminate\Queue\Console\PruneFailedJobsCommand as QueuePruneFailedJobsCommand;
 use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
+use Illuminate\Queue\Console\ResumeCommand as QueueResumeCommand;
 use Illuminate\Queue\Console\RetryBatchCommand as QueueRetryBatchCommand;
 use Illuminate\Queue\Console\RetryCommand as QueueRetryCommand;
 use Illuminate\Queue\Console\TableCommand;
@@ -150,9 +153,12 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueForget' => ForgetFailedQueueCommand::class,
         'QueueListen' => QueueListenCommand::class,
         'QueueMonitor' => QueueMonitorCommand::class,
+        'QueuePause' => QueuePauseCommand::class,
+        'QueuePauseList' => QueuePauseListCommand::class,
         'QueuePruneBatches' => QueuePruneBatchesCommand::class,
         'QueuePruneFailedJobs' => QueuePruneFailedJobsCommand::class,
         'QueueRestart' => QueueRestartCommand::class,
+        'QueueResume' => QueueResumeCommand::class,
         'QueueRetry' => QueueRetryCommand::class,
         'QueueRetryBatch' => QueueRetryBatchCommand::class,
         'QueueWork' => QueueWorkCommand::class,

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'queue:pause')]
+class PauseCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:pause {queue : The name of the queue to pause}
+                                       {--ttl=86400 : The TTL for the pause in seconds}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pause processing for a specific queue';
+
+    /**
+     * The queue manager instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Factory
+     */
+    protected $manager;
+
+    /**
+     * Create a new queue pause command.
+     *
+     * @param  \Illuminate\Contracts\Queue\Factory  $manager
+     */
+    public function __construct(QueueManager $manager)
+    {
+        parent::__construct();
+
+        $this->manager = $manager;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $queue = $this->argument('queue');
+        $ttl = (int) $this->option('ttl');
+
+        $this->manager->pause($queue, $ttl);
+
+        $this->components->info("Queue [{$queue}] has been paused.");
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Queue/Console/PauseListCommand.php
+++ b/src/Illuminate/Queue/Console/PauseListCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'queue:pause:list')]
+class PauseListCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:pause:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all currently paused queues';
+
+    /**
+     * The queue manager instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Factory
+     */
+    protected $manager;
+
+    /**
+     * Create a new queue pause list command.
+     *
+     * @param  \Illuminate\Contracts\Queue\Factory  $manager
+     */
+    public function __construct(QueueManager $manager)
+    {
+        parent::__construct();
+
+        $this->manager = $manager;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $pausedQueues = $this->manager->getPausedQueues();
+
+        if (empty($pausedQueues)) {
+            $this->components->info('No queues are currently paused.');
+
+            return 0;
+        }
+
+        $this->components->info('Paused Queues:');
+
+        $this->table(
+            ['Queue Name'],
+            collect($pausedQueues)->map(fn ($queue) => [$queue])->toArray()
+        );
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Queue/Console/ResumeCommand.php
+++ b/src/Illuminate/Queue/Console/ResumeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'queue:resume')]
+class ResumeCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:resume {queue : The name of the queue to resume}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Resume processing for a paused queue';
+
+    /**
+     * The queue manager instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Factory
+     */
+    protected $manager;
+
+    /**
+     * Create a new queue resume command.
+     *
+     * @param  \Illuminate\Contracts\Queue\Factory  $manager
+     */
+    public function __construct(QueueManager $manager)
+    {
+        parent::__construct();
+
+        $this->manager = $manager;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $queue = $this->argument('queue');
+
+        if (! $this->manager->isPaused($queue)) {
+            $this->components->warn("Queue [{$queue}] is not paused.");
+
+            return 1;
+        }
+
+        $this->manager->resume($queue);
+
+        $this->components->info("Queue [{$queue}] has been resumed.");
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -372,6 +372,11 @@ class Worker
             }
 
             foreach (explode(',', $queue) as $index => $queue) {
+                // Skip paused queues
+                if ($this->isQueuePaused($queue)) {
+                    continue;
+                }
+
                 if (! is_null($job = $popJobCallback($queue, $index))) {
                     $this->raiseAfterJobPopEvent($connection->getConnectionName(), $job);
 
@@ -385,6 +390,21 @@ class Worker
 
             $this->sleep(1);
         }
+    }
+
+    /**
+     * Determine if a queue is paused.
+     *
+     * @param  string  $queue
+     * @return bool
+     */
+    protected function isQueuePaused($queue)
+    {
+        if (! $this->cache) {
+            return false;
+        }
+
+        return (bool) $this->cache->get("queue_paused:{$queue}", false);
     }
 
     /**


### PR DESCRIPTION
# Problem

There is no way to pause a single queue in Laravel.
If you want to stop one queue, you must stop **all queue workers** — this halts **all queues**, not just the one you need to pause.

---

# Solution

Add **queue pause and resume** functionality.
Workers will skip paused queues but continue processing other queues.

---

```php
Queue::pause('emails');
Queue::resume('emails');
Queue::isPaused('emails');
```

### Artisan Commands

```bash
php artisan queue:pause emails
php artisan queue:resume emails
php artisan queue:pause:list
```

---

# How It Works

* Pause status stored in cache
* Workers check cache before processing each queue
* Paused queues are skipped
* Jobs remain in queue until resumed
* Works with all queue drivers

---

# Benefits

* No lost jobs
* Other queues keep working
* Simple to use
* No breaking changes

---

# Example

```php
Queue::pause('emails');
// Perform maintenance
Queue::resume('emails');
```

This feature provides **better queue control** without stopping all workers.
