### PR TITLE
[12.x] Add --json output option to queue:failed command

### DIFF
--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -139,7 +139,6 @@ class ListFailedCommand extends Command
         );
     }
 
-
     /**
      * Display the failed jobs as JSON.
      *

--- a/tests/Queue/QueueListFailedCommandTest.php
+++ b/tests/Queue/QueueListFailedCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Queue\Failed\NullFailedJobProvider;
+use Orchestra\Testbench\TestCase;
+
+class QueueListFailedCommandTest extends TestCase
+{
+    public function testListFailedJobsAsJsonWhenEmpty()
+    {
+        $this->app->instance('queue.failer', new NullFailedJobProvider);
+
+        $this->artisan('queue:failed', ['--json' => true])
+            ->expectsOutput(json_encode([
+                'failed_jobs' => [],
+                'count' => 0,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
+            ->assertExitCode(0);
+    }
+
+    public function testListFailedJobsAsTableWhenEmpty()
+    {
+        $this->app->instance('queue.failer', new NullFailedJobProvider);
+
+        $this->artisan('queue:failed')
+            ->expectsOutputToContain('No failed jobs found')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
## Purpose
Adds `--json` output option to `queue:failed` command for automation and monitoring use cases.

## Changes
- Converted `$name` to `$signature` with `--json` option definition
- Modified `handle()` method to support JSON output
- Added `displayFailedJobsAsJson()` method
- Added tests for JSON output (empty state)
- Maintains existing table output as default

## Example Usage

**Command:**
```bash
php artisan queue:failed --json
```

**Output:**
```json
{
  "failed_jobs": [
    {
      "id": "1234",
      "uuid": "550e8400-e29b-41d4-a716-446655440000",
      "connection": "redis",
      "queue": "emails",
      "class": "App\\Jobs\\SendEmail",
      "failed_at": "2025-11-21 10:30:00",
      "exception": "Connection timeout..."
    }
  ],
  "count": 1
}
```

**Benefits:**
- Enables CI/CD pipeline integration
- Supports monitoring and alerting systems
- Allows programmatic failed job analysis
- Follows recent pattern (schedule:list --json in PR [#57741](https://github.com/laravel/framework/pull/57741))

**Backwards Compatibility:**
Fully backwards compatible - optional flag, default behavior unchanged.

## Future Work
Filtering options (--queue, --connection, --after, --class) will be added in a separate PR to keep this change focused and easy to review.