### PR TITLE
[13.x] Update verification email subject capitalization

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -62,7 +62,7 @@ class VerifyEmail extends Notification
     protected function buildMailMessage($url)
     {
         return (new MailMessage)
-            ->subject(Lang::get('Verify email address'))
+            ->subject(Lang::get('Verify your email address'))
             ->line(Lang::get('Please click the button below to verify your email address.'))
             ->action(Lang::get('Verify Email Address'), $url)
             ->line(Lang::get('If you did not create an account, no further action is required.'));

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -62,7 +62,7 @@ class VerifyEmail extends Notification
     protected function buildMailMessage($url)
     {
         return (new MailMessage)
-            ->subject(Lang::get('Verify Email Address'))
+            ->subject(Lang::get('Verify email address'))
             ->line(Lang::get('Please click the button below to verify your email address.'))
             ->action(Lang::get('Verify Email Address'), $url)
             ->line(Lang::get('If you did not create an account, no further action is required.'));


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/57882 

In the above PR I used _Title Case_, however it was later changed to use _Sentence case_ (https://github.com/laravel/framework/pull/57882/commits/64a8f469fff34f6fcac6078236aff77e4c446844), this now makes it inconsistent with the email verification subject. This PR updates the verification email subject to make the capitalization consistent.