### PR TITLE
[12.x] Fixup PHP 8.5 deprecations in `SupportArrTest`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -844,10 +844,10 @@ class Arr
      *
      * @param  array  $array
      * @param  mixed  $value
-     * @param  mixed  $key
+     * @param  array-key  $key
      * @return array
      */
-    public static function prepend($array, $value, $key = null)
+    public static function prepend($array, $value, $key = '')
     {
         if (func_num_args() == 2) {
             array_unshift($array, $value);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -187,7 +187,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first', 'second'], $values);
 
         // Test dividing an array with null key
-        [$keys, $values] = Arr::divide([null => 'Null', 1 => 'one']);
+        [$keys, $values] = Arr::divide(['' => 'Null', 1 => 'one']);
         $this->assertEquals([null, 1], $keys);
         $this->assertEquals(['Null', 'one'], $values);
 
@@ -197,7 +197,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);
 
         // Test dividing an array where the values are arrays
-        [$keys, $values] = Arr::divide([null => ['one' => 1, 2 => 'second'], 1 => 'one']);
+        [$keys, $values] = Arr::divide(['' => ['one' => 1, 2 => 'second'], 1 => 'one']);
         $this->assertEquals([null, 1], $keys);
         $this->assertEquals([['one' => 1, 2 => 'second'], 'one'], $values);
     }
@@ -1044,8 +1044,8 @@ class SupportArrTest extends TestCase
         $array = Arr::prepend(['one' => 1, 'two' => 2], 0, 'zero');
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $array);
 
-        $array = Arr::prepend(['one' => 1, 'two' => 2], 0, null);
-        $this->assertEquals([null => 0, 'one' => 1, 'two' => 2], $array);
+        $array = Arr::prepend(['one' => 1, 'two' => 2], 0, '');
+        $this->assertEquals(['' => 0, 'one' => 1, 'two' => 2], $array);
 
         $array = Arr::prepend(['one', 'two'], null, '');
         $this->assertEquals(['' => null, 'one', 'two'], $array);
@@ -1547,9 +1547,9 @@ class SupportArrTest extends TestCase
         Arr::forget($array, 'products.desk.final.taxes');
         $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
 
-        $array = ['products' => ['desk' => ['price' => 50], null => 'something']];
+        $array = ['products' => ['desk' => ['price' => 50], '' => 'something']];
         Arr::forget($array, ['products.amount.all', 'products.desk.price']);
-        $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
+        $this->assertEquals(['products' => ['desk' => [], '' => 'something']], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@example.com' => 'Jane'];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Spotted in context of #57231, some tests were reported to use `null` as array-key, which is deprecated in PHP 8.5. This PR changes occurrences to empty string, which is the proposed replacement.