### PR TITLE
[12.x] Use isEmpty() method instead of redundant count() checks in FakeProcessSequence

### DIFF
--- a/src/Illuminate/Process/FakeProcessSequence.php
+++ b/src/Illuminate/Process/FakeProcessSequence.php
@@ -107,11 +107,11 @@ class FakeProcessSequence
      */
     public function __invoke()
     {
-        if ($this->failWhenEmpty && count($this->processes) === 0) {
+        if ($this->failWhenEmpty && $this->isEmpty()) {
             throw new OutOfBoundsException('A process was invoked, but the process result sequence is empty.');
         }
 
-        if (! $this->failWhenEmpty && count($this->processes) === 0) {
+        if (! $this->failWhenEmpty && $this->isEmpty()) {
             return value($this->emptyProcess ?? new FakeProcessResult);
         }
 


### PR DESCRIPTION
This PR simplifies the `FakeProcessSequence::__invoke()` method by using the existing `isEmpty()` method instead of directly checking `count($this->processes) === 0`.

**Changes:**
- Replaced `count($this->processes) === 0` with `$this->isEmpty()` on lines 110 and 114
- The functionality remains exactly the same, just cleaner and more maintainable code
- Uses the existing `isEmpty()` method that was already defined in the class

**Benefits:**
- Reduces code duplication
- Makes the code more maintainable (if the empty check logic needs to change, it only needs to be updated in one place)
- More readable and follows DRY principles