### PR TITLE
[12.x] Allow CachedState properties to be nullable

### DIFF
--- a/src/Illuminate/Foundation/Testing/CachedState.php
+++ b/src/Illuminate/Foundation/Testing/CachedState.php
@@ -4,6 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 class CachedState
 {
-    public static array $cachedRoutes;
-    public static array $cachedConfig;
+    public static ?array $cachedRoutes = null;
+    public static ?array $cachedConfig = null;
 }


### PR DESCRIPTION
I'm using `WithCachedRoutes` in my test case - I have a test where I check various permissions, the routes in my web.php are flagged, depending on the feature so I need to make sure the test is refreshed as older cached routes don't have the permissions I'm checking.

I'd like the ability to do the below in my test - without the need for a new test case etc: 

```php
    public function setUp(): void
    {
        // We ensure each test has freshly cached routes due to testing feature based permissions below.
        CachedState::$cachedRoutes = null;

        parent::setUp();
    }
```

I've adjusted both properties to allow for null to keep them inline. There could probably be further adjustments to allow for methods to do this like `withoutCachedRoutes` for better dx, but for now I just want to do it myself.

Dont think it's a breaking change, but open to feedback - cheers 👍🏻 
