### PR TITLE
[11.x] Optimize ensureCastsAreStringValues to avoid copy-on-write overhead

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -777,6 +777,11 @@ trait HasAttributes
     protected function ensureCastsAreStringValues($casts)
     {
         foreach ($casts as $attribute => $cast) {
+            // Skip unchanged values to avoid copy-on-write memory overhead
+            if (! is_array($cast)) {
+                continue;
+            }
+
             $casts[$attribute] = match (true) {
                 is_array($cast) => value(function () use ($cast) {
                     if (count($cast) === 1) {


### PR DESCRIPTION
 This PR optimizes the `ensureCastsAreStringValues` method to skip processing cast values that are already strings, avoiding unnecessary array copy-on-write operations.

  ### Changes
  - Added an early continue when the cast value is not an array, skipping the match expression
  - This reduces memory overhead when initializing models with many string-format casts

  ### Impact
  - Improves memory efficiency for models with numerous cast definitions
  - Preserves existing behavior (all 22 cast-related tests pass)
  - No breaking changes

  ### Testing
  All existing cast-related tests pass, including:
  - `testMergeCastsMergesCastsUsingArrays`
  - `testsCastOnArrayFormatWithOneElement`
  - All other cast-related tests in `DatabaseEloquentModelTest`
