### PR TITLE
[12.x] Fix creating and filling a model instance twice for every record

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1396,7 +1396,7 @@ class Builder implements BuilderContract
      * @param  array  $values
      * @return array
      */
-    protected function addUniqueIdsToUpsertValues(array $values)
+    public function addUniqueIdsToUpsertValues(array $values)
     {
         if (! $this->model->usesUniqueIds()) {
             return $values;
@@ -1419,7 +1419,7 @@ class Builder implements BuilderContract
      * @param  array  $values
      * @return array
      */
-    protected function addTimestampsToUpsertValues(array $values)
+    public function addTimestampsToUpsertValues(array $values)
     {
         if (! $this->model->usesTimestamps()) {
             return $values;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1971,7 +1971,7 @@ trait HasAttributes
      *
      * @return array
      */
-    protected function getAttributesForInsert()
+    public function getAttributesForInsert()
     {
         return $this->getAttributes();
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -471,7 +471,7 @@ abstract class Factory
         $query = $model->newQueryWithoutScopes();
 
         $query->fillAndInsert(
-            $madeCollection->map(fn (Model $model) => $model->getAttributes())->all()
+            $madeCollection->map(fn (Model $model) => $model->getAttributesForInsert())->all()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -470,9 +470,13 @@ abstract class Factory
 
         $query = $model->newQueryWithoutScopes();
 
-        $query->fillAndInsert(
-            $madeCollection->map(fn (Model $model) => $model->getAttributesForInsert())->all()
-        );
+        $values = $madeCollection->map(fn (Model $model) => $model->getAttributesForInsert())
+            ->all();
+
+        $values = $query->addUniqueIdsToUpsertValues($values);
+        $values = $query->addTimestampsToUpsertValues($values);
+
+        $query->insert($values);
     }
 
     /**


### PR DESCRIPTION
The new Eloquent `Factory::insert()` method currently instantiates and fills a model twice for every record, which I think seems inefficient. More importantly it unnecessarily casts raw attribute values back and forth to eventually insert them, which I think is an anti-pattern. 

One of the issues this causes has been pointed out [here](https://github.com/laravel/framework/pull/57600#issuecomment-3532265736). This PR aims to fix this issue of double quoting of array casted JSON columns, as an alternative to #57794.