### PR TITLE
[12.x] Use `scopedIf` in `CacheManager::memo()`

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -81,11 +81,9 @@ class CacheManager implements FactoryContract
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
-        if (! $this->app->bound($bindingKey = "cache.__memoized:{$driver}")) {
-            $this->app->scoped($bindingKey, fn () => $this->repository(
-                new MemoizedStore($driver, $this->store($driver)), ['events' => false]
-            ));
-        }
+        $this->app->scopedIf($bindingKey = "cache.__memoized:{$driver}", fn() => $this->repository(
+            new MemoizedStore($driver, $this->store($driver)), ['events' => false]
+        ));
 
         return $this->app->make($bindingKey);
     }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -81,7 +81,7 @@ class CacheManager implements FactoryContract
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
-        $this->app->scopedIf($bindingKey = "cache.__memoized:{$driver}", fn() => $this->repository(
+        $this->app->scopedIf($bindingKey = "cache.__memoized:{$driver}", fn () => $this->repository(
             new MemoizedStore($driver, $this->store($driver)), ['events' => false]
         ));
 


### PR DESCRIPTION
This is a minor code refactor. It replaces the `if` statement with the `scopedIf` method.