### PR TITLE
[12.x] Remove useless variables in catch statements

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -182,7 +182,7 @@ class ConnectionFactory
 
                 try {
                     return $this->createConnector($config)->connect($config);
-                } catch (PDOException $e) {
+                } catch (PDOException) {
                     continue;
                 }
             }

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -44,7 +44,7 @@ class ServeFile
                     }
                 }
             );
-        } catch (PathTraversalDetected $e) {
+        } catch (PathTraversalDetected) {
             abort(404);
         }
     }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -199,7 +199,7 @@ abstract class Job
 
             try {
                 $batchRepository->rollBack();
-            } catch (Throwable $e) {
+            } catch (Throwable) {
                 // ...
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1216,7 +1216,7 @@ class Str
     {
         try {
             return (string) $value;
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return $fallback;
         }
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -475,7 +475,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         try {
             $post->tags()->findSole($tag);
             $this->fail('Expected RecordsNotFoundException was not thrown.');
-        } catch (RecordsNotFoundException $e) {
+        } catch (RecordsNotFoundException) {
             $this->assertTrue(true);
         }
     }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -196,7 +196,7 @@ class EventFakeTest extends TestCase
 
                 throw new Exception('foo');
             });
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         Event::assertNotDispatched(ShouldDispatchAfterCommitEvent::class);

--- a/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
+++ b/tests/Integration/Events/ShouldDispatchAfterCommitEventTest.php
@@ -186,7 +186,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
                     Event::dispatch(new AnotherShouldDispatchAfterCommitTestEvent);
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 
@@ -207,7 +207,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
 
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 //
             }
         });
@@ -232,7 +232,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
                     Event::dispatch(new AnotherShouldDispatchAfterCommitTestEvent);
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 
@@ -255,7 +255,7 @@ class ShouldDispatchAfterCommitEventTest extends TestCase
 
                     throw new \Exception;
                 });
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1637,7 +1637,7 @@ class TestResponseTest extends TestCase
         try {
             $response->assertExactJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo']]], 'foo', 'foobar', 0, 'bars', 'barfoo', 'numeric_keys']);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 
@@ -1651,7 +1651,7 @@ class TestResponseTest extends TestCase
         try {
             $response->assertExactJsonStructure(['*' => ['foo', 'bar']]);
             $failed = false;
-        } catch (AssertionFailedError $e) {
+        } catch (AssertionFailedError) {
             $failed = true;
         }
 


### PR DESCRIPTION
**Remove unused exception variables in catch blocks**

This PR cleans up several catch statements by removing exception variables that were never used. Since PHP 8 allows catch (Exception) without a variable, these assignments were unnecessary.

**Why:**

- Reduces noise and avoids unused-variable warnings.
- No behavioral changes — purely a refactor.
- Keeps the codebase more consistent and readable.

**Impact:**

- Safe for Laravel’s supported PHP versions.
- No logic, flow, or public API changes
- No tests needed.