### PR TITLE
[12.x] Add `encoding` validation rule for uploaded files

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -52,7 +52,7 @@ return [
     'doesnt_end_with' => 'The :attribute field must not end with one of the following: :values.',
     'doesnt_start_with' => 'The :attribute field must not start with one of the following: :values.',
     'email' => 'The :attribute field must be a valid email address.',
-    'encoding' => 'The :attribute file must be a valid :encoding file.',
+    'encoding' => 'The :attribute field must be in :encoding encoding.',
     'ends_with' => 'The :attribute field must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -52,7 +52,7 @@ return [
     'doesnt_end_with' => 'The :attribute field must not end with one of the following: :values.',
     'doesnt_start_with' => 'The :attribute field must not start with one of the following: :values.',
     'email' => 'The :attribute field must be a valid email address.',
-    'encoding' => 'The :attribute field must be in :encoding encoding.',
+    'encoding' => 'The :attribute field must encoded in :encoding.',
     'ends_with' => 'The :attribute field must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -52,6 +52,7 @@ return [
     'doesnt_end_with' => 'The :attribute field must not end with one of the following: :values.',
     'doesnt_start_with' => 'The :attribute field must not start with one of the following: :values.',
     'email' => 'The :attribute field must be a valid email address.',
+    'encoding' => 'The :attribute file must be a valid :encoding file.',
     'ends_with' => 'The :attribute field must end with one of the following: :values.',
     'enum' => 'The selected :attribute is invalid.',
     'exists' => 'The selected :attribute is invalid.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -130,6 +130,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the encoding rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceEncoding($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':encoding', $parameters[0], $message);
+    }
+
+    /**
      * Replace all place-holders for the extensions rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1190,6 +1190,20 @@ trait ValidatesAttributes
         return $extra;
     }
 
+    public function validateEncoding($attribute, $value, $parameters)
+    {
+        if (! $this->isValidFileInstance($value)) {
+            return false;
+        }
+
+        try {
+            return @mb_check_encoding($value->getContent(), $parameters[0]);
+        } catch (ValueError) {
+            // An invalid encoding was given.
+            return false;
+        }
+    }
+
     /**
      * Validate the extension of a file upload attribute is in a set of defined extensions.
      *

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1194,12 +1194,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'encoding');
 
-        try {
-            return @mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
-        } catch (ValueError) {
-            // An invalid encoding was given.
-            return false;
+        if (! in_array(mb_strtolower($parameters[0]), array_map(mb_strtolower(...), mb_list_encodings()))) {
+            throw new InvalidArgumentException("Validation rule encoding parameter \"{$parameters[0]}\" is not a valid encoding.");
         }
+
+        return @mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1190,6 +1190,14 @@ trait ValidatesAttributes
         return $extra;
     }
 
+    /**
+     * Validate the encoding of an attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
     public function validateEncoding($attribute, $value, $parameters)
     {
         $this->requireParameterCount(1, $parameters, 'encoding');

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1198,7 +1198,7 @@ trait ValidatesAttributes
             throw new InvalidArgumentException("Validation rule encoding parameter \"{$parameters[0]}\" is not a valid encoding.");
         }
 
-        return @mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
+        return mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -960,6 +960,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the encoding of an attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateEncoding($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'encoding');
+
+        if (! in_array(mb_strtolower($parameters[0]), array_map(mb_strtolower(...), mb_list_encodings()))) {
+            throw new InvalidArgumentException("Validation rule encoding parameter [{$parameters[0]}] is not a valid encoding.");
+        }
+
+        return mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
+    }
+
+    /**
      * Validate the existence of an attribute value in a database table.
      *
      * @param  string  $attribute
@@ -1188,25 +1207,6 @@ trait ValidatesAttributes
         }
 
         return $extra;
-    }
-
-    /**
-     * Validate the encoding of an attribute.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
-     * @return bool
-     */
-    public function validateEncoding($attribute, $value, $parameters)
-    {
-        $this->requireParameterCount(1, $parameters, 'encoding');
-
-        if (! in_array(mb_strtolower($parameters[0]), array_map(mb_strtolower(...), mb_list_encodings()))) {
-            throw new InvalidArgumentException("Validation rule encoding parameter \"{$parameters[0]}\" is not a valid encoding.");
-        }
-
-        return mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1192,12 +1192,10 @@ trait ValidatesAttributes
 
     public function validateEncoding($attribute, $value, $parameters)
     {
-        if (! $this->isValidFileInstance($value)) {
-            return false;
-        }
+        $this->requireParameterCount(1, $parameters, 'encoding');
 
         try {
-            return @mb_check_encoding($value->getContent(), $parameters[0]);
+            return @mb_check_encoding($value instanceof File ? $value->getContent() : $value, $parameters[0]);
         } catch (ValueError) {
             // An invalid encoding was given.
             return false;

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -46,9 +46,9 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected $maximumFileSize = null;
 
     /**
-     * The encoding that the file must be.
+     * The required file encoding.
      *
-     * @var null|string
+     * @var string|null
      */
     protected $encoding = null;
 

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -215,7 +215,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Indicate that the uploaded file should be in the given encoding.
      *
-     * @param string $encoding
+     * @param  string  $encoding
      * @return $this
      */
     public function encoding($encoding)

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -46,6 +46,13 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected $maximumFileSize = null;
 
     /**
+     * The encoding that the file must be.
+     *
+     * @var null|string
+     */
+    protected $encoding = null;
+
+    /**
      * An array of custom rules that will be merged into the validation rules.
      *
      * @var array
@@ -206,6 +213,19 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Indicate that the uploaded file should be in the given encoding.
+     *
+     * @param string $encoding
+     * @return $this
+     */
+    public function encoding($encoding)
+    {
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
      * Convert a potentially human-friendly file size to kilobytes.
      *
      * @param  string|int  $size
@@ -290,6 +310,10 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
             $this->minimumFileSize !== $this->maximumFileSize => "between:{$this->minimumFileSize},{$this->maximumFileSize}",
             default => "size:{$this->minimumFileSize}",
         };
+
+        if ($this->encoding) {
+            $rules[] = 'encoding:'.$this->encoding;
+        }
 
         return array_merge(array_filter($rules), $this->customRules);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -188,6 +188,7 @@ class Validator implements ValidatorContract
     protected $fileRules = [
         'Between',
         'Dimensions',
+        'Encoding',
         'Extensions',
         'File',
         'Image',
@@ -196,7 +197,6 @@ class Validator implements ValidatorContract
         'Mimetypes',
         'Min',
         'Size',
-        'Encoding',
     ];
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -196,6 +196,7 @@ class Validator implements ValidatorContract
         'Mimetypes',
         'Min',
         'Size',
+        'Encoding',
     ];
 
     /**

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -357,6 +357,20 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
+    public function testEncoding()
+    {
+        $this->fails(
+            File::default()->encoding('UTF-8'),
+            UploadedFile::fake()->createWithContent('utf8.txt', "\xf0\x28\x8c\x28"), // Invalid 4 byte UTF-8 sequence.
+            ['validation.encoding'],
+        );
+
+        $this->passes(
+            File::default()->encoding('UTF-8'),
+            UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
+        );
+    }
+
     public function testMacro()
     {
         File::macro('toDocument', function () {

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -359,15 +359,36 @@ class ValidationFileRuleTest extends TestCase
 
     public function testEncoding()
     {
+        // ACSII file containing UTF-8.
+        $this->fails(
+            File::default()->encoding('ASCII'),
+            UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
+            ['validation.encoding'],
+        );
+
+        // UTF-8 file containing invalid UTF-8 byte sequence.
         $this->fails(
             File::default()->encoding('UTF-8'),
-            UploadedFile::fake()->createWithContent('utf8.txt', "\xf0\x28\x8c\x28"), // Invalid 4 byte UTF-8 sequence.
+            UploadedFile::fake()->createWithContent('utf8.txt', "\xf0\x28\x8c\x28"),
             ['validation.encoding'],
         );
 
         $this->passes(
             File::default()->encoding('UTF-8'),
             UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
+        );
+    }
+
+    public function testEncodingWithInvalidParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule encoding parameter "FOOBAR" is not a valid encoding.');
+
+        // Invalid encoding.
+        $this->fails(
+            File::default()->encoding('FOOBAR'),
+            UploadedFile::fake()->createWithContent('utf8.txt', ''),
+            ['validation.encoding'],
         );
     }
 

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -362,27 +362,27 @@ class ValidationFileRuleTest extends TestCase
         // ASCII file containing UTF-8.
         $this->fails(
             File::default()->encoding('ascii'),
-            UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
+            UploadedFile::fake()->createWithContent('foo.txt', '✌️'),
             ['validation.encoding'],
         );
 
         // UTF-8 file containing invalid UTF-8 byte sequence.
         $this->fails(
             File::default()->encoding('utf-8'),
-            UploadedFile::fake()->createWithContent('utf8.txt', "\xf0\x28\x8c\x28"),
+            UploadedFile::fake()->createWithContent('foo.txt', "\xf0\x28\x8c\x28"),
             ['validation.encoding'],
         );
 
         $this->passes(
             File::default()->encoding('utf-8'),
-            UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
+            UploadedFile::fake()->createWithContent('foo.txt', '✌️'),
         );
 
         $this->passes(
             File::default()->encoding('utf-8'),
             [
-                UploadedFile::fake()->createWithContent('utf8-1.txt', '✌️'),
-                UploadedFile::fake()->createWithContent('utf8-2.txt', '👍'),
+                UploadedFile::fake()->createWithContent('foo-1.txt', '✌️'),
+                UploadedFile::fake()->createWithContent('foo-2.txt', '👍'),
             ]
         );
     }
@@ -395,7 +395,7 @@ class ValidationFileRuleTest extends TestCase
         // Invalid encoding.
         $this->fails(
             File::default()->encoding('FOOBAR'),
-            UploadedFile::fake()->createWithContent('utf8.txt', ''),
+            UploadedFile::fake()->createWithContent('foo.txt', ''),
             ['validation.encoding'],
         );
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -361,20 +361,20 @@ class ValidationFileRuleTest extends TestCase
     {
         // ASCII file containing UTF-8.
         $this->fails(
-            File::default()->encoding('ASCII'),
+            File::default()->encoding('ascii'),
             UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
             ['validation.encoding'],
         );
 
         // UTF-8 file containing invalid UTF-8 byte sequence.
         $this->fails(
-            File::default()->encoding('UTF-8'),
+            File::default()->encoding('utf-8'),
             UploadedFile::fake()->createWithContent('utf8.txt', "\xf0\x28\x8c\x28"),
             ['validation.encoding'],
         );
 
         $this->passes(
-            File::default()->encoding('UTF-8'),
+            File::default()->encoding('utf-8'),
             UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
         );
     }

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -359,7 +359,7 @@ class ValidationFileRuleTest extends TestCase
 
     public function testEncoding()
     {
-        // ACSII file containing UTF-8.
+        // ASCII file containing UTF-8.
         $this->fails(
             File::default()->encoding('ASCII'),
             UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -377,6 +377,14 @@ class ValidationFileRuleTest extends TestCase
             File::default()->encoding('utf-8'),
             UploadedFile::fake()->createWithContent('utf8.txt', '✌️'),
         );
+
+        $this->passes(
+            File::default()->encoding('utf-8'),
+            [
+                UploadedFile::fake()->createWithContent('utf8-1.txt', '✌️'),
+                UploadedFile::fake()->createWithContent('utf8-2.txt', '👍'),
+            ]
+        );
     }
 
     public function testEncodingWithInvalidParameter()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This adds a new `encoding` validation rule that checks the contents of a file matches a specific encoding using `mb_check_encoding()`. In my case I want to ensure user uploaded files such as spreadsheets from office suite software is actually UTF-8, so it can be safely processed.

It can be used as a typical validation: `['file', 'encoding:utf-8']` or via the file rule builder: `File::rule()->encoding('utf-8')`. It also works for strings.

