### PR TITLE
[12.x] Add `stringable` and `uri` to Config repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,7 +6,10 @@ use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Uri;
 use InvalidArgumentException;
 
 class Repository implements ArrayAccess, ConfigContract
@@ -198,6 +201,30 @@ class Repository implements ArrayAccess, ConfigContract
     public function collection(string $key, $default = null): Collection
     {
         return new Collection($this->array($key, $default));
+    }
+
+    /**
+     * Get the specified string configuration value as a stringable instance.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return Stringable
+     */
+    public function stringable(string $key, $default = null): Stringable
+    {
+        return Str::of($this->string($key, $default));
+    }
+
+    /**
+     * Get the specified string configuration value as a URI instance.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return Uri
+     */
+    public function uri(string $key, $default = null): Uri
+    {
+        return Uri::of($this->string($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -12,6 +12,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool boolean(string $key, \Closure|bool|null $default = null)
  * @method static array array(string $key, \Closure|array|null $default = null)
  * @method static \Illuminate\Support\Collection collection(string $key, \Closure|array|null $default = null)
+ * @method static \Illuminate\Support\Stringable stringable(string $key, \Closure|array|null $default = null)
+ * @method static \Illuminate\Support\Uri uri(string $key, \Closure|array|null $default = null)
  * @method static void set(array|string $key, mixed $value = null)
  * @method static void prepend(string $key, mixed $value)
  * @method static void push(string $key, mixed $value)

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
+use Illuminate\Support\Uri;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -29,6 +31,7 @@ class RepositoryTest extends TestCase
             'boolean' => true,
             'integer' => 1,
             'float' => 1.1,
+            'uri' => 'https://laravel.com',
             'associate' => [
                 'x' => 'xxx',
                 'y' => 'yyy',
@@ -303,6 +306,22 @@ class RepositoryTest extends TestCase
         $this->expectExceptionMessageMatches('#^Configuration value for key \[a\] must be a string, (.*) given.#');
 
         $this->repository->string('a');
+    }
+
+    public function testItGetsAsStringable(): void
+    {
+        $stringable = $this->repository->stringable('a.b');
+
+        $this->assertInstanceOf(Stringable::class, $stringable);
+        $this->assertSame('c', (string) $stringable);
+    }
+
+    public function testItGetsAsUri(): void
+    {
+        $uri = $this->repository->uri('uri');
+
+        $this->assertInstanceOf(Uri::class, $uri);
+        $this->assertSame('https://laravel.com', (string) $uri);
     }
 
     public function testItGetsAsArray(): void


### PR DESCRIPTION
Since `Config::collection` exists, it makes sense to also support casting to Stringable and Uri.