### PR TITLE
[12.x] Fix flaky test in CacheArrayStore (increment)

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -117,6 +117,8 @@ class CacheArrayStoreTest extends TestCase
 
     public function testNonExistingKeysCanBeIncremented()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $store = new ArrayStore;
         $result = $store->increment('foo');
         $this->assertEquals(1, $result);


### PR DESCRIPTION
This PR fixes a flaky test by freezing time before the increment operation in `testNonExistingKeysCanBeIncremented`.

**Problem:**
Without freezing time, there's a small window where time can advance between when the cache value is incremented (which records a timestamp) and when subsequent time-based checks occur. This can cause the test to fail intermittently.

**Solution:**
Add `Carbon::setTestNow(Carbon::now());` before the `increment()` operation to ensure consistent timing throughout the test.