### PR TITLE
[12.x] Add error message to Resume, Restart & Pause commands when disabling worker cache

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
 use Illuminate\Queue\Worker;
-use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:pause')]
@@ -36,7 +35,9 @@ class PauseCommand extends Command
     public function handle(QueueManager $manager)
     {
         if (! Worker::$pausable) {
-            throw new RuntimeException('Worker::$pausable must be set to true to use this command.');
+            $this->components->error('Worker::$pausable must be set to true to use this command.');
+
+            return 1;
         }
 
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -5,6 +5,8 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
+use Illuminate\Queue\Worker;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:pause')]
@@ -33,6 +35,10 @@ class PauseCommand extends Command
      */
     public function handle(QueueManager $manager)
     {
+        if (! Worker::$pausable) {
+            throw new RuntimeException('Worker::$pausable must be set to true to use this command.');
+        }
+
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
         $manager->pause($connection, $queue);

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -4,7 +4,9 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Worker;
 use Illuminate\Support\InteractsWithTime;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:restart')]
@@ -52,6 +54,10 @@ class RestartCommand extends Command
      */
     public function handle()
     {
+        if (! Worker::$restartable) {
+            throw new RuntimeException('Worker::$restartable must be set to true to use this command.');
+        }
+
         $this->cache->forever('illuminate:queue:restart', $this->currentTime());
 
         $this->components->info('Broadcasting queue restart signal.');

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Worker;
 use Illuminate\Support\InteractsWithTime;
-use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:restart')]
@@ -55,7 +54,9 @@ class RestartCommand extends Command
     public function handle()
     {
         if (! Worker::$restartable) {
-            throw new RuntimeException('Worker::$restartable must be set to true to use this command.');
+            $this->components->error('Worker::$restartable must be set to true to use this command.');
+
+            return;
         }
 
         $this->cache->forever('illuminate:queue:restart', $this->currentTime());

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -49,18 +49,20 @@ class RestartCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int
      */
     public function handle()
     {
         if (! Worker::$restartable) {
             $this->components->error('Worker::$restartable must be set to true to use this command.');
 
-            return;
+            return self::FAILURE;
         }
 
         $this->cache->forever('illuminate:queue:restart', $this->currentTime());
 
         $this->components->info('Broadcasting queue restart signal.');
+
+        return self::SUCCESS;
     }
 }

--- a/src/Illuminate/Queue/Console/ResumeCommand.php
+++ b/src/Illuminate/Queue/Console/ResumeCommand.php
@@ -5,6 +5,8 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
+use Illuminate\Queue\Worker;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:resume', aliases: ['queue:continue'])]
@@ -40,6 +42,10 @@ class ResumeCommand extends Command
      */
     public function handle(QueueManager $manager)
     {
+        if (! Worker::$pausable) {
+            throw new RuntimeException('Worker::$pausable must be set to true to use this command.');
+        }
+
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
         $manager->resume($connection, $queue);

--- a/src/Illuminate/Queue/Console/ResumeCommand.php
+++ b/src/Illuminate/Queue/Console/ResumeCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
 use Illuminate\Queue\Worker;
-use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:resume', aliases: ['queue:continue'])]
@@ -43,7 +42,9 @@ class ResumeCommand extends Command
     public function handle(QueueManager $manager)
     {
         if (! Worker::$pausable) {
-            throw new RuntimeException('Worker::$pausable must be set to true to use this command.');
+            $this->components->error('Worker::$pausable must be set to true to use this command.');
+
+            return 1;
         }
 
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));


### PR DESCRIPTION
Off the back of https://github.com/laravel/framework/pull/57975 - I thought it would be useful to add these error messages (which came to mind by the Exception suggestion by @cosmastech 🙏🏻 )


I've used messages as feels more command like than an exception.

This just means the commands can't run - cache keys aren't set etc if we know they're not going to be used as we've explicitly turned them off in the Worker

I've also added a return type to the restart command, so it's clear and follows elsewhere (such as the cache clear command)


Any suggestions let me know! 


Cheers.