### PR TITLE
[12.x] Add dark mode support for email templates and extract media queries

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/header.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/header.blade.php
@@ -3,7 +3,7 @@
 <td class="header">
 <a href="{{ $url }}" style="display: inline-block;">
 @if (trim($slot) === 'Laravel')
-<img src="https://laravel.com/img/notification-logo-v2.1.png" class="logo" alt="Laravel Logo">
+<img src="https://laravel.com/img/notification-logo-v2.1.png" class="logo laravel-logo" alt="Laravel Logo">
 @else
 {!! $slot !!}
 @endif

--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -4,8 +4,8 @@
 <title>{{ config('app.name') }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="color-scheme" content="light">
-<meta name="supported-color-schemes" content="light">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
 <style>
 @media only screen and (max-width: 600px) {
 .inner-body {
@@ -22,6 +22,8 @@ width: 100% !important;
 width: 100% !important;
 }
 }
+
+{!! \Illuminate\Mail\Markdown::getHeadStyles() !!}
 </style>
 {!! $head ?? '' !!}
 </head>

--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -295,3 +295,94 @@ img {
 .break-all {
     word-break: break-all;
 }
+
+/* Dark Mode */
+
+@media (prefers-color-scheme: dark) {
+    body,
+    .wrapper,
+    .body {
+        background-color: #18181b !important;
+    }
+
+    .inner-body {
+        background-color: #27272a !important;
+        border-color: #3f3f46 !important;
+    }
+
+    p,
+    ul,
+    ol,
+    blockquote,
+    span,
+    td {
+        color: #e4e4e7 !important;
+    }
+
+    a {
+        color: #a5b4fc !important;
+    }
+
+    h1,
+    h2,
+    h3,
+    .header a {
+        color: #fafafa !important;
+    }
+
+    .logo {
+        filter: invert(23%) sepia(5%) saturate(531%) hue-rotate(202deg) brightness(96%) contrast(91%) !important;
+    }
+
+    .button-primary,
+    .button-blue {
+        background-color: #fafafa !important;
+        border-color: #fafafa !important;
+        color: #18181b !important;
+    }
+
+    .button-secondary {
+        background-color: #3f3f46 !important;
+        border-color: #3f3f46 !important;
+        color: #fafafa !important;
+    }
+
+    .button-success,
+    .button-green {
+        background-color: #22c55e !important;
+        border-color: #22c55e !important;
+        color: #fff !important;
+    }
+
+    .button-error,
+    .button-red {
+        background-color: #ef4444 !important;
+        border-color: #ef4444 !important;
+        color: #fff !important;
+    }
+
+    .footer p,
+    .footer a {
+        color: #71717a !important;
+    }
+
+    .panel {
+        border-left-color: #d4d4d8 !important;
+    }
+
+    .panel-content {
+        background-color: #3f3f46 !important;
+    }
+
+    .panel-content p {
+        color: #e4e4e7 !important;
+    }
+
+    .subcopy {
+        border-top-color: #3f3f46 !important;
+    }
+
+    .table th {
+        border-bottom-color: #3f3f46 !important;
+    }
+}

--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -330,7 +330,7 @@ img {
         color: #fafafa !important;
     }
 
-    .logo {
+    .laravel-logo {
         filter: invert(23%) sepia(5%) saturate(531%) hue-rotate(202deg) brightness(96%) contrast(91%) !important;
     }
 


### PR DESCRIPTION
Better alternative to #57989 

<img width="833" height="550" alt="image" src="https://github.com/user-attachments/assets/81ff9b8a-5c47-4fda-8bdb-9c8a8cf76aa2" />
