### PR TITLE
[12.x] Fix `Factory@insert()` to allow for array casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,7 @@ abstract class Factory
         $query = $model->newQueryWithoutScopes();
 
         $query->fillAndInsert(
-            $madeCollection->map(fn (Model $model) => $model->getAttributes())->all()
+            $madeCollection->withoutAppends()->map(fn (Model $model) => $model->attributesToArray())->all()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,10 @@ abstract class Factory
         $query = $model->newQueryWithoutScopes();
 
         $query->fillAndInsert(
-            $madeCollection->withoutAppends()->map(fn (Model $model) => $model->attributesToArray())->all()
+            $madeCollection->withoutAppends()
+                ->setHidden([])
+                ->map(static fn (Model $model) => $model->attributesToArray())
+                ->all()
         );
     }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -1012,6 +1012,18 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertEquals('abc', $userModel->options);
     }
 
+    public function test_factory_can_insert_with_array_casts()
+    {
+        (new FactoryTestUserWithArrayFactory())->count(2)->insert();
+        $users = DB::table('users')->get();
+        foreach($users as $user) {
+            $this->assertEquals(['rtj'], json_decode($user->options, true));
+            $createdAt = Carbon::parse($user->created_at);
+            $updatedAt = Carbon::parse($user->updated_at);
+            $this->assertEquals($updatedAt, $createdAt);
+        }
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -1233,6 +1245,28 @@ class FactoryTestUseFactoryAttribute extends Eloquent
 {
     use HasFactory;
 }
+
+class FactoryTestUserWithArray extends Eloquent
+{
+    protected $table = 'users';
+    protected function casts()
+    {
+        return ['options' => 'array'];
+    }
+}
+
+class FactoryTestUserWithArrayFactory extends Factory
+{
+    protected $model = FactoryTestUserWithArray::class;
+    public function definition()
+    {
+        return [
+            'name' => 'killer mike',
+            'options' => ['rtj'],
+        ];
+    }
+}
+
 
 enum Name: string
 {


### PR DESCRIPTION
This fix stops double quoting JSON arrays when using `Factory@insert()`.

---
Thanks to @zepfietje for reporting this issue and providing reproduction steps. 🙇 https://github.com/laravel/framework/pull/57600#issuecomment-3532265736

@riesjart You had mentioned there were multiple reasons for not using `$model->toArray()` in [your PR](https://github.com/laravel/framework/pull/57670#issue-3588418310). Do you see any issue with this change? 