### PR TITLE
Fix addDay/subDay calls in ManagesFrequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -63,9 +63,9 @@ trait ManagesFrequencies
 
         if ($endTime->lessThan($startTime)) {
             if ($startTime->greaterThan($now)) {
-                $startTime = $startTime->subDay(1);
+                $startTime = $startTime->subDay();
             } else {
-                $endTime = $endTime->addDay(1);
+                $endTime = $endTime->addDay();
             }
         }
 


### PR DESCRIPTION
This PR removes the unnecessary parameter previously passed to addDay() and subDay() within the ManagesFrequencies::inTimeInterval() method.

In Carbon, the addDay() and subDay() methods do not accept any parameters—they always shift the date by exactly one day. When a variable increment or decrement is required, the correct methods to use are addDays($n) and subDays($n).

The existing implementation behaved correctly only because Carbon silently ignores extra arguments, but relying on this behavior is technically incorrect and may lead to confusion or unexpected issues in the future.
This PR aligns the code with Carbon’s documented API and ensures clearer, more maintainable date-manipulation logic.

**Impact**
**- No breaking changes: behavior remains identical, as only incorrect arguments were removed.**
**- Improved code correctness: eliminates reliance on undefined method signatures.**
**- Increased maintainability: future contributors can rely on consistent and documented API usage.**