### PR TITLE
[12.x]  Add early return to Str::unwrap() for empty wrappers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -497,7 +497,11 @@ class Str
      */
     public static function unwrap($value, $before, $after = null)
     {
-        if (static::startsWith($value, $before)) {
+        if ($before === '' && ($after === '' || $after === null)) {
+            return $value;
+        }
+
+        if ($before !== '' && static::startsWith($value, $before)) {
             $value = static::substr($value, static::length($before));
         }
 


### PR DESCRIPTION
This PR adds an early return optimization to the `Str::unwrap()` method when both wrappers are empty strings.

**Changes:**
- Added early return check when both `$before` and `$after` are empty
- Added check to skip `startsWith()` when `$before` is empty
- Avoids unnecessary function calls for edge cases
- Improves performance and maintains consistency with `Str::start()` and `Str::finish()`

**Before:**
```php
public static function unwrap($value, $before, $after = null)
{
    if (static::startsWith($value, $before)) {
        $value = static::substr($value, static::length($before));
    }

    if (static::endsWith($value, $after ??= $before)) {
        $value = static::substr($value, 0, -static::length($after));
    }

    return $value;
}
```

**After:**
```php
public static function unwrap($value, $before, $after = null)
{
    if ($before === '' && ($after === '' || $after === null)) {
        return $value;
    }

    if ($before !== '' && static::startsWith($value, $before)) {
        $value = static::substr($value, static::length($before));
    }

    if (static::endsWith($value, $after ??= $before)) {
        $value = static::substr($value, 0, -static::length($after));
    }

    return $value;
}
```
