### PR TITLE
[12.x] Update RequestException@report() to return false

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -83,9 +83,9 @@ class RequestException extends HttpClientException
     /**
      * Prepare the exception message.
      *
-     * @return void
+     * @return bool
      */
-    public function report(): void
+    public function report()
     {
         if ($this->hasBeenSummarized) {
             return;
@@ -94,6 +94,8 @@ class RequestException extends HttpClientException
         $this->message = $this->prepareMessage($this->response);
 
         $this->hasBeenSummarized = true;
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -87,13 +87,11 @@ class RequestException extends HttpClientException
      */
     public function report()
     {
-        if ($this->hasBeenSummarized) {
-            return;
+        if (! $this->hasBeenSummarized) {
+            $this->message = $this->prepareMessage($this->response);
+
+            $this->hasBeenSummarized = true;
         }
-
-        $this->message = $this->prepareMessage($this->response);
-
-        $this->hasBeenSummarized = true;
 
         return false;
     }

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -13,12 +13,9 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
-use Mockery;
 use Monolog\Handler\TestHandler;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -291,7 +288,6 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
 
     public function test_it_reports_request_exceptions()
     {
-        //Exceptions::fake();
         config(['logging.default' => 'test_log']);
         config(['logging.channels.test_log' => [
             'driver' => 'monolog',

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -9,10 +9,17 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Testing\Fakes\ExceptionHandlerFake;
+use Mockery;
+use Monolog\Handler\TestHandler;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Process\PhpProcess;
@@ -281,4 +288,30 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
             'success' => false,
         ]);
     }
+
+    public function test_it_reports_request_exceptions()
+    {
+        //Exceptions::fake();
+        config(['logging.default' => 'test_log']);
+        config(['logging.channels.test_log' => [
+            'driver' => 'monolog',
+            'handler' => TestHandler::class,
+        ]]);
+        Log::setDefaultDriver('test_log');
+        Http::fake([
+            '*' => Http::response('a really long message is being returned', status:500),
+        ]);
+
+        RequestException::truncateAt(8);
+        try {
+            Http::throw()->get('http://laravel.test');
+        } catch (RequestException $requestException) {
+            report($requestException);
+        }
+
+        $recordedLogs = Log::getLogger()->getHandlers()[0]->getRecords();
+        $this->assertCount(1, $recordedLogs);
+        $this->assertStringContainsString('a really (truncated...)', $recordedLogs[0]['message']);
+    }
 }
+


### PR DESCRIPTION
This will allow for reporting via `report($requestException)` to do its thing.