### PR TITLE
Add Base64 Validation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -688,6 +688,31 @@ class Str
     }
 
     /**
+     * Determine if a given value is valid Base64.
+     *
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
+     */
+    public static function isBase64($value)
+    {
+        if (! is_string($value) || $value === '') {
+            return false;
+        }
+
+        if (! preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $value)) {
+            return false;
+        }
+
+        $decoded = base64_decode($value, true);
+        if ($decoded === false) {
+            return false;
+        }
+        return base64_encode($decoded) === $value;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -444,6 +444,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string is valid Base64.
+     *
+     * @return bool
+     */
+    public function isBase64()
+    {
+        return Str::isBase64($this->value);
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -726,6 +726,19 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isMatch(['/^[a-zA-Z,!]+$/', '/^(.*(.*(.*)))/'], 'Hello, Laravel!'));
     }
 
+    public function testIsBase64()
+    {
+        $this->assertTrue(Str::isBase64('SGVsbG8gV29ybGQ='));
+        $this->assertTrue(Str::isBase64('TGFyYXZlbA=='));
+
+        $this->assertFalse(Str::isBase64(''));
+        $this->assertFalse(Str::isBase64('invalid!!!'));
+
+        $this->assertFalse(Str::isBase64(null));
+        $this->assertFalse(Str::isBase64([]));
+        $this->assertFalse(Str::isBase64(123));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -7,6 +7,7 @@ use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
@@ -999,6 +1000,17 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable($multilineValue)->is('use Exception;'));
         $this->assertFalse($this->stringable($multilineValue)->is('use Exception;*'));
         $this->assertTrue($this->stringable($multilineValue)->is('*use Exception;'));
+    }
+
+    public function testIsBase64()
+    {
+        $this->assertTrue($this->stringable('SGVsbG8gV29ybGQ=')->isBase64());
+        $this->assertTrue($this->stringable('TGFyYXZlbA==')->isBase64());
+
+        $this->assertFalse($this->stringable('')->isBase64());
+        $this->assertFalse($this->stringable('invalid!!!')->isBase64());
+        $this->assertFalse($this->stringable('Hello World')->isBase64());
+        $this->assertFalse($this->stringable(null)->isBase64());
     }
 
     public function testKebab()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -7,7 +7,6 @@ use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;


### PR DESCRIPTION
This PR introduces the `Str::isBase64()` helper method to validate Base64 strings.

This helper is useful for validating API file uploads, JSON payloads and other base64 encoded data before decoding. 