### PR TITLE
[12.x] Fix Accept header cache invalidation when header is modified

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -64,7 +64,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $routeResolver;
 
     /**
-     * The cached Accept header value used to detect changes.
+     * The cached "Accept" header value.
      *
      * @var string|null
      */
@@ -361,6 +361,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function userAgent()
     {
         return $this->headers->get('User-Agent');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[\Override]
+    public function getAcceptableContentTypes(): array
+    {
+        $currentAcceptHeader = $this->headers->get('Accept');
+
+        if ($this->cachedAcceptHeader !== $currentAcceptHeader) {
+            // Flush acceptable content types so Symfony re-calculates them...
+            $this->acceptableContentTypes = null;
+            $this->cachedAcceptHeader = $currentAcceptHeader;
+        }
+
+        return parent::getAcceptableContentTypes();
     }
 
     /**
@@ -818,23 +835,5 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function __get($key)
     {
         return Arr::get($this->all(), $key, fn () => $this->route($key));
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * Override to clear cache when Accept header changes.
-     */
-    #[\Override]
-    public function getAcceptableContentTypes(): array
-    {
-        $currentAcceptHeader = $this->headers->get('Accept');
-
-        if ($this->cachedAcceptHeader !== $currentAcceptHeader) {
-            $this->acceptableContentTypes = null;
-            $this->cachedAcceptHeader = $currentAcceptHeader;
-        }
-
-        return parent::getAcceptableContentTypes();
     }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -832,9 +832,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         if ($this->cachedAcceptHeader !== $currentAcceptHeader) {
             $this->acceptableContentTypes = null;
+            $this->cachedAcceptHeader = $currentAcceptHeader;
         }
-
-        $this->cachedAcceptHeader = $currentAcceptHeader;
 
         return parent::getAcceptableContentTypes();
     }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -64,6 +64,13 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     protected $routeResolver;
 
     /**
+     * The cached Accept header value used to detect changes.
+     *
+     * @var string|null
+     */
+    protected $cachedAcceptHeader;
+
+    /**
      * Create a new Illuminate HTTP request from server variables.
      *
      * @return static
@@ -811,5 +818,24 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function __get($key)
     {
         return Arr::get($this->all(), $key, fn () => $this->route($key));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Override to clear cache when Accept header changes.
+     */
+    #[\Override]
+    public function getAcceptableContentTypes(): array
+    {
+        $currentAcceptHeader = $this->headers->get('Accept');
+
+        if ($this->cachedAcceptHeader !== $currentAcceptHeader) {
+            $this->acceptableContentTypes = null;
+        }
+
+        $this->cachedAcceptHeader = $currentAcceptHeader;
+
+        return parent::getAcceptableContentTypes();
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1425,6 +1425,79 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->accepts('application/baz+json'));
     }
 
+    public function testWantsJsonRespectsHeaderChanges()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
+        
+        $this->assertFalse($request->wantsJson());
+        
+        $this->assertTrue($request->acceptsAnyContentType());
+        
+        $request->headers->set('Accept', 'application/json');
+
+        $this->assertTrue($request->wantsJson(), 'wantsJson() should return true after Accept header is changed to application/json');
+    }
+
+    public function testAcceptsJsonRespectsHeaderChanges()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
+
+        $this->assertTrue($request->acceptsAnyContentType());
+
+        $request->headers->set('Accept', 'application/json');
+
+        $this->assertTrue($request->acceptsJson(), 'acceptsJson() should return true after Accept header is changed to application/json');
+    }
+
+    public function testPrefersRespectsHeaderChanges()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
+        
+        $this->assertTrue($request->acceptsAnyContentType());
+        
+        $request->headers->set('Accept', 'application/json');
+        
+        $this->assertSame('json', $request->prefers(['html', 'json']), 'prefers() should return json after Accept header is changed to application/json');
+    }
+
+    public function testWantsJsonWorksWhenHeaderSetBeforeFirstCall()
+    {
+        $request = Request::create('/', 'GET', [], [], [], []);
+        
+        $request->headers->set('Accept', 'application/json');
+        
+        $this->assertTrue($request->wantsJson(), 'wantsJson() should return true when Accept header is set to application/json');
+    }
+
+    public function testCacheClearedWhenTransitioningFromUnsetToSetHeader()
+    {
+        $request = Request::create('/', 'GET', [], [], [], []);
+        
+        $request->getAcceptableContentTypes();
+        
+        $request->headers->set('Accept', 'application/json');
+        
+        $this->assertTrue($request->wantsJson(), 'wantsJson() should return true after Accept header is set from null to application/json');
+        
+        $this->assertTrue($request->acceptsJson(), 'acceptsJson() should return true after Accept header is set from null to application/json');
+    }
+
+    public function testAcceptsJsonWorksWhenHeaderChangedMultipleTimes()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html']);
+        
+        $this->assertFalse($request->acceptsJson());
+        
+        $request->headers->set('Accept', 'application/json');
+        $this->assertTrue($request->acceptsJson());
+        
+        $request->headers->set('Accept', 'text/html');
+        $this->assertFalse($request->acceptsJson());
+        
+        $request->headers->set('Accept', 'application/json');
+        $this->assertTrue($request->acceptsJson());
+    }
+
     public function testBadAcceptHeader()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'Mozilla/5.0 (Windows; U; Windows NT 5.1; pt-PT; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729)']);


### PR DESCRIPTION
When modifying the Accept header in middleware using `$request->headers->set('Accept', 'application/json')`, methods like `wantsJson()`, `acceptsJson()`, and `prefers()` would return stale values because Symfony's `getAcceptableContentTypes()` caches the result and doesn't clear it when headers are changed.

This caused issues in middleware scenarios like:

```php
if ($request->acceptsAnyContentType()) {
    $request->headers->set('Accept', 'application/json');
}
if (!$request->wantsJson()) {
    return response()->json(['message' => 'Not Acceptable.'], 406);
}
```

Even after setting the Accept header to `application/json`, `wantsJson()` would still return `false` because it was using the cached value from before the header change.

Fixes: https://github.com/laravel/framework/issues/57868
