### PR TITLE
[12.x] Pause a queue for given seconds

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -212,6 +212,21 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Pause a queue by its connection and name for a given number of seconds.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  int  $seconds
+     * @return void
+     */
+    public function pauseFor($connection, $queue, $seconds)
+    {
+        $this->app['cache']
+            ->store()
+            ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $seconds);
+    }
+
+    /**
      * Resume a paused queue by its connection and name.
      *
      * @param  string  $connection

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -216,14 +216,14 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $connection
      * @param  string  $queue
-     * @param  \DateInterval|int  $seconds
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return void
      */
-    public function pauseFor($connection, $queue, $seconds)
+    public function pauseFor($connection, $queue, $ttl)
     {
         $this->app['cache']
             ->store()
-            ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $seconds);
+            ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -212,7 +212,7 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Pause a queue by its connection and name for a given number of seconds.
+     * Pause a queue by its connection and name for a given amount of time.
      *
      * @param  string  $connection
      * @param  string  $queue

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -216,7 +216,7 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $connection
      * @param  string  $queue
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
      * @return void
      */
     public function pauseFor($connection, $queue, $ttl)

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -216,7 +216,7 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $connection
      * @param  string  $queue
-     * @param  int  $seconds
+     * @param  \DateInterval|int  $seconds
      * @return void
      */
     public function pauseFor($connection, $queue, $seconds)

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static bool connected(string|null $name = null)
  * @method static \Illuminate\Contracts\Queue\Queue connection(string|null $name = null)
  * @method static void pause(string $connection, string $queue)
- * @method static void pauseFor(string $connection, string $queue, int $seconds)
+ * @method static void pauseFor(string $connection, string $queue, \DateTimeInterface|\DateInterval|int  $ttl)
  * @method static void resume(string $connection, string $queue)
  * @method static bool isPaused(string $connection, string $queue)
  * @method static void extend(string $driver, \Closure $resolver)

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static bool connected(string|null $name = null)
  * @method static \Illuminate\Contracts\Queue\Queue connection(string|null $name = null)
  * @method static void pause(string $connection, string $queue)
+ * @method static void pauseFor(string $connection, string $queue, int $seconds)
  * @method static void resume(string $connection, string $queue)
  * @method static bool isPaused(string $connection, string $queue)
  * @method static void extend(string $driver, \Closure $resolver)

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -51,15 +52,23 @@ class QueuePauseResumeTest extends TestCase
 
     public function testPauseQueueWithTTL()
     {
-        $this->manager->pause('redis', 'default', 60);
+        Carbon::setTestNow();
+        $this->manager->pauseFor('redis', 'default', 30);
 
         $this->assertTrue($this->manager->isPaused('redis', 'default'));
+
+        Carbon::setTestNow(Carbon::now()->addMinute());
+        $this->assertFalse($this->manager->isPaused('redis', 'default'));
     }
 
     public function testPauseQueueIndefinitely()
     {
-        $this->manager->pause('redis', 'default', null);
+        Carbon::setTestNow();
+        $this->manager->pause('redis', 'default');
 
+        $this->assertTrue($this->manager->isPaused('redis', 'default'));
+
+        Carbon::setTestNow(Carbon::now()->addYear());
         $this->assertTrue($this->manager->isPaused('redis', 'default'));
     }
 


### PR DESCRIPTION
PR #57800 added the `QueueManager@pause()` method to allow pausing a given queue.

This method pauses the queue indefinitely by using a cache's store `forever()` method.

As such a queue can only be resumed by calling the `QueueManager@resume()` method added in the same PR.

When consuming an external API with rate limiting, one can get a `429` response when the rate limit is surpassed. 

Often times this response is accompanied by the `Retry-After` header that gives the number of seconds to wait before retrying.

Currently, one would need to keep track of those seconds to manually pause a queue (when a `429` response is received) and manually resume a queue (when the timeout is expired).

**This PR**
- Adds the `QueueManager@pauseFor()` method that allows passing the number of seconds a queue should be paused.
- Fixes some test cases and adds relevant assertions to test for the presented use case.
  - It seems the original PR aimed for allowing the seconds to be passed, so there were already tests in place testing for a third `$seconds` argument.
