### PR TITLE
[12.x] Fix unable to flush redis tagged cache when prefix contains `-` instead of `_`

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -156,7 +156,7 @@ class RedisTaggedCache extends TaggedCache
                 $script,
                 count($keysToBeDeleted),
                 ...$keysToBeDeleted,
-                ...[$cachePrefix, ...$cacheTags]
+                ...[str_replace('-', '%-', $cachePrefix), ...$cacheTags]
             );
         }
 

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Sleep;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class RedisStoreTest extends TestCase
 {
@@ -93,8 +94,12 @@ class RedisStoreTest extends TestCase
         $this->assertNull($value);
     }
 
-    public function testTagsCanBeAccessed()
+    #[TestWith(['laravel_cache_'])]
+    #[TestWith(['laravel-cache-'])]
+    public function testTagsCanBeAccessed(string $cachePrefix)
     {
+        config(['cache.prefix' => $cachePrefix]);
+
         Cache::store('redis')->clear();
 
         Cache::store('redis')->tags(['people', 'author'])->put('name', 'Sally', 5);


### PR DESCRIPTION
<img width="1354" height="1522" alt="CleanShot 2025-11-27 at 09 53 36@2x" src="https://github.com/user-attachments/assets/5edb57a9-e11f-45b3-bed7-71bb10996066" />
