### PR TITLE
[12.x] Add default parameter support to `Request::fluent()` method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -118,11 +118,14 @@ trait InteractsWithInput
      * Retrieve input from the request as a Fluent object instance.
      *
      * @param  array|string|null  $key
+     * @param  array  $default
      * @return \Illuminate\Support\Fluent
      */
-    public function fluent($key = null)
+    public function fluent($key = null, array $default = [])
     {
-        return new Fluent(is_array($key) ? $this->only($key) : $this->input($key));
+        $value = is_array($key) ? $this->only($key) : $this->input($key);
+
+        return new Fluent($value ?? $default);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -597,7 +597,7 @@ class HttpRequestTest extends TestCase
             'user' => [
                 'name' => 'Michael',
                 'role' => 'admin',
-            ], 
+            ],
             'users' => null,
         ]);
         $this->assertSame(['name' => 'Michael', 'role' => 'admin'], $request->fluent('user')->toArray());

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -591,6 +591,20 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf(SymfonyUploadedFile::class, $request['file']);
     }
 
+    public function testFluentMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'user' => [
+                'name' => 'Michael',
+                'role' => 'admin',
+            ], 
+            'users' => null,
+        ]);
+        $this->assertSame(['name' => 'Michael', 'role' => 'admin'], $request->fluent('user')->toArray());
+        $this->assertSame([], $request->fluent('users')->toArray());
+        $this->assertSame([], $request->fluent('not_found')->toArray());
+    }
+
     public function testStringMethod()
     {
         $request = Request::create('/', 'GET', [


### PR DESCRIPTION
### Summary
This PR enhances the `fluent()` method in the Request class to support a default value when the requested input is missing. This improves the developer experience and prevents potential null-related issues.

### Changes
- Updated method signature to accept a second parameter: `$default = []`.
- Modified method logic to return the provided default value when the input key is absent.
- Ensures `Fluent` always receives a valid array structure.