### PR TITLE
[12.x] make setting multiple aliases at once possible

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -27,13 +27,10 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
 
         $this->registerBatchServices();
 
-        $this->app->alias(
-            Dispatcher::class, DispatcherContract::class
-        );
-
-        $this->app->alias(
-            Dispatcher::class, QueueingDispatcherContract::class
-        );
+        $this->app->alias(Dispatcher::class, [
+            DispatcherContract::class,
+            QueueingDispatcherContract::class,
+        ]);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Contracts\Container\SelfBuilding;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use LogicException;
 use ReflectionAttribute;
@@ -718,22 +719,24 @@ class Container implements ArrayAccess, ContainerContract
      * Alias a type to a different name.
      *
      * @param  string  $abstract
-     * @param  string  $alias
+     * @param  array|string  $aliases
      * @return void
      *
      * @throws \LogicException
      */
-    public function alias($abstract, $alias)
+    public function alias($abstract, $aliases)
     {
-        if ($alias === $abstract) {
-            throw new LogicException("[{$abstract}] is aliased to itself.");
+        foreach (Arr::wrap($aliases) as $alias) {
+            if ($alias === $abstract) {
+                throw new LogicException("[{$abstract}] is aliased to itself.");
+            }
+
+            $this->removeAbstractAlias($alias);
+
+            $this->aliases[$alias] = $abstract;
+
+            $this->abstractAliases[$abstract][] = $alias;
         }
-
-        $this->removeAbstractAlias($alias);
-
-        $this->aliases[$alias] = $abstract;
-
-        $this->abstractAliases[$abstract][] = $alias;
     }
 
     /**

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -29,12 +29,12 @@ interface Container extends ContainerInterface
      * Alias a type to a different name.
      *
      * @param  string  $abstract
-     * @param  string  $alias
+     * @param  array|string  $aliases
      * @return void
      *
      * @throws \LogicException
      */
-    public function alias($abstract, $alias);
+    public function alias($abstract, $aliases);
 
     /**
      * Assign a set of tags to a given binding.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1674,9 +1674,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             'validator' => [\Illuminate\Validation\Factory::class, \Illuminate\Contracts\Validation\Factory::class],
             'view' => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ] as $key => $aliases) {
-            foreach ($aliases as $alias) {
-                $this->alias($key, $alias);
-            }
+            $this->alias($key, $aliases);
         }
     }
 

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -33,12 +33,9 @@ class NotificationServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ChannelManager::class, fn ($app) => new ChannelManager($app));
 
-        $this->app->alias(
-            ChannelManager::class, DispatcherContract::class
-        );
-
-        $this->app->alias(
-            ChannelManager::class, FactoryContract::class
-        );
+        $this->app->alias(ChannelManager::class, [
+            DispatcherContract::class,
+            FactoryContract::class,
+        ]);
     }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -263,9 +263,12 @@ class ContainerTest extends TestCase
         $container['foo'] = 'bar';
         $container->alias('foo', 'baz');
         $container->alias('baz', 'bat');
+        $container->alias('bat', ['waldo', 'fred']);
         $this->assertSame('bar', $container->make('foo'));
         $this->assertSame('bar', $container->make('baz'));
         $this->assertSame('bar', $container->make('bat'));
+        $this->assertSame('bar', $container->make('waldo'));
+        $this->assertSame('bar', $container->make('fred'));
     }
 
     public function testAliasesWithArrayOfParameters()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Being able to set multiple aliases for a binding with a single call is convenient, this PR accomplishes that and does not break any existing code.
