### PR TITLE
[12.x] Remove 'wrapper' Symfony `Request::get` override

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -425,21 +425,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
-     *
-     * Instead, you may use the "input" method.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    #[\Override]
-    public function get(string $key, mixed $default = null): mixed
-    {
-        return parent::get($key, $default);
-    }
-
-    /**
      * Get the JSON payload for the request.
      *
      * @param  string|null  $key


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR removes the no-op wrapper extension of the Symfony `get` method on the `Request` class, given its deprecation in Symfony 7.4 (see https://github.com/symfony/symfony/pull/61948) and subsequent removal in 8.0.

Given this override is a no-op, only existing to add some notes to discourage its use (see https://github.com/laravel/framework/commit/d7d5dfccfbcbff786caabf2c688d97fc54a5519b), and the Symfony counterpat deprecation should now already discourage usage through their deprecation message, this should be safely removeable. 

It will remain functional with Laravel 12, but might not longer be available in v13 if that will indeed allow ^8.0 for Symfony, making it potentially worth mentioning in the upgrade guide at that point, given that it may still occur in userland code (see e.g. #57962). Alternatively, one may opt even to target this change to the `master` branch instead of `12.x`.