### PR TITLE
[12.x] Improve typehints for `QueriesRelationships`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -29,7 +29,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
@@ -80,7 +80,7 @@ trait QueriesRelationships
      *
      * @param  string  $relations
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>): mixed)|null  $callback
      * @return $this
@@ -122,7 +122,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -164,7 +164,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -180,7 +180,7 @@ trait QueriesRelationships
      * @param  string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function withWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -197,7 +197,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -241,7 +241,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
@@ -325,7 +325,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
@@ -370,7 +370,7 @@ trait QueriesRelationships
      * @param  string|array<int, string>  $types
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -387,7 +387,7 @@ trait QueriesRelationships
      * @param  string|array<int, string>  $types
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return $this
      */
     public function orWhereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -1025,7 +1025,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Builder<*>  $hasQuery
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @param  string  $boolean
      * @return $this
      */
@@ -1089,7 +1089,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @param  string  $boolean
      * @return $this
      */
@@ -1122,7 +1122,7 @@ trait QueriesRelationships
      * Check if we can run an "exists" query to optimize performance.
      *
      * @param  string  $operator
-     * @param  int  $count
+     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
      * @return bool
      */
     protected function canUseExistsForExistenceCheck($operator, $count)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -29,7 +29,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @return $this
@@ -80,7 +80,7 @@ trait QueriesRelationships
      *
      * @param  string  $relations
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>): mixed)|null  $callback
      * @return $this
@@ -122,7 +122,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>|string  $relation
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -164,7 +164,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -180,7 +180,7 @@ trait QueriesRelationships
      * @param  string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function withWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -197,7 +197,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, *, *>|string  $relation
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -241,7 +241,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @return $this
@@ -325,7 +325,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<*, *>|string  $relation
      * @param  string|array<int, string>  $types
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
@@ -370,7 +370,7 @@ trait QueriesRelationships
      * @param  string|array<int, string>  $types
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -387,7 +387,7 @@ trait QueriesRelationships
      * @param  string|array<int, string>  $types
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>, string): mixed)|null  $callback
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return $this
      */
     public function orWhereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
@@ -1025,7 +1025,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Builder<*>  $hasQuery
      * @param  \Illuminate\Database\Eloquent\Relations\Relation<*, *, *>  $relation
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
      * @return $this
      */
@@ -1089,7 +1089,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @param  string  $boolean
      * @return $this
      */
@@ -1122,7 +1122,7 @@ trait QueriesRelationships
      * Check if we can run an "exists" query to optimize performance.
      *
      * @param  string  $operator
-     * @param  int|\Illuminate\Contracts\Database\Query\Expression  $count
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
      * @return bool
      */
     protected function canUseExistsForExistenceCheck($operator, $count)


### PR DESCRIPTION
In the `has*()` family of methods from `QueriesRelationships` it is perfectly fine to use a raw expression instead of a fixed integer for `$count`. This PR updates the docblocks to reflect that. For example:

```php
$query->has('relation', '>=', DB::raw('another_column'));
```