### PR TITLE
[12.x] Fix: `Storage::exists(null)` throws exception instead of returning `false`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -209,7 +209,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function exists($path)
     {
-        return ! empty($path) && $this->driver->has($path);
+        return $this->isValidPath($path) && $this->driver->has($path);
     }
 
     /**
@@ -220,7 +220,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function missing($path)
     {
-        return ! empty($path) && ! $this->exists($path);
+        return $this->isValidPath($path) && ! $this->exists($path);
     }
 
     /**
@@ -231,7 +231,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function fileExists($path)
     {
-        return ! empty($path) && $this->driver->fileExists($path);
+        return $this->isValidPath($path) && $this->driver->fileExists($path);
     }
 
     /**
@@ -242,7 +242,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function fileMissing($path)
     {
-        return ! empty($path) && ! $this->fileExists($path);
+        return $this->isValidPath($path) && ! $this->fileExists($path);
     }
 
     /**
@@ -253,7 +253,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function directoryExists($path)
     {
-        return ! empty($path) && $this->driver->directoryExists($path);
+        return $this->isValidPath($path) && $this->driver->directoryExists($path);
     }
 
     /**
@@ -264,7 +264,12 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function directoryMissing($path)
     {
-        return ! empty($path) && ! $this->directoryExists($path);
+        return $this->isValidPath($path) && ! $this->directoryExists($path);
+    }
+
+    protected function isValidPath($path)
+    {
+        return ! is_null($path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -209,7 +209,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function exists($path)
     {
-        return $this->driver->has($path);
+        return ! empty($path) && $this->driver->has($path);
     }
 
     /**
@@ -220,7 +220,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function missing($path)
     {
-        return ! $this->exists($path);
+        return ! empty($path) && ! $this->exists($path);
     }
 
     /**
@@ -231,7 +231,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function fileExists($path)
     {
-        return $this->driver->fileExists($path);
+        return ! empty($path) && $this->driver->fileExists($path);
     }
 
     /**
@@ -242,7 +242,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function fileMissing($path)
     {
-        return ! $this->fileExists($path);
+        return ! empty($path) && ! $this->fileExists($path);
     }
 
     /**
@@ -253,7 +253,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function directoryExists($path)
     {
-        return $this->driver->directoryExists($path);
+        return ! empty($path) && $this->driver->directoryExists($path);
     }
 
     /**
@@ -264,7 +264,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function directoryMissing($path)
     {
-        return ! $this->directoryExists($path);
+        return ! empty($path) && ! $this->directoryExists($path);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -143,6 +143,8 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->exists('file.txt'));
         $this->assertTrue($filesystemAdapter->fileExists('file.txt'));
+        $this->assertFalse($filesystemAdapter->exists(null));
+        $this->assertTrue($filesystemAdapter->fileExists(null));
     }
 
     public function testMissing()
@@ -150,6 +152,8 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->missing('file.txt'));
         $this->assertTrue($filesystemAdapter->fileMissing('file.txt'));
+        $this->assertFalse($filesystemAdapter->missing(null));
+        $this->assertTrue($filesystemAdapter->fileMissing(null));
     }
 
     public function testDirectoryExists()
@@ -157,12 +161,14 @@ class FilesystemAdapterTest extends TestCase
         $this->filesystem->write('/foo/bar/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryExists('/foo/bar'));
+        $this->assertFalse($filesystemAdapter->directoryExists(null));
     }
 
     public function testDirectoryMissing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
         $this->assertTrue($filesystemAdapter->directoryMissing('/foo/bar'));
+        $this->assertFalse($filesystemAdapter->directoryMissing(null));
     }
 
     public function testPath()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -144,7 +144,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->exists('file.txt'));
         $this->assertTrue($filesystemAdapter->fileExists('file.txt'));
         $this->assertFalse($filesystemAdapter->exists(null));
-        $this->assertTrue($filesystemAdapter->fileExists(null));
+        $this->assertFalse($filesystemAdapter->fileExists(null));
     }
 
     public function testMissing()
@@ -153,7 +153,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->missing('file.txt'));
         $this->assertTrue($filesystemAdapter->fileMissing('file.txt'));
         $this->assertFalse($filesystemAdapter->missing(null));
-        $this->assertTrue($filesystemAdapter->fileMissing(null));
+        $this->assertFalse($filesystemAdapter->fileMissing(null));
     }
 
     public function testDirectoryExists()


### PR DESCRIPTION
Fix #57976 

This PR updates Laravel’s filesystem adapter to safely handle null paths instead of throwing an exception when calling methods such as:

- `exists()`
- `missing()`
- `fileExists()`
- `fileMissing()`
- `directoryExists()`
- `directoryMissing()`

This aligns their behavior with other Laravel helpers and helps developers write simpler and more convenient code.