### PR TITLE
[12.x] Add parameter validation to Collection::sliding() method.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1282,8 +1282,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Create chunks representing a "sliding window" view of the items in the collection.
      *
-     * @param  int  $size
-     * @param  int  $step
+     * @param  positive-int  $size
+     * @param  positive-int  $step
      * @return static<int, static>
      *
      * @throws \InvalidArgumentException
@@ -1291,11 +1291,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function sliding($size = 2, $step = 1)
     {
         if ($size < 1) {
-            throw new InvalidArgumentException('Size must be at least 1.');
-        }
-
-        if ($step < 1) {
-            throw new InvalidArgumentException('Step must be at least 1.');
+            throw new InvalidArgumentException('Size value must be at least 1.');
+        } elseif ($step < 1) {
+            throw new InvalidArgumentException('Step value must be at least 1.');
         }
 
         $chunks = floor(($this->count() - $size) / $step) + 1;

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1285,9 +1285,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  int  $size
      * @param  int  $step
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function sliding($size = 2, $step = 1)
     {
+        if ($size < 1) {
+            throw new InvalidArgumentException('Size must be at least 1.');
+        }
+
+        if ($step < 1) {
+            throw new InvalidArgumentException('Step must be at least 1.');
+        }
+
         $chunks = floor(($this->count() - $size) / $step) + 1;
 
         return static::times($chunks, fn ($number) => $this->slice(($number - 1) * $step, $size));

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1215,8 +1215,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Create chunks representing a "sliding window" view of the items in the collection.
      *
-     * @param  int  $size
-     * @param  int  $step
+     * @param  positive-int  $size
+     * @param  positive-int  $step
      * @return static<int, static>
      *
      * @throws \InvalidArgumentException
@@ -1224,11 +1224,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function sliding($size = 2, $step = 1)
     {
         if ($size < 1) {
-            throw new InvalidArgumentException('Size must be at least 1.');
-        }
-
-        if ($step < 1) {
-            throw new InvalidArgumentException('Step must be at least 1.');
+            throw new InvalidArgumentException('Size value must be at least 1.');
+        } elseif ($step < 1) {
+            throw new InvalidArgumentException('Step value must be at least 1.');
         }
 
         return new static(function () use ($size, $step) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1218,9 +1218,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  int  $size
      * @param  int  $step
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function sliding($size = 2, $step = 1)
     {
+        if ($size < 1) {
+            throw new InvalidArgumentException('Size must be at least 1.');
+        }
+
+        if ($step < 1) {
+            throw new InvalidArgumentException('Step must be at least 1.');
+        }
+
         return new static(function () use ($size, $step) {
             $iterator = $this->getIterator();
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -454,14 +454,14 @@ class SupportCollectionTest extends TestCase
             $collection::times(5)->sliding(0, 1)->toArray();
             $this->fail('Expected InvalidArgumentException for size = 0');
         } catch (\InvalidArgumentException $e) {
-            $this->assertSame('Size must be at least 1.', $e->getMessage());
+            $this->assertSame('Size value must be at least 1.', $e->getMessage());
         }
 
         try {
             $collection::times(5)->sliding(-1, 1)->toArray();
             $this->fail('Expected InvalidArgumentException for size = -1');
         } catch (\InvalidArgumentException $e) {
-            $this->assertSame('Size must be at least 1.', $e->getMessage());
+            $this->assertSame('Size value must be at least 1.', $e->getMessage());
         }
 
         // Test invalid step parameter (step must be at least 1)
@@ -470,14 +470,14 @@ class SupportCollectionTest extends TestCase
             $collection::times(5)->sliding(2, 0)->toArray();
             $this->fail('Expected InvalidArgumentException for step = 0');
         } catch (\InvalidArgumentException $e) {
-            $this->assertSame('Step must be at least 1.', $e->getMessage());
+            $this->assertSame('Step value must be at least 1.', $e->getMessage());
         }
 
         try {
             $collection::times(5)->sliding(2, -1)->toArray();
             $this->fail('Expected InvalidArgumentException for step = -1');
         } catch (\InvalidArgumentException $e) {
-            $this->assertSame('Step must be at least 1.', $e->getMessage());
+            $this->assertSame('Step value must be at least 1.', $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -447,6 +447,38 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf($collection, $chunks);
         $this->assertInstanceOf($collection, $chunks->first());
         $this->assertInstanceOf($collection, $chunks->skip(1)->first());
+
+        // Test invalid size parameter (size must be at least 1)
+        // instead of throwing an error. Now it throws InvalidArgumentException.
+        try {
+            $collection::times(5)->sliding(0, 1)->toArray();
+            $this->fail('Expected InvalidArgumentException for size = 0');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Size must be at least 1.', $e->getMessage());
+        }
+
+        try {
+            $collection::times(5)->sliding(-1, 1)->toArray();
+            $this->fail('Expected InvalidArgumentException for size = -1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Size must be at least 1.', $e->getMessage());
+        }
+
+        // Test invalid step parameter (step must be at least 1)
+        // Now it throws InvalidArgumentException with an error message.
+        try {
+            $collection::times(5)->sliding(2, 0)->toArray();
+            $this->fail('Expected InvalidArgumentException for step = 0');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Step must be at least 1.', $e->getMessage());
+        }
+
+        try {
+            $collection::times(5)->sliding(2, -1)->toArray();
+            $this->fail('Expected InvalidArgumentException for step = -1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Step must be at least 1.', $e->getMessage());
+        }
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
This PR adds parameter validations to `Collection::sliding()` and `LazyCollection::sliding()` methods.
The methods will throw an `InvalidArgumentException` when the `$steps` and `$size` parameters are <1.

With that way we have 2 issues fixed.

1) Size of 0 produced empty chunks.
  ```
  // Before fix:
  Collection::times(5)->sliding(0, 1)->toArray();
  // Result: [[], [], [], [], [], []]

  // Mathematical calculation:
  // $chunks = floor((count - size) / step) + 1
  // $chunks = floor((5 - 0) / 1) + 1 // 6
  // Each chunk has size 0, resulting in 6 empty arrays
```

2) Step of 0 caused DivisionByZeroError
```
  // Before fix:
  Collection::times(5)->sliding(2, 0)->toArray();
  // Result: DivisionByZeroError

  // Mathematical calculation:
  // $chunks = floor((5 - 2) / 0) + 1 = DivisionByZeroError
```

Thank you.