### PR TITLE
[12.x] Add `Arr::safeExplode()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1240,10 +1240,10 @@ class Arr
     public static function safeExplode(string $value, string $delimiter, int $limit = PHP_INT_MAX, $fill = null): array
     {
         $length = match (true) {
-            $limit > 0 => $limit,
             $limit === 0 => 1,
             $limit < 0 => substr_count($value, $delimiter) - ($limit + 1),
             $limit > ($size = substr_count($value, $delimiter) + 1) => $size,
+            default => $limit,
         };
 
         return array_pad(explode($delimiter, $value, $limit), $length, $fill);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1234,6 +1234,9 @@ class Arr
         return is_array($value) ? $value : [$value];
     }
 
+    /**
+     * @return $fill is string ? list<string> : list<mixed>
+     */
     public static function safeExplode(string $value, string $delimiter, int $limit = PHP_INT_MAX, $fill = null): array
     {
         $length = match ($limit) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1241,7 +1241,6 @@ class Arr
     {
         $length = match (true) {
             $limit === 0 => 1,
-            $limit < 0 => substr_count($value, $delimiter) - ($limit + 1),
             $limit > ($size = substr_count($value, $delimiter) + 1) => $size,
             default => $limit,
         };

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1233,4 +1233,15 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    public static function safeExplode(string $value, string $delimiter, int $limit = PHP_INT_MAX, $fill = null): array
+    {
+        $length = match ($limit) {
+            $limit > 0 => $limit,
+            $limit === 0 => 1,
+            $limit < 0 => count($exploded) - ($limit - 1),
+        };
+
+        return array_pad(explode($delimiter, $value, $limit), $length, $fill);
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1243,7 +1243,7 @@ class Arr
             $limit > 0 => $limit,
             $limit === 0 => 1,
             $limit < 0 => substr_count($value, $delimiter) - ($limit + 1),
-            $limit === PHP_INT_MAX && ($size = substr_count($value, $delimiter) + 1) => $size,
+            $limit > ($size = substr_count($value, $delimiter) + 1) => $size,
         };
 
         return array_pad(explode($delimiter, $value, $limit), $length, $fill);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1239,9 +1239,11 @@ class Arr
      */
     public static function safeExplode(string $value, string $delimiter, int $limit = PHP_INT_MAX, $fill = null): array
     {
+        $maxSize = substr_count($value, $delimiter) + 1;
         $length = match (true) {
             $limit === 0 => 1,
-            $limit > ($size = substr_count($value, $delimiter) + 1) => $size,
+            $limit < 0 => $maxSize - $limit,
+            $limit > $maxSize => $maxSize,
             default => $limit,
         };
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1239,10 +1239,10 @@ class Arr
      */
     public static function safeExplode(string $value, string $delimiter, int $limit = PHP_INT_MAX, $fill = null): array
     {
-        $length = match ($limit) {
+        $length = match (true) {
             $limit > 0 => $limit,
             $limit === 0 => 1,
-            $limit < 0 => count($exploded) - ($limit - 1),
+            $limit < 0 => substr_count($value, $delimiter) - ($limit + 1),
         };
 
         return array_pad(explode($delimiter, $value, $limit), $length, $fill);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1243,6 +1243,7 @@ class Arr
             $limit > 0 => $limit,
             $limit === 0 => 1,
             $limit < 0 => substr_count($value, $delimiter) - ($limit + 1),
+            $limit === PHP_INT_MAX && ($size = substr_count($value, $delimiter) + 1) => $size,
         };
 
         return array_pad(explode($delimiter, $value, $limit), $length, $fill);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1841,7 +1841,7 @@ class SupportArrTest extends TestCase
      * @param  array{0: string, 1: string, 2?: int, 3?: mixed}  $input
      * @param  list<string|null>  $expected
      */
-    #[DataProvider('provideSafeExplode')
+    #[DataProvider('provideSafeExplode')]
     public function testSafeExplode(array $input, array $expected)
     {
         $this->assertEquals($expected, Arr::safeExplode(...$input));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -1840,6 +1841,7 @@ class SupportArrTest extends TestCase
      * @param  array{0: string, 1: string, 2?: int, 3?: mixed}  $input
      * @param  list<string|null>  $expected
      */
+    #[DataProvider('provideSafeExplode')
     public function testSafeExplode(array $input, array $expected)
     {
         $this->assertEquals($expected, Arr::safeExplode(...$input));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1835,4 +1835,29 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    /**
+     * @param  array{0: string, 1: string, 2?: int, 3?: mixed}  $input
+     * @param  list<string|null>  $expected
+     */
+    public function testSafeExplode(array $input, array $expected)
+    {
+        $this->assertEquals($expected, Arr::safeExplode(...$input));
+    }
+
+    /**
+     * @return array{array{0: string, 1: string, 2?: int, 3?: mixed}, list<string|null>}
+     */
+    public static function provideSafeExplode(): array
+    {
+        return [
+            [['foo:bar', ':'], ['foo', 'bar']],
+            [['foo:bar', ':', 2, null], ['foo', 'bar']],
+            [['foo', ':', 2, null], ['foo', null]],
+            [['foo:bar', ':', 1], ['foo:bar']],
+            [['foo:bar', ':', 0], ['foo:bar']],
+            [['foo:bar:baz', ':', -1], ['foo', 'bar']],
+            [['foo:bar', ':', -2, null], [null, null]],
+        ];
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1853,13 +1853,13 @@ class SupportArrTest extends TestCase
     public static function provideSafeExplode(): array
     {
         return [
-            [['foo:bar', ':'], ['foo', 'bar']],
-            [['foo:bar', ':', 2, null], ['foo', 'bar']],
-            [['foo', ':', 2, null], ['foo', null]],
-            [['foo:bar', ':', 1], ['foo:bar']],
-            [['foo:bar', ':', 0], ['foo:bar']],
-            [['foo:bar:baz', ':', -1], ['foo', 'bar']],
-            [['foo:bar', ':', -2, null], [null, null]],
+            'no padding needed, use defaults' => [['foo:bar', ':'], ['foo', 'bar']],
+            'no padding needed, explicit values' => [['foo:bar', ':', 2, null], ['foo', 'bar']],
+            'one entry needs to be passed, null padding given' => [['foo', ':', 2, null], ['foo', null]],
+            'limit set to 1, only one entry returned' => [['foo:bar', ':', 1], ['foo:bar']],
+            'limit set to 0, treated the same as with 1' => [['foo:bar', ':', 0], ['foo:bar']],
+            'negative limit given, correctly exploded from end of array, no padding needed' => [['foo:bar:baz', ':', -1], ['foo', 'bar']],
+            'negative limit given, correctly exploded from end of array, both resulting entries correctly padded with null' => [['foo:bar', ':', -2, null], [null, null]],
         ];
     }
 }


### PR DESCRIPTION
Just a quality of live improvement/convenience feature/shortcut.

If you want to use array destructuring, you need to make sure, the resulting collection has enough items:
```php
[$foo, $bar] = explode(':', 'foo:bar', 2); // ✅ ['foo', 'bar']
[$foo, $bar] = explode(':', 'foo', 2); // ❌ Offset 1 does not exist
[$foo, $bar] = array_pad(explode(':', 'foo', 2), 2, null); // ✅ ['foo', null], but 2 is redundant here yet required
```

This PR removes the need (and potential source of error to pass 2 twice:
```php
[$foo, $bar] = Arr::safeExplode('foo', ':', 2, null); // ✅ ['foo', null]
```
as this is a common use case

`$limit` is adjusted so that `$length` in `array_pad()` works (it takes only non-negative numbers) the same way as in `explode()`:

> * If limit is set and positive, the returned array will contain a maximum of limit elements with the last element containing the rest of string.
> * If the limit parameter is negative, all components except the last -limit are returned.
> * If the limit parameter is zero, then this is treated as 1.


ℹ️ The change is backwards-compatible as it defaults to `false` and continues to function as before if not set to `true`

Similar to #57879 but for when you don't need a collection.