### PR TITLE
[12.x] Add parameter validation to Collection and LazyCollection `split()` & `splitIn()` methods.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1349,11 +1349,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Split a collection into a certain number of groups.
      *
-     * @param  int  $numberOfGroups
+     * @param  positive-int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function split($numberOfGroups)
     {
+        if ($numberOfGroups <= 0) {
+            throw new InvalidArgumentException('Number of groups must be greater than 0.');
+        }
+
         if ($this->isEmpty()) {
             return new static;
         }
@@ -1386,11 +1392,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
-     * @param  int  $numberOfGroups
+     * @param  positive-int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function splitIn($numberOfGroups)
     {
+        if ($numberOfGroups <= 0) {
+            throw new InvalidArgumentException('Number of groups must be greater than 0.');
+        }
+
         return $this->chunk((int) ceil($this->count() / $numberOfGroups));
     }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1341,11 +1341,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Split a collection into a certain number of groups.
      *
-     * @param  int  $numberOfGroups
+     * @param  positive-int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function split($numberOfGroups)
     {
+        if ($numberOfGroups <= 0) {
+            throw new InvalidArgumentException('Number of groups must be greater than 0.');
+        }
+
         return $this->passthru('split', func_get_args());
     }
 
@@ -1446,11 +1452,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
-     * @param  int  $numberOfGroups
+     * @param  positive-int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function splitIn($numberOfGroups)
     {
+        if ($numberOfGroups <= 0) {
+            throw new InvalidArgumentException('Number of groups must be greater than 0.');
+        }
+
         return $this->chunk((int) ceil($this->count() / $numberOfGroups));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5082,6 +5082,7 @@ class SupportCollectionTest extends TestCase
             })->toArray()
         );
     }
+    
     #[DataProvider('collectionClassProvider')]
     public function testSplitThrowsExceptionForZeroGroups($collection)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2286,6 +2286,14 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testSplitInThrowsExceptionForZeroGroups($collection)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Number of groups must be greater than 0.');
+        $collection::times(5)->splitIn(0);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testChunkWhileOnEqualElements($collection)
     {
         $data = (new $collection(['A', 'A', 'B', 'B', 'C', 'C', 'C']))
@@ -5073,6 +5081,13 @@ class SupportCollectionTest extends TestCase
                 return $chunk->values()->toArray();
             })->toArray()
         );
+    }
+    #[DataProvider('collectionClassProvider')]
+    public function testSplitThrowsExceptionForZeroGroups($collection)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Number of groups must be greater than 0.');
+        $collection::times(5)->split(0);
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5082,7 +5082,7 @@ class SupportCollectionTest extends TestCase
             })->toArray()
         );
     }
-    
+
     #[DataProvider('collectionClassProvider')]
     public function testSplitThrowsExceptionForZeroGroups($collection)
     {


### PR DESCRIPTION
Hello, this PR adds validations to `Collection::split()`, `Collection::splitIn()` and `LazyCollection::split()`, `LazyCollection:splitIn()` methods.
The methods previously would return error (DivisionByZeroError). Now it returns an `InvalidArgumentException` if the parameter is <=0