### PR TITLE
[12.x]  Add early return to Str::start() for empty prefix

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1402,6 +1402,10 @@ class Str
      */
     public static function start($value, $prefix)
     {
+        if ($prefix === '') {
+            return $value;
+        }
+
         $quoted = preg_quote($prefix, '/');
 
         return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);


### PR DESCRIPTION
This PR adds an early return optimization to the `Str::start()` method when the prefix is an empty string.

**Changes:**
- Added early return check when `$prefix === ''`
- Avoids unnecessary `preg_quote()` and `preg_replace()` calls for empty prefix
- Improves performance for edge cases
- Maintains consistency with similar methods in the codebase

**Before:**
```php
public static function start($value, $prefix)
{
    $quoted = preg_quote($prefix, '/');
    return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
}
```

**After:**
```php
public static function start($value, $prefix)
{
    if ($prefix === '') {
        return $value;
    }
    
    $quoted = preg_quote($prefix, '/');
    return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
}
```
