### PR TITLE
[12.x] RateLimiter remaining to 0 to prevent negative values.

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -232,7 +232,7 @@ class RateLimiter
 
         $attempts = $this->attempts($key);
 
-        return $maxAttempts - $attempts;
+        return max(0, $maxAttempts - $attempts);
     }
 
     /**

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
-use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -74,6 +75,18 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter = new RateLimiter($cache);
 
         $rateLimiter->hit('key', 1);
+    }
+
+    public function testRemainingIsNotNegative(): void
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->with('key', 0)->andReturn(5);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertSame(0, $rateLimiter->remaining('key', 3));
+        $this->assertSame(0, $rateLimiter->retriesLeft('key', 3));
     }
 
     public function testRetriesLeftReturnsCorrectCount()


### PR DESCRIPTION
This PR ensures that `remaining()` and `retriesLeft()` in the `CacheLimiter` will never return negative values when the attempt counter exceeds the allowed attempts.

When the rate limit counter exceeds the `maxAttempts` the calculation `$maxAttempts - $attempts` can be a negative number. The solution uses `max(0, $maxAttempts - $attempts)` to clamp the result to 0.
