### PR TITLE
[12.x] Resolve failing encoding test 

### DIFF
--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -390,7 +390,7 @@ class ValidationFileRuleTest extends TestCase
     public function testEncodingWithInvalidParameter()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Validation rule encoding parameter "FOOBAR" is not a valid encoding.');
+        $this->expectExceptionMessage('Validation rule encoding parameter [FOOBAR] is not a valid encoding.');
 
         // Invalid encoding.
         $this->fails(


### PR DESCRIPTION
Noticed the test were failing here https://github.com/laravel/framework/actions/runs/19509172915/job/55843915388#step:7:238 

Looks like the formatting changed but the test wasn't updated 🫡 

