### PR TITLE
Make LengthAwarePaginator::elements() public

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -143,7 +143,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return array
      */
-    protected function elements()
+    public function elements()
     {
         $window = UrlWindow::make($this);
 


### PR DESCRIPTION

Make LengthAwarePaginator::elements() method from protected to public in order to make it available in code and views?


See : https://github.com/laravel/framework/issues/57854

Regards,
Julien
