### PR TITLE
Pass Laravel context through with schedule tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -198,7 +198,7 @@ class Event
      */
     protected function execute($container)
     {
-        $context = escapeshellarg(json_encode($container[Repository::class]->dehydrate()));
+        $context = json_encode($container[Repository::class]->dehydrate());
 
         return Process::fromShellCommandline(
             $this->buildCommand(), base_path(), ['__LARAVEL_CONTEXT' => $context], null, null

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -11,6 +11,7 @@ use Illuminate\Console\Application;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Log\Context\Repository;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Stringable;
@@ -197,8 +198,10 @@ class Event
      */
     protected function execute($container)
     {
+        $context = escapeshellarg(json_encode($container[Repository::class]->dehydrate()));
+
         return Process::fromShellCommandline(
-            $this->buildCommand(), base_path(), null, null, null
+            $this->buildCommand(), base_path(), ['__LARAVEL_CONTEXT' => $context], null, null
         )->run(
             laravel_cloud()
                 ? fn ($type, $line) => fwrite($type === 'out' ? STDOUT : STDERR, $line)

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -23,6 +23,7 @@ class ContextServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->app->resolving(Repository::class, function (Repository $repository) {
                 $context = Env::get('__LARAVEL_CONTEXT');
+
                 if ($context && $context = json_decode($context, associative: true)) {
                     $repository->hydrate($context);
                 }

--- a/src/Illuminate/Log/Context/ContextServiceProvider.php
+++ b/src/Illuminate/Log/Context/ContextServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Log\Context;
 use Illuminate\Contracts\Log\ContextLogProcessor as ContextLogProcessorContract;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Queue;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,6 +30,10 @@ class ContextServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $env = Env::get('__LARAVEL_CONTEXT', '');
+        /** @phpstan-ignore staticMethod.notFound */
+        Context::hydrate(json_decode($env, true));
+
         Queue::createPayloadUsing(function ($connection, $queue, $payload) {
             /** @phpstan-ignore staticMethod.notFound */
             $context = Context::dehydrate();


### PR DESCRIPTION
This propagates the Laravel Context through with Schedule Tasks so they carry the same contextual information from the schedule definition. Similar to how jobs, dispatched from requests or other jobs or commands carry the context from those entrypoints, this follows suit with schedule tasks.
