### PR TITLE
[12.x] Modernize type casting

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -63,6 +63,7 @@
             "on_multiline": "ignore"
         },
         "method_chaining_indentation": true,
+        "modernize_types_casting": true,
         "multiline_whitespace_before_semicolons": {
             "strategy": "no_multi_line"
         },


### PR DESCRIPTION
This PR refactors several parts of the codebase to use more explicit and modern PHP typecasting (e.g., `(int)`, `(float)`, ect...) for better readability and intent.

**Why:**

- Enhances clarity of type conversions.
- No functional changes — purely a cleanup.

**Impact:**

- Fully backward-compatible.
- No behavioral changes.
- Requires review of casting correctness only.

cf. https://mlocati.github.io/php-cs-fixer-configurator/#version:3.88|fixer:modernize_types_casting

---

`pint` was not run against those changes, as it would break `StyleCI`