### PR TITLE
[12.x] Add unlessEmpty and unlessNotEmpty methods to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1318,7 +1318,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return $this->when($this->test($pattern), $callback, $default);
     }
 
-     /**
+    /**
      * Execute the given callback unless the string is empty.
      *
      * @param  callable  $callback
@@ -1330,7 +1330,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return $this->unless($this->isEmpty(), $callback, $default);
     }
 
-     /**
+    /**
      * Execute the given callback unless the string is not empty.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1318,25 +1318,25 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         return $this->when($this->test($pattern), $callback, $default);
     }
 
-    /**
-    * Execute the given callback unless the string is empty.
-    *
-    * @param  callable  $callback
-    * @param  callable|null  $default
-    * @return static
-    */
+     /**
+     * Execute the given callback unless the string is empty.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
     public function unlessEmpty(callable $callback, ?callable $default = null)
     {
         return $this->unless($this->isEmpty(), $callback, $default);
     }
 
-    /**
-    * Execute the given callback unless the string is not empty.
-    *
-    * @param  callable  $callback
-    * @param  callable|null  $default
-    * @return static
-    */
+     /**
+     * Execute the given callback unless the string is not empty.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
     public function unlessNotEmpty(callable $callback, ?callable $default = null)
     {
         return $this->unless(! $this->isEmpty(), $callback, $default);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1319,6 +1319,30 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+    * Execute the given callback unless the string is empty.
+    *
+    * @param  callable  $callback
+    * @param  callable|null  $default
+    * @return static
+    */
+    public function unlessEmpty(callable $callback, ?callable $default = null)
+    {
+        return $this->unless($this->isEmpty(), $callback, $default);
+    }
+
+    /**
+    * Execute the given callback unless the string is not empty.
+    *
+    * @param  callable  $callback
+    * @param  callable|null  $default
+    * @return static
+    */
+    public function unlessNotEmpty(callable $callback, ?callable $default = null)
+    {
+        return $this->unless(! $this->isEmpty(), $callback, $default);
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  int  $words

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
+use Illuminate\Support\Str;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
@@ -1590,5 +1591,39 @@ class SupportStringableTest extends TestCase
 
         $this->assertNotSame('foo', $encrypted->value());
         $this->assertSame('foo', $encrypted->decrypt()->value());
+    }
+    
+    public function testUnlessEmpty()
+    {
+        $this->assertSame('', (string) Str::of('')->unlessEmpty(fn ($string) => $string->append('foo')));
+    
+        $this->assertSame('barfoo', (string) Str::of('bar')->unlessEmpty(fn ($string) => $string->append('foo')));
+    
+        $this->assertSame('default', (string) Str::of('')->unlessEmpty(
+            fn ($string) => $string->append('foo'),
+            fn ($string) => $string->append('default')
+        ));
+    
+        $this->assertSame('barfoo', (string) Str::of('bar')->unlessEmpty(
+            fn ($string) => $string->append('foo'),
+            fn ($string) => $string->append('default')
+        ));
+    }
+    
+    public function testUnlessNotEmpty()
+    {
+        $this->assertSame('bar', (string) Str::of('bar')->unlessNotEmpty(fn ($string) => $string->append('foo')));
+    
+        $this->assertSame('foo', (string) Str::of('')->unlessNotEmpty(fn ($string) => $string->append('foo')));
+    
+        $this->assertSame('bardefault', (string) Str::of('bar')->unlessNotEmpty(
+            fn ($string) => $string->append('foo'),
+            fn ($string) => $string->append('default')
+        ));
+    
+        $this->assertSame('foo', (string) Str::of('')->unlessNotEmpty(
+            fn ($string) => $string->append('foo'),
+            fn ($string) => $string->append('default')
+        ));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1603,7 +1603,7 @@ class SupportStringableTest extends TestCase
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')
         ));
