### PR TITLE
[12.x] Add reload command and allow services to register

### DIFF
--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -32,7 +32,7 @@ class ReloadCommand extends Command
      */
     public function handle()
     {
-        $this->components->info('Reloading running services..');
+        $this->components->info('Reloading services.');
 
         $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
             ->map(fn ($except) => trim($except))

--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'reload')]
+class ReloadCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'reload';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reload running services';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->components->info('Reloading running services..');
+
+        $exceptions = Collection::wrap(explode(',', $this->option('except') ?? ''))
+            ->map(fn ($except) => trim($except))
+            ->filter()
+            ->unique()
+            ->flip();
+
+        $tasks = Collection::wrap($this->getReloadTasks())
+            ->reject(fn ($command, $key) => $exceptions->hasAny([$command, $key]))
+            ->toArray();
+
+        foreach ($tasks as $description => $command) {
+            $this->components->task($description, fn () => $this->callSilently($command) == 0);
+        }
+
+        $this->newLine();
+    }
+
+    /**
+     * Get the commands that should be run to clear the "optimization" files.
+     *
+     * @return array
+     */
+    public function getReloadTasks()
+    {
+        return [
+            'queue' => 'queue:restart',
+            ...ServiceProvider::$reloadCommands,
+        ];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['except', 'e', InputOption::VALUE_OPTIONAL, 'The commands to skip'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -70,6 +70,7 @@ use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\PackageDiscoverCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\ProviderMakeCommand;
+use Illuminate\Foundation\Console\ReloadCommand;
 use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
@@ -160,6 +161,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueRetry' => QueueRetryCommand::class,
         'QueueRetryBatch' => QueueRetryBatchCommand::class,
         'QueueWork' => QueueWorkCommand::class,
+        'Reload' => ReloadCommand::class,
         'RouteCache' => RouteCacheCommand::class,
         'RouteClear' => RouteClearCommand::class,
         'RouteList' => RouteListCommand::class,

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -481,28 +481,6 @@ abstract class ServiceProvider
     }
 
     /**
-     * Get a short descriptive key for the current service provider.
-     *
-     * @param  string|null  $key
-     * @return string
-     */
-    protected function getProviderKey(?string $key = null): string
-    {
-        $key ??= (string) Str::of(get_class($this))
-            ->classBasename()
-            ->before('ServiceProvider')
-            ->kebab()
-            ->lower()
-            ->trim();
-
-        if (empty($key)) {
-            $key = class_basename(get_class($this));
-        }
-
-        return $key;
-    }
-
-    /**
      * Register commands that should run on "optimize" or "optimize:clear".
      *
      * @param  string|null  $optimize
@@ -535,6 +513,28 @@ abstract class ServiceProvider
         $key = $this->getProviderKey($key);
 
         static::$reloadCommands[$key] = $reload;
+    }
+
+    /**
+     * Get a short descriptive key for the current service provider.
+     *
+     * @param  string|null  $key
+     * @return string
+     */
+    protected function getProviderKey(?string $key = null): string
+    {
+        $key ??= (string) Str::of(get_class($this))
+            ->classBasename()
+            ->before('ServiceProvider')
+            ->kebab()
+            ->lower()
+            ->trim();
+
+        if (empty($key)) {
+            $key = class_basename(get_class($this));
+        }
+
+        return $key;
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -73,6 +73,13 @@ abstract class ServiceProvider
     public static array $optimizeClearCommands = [];
 
     /**
+     * Commands that should be run during the "reload" command.
+     *
+     * @var array<string, string>
+     */
+    public static array $reloadCommands = [];
+
+    /**
      * Create a new service provider instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -474,14 +481,12 @@ abstract class ServiceProvider
     }
 
     /**
-     * Register commands that should run on "optimize" or "optimize:clear".
+     * Get a short descriptive key for the current service provider.
      *
-     * @param  string|null  $optimize
-     * @param  string|null  $clear
      * @param  string|null  $key
-     * @return void
+     * @return string
      */
-    protected function optimizes(?string $optimize = null, ?string $clear = null, ?string $key = null)
+    protected function getProviderKey(?string $key = null): string
     {
         $key ??= (string) Str::of(get_class($this))
             ->classBasename()
@@ -494,6 +499,21 @@ abstract class ServiceProvider
             $key = class_basename(get_class($this));
         }
 
+        return $key;
+    }
+
+    /**
+     * Register commands that should run on "optimize" or "optimize:clear".
+     *
+     * @param  string|null  $optimize
+     * @param  string|null  $clear
+     * @param  string|null  $key
+     * @return void
+     */
+    protected function optimizes(?string $optimize = null, ?string $clear = null, ?string $key = null)
+    {
+        $key = $this->getProviderKey($key);
+
         if ($optimize) {
             static::$optimizeCommands[$key] = $optimize;
         }
@@ -501,6 +521,20 @@ abstract class ServiceProvider
         if ($clear) {
             static::$optimizeClearCommands[$key] = $clear;
         }
+    }
+
+    /**
+     * Register commands that should run on "reload".
+     *
+     * @param  string|null  $reload
+     * @param  string|null  $key
+     * @return void
+     */
+    protected function reloads(string $reload, ?string $key = null)
+    {
+        $key = $this->getProviderKey($key);
+
+        static::$reloadCommands[$key] = $reload;
     }
 
     /**


### PR DESCRIPTION
Add a `php artisan reload` command and allow service provider to add their own commands, similar to the `optimize` command.

This will make it easier for services to have 1 command to add in their deployment steps, after the deployment is completed.

```php
public function boot()
{
    $this->reloads('reverb:restart');
}
```

It adds the queue command by default, because that command is added by the core. Horizon could perhaps register it on the same 'queue' key to avoid reloading. Services like Pulse, Reverb etc could hook into this similarly.

Alternative for https://github.com/laravel/framework/pull/51993