### PR TITLE
Add daysOfMonth() method to schedule tasks on specific days

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -569,6 +569,21 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run on specific days of the month.
+     *
+     * @param  array<int<1, 31>>|int<1, 31>  ...$days
+     * @return $this
+     */
+    public function daysOfMonth(...$days)
+    {
+        $days = count($days) === 1 && is_array($days[0]) ? $days[0] : $days;
+
+        $this->dailyAt('0:0');
+
+        return $this->spliceIntoPosition(3, implode(',', $days));
+    }
+
+    /**
      * Schedule the event to run quarterly.
      *
      * @return $this

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -104,4 +104,16 @@ class EventTest extends TestCase
 
         $this->assertSame('fancy-command-description', $event->mutexName());
     }
+
+    public function testDaysOfMonthMethod()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $event->daysOfMonth(1, 15);
+        $this->assertSame('0 0 1,15 * *', $event->getExpression());
+
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->daysOfMonth([1, 10, 20, 30]);
+        $this->assertSame('0 0 1,10,20,30 * *', $event->getExpression());
+    }
 }


### PR DESCRIPTION
## Problem

Currently, Laravel only provides limited options for scheduling tasks on specific days of the month:
- `monthlyOn()` - runs on a single day
- `twiceMonthly()` - runs on exactly two days
- `lastDayOfMonth()` - runs on the last day

There's no built-in way to schedule tasks on **multiple arbitrary days** of the month (e.g., 1st, 10th, 15th, 20th).

### Current Workaround:
```php
// Developers must manually specify cron expression
$schedule->command('generate-reports')
    ->cron('0 0 1,10,20 * *'); // Hard to read and error-prone
```

---

## Solution

Add a `daysOfMonth()` method that allows scheduling tasks to run on multiple specific days of the month with a clean, intuitive API.

### New API:
```php
// Variadic syntax
$schedule->command('generate-reports')
    ->daysOfMonth(1, 10, 20);

// Array syntax
$schedule->command('generate-reports')
    ->daysOfMonth([1, 10, 20]);
```

---

## Implementation

Added `daysOfMonth()` method to the `ManagesFrequencies` trait that accepts multiple day values and builds the appropriate cron expression:

```php
public function daysOfMonth(...$days)
{
    $days = count($days) === 1 && is_array($days[0]) ? $days[0] : $days;
    
    $this->dailyAt('0:0');
    
    return $this->spliceIntoPosition(3, implode(',', $days));
}
```

**Cron Expression:** `0 0 1,10,20 * *` (midnight on days 1, 10, and 20)

---

## Use Cases

### Payroll Processing (Multiple Payment Dates)
```php
$schedule->command('process-payroll')
    ->daysOfMonth(1, 15) // 1st and 15th of each month
    ->timezone('America/New_York');
```

### Weekly Reports on Specific Dates
```php
$schedule->command('generate-weekly-report')
    ->daysOfMonth(7, 14, 21, 28) // Every week approximately
    ->at('09:00');
```

### Quarterly Maintenance Tasks
```php
$schedule->command('quarterly-cleanup')
    ->daysOfMonth(1, 10, 20, 30) // Spread throughout month
    ->sendOutputTo('/var/log/cleanup.log');
```

### Mid-Month and End-Month Billing
```php
$schedule->command('generate-invoices')
    ->daysOfMonth(15, 30) // Mid-month and end of month
    ->emailOutputOnFailure('billing@example.com');
```
