### PR TITLE
[12.x] Add `disableConfigCache` method to the `WithCachedConfig` trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CachedState.php
+++ b/src/Illuminate/Foundation/Testing/CachedState.php
@@ -4,6 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 class CachedState
 {
-    public static array $cachedRoutes;
-    public static array $cachedConfig;
+    public static ?array $cachedRoutes = null;
+    public static ?array $cachedConfig = null;
 }

--- a/src/Illuminate/Foundation/Testing/WithCachedConfig.php
+++ b/src/Illuminate/Foundation/Testing/WithCachedConfig.php
@@ -38,4 +38,19 @@ trait WithCachedConfig
 
         LoadConfiguration::alwaysUse(static fn () => CachedState::$cachedConfig);
     }
+
+    /**
+     * Disable the configuration cache for the current test.
+     *
+     * @return $this
+     */
+    protected function disableConfigCache()
+    {
+        $this->app->instance('config_loaded_from_cache', false);
+
+        CachedState::$cachedConfig = null;
+        LoadConfiguration::alwaysUse(null);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This addition is a follow-up to #57663 and makes it possible to use `WithCachedConfig` in the base `TestCase` and disable it for certain tests that override the ENV or Config.

For example for these two test examples which fail without the `disableConfigCache`:

```php
<?php declare(strict_types=1);

namespace Tests\Unit;

use Illuminate\Contracts\Encryption\DecryptException;
use PHPUnit\Framework\Attributes\Test;
use Tests\TestCase;

final class EncrypterTest extends TestCase
{
    private string $originalAppKey;
    private string $oldAppKey;

    protected function setUp(): void
    {
        parent::setUp();

        $this->disableConfigCache();

        $this->oldAppKey = 'A6Ic4cFVOr5veD9TferaIhgDyNnqz3eq';
        /** @phpstan-ignore disallowed.function */
        putenv('APP_PREVIOUS_KEYS=' . $this->oldAppKey);
        $this->originalAppKey = config('app.key');
    }

    protected function tearDown(): void
    {
        $this->setAppKeyAndClearEncrypterInstance($this->originalAppKey);

        parent::tearDown();
    }

    #[Test]
    public function it_can_encrypt_and_decrypt_using_regular_app_key(): void
    {
        $payload = fake()->text();

        $encrypted = encrypt($payload);

        self::assertNotSame($encrypted, $payload);

        $decrypted = decrypt($encrypted);

        self::assertSame($decrypted, $payload);
    }

    #[Test]
    public function it_can_decrypt_payload_with_old_app_key(): void
    {
        $payload = fake()->text();

        $this->setAppKeyAndClearEncrypterInstance($this->oldAppKey);

        $encrypted = encrypt($payload);

        self::assertNotSame($encrypted, $payload);

        $this->setAppKeyAndClearEncrypterInstance($this->originalAppKey);

        $decrypted = decrypt($encrypted);

        self::assertSame($decrypted, $payload);
    }

    #[Test]
    public function decrypting_payload_with_invalid_old_app_key_throws_exception(): void
    {
        $payload = fake()->text();

        $this->expectException(DecryptException::class);

        $incorrectOldAppKey = 'd5So7vPWLw9dnR2UfswmJidBpEhyr5tq';

        $this->setAppKeyAndClearEncrypterInstance($incorrectOldAppKey);

        $encrypted = encrypt($payload);

        self::assertNotSame($encrypted, $payload);

        $this->setAppKeyAndClearEncrypterInstance($this->originalAppKey);

        decrypt($encrypted);
    }

    private function setAppKeyAndClearEncrypterInstance(string $appKey): void
    {
        config()->set('app.key', $appKey);

        app()->forgetInstance('encrypter');
    }
}

```

And

```php
<?php declare(strict_types=1);

namespace Tests\Unit;

use Illuminate\Foundation\Console\PackageDiscoverCommand;
use Illuminate\Support\Env;
use Illuminate\Testing\PendingCommand;
use PHPUnit\Framework\Attributes\Test;
use Tests\TestCase;

final class CreateProjectTest extends TestCase
{
    private string $appKey;

    protected function setUp(): void
    {
        parent::setUp();

        $this->disableConfigCache();

        $this->appKey = config('app.key');

        Env::enablePutenv();

        /** @phpstan-ignore disallowed.function */
        putenv('APP_KEY=');
        $_SERVER['APP_KEY'] = null;
        $_ENV['APP_KEY'] = null;

        $this->refreshApplication();
    }

    protected function assertPreConditions(): void
    {
        self::assertEmpty(config('app.key'));
    }

    protected function tearDown(): void
    {
        parent::tearDown();

        /** @phpstan-ignore disallowed.function */
        putenv('APP_KEY=' . $this->appKey);
        $_SERVER['APP_KEY'] = $this->appKey;
        $_ENV['APP_KEY'] = $this->appKey;
    }

    #[Test]
    public function it_can_discover_packages_without_an_app_key_set(): void
    {
        $pendingCommand = $this->artisan(PackageDiscoverCommand::class);

        if (! $pendingCommand instanceof PendingCommand) {
            throw new \RuntimeException('Expecting to mockConsoleOutput');
        }

        $pendingCommand->assertSuccessful();
    }
}

```