### PR TITLE
[12.x] Add tomorrow() and yesterday() dates helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -979,6 +979,32 @@ if (! function_exists('today')) {
     }
 }
 
+if (! function_exists('tomorrow')) {
+    /**
+     * Create a new Carbon instance for tomorrow.
+     *
+     * @param  \DateTimeZone|\UnitEnum|string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function tomorrow($tz = null): CarbonInterface
+    {
+        return Date::tomorrow(enum_value($tz));
+    }
+}
+
+if (! function_exists('yesterday')) {
+    /**
+     * Create a new Carbon instance for yesterday.
+     *
+     * @param  \DateTimeZone|\UnitEnum|string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     */
+    function yesterday($tz = null): CarbonInterface
+    {
+        return Date::yesterday(enum_value($tz));
+    }
+}
+
 if (! function_exists('trans')) {
     /**
      * Translate the given message.


### PR DESCRIPTION
The Date facade already has the methods `tomorrow()` and `yesterday()`, but only the `today()` helper exists. 
It would be very handy to have those as helpers too for date intensive applications.
Since it is only an addition of 2 helpers it doesn't break anything

We could the do things like `tomorrow()->addHours(6)` to schedule something next morning for example