### PR TITLE
[12.x] Add method to retrieve list of paused queues

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -241,10 +241,10 @@ class QueueManager implements FactoryContract, MonitorContract
 
         $this->app['cache']
             ->store()->put(
-            "illuminate:queue:paused-list:{$connection}",
-            array_values(array_unique(array_merge($pausedQueues,
-                [$queue])))
-        );
+                "illuminate:queue:paused-list:{$connection}",
+                array_values(array_unique(array_merge($pausedQueues,
+                    [$queue])))
+            );
     }
 
     /**
@@ -280,9 +280,9 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['cache']
             ->store()
             ->put(
-            "illuminate:queue:paused-list:{$connection}",
-            array_values(array_diff($pausedQueues, [$queue]))
-        );
+                "illuminate:queue:paused-list:{$connection}",
+                array_values(array_diff($pausedQueues, [$queue]))
+            );
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static \Illuminate\Contracts\Queue\Queue connection(string|null $name = null)
  * @method static void pause(string $connection, string $queue)
  * @method static void pauseFor(string $connection, string $queue, \DateTimeInterface|\DateInterval|int $ttl)
+ * @method static array getPausedQueueList(string $connection)
  * @method static void resume(string $connection, string $queue)
  * @method static bool isPaused(string $connection, string $queue)
  * @method static void extend(string $driver, \Closure $resolver)

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -155,6 +155,5 @@ class QueuePauseResumeTest extends TestCase
         $this->assertFalse($this->manager->isPaused('redis', 'default'));
 
         $this->assertEquals(['notifications'], $this->manager->getPausedQueueList('redis'));
-
     }
 }


### PR DESCRIPTION
This PR adds a `getPausedQueueList()` method to the `QueueManager`, which returns the list of currently paused queues for a given connection.

With this we provide a way to list all paused queues without having to track them manually.

