### PR TITLE
[12.x] Allow translation of the "Service Unavailable" message used by the maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -100,7 +100,7 @@ class PreventRequestsDuringMaintenance
 
             throw new HttpException(
                 $data['status'] ?? 503,
-                'Service Unavailable',
+                __('Service Unavailable'),
                 null,
                 $this->getHeaders($data)
             );


### PR DESCRIPTION
The [default maintenance page](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Exceptions/views/503.blade.php) displays a translatable message "Service Unavailable".
In JSON responses, currently there is the same message, "Service Unavailable", but it is not translatable. In this PR I'm making it translatable, so that the view and JSON error are consistent.