### PR TITLE
[12.x] Add ability to ignore queuePaused \ queueShouldRestart cache checks

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,6 +107,20 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
+     * Indicates if the worker should check for restart.
+     *
+     * @var bool
+     */
+    public static $checkRestart = true;
+
+    /**
+     * Indicates if the worker should check for paused queues.
+     *
+     * @var bool
+     */
+    public static $checkPaused = true;
+
+    /**
      * Create a new queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $manager
@@ -400,6 +414,10 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
+        if (! static::$checkPaused) {
+            return false;
+        }
+
         return $this->cache && (bool) $this->cache->get(
             "illuminate:queue:paused:{$connectionName}:{$queue}", false
         );
@@ -750,6 +768,10 @@ class Worker
      */
     protected function getTimestampOfLastQueueRestart()
     {
+        if (! static::$checkRestart) {
+            return null;
+        }
+
         if ($this->cache) {
             return $this->cache->get('illuminate:queue:restart');
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,18 +107,18 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
-     * Indicates if the worker should disable the check for the last restart.
+     * Indicates if the worker should check for the restart signal in the cache.
      *
      * @var bool
      */
-    public static $disableLastRestartCheck = false;
+    public static $restartable = true;
 
     /**
-     * Indicates if the worker should disable the check for paused queues.
+     * Indicates if the worker should check for the paused signal in the cache.
      *
      * @var bool
      */
-    public static $disablePausedQueueCheck = false;
+    public static $pausable = true;
 
     /**
      * Create a new queue worker.
@@ -414,7 +414,7 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
-        if (static::$disablePausedQueueCheck) {
+        if (! static::$pausable) {
             return false;
         }
 
@@ -758,7 +758,7 @@ class Worker
      */
     protected function queueShouldRestart($lastRestart)
     {
-        if (static::$disableLastRestartCheck) {
+        if (! static::$restartable) {
             return false;
         }
 
@@ -772,7 +772,7 @@ class Worker
      */
     protected function getTimestampOfLastQueueRestart()
     {
-        if (static::$disableLastRestartCheck) {
+        if (! static::$restartable) {
             return null;
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,18 +107,18 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
-     * Indicates if the worker should check for the last restart.
+     * Indicates if the worker should disable the check for the last restart.
      *
      * @var bool
      */
-    public static $checkLastRestart = true;
+    public static $disableLastRestartCheck = false;
 
     /**
-     * Indicates if the worker should check for paused queues.
+     * Indicates if the worker should disable the check for paused queues.
      *
      * @var bool
      */
-    public static $checkPausedQueues = true;
+    public static $disablePausedQueueCheck = false;
 
     /**
      * Create a new queue worker.
@@ -414,7 +414,7 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
-        if (! static::$checkPausedQueues) {
+        if (static::$disablePausedQueueCheck) {
             return false;
         }
 
@@ -758,7 +758,7 @@ class Worker
      */
     protected function queueShouldRestart($lastRestart)
     {
-        if (! static::$checkLastRestart) {
+        if (static::$disableLastRestartCheck) {
             return false;
         }
 
@@ -772,7 +772,7 @@ class Worker
      */
     protected function getTimestampOfLastQueueRestart()
     {
-        if (! static::$checkLastRestart) {
+        if (static::$disableLastRestartCheck) {
             return null;
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -111,14 +111,14 @@ class Worker
      *
      * @var bool
      */
-    public static $checkRestart = true;
+    public static $checkLastRestart = true;
 
     /**
      * Indicates if the worker should check for paused queues.
      *
      * @var bool
      */
-    public static $checkPaused = true;
+    public static $checkPausedQueues = true;
 
     /**
      * Create a new queue worker.
@@ -386,7 +386,7 @@ class Worker
             }
 
             foreach (explode(',', $queue) as $index => $queue) {
-                if ($this->queuePaused($connection->getConnectionName(), $queue)) {
+                if (static::$checkPausedQueues && $this->queuePaused($connection->getConnectionName(), $queue)) {
                     continue;
                 }
 
@@ -414,10 +414,6 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
-        if (! static::$checkPaused) {
-            return false;
-        }
-
         return $this->cache && (bool) $this->cache->get(
             "illuminate:queue:paused:{$connectionName}:{$queue}", false
         );
@@ -758,6 +754,10 @@ class Worker
      */
     protected function queueShouldRestart($lastRestart)
     {
+        if (! static::$checkLastRestart) {
+            return false;
+        }
+
         return $this->getTimestampOfLastQueueRestart() != $lastRestart;
     }
 
@@ -768,7 +768,7 @@ class Worker
      */
     protected function getTimestampOfLastQueueRestart()
     {
-        if (! static::$checkRestart) {
+        if (! static::$checkLastRestart) {
             return null;
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -386,7 +386,7 @@ class Worker
             }
 
             foreach (explode(',', $queue) as $index => $queue) {
-                if (static::$checkPausedQueues && $this->queuePaused($connection->getConnectionName(), $queue)) {
+                if ($this->queuePaused($connection->getConnectionName(), $queue)) {
                     continue;
                 }
 
@@ -414,6 +414,10 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
+        if (! static::$checkPausedQueues) {
+            return false;
+        }
+
         return $this->cache && (bool) $this->cache->get(
             "illuminate:queue:paused:{$connectionName}:{$queue}", false
         );

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,7 +107,7 @@ class Worker
     public static $memoryExceededExitCode;
 
     /**
-     * Indicates if the worker should check for restart.
+     * Indicates if the worker should check for the last restart.
      *
      * @var bool
      */

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -191,7 +191,7 @@ class WorkCommandTest extends QueueTestCase
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$disableLastRestartCheck = true;
+        Worker::$restartable = false;
 
         $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
@@ -213,14 +213,14 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
 
-        Worker::$disableLastRestartCheck = false;
+        Worker::$restartable = true;
     }
 
     public function testDisablePauseQueueCheck()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$disablePausedQueueCheck = true;
+        Worker::$pausable = false;
 
         $cache = m::mock(Repository::class);
 
@@ -243,7 +243,7 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
 
-        Worker::$disablePausedQueueCheck = false;
+        Worker::$pausable = true;
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Queue;
-use Mockery;
+use Mockery as m;
 use Orchestra\Testbench\Attributes\WithMigration;
 use RuntimeException;
 
@@ -193,10 +193,10 @@ class WorkCommandTest extends QueueTestCase
 
         Worker::$checkRestart = false;
 
-        $cache = Mockery::mock(Repository::class);
+        $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
 
-        $cacheManager = Mockery::mock(CacheManager::class);
+        $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);
         $cacheManager->shouldReceive('store')->andReturn($cache);
 
@@ -218,13 +218,13 @@ class WorkCommandTest extends QueueTestCase
 
         Worker::$checkPaused = false;
 
-        $cache = Mockery::mock(Repository::class);
+        $cache = m::mock(Repository::class);
 
         $cache->shouldReceive('get')->with('illuminate:queue:restart')->andReturn(null);
 
-        $cache->shouldNotReceive('get')->with(Mockery::pattern('/^illuminate:queue:paused:/'), false);
+        $cache->shouldNotReceive('m')->with(m::pattern('/^illuminate:queue:paused:/'), false);
 
-        $cacheManager = Mockery::mock(CacheManager::class);
+        $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);
         $cacheManager->shouldReceive('store')->andReturn($cache);
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -195,6 +195,7 @@ class WorkCommandTest extends QueueTestCase
 
         $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
+        $cache->shouldReceive('get')->with(m::pattern('/^illuminate:queue:paused:/'), false);
 
         $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);
@@ -221,8 +222,7 @@ class WorkCommandTest extends QueueTestCase
         $cache = m::mock(Repository::class);
 
         $cache->shouldReceive('get')->with('illuminate:queue:restart')->andReturn(null);
-
-        $cache->shouldNotReceive('m')->with(m::pattern('/^illuminate:queue:paused:/'), false);
+        $cache->shouldNotReceive('get')->with(m::pattern('/^illuminate:queue:paused:/'), false);
 
         $cacheManager = m::mock(CacheManager::class);
         $cacheManager->shouldReceive('driver')->andReturn($cache);

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -210,6 +210,9 @@ class WorkCommandTest extends QueueTestCase
             '--stop-when-empty' => true,
         ]);
 
+        $this->assertSame(0, Queue::size());
+        $this->assertTrue(FirstJob::$ran);
+
         Worker::$checkLastRestart = true;
     }
 
@@ -236,6 +239,9 @@ class WorkCommandTest extends QueueTestCase
             '--max-jobs' => 1,
             '--stop-when-empty' => true,
         ]);
+
+        $this->assertSame(0, Queue::size());
+        $this->assertTrue(FirstJob::$ran);
 
         Worker::$checkPausedQueues = true;
     }

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -187,11 +187,11 @@ class WorkCommandTest extends QueueTestCase
         Worker::$memoryExceededExitCode = null;
     }
 
-    public function testDisableRestartCheck()
+    public function testDisableLastRestartCheck()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$checkRestart = false;
+        Worker::$checkLastRestart = false;
 
         $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
@@ -209,14 +209,14 @@ class WorkCommandTest extends QueueTestCase
             '--stop-when-empty' => true,
         ]);
 
-        Worker::$checkRestart = true;
+        Worker::$checkLastRestart = true;
     }
 
     public function testDisablePauseCheck()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$checkPaused = false;
+        Worker::$checkPausedQueues = false;
 
         $cache = m::mock(Repository::class);
 
@@ -237,7 +237,7 @@ class WorkCommandTest extends QueueTestCase
             '--stop-when-empty' => true,
         ]);
 
