### PR TITLE
Allow File Search using `Storage::files()`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -871,13 +871,16 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
+     * @param  string|null $search
      * @return array
      */
-    public function files($directory = null, $recursive = false)
+    public function files($directory = null, $recursive = false, $search = null)
     {
         return $this->driver->listContents($directory ?? '', $recursive)
-            ->filter(function (StorageAttributes $attributes) {
-                return $attributes->isFile();
+            ->filter(function (StorageAttributes $attributes) use ($search) {
+                return $attributes->isFile() && (
+                    is_null($search) || Str::is($search, $attributes->path())
+                );
             })
             ->sortByPath()
             ->map(function (StorageAttributes $attributes) {
@@ -890,11 +893,12 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get all of the files from the given directory (recursive).
      *
      * @param  string|null  $directory
+     * @param  string|null $search
      * @return array
      */
-    public function allFiles($directory = null)
+    public function allFiles($directory = null, $search = null)
     {
-        return $this->files($directory, true);
+        return $this->files($directory, true, $search);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -767,4 +767,16 @@ class FilesystemAdapterTest extends TestCase
         $path = $filesystemAdapter->path('different');
         $this->assertEquals('my-root/someprefix/different', $path);
     }
+
+    public function testSearchFiles()
+    {
+        $this->filesystem->write('body.txt', 'Hello World');
+        $this->filesystem->write('file1.txt', 'Hello World');
+        $this->filesystem->write('file.txt', 'Hello World');
+        $this->filesystem->write('existing.txt', 'Dear Kate');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->assertSame($filesystemAdapter->files(null, false, 'file*'), ['file.txt', 'file1.txt']);
+    }
 }


### PR DESCRIPTION
Hey 👋 

This PR makes a change to the `Storage::files()` method by allowing it to accept a _search_ argument. I recently had a need for this in an app I was building where I wanted to find files based on the name containing a specific word, my userland solution was:

```php
$files = collect(Storage::disk('public')->files())->filter(function ($file) {
    return Str::contains($file, 'google');
})->values()->toArray()
```

Which returned exactly what I needed, however, I thought there might be a nicer way of doing this within the `files()` method itself, as that already lists every file anyway, so I came up with this:

```php
$files = Storage::disk('public')->files(search: 'google*');
```

Or if you don't want to use named arguments:

```php
Storage::disk('public')->files(null, false, 'google*');
```

Both ways render the same result, I'm just proposing a way of having to write less code to search for specific files:

```php
array:2 [
  "My Proposal" => array:1 [
    0 => "google.txt"
  ]
  "Existing Behaviour" => array:1 [
    0 => "google.txt"
  ]
]
```

I've added a new test into `tests/Filesystem/FilesystemAdapterTest.php` which shows this new behaviour working. I'd be happy to make any suggested changes though! 

Thanks in advance for the consideration 🍻 