### PR TITLE
[13.x] Simplify preg_replace_array callback by removing unnecessary foreach loop

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }


### PR DESCRIPTION
This PR simplifies the `preg_replace_array` callback by removing the unnecessary `foreach` loop.

The `foreach` loop was redundant since it only executed once and immediately returned the result of `array_shift($replacements)`.

**Changes:**
- Removed the unnecessary `foreach` loop in the `preg_replace_array` callback
- The functionality remains exactly the same, just cleaner code

This is the same change as #57901 but for the master branch.