### PR TITLE
[12.x] Fix Cache spy not working with memoized cache

### DIFF
--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -83,10 +83,10 @@ class Cache extends Facade
     {
         if (! static::isMock()) {
             $class = static::getMockableClass();
-            $realInstance = static::getFacadeRoot();
+            $instance = static::getFacadeRoot();
 
-            if ($realInstance && $class) {
-                return tap(Mockery::spy($realInstance)->makePartial(), function ($spy) {
+            if ($class && $instance) {
+                return tap(Mockery::spy($instance)->makePartial(), function ($spy) {
                     static::swap($spy);
                 });
             }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Mockery;
+
 /**
  * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
@@ -70,5 +72,28 @@ class Cache extends Facade
     protected static function getFacadeAccessor()
     {
         return 'cache';
+    }
+
+    /**
+     * Convert the facade into a Mockery spy.
+     *
+     * @return \Mockery\MockInterface
+     */
+    public static function spy()
+    {
+        if (! static::isMock()) {
+            $class = static::getMockableClass();
+            $realInstance = static::getFacadeRoot();
+
+            if ($realInstance && $class) {
+                return tap(Mockery::spy($realInstance)->makePartial(), function ($spy) {
+                    static::swap($spy);
+                });
+            }
+
+            return tap($class ? Mockery::spy($class) : Mockery::spy(), function ($spy) {
+                static::swap($spy);
+            });
+        }
     }
 }

--- a/tests/Cache/CacheSpyMemoTest.php
+++ b/tests/Cache/CacheSpyMemoTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Closure;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Facade;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\LegacyMockInterface;
+use PHPUnit\Framework\TestCase;
+
+class CacheSpyMemoTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new Container;
+
+        $container->instance('config', new ConfigRepository([
+            'cache' => [
+                'default' => 'array',
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ]));
+
+        $container->instance('cache', new CacheManager($container));
+
+        Facade::setFacadeApplication($container);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
+    }
+
+    public function test_cache_spy_works_with_memoized_cache()
+    {
+        $cache = Cache::spy();
+
+        Cache::memo()->remember('key', 60, fn() => 'bar');
+
+        $cache->shouldHaveReceived('memo')->once();
+    }
+
+    public function test_cache_spy_tracks_remember_on_memoized_cache_as_described_in_issue()
+    {
+        $cache = Cache::spy();
+
+        $memoizedCache = Cache::memo();
+        $value = $memoizedCache->remember('key', 60, fn() => 'bar');
+        
+        $this->assertSame('bar', $value);
+        
+        $memoizedCache->shouldHaveReceived('remember')->once()->with('key', 60, Mockery::type(Closure::class));
+    }
+
+    public function test_cache_spy_tracks_remember_calls_on_memoized_cache()
+    {
+        $cache = Cache::spy();
+
+        $memoizedCache = Cache::memo();
+        $memoizedCache->remember('key', 60, fn() => 'bar');
+
+        $memoizedCache->shouldHaveReceived('remember')->once()->with('key', 60, Mockery::type(Closure::class));
+    }
+
+    public function test_cache_spy_memo_returns_spied_repository()
+    {
+        $cache = Cache::spy();
+
+        $memoizedCache = Cache::memo();
+
+        $this->assertInstanceOf(LegacyMockInterface::class, $memoizedCache);
+
+        $memoizedCache->remember('key', 60, fn() => 'bar');
+
+        $memoizedCache->shouldHaveReceived('remember')->once();
+    }
+}
+


### PR DESCRIPTION
Fixes issue #57853 where using `Cache::spy()` with `Cache::memo()->remember()` would fail with "Call to a member function remember() on null".

When you call `Cache::spy()` and then try to use `Cache::memo()->remember()`, the spy wasn't forwarding calls to the real CacheManager, so `memo()` was returning null. This meant you couldn't test code that uses memoized cache with spies.