### PR TITLE
[12.x] Add @active Blade directive for navigation highlighting

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -182,6 +182,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the active statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileActive($condition)
+    {
+        return "<?php if{$condition}: echo 'active'; endif; ?>";
+    }
+
+    /**
      * Compile the else-if statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -43,4 +43,20 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+     public function testActiveStatementsAreCompiled()
+    {
+        $string = '<a @active(request()->routeIs(\'home\'))>Home</a>';
+        $expected = "<a <?php if(request()->routeIs('home')): echo 'active'; endif; ?>>Home</a>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testActiveStatementsWithComplexConditions()
+    {
+        $string = '<li @active($current === \'dashboard\')>Dashboard</li>';
+        $expected = "<li <?php if(\$current === 'dashboard'): echo 'active'; endif; ?>>Dashboard</li>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -44,7 +44,7 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-     public function testActiveStatementsAreCompiled()
+    public function testActiveStatementsAreCompiled()
     {
         $string = '<a @active(request()->routeIs(\'home\'))>Home</a>';
         $expected = "<a <?php if(request()->routeIs('home')): echo 'active'; endif; ?>>Home</a>";


### PR DESCRIPTION
## Purpose
Adds `@active` Blade directive to simplify navigation active state highlighting, one of the most common patterns in Laravel applications.

## Changes
- Added `compileActive()` method to `CompilesConditionals` trait
- Added comprehensive tests covering basic and complex condition usage
- Follows the same pattern as existing `@checked`, `@selected`, `@disabled` directives

## Example Usage

**Before:**
```blade
<a class="{{ request()->routeIs('home') ? 'active' : '' }}" href="/">Home</a>
<a class="{{ $current === 'dashboard' ? 'active' : '' }}" href="/dashboard">Dashboard</a>
```

**After:**
```blade
<a class="@active(request()->routeIs('home'))" href="/">Home</a>
<a class="@active($current === 'dashboard')" href="/dashboard">Dashboard</a>
```

**Benefits:**
- More readable navigation code
- Consistent with existing @checked, @selected, @disabled directives

**Backwards Compatibility:**
Fully backwards compatible - new directive, no breaking changes.

**Testing:**
- Added 2 tests
- Both tests follow existing patterns from `BladeCheckedStatementsTest`
- Tests cover basic and a more complex conditional expressions