### PR TITLE
[12.x] Optimize ensureCastsAreStringValues to avoid copy-on-write overhead

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -790,6 +790,11 @@ trait HasAttributes
     protected function ensureCastsAreStringValues($casts)
     {
         foreach ($casts as $attribute => $cast) {
+            // Skip unchanged values to avoid copy-on-write memory overhead
+            if (! is_array($cast) && ! is_object($cast)) {
+                continue;
+            }
+
             $casts[$attribute] = match (true) {
                 is_object($cast) => value(function () use ($cast, $attribute) {
                     if ($cast instanceof Stringable) {


### PR DESCRIPTION
  This PR optimizes the `ensureCastsAreStringValues` method in the `HasAttributes` trait to skip processing cast values that are already in string format, avoiding unnecessary array copy-on-write operations.

  ## Problem

  When initializing models with many cast definitions, the `ensureCastsAreStringValues` method processes every cast value through the match expression, even when the value is already a string and doesn't need conversion. This triggers PHP's copy-on-write mechanism, creating unnecessary memory overhead.

  ## Solution

  Added an early `continue` statement to skip processing when the cast value is neither an array nor an object:

  ```php
  // Skip unchanged values to avoid copy-on-write memory overhead
  if (! is_array($cast) && ! is_object($cast)) {
      continue;
  }

  This optimization:
  - Skips the match expression for string cast values (no conversion needed)
  - Preserves object validation (ensuring objects implement Stringable)
  - Maintains array-to-string conversion for array-formatted casts
  - Reduces memory overhead during model initialization

  Impact

  - Performance: Improved memory efficiency for models with numerous cast definitions
  - Compatibility: No breaking changes - all existing behavior preserved
  - 12.x Specific: Maintains object cast validation introduced in 12.x

  Testing

  All 33 cast-related tests pass, including:
  - testMergeCastsMergesCastsUsingArrays - Array cast conversion
  - testsCastOnArrayFormatWithOneElement - Single element array handling
  - testUsingPlainObjectAsCastThrowsException - Object validation (12.x specific)
  - testMergeingStringableObjectCastUSesStringRepresentation - Stringable objects
  - All other cast-related tests in DatabaseEloquentModelTest

  Note

  This optimization differs slightly from the 11.x version, which only checks for arrays, as 12.x introduced object cast support with Stringable validation that must be preserved.