### PR TITLE
[12.x] Add Session contextual attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Session.php
+++ b/src/Illuminate/Container/Attributes/Session.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Session implements ContextualAttribute
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(public string $key, public mixed $default = null)
+    {
+    }
+
+    /**
+     * Resolve the session value.
+     *
+     * @param  self  $attribute
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return mixed
+     */
+    public static function resolve(self $attribute, Container $container)
+    {
+        return $container->make('session')->get($attribute->key, $attribute->default);
+    }
+}

--- a/tests/Container/ContextualAttributeBindingTest.php
+++ b/tests/Container/ContextualAttributeBindingTest.php
@@ -17,6 +17,7 @@ use Illuminate\Container\Attributes\Database;
 use Illuminate\Container\Attributes\Give;
 use Illuminate\Container\Attributes\Log;
 use Illuminate\Container\Attributes\RouteParameter;
+use Illuminate\Container\Attributes\Session;
 use Illuminate\Container\Attributes\Storage;
 use Illuminate\Container\Attributes\Tag;
 use Illuminate\Container\Container;
@@ -183,6 +184,20 @@ class ContextualAttributeBindingTest extends TestCase
         });
 
         $container->make(ConfigTest::class);
+    }
+
+    public function testSessionAttribute()
+    {
+        $container = new Container;
+        $container->singleton('session', function () {
+            $repository = m::mock(Repository::class);
+            $repository->shouldReceive('get')->with('foo', null)->andReturn('foo');
+            $repository->shouldReceive('get')->with('bar', null)->andReturn('bar');
+
+            return $repository;
+        });
+
+        $container->make(SessionTest::class);
     }
 
     public function testDatabaseAttribute()
@@ -487,6 +502,13 @@ final class CacheTest
 final class ConfigTest
 {
     public function __construct(#[Config('foo')] string $foo, #[Config('bar')] string $bar)
+    {
+    }
+}
+
+final class SessionTest
+{
+    public function __construct(#[Session('foo')] string $foo, #[Session('bar')] string $bar)
     {
     }
 }


### PR DESCRIPTION
This PR adds a new `Session` [contextual attribute](https://laravel.com/docs/12.x/container#contextual-attributes) - to pull out values from the session.

Example:

```php
class FooController
{
    public function __construct(#[Session('foo')] public string $foo)
    {
    }
}
```