### PR TITLE
[12.x] Fix `DatabaseSessionHandler::performInsert` should not suppress all QueryException's

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -5,11 +5,11 @@ namespace Illuminate\Session;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use SessionHandlerInterface;
-use Illuminate\Database\UniqueConstraintViolationException;
 
 class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerInterface
 {

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -5,11 +5,11 @@ namespace Illuminate\Session;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use SessionHandlerInterface;
+use Illuminate\Database\UniqueConstraintViolationException;
 
 class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerInterface
 {
@@ -155,7 +155,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $this->performUpdate($sessionId, $payload);
         }
     }


### PR DESCRIPTION
# Problem

`Illuminate/Session/DatabaseSessionHandler@performInsert()` (introduced in 06c9fa0d82ff93da08557a8926dda6e77676a73f) catches **_every_** query exception, resulting in developers confusion when session is lost due to misconfigurations on `sessions`/`users` table (or database configuration in general).

some related issues i've found:
- https://github.com/laravel/framework/issues/50299
- https://github.com/laravel/nova-issues/issues/1740#issuecomment-932815024
- https://github.com/filamentphp/filament/discussions/10736
- https://stackoverflow.com/questions/52583886/post-request-in-laravel-error-419-sorry-your-session-419-your-page-has-exp#comment93196925_52583886
- https://github.com/laravel/framework/discussions/39826 (possibly)
- https://github.com/filamentphp/filament/issues/13394 (possibly)

while not very common, it is extremely hard to debug since there's no error/log of what's actually gone wrong; and also, it usually drives developers with less understanding of what csrf actually does to [dangerous places](https://github.com/laravel/telescope/issues/64#issuecomment-432590494).

# Solution

change the catch scope to catch only UniqueConstraintViolationException (which was added later in [10.x](14e8ee439fe28d98992442b418b07a9cf121e013) which is thrown by the [database connection handler](https://github.com/laravel/framework/blob/686d479370b0ef93c53acace8cefbf50478b5316/src/Illuminate/Database/Connection.php#L818).