### PR TITLE
[12.x] Always restore missing-attribute flag in `offsetExists()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2447,11 +2447,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::$modelsShouldPreventAccessingMissingAttributes = false;
 
-        $result = ! is_null($this->getAttribute($offset));
-
-        static::$modelsShouldPreventAccessingMissingAttributes = $shouldPrevent;
-
-        return $result;
+        try {
+            return ! is_null($this->getAttribute($offset));
+        } finally {
+            static::$modelsShouldPreventAccessingMissingAttributes = $shouldPrevent;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR updates the `offsetExists()` method to ensure that the `modelsShouldPreventAccessingMissingAttributes` static flag is always restored to its previous value. The method temporarily disables the flag while checking for an attribute, but if `getAttribute()` throws an exception, the flag would remain in the wrong state