- 
+
         $this->assertSame('barfoo', (string) Str::of('bar')->unlessEmpty(
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -7,9 +7,9 @@ use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
-use Illuminate\Support\Str;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;
@@ -1592,35 +1592,35 @@ class SupportStringableTest extends TestCase
         $this->assertNotSame('foo', $encrypted->value());
         $this->assertSame('foo', $encrypted->decrypt()->value());
     }
-    
+
     public function testUnlessEmpty()
     {
         $this->assertSame('', (string) Str::of('')->unlessEmpty(fn ($string) => $string->append('foo')));
-    
+
         $this->assertSame('barfoo', (string) Str::of('bar')->unlessEmpty(fn ($string) => $string->append('foo')));
-    
+
         $this->assertSame('default', (string) Str::of('')->unlessEmpty(
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')
         ));
-    
+ 
         $this->assertSame('barfoo', (string) Str::of('bar')->unlessEmpty(
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')
         ));
     }
-    
+
     public function testUnlessNotEmpty()
     {
         $this->assertSame('bar', (string) Str::of('bar')->unlessNotEmpty(fn ($string) => $string->append('foo')));
-    
+
         $this->assertSame('foo', (string) Str::of('')->unlessNotEmpty(fn ($string) => $string->append('foo')));
-    
+
         $this->assertSame('bardefault', (string) Str::of('bar')->unlessNotEmpty(
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')
         ));
-    
+
         $this->assertSame('foo', (string) Str::of('')->unlessNotEmpty(
             fn ($string) => $string->append('foo'),
             fn ($string) => $string->append('default')


### PR DESCRIPTION
## Purpose
Adds `unlessEmpty()` and `unlessNotEmpty()` methods to `Stringable` to bring it to API parity with `Collection`, which already has these methods.

## Current State

**Collection has:**
- [x] `unless($value, $callback, $default)` (via Conditionable trait)
- [x] `unlessEmpty($callback, $default)`
- [x] `unlessNotEmpty($callback, $default)`

**Stringable has:**
- [x] `unless($value, $callback, $default)` (via Conditionable trait) 
- [ ] `unlessEmpty($callback, $default)` - **MISSING**
- [ ] `unlessNotEmpty($callback, $default)` - **MISSING**

This PR adds the missing two methods to complete the API symmetry.

## Changes
- Added `unlessEmpty($callback, $default)` method to Stringable
- Added `unlessNotEmpty($callback, $default)` method to Stringable
- Added comprehensive tests for both methods

## Example Usage

**Before:**
```php
// Awkward - checking if empty
Str::of($input)->unless($input === '', fn($s) => $s->append('suffix'))

// Double negation
Str::of($input)->unless(! $input, fn($s) => $s->upper())
```

**After**
```php
// Clean and expressive
Str::of($input)->unlessEmpty(fn($s) => $s->append('suffix'))

Str::of($input)->unlessNotEmpty(fn($s) => $s->upper())
```

**Real-world example**
```php
// Apply formatting unless string is empty
$name = Str::of($userInput)
    ->trim()
    ->unlessEmpty(fn($s) => $s->title())
    ->unlessEmpty(fn($s) => $s->append('.'), fn($s) => $s->append('N/A')); 
```

**Benefits**

- API consistency: Matches Collection's `unlessEmpty` and `unlessNotEmpty` methods
- Better readability: More expressive than `unless(empty())` or `unless(! empty())`
- Completes the API: Stringable already has `whenEmpty` and `whenNotEmpty`, now has the unless variants
- Follows Laravel patterns: Collection has had these methods for years

**Backwards Compatibility**
- Fully backwards compatible - pure addition with no breaking changes.

**Related**
- Collection has had `unlessEmpty` and `unlessNotEmpty` since Laravel 5.x
- Stringable already has `unless()` via Conditionable trait
- Stringable already has `whenEmpty()` and `whenNotEmpty()`
- This completes the conditional API symmetry