### PR TITLE
[12.x] fix: continue route matching rather than returning second fallbackRoute

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -83,8 +83,8 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
 
         foreach ($routes as $route) {
             if ($route->matches($request, $includingMethod)) {
-                if ($route->isFallback && $fallbackRoute === null) {
-                    $fallbackRoute = $route;
+                if ($route->isFallback) {
+                    $fallbackRoute ??= $route;
 
                     continue;
                 }


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/57871 introduced a very slight change to the behaviour of matching fallback routes.

Before https://github.com/laravel/framework/pull/57871: Return first non-fallback route match, otherwise return first fallback route match.

After https://github.com/laravel/framework/pull/57871: Return the second matching fallback route (if one exist), otherwise return the first non-fallback route match, otherwise return the first fallback route.

Reasoning:
After the first fallbackRoute is matched, the next fallbackRoute will no longer get caught by the ->isFallback guard, due to the === null check. This causes the next matching fallbackRoute to be returned, rather than continuing through the non-fallback routes.

To fix this, I've removed the === null check, causing the loop to continue. I used null coalescing assignment to ensure only the first fallback route is captured.