### PR TITLE
[12.x] Add `milliseconds`, `weeks`, and `months` duration helpers to `Illuminate\Support`

### DIFF
--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -66,6 +66,16 @@ if (! function_exists('Illuminate\Support\now')) {
     }
 }
 
+if (! function_exists('Illuminate\Support\milliseconds')) {
+    /**
+     * Get the current date / time plus the given number of milliseconds.
+     */
+    function milliseconds(int|float $milliseconds): CarbonInterval
+    {
+        return CarbonInterval::milliseconds($milliseconds);
+    }
+}
+
 if (! function_exists('Illuminate\Support\seconds')) {
     /**
      * Get the current date / time plus the given number of seconds.
@@ -103,6 +113,26 @@ if (! function_exists('Illuminate\Support\days')) {
     function days(int $days): CarbonInterval
     {
         return CarbonInterval::days($days);
+    }
+}
+
+if (! function_exists('Illuminate\Support\weeks')) {
+    /**
+     * Get the current date / time plus the given number of weeks.
+     */
+    function weeks(int $weeks): CarbonInterval
+    {
+        return CarbonInterval::weeks($weeks);
+    }
+}
+
+if (! function_exists('Illuminate\Support\months')) {
+    /**
+     * Get the current date / time plus the given number of months.
+     */
+    function months(int $months): CarbonInterval
+    {
+        return CarbonInterval::months($months);
     }
 }
 

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -66,6 +66,16 @@ if (! function_exists('Illuminate\Support\now')) {
     }
 }
 
+if (! function_exists('Illuminate\Support\microseconds')) {
+    /**
+     * Get the current date / time plus the given number of microseconds.
+     */
+    function microseconds(int $microseconds): CarbonInterval
+    {
+        return CarbonInterval::microseconds($microseconds);
+    }
+}
+
 if (! function_exists('Illuminate\Support\milliseconds')) {
     /**
      * Get the current date / time plus the given number of milliseconds.

--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -70,7 +70,7 @@ if (! function_exists('Illuminate\Support\milliseconds')) {
     /**
      * Get the current date / time plus the given number of milliseconds.
      */
-    function milliseconds(int|float $milliseconds): CarbonInterval
+    function milliseconds(int $milliseconds): CarbonInterval
     {
         return CarbonInterval::milliseconds($milliseconds);
     }


### PR DESCRIPTION
This PR adds three missing duration helpers to `Illuminate\Support`:  
`milliseconds()`, `weeks()`, and `months()`.  
They return `CarbonInterval` instances, matching the existing `seconds`, `minutes`, `hours`, `days`, and `years` helpers.

### Why?
These units are commonly used when working with cache TTLs, scheduled tasks, HTTP client timeouts, retry delays, and time-based tests.  
While developers can call `CarbonInterval::milliseconds()` directly, Laravel already standardizes duration helpers as a more readable and consistent API.

### Benefits
- More expressive and complete set of duration helpers  
- Cleaner code for common time calculations  
- No breaking changes (helpers are added behind `function_exists`)

Edit:
Also added `microseconds`. I think this is needed less often, but since `milliseconds` only supports an `int` value, it will be useful for the project that this PR was created for, since we currently pass a float to `CarbonInterval::milliseconds()`, which is supported and has the desired effect, despite the docblock only notating `int` as value in CarbonInterval.
I would also be open to letting `milliseconds()` accept a `int|float`, which will probably remove the need for `microseconds()` for most people