### PR TITLE
[12.x] Optimize cache and cache_locks timeout

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -14,13 +14,13 @@ return new class extends Migration
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->primary();
             $table->mediumText('value');
-            $table->integer('expiration');
+            $table->integer('expiration')->index();
         });
 
         Schema::create('cache_locks', function (Blueprint $table) {
             $table->string('key')->primary();
             $table->string('owner');
-            $table->integer('expiration');
+            $table->integer('expiration')->index();
         });
     }
 


### PR DESCRIPTION
In very high throughput applications that rely on the database driver for cache locks, the expiration cleanup starts to result in high lock wait times because there is no index on the `expiration` column.

This pull request adds an index to the table create migration stub for the `cache` and `cache_locks` tables.

Before adding index (these stats are over a 15 min period):
<img width="2126" height="246" alt="Screenshot 2025-11-28 at 10 03 30 AM" src="https://github.com/user-attachments/assets/125906b2-7ee3-4a42-8dba-f65d2ed3f3cb" />

After adding index (at 10:13):
<img width="2142" height="664" alt="image" src="https://github.com/user-attachments/assets/22369129-7cd6-45ef-a7e1-76703ad513d5" />
