### PR TITLE
[13.x] Add method to detect if app is running in CI environment

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -100,6 +100,13 @@ interface Application extends Container
     public function runningUnitTests();
 
     /**
+     * Determine if the application is running in a continuous integration environment.
+     *
+     * @return bool
+     */
+    public function runningInContinuousIntegration();
+
+    /**
      * Determine if the application is running with debug mode enabled.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -188,6 +188,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $isRunningInConsole;
 
     /**
+     * Indicates if the application is running in a continuous integration environment.
+     *
+     * @var bool|null
+     */
+    protected $isRunningInContinuousIntegration;
+
+    /**
      * The application namespace.
      *
      * @var string
@@ -832,6 +839,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function runningUnitTests()
     {
         return $this->bound('env') && $this['env'] === 'testing';
+    }
+
+    /**
+     * Determine if the application is running in a continuous integration environment.
+     *
+     * @return bool
+     */
+    public function runningInContinuousIntegration()
+    {
+        return $this->isRunningInContinuousIntegration ??= Env::get('CI') === true;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This adds a `runningInContinuousIntegration()` method. It's useful for skipping flaky tests that require investigation, or configuring CI specific setup before tests.

It checks the `CI` environment variable is `true`, as it seems standard across various services:

- GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
- GitLab: https://docs.gitlab.com/ci/variables/predefined_variables/#variable-availability
- BitBucket: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
- Travis: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
- Circle: https://circleci.com/docs/reference/variables/