### PR TITLE
[12.x] Improve return type of `Str::replace()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1228,7 +1228,7 @@ class Str
      * @param  string|iterable<string>  $replace
      * @param  string|iterable<string>  $subject
      * @param  bool  $caseSensitive
-     * @return string|string[]
+     * @return ($subject is string ? string : string[])
      */
     public static function replace($search, $replace, $subject, $caseSensitive = true)
     {

--- a/types/Support/Str.php
+++ b/types/Support/Str.php
@@ -33,3 +33,11 @@ if (Str::isUuid($uuid)) {
 } else {
     assertType('mixed', $uuid);
 }
+
+/**
+ * @var string $search
+ * @var string $replace
+ * @var string $subject
+ */
+assertType('string', Str::replace($search, $replace, $subject));
+assertType('array<string>', Str::replace($search, $replace, [$subject]));


### PR DESCRIPTION
The `Str::replace(...)` method returns a `string` when the subject was a string, otherwise it returns an `array`. This PR makes PHPStan aware of what the method returns based on the input.