### PR TITLE
[13.x] Default `PendingRequest@pool()` to use 2 for concurrency

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -888,7 +888,7 @@ class PendingRequest
      * @param  int|null  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */
-    public function pool(callable $callback, ?int $concurrency = null)
+    public function pool(callable $callback, ?int $concurrency = 2)
     {
         $results = [];
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -885,10 +885,10 @@ class PendingRequest
      * Send a pool of asynchronous requests concurrently.
      *
      * @param  (callable(\Illuminate\Http\Client\Pool): mixed)  $callback
-     * @param  int|null  $concurrency
+     * @param  int|null|(callable(non-negative-int): int)  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */
-    public function pool(callable $callback, ?int $concurrency = 2)
+    public function pool(callable $callback, int|callable|null $concurrency = 2)
     {
         $results = [];
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -888,7 +888,7 @@ class PendingRequest
      * @param  int|null  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */
-    public function pool(callable $callback, ?int $concurrency = 2)
+    public function pool(callable $callback, ?int $concurrency = 0)
     {
         $results = [];
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -885,10 +885,10 @@ class PendingRequest
      * Send a pool of asynchronous requests concurrently.
      *
      * @param  (callable(\Illuminate\Http\Client\Pool): mixed)  $callback
-     * @param  int|null|(callable(non-negative-int): int)  $concurrency
+     * @param  int|null  $concurrency
      * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
      */
-    public function pool(callable $callback, int|callable|null $concurrency = 2)
+    public function pool(callable $callback, ?int $concurrency = 2)
     {
         $results = [];
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3527,14 +3527,14 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $responses[0]->status());
         $this->assertSame(200, $responses[1]->status());
 
-        $this->expectException(StrayRequestException::class);
-        $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
-
-        $this->factory->pool(function (Pool $pool) {
+        [$exception] = $this->factory->pool(function (Pool $pool) {
             return [
                 $pool->get('https://laravel.com'),
             ];
-        }, null);
+        });
+
+        $this->assertInstanceOf(StrayRequestException::class, $exception);
+        $this->assertEquals('Attempted request to [https://laravel.com] without a matching fake.', $exception->getMessage());
     }
 
     public function testPreventingStrayRequests()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3534,7 +3534,7 @@ class HttpClientTest extends TestCase
             return [
                 $pool->get('https://laravel.com'),
             ];
-        });
+        }, null);
     }
 
     public function testPreventingStrayRequests()


### PR DESCRIPTION
The fact that this defaults to null feels like a major footgun. Developers will think that they are getting the benefit of concurrent requests when in fact they are just being executed in series. Within the underlying Guzzle library, passing null does mean to execute without a cap.

Is 2 the right number? I have no idea. But I think anything is better than just defaulting to serial execution. Or we could change it to pass `0` which I think would allow for unbounded concurrency.