### PR TITLE
[12.x] `Str::lines()` method to split strings.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1881,6 +1881,26 @@ class Str
     }
 
     /**
+     * Split a string into lines
+     *
+     * @param string $string
+     * @param bool $skipEmpty
+     * @return array<int, string>
+     */
+    public static function lines($string, $skipEmpty = true)
+    {
+        if ($string === '') {
+            return [];
+        }
+
+        $lines = preg_split('/\r\n|\r|\n/', $string);
+
+        return $skipEmpty
+            ? array_values(array_filter($lines, fn($line) => $line !== ''))
+            : $lines;
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1392,6 +1392,40 @@ class SupportStrTest extends TestCase
         $this->assertEquals('❤Multi<br />Byte☆❤☆❤☆❤', Str::wordWrap('❤Multi Byte☆❤☆❤☆❤', 3, '<br />'));
     }
 
+    public function testLines()
+    {
+        $text = "line1\nline2\nline3";
+        $textWithEmpty = "line1\n\nline2\n\nline3";
+        $textWithWhitespace = "line1\n \nline2\n \nline3";
+        $textWindows = "line1\r\nline2\r\nline3";
+        $textWindowsWithEmpty = "line1\r\n\r\nline2\r\n\r\nline3";
+
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($text));
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($text, false));
+
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($textWithEmpty));
+        $this->assertEquals(['line1', '', 'line2', '', 'line3'], Str::lines($textWithEmpty, false));
+
+        $this->assertEquals(['line1', ' ', 'line2', ' ', 'line3'], Str::lines($textWithWhitespace));
+        $this->assertEquals(['line1', ' ', 'line2', ' ', 'line3'], Str::lines($textWithWhitespace, false));
+
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($textWindows));
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($textWindows, false));
+
+        $this->assertEquals(['line1', 'line2', 'line3'], Str::lines($textWindowsWithEmpty));
+        $this->assertEquals(['line1', '', 'line2', '', 'line3'], Str::lines($textWindowsWithEmpty, false));
+
+
+        $this->assertEquals([], Str::lines(''));
+
+        $this->assertEquals(['line1'], Str::lines('line1'));
+
+        $this->assertEquals(['', '', ''], Str::lines("\n\n", false));
+
+        $this->assertEquals(['emoji😀', 'test🎉'], Str::lines("emoji😀\ntest🎉"));
+
+    }
+
     public static function validUuidList()
     {
         return [


### PR DESCRIPTION
This PR introduces a new method `Str::lines()` that splits a string into an array of lines.
By default, it skips empty lines, with an option to include them by passing `false` as the second argument (`$skipEmpty`). The method preserves whitespace and supports different line endings. This function can be useful when processing multi line input from forms, log files or text files.