### PR TITLE
[11.x] Fix `Request::getAcceptableContentTypes()` changes in Symfony 7.4

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -55,6 +55,10 @@ trait InteractsWithContentTypes
         $types = (array) $contentTypes;
 
         foreach ($accepts as $accept) {
+            if ($accept && $pos = strpos($accept, ';')) {
+                $accept = trim(substr($accept, 0, $pos));
+            }
+
             if ($accept === '*/*' || $accept === '*') {
                 return true;
             }
@@ -86,6 +90,10 @@ trait InteractsWithContentTypes
         $contentTypes = (array) $contentTypes;
 
         foreach ($accepts as $accept) {
+            if ($accept && $pos = strpos($accept, ';')) {
+                $accept = trim(substr($accept, 0, $pos));
+            }
+
             if (in_array($accept, ['*/*', '*'])) {
                 return $contentTypes[0];
             }


### PR DESCRIPTION
Backports #57783.