### PR TITLE
[12.x] Pass `LoggerInterface` when constructing `RoundrobinTransport` instance

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -430,7 +430,7 @@ class MailManager implements FactoryContract
                 : $this->createSymfonyTransport($config);
         }
 
-        return new $class($transports, $config['retry_after'] ?? 60);
+        return new $class($transports, $config['retry_after'] ?? 60, $this->app->make(LoggerInterface::class));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
(This is #56244 repeated now Symfony 7.4 is released)

As a follow-up to https://github.com/symfony/symfony/pull/60110 which introduces an additional constructor property `logger` to the `RoundRobinTransport` class, this PR ensures the app-bound `LoggerInterface` will be passed when constructing such a class.

~~Note that this will require Symfony 7.4.0 or higher, which is [due for release in November 2025](https://symfony.com/releases/7.4). Given that passing additional parameters to constructors is allowed in PHP (they are just silently ignored), this PR as such is both backwards and forwards compatible, however at current would do effectively nothing. If therefore it is preferable to keep this as draft until (near) the release of Symfony 7.4, that is also perfectly fine with me.~~
