### PR TITLE
[12.x] Update `path` method return type to always be a non-null string

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -161,6 +161,8 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      * Get the URI's path.
      *
      * Empty or missing paths are returned as a single "/".
+     *
+     * @return non-empty-string
      */
     public function path(): string
     {

--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -162,7 +162,7 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
      *
      * Empty or missing paths are returned as a single "/".
      */
-    public function path(): ?string
+    public function path(): string
     {
         $path = trim((string) $this->uri->getPath(), '/');
 


### PR DESCRIPTION
Updates the `path()` return type in the **Uri** class from `?string` to `string` to improve type correctness, enhance code quality, and align with **PHPStan** analysis.