### PR TITLE
[12.x] optimize `AbstractRouteCollection@matchAgainstRoute()`

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -80,6 +80,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
         $fallbackRoute = null;
+
         foreach ($routes as $route) {
             if ($route->matches($request, $includingMethod)) {
                 if ($route->isFallback && $fallbackRoute === null) {

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -79,13 +79,20 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
-        [$fallbacks, $routes] = (new Collection($routes))->partition(function ($route) {
-            return $route->isFallback;
-        });
+        $fallbackRoute = null;
+        foreach ($routes as $route) {
+            if ($route->matches($request, $includingMethod)) {
+                if ($route->isFallback && $fallbackRoute === null) {
+                    $fallbackRoute = $route;
 
-        return $routes->merge($fallbacks)->first(
-            fn (Route $route) => $route->matches($request, $includingMethod)
-        );
+                    continue;
+                }
+
+                return $route;
+            }
+        }
+
+        return $fallbackRoute;
     }
 
     /**


### PR DESCRIPTION
Keep a pointer to the first matching fallback route, but only loop through the routes once.