### PR TITLE
[12.x] Bump symfony/http-foundation to ^7.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/console": "^7.2.0",
         "symfony/error-handler": "^7.2.0",
         "symfony/finder": "^7.2.0",
-        "symfony/http-foundation": "^7.2.0",
+        "symfony/http-foundation": "^7.3.7",
         "symfony/http-kernel": "^7.2.0",
         "symfony/mailer": "^7.2.0",
         "symfony/mime": "^7.2.0",


### PR DESCRIPTION
This PR updates the minimum required version of `symfony/http-foundation` to `^7.3.7` to patch the security vulnerability **CVE-2025-64500**. This targets the `12.x` branch.

**Note:** This PR is submitted publicly because the vulnerability (CVE-2025-64500) and its corresponding fix (upgrading `symfony/http-foundation`) are already public knowledge. This PR does not disclose a new or private vulnerability.

**Vulnerability Details:**
- **CVE:** CVE-2025-64500
- **Advisory:** https://github.com/advisories/GHSA-3rg7-wf37-54rm
- **Description:** Symfony's `Request` class improperly interprets some `PATH_INFO` values, which can lead to representing some URLs with a path that doesn't start with a `/`. This could allow bypassing certain access control rules that assume a leading `/`.

This change ensures all new installations of the framework pull in the patched version.