### PR TITLE
Simplify preg_replace_array callback by removing unnecessary foreach loop

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }


### PR DESCRIPTION
This PR simplifies the callback function in the `preg_replace_array` helper by removing an unnecessary `foreach` loop that only executes once.

**Current Code:**
```php
return preg_replace_callback($pattern, function () use (&$replacements) {
    foreach ($replacements as $value) {
        return array_shift($replacements);
    }
}, $subject);
```

**Improved Code:**
```php
return preg_replace_callback($pattern, function () use (&$replacements) {
    return array_shift($replacements);
}, $subject);
```

**Why this change:**
- The `foreach` loop is redundant since it always returns on the first iteration
- The loop variable `$value` is never used
- The simplified version is clearer and more maintainable
- Behavior remains exactly the same

This change improves code clarity without affecting functionality.