### PR TITLE
[12.x] Incorrect result of MemoizedStore::many with numeric keys and empty prefix

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -68,12 +68,9 @@ class MemoizedStore implements LockProvider, Store
 
         if (count($missing) > 0) {
             $retrieved = tap($this->repository->many($missing), function ($values) {
-                $this->cache = [
-                    ...$this->cache,
-                    ...collect($values)->mapWithKeys(fn ($value, $key) => [
-                        $this->prefix($key) => $value,
-                    ]),
-                ];
+                foreach ($values as $key => $value) {
+                    $this->cache[$this->prefix($key)] = $value;
+                }
             });
         }
 

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -121,6 +121,21 @@ class MemoizedStoreTest extends TestCase
         $this->assertSame($cacheValue, $memoValue);
     }
 
+    public function test_it_uses_correct_keys_for_getMultiple_with_empty_prefix()
+    {
+        Cache::setPrefix(null);
+
+        $data = [
+            '1' => 'one',
+            0 => 'zero',
+        ];
+        Cache::putMany($data);
+
+        $this->assertSame($data, Cache::memo()->many(array_keys($data)));
+        // ensure correct on the second memoized retrieval
+        $this->assertSame($data, Cache::memo()->many(array_keys($data)));
+    }
+
     public function test_null_values_are_memoized_when_retrieving_multiple_values()
     {
         $live = Cache::getMultiple(['name.0', 'name.1']);


### PR DESCRIPTION
When underlying cache in MemoizedStore has emplty prefix (null or '' like in ArrayStore), it may work incorrectly with integer and numeric string keys.

Failing test example https://github.com/laravel/framework/actions/runs/19592949064/job/56113726066

That's because of PHP's specifics of merging arrays with numeric keys (see https://www.php.net/manual/en/function.array-merge.php , for demo https://onlinephp.io?s=s7EvyCjg5eLlKkssik8pzS3QiObl4tTT04uO1YEyeLkUoEDdUF3B1k5BPT8vVV0HSdgAIlyVWpQPEucEaY3VtOblAgA%2C&v=8.3.21)

Previous fix in same method in #55503