-        Worker::$checkPaused = true;
+        Worker::$checkPausedQueues = true;
     }
 
     public function testFailedJobListenerOnlyRunsOnce()

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -191,7 +191,7 @@ class WorkCommandTest extends QueueTestCase
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$checkLastRestart = false;
+        Worker::$disableLastRestartCheck = true;
 
         $cache = m::mock(Repository::class);
         $cache->shouldNotReceive('get')->with('illuminate:queue:restart');
@@ -213,14 +213,14 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
 
-        Worker::$checkLastRestart = true;
+        Worker::$disableLastRestartCheck = false;
     }
 
-    public function testDisablePauseCheck()
+    public function testDisablePauseQueueCheck()
     {
         $this->markTestSkippedWhenUsingQueueDrivers(['redis', 'beanstalkd']);
 
-        Worker::$checkPausedQueues = false;
+        Worker::$disablePausedQueueCheck = true;
 
         $cache = m::mock(Repository::class);
 
@@ -243,7 +243,7 @@ class WorkCommandTest extends QueueTestCase
         $this->assertSame(0, Queue::size());
         $this->assertTrue(FirstJob::$ran);
 
-        Worker::$checkPausedQueues = true;
+        Worker::$disablePausedQueueCheck = false;
     }
 
     public function testFailedJobListenerOnlyRunsOnce()


### PR DESCRIPTION
In one of my environments, I have 7+ queue workers, each for specific use cases.

Each queue worker hits the cache to check if it should restart and if it needs to pause for each job.

Using the database cache store means this can quickly become quite heavy - as each worker hits the database.  It also appears in Nightwatch a lot, which is what led me to this PR.  (ie 7 workers, 2 cache keys - each job -  within 24 hours- a lot of cache hits!)


<img width="879" height="61" alt="image" src="https://github.com/user-attachments/assets/2dd6c933-623a-4c13-b638-0bc404614878" />

I'm not going to be using these commands (ie restart or pause) - so it would be nice to add the option to disable them & rather than having to extend the cache manager / adjust the queue.worker singleton with some custom solution, I thought this would be nice and at least help the dx. 

TLDR - cache keys are hit alot, feels like a lot of overhead if you don't use the restart/pause commands, this adds a way to turn it off.

They default to false so completely opt in, so shouldn't be any breaking changes. Happy to target 13.x if you prefer & open to feedback- thanks!

