### PR TITLE
[12.x] Fix Arr::first for ArrayObject and AsArrayObject values

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -242,7 +242,7 @@ class Arr
     }
 
     /**
-     * Return the first element in an array passing a given truth test.
+     * Return the first element in an iterable passing a given truth test.
      *
      * @template TKey
      * @template TValue

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -271,6 +271,8 @@ class Arr
             return value($default);
         }
 
+        $array = static::from($array);
+
         $key = array_find_key($array, $callback);
 
         return $key !== null ? $array[$key] : value($default);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -376,6 +376,15 @@ class SupportArrTest extends TestCase
         $this->assertNull(Arr::first($cursor));
     }
 
+    public function testFirstWorksWithArrayObject()
+    {
+        $arrayObject = new ArrayObject([0, 10, 20]);
+
+        $result = Arr::first($arrayObject, fn ($value) => $value === 0);
+
+        $this->assertSame(0, $result);
+    }
+
     public function testJoin()
     {
         $this->assertSame('a, b, c', Arr::join(['a', 'b', 'c'], ', '));


### PR DESCRIPTION
This PR fixes a regression where `Arr::first()` fails when the input is an `ArrayObject` or an Eloquent cast using `AsArrayObject`.

### Summary

In Laravel 12.39, `Arr::first()` was updated to use PHP 8.4's new `array_find_key()` function.  
However, `array_find_key()` **only accepts native arrays**, not `ArrayObject` or other array-like values.

This causes a type error when calling `Arr::first()` on model attributes cast using `AsArrayObject`, e.g.:

```php
$product = Product::first();

Arr::first($product->prices, fn ($price) => $price === 0);
```

Error:

```
array_find_key(): Argument #1 ($array) must be of type array, Illuminate\Database\Eloquent\Casts\ArrayObject given
```

### Fix

This PR normalizes the input using `Arr::from()` before passing it to `array_find_key()`, restoring support for:

- `ArrayObject`
- `Illuminate\Database\Eloquent\Casts\ArrayObject` (Eloquent `AsArrayObject`)
- other Traversable / array-like values that worked before the regression

The behavior is fully backward-compatible.

### Related Issue

Fixes #57959
