### PR TITLE
[12.x] Fix deprecation error in `HasAttributes::addDateAttributesToArray()` when `UPDATED_AT = null` and model is cast to array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,10 +250,8 @@ trait HasAttributes
      */
     protected function addDateAttributesToArray(array $attributes)
     {
-        $dates = array_filter($this->getDates());
-
         foreach ($dates as $key) {
-            if (! isset($attributes[$key])) {
+            if (is_null($key) || ! isset($attributes[$key])) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1622,7 +1622,7 @@ trait HasAttributes
     /**
      * Get the attributes that should be converted to dates.
      *
-     * @return array
+     * @return array<int, string|null>
      */
     public function getDates()
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,7 +250,7 @@ trait HasAttributes
      */
     protected function addDateAttributesToArray(array $attributes)
     {
-        foreach ($dates as $key) {
+        foreach ($this->getDates() as $key) {
             if (is_null($key) || ! isset($attributes[$key])) {
                 continue;
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,7 +250,9 @@ trait HasAttributes
      */
     protected function addDateAttributesToArray(array $attributes)
     {
-        foreach ($this->getDates() as $key) {
+        $dates = array_filter($this->getDates());
+
+        foreach ($dates as $key) {
             if (! isset($attributes[$key])) {
                 continue;
             }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -11,6 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {
+    /** {@inheritdoc} */
     protected function afterRefreshingDatabase()
     {
         Schema::create('test_model1', function (Blueprint $table) {
@@ -19,6 +20,15 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->datetime('datetime_field')->nullable();
             $table->date('immutable_date_field')->nullable();
             $table->datetime('immutable_datetime_field')->nullable();
+        });
+
+        Schema::create('test_model2', function (Blueprint $table) {
+            $table->increments('id');
+            $table->date('date_field')->nullable();
+            $table->datetime('datetime_field')->nullable();
+            $table->date('immutable_date_field')->nullable();
+            $table->datetime('immutable_datetime_field')->nullable();
+            $table->timestamp('created_at')->nullable();
         });
     }
 
@@ -113,12 +123,47 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
         $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
     }
+
+    public function testDatesCanBeSerializedToArray()
+    {
+        $this->freezeSecond(function ($now) {
+            $user = TestModel2::create([
+                'date_field' => '2019-10-01',
+                'datetime_field' => '2019-10-01 10:15:20',
+                'immutable_date_field' => '2019-10-01',
+                'immutable_datetime_field' => '2019-10-01 10:15:20',
+            ]);
+
+            $this->assertSame([
+                'date_field' => '2019-10',
+                'datetime_field' => '2019-10 10:15',
+                'immutable_date_field' => '2019-10',
+                'immutable_datetime_field' => '2019-10 10:15',
+                'created_at' => $now->toISOString(),
+                'id' => $user->getKey(),
+            ], $user->toArray());
+        });
+    }
 }
 
 class TestModel1 extends Model
 {
     public $table = 'test_model1';
     public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'date_field' => 'date:Y-m',
+        'datetime_field' => 'datetime:Y-m H:i',
+        'immutable_date_field' => 'date:Y-m',
+        'immutable_datetime_field' => 'datetime:Y-m H:i',
+    ];
+}
+
+class TestModel2 extends Model
+{
+    public $table = 'test_model2';
+    const UPDATED_AT = null;
     protected $guarded = [];
 
     public $casts = [

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -28,7 +28,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->datetime('datetime_field')->nullable();
             $table->date('immutable_date_field')->nullable();
             $table->datetime('immutable_datetime_field')->nullable();
-            $table->timestamp('created_at')->nullable();
+            $table->timestamps();
         });
     }
 
@@ -134,14 +134,16 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
                 'immutable_datetime_field' => '2019-10-01 10:15:20',
             ]);
 
+            $this->assertSame(['created_at', null], $user->getDates());
+
             $this->assertSame([
+                'id' => $user->getKey(),
                 'date_field' => '2019-10',
                 'datetime_field' => '2019-10 10:15',
                 'immutable_date_field' => '2019-10',
                 'immutable_datetime_field' => '2019-10 10:15',
                 'created_at' => $now->toISOString(),
-                'id' => $user->getKey(),
-            ], $user->toArray());
+            ], $user->fresh()->toArray());
         });
     }
 }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -28,7 +28,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->datetime('datetime_field')->nullable();
             $table->date('immutable_date_field')->nullable();
             $table->datetime('immutable_datetime_field')->nullable();
-            $table->timestamps();
+            $table->timestamp('created_at')->nullable();
         });
     }
 
@@ -136,6 +136,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
 
             $this->assertSame(['created_at', null], $user->getDates());
 
+            $user->refresh();
+
             $this->assertSame([
                 'id' => $user->getKey(),
                 'date_field' => '2019-10',
@@ -143,7 +145,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
                 'immutable_date_field' => '2019-10',
                 'immutable_datetime_field' => '2019-10 10:15',
                 'created_at' => $now->toISOString(),
-            ], $user->fresh()->toArray());
+            ], $user->attributesToArray());
         });
     }
 }


### PR DESCRIPTION
fix #57920