### PR TITLE
[12.x] Add wildcard pattern support to TrimStrings middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -78,7 +78,7 @@ class TrimStrings extends TransformsRequest
      */
     protected function shouldSkip($key, $except)
     {
-        return in_array($key, $except, true);
+        return Str::is($except, $key);
     }
 
     /**


### PR DESCRIPTION
This PR adds wildcard pattern support to the `TrimStrings` middleware's `$except` array, so we can skip trimming for nested request parameters like `foo.bar.*.name`.

## Background

We need to trim strings globally, but some interfaces require preserving whitespace as valid input. The current `shouldSkip` method uses `in_array($key, $except, true)` which only does exact matching, so you can't use patterns like `users.*.email` to exclude nested fields.

This was requested in [#48212](https://github.com/laravel/framework/issues/48212) and [#50901](https://github.com/laravel/framework/issues/50901).

## Changes

Changed `shouldSkip` to use `Str::is()` instead of `in_array()`, which supports Laravel's wildcard patterns. This lets you use `TrimStrings::except()` to define exceptions for nested fields that need to preserve whitespace.

Backward compatible - exact matches still work the same way.

## Usage

You can use wildcard patterns in two ways:

**Via `TrimStrings::except()`:**

```php
// In AppServiceProvider
TrimStrings::except([
    'users.*.name',
    'orders.*.items.*.meta.title',
    'orders.*.items.*.meta.tags.*',
]);
```

**Or in a custom middleware:**

```php
class TrimStrings extends Middleware
{
    protected $except = [
        'users.*.name',
        'orders.*.items.*.meta.title',
        'orders.*.items.*.meta.tags.*',
    ];
}
```
