### PR TITLE
[12.x] Add `throwUnless()` to `Illuminate\Http\Client\Response`

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -344,6 +344,19 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
+     * Throw an exception if a server or client error occurred and the given condition evaluates to false.
+     *
+     * @param  \Closure|bool  $condition
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwUnless($condition)
+    {
+        return $this->throwIf(! $condition);
+    }
+
+    /**
      * Throw an exception if the response status code matches the given code.
      *
      * @param  int|(\Closure(int, \Illuminate\Http\Client\Response): bool)|callable  $statusCode

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3188,6 +3188,35 @@ class HttpClientTest extends TestCase
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
     }
 
+    public function testRequestExceptionIsThrownWhenUnlessConditionIsNotSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 400),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwUnless(false);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIsNotThrownWhenUnlessConditionIsSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['result' => ['foo' => 'bar']], 400),
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api')->throwUnless(true);
+
+        $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+    }
+
     public function testRequestExceptionIsThrowIfConditionClosureIsSatisfied()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR adds `throwUnless()` to the HTTP client's response object that's documented in https://laravel.com/docs/12.x/http-client#throwing-exceptions but apparently has only been implemented on `PendingRequest`.