### PR TITLE
[12.x] Allow enum() and set() Blueprint methods to accept BackedEnum class-string

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -1098,13 +1099,16 @@ class Blueprint
     /**
      * Create a new enum column on the table.
      *
-     * @param  string  $column
-     * @param  array  $allowed
+     * @param  array<string|\BackedEnum>|class-string<\BackedEnum>  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum(string $column, array|string $allowed)
     {
-        $allowed = array_map(fn ($value) => enum_value($value), $allowed);
+        if (is_string($allowed) && is_subclass_of($allowed, BackedEnum::class)) {
+            $allowed = array_column($allowed::cases(), 'value');
+        } else {
+            $allowed = array_map(fn ($value) => enum_value($value), $allowed);
+        }
 
         return $this->addColumn('enum', $column, compact('allowed'));
     }
@@ -1112,12 +1116,17 @@ class Blueprint
     /**
      * Create a new set column on the table.
      *
-     * @param  string  $column
-     * @param  array  $allowed
+     * @param  array<string|\BackedEnum>|class-string<\BackedEnum>  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function set($column, array $allowed)
+    public function set(string $column, array|string $allowed)
     {
+        if (is_string($allowed) && is_subclass_of($allowed, BackedEnum::class)) {
+            $allowed = array_column($allowed::cases(), 'value');
+        } else {
+            $allowed = array_map(fn ($value) => enum_value($value), $allowed);
+        }
+
         return $this->addColumn('set', $column, compact('allowed'));
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Tests\Database\Fixtures\Enums\Foo;
+use Illuminate\Tests\Database\Fixtures\Enums\UserRole;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -842,6 +843,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `status` enum(\'bar\') not null', $statements[1]);
     }
 
+    public function testAddingEnumWithBackedEnum()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->enum('role', UserRole::class);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` enum(\'admin\', \'member\', \'guest\') not null', $statements[0]);
+    }
+
     public function testAddingSet()
     {
         $blueprint = new Blueprint($this->getConnection(), 'users');
@@ -850,6 +861,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
+    }
+
+    public function testAddingSetWithBackedEnum()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->set('role', UserRole::class);
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` set(\'admin\', \'member\', \'guest\') not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/Fixtures/Enums/UserRole.php
+++ b/tests/Database/Fixtures/Enums/UserRole.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Enums;
+
+enum UserRole: string
+{
+    case Admin = 'admin';
+    case Member = 'member';
+    case Guest = 'guest';
+}


### PR DESCRIPTION
This allows passing a BackedEnum class directly to automatically extract all case values:

```php
<?php

namespace App\Enums;

enum ContentStatus: string
{
    case Pending = 'pending';
    case Active = 'active';
    case Cancelled = 'cancelled';
}
```

```php
$table->enum('status', ContentStatus::class);
```

This also works with the set() method:

```php
  $table->set('permissions', UserPermission::class);
```

This keeps backward compatibility with existing approaches:

```php
  // Array of strings (unchanged)
  $table->enum('status', ['pending', 'active', 'cancelled']);

  // Array of enum instances (already supported in 12.x)
  $table->enum('status', [ContentStatus::Pending, ContentStatus::Active]);

  // BackedEnum class-string (new)
  $table->enum('status', ContentStatus::class);
```
