### PR TITLE
Add option to WorkCommand for ignoring reset signal in jobs

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -36,6 +36,7 @@ class WorkCommand extends Command
                             {--queue= : The names of the queues to work}
                             {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--once : Only process the next job on the queue}
+                            {--ignore-reset-signal : Ignore reset signal in order to reduce cache call}
                             {--stop-when-empty : Stop when the queue is empty}
                             {--delay=0 : The number of seconds to delay failed jobs (Deprecated)}
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
@@ -169,6 +170,7 @@ class WorkCommand extends Command
             $this->option('max-jobs'),
             $this->option('max-time'),
             $this->option('rest'),
+            $this->option('ignore-reset-signal'),
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -315,7 +315,7 @@ class Worker
         return match (true) {
             $this->shouldQuit => static::EXIT_SUCCESS,
             $this->memoryExceeded($options->memory) => static::$memoryExceededExitCode ?? static::EXIT_MEMORY_LIMIT,
-            $this->queueShouldRestart($lastRestart) => static::EXIT_SUCCESS,
+            ! $options->ignoreResetSignal && $this->queueShouldRestart($lastRestart) => static::EXIT_SUCCESS,
             $options->stopWhenEmpty && is_null($job) => static::EXIT_SUCCESS,
             $options->maxTime && hrtime(true) / 1e9 - $startTime >= $options->maxTime => static::EXIT_SUCCESS,
             $options->maxJobs && $jobsProcessed >= $options->maxJobs => static::EXIT_SUCCESS,

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -82,6 +82,13 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * Indicates if the worker should ignore reset signal. This is used when you want decrease cache queries on illuminate:queue:restart.
+     *
+     * @var bool
+     */
+    public $ignoreResetSignal;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -108,6 +115,7 @@ class WorkerOptions
         $maxJobs = 0,
         $maxTime = 0,
         $rest = 0,
+        $ignoreResetSignal = false,
     ) {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -120,5 +128,6 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->ignoreResetSignal = $ignoreResetSignal;
     }
 }


### PR DESCRIPTION
Adds new `--ignore-reset-signal` option to `WorkCommand`. This helps large-size projects to avoid multiple cache queries to `illuminate:queue:restart` key. Useful when we are running multiple `queue:work` commands in large-size projects.

