### PR TITLE
[12.x] Allow any `\Stringable` implementation for `Illuminate\Support\Stringable::exactly()`

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -293,13 +293,13 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Determine if the string is an exact match with the given value.
      *
-     * @param  \Illuminate\Support\Stringable|string  $value
+     * @param  BaseStringable|string  $value
      * @return bool
      */
     public function exactly($value)
     {
-        if ($value instanceof Stringable) {
-            $value = $value->toString();
+        if ($value instanceof BaseStringable) {
+            $value = (string) $value;
         }
 
         return $this->value === $value;

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1477,6 +1477,13 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Foo')->exactly('foo'));
         $this->assertFalse($this->stringable('[]')->exactly([]));
         $this->assertFalse($this->stringable('0')->exactly(0));
+        $this->assertTrue($this->stringable('foo')->exactly(new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return 'foo';
+            }
+        }));
+        $this->assertFalse($this->stringable('foo')->exactly(new class () {}));
     }
 
     public function testToInteger()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1477,13 +1477,14 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Foo')->exactly('foo'));
         $this->assertFalse($this->stringable('[]')->exactly([]));
         $this->assertFalse($this->stringable('0')->exactly(0));
-        $this->assertTrue($this->stringable('foo')->exactly(new class () implements \Stringable {
+        $this->assertTrue($this->stringable('foo')->exactly(new class() implements \Stringable
+        {
             public function __toString(): string
             {
                 return 'foo';
             }
         }));
-        $this->assertFalse($this->stringable('foo')->exactly(new class () {}));
+        $this->assertFalse($this->stringable('foo')->exactly(new class() {}));
     }
 
     public function testToInteger()


### PR DESCRIPTION
Currently, `Illuminate\Support\Stringable::exactly()` only supports `string` or an instance of `Illuminate\Support\Stringable` as the  `$value` parameter.

This PR aims to enhance the allowed types for `exactly()` by accepting any object that implements `\Stringable`.

Let's assume we have an object like this:

```php
$object = new class () implements \Stringable {
    public function __toString(): string
    {
        return "foo";
    }
}
```

Earlier:

```php
Str::of('foo')->exactly($object); // false
```

Now: 

```php
Str::of('foo')->exactly($object); // true
```