### PR TITLE
[12.x] Type-hint the `ResourceCollection::$collection` property as nullable

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -23,7 +23,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     /**
      * The mapped collection instance.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     public $collection;
 


### PR DESCRIPTION
The `$collection` property of `Illuminate\Http\Resources\Json\ResourceCollection` is currently type hinted as `Illuminate\Support\Collection`, but it can also be `null`:

```
$missingValue = new Illuminate\Http\Resources\MissingValue();
$resource = JsonResource::collection($missingValue);
$resource->collection; // this is null
```

This commonly happens when doing `JsonResource::collection($this->whenLoaded('relation'))`.

Here I'm changing the type-hinting annotation to include the `null` value.