### PR TITLE
[13.x] Use isEmpty() method instead of redundant count() checks in FakeProcessSequence

### DIFF
--- a/src/Illuminate/Process/FakeProcessSequence.php
+++ b/src/Illuminate/Process/FakeProcessSequence.php
@@ -107,11 +107,11 @@ class FakeProcessSequence
      */
     public function __invoke()
     {
-        if ($this->failWhenEmpty && count($this->processes) === 0) {
+        if ($this->failWhenEmpty && $this->isEmpty()) {
             throw new OutOfBoundsException('A process was invoked, but the process result sequence is empty.');
         }
 
-        if (! $this->failWhenEmpty && count($this->processes) === 0) {
+        if (! $this->failWhenEmpty && $this->isEmpty()) {
             return value($this->emptyProcess ?? new FakeProcessResult);
         }
 


### PR DESCRIPTION
Currently, there are places where we check count($this->processes) === 0 directly. However, the class already has a dedicated method isEmpty() that performs the same check:

```php
public function isEmpty()
{
    return count($this->processes) === 0;
}
```

This PR updates the code to use isEmpty() instead of direct count() checks. This improves readability and ensures consistency, as the isEmpty() method is already used in multiple places.