### PR TITLE
[12.x] create new `@hasStack` Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -138,6 +138,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the has-stack statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileHasStack($expression)
+    {
+        return "<?php if (! \$__env->isStackEmpty{$expression}): ?>";
+    }
+
+    /**
      * Compile the section-missing statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -148,7 +148,7 @@ trait ManagesStacks
      */
     public function yieldPushContent($section, $default = '')
     {
-        if (! isset($this->pushes[$section]) && ! isset($this->prepends[$section])) {
+        if ($this->isStackEmpty($section)) {
             return $default;
         }
 
@@ -163,6 +163,14 @@ trait ManagesStacks
         }
 
         return $output;
+    }
+
+    /**
+     * Determine if the stack has any content in it.
+     */
+    public function isStackEmpty(string $section): bool
+    {
+        return ! isset($this->pushes[$section]) && ! isset($this->prepends[$section]);
     }
 
     /**

--- a/tests/View/Blade/BladeHasStackTest.php
+++ b/tests/View/Blade/BladeHasStackTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeHasStackTest extends AbstractBladeTestCase
+{
+    public function testHasStackStatementsAreCompiled()
+    {
+        $string = '@hasStack("stack")
+breeze
+@endif';
+        $expected = '<?php if (! $__env->isStackEmpty("stack")): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Concerns/ManagesStacksTest.php
+++ b/tests/View/Concerns/ManagesStacksTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\View\Concerns;
+
+use Illuminate\View\Concerns\ManagesStacks;
+use PHPUnit\Framework\TestCase;
+
+class ManagesStacksTest extends TestCase
+{
+    public function testStackIsEmpty()
+    {
+        $this->assertTrue((new FakeViewFactory)->isStackEmpty('my-stack'));
+    }
+
+    public function testStackIsNotEmptyWithPushedContent()
+    {
+        $object = new FakeViewFactory;
+        $object->startPush('my-stack', 'some pushed content');
+
+        $this->assertFalse($object->isStackEmpty('my-stack'));
+    }
+
+    public function testStackIsNotEmptyWithPrependedContent()
+    {
+        $object = new FakeViewFactory;
+        $object->startPrepend('my-stack', 'some prepended content');
+
+        $this->assertFalse($object->isStackEmpty('my-stack'));
+    }
+}
+
+class FakeViewFactory {
+
+    use ManagesStacks;
+
+    protected int $renderCount = 0;
+}

--- a/tests/View/Concerns/ManagesStacksTest.php
+++ b/tests/View/Concerns/ManagesStacksTest.php
@@ -29,8 +29,8 @@ class ManagesStacksTest extends TestCase
     }
 }
 
-class FakeViewFactory {
-
+class FakeViewFactory
+{
     use ManagesStacks;
 
     protected int $renderCount = 0;


### PR DESCRIPTION
this new `@hasStack` directive can be used to wrap `@stack` directives for conditional output depending on if the stack is empty or not. this can be useful if you want some wrapping code around the stack only if it is not empty.

```blade
@hasstack('list')
    <ul>
        @stack('list')
    </ul>
@endif
```

if you pass content to the stack

```blade
@push('list')
    <li>Item 1</li>
@endpush
```

you will get the output

```html
<ul>
    <li>Item 1</li>
</ul>
```

but if nothing gets pushed, you'll get **no** output.  this helps avoid the orphaned DOM you may have settled for previously.  also helps avoid extra spacing you may have had previously due to `gap` styling on a parent element.

mimicked the `@hasSection` directive for naming.