### PR TITLE
[12.x] Fix flaky test in ArraySessionHandler (garbage collection)

### DIFF
--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -100,6 +100,7 @@ class ArraySessionHandlerTest extends TestCase
 
         $this->assertSame(0, $handler->gc(300));
 
+        Carbon::setTestNow(Carbon::now());
         $handler->write('foo', 'bar');
         $this->assertSame(0, $handler->gc(300));
         $this->assertSame('bar', $handler->read('foo'));


### PR DESCRIPTION
This PR fixes a flaky test by freezing time before the write operation in `test_it_cleans_up_old_sessions`.

**Problem:**
Without freezing time, there's a small window where time can advance between when the session is written (which records a timestamp) and when the garbage collection check occurs. This can cause the test to fail intermittently.

**Solution:**
Add `Carbon::setTestNow(Carbon::now());` before the first `write()` operation to ensure consistent timing throughout the test.

**Related:**
This follows the same pattern as #57864.