### PR TITLE
[12.x] Add `Toonable` interface

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -6,6 +6,7 @@ use CachingIterator;
 use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Toonable;
 use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
@@ -18,7 +19,7 @@ use Traversable;
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>
  */
-interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
+interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable, Toonable
 {
     /**
      * Create a new collection instance if the value isn't one already.
@@ -1277,6 +1278,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return string
      */
     public function toPrettyJson(int $options = 0);
+
+    /**
+     * Convert the object to its TOON representation.
+     *
+     * @return string
+     */
+    public function toToon(): string;
 
     /**
      * Get a CachingIterator instance.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -56,7 +56,8 @@ use function Illuminate\Support\enum_value;
  */
 trait EnumeratesValues
 {
-    use Conditionable;
+    use Conditionable,
+        ToonCast;
 
     /**
      * Indicates that the object's string representation should be escaped when __toString is invoked.

--- a/src/Illuminate/Contracts/Support/Toonable.php
+++ b/src/Illuminate/Contracts/Support/Toonable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Toonable
+{
+    /**
+     * Convert the object to its TOON representation.
+     *
+     * @return string
+     */
+    public function toToon(): string;
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Toonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
@@ -26,6 +27,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\ToonCast;
 use JsonException;
 use JsonSerializable;
 use LogicException;
@@ -35,7 +37,7 @@ use Stringable;
 
 use function Illuminate\Support\enum_value;
 
-abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, UrlRoutable
+abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, Stringable, Toonable, UrlRoutable
 {
     use Concerns\HasAttributes,
         Concerns\HasEvents,
@@ -47,7 +49,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\GuardsAttributes,
         Concerns\PreventsCircularRecursion,
         Concerns\TransformsToResource,
-        ForwardsCalls;
+        ForwardsCalls,
+        ToonCast;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -6,9 +6,11 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Toonable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ToonCast;
 use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
@@ -20,11 +22,14 @@ use Traversable;
  * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @implements \ArrayAccess<TKey, TValue>
  */
-class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable
+class Fluent implements Arrayable, ArrayAccess, IteratorAggregate, Jsonable, JsonSerializable, Toonable
 {
-    use Conditionable, InteractsWithData, Macroable {
-        __call as macroCall;
-    }
+    use Conditionable,
+        InteractsWithData,
+        ToonCast,
+        Macroable {
+            __call as macroCall;
+        }
 
     /**
      * All of the attributes set on the fluent instance.

--- a/src/Illuminate/Support/Traits/ToonCast.php
+++ b/src/Illuminate/Support/Traits/ToonCast.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Stringable;
+
+trait ToonCast
+{
+    /**
+     * Convert the object to its TOON representation.
+     *
+     * @return string
+     */
+    public function toToon(): string
+    {
+        $data = match (true) {
+            $this instanceof Arrayable => $this->toArray(),
+            $this instanceof Jsonable => json_decode($this->toJson(), true),
+            default => (array) $this,
+        };
+
+        return $this->convertToToon($data);
+    }
+
+    /**
+     * Convert array data to TOON format.
+     *
+     * @param  array  $data
+     * @param  int  $indent
+     * @return string
+     */
+    protected function convertToToon(array $data, int $indent = 0): string
+    {
+        $result = [];
+        $prefix = str_repeat('  ', $indent);
+
+        foreach ($data as $key => $value) {
+            if (! is_array($value)) {
+                $result[] = $prefix . $key . ': ' . $this->formatValue($value);
+
+                continue;
+            }
+
+            if ($value === []) {
+                $result[] = $prefix . $key . ': []';
+
+                continue;
+            }
+
+            if ($this->isAssociativeArray($value)) {
+                $result[] = $prefix . $key . ':';
+                $result[] = $this->convertToToon($value, $indent + 1);
+
+                continue;
+            }
+
+            if ($this->isArrayOfObjects($value)) {
+                $keys = array_keys($value[0]);
+                $count = count($value);
+                $result[] = $prefix . $key . '[' . $count . ']{' . implode(',', $keys) . '}:';
+
+                foreach ($value as $item) {
+                    $values = array_map(fn ($k) => $this->formatValue($item[$k]), $keys);
+                    $result[] = $prefix . '  ' . implode(',', $values);
+                }
+
+                continue;
+            }
+
+            $count = count($value);
+            $formattedValues = array_map([$this, 'formatValue'], $value);
+            $result[] = $prefix . $key . '[' . $count . ']: ' . implode(',', $formattedValues);
+        }
+
+        return implode("\n", array_filter($result));
+    }
+
+    /**
+     * Check if array is associative.
+     *
+     * @param  array  $array
+     * @return bool
+     */
+    protected function isAssociativeArray(array $array): bool
+    {
+        return $array === []
+            ? false
+            : array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
+     * Check if array contains objects (associative arrays).
+     *
+     * @param  array  $array
+     * @return bool
+     */
+    protected function isArrayOfObjects(array $array): bool
+    {
+        if ($array === []) {
+            return false;
+        }
+
+        foreach ($array as $item) {
+            if (! is_array($item) || ! $this->isAssociativeArray($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Format value for TOON output.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function formatValue(mixed $value): string
+    {
+        return match (true) {
+            is_bool($value) => $value ? 'true' : 'false',
+            is_null($value) => 'null',
+            is_string($value) => $value,
+            $value instanceof Stringable => $value->toString(),
+            default => (string) $value,
+        };
+    }
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3481,6 +3481,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertStringContainsString('"number": 123', $results);
     }
 
+    public function testModelToToon(): void
+    {
+        $user = new EloquentModelStub(['name' => 'Mateus', 'active' => true]);
+        $result = $user->toToon();
+
+        $this->assertStringContainsString('name: Mateus', $result);
+        $this->assertStringContainsString('active: true', $result);
+    }
+
     public function testFillableWithMutators()
     {
         $model = new EloquentModelWithMutators;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -667,6 +667,16 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testToToon($collection): void
+    {
+        $c = new $collection(['name' => 'Taylor', 'age' => 30]);
+        $result = $c->toToon();
+
+        $this->assertStringContainsString('name: Taylor', $result);
+        $this->assertStringContainsString('age: 30', $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testCastingToStringJsonEncodesTheToArrayResult($collection)
     {
         $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -145,6 +145,15 @@ class SupportFluentTest extends TestCase
         $this->assertStringContainsString('    ', $results);
     }
 
+    public function testToToon(): void
+    {
+        $fluent = new Fluent(['name' => 'Taylor', 'age' => 30]);
+        $result = $fluent->toToon();
+
+        $this->assertStringContainsString('name: Taylor', $result);
+        $this->assertStringContainsString('age: 30', $result);
+    }
+
     public function testScope()
     {
         $fluent = new Fluent(['user' => ['name' => 'taylor']]);


### PR DESCRIPTION
## Overview

The **TOON (Token-Oriented Object Notation)** is a new format that's getting popular because of LLMs. You can read more about it here:
https://github.com/toon-format/toon

This JSON structure:
```json
{
  "context": {
    "task": "Our favorite hikes together",
    "location": "Boulder",
    "season": "spring_2025"
  },
  "friends": ["ana", "luis", "sam"],
  "hikes": [
    {
      "id": 1,
      "name": "Blue Lake Trail",
      "distanceKm": 7.5,
      "elevationGain": 320,
      "companion": "ana",
      "wasSunny": true
    },
    {
      "id": 2,
      "name": "Ridge Overlook",
      "distanceKm": 9.2,
      "elevationGain": 540,
      "companion": "luis",
      "wasSunny": false
    },
    {
      "id": 3,
      "name": "Wildflower Loop",
      "distanceKm": 5.1,
      "elevationGain": 180,
      "companion": "sam",
      "wasSunny": true
    }
  ]
}
```

When converted to the TOON format would look like this:
```
context:
  task: Our favorite hikes together
  location: Boulder
  season: spring_2025
friends[3]: ana,luis,sam
hikes[3]{id,name,distanceKm,elevationGain,companion,wasSunny}:
  1,Blue Lake Trail,7.5,320,ana,true
  2,Ridge Overlook,9.2,540,luis,false
  3,Wildflower Loop,5.1,180,sam,true
```

This PR aims to add a new `Toonable` interface and a `ToonCast` trait that's applied to:
- Eloquent Models
- Collections
- Fluent class

Adding a `toToon` method that converts these into TOON format.

## Example

```php
$collection = collect(['name' => 'Taylor', 'age' => 30]);
$collection->toToon();
// name: Taylor
// age: 30
```