### PR TITLE
[12.x] Fix flaky test in ArraySessionHandler (expired session)

### DIFF
--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -58,6 +58,7 @@ class ArraySessionHandlerTest extends TestCase
     {
         $handler = new ArraySessionHandler(10);
 
+        Carbon::setTestNow(Carbon::now());
         $handler->write('foo', 'bar');
 
         Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());


### PR DESCRIPTION
This PR fixes a flaky test by freezing time before the write operation in `test_it_reads_data_from_an_expired_session`.

**Problem:**
Without freezing time, there's a small window where time can advance between when the session is written (which records a timestamp) and when the expiration check occurs. This can cause the test to fail intermittently.

**Solution:**
Add `Carbon::setTestNow(Carbon::now());` before the `write()` operation to ensure consistent timing throughout the test.