### PR TITLE
[12.x] Fixing RedisTaggedCache::flushStale with PhpRedisClusterConnection

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -86,6 +86,7 @@ class RedisTagSet extends TagSet
         };
 
         $connection = $this->store->connection();
+
         if ($connection instanceof PhpRedisConnection) {
             $flushStaleEntries($connection);
         } else {

--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -79,11 +79,18 @@ class RedisTagSet extends TagSet
      */
     public function flushStaleEntries()
     {
-        $this->store->connection()->pipeline(function ($pipe) {
+        $flushStaleEntries = function ($pipe) {
             foreach ($this->tagIds() as $tagKey) {
                 $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
             }
-        });
+        };
+
+        $connection = $this->store->connection();
+        if ($connection instanceof PhpRedisConnection) {
+            $flushStaleEntries($connection);
+        } else {
+            $connection->pipeline($flushStaleEntries);
+        }
     }
 
     /**

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -232,8 +232,6 @@ class RedisStoreTest extends TestCase
 
     public function testMultipleItemsCanBeSetAndRetrieved()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         $store = Cache::store('redis');
         $result = $store->put('foo', 'bar', 10);
         $resultMany = $store->putMany([


### PR DESCRIPTION
Split from https://github.com/laravel/framework/pull/57714

Unskipping RedisStoreTest with Redis Cluster connections. Skipping just certain tests, that are failing with Predis to fix them later.

Test fails (see https://github.com/laravel/framework/actions/runs/19523922792/job/55892703186?pr=57837) with `Call to undefined method RedisCluster::pipeline()`. phpredis currently does not have support for pipelining in redis cluster (see https://github.com/phpredis/phpredis/blob/develop/cluster.md#pipelining).

To fix this case only for PhpRedisClusterConnection runninng same commands without pipeline in RedisTagSet::flushStaleEntries.


