### PR TITLE
[12.x] Improve discarded attribute violation callable typehints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -215,7 +215,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The callback that is responsible for handling discarded attribute violations.
      *
-     * @var callable|null
+     * @var (callable(self, array))|null
      */
     protected static $discardedAttributeViolationCallback;
 
@@ -548,7 +548,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling discarded attribute violations.
      *
-     * @param  callable|null  $callback
+     * @param  (callable(self, array))|null  $callback
      * @return void
      */
     public static function handleDiscardedAttributeViolationUsing(?callable $callback)


### PR DESCRIPTION
This PR improves the typehints for the discarded attribute violation callback by specifying the exact callable signature.

Improved the lazy loading violation callback typehints, this change makes the callable signature more explicit by changing from `callable|null` to `(callable(self, array))|null`.

The callback receives:
- The model instance (`self`)
- An array of discarded attribute keys (`array`)

This provides better IDE support and makes the expected callback signature clearer to developers.