### PR TITLE
[12.x] Introduce `#[Proxy]` attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Lazy.php
+++ b/src/Illuminate/Container/Attributes/Lazy.php
@@ -5,6 +5,6 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
-class Proxy
+class Lazy
 {
 }

--- a/src/Illuminate/Container/Attributes/Lazy.php
+++ b/src/Illuminate/Container/Attributes/Lazy.php
@@ -3,8 +3,16 @@
 namespace Illuminate\Container\Attributes;
 
 use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use ReflectionNamedType;
+use ReflectionParameter;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
-class Lazy
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
+class Lazy implements ContextualAttribute
 {
+    public static function resolve(self $attribute, Container $container, ReflectionNamedType $type)
+    {
+        return proxy($type->getName(), fn () => $container->make($type->getName()));
+    }
 }

--- a/src/Illuminate/Container/Attributes/Lazy.php
+++ b/src/Illuminate/Container/Attributes/Lazy.php
@@ -6,13 +6,12 @@ use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use ReflectionNamedType;
-use ReflectionParameter;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
 class Lazy implements ContextualAttribute
 {
     public static function resolve(self $attribute, Container $container, ReflectionNamedType $type)
     {
-        return proxy($type->getName(), fn () => $container->make($type->getName()));
+        return proxy($type->getName(), static fn () => $container->make($type->getName()));
     }
 }

--- a/src/Illuminate/Container/Attributes/Proxy.php
+++ b/src/Illuminate/Container/Attributes/Proxy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Container\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
+class Proxy
+{
+}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1167,7 +1167,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         if (! in_array($concrete, $withoutLazyFor) && ! empty($reflector->getAttributes(Lazy::class))) {
-            return proxy($concrete, fn () => $this->build($concrete, array_push($withoutLazyFor, $concrete)));
+            return proxy($concrete, fn () => $this->build($concrete, [...$withoutLazyFor, $concrete]));
         }
 
         $dependencies = $constructor->getParameters();

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1167,7 +1167,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         if (! in_array($concrete, $withoutLazyFor) && ! empty($reflector->getAttributes(Lazy::class))) {
-            return proxy($concrete, fn () => $this->build($concrete, [$concrete]));
+            return proxy($concrete, fn () => $this->build($concrete, array_push($withoutLazyFor, $concrete)));
         }
 
         $dependencies = $constructor->getParameters();
@@ -1244,7 +1244,6 @@ class Container implements ArrayAccess, ContainerContract
 
             $result = null;
 
-            //
             if (! is_null($attribute = Util::getContextualAttributeFromDependency($dependency))) {
                 $result = $this->resolveFromAttribute($attribute, $dependency->getType());
             }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -20,6 +20,7 @@ use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
+use ReflectionNamedType;
 use ReflectionParameter;
 use TypeError;
 
@@ -1243,8 +1244,9 @@ class Container implements ArrayAccess, ContainerContract
 
             $result = null;
 
+            //
             if (! is_null($attribute = Util::getContextualAttributeFromDependency($dependency))) {
-                $result = $this->resolveFromAttribute($attribute);
+                $result = $this->resolveFromAttribute($attribute, $dependency->getType());
             }
 
             // If the class is null, it means the dependency is a string or some other
@@ -1395,7 +1397,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionAttribute  $attribute
      * @return mixed
      */
-    public function resolveFromAttribute(ReflectionAttribute $attribute)
+    public function resolveFromAttribute(ReflectionAttribute $attribute, ?ReflectionNamedType $type = null)
     {
         $handler = $this->contextualAttributes[$attribute->getName()] ?? null;
 
@@ -1409,7 +1411,7 @@ class Container implements ArrayAccess, ContainerContract
             throw new BindingResolutionException("Contextual binding attribute [{$attribute->getName()}] has no registered handler.");
         }
 
-        return $handler($instance, $this);
+        return $handler($instance, $this, $type);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -6,7 +6,7 @@ use ArrayAccess;
 use Closure;
 use Exception;
 use Illuminate\Container\Attributes\Bind;
