### PR TITLE
[12.x] Allow passing a callback to `Pool@as()`

### DIFF
--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -46,7 +46,6 @@ class Pool
      *
      * @param  string  $key
      * @param  (callable(\Illuminate\Http\Client\PendingRequest): \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\PromiseInterface|null)|null  $callback
-     *
      * @return \Illuminate\Http\Client\PendingRequest
      */
     public function as(string $key, ?callable $callback = null)

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -45,11 +45,19 @@ class Pool
      * Add a request to the pool with a key.
      *
      * @param  string  $key
+     * @param  (callable(\Illuminate\Http\Client\PendingRequest): ?\Illuminate\Http\Client\PendingRequest)|null  $callback
+     *
      * @return \Illuminate\Http\Client\PendingRequest
      */
-    public function as(string $key)
+    public function as(string $key, ?callable $callback = null)
     {
-        return $this->pool[$key] = $this->asyncRequest();
+        if ($callback === null) {
+            return $this->pool[$key] = $this->asyncRequest();
+        }
+
+        $newRequest = $this->asyncRequest();
+
+        return $this->pool[$key] = $callback($newRequest) ?? $newRequest;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -45,7 +45,7 @@ class Pool
      * Add a request to the pool with a key.
      *
      * @param  string  $key
-     * @param  (callable(\Illuminate\Http\Client\PendingRequest): ?\Illuminate\Http\Client\PendingRequest)|null  $callback
+     * @param  (callable(\Illuminate\Http\Client\PendingRequest): \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\PromiseInterface|null)|null  $callback
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -59,7 +59,7 @@ class HttpClientTest extends TestCase
                     ->then(fn (Response $response): int => strlen($response->getBody()))
             );
             $pool->as('nightwatch')->get('https://nightwatch.laravel.com');
-        });
+        }, 3);
 
         $this->assertInstanceOf(Response::class, $responses['laravel']);
         $this->assertEquals(5, $responses['forge']);

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -3,6 +3,9 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
@@ -36,5 +39,32 @@ class HttpClientTest extends TestCase
         Facade::clearResolvedInstances();
 
         $this->assertCount(2, Http::getGlobalMiddleware());
+    }
+
+    public function testPoolCanReceiveCallback(): void
+    {
+        Http::fake([
+            'https://laravel.com*' => Http::response('Laravel'),
+            'https://forge.laravel.com*' => Http::response('Forge'),
+            'https://nightwatch.laravel.com*' => Http::response('Tim n Jess'),
+        ]);
+
+        $responses = Http::pool(function (Pool $pool) {
+            $pool->as('laravel', function (PendingRequest $request) {
+                $request->get('https://laravel.com');
+            });
+            $pool->as(
+                'forge',
+                fn (PendingRequest $request) => $request->get('https://forge.laravel.com')
+                    ->then(fn (Response $response): int => strlen($response->getBody()))
+            );
+            $pool->as('nightwatch')->get('https://nightwatch.laravel.com');
+        });
+
+        $this->assertInstanceOf(Response::class, $responses['laravel']);
+        $this->assertEquals(5, $responses['forge']);
+        $this->assertEquals('Tim n Jess', $responses['nightwatch']->getBody());
+
+        $this->assertCount(3, Http::recorded());
     }
 }


### PR DESCRIPTION
Guzzle Promises are immutable, which means userland chaining isn't possible since we don't have access to the underlying array.

For example, this will not work to return the string length of each request. It will instead just return the responses.

```php
$response = Http::pool(function (Pool $pool) {
    $pool->as('cosmatech')
        ->get('https://cosmastech.com')
        ->then(
            fn ($response) => strlen($response->body())
        );
    $pool->as('laravel')
        ->get('https://laravel.com')
        ->then(
            fn ($response) => strlen($response->body())
        );
});

dd($response);
/*
array:2 [
  "cosmatech" => Illuminate\Http\Client\Response {
   ...
   },
   "laravel" => Illuminate\Http\Client\Response {
   ...
   }
]
*/
```

Were this PR to be accepted, then the above can be converted to:

```php
$response = Http::pool(function (Pool $pool) {
    $pool->as('cosmatech', fn (PendingRequest $pr) =>
        $pr->get('https://cosmastech.com')
            ->then(fn ($response) =>  strlen($response->body()))
    );
    $pool->as('laravel', function(PendingRequest $pr) {
        return $pr->get('https://laravel.com')->then(fn ($response) =>  strlen($response->body()));
    });
});

dd($response);
/*
array:2 [
  "cosmatech" => 9095
  "laravel" => 1422023
]
*/
```

## Alternative
I do not feel like this is necessarily the most ergonomic solution as it's kinda callback hell, but it's a pretty big retooling to make this work otherwise.

We _could_ allow forwarding calls to the PendingRequest to the underlying promise if the request is async. 🤷  I tried making this work with a `__call` method on PendingRequest, but that still has the same problem where we are mutating state but it's not associated with the request. I think we would either need a Laravel-owned Promise that allows for fluent chaining (this isn't necessarily easy, since the Guzzle Promise has a lot of private state that we cannot access).

Or maybe the PendingRequest is always based on Promises?