### PR TITLE
[12.x] Improve missing attribute violation callable typehints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -229,7 +229,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * The callback that is responsible for handling missing attribute violations.
      *
-     * @var callable|null
+     * @var (callable(self, string))|null
      */
     protected static $missingAttributeViolationCallback;
 
@@ -570,7 +570,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling missing attribute violations.
      *
-     * @param  callable|null  $callback
+     * @param  (callable(self, string))|null  $callback
      * @return void
      */
     public static function handleMissingAttributeViolationUsing(?callable $callback)


### PR DESCRIPTION
This PR improves the typehints for the missing attribute violation callback by specifying the exact callable signature.

Improved the lazy loading violation callback typehints, this change makes the callable signature more explicit by changing from `callable|null` to `(callable(self, string))|null`.

The callback receives:
- The model instance (`self`)
- The missing attribute key (`string`)

This provides better IDE support and makes the expected callback signature clearer to developers.