### PR TITLE
[12.x]  Add early return to Str::finish() for empty cap

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -469,6 +469,10 @@ class Str
      */
     public static function finish($value, $cap)
     {
+        if ($cap === '') {
+            return $value;
+        }
+
         $quoted = preg_quote($cap, '/');
 
         return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;


### PR DESCRIPTION
This PR adds an early return optimization to the `Str::finish()` method when the cap is an empty string.

**Changes:**
- Added early return check when `$cap === ''`
- Avoids unnecessary `preg_quote()` and `preg_replace()` calls for empty cap
- Improves performance for edge cases
- Maintains consistency with `Str::start()` method

**Before:**
```php
public static function finish($value, $cap)
{
    $quoted = preg_quote($cap, '/');
    return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
}
```

**After:**
```php
public static function finish($value, $cap)
{
    if ($cap === '') {
        return $value;
    }
    
    $quoted = preg_quote($cap, '/');
    return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
}
```
