### PR TITLE
[12.x] Improve typehints for `Http::pool()`

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -886,7 +886,7 @@ class PendingRequest
      *
      * @param  callable  $callback
      * @param  int|null  $concurrency
-     * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException>
+     * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */
     public function pool(callable $callback, ?int $concurrency = null)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -886,7 +886,7 @@ class PendingRequest
      *
      * @param  callable  $callback
      * @param  int|null  $concurrency
-     * @return array<array-key, \Illuminate\Http\Client\Response>
+     * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException>
      */
     public function pool(callable $callback, ?int $concurrency = null)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -884,7 +884,7 @@ class PendingRequest
     /**
      * Send a pool of asynchronous requests concurrently.
      *
-     * @param  callable  $callback
+     * @param  (callable(\Illuminate\Http\Client\Pool): mixed)  $callback
      * @param  int|null  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */


### PR DESCRIPTION
* narrows `$callback`'s callable
* return type includes RequestException and ConnectionException