### PR TITLE
[12.x] Add `Collection::pad()` shortcut to `Str::explode()`

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -329,6 +329,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         $exploded = new Collection(explode($delimiter, $this->value, $limit));
 
         if ($pad) {
+            if ($limit === 0) {
+                $limit = 1;
+            } else if ($limit < 0) {
+                $limit = count($exploded) - ($limit - 1);
+            }
+
             $exploded->pad($limit, $padding);
         }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -331,7 +331,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         if ($pad) {
             if ($limit === 0) {
                 $limit = 1;
-            } else if ($limit < 0) {
+            } elseif ($limit < 0) {
                 $limit = count($exploded) - ($limit - 1);
             }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -331,7 +331,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         if ($pad) {
             $exploded->pad($limit, $padding);
         }
-        
+
         return $exploded;
     }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -324,9 +324,15 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      * @param  int  $limit
      * @return \Illuminate\Support\Collection<int, string>
      */
-    public function explode($delimiter, $limit = PHP_INT_MAX)
+    public function explode($delimiter, $limit = PHP_INT_MAX, $pad = false, $padding = null)
     {
-        return new Collection(explode($delimiter, $this->value, $limit));
+        $exploded = new Collection(explode($delimiter, $this->value, $limit));
+
+        if ($pad) {
+            $exploded->pad($limit, $padding);
+        }
+        
+        return $exploded;
     }
 
     /**


### PR DESCRIPTION
Just a quality of live improvement/convenience feature/shortcut.

If you want to use array destructuring, you need to make sure, the resulting collection has enough items:
```php
[$foo, $bar] = Str::of('foo:bar')->explode(':', 2); // ✅ ['foo', 'bar']
[$foo, $bar] = Str::of('foo')->explode(':', 2); // ❌ Offset 1 does not exist
[$foo, $bar] = Str::of('foo')->explode(':', 2)->pad(2, null); // ✅ ['foo', null], but 2 is redundant here yet required
```

This PR removes the need (and potential source of error to pass 2 twice:
```php
[$foo, $bar] = Str::of('foo')->explode(':', 2, true, null); // ✅ ['foo', null]
```
as this is a common use case

`$limit` is adjusted so that `$length` in `array_pad()` works (it takes only non-negative numbers) the same way as in `explode()`:

> * If limit is set and positive, the returned array will contain a maximum of limit elements with the last element containing the rest of string.
> * If the limit parameter is negative, all components except the last -limit are returned.
> * If the limit parameter is zero, then this is treated as 1.


ℹ️ The change is backwards-compatible as it defaults to `false` and continues to function as before if not set to `true`