### PR TITLE
[12.x] Simplify `ParsesQueue@parseQueue` logic

### DIFF
--- a/src/Illuminate/Queue/Console/Concerns/ParsesQueue.php
+++ b/src/Illuminate/Queue/Console/Concerns/ParsesQueue.php
@@ -12,10 +12,11 @@ trait ParsesQueue
      */
     protected function parseQueue($queue)
     {
-        [$connection, $queue] = array_pad(explode(':', $queue, 2), 2, null);
+        [$connection, $queue] = array_pad(explode(':', $queue, 2), -2, null);
 
-        return isset($queue)
-            ? [$connection, $queue]
-            : [$this->laravel['config']['queue.default'], $connection];
+        return [
+            $connection ?? $this->laravel['config']['queue.default'],
+            $queue ?: 'default',
+        ];
     }
 }


### PR DESCRIPTION
- PR #57800 introduced queue pause/resume
- PR #57863 cleaned up the code and moved the queue parsing logic to a common trait to be used by both `queue:pause` and `queue:resume` commands

**This PR**

- Tidies up the queue parsing logic within the `Illuminate\Queue\Console\Concerns\ParsesQueue@parseQueue` method
  - If a negative length is given to `array_pad`, then the array is padded to the left, and as such the queue value always ends up on the `$queue` variable.
  - By defaulting `$connection` to null, we can remove the ternary operator from the return statement and use the null coalescing operator to replace a missing value with its default value, without context swapping the `$connection` and `$queue` variables.
- Adds test cases to ensure parsing happens as expected.

I also defaulted `$queue` to the `default` queue when an empty string is given, but I can revert that if wanted.