### PR TITLE
[12.x]  Remove unnecessary foreach loop in preg_replace_array helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }


### PR DESCRIPTION
This PR removes an unnecessary foreach loop in the `preg_replace_array()` helper function.

**Changes:**
- Simplified the callback function by removing the redundant foreach loop
- The loop was only executing once and the loop variable was never used
- This improves code clarity and has a minor performance benefit

**Before:**
```php
return preg_replace_callback($pattern, function () use (&$replacements) {
    foreach ($replacements as $value) {
        return array_shift($replacements);
    }
}, $subject);
```

**After:**
```php
return preg_replace_callback($pattern, function () use (&$replacements) {
    return array_shift($replacements);
}, $subject);
```
