### PR TITLE
add route that only binds deleted data, abort when data is not soft deleted

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2222,6 +2222,18 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Retrieve the trashed model for a bound value.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveTrashedRouteBinding($value, $field = null)
+    {
+        return $this->resolveRouteBindingQuery($this, $value, $field)->onlyTrashed()->first();
+    }
+
+    /**
      * Retrieve the child model for a bound value.
      *
      * @param  string  $childType
@@ -2245,6 +2257,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function resolveSoftDeletableChildRouteBinding($childType, $value, $field)
     {
         return $this->resolveChildRouteBindingQuery($childType, $value, $field)->withTrashed()->first();
+    }
+
+    /**
+     * Retrieve the child trashed model for a bound value.
+     *
+     * @param  string  $childType
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveTrashedChildRouteBinding($childType, $value, $field)
+    {
+        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->onlyTrashed()->first();
     }
 
     /**

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -177,6 +177,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
                 'withTrashed' => $route->allowsTrashedBindings(),
+                'onlyTrashed' => $route->allowsOnlyTrashedBindings(),
             ];
         }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -298,7 +298,8 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null)
-            ->withTrashed($attributes['withTrashed'] ?? false);
+            ->withTrashed($attributes['withTrashed'] ?? false)
+            ->onlyTrashed($attributes['onlyTrashed'] ?? false);
     }
 
     /**

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -294,6 +294,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Define which routes should allow "only trashed" models to be retrieved when resolving implicit model bindings.
+     *
+     * @param  array  $methods
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function onlyTrashed(array $methods = [])
+    {
+        $this->options['onlyTrashed'] = $methods;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -129,6 +129,11 @@ class ResourceRegistrar
                 $route->withTrashed();
             }
 
+            if (isset($options['onlyTrashed']) &&
+                in_array($m, ! empty($options['onlyTrashed']) ? $options['onlyTrashed'] : array_intersect($resourceMethods, ['show', 'edit', 'update']))) {
+                $route->onlyTrashed();
+            }
+
             $collection->add($route);
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -109,6 +109,12 @@ class Route
     protected $withTrashedBindings = false;
 
     /**
+     * Indicates "only trashed" models can be retrieved when resolving implicit model bindings for this route.
+     *
+     * @var bool
+     */
+    protected $onlyTrashedBindings = false;
+    /**
      * Indicates the maximum number of seconds the route should acquire a session lock for.
      *
      * @var int|null
@@ -619,6 +625,29 @@ class Route
     public function allowsTrashedBindings()
     {
         return $this->withTrashedBindings;
+    }
+
+    /**
+     * Allow "only trashed" models to be retrieved when resolving implicit model bindings for this route.
+     *
+     * @param  bool  $onlyTrashed
+     * @return $this
+     */
+    public function onlyTrashed($onlyTrashed = true)
+    {
+        $this->onlyTrashedBindings = $onlyTrashed;
+
+        return $this;
+    }
+
+    /**
+     * Determines if the route allows "only trashed" models to be retrieved when resolving implicit model bindings.
+     *
+     * @return bool
+     */
+    public function allowsOnlyTrashedBindings()
+    {
+        return $this->onlyTrashedBindings;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -67,9 +67,12 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            $routeBindingMethod = $route?->allowsTrashedBindings() && $instance::isSoftDeletable()
-                ? 'resolveSoftDeletableRouteBinding'
-                : 'resolveRouteBinding';
+            $routeBindingMethod = match (true) {
+                ! $instance::isSoftDeletable() => 'resolveRouteBinding',
+                $route?->allowsOnlyTrashedBindings() => 'resolveTrashedRouteBinding',
+                $route?->allowsTrashedBindings() => 'resolveSoftDeletableRouteBinding',
+                default => 'resolveRouteBinding',
+            };
 
             if ($model = $instance->{$routeBindingMethod}($value)) {
                 return $model;

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -46,6 +46,17 @@ class RouteBindingTest extends TestCase
         $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
         $this->assertInstanceOf(ExplicitRouteBindingSoftDeletableUser::class, $callback(1, $route));
     }
+
+    public function test_it_can_resolve_the_explicit_soft_deleted_model_for_the_given_route_with_only_trashed()
+    {
+        $container = Container::getInstance();
+
+        $route = (new Route('GET', '/users/{user}', function () {
+        }))->onlyTrashed();
+
+        $callback = RouteBinding::forModel($container, ExplicitRouteBindingSoftDeletableUser::class);
+        $this->assertInstanceOf(ExplicitRouteBindingSoftDeletableUser::class, $callback(1, $route));
+    }
 }
 
 class ExplicitRouteBindingUser extends Model

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -162,6 +162,13 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($route->allowsTrashedBindings());
     }
 
+    public function testGetRouteWithOnlyTrashed()
+    {
+        $route = $this->router->get('users', [RouteRegistrarControllerStub::class, 'index'])->onlyTrashed();
+
+        $this->assertTrue($route->allowsOnlyTrashedBindings());
+    }
+
     public function testResourceWithTrashed()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
@@ -174,6 +181,22 @@ class RouteRegistrarTest extends TestCase
         /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertTrue($route->allowsTrashedBindings());
+        }
+    }
+
+    public function testResourceWithOnlyTrashed()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+            ->only(['show', 'edit', 'update'])
+            ->onlyTrashed([
+                'show',
+                'edit',
+                'update',
+            ]);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertTrue($route->allowsOnlyTrashedBindings());
         }
     }
 


### PR DESCRIPTION
Laravel already has Route::{method}()->withTrashed() / Route::resource()->withTrashed();
But after conducting some search, I can't find any related to onlyTrashed();
Use case of this onlyTrashed() in my opinion is suited to the application where we want to do a restore, so the route bind must be a soft-deleted data.

As an example:
```
// web.php
Route::patch('posts/{post}/restore', [PostController::class, 'restore']);

// PostController.php
public function restore(Post $post)
{
    $post->restore();
}
```
✨ Only restored data is the one that already deleted without needing the complexity to add gate. Meanwhile for using withTrashed it still grabs non-deleted data.