### PR TITLE
[12.x] Fixing RedisTaggedCache::flushValues with PredisClusterConnection

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -194,6 +194,7 @@ class RedisTaggedCache extends TaggedCache
             ->chunk(1000);
 
         $connection = $this->store->connection();
+
         foreach ($entries as $cacheKeys) {
             if ($connection instanceof PredisClusterConnection) {
                 $connection->pipeline(function ($connection) use ($cacheKeys) {

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -193,8 +193,17 @@ class RedisTaggedCache extends TaggedCache
             ->map(fn (string $key) => $this->store->getPrefix().$key)
             ->chunk(1000);
 
+        $connection = $this->store->connection();
         foreach ($entries as $cacheKeys) {
-            $this->store->connection()->del(...$cacheKeys);
+            if ($connection instanceof PredisClusterConnection) {
+                $connection->pipeline(function ($connection) use ($cacheKeys) {
+                    foreach ($cacheKeys as $cacheKey) {
+                        $connection->del($cacheKey);
+                    }
+                });
+            } else {
+                $connection->del(...$cacheKeys);
+            }
         }
     }
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -6,7 +6,6 @@ use DateTime;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
-use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Sleep;
 use Mockery as m;
@@ -96,8 +95,6 @@ class RedisStoreTest extends TestCase
 
     public function testTagsCanBeAccessed()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['people', 'author'])->put('name', 'Sally', 5);
@@ -114,8 +111,6 @@ class RedisStoreTest extends TestCase
 
     public function testTagEntriesCanBeStoredForever()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['people', 'author'])->forever('name', 'Sally');
@@ -274,8 +269,6 @@ class RedisStoreTest extends TestCase
 
     public function testTagsCanBeFlushedWithLargeNumberOfKeys()
     {
-        $this->markTestSkippedWithPredisClusterConnection();
-
         Cache::store('redis')->clear();
 
         $tags = ['large-test-'.time()];
@@ -296,13 +289,5 @@ class RedisStoreTest extends TestCase
 
         $keyCount = Cache::store('redis')->connection()->keys('*');
         $this->assertCount(0, $keyCount);
-    }
-
-    protected function markTestSkippedWithPredisClusterConnection()
-    {
-        $this->markTestSkippedWhen(
-            $this->app['redis']->connection() instanceof PredisClusterConnection,
-            'This test currently fails on Predis Cluster connection',
-        );
     }
 }


### PR DESCRIPTION
Split from https://github.com/laravel/framework/pull/57714

Unskipping last tests in RedisStoreTest. They're failing with `Cannot use 'DEL' with redis-cluster` (see https://github.com/laravel/framework/actions/runs/19557692214/job/56003381622?pr=57848).

Unlike KEYS command from (https://github.com/laravel/framework/pull/57841), DEL works correctly with PredisclusterConnection, if all of keys hashes to same slot. So just bringing new DEL implementation to PredisClusterConnection would change behavior, making multiple calls where previously was one.

So i fix only RedisTaggedCache::flushValues for such case. Assuming, if we are speaking about tagged cache, in most cases keys wil hash to different slots. So deleting each key separately, wrapping it with pipeline to reduce waiting.