### PR TITLE
Allow passing environment variables to scheduled tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -105,6 +105,18 @@ class CallbackEvent extends Event
     }
 
     /**
+     * Set the additional environment variables for the callback.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function env(array $environment)
+    {
+        throw new RuntimeException('Scheduled closures can not set environment variables.');
+    }
+
+    /**
      * Run the callback.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -91,6 +91,13 @@ class Event
     public $exitCode;
 
     /**
+     * The additional environment variables for the command.
+     *
+     * @var array
+     */
+    public $environment = [];
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -198,7 +205,7 @@ class Event
     protected function execute($container)
     {
         return Process::fromShellCommandline(
-            $this->buildCommand(), base_path(), null, null, null
+            $this->buildCommand(), base_path(), $this->environment, null, null
         )->run(
             laravel_cloud()
                 ? fn ($type, $line) => fwrite($type === 'out' ? STDOUT : STDERR, $line)
@@ -472,6 +479,18 @@ class Event
         }
 
         return "Scheduled Job Output For [{$this->command}]";
+    }
+
+    /**
+     * Set the additional environment variables for the command.
+     *
+     * @return $this
+     */
+    public function env(array $environment)
+    {
+        $this->environment = $environment;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
With this change, it allows us to pass environment variables to scheduled tasks similar to the `Process` facade.

Useful for commands or any other schedule tasks that need to override the environment variable for some uses but not all.

Example `routes/console.php`:

```
<?php

// process podcasts in default english
Schedule::command('app:process-podcasts')->everyHour();
// process podcasts in french
Schedule::command('app:process-podcasts')->env(['LANG' => 'fr'])->everyHour();

// prior:
Schedule::exec('LANG=fr php artisan app:process-podcasts')->everyHour();
```

This is only applicable to `::exec()` and `::command()` tasks that use the Symfony process package. `::job()` and `::call()` do not use it. As such, the method is overridden to throw an exception similar to   `runInBackground()`.
