### PR TITLE
[12.x] Add `PendingRequest@withRequestContext()`

### DIFF
--- a/src/Illuminate/Http/Client/ConnectionException.php
+++ b/src/Illuminate/Http/Client/ConnectionException.php
@@ -4,5 +4,10 @@ namespace Illuminate\Http\Client;
 
 class ConnectionException extends HttpClientException
 {
-    //
+    /**
+     * The context passed when creating the request.
+     *
+     * @var array<array-key, mixed>
+     */
+    public array $requestContext = [];
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -230,6 +230,13 @@ class PendingRequest
     protected $truncateExceptionsAt = null;
 
     /**
+     * The request context.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected array $requestContext = [];
+
+    /**
      * Create a new HTTP Client instance.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -360,6 +367,19 @@ class PendingRequest
         return tap($this, function () use ($format) {
             $this->bodyFormat = $format;
         });
+    }
+
+    /**
+     * Add contextual data to be attached to the Response.
+     *
+     * @param  array<array-key, mixed>  $requestContext
+     * @return $this
+     */
+    public function withRequestContext(array $requestContext)
+    {
+        $this->requestContext = array_merge_recursive($this->requestContext, $requestContext);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1697,6 +1697,7 @@ class PendingRequest
     protected function marshalConnectionException(ConnectException $e)
     {
         $exception = new ConnectionException($e->getMessage(), 0, $e);
+        $exception->requestContext = $this->requestContext;
 
         $request = new Request($e->getRequest());
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1527,6 +1527,8 @@ class PendingRequest
     protected function newResponse($response)
     {
         return tap(new Response($response), function (Response $laravelResponse) {
+            $laravelResponse->setRequestContext($this->requestContext);
+
             if ($this->truncateExceptionsAt === null) {
                 return;
             }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -36,7 +36,7 @@ class RequestException extends HttpClientException
 
     /**
      * The context passed when creating the request.
-     * 
+     *
      * @var array<array-key, mixed>
      */
     public array $requestContext = [];

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -35,6 +35,13 @@ class RequestException extends HttpClientException
     public $hasBeenSummarized = false;
 
     /**
+     * The context passed when creating the request.
+     * 
+     * @var array<array-key, mixed>
+     */
+    public array $requestContext = [];
+
+    /**
      * Create a new exception instance.
      *
      * @param  \Illuminate\Http\Client\Response  $response

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -55,6 +55,13 @@ class Response implements ArrayAccess, Stringable
     protected $truncateExceptionsAt = null;
 
     /**
+     * Contextual data from the request.
+     * 
+     * @var array<array-key, mixed>
+     */
+    protected array $requestContext = [];
+
+    /**
      * Create a new response instance.
      *
      * @param  \Psr\Http\Message\MessageInterface  $response
@@ -64,6 +71,29 @@ class Response implements ArrayAccess, Stringable
         $this->response = $response;
     }
 
+    /**
+     * Set the request's context.
+     *
+     * @param  array<array-key, mixed>  $context
+     * @return $this
+     */
+    public function setRequestContext(array $context)
+    {
+        $this->requestContext = $context;
+
+        return $this;
+    }
+
+    /**
+     * Get the context set on the request.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function getRequestContext(): array
+    {
+        return $this->requestContext;
+    }
+    
     /**
      * Get the body of the response.
      *

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -56,7 +56,7 @@ class Response implements ArrayAccess, Stringable
 
     /**
      * Contextual data from the request.
-     * 
+     *
      * @var array<array-key, mixed>
      */
     protected array $requestContext = [];
@@ -93,7 +93,7 @@ class Response implements ArrayAccess, Stringable
     {
         return $this->requestContext;
     }
-    
+
     /**
      * Get the body of the response.
      *

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -334,7 +334,12 @@ class Response implements ArrayAccess, Stringable
     public function toException()
     {
         if ($this->failed()) {
-            return new RequestException($this, $this->truncateExceptionsAt);
+            return tap(
+                new RequestException($this, $this->truncateExceptionsAt),
+                function (RequestException $e) {
+                    $e->requestContext = $this->requestContext;
+                }
+            );
         }
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4219,6 +4219,22 @@ class HttpClientTest extends TestCase
         $this->assertSame(['name' => 'testRequestExceptionHasRequestContext'], $e->requestContext);
     }
 
+    public function testConnectionExceptionHasRequestContext()
+    {
+        $this->factory->fake(['https://laravel.com' => $this->factory::failedConnection('This thang failed')]);
+
+        $pendingRequest = $this->factory->withRequestContext(['name' => 'testConnectionExceptionHasRequestContext']);
+
+        $e = null;
+        try {
+            $pendingRequest->get('https://laravel.com');
+        } catch (ConnectionException $exception) {
+            $e = $exception;
+        }
+
+        $this->assertEquals(['name' => 'testConnectionExceptionHasRequestContext'], $e->requestContext);
+    }
+
     public static function methodsReceivingArrayableDataProvider()
     {
         return [


### PR DESCRIPTION
Allow passing some contextual data about the request to the Response. When we are pooling requests and taking advantage of the fact that they are Promises, we can do some very cool things with nice developer experience. However, we lose the contextual data about the request we are making.

## Use Case
Say I want to pool a number of requests and handle the mapping using `then()` from the Guzzle Promise. It's possible that we have an API that doesn't use HTTP status codes to indicate a failure, and we want to be able to log some details in the failure.

```php
/**
 * @param  list<array{name: string, email: string, tenantId: int, message: string}> $issues
 * @return array<int, ?CreatedIssue>
 */
public function createIssues(array $issues)
{
    return Http::pool(function (Pool $pool) use ($issues) {
        foreach ($issues as $issue) {
            $pool->withRequestContext([
                    'email' => $issue['email'],
                    'tenant_id' => $issue['tenantId'],
                ])
                ->post('https://issue-tracker.dev/issues', $issue)
                ->then($this->mapIntoResponse(...));
        }
    });
}

private function mapIntoResponse(Response|ConnectionException $response): ?CreatedIssue
{
    if ($response instanceof ConnectionException) {
        Log::error(
            'Connection failed when creating issue',
            ['tenant_id' => $response->requestContext['tenant_id']]
        );

        return null;
    }

    $json = $response->json();

    if (isset($response['errors'])) {
        if (isset($response['errors']['email'])) {
            Log::error("User has invalid email. Setting state to invalid.");
            User::query()->where('email', $response->getRequestContext()['email'])->update(['valid' => false]);
        }

        return null;
    }

    return new CreatedIssue($json);
}
```

#### Note

I had considered adding a `context()` method to both the ConnectionException and RequestException, but opted not to. An uncaught exception would automatically log the contextual data, which may not be desirable for developers (since it could contain PII).