### PR TITLE
[12.x] PendingRequest HTTP methods may also return promises

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -790,7 +790,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|string|null  $query
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */
@@ -806,7 +806,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|string|null  $query
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */
@@ -822,7 +822,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable  $data
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */
@@ -838,7 +838,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable  $data
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */
@@ -854,7 +854,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable  $data
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */
@@ -870,7 +870,7 @@ class PendingRequest
      *
      * @param  string  $url
      * @param  array|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable  $data
-     * @return \Illuminate\Http\Client\Response
+     * @return \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface
      *
      * @throws \Illuminate\Http\Client\ConnectionException
      */


### PR DESCRIPTION
I'm doing my first foray into HTTP pooling, and wow, this is dope.

Because of the typehints, I wasn't aware something like this was possible:

```php
class FetchShopifyProductFactory
{
    public function buildPendingRequest(int $productId, ?PendingRequest $pendingRequest = null)
    {
        $pendingRequest = $pendingRequest ?? Http::createPendingRequest();

        return $pendingRequest
            ->async()
            ->get("orders/{$productId}.json")
            ->then(function (Response|RequestException|ConnectionException $r) {
                if ($r instanceof \Throwable) {
                    return $r;
                }

                return ShopifyProduct::from($r->json());
            });
    }
}

$fetchShopifyProductFactory  = new FetchShopifyProductFactory;

/** @var array<string, ShopifyProduct|RequestException|ConnectionException> $results */
$results = Http::pool(static function (Pool $pool) use ($fetchShopifyProductFactory) {
    $fetchShopifyProductFactory->buildPendingRequest(123, $pool->as('product_123'));
    $fetchShopifyProductFactory->buildPendingRequest(867, $pool->as('product_876'));
});

$results['product_123'] instanceof ShopifyProduct; // true

// or
$fetchShopifyProductFactory->buildPendingRequest(123)->wait() instanceof ShopifyProduct; // true

```