### PR TITLE
Add `--middleware` filter to `route:list`

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -268,6 +268,7 @@ class RouteListCommand extends Command
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||
+            ($this->option('middleware') && ! Str::contains($route['middleware'], $this->option('middleware'))) ||
             ($this->option('except-vendor') && $route['vendor']) ||
             ($this->option('only-vendor') && ! $route['vendor'])) {
             return;
@@ -500,6 +501,7 @@ class RouteListCommand extends Command
             ['action', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by action'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
+            ['middleware', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by middleware'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -190,4 +190,14 @@ class RouteListCommandTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
+
+    public function testFilterByMiddleware()
+    {
+        $this->app->call('route:list', ['--json' => true, '--middleware' => 'auth']);
+        $output = $this->app->output();
+
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+
+        $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
+    }
 }

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -193,7 +193,7 @@ class RouteListCommandTest extends TestCase
 
     public function testFilterByMiddleware()
     {
-        $this->app->call('route:list', ['--json' => true, '--middleware' => 'auth']);
+        $this->app->call('route:list', ['--json' => true, '-v' => true, '--middleware' => 'auth']);
         $output = $this->app->output();
 
         $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';


### PR DESCRIPTION
This adds a `--middleware` option to filter the `route:list` output by middleware. This can be a single middleware class name or a middleware group name. Like the other filters, it is a simple string contains check. So partial searches are accepted.

```sh
php artisan route:list --middleware=api
php artisan route:list --middleware=ThrottleRequests
```

Note, to filter by middleware within a middleware group, you may need to increase the verbosity with the `-v` or `-vv` option - just as you would to display middleware in the output.

```sh
php artisan route:list -vv --middleware='App\Http\Middleware\ForcePageCache'
```