### PR TITLE
[12.x] Fix flaky test

### DIFF
--- a/tests/Integration/Session/DatabaseSessionHandlerTest.php
+++ b/tests/Integration/Session/DatabaseSessionHandlerTest.php
@@ -59,6 +59,7 @@ class DatabaseSessionHandlerTest extends DatabaseTestCase
         $connection = $this->app['db']->connection();
 
         $handler = new DatabaseSessionHandler($connection, 'sessions', 1, $this->app);
+        Carbon::setTestNow(Carbon::now());
         $handler->write('simple_id_1', 'abcd');
         $this->assertEquals(0, $handler->gc(1));
 


### PR DESCRIPTION
This test flaked in a recent run. To prevent this, we can freeze time in this test

Failing run: https://github.com/laravel/framework/actions/runs/19595266162/job/56119070055#step:7:236