### PR TITLE
QueryException.php update formatMessage to use getRawSql method

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -64,7 +64,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($connectionName, $sql, $bindings, Throwable $previous)
     {
-        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        return $previous->getMessage().' (Connection: '.$connectionName.', SQL: '.$this->getRawSql().')';
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database;
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use PDOException;
 use Throwable;
 


### PR DESCRIPTION
# Fix: Improve SQL query rendering in QueryException

## Problem

This Pull Request addresses an issue where the SQL query displayed in a database exception message (e.g., in `QueryException::formatMessage`) was rendered incorrectly, specifically within the `VALUES` clause of `INSERT` statements.

When binding parameters if a value was **empty or NULL**, the formatting logic sometimes failed to explicitly render the corresponding value or placeholder, resulting in two commas appearing sequentially in the displayed SQL: `..., value1, , value3, ...`.

This faulty rendering led developers to believe there was a **syntax error** in the generated SQL (an incorrect number of parameters/values), when the actual issue was only in the **display logic** of the exception handler.

The incorrect formatting masked the true structure of the query and the bound parameters, hindering debugging efforts.

**Example of Incorrect Rendering:**
```sql
insert into "jos_iwa_doc_students2_requests" 
("actualresidenceplace__cat_kato", "actualresidenceplace__kator", "actualresidenceplace_address", "actualresidenceplace_country", "actualresidenceplace_switch", "arrival__cat_kato", "arrival__kator", "arrival_country", "author_access", "awards_switch", "benefits_switch", "birthplace__cat_kato", "birthplace__kator", "birthplace_country", "birthplace_switch", "cat2_controller_list", "cat2_student_requests_tag", "cat2_student_type", "cat2_study_curriculum_type", "cat2_study_degree_types", "cat2_study_term__group", "cat_advertising", "cat_buh_discounts", "cat_buh_discounts_size", "cat_buh_source_financing", "cat_buh_surcharge", "cat_individual_citizenship", "cat_individual_gender", "cat_individual_maritalstatus", "cat_individual_nationality", "cat_individual_passportdepartment", "cat_individual_passporttype", "cat_structureuz_faculties", "cat_student_status", "cat_study_formationtypes", "cat_study_forms", "cat_study_languages", "cat_study_level_program", "cat_study_period", "cat_study_spec", "cat_study_years", "cat_study_yearscourse", "checked_out", "checked_out_time", "code", "competitions_switch", "created", "created_by", "current_gpa", "current_kzcs_all", "current_kzcs_done", "datebirth", "discount_switch", "discounts_term", "doc_date", "doc_study2_calendar", "doc_study2_transcript_journal", "doctorlistener__certificate_date", "doctorlistener__certificate_number", "doctorlistener__certificate_serial", "doctorlistener__enroll_year", "doctorlistener__epvo_dict_center_university", "doctorlistener__graduation_year", "doctorlistener__remain_switch", "doctorlistener__spec_code", "doctorlistener__spec_name_en", "doctorlistener__spec_name_kz", "doctorlistener__spec_name_ru", "dorm_need_switch", "dorm_provided_switch", "email", "email_personal", "enroll__doc_students2_orders", "enroll_order_date", "enroll_order_num", "enroll_switch", "epvo_ignore", "epvo_org_external_listener", "epvo_org_graduates", "epvo_org_student", "epvo_org_study_forms", "epvo_synced", "firstname", "firstname_en", "funding_program", "graduate__cat2_study_term", "graduate__cat_structureuz_faculties", "graduate__cat_study_academic_degree", "graduate__cat_study_forms", "graduate__cat_study_languages", "graduate__cat_study_masters_directions", "graduate__cat_study_period", "graduate__cat_study_spec", "graduate__cat_study_years", "graduate__certificate_date", "graduate__certificate_number", "graduate__certificate_perfect_switch", "graduate__certificate_serial", "graduate__reg_number", "graduate_switch", "grant_date", "grant_number", "has_transcript_switch", "id", "iin", "iin_prove_switch", "imageupload", "interests_switch", "lastname", "lastname_en", "livepermit_finishdate", "livepermit_startdate", "livepermit_type", "modified", "modified_by", "mshi_status_date", "mshi_status_flag", "passport_date", "passport_date_finish", "passport_file", "passport_issuing", "passport_number", "passport_serial", "phonehome", "phonemobile", "placement_switch", "platonus_id", "published", "remain__cat2_study_curriculum_type", "remain__cat2_study_term__group", "remain__cat_buh_source_financing", "remain__cat_structureuz_faculties", "remain__cat_student_status", "remain__cat_study_formationtypes", "remain__cat_study_forms", "remain__cat_study_languages", "remain__cat_study_level_program", "remain__cat_study_period", "remain__cat_study_spec", "remain__cat_study_years", "remain__cat_study_yearscourse", "remain__firstname", "remain__lastname", "remain__order_date", "remain__order_number", "remain__secondname", "remain_switch", "residenceplace__cat_kato", "residenceplace__kator", "residenceplace_address", "residenceplace_country", "residenceplace_status_locality", "secondname", "social_network_facebook", "social_network_instagram", "social_network_linkedin", "social_network_tiktok", "social_network_twitter", "social_network_vk", "surcharge_switch", "term_offset", "total_tests", "turan_facebook_switch", "turan_instagram_switch", "turan_vk_switch", "turan_youtube_switch", "updated_transcript", "version", "version_xml")
 values (?, , , 0, 0, ?, , ?, {801}, 0, 0, ?, , 0, 0, 25, {}, 1, 1, 1, 2, {}, ?, ?, 2, ?, ?, ?, ?, ?, 2, 1, 2, 1, 1, 1, 1, 1, 5, 28, 18, 2, ?, ?, 17180141, 0, 2018-07-02 00:00:00, 801, ?, ?, ?, ?, 0, 0, 2018-07-02 00:00:00, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, 0, 0, , ?, ?, 2017-08-28, 254, 1, 0, ?, 21721, 9797, 1, 1, Жұлдыз, , ?, 4, ?, 23, ?, ?, ?, ?, ?, 21, 2021-06-22, 00017912652, 0, BD, 20223, 1, ?, , 0, 2661, XXX, 0, null, 0, XXX, , ?, ?, ?, 2018-07-02 00:00:00, 801, 2025-02-05 08:36:08, 2, 2015-07-13, ?, ?, МВД РК , XXX, , , +7(776)XXX, 0, 9797, 1, 1, 2, 2, 2, 4, 1, 1, 1, 1, 5, 28, 18, 4, Жұлдыз, XXX, ?, ?, XXX, 1, ?, , , 1, 0, XXX, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1)
```

**Example of Сorrect Rendering:**
```sql
insert into "jos_iwa_doc_students2_requests" 
("actualresidenceplace__cat_kato", "actualresidenceplace__kator", "actualresidenceplace_address", "actualresidenceplace_country", "actualresidenceplace_switch", "arrival__cat_kato", "arrival__kator", "arrival_country", "author_access", "awards_switch", "benefits_switch", "birthplace__cat_kato", "birthplace__kator", "birthplace_country", "birthplace_switch", "cat2_controller_list", "cat2_student_requests_tag", "cat2_student_type", "cat2_study_curriculum_type", "cat2_study_degree_types", "cat2_study_term__group", "cat_advertising", "cat_buh_discounts", "cat_buh_discounts_size", "cat_buh_source_financing", "cat_buh_surcharge", "cat_individual_citizenship", "cat_individual_gender", "cat_individual_maritalstatus", "cat_individual_nationality", "cat_individual_passportdepartment", "cat_individual_passporttype", "cat_structureuz_faculties", "cat_student_status", "cat_study_formationtypes", "cat_study_forms", "cat_study_languages", "cat_study_level_program", "cat_study_period", "cat_study_spec", "cat_study_years", "cat_study_yearscourse", "checked_out", "checked_out_time", "code", "competitions_switch", "created", "created_by", "current_gpa", "current_kzcs_all", "current_kzcs_done", "datebirth", "discount_switch", "discounts_term", "doc_date", "doc_study2_calendar", "doc_study2_transcript_journal", "doctorlistener__certificate_date", "doctorlistener__certificate_number", "doctorlistener__certificate_serial", "doctorlistener__enroll_year", "doctorlistener__epvo_dict_center_university", "doctorlistener__graduation_year", "doctorlistener__remain_switch", "doctorlistener__spec_code", "doctorlistener__spec_name_en", "doctorlistener__spec_name_kz", "doctorlistener__spec_name_ru", "dorm_need_switch", "dorm_provided_switch", "email", "email_personal", "enroll__doc_students2_orders", "enroll_order_date", "enroll_order_num", "enroll_switch", "epvo_ignore", "epvo_org_external_listener", "epvo_org_graduates", "epvo_org_student", "epvo_org_study_forms", "epvo_synced", "firstname", "firstname_en", "funding_program", "graduate__cat2_study_term", "graduate__cat_structureuz_faculties", "graduate__cat_study_academic_degree", "graduate__cat_study_forms", "graduate__cat_study_languages", "graduate__cat_study_masters_directions", "graduate__cat_study_period", "graduate__cat_study_spec", "graduate__cat_study_years", "graduate__certificate_date", "graduate__certificate_number", "graduate__certificate_perfect_switch", "graduate__certificate_serial", "graduate__reg_number", "graduate_switch", "grant_date", "grant_number", "has_transcript_switch", "id", "iin", "iin_prove_switch", "imageupload", "interests_switch", "lastname", "lastname_en", "livepermit_finishdate", "livepermit_startdate", "livepermit_type", "modified", "modified_by", "mshi_status_date", "mshi_status_flag", "passport_date", "passport_date_finish", "passport_file", "passport_issuing", "passport_number", "passport_serial", "phonehome", "phonemobile", "placement_switch", "platonus_id", "published", "remain__cat2_study_curriculum_type", "remain__cat2_study_term__group", "remain__cat_buh_source_financing", "remain__cat_structureuz_faculties", "remain__cat_student_status", "remain__cat_study_formationtypes", "remain__cat_study_forms", "remain__cat_study_languages", "remain__cat_study_level_program", "remain__cat_study_period", "remain__cat_study_spec", "remain__cat_study_years", "remain__cat_study_yearscourse", "remain__firstname", "remain__lastname", "remain__order_date", "remain__order_number", "remain__secondname", "remain_switch", "residenceplace__cat_kato", "residenceplace__kator", "residenceplace_address", "residenceplace_country", "residenceplace_status_locality", "secondname", "social_network_facebook", "social_network_instagram", "social_network_linkedin", "social_network_tiktok", "social_network_twitter", "social_network_vk", "surcharge_switch", "term_offset", "total_tests", "turan_facebook_switch", "turan_instagram_switch", "turan_vk_switch", "turan_youtube_switch", "updated_transcript", "version", "version_xml") 
values (null, '', '', 0, 0, null, '', null, '{801}', 0, 0, null, '', 0, 0, 25, '{}', 1, 1, 1, 2, '{}', null, null, 2, null, null, null, null, null, 2, 1, 2, 1, 1, 1, 1, 1, 5, 28, 18, 2, null, null, '17180141', 0, '2018-07-02 00:00:00', 801, null, null, null, null, 0, 0, '2018-07-02 00:00:00', null, null, null, null, null, null, null, null, 0, null, null, null, null, 0, 0, '', null, null, '2017-08-28', '254', 1, 0, null, 21721, 9797, 1, 1, 'Жұлдыз', '', null, 4, null, 23, null, null, null, null, null, 21, '2021-06-22', '00017912652', 0, 'BD', '20223', 1, null, '', 0, 2661, 'XXX', 0, 'null', 0, 'XXX', '', null, null, null, '2018-07-02 00:00:00', 801, '2025-02-05 08:36:08', 2, '2015-07-13', null, null, 'МВД РК ', 'XXX', '', '', '+7(776)XXX', 0, 9797, 1, 1, 2, 2, 2, 4, 1, 1, 1, 1, 5, 28, 18, 4, 'Жұлдыз', 'XXX', null, null, 'XXX', 1, null, '', '', 1, 0, 'XXX', null, null, null, null, null, null, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1)
```

