### PR TITLE
[12.x] Flush only active buffers while streaming response using a generator

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -203,7 +203,7 @@ class ResponseFactory implements FactoryContract
             return new StreamedResponse(function () use ($callback) {
                 foreach ($callback() as $chunk) {
                     echo $chunk;
-                    ob_flush();
+                    when(ob_get_level() > 0, fn () => ob_flush());
                     flush();
                 }
             }, $status, array_merge($headers, ['X-Accel-Buffering' => 'no']));


### PR DESCRIPTION
This PR fixes the "**ob_flush(): Failed to flush buffer. No buffer to flush**" error when passing a generator function in the response factory `stream` method.

<img width="2349" height="1297" alt="Screenshot from 2025-11-27 21-51-17" src="https://github.com/user-attachments/assets/1827105a-86ac-4af9-b28a-4e0d5c9caf24" />

