### PR TITLE
Introduce `lazy` object and `proxy` object support helpers

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Contracts\Container\SelfBuilding;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\ReflectsClosures;
 use LogicException;
 use ReflectionAttribute;
 use ReflectionClass;
@@ -26,6 +27,8 @@ use TypeError;
 
 class Container implements ArrayAccess, ContainerContract
 {
+    use ReflectsClosures;
+
     /**
      * The current globally available container (if any).
      *
@@ -566,35 +569,6 @@ class Container implements ArrayAccess, ContainerContract
         foreach ($abstracts as $abstract) {
             $this->bind($abstract, $concrete, $shared);
         }
-    }
-
-    /**
-     * Get the class names / types of the return type of the given Closure.
-     *
-     * @param  \Closure  $closure
-     * @return list<class-string>
-     *
-     * @throws \ReflectionException
-     */
-    protected function closureReturnTypes(Closure $closure)
-    {
-        $reflection = new ReflectionFunction($closure);
-
-        if ($reflection->getReturnType() === null ||
-            $reflection->getReturnType() instanceof ReflectionIntersectionType) {
-            return [];
-        }
-
-        $types = $reflection->getReturnType() instanceof ReflectionUnionType
-            ? $reflection->getReturnType()->getTypes()
-            : [$reflection->getReturnType()];
-
-        return (new Collection($types))
-            ->reject(fn ($type) => $type->isBuiltin())
-            ->reject(fn ($type) => in_array($type->getName(), ['static', 'self']))
-            ->map(fn ($type) => $type->getName())
-            ->values()
-            ->all();
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Optional;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
+use Illuminate\Support\Traits\ReflectsClosures;
 
 if (! function_exists('append_config')) {
     /**
@@ -196,6 +197,54 @@ if (! function_exists('literal')) {
     }
 }
 
+if (! function_exists('lazy') && version_compare(phpversion(), '8.4.0', '>=')) {
+    /**
+     * Create a lazy instance.
+     *
+     * @template TValue of object
+     *
+     * @param  class-string<TValue>|(\Closure(TValue): mixed)  $class
+     * @param  (\Closure(TValue): mixed)|int  $callback
+     * @param  int  $options
+     * @param  array<string, mixed>  $eager
+     * @return TValue
+     */
+    function lazy($class, $callback = 0, $options = 0, $eager = [])
+    {
+        static $closureReflector;
+
+        $closureReflector ??= new class
+        {
+            use ReflectsClosures;
+
+            public function typeFromParameter($callback)
+            {
+                return $this->firstClosureParameterType($callback);
+            }
+        };
+
+        [$class, $callback, $options] = is_string($class)
+            ? [$class, $callback, $options]
+            : [$closureReflector->typeFromParameter($class), $class, $callback ?: $options];
+
+        $reflectionClass = new ReflectionClass($class);
+
+        $instance = $reflectionClass->newLazyGhost(function ($instance) use ($callback) {
+            $result = $callback($instance);
+
+            if (is_array($result)) {
+                $instance->__construct(...$result);
+            }
+        }, $options);
+
+        foreach ($eager as $property => $value) {
+            $reflectionClass->getProperty($property)->setRawValueWithoutLazyInitialization($instance, $value);
+        }
+
+        return $instance;
+    }
+}
+
 if (! function_exists('object_get')) {
     /**
      * Get an item from an object using "dot" notation.
@@ -292,6 +341,39 @@ if (! function_exists('preg_replace_array')) {
                 return array_shift($replacements);
             }
         }, $subject);
+    }
+}
+
+if (! function_exists('proxy') && version_compare(phpversion(), '8.4.0', '>=')) {
+    /**
+     * Create a lazy proxy instance.
+     *
+     * @template TValue of object
+     *
+     * @param  class-string<TValue>|(\Closure(TValue): TValue)  $class
+     * @param  (\Closure(TValue): TValue)|int  $callback
+     * @param  int  $options
+     * @return TValue
+     */
+    function proxy($class, $callback = 0, $options = 0)
+    {
+        static $closureReflector;
+
+        $closureReflector = new class
+        {
+            use ReflectsClosures;
+
+            public function typeFromParameter($callback)
+            {
+                return $this->firstClosureParameterType($callback);
+            }
+        };
+
+        [$class, $callback, $options] = is_string($class)
+            ? [$class, $callback, $options]
+            : [$closureReflector->typeFromParameter($class), $class, $callback ?: $options];
+
+        return (new ReflectionClass($class))->newLazyProxy($callback, $options);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -364,15 +364,15 @@ if (! function_exists('proxy')) {
         {
             use ReflectsClosures;
 
-            public function typeFromParameter($callback)
+            public function get($callback)
             {
-                return $this->firstClosureParameterType($callback);
+                return $this->closureReturnTypes($callback)[0] ?? $this->firstClosureParameterType($callback);
             }
         };
 
         [$class, $callback, $options] = is_string($class)
             ? [$class, $callback, $options]
-            : [$closureReflector->typeFromParameter($class), $class, $callback ?: $options];
+            : [$closureReflector->get($class), $class, $callback ?: $options];
 
         $reflectionClass = new ReflectionClass($class);
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -197,7 +197,7 @@ if (! function_exists('literal')) {
     }
 }
 
-if (! function_exists('lazy') && version_compare(phpversion(), '8.4.0', '>=')) {
+if (! function_exists('lazy')) {
     /**
      * Create a lazy instance.
      *
@@ -344,7 +344,7 @@ if (! function_exists('preg_replace_array')) {
     }
 }
 
-if (! function_exists('proxy') && version_compare(phpversion(), '8.4.0', '>=')) {
+if (! function_exists('proxy')) {
     /**
      * Create a lazy proxy instance.
      *

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -2142,6 +2142,25 @@ class SupportHelpersTest extends TestCase
 
         $instance->first;
     }
+
+    public function testProxyCanUseClosureReturnTypeForClassDetection(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+        $factory = fn () => new SupportLazyClass('foo', 'bar');
+
+        $instance = proxy(fn (): SupportLazyClass => $factory());
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
 }
 
 trait SupportTestTraitOne

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1512,6 +1512,584 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testLazy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
+            $instance->__construct('foo', 'bar');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyCanAcceptShortClosure(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => $instance->__construct('foo', 'bar'));
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyThrowsExceptionWhenConstructorIsNotCalled()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
+            //
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+
+        $instance->first;
+    }
+
+    public function testLazyCanAcceptHashForProperties(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => [
+            'second' => 'bar',
+            'first' => 'foo',
+        ]);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyCanAcceptListForProperties(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['foo', 'bar']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyCanAcceptSingleValueForConstructor(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClassWithArrayParameter::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClassWithArrayParameter::class, fn (SupportLazyClassWithArrayParameter $instance) => [['foo']]);
+
+        $this->assertFalse(SupportLazyClassWithArrayParameter::$constructorCalled);
+        $this->assertSame(['foo'], $instance->first);
+        $this->assertTrue(SupportLazyClassWithArrayParameter::$constructorCalled);
+
+        SupportLazyClassWithArrayParameter::$constructorCalled = false;
+    }
+
+    public function testLazySupportsPositionAndNamedArguments(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['foo', 'second' => 'bar']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyThrowsWhenPositionalArgumentsComeAfterNamedArguments(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn (SupportLazyClass $instance) => ['second' => 'bar', 'foo']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Cannot use positional argument after named argument during unpacking');
+
+        $instance->first;
+    }
+
+    public function testLazyCanReturnInitializedObject(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
+            $instance->__construct('foo');
+
+            return $instance;
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertNull($instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testLazyMustInitilizeObject(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
+            return new SupportLazyClass('foo');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+
+        $instance->first;
+    }
+
+    public function testLazyCanEagerlySetProperties(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(SupportLazyClass::class, fn () => ['foo', 'bar'], eager: ['eager' => 'baz']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('baz', $instance->eager);
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('baz', $instance->eager);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(function (SupportLazyClass $instance) {
+            $instance->__construct('foo', 'bar');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazyCanAcceptShortClosure(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClass $instance) => $instance->__construct('foo', 'bar'));
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazyThrowsExceptionWhenConstructorIsNotCalled()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $instance = lazy(function (SupportLazyClass $instance) {
+            //
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+
+        $instance->first;
+    }
+
+    public function testClosureOnlyLazyThrowsWhenNotClassSpecifiedInClosure()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+
+        lazy(function ($instance) {
+            //
+        });
+    }
+
+    public function testClosureOnlyLazyCanAcceptHashForProperties(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClass $instance) => [
+            'second' => 'bar',
+            'first' => 'foo',
+        ]);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazyCanAcceptListForProperties(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClass $instance) => ['foo', 'bar']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClousureOnlyLazyCanAcceptSingleValueForConstructor(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClassWithArrayParameter::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClassWithArrayParameter $instance) => [['foo']]);
+
+        $this->assertFalse(SupportLazyClassWithArrayParameter::$constructorCalled);
+        $this->assertSame(['foo'], $instance->first);
+        $this->assertTrue(SupportLazyClassWithArrayParameter::$constructorCalled);
+
+        SupportLazyClassWithArrayParameter::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazySupportsPositionAndNamedArguments(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClass $instance) => ['foo', 'second' => 'bar']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazyThrowsWhenPositionalArgumentsComeAfterNamedArguments(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(fn (SupportLazyClass $instance) => ['second' => 'bar', 'foo']);
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Cannot use positional argument after named argument during unpacking');
+
+        $instance->first;
+    }
+
+    public function testClosureOnlyLazyCanReturnInitializedObject(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(function (SupportLazyClass $instance) {
+            $instance->__construct('foo');
+
+            return $instance;
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertNull($instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyLazyMustInitilizeObject(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = lazy(function (SupportLazyClass $instance) {
+            return new SupportLazyClass('foo');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Typed property Illuminate\Tests\Support\SupportLazyClass::$first must not be accessed before initialization');
+
+        $instance->first;
+    }
+
+    public function testProxy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
+            return new SupportLazyClass('foo', 'bar');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testProxyCanAcceptShortClosure(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(SupportLazyClass::class, fn (SupportLazyClass $proxy) => new SupportLazyClass('foo', 'bar'));
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testProxyThrowsExceptionWhenConstructorIsNotCalled()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
+            //
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
+
+        $instance->first;
+    }
+
+    public function testProxyMustNotInitilizeProxy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
+            $proxy->__construct('foo');
+
+            return $proxy;
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Lazy proxy factory must return a non-lazy object');
+
+        $instance->first;
+    }
+
+    public function testClosureOnlyProxy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(function (SupportLazyClass $proxy) {
+            return new SupportLazyClass('foo', 'bar');
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyProxyCanAcceptShortClosure(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(fn (SupportLazyClass $proxy) => new SupportLazyClass('foo', 'bar'));
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->assertSame('foo', $instance->first);
+        $this->assertTrue(SupportLazyClass::$constructorCalled);
+        $this->assertSame('bar', $instance->second);
+
+        SupportLazyClass::$constructorCalled = false;
+    }
+
+    public function testClosureOnlyProxyThrowsExceptionWhenConstructorIsNotCalled()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $instance = proxy(function (SupportLazyClass $proxy) {
+            //
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Lazy proxy factory must return an instance of a class compatible with Illuminate\Tests\Support\SupportLazyClass, null returned');
+
+        $instance->first;
+    }
+
+    public function testClosureOnlyProxyThrowsWhenNotClassSpecifiedInClosure()
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The first parameter of the given Closure is missing a type hint.');
+
+        proxy(function ($proxy) {
+            //
+        });
+    }
+
+    public function testClosureOnlyProxyMustNotInitilizeProxy(): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
+        SupportLazyClass::$constructorCalled = false;
+
+        $instance = proxy(function (SupportLazyClass $proxy) {
+            $proxy->__construct('foo');
+
+            return $proxy;
+        });
+
+        $this->assertFalse(SupportLazyClass::$constructorCalled);
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Lazy proxy factory must return a non-lazy object');
+
+        $instance->first;
+    }
 }
 
 trait SupportTestTraitOne
@@ -1606,4 +2184,31 @@ class SupportTestCountable implements Countable
     {
         return 0;
     }
+}
+
+class SupportLazyClass
+{
+    public static bool $constructorCalled = false;
+
+    public string $eager = '';
+
+    public function __construct(
+        public string $first,
+        public ?string $second = null,
+    ) {
+        self::$constructorCalled = true;
+    }
+    //
+}
+
+class SupportLazyClassWithArrayParameter
+{
+    public static bool $constructorCalled = false;
+
+    public function __construct(
+        public array $first,
+    ) {
+        self::$constructorCalled = true;
+    }
+    //
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1961,7 +1961,7 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testProxyThrowsExceptionWhenConstructorIsNotCalled()
+    public function testProxyThrowsExceptionWhenObjectIsNotReturned()
     {
         if (version_compare(phpversion(), '8.4.0', '<')) {
             $this->markTestSkipped();
@@ -2040,7 +2040,7 @@ class SupportHelpersTest extends TestCase
         SupportLazyClass::$constructorCalled = false;
     }
 
-    public function testClosureOnlyProxyThrowsExceptionWhenConstructorIsNotCalled()
+    public function testClosureOnlyProxyThrowsExceptionWhenObjectIsNotReturned()
     {
         if (version_compare(phpversion(), '8.4.0', '<')) {
             $this->markTestSkipped();

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1930,10 +1930,9 @@ class SupportHelpersTest extends TestCase
         }
 
         SupportLazyClass::$constructorCalled = false;
+        $factory = fn () => new SupportLazyClass('foo', 'bar');
 
-        $instance = proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
-            return new SupportLazyClass('foo', 'bar');
-        });
+        $instance = proxy(SupportLazyClass::class, fn (SupportLazyClass $proxy) => $factory());
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->assertSame('foo', $instance->first);
@@ -1950,8 +1949,9 @@ class SupportHelpersTest extends TestCase
         }
 
         SupportLazyClass::$constructorCalled = false;
+        $factory = fn () => new SupportLazyClass('foo', 'bar');
 
-        $instance = proxy(SupportLazyClass::class, fn (SupportLazyClass $proxy) => new SupportLazyClass('foo', 'bar'));
+        $instance = proxy(SupportLazyClass::class, fn (SupportLazyClass $proxy) => $factory());
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->assertSame('foo', $instance->first);
@@ -2007,9 +2007,10 @@ class SupportHelpersTest extends TestCase
         }
 
         SupportLazyClass::$constructorCalled = false;
+        $factory = fn () => new SupportLazyClass('foo', 'bar');
 
-        $instance = proxy(function (SupportLazyClass $proxy) {
-            return new SupportLazyClass('foo', 'bar');
+        $instance = proxy(function (SupportLazyClass $proxy) use ($factory) {
+            return $factory();
         });
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
@@ -2027,8 +2028,9 @@ class SupportHelpersTest extends TestCase
         }
 
         SupportLazyClass::$constructorCalled = false;
+        $factory = fn () => new SupportLazyClass('foo', 'bar');
 
-        $instance = proxy(fn (SupportLazyClass $proxy) => new SupportLazyClass('foo', 'bar'));
+        $instance = proxy(fn (SupportLazyClass $proxy) => $factory());
 
         $this->assertFalse(SupportLazyClass::$constructorCalled);
         $this->assertSame('foo', $instance->first);

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -90,3 +90,17 @@ assertType('10', with(new User(), function ($user) {
 
     return 10;
 }));
+
+assertType('SupportLazyClass', lazy(SupportLazyClass::class, function (SupportLazyClass $instance) {
+    return [];
+}));
+assertType('SupportLazyClass', proxy(SupportLazyClass::class, function (SupportLazyClass $proxy) {
+    return new SupportLazyClass();
+}));
+assertType('SupportLazyClass', lazy(fn (SupportLazyClass $instance) => []));
+assertType('SupportLazyClass', proxy(fn (SupportLazyClass $proxy) => new SupportLazyClass));
+
+class SupportLazyClass
+{
+    //
+}

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -99,6 +99,7 @@ assertType('SupportLazyClass', proxy(SupportLazyClass::class, function (SupportL
 }));
 assertType('SupportLazyClass', lazy(fn (SupportLazyClass $instance) => []));
 assertType('SupportLazyClass', proxy(fn (SupportLazyClass $proxy) => new SupportLazyClass));
+assertType('SupportLazyClass', proxy(fn (): SupportLazyClass => new SupportLazyClass));
 
 class SupportLazyClass
 {


### PR DESCRIPTION
PHP's new [lazy objects](https://www.php.net/manual/en/language.oop5.lazy-objects.php) are very cool and useful for keeping the memory footprint low and improving performance in some use cases.

Unfortunately they are also super clunky to use.

Example of using the native API to create a ghost and a proxy:

```php
<?php

use Illuminate\Support\Facades\Http;
use ReflectionClass;
use Vendor\Facades\ResultFactory;
use Vendor\Result;

$response = Http::post(...);

$instance = (new ReflectionClass(Result::class))->newLazyGhost(fn (Result $instance) => $instance->__construct($response->json()));
$instance = (new ReflectionClass(Result::class))->newLazyProxy(fn (Result $proxy) => ResultFactory::make($response->json()));
```

## Clunky?

Yes. Clunky.

1. Rather verbose (and we haven't even tried eagerly setting properties yet)
2. Have to reach for reflection. _Feels_ heavy.
3. The subtle different between calling `__construct` when creating a ghost vs returning a new instance when creating a proxy.
4. In general, having the call `$object->__construct` feels nasty.
5. When creating a proxy, I have to receive the proxy object but I never want to do anything with it.

This PR introduces two new support helpers, `lazy` and `proxy`, in hopes to make using these features more ergonomic.

Re-worked example using the proposed helpers:

```php
<?php

use Illuminate\Support\Facades\Http;
use Vendor\Facades\ResultFactory;
use Vendor\Result;
use function Illuminate\Support\lazy;
use function Illuminate\Support\proxy;

$response = Http::get(...);

$instance = lazy(Result::class, fn () => [$response->json()]);
$instance = proxy(Result::class, fn (): Result => ResultFactory::make($response->json()));
```

You may be thinking _Hey, this is an older style Laravel API. We should be able to pass a single closure through like so:_

```php
<?php

$instance = lazy(fn (Result $instance) => [$response->json()]);
$instance = proxy(fn (Result $proxy) => ResultFactory::make($response->json()));
```

If that is you, please hold back your feelings until the end. For now, I'll stick with the `lazy($class, $callback)` API.

## Eagerly setting properties

Ghost objects allow you to eagerly set properties. Using the native APIs we would need the following:

```php
<?php

use Illuminate\Support\Facades\Http;
use ReflectionClass;
use Vendor\Facades\ResultFactory;
use Vendor\Result;

$response = Http::post(...);

$reflectionClass = new ReflectionClass(Result::class);
$instance = $reflectionClass->newLazyGhost(fn (Result $instance) => $instance->__construct($response->json()));
$reflectionClass->getProperty('createdAt')->setRawValueWithoutLazyInitialization($instance, now());
```

The `lazy` and `proxy` helper allow you to pass eager values through as a named parameter using a hash map:

```php
<?php

use Illuminate\Support\Facades\Http;
use ReflectionClass;
use Vendor\Facades\ResultFactory;
use Vendor\Result;

$response = Http::post(...);

$instance = lazy(Result::class, fn () => [$response->json()], eager: ['createdAt' => now()]);

```

### Proxy quirks

The way that lazy and proxy objects work regarding eager properties is slightly different. Lazy objects persist their eager properties after they are resolved / interacted with, however proxy objects do not.

## Naming

I've opted for `lazy` over `ghost` as a function name, even though PHP calls them ghosts.

- To me, `ghost` makes me feel like I'm gonna have to look up the difference between a ghost and a proxy every time I reach for them. `lazy` vs `proxy` feels more clearer to me.
- We already use `lazy` in the framework for similar things.

## Full API examples

### Lazy

`lazy` is the go to when you are in full control of creating the object, e.g., if you would otherwise call `new Result` yourself, whether the class is in your namespace or a vendor namespace.

```php
<?php

namespace App;

use App\Service\Result;
use function Illuminate\Support\lazy;

class Result
{
    public function __construct(
        public $param1,
        public $param2,
    ) {
        //
    }
}

/*
 * Provide a list of args for the constructor...
 */

$instance = lazy(Result::class, fn () => [$arg1, $arg2]);

/*
 * Provide the arguments using named parameters...
 */

$instance = lazy(Result::class, fn () => [
    'param2' => $arg2,
    'param1' => $arg1,
]);

/*
 * As an escape hatch, the closure does receive the lazy
 * object so you can call the constructor manually or other set up functions...
 */

$instance = lazy(Result::class, function ($instance) {
    $instance->__construct($arg1, $arg2);

    $instance->moreSetup();
});


/*
 * NOTE when passing an array as the first argument, you need to wrap it in an array...
 */
$arg1 = [];
$instance = lazy(Result::class, fn () => [$arg1]);
// or...
$instance = lazy(Result::class, fn () => [[]]);
```

Even with the more verbose escape hatch, it feels much more ergonomic to me. A comparison:

```php
$instance = (new ReflectionClass(Result::class))->newLazyGhost(fn (Result $instance) => $instance->__construct($response->json()));

$instance = lazy(Result::class, fn () => [$response->json()]);
```

### Proxy

`proxy` is what you would use for if you are not in control of instantiating the object and a 3rd party is in charge of creating the object. You can make make their instantiation logic lazy:

```php
<?php

namespace App;

use Vendor\Facades\Service;
use Vendor\Result;
use function Illuminate\Support\proxy;

/*
 * Provide a list of args for the constructor...
 */

$instance = proxy(Result::class, Service::get(...));

// return type driven

$instance = proxy(fn (): Result => ResultFactory::make($response->json()));
```

## Supplemental APIs

In similar APIs, Laravel has opted for determining the type from the closure. Although this is possible, I propose that we offer this as a secondary API, rather than the primarily documented API. I think it is fair to assume some people will attempt this API, based on previous Laravel experience, so it makes sense to support it. I'll outline below why I don't think it is a great primary API, though.

```diff
<?php

- $instance = lazy(Result::class, fn () => [$response->json()]);
+ $instance = lazy(fn (Result $instance) => [$response->json()]);

- $instance = proxy(Result::class, fn () => ResultFactory::make($response->json()));
+ $instance = proxy(fn (Result $proxy) => ResultFactory::make($response->json()));
```

Given that majority of use-cases, in my opinion, are going to return an array of arguments, being forced to pass through the object as a variable to then never use does not feel nice:

```php
<?php

$instance = lazy(fn (Result $instance) => [$response->json()]);
$instance = proxy(fn (Result $proxy) => ResultFactory::make($response->json()));
```

Notice we never reference `$instance` or `$proxy` variables in the closure. Sure, we could do take a leaf out of the JS book and use `$_` but it still feels off to me:

```php
<?php

$instance = lazy(fn (Result $_) => [$response->json()]);
$instance = proxy(fn (Result $_) => ResultFactory::make($response->json()));
```

I love other APIs that do this, but in all of those cases I want the thing I'm accepting. That isn't really the case with these helpers.

Comparing side-by-side for a vibes check:

```php
<?php

$instance = lazy(fn (Result $_) => [$response->json()]);
$instance = lazy(Result::class, fn () => [$response->json()]);
```

The only time this particular API is an improvement on the suggested primary API is for the `lazy` helper when you need to call additional APIs when constructing, which also feels like a usage outlier:

```php
<?php

$instance = lazy(function (Result $instance) {
    $instance->__construct($arg1, $arg2);

    $instance->moreSetup();
});
```

## What if I only have a single argument to pass?

I went back and forth on this a bit, e.g., offering the ability to accept a single argument rather than an array:

```diff
- $instance = lazy(Result::class, fn () => [$response->body()]);
+ $instance = lazy(Result::class, fn () => $response->body());
```

If feel this adds ambiguity. What if I want to accept a single argument that _is_ an array? You still need to wrap it in an array. Because of this, I felt keeping it simple and requiring a wrapping array was the best approach.