### PR TITLE
fix: use mb_strlen in substrReplace for multibyte safety

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1748,7 +1748,7 @@ class Str
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
         if ($length === null) {
-            $length = strlen($string);
+            $length = mb_strlen($string);
         }
 
         return substr_replace($string, $replace, $offset, $length);


### PR DESCRIPTION
refs: https://github.com/laravel/framework/issues/57838