### PR TITLE
[12.x] dark mode support for mail

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -4,9 +4,92 @@
 <title>{{ config('app.name') }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="color-scheme" content="light">
-<meta name="supported-color-schemes" content="light">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <style>
+@media (prefers-color-scheme: dark) {
+body,
+.wrapper,
+.body {
+background-color: #18181b !important;
+}
+
+.inner-body {
+background-color: #27272a !important;
+border-color: #3f3f46 !important;
+}
+
+p,
+ul,
+ol,
+blockquote,
+span,
+td {
+color: #e4e4e7 !important;
+}
+
+a {
+color: #a5b4fc !important;
+}
+
+h1,
+h2,
+h3,
+.header a {
+color: #fafafa !important;
+}
+
+.logo {
+    filter: invert(23%) sepia(5%) saturate(531%) hue-rotate(202deg) brightness(96%) contrast(91%) !important;
+}
+
+.button-primary,
+.button-blue {
+background-color: #fafafa !important;
+border-color: #fafafa !important;
+color: #18181b !important;
+}
+
+.button-success,
+.button-green {
+background-color: #22c55e !important;
+border-color: #22c55e !important;
+color: #fff !important;
+}
+
+.button-error,
+.button-red {
+background-color: #ef4444 !important;
+border-color: #ef4444 !important;
+color: #fff !important;
+}
+
+.footer p,
+.footer a {
+color: #71717a !important;
+}
+
+.panel-content {
+background-color: #3f3f46 !important;
+}
+
+.panel-content p {
+color: #e4e4e7 !important;
+}
+
+.panel {
+border-color: #fff !important;
+}
+
+.subcopy {
+border-top-color: #3f3f46 !important;
+}
+
+.table th {
+border-bottom-color: #3f3f46 !important;
+}
+}
+
 @media only screen and (max-width: 600px) {
 .inner-body {
 width: 100% !important;


### PR DESCRIPTION
Quick note: we can't rely on `default.css` alone for dark-mode because the Markdown renderer sends the theme through `CssToInlineStyles` which inlines normal rules into `style=""` attributes — media queries like `@media (prefers-color-scheme: dark)` cannot be inlined and therefore must be present as stylesheet rules in the final `<head>` to work. For this PR I placed the `@media` block in `layout.blade.php` so it ends up in the email head and can override the inlined light-mode styles (using !important).

Alternative https://github.com/laravel/framework/pull/57995 (preferred long-term): keep the single `default.css` as source-of-truth and modify `Illuminate\Mail\Markdown` to extract `@media` blocks and expose them (e.g. `Markdown::getHead()`), then emit that in the layout head — this preserves one CSS file while ensuring media queries reach the final HTML.
<img width="833" height="550" alt="image" src="https://github.com/user-attachments/assets/8536bd59-736b-4f02-b0a1-82051bc7a08d" />