### PR TITLE
[12.x] Log: Allow scoping log context to a callback

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -219,6 +219,22 @@ class Logger implements LoggerInterface
     }
 
     /**
+     * Execute the callback with extra scoped log context.
+     *
+     * @param  array  $context
+     * @param  callable  $callback
+     */
+    public function withScopedContext(array $context, callable $callback)
+    {
+        try {
+            $this->withContext($context);
+            $callback();
+        } finally {
+            $this->withoutContext(array_keys($context));
+        }
+    }
+
+    /**
      * Register a new callback handler for when a log event is triggered.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -28,6 +28,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Log\LogManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
  * @method static void write(string $level, \Illuminate\Contracts\Support\Arrayable|\Illuminate\Contracts\Support\Jsonable|\Illuminate\Support\Stringable|array|string $message, array $context = [])
  * @method static \Illuminate\Log\Logger withContext(array $context = [])
+ * @method static void withScopedContext(array $context, callable $callback)
  * @method static void listen(\Closure $callback)
  * @method static \Psr\Log\LoggerInterface getLogger()
  * @method static \Illuminate\Contracts\Events\Dispatcher getEventDispatcher()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Description

This PR adds a `Log::withScopedContext` method that allows one to add log context that is scoped to that callback. After the callback is executed the extra log context is removed again.

```php
// Any logs after this have the general context.
Log::withContext(['general' => 'context']);

Log::withScopedContext(['scoped => context'], function () {
    // Any logs here have both the general- and scoped context, scoped context is automatically removed afterwards.
});

// Any logs here have just the general context again.
```

# Advantages
This mainly eases the use of https://github.com/laravel/framework/pull/55181#issue-2951810725 and has similar advantages of using the callback with 
```php
Cache::lock()->get(function () {
    // Lock is automatically released afterwards.
});
```

# Why
I frequently have code that executes separate tasks, e.g. custom jobs that do batches of work. There is a general context for the complete batch, plus a separate context for each unit of work. This means adding context before each unit of work and removing it afterwards. 

I currently use `Log::withContext(...)` combined with `Log::withoutContext(...)`  afterwards, as described in the PR above. However, this can be a hassle for two reasons:
 - Whenever you add context at the start, you need to remember to remove it again at the end.
 - You need to remember to correctly handle removing the extra context in your exception handling as well.

This current solution addresses both problems.

# Potential other solution
I could also see this working as an extension to `Log::withContext(...)`, by having the callback as a nullable second parameter. It would then function even more similar to how `Cache::lock()->get(...)` works. I mainly chose the current solution for clarity, but have no real preference. 

# Problems with the current solution
One unfortunate result of this solution is that it does not guarantee that the context at the end is the same as beforehand. This is primarily due to the `array_merge` usage in `Log::withContext(...)`. This is fine for my use case, but it is something to take note of.