### PR TITLE
[12.x] Fix cache:clear command exit code on failure

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -57,7 +57,7 @@ class ClearCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int
      */
     public function handle()
     {
@@ -70,7 +70,9 @@ class ClearCommand extends Command
         $this->flushFacades();
 
         if (! $successful) {
-            return $this->components->error('Failed to clear cache. Make sure you have the appropriate permissions.');
+            $this->components->error('Failed to clear cache. Make sure you have the appropriate permissions.');
+
+            return self::FAILURE;
         }
 
         $this->laravel['events']->dispatch(
@@ -78,6 +80,8 @@ class ClearCommand extends Command
         );
 
         $this->components->info('Application cache cleared successfully.');
+
+        return self::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
## Summary

The `cache:clear` command was returning `void` (which Symfony Console interprets as exit code `0`) even when the cache flush operation failed. While the error message is printed to stdout, the exit code doesn't reflect the failure, which breaks the standard Unix convention that automation tools rely on.

## Problem

```php
// Before: returns void (exit code 0) even on failure
if (! $successful) {
    return $this->components->error('Failed to clear cache...');
}
```

The `$this->components->error()` method returns `void`, so the command exits with code `0` despite the failure. Tools can still detect failure by parsing stdout, but this is fragile compared to checking exit codes.

## Solution

```php
// After: properly returns exit code 1 on failure
if (! $successful) {
    $this->components->error('Failed to clear cache...');
    return self::FAILURE;
}
```

This follows the pattern used consistently in other Laravel commands like `db:wipe`, `migrate`, `db:seed`, etc.

## Changes

- Return `self::FAILURE` (exit code 1) when cache flush fails
- Return `self::SUCCESS` (exit code 0) on successful cache clear
- Update PHPDoc return type from `void` to `int`