### PR TITLE
[12.x] Fixing MemoizedStore with Redis Cluster

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 class RedisStore extends TaggableStore implements LockProvider
 {
     use RetrievesMultipleKeys {
+        many as private manyAlias;
         putMany as private putManyAlias;
     }
 
@@ -91,6 +92,11 @@ class RedisStore extends TaggableStore implements LockProvider
         $results = [];
 
         $connection = $this->connection();
+
+        // PredisClusterConnection do not support reading multiple values if the keys hash differently...
+        if ($connection instanceof PredisClusterConnection) {
+            return $this->manyAlias($keys);
+        }
 
         $values = $connection->mget(array_map(function ($key) {
             return $this->prefix.$key;

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -93,7 +93,7 @@ class RedisStore extends TaggableStore implements LockProvider
 
         $connection = $this->connection();
 
-        // PredisClusterConnection do not support reading multiple values if the keys hash differently...
+        // PredisClusterConnection does not support reading multiple values if the keys hash differently...
         if ($connection instanceof PredisClusterConnection) {
             return $this->manyAlias($keys);
         }

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -13,8 +13,6 @@ use Illuminate\Cache\Events\RetrievingManyKeys;
 use Illuminate\Cache\Events\WritingKey;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -33,14 +31,9 @@ class MemoizedStoreTest extends TestCase
 
         $this->setUpRedis();
 
-        $connection = $this->app['redis']->connection();
-        $this->markTestSkippedWhen(
-            $connection instanceof PhpRedisClusterConnection || $connection instanceof PredisClusterConnection,
-            'flushAll and many currently not supported for Redis Cluster connections',
-        );
-
         Config::set('cache.default', 'redis');
-        Redis::flushAll();
+        Redis::connection(Config::get('cache.stores.redis.connection'))->flushDb();
+        Redis::connection(Config::get('cache.stores.redis.lock_connection'))->flushDb();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR is split from of https://github.com/laravel/framework/pull/57714

MemoizedStoreTest was skipped in https://github.com/laravel/framework/pull/57710, it was failing with RedisCluster, because such commands as FlushAll and FlushDb should be called on each node separately. 
Laravel already has implementation for flushDb over all nodes in cluster. So just replacing flushAll with flushing databases used in test to unskip it.

After that test failed on PredisClusterConnection (see https://github.com/laravel/framework/actions/runs/19509599522/job/55845498143)
That's because MemoizedStore relies heavily on `many` method, that do not work on PredisCluster, if keys hashes to different slots. PHPRedis mget implementation works well even if key hashes differs.

So, i replicated solution from https://github.com/laravel/framework/pull/53940 , but only for PredisCluster.