### PR TITLE
[12.x] Moving redis integration tests

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Execute Cache tests
         run: vendor/bin/phpunit tests/Integration/Cache
         env:
+          CACHE_STORE: redis
           REDIS_CACHE_CONNECTION: cache
           REDIS_CACHE_LOCK_CONNECTION: cache
           REDIS_CLIENT: ${{ matrix.client }}
@@ -117,6 +118,7 @@ jobs:
       - name: Execute Cache tests
         run: vendor/bin/phpunit tests/Integration/Cache
         env:
+          CACHE_STORE: redis
           REDIS_CACHE_CONNECTION: default
           REDIS_CACHE_LOCK_CONNECTION: default
           REDIS_CLIENT: ${{ matrix.client }}

--- a/tests/Integration/Cache/PhpRedisBackoffTest.php
+++ b/tests/Integration/Cache/PhpRedisBackoffTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Env;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Redis;
+
+#[RequiresPhpExtension('redis')]
+class PhpRedisBackoffTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRedis();
+
+        $client = $this->redis['phpredis']->connection()->client();
+        if (! $client instanceof Redis) {
+            $this->markTestSkipped('Backoff option is only supported with phpredis in non-cluster mode');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->tearDownRedis();
+    }
+
+    #[DataProvider('phpRedisBackoffAlgorithmsProvider')]
+    public function testPhpRedisBackoffAlgorithmParsing($friendlyAlgorithmName, $expectedAlgorithm)
+    {
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
+
+        $manager = new RedisManager(new Application(), 'phpredis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'backoff_algorithm' => $friendlyAlgorithmName,
+            ],
+        ]);
+
+        $this->assertEquals(
+            $expectedAlgorithm,
+            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
+        );
+    }
+
+    #[DataProvider('phpRedisBackoffAlgorithmsProvider')]
+    public function testPhpRedisBackoffAlgorithm($friendlyAlgorithm, $expectedAlgorithm)
+    {
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
+
+        $manager = new RedisManager(new Application(), 'phpredis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'backoff_algorithm' => $expectedAlgorithm,
+            ],
+        ]);
+
+        $this->assertEquals(
+            $expectedAlgorithm,
+            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
+        );
+    }
+
+    public function testAnInvalidPhpRedisBackoffAlgorithmIsConvertedToDefault()
+    {
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
+
+        $manager = new RedisManager(new Application(), 'phpredis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'backoff_algorithm' => 7,
+            ],
+        ]);
+
+        $this->assertEquals(
+            Redis::BACKOFF_ALGORITHM_DEFAULT,
+            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
+        );
+    }
+
+    public function testItFailsWithAnInvalidPhpRedisAlgorithm()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Algorithm [foo] is not a valid PhpRedis backoff algorithm');
+
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
+
+        (new RedisManager(new Application(), 'phpredis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'backoff_algorithm' => 'foo',
+            ],
+        ]))->connection();
+    }
+
+    public static function phpRedisBackoffAlgorithmsProvider()
+    {
+        if (! class_exists(Redis::class)) {
+            return [];
+        }
+
+        return [
+            ['default', Redis::BACKOFF_ALGORITHM_DEFAULT],
+            ['decorrelated_jitter', Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER],
+            ['equal_jitter', Redis::BACKOFF_ALGORITHM_EQUAL_JITTER],
+            ['exponential', Redis::BACKOFF_ALGORITHM_EXPONENTIAL],
+            ['uniform', Redis::BACKOFF_ALGORITHM_UNIFORM],
+            ['constant', Redis::BACKOFF_ALGORITHM_CONSTANT],
+        ];
+    }
+}

--- a/tests/Integration/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Integration/Cache/RedisCacheIntegrationTest.php
@@ -5,15 +5,10 @@ namespace Illuminate\Tests\Integration\Cache;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Redis\RedisManager;
-use Illuminate\Support\Env;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
-use Redis;
 
 #[RequiresPhpExtension('redis')]
 class RedisCacheIntegrationTest extends TestCase
@@ -88,97 +83,5 @@ class RedisCacheIntegrationTest extends TestCase
         $repository = new Repository($store);
         $repository->forever('k', null);
         $this->assertFalse($repository->add('k', 'v', 60));
-    }
-
-    #[DataProvider('phpRedisBackoffAlgorithmsProvider')]
-    public function testPhpRedisBackoffAlgorithmParsing($friendlyAlgorithmName, $expectedAlgorithm)
-    {
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        $manager = new RedisManager(new Application(), 'phpredis', [
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'backoff_algorithm' => $friendlyAlgorithmName,
-            ],
-        ]);
-
-        $this->assertEquals(
-            $expectedAlgorithm,
-            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
-        );
-    }
-
-    #[DataProvider('phpRedisBackoffAlgorithmsProvider')]
-    public function testPhpRedisBackoffAlgorithm($friendlyAlgorithm, $expectedAlgorithm)
-    {
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        $manager = new RedisManager(new Application(), 'phpredis', [
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'backoff_algorithm' => $expectedAlgorithm,
-            ],
-        ]);
-
-        $this->assertEquals(
-            $expectedAlgorithm,
-            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
-        );
-    }
-
-    public function testAnInvalidPhpRedisBackoffAlgorithmIsConvertedToDefault()
-    {
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        $manager = new RedisManager(new Application(), 'phpredis', [
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'backoff_algorithm' => 7,
-            ],
-        ]);
-
-        $this->assertEquals(
-            Redis::BACKOFF_ALGORITHM_DEFAULT,
-            $manager->connection()->client()->getOption(Redis::OPT_BACKOFF_ALGORITHM)
-        );
-    }
-
-    public function testItFailsWithAnInvalidPhpRedisAlgorithm()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Algorithm [foo] is not a valid PhpRedis backoff algorithm');
-
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        (new RedisManager(new Application(), 'phpredis', [
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'backoff_algorithm' => 'foo',
-            ],
-        ]))->connection();
-    }
-
-    public static function phpRedisBackoffAlgorithmsProvider()
-    {
-        if (! class_exists(Redis::class)) {
-            return [];
-        }
-
-        return [
-            ['default', Redis::BACKOFF_ALGORITHM_DEFAULT],
-            ['decorrelated_jitter', Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER],
-            ['equal_jitter', Redis::BACKOFF_ALGORITHM_EQUAL_JITTER],
-            ['exponential', Redis::BACKOFF_ALGORITHM_EXPONENTIAL],
-            ['uniform', Redis::BACKOFF_ALGORITHM_UNIFORM],
-            ['constant', Redis::BACKOFF_ALGORITHM_CONSTANT],
-        ];
     }
 }

--- a/tests/Integration/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Integration/Cache/RedisCacheIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Cache;
+namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RedisStore;


### PR DESCRIPTION
RedisCacheIntegrationTest is located outside of Integration folder and is not called with all possible redis configurations. Moving it to Integration folder.

Extracted PhpRedisBackoffTest from RedisCacheIntegrationTest, as it covers not cache, but only RedisConnector specific option

Also setting CACHE_STORE=redis for Redis integration tests to be sure current and future tests use RedisStore and not default ArrayStore (defined in vendor/orchestra/testbench-core/laravel/config/cache.php)