### PR TITLE
[12.x] Enhancement: Enable wildcard support in Console Command directory registration

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -353,7 +353,7 @@ class Kernel implements KernelContract
         $paths = array_unique(Arr::wrap($paths));
 
         $paths = array_filter($paths, function ($path) {
-            return is_dir($path);
+            return is_dir($path) || glob($path, GLOB_ONLYDIR) !== false;
         });
 
         if (empty($paths)) {


### PR DESCRIPTION
This PR is a simple nice-to-have, to keep Command directory registration clean. Admittedly, the same result can easily be achieved within a developers own codebase.

While the `Finder::class` supports wildcards, the initial directory check, which uses the standard `is_dir()` method, filters out entries attempting the use of wildcards.

**Example cases**

Within `bootstrap/app.php`, you might be using something like:
```php
->withCommands([
    __DIR__ . '/../app/Domain/Subdirectory1/Commands',
    __DIR__ . '/../app/Domain/Subdirectory2/Commands',
    __DIR__ . '/../app/Domain/Subdirectory3/Commands',
    __DIR__ . '/../app/Domain/Subdirectory4/Commands',
    __DIR__ . '/../app/Domain/Subdirectory5/Commands',
])
```
or 
```php
->withCommands([
    ...(glob(__DIR__ . '/../app/Domain/*/Commands', GLOB_ONLYDIR) ?: []),
])
```

This PR would allow something a little lighter:
```php
->withCommands([
    __DIR__ . '/../app/Domain/*/Commands',
])
```

Similarly, within the Console Kernel file, you could do the same:
```php
$this->load([
    __DIR__ . '/Commands',
    __DIR__ . '/../Domain/*/Commands',
]);
```

