### PR TITLE
[12.x] PredisClusterConnection::keys()

### DIFF
--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -22,4 +22,21 @@ class PredisClusterConnection extends PredisConnection
             $node->executeCommand(tap(new $command)->setArguments(func_get_args()));
         }
     }
+
+    /**
+     * Returns the keys that match a certain pattern.
+     *
+     * @param  string  $pattern
+     * @return array
+     */
+    public function keys(string $pattern)
+    {
+        $keys = [];
+
+        foreach ($this->client as $node) {
+            $keys[] = $node->keys($pattern);
+        }
+
+        return array_merge(...$keys);
+    }
 }

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -8,23 +8,7 @@ use Predis\Command\ServerFlushDatabase;
 class PredisClusterConnection extends PredisConnection
 {
     /**
-     * Flush the selected Redis database on all cluster nodes.
-     *
-     * @return void
-     */
-    public function flushdb()
-    {
-        $command = class_exists(ServerFlushDatabase::class)
-            ? ServerFlushDatabase::class
-            : FLUSHDB::class;
-
-        foreach ($this->client as $node) {
-            $node->executeCommand(tap(new $command)->setArguments(func_get_args()));
-        }
-    }
-
-    /**
-     * Returns the keys that match a certain pattern.
+     * Get the keys that match the given pattern.
      *
      * @param  string  $pattern
      * @return array
@@ -38,5 +22,21 @@ class PredisClusterConnection extends PredisConnection
         }
 
         return array_merge(...$keys);
+    }
+
+    /**
+     * Flush the selected Redis database on all cluster nodes.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        $command = class_exists(ServerFlushDatabase::class)
+            ? ServerFlushDatabase::class
+            : FLUSHDB::class;
+
+        foreach ($this->client as $node) {
+            $node->executeCommand(tap(new $command)->setArguments(func_get_args()));
+        }
     }
 }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -148,8 +148,6 @@ class RedisStoreTest extends TestCase
 
     public function testIncrementedTagEntriesProperlyTurnStale()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['votes'])->add('person-1', 0, $seconds = 1);
@@ -166,8 +164,6 @@ class RedisStoreTest extends TestCase
 
     public function testPastTtlTagEntriesAreNotAdded()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['votes'])->add('person-1', 0, new DateTime('yesterday'));
@@ -181,8 +177,6 @@ class RedisStoreTest extends TestCase
 
     public function testPutPastTtlTagEntriesProperlyTurnStale()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['votes'])->put('person-1', 0, new DateTime('yesterday'));
@@ -194,8 +188,6 @@ class RedisStoreTest extends TestCase
 
     public function testTagsCanBeFlushedBySingleKey()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['people', 'author'])->put('person-1', 'Sally', 5);
@@ -212,8 +204,6 @@ class RedisStoreTest extends TestCase
 
     public function testStaleEntriesCanBeFlushed()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['people', 'author'])->put('person-1', 'Sally', 1);


### PR DESCRIPTION
Split from https://github.com/laravel/framework/pull/57714

Unskipping some more tests in RedisStoreTest. The're failing with `Cannot use 'KEYS' with redis-cluster.` (see https://github.com/laravel/framework/actions/runs/19545929346/job/55964541433?pr=57841).

Other commands like MGET, MSET, DEL fails only when keys hashes to different slots. Unlike them KEYS command is not working with cluster at all. See vendor/predis/predis/src/Cluster/ClusterStrategy.php, it does not lists KEYS command at all, meaning it will never found slot and node and allways fail.

As far as keys command was never really working with PredisClusterConnection, adding such method will not break any backward compatibility. keys method work same way as flushdb method, aggregating results over all nodes.

Couple not related to PR checks are failing