### PR TITLE
[13.x] Update reset password notification subject

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -74,7 +74,7 @@ class ResetPassword extends Notification
     protected function buildMailMessage($url)
     {
         return (new MailMessage)
-            ->subject(Lang::get('Reset Your Password'))
+            ->subject(Lang::get('Reset your password'))
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::get('Reset Password'), $url)
             ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]))

--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -74,7 +74,7 @@ class ResetPassword extends Notification
     protected function buildMailMessage($url)
     {
         return (new MailMessage)
-            ->subject(Lang::get('Reset Password Notification'))
+            ->subject(Lang::get('Reset Your Password'))
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::get('Reset Password'), $url)
             ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]))

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -120,7 +120,7 @@ class ForgotPasswordTest extends TestCase
 
         ResetPassword::toMailUsing(function ($notifiable, $token) {
             return (new MailMessage)
-                ->subject(__('Reset Password Notification'))
+                ->subject(__('Reset Your Password'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
                 ->action(__('Reset Password'), route('custom.password.reset', $token))
                 ->line(__('If you did not request a password reset, no further action is required.'));

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -120,7 +120,7 @@ class ForgotPasswordTest extends TestCase
 
         ResetPassword::toMailUsing(function ($notifiable, $token) {
             return (new MailMessage)
-                ->subject(__('Reset Your Password'))
+                ->subject(__('Reset your password'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
                 ->action(__('Reset Password'), route('custom.password.reset', $token))
                 ->line(__('If you did not request a password reset, no further action is required.'));

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -98,7 +98,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
 
         ResetPassword::toMailUsing(function ($notifiable, $token) {
             return (new MailMessage)
-                ->subject(__('Reset Your Password'))
+                ->subject(__('Reset your password'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
                 ->action(__('Reset Password'), route('custom.password.reset', $token))
                 ->line(__('If you did not request a password reset, no further action is required.'));

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -98,7 +98,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
 
         ResetPassword::toMailUsing(function ($notifiable, $token) {
             return (new MailMessage)
-                ->subject(__('Reset Password Notification'))
+                ->subject(__('Reset Your Password'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
                 ->action(__('Reset Password'), route('custom.password.reset', $token))
                 ->line(__('If you did not request a password reset, no further action is required.'));


### PR DESCRIPTION
This PR updates the default subject line used for Laravel’s password-reset email.

The current subject, **"Reset  Password Notification**" has a boilerplate feel and doesn’t align with subject lines used by major services, which typically use a more direct, user-focused phrase. The screenshot below shows Laravel’s default subject line compared to those used by several well-known platforms.

This PR changes the default subject to **“Reset Your Password”**

_I’m targeting 13.x, as this may be a breaking change for developers who reference this string in their tests or translation files._

<img width="873" height="278" alt="SCR-20251124-lxie" src="https://github.com/user-attachments/assets/3eab24a9-13a7-4f45-baba-857e3a824463" />