-use Illuminate\Container\Attributes\Proxy;
+use Illuminate\Container\Attributes\Lazy;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -1165,7 +1165,7 @@ class Container implements ArrayAccess, ContainerContract
             return $instance;
         }
 
-        if (! in_array($concrete, $withoutLazyFor) && ! empty($reflector->getAttributes(Proxy::class))) {
+        if (! in_array($concrete, $withoutLazyFor) && ! empty($reflector->getAttributes(Lazy::class))) {
             return proxy($concrete, fn () => $this->build($concrete, [$concrete]));
         }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1213,7 +1213,9 @@ class WildcardConcrete implements WildcardOnlyInterface
 {
 }
 
-// The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
+/*
+ * The order of these attributes matters because we want to ensure we only fallback to '*' when there's no more specific environment.
+ */
 #[Bind(FallbackConcrete::class)]
 #[Bind(ProdConcrete::class, environments: 'prod')]
 interface WildcardAndProdInterface

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Container;
 
 use Attribute;
 use Illuminate\Container\Attributes\Bind;
-use Illuminate\Container\Attributes\Proxy;
+use Illuminate\Container\Attributes\Lazy;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Container\Container;
@@ -232,7 +232,7 @@ class ContainerTest extends TestCase
         $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
         $class = $container->make(ProxyDependenciesClass::class);
         $this->assertTrue((new ReflectionClass($class))->isUninitializedLazyObject($class));
-        $class->stubby;
+        $this->assertTrue($class->stubbyIsSet());
         $this->assertFalse((new ReflectionClass($class))->isUninitializedLazyObject($class));
     }
 
@@ -1230,12 +1230,16 @@ class RequestDtoDependency implements RequestDtoDependencyContract
     }
 }
 
-#[Proxy]
+#[Lazy]
 class ProxyDependenciesClass
 {
     public function __construct(
         public IContainerContractStub $stubby
     ) {
-        //dd('i have been constructed!');
+    }
+
+    public function stubbyIsSet(): bool
+    {
+        return isset($this->stubby);
     }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -228,6 +228,10 @@ class ContainerTest extends TestCase
 
     public function testLazyObjects()
     {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
         $container = new Container;
         $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
         $class = $container->make(ProxyDependenciesClass::class);
@@ -238,6 +242,10 @@ class ContainerTest extends TestCase
 
     public function testObjectWithLazyDependencies()
     {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $this->markTestSkipped();
+        }
+
         $container = new Container;
         $container->bind(IContainerContractStub::class, ContainerImplementationStub::class);
         $class = $container->make(ClassWithLazyDependencies::class);


### PR DESCRIPTION
allow users to mark classes or dependencies which should be built lazily

Building off of @timacdonald's work in https://github.com/laravel/framework/pull/57831/

## Why would anyone need this
If you've worked in a legacy project, you might've come across junk-drawer service classes that look like this:

```php
class PaymentService
{
    public function __construct(
        public CustomerService $customerService,
        public StripeService $stripeService,
        public PayPalService $paypalService,
        public XeroService $xeroService,
        public ReceiptService $receiptService
        // .... imagine 10 more services
    ) {}
    
    // imagine 10 functions, spread out across 1500 lines of code, none of which use all the dependencies

    public function getStripeCustomer(Customer $customer): StripeCustomer
    {
        return $this->stripeService->getCustomerByEmail($customer->email);
    }
}
```

When I call `PaymentService@getStripeCustomer()`, I am constructing all of the dependencies just to call one of them.

**In an ideal world**, this would be refactored into smaller components with fewer dependencies in each. That's not always a price a development team can pay all at once.

To simplify this, I am proposing introducing a `#[Lazy]` attribute, which can be applied to either a class or individual parameters.

```php
class PaymentService
{
    public function __construct(
        #[Lazy] public CustomerService $customerService,
        #[Lazy] public StripeService $stripeService,
        // ...
    ) {}
}
```
## Naming
Technically this is built using the `proxy()` function. I'm not sure that naming the attribute something other than Lazy is worth the distinction.

## Other ideas
Adding a parameter `bool $dependencies` that would also make all of the dependencies lazy for the class