### PR TITLE
[12.x] Use null coalesce assignment operator in `camel` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -225,11 +225,7 @@ class Str
      */
     public static function camel($value)
     {
-        if (isset(static::$camelCache[$value])) {
-            return static::$camelCache[$value];
-        }
-
-        return static::$camelCache[$value] = lcfirst(static::studly($value));
+        return static::$camelCache[$value] ??= lcfirst(static::studly($value));
     }
 
     /**


### PR DESCRIPTION
Refactored the `camel()` method to use PHP’s modern null coalesce assignment operator (??=) instead of a manual isset check for cleaner and more concise code