### PR TITLE
[12.x] Add first-party support for sending emails with Mailtrap

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -65,6 +65,10 @@ return [
             'transport' => 'resend',
         ],
 
+        'mailtrap' => [
+            'transport' => 'mailtrap',
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,10 @@ return [
         ],
     ],
 
+    'mailtrap' => [
+        'key' => env('MAILTRAP_API_KEY'),
+        'is_sandbox' => env('MAILTRAP_SANDBOX_ENABLED', false),
+        'inbox_id' => env('MAILTRAP_INBOX_ID'),
+    ],
+
 ];

--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -15,3 +15,5 @@ parameters:
         - "#has invalid type#"
         - "#Instantiated class [a-zA-Z0-9\\\\_]+ not found.#"
         - "#Unsafe usage of new static#"
+        - '#^Call to static method initSendingEmails\(\) on an unknown class Mailtrap\\MailtrapClient\.$#'
+        - '#^Property Illuminate\\Mail\\Transport\\MailtrapTransport\:\:\$mailtrap has unknown class Mailtrap\\Api\\EmailsSendApiInterface as its type\.$#'

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -333,10 +333,10 @@ class MailManager implements FactoryContract
     {
         return new MailtrapTransport(
             MailtrapClient::initSendingEmails(
-                $config['key'],
-                $config['is_bulk'],
-                $config['is_sandbox'],
-                $config['inbox_id'],
+                $config['key'] ?? $this->app['config']->get('services.mailtrap.key'),
+                (bool) ($config['is_bulk'] ?? $this->app['config']->get('services.mailtrap.is_bulk')),
+                (bool) ($config['is_sandbox'] ?? $this->app['config']->get('services.mailtrap.is_sandbox')),
+                $config['inbox_id'] ?? $this->app['config']->get('services.mailtrap.inbox_id'),
             ),
         );
     }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -335,6 +335,7 @@ class MailManager implements FactoryContract
             MailtrapClient::initSendingEmails(
                 $config['key'],
                 $config['is_bulk'],
+                $config['is_sandbox'],
                 $config['inbox_id'],
             ),
         );

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Mail\Factory as FactoryContract;
 use Illuminate\Log\LogManager;
 use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Mail\Transport\LogTransport;
+use Illuminate\Mail\Transport\MailtrapTransport;
 use Illuminate\Mail\Transport\ResendTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\SesV2Transport;
@@ -16,6 +17,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Mailtrap\MailtrapClient;
 use Psr\Log\LoggerInterface;
 use Resend;
 use Symfony\Component\HttpClient\HttpClient;
@@ -318,6 +320,23 @@ class MailManager implements FactoryContract
     {
         return new ResendTransport(
             Resend::client($config['key'] ?? $this->app['config']->get('services.resend.key')),
+        );
+    }
+
+    /**
+     * Create an instance of the Mailtrap Transport driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Mail\Transport\MailtrapTransport
+     */
+    protected function createMailtrapTransport(array $config)
+    {
+        return new MailtrapTransport(
+            MailtrapClient::initSendingEmails(
+                $config['key'],
+                $config['is_bulk'],
+                $config['inbox_id'],
+            ),
         );
     }
 

--- a/src/Illuminate/Mail/Transport/MailtrapTransport.php
+++ b/src/Illuminate/Mail/Transport/MailtrapTransport.php
@@ -28,13 +28,7 @@ class MailtrapTransport extends AbstractTransport
         $email = MessageConverter::toEmail($message->getOriginalMessage());
 
         try {
-            $result = $this->mailtrap->send($email);
-
-            throw_if(
-                $result->getStatusCode() !== Response::HTTP_OK,
-                Exception::class,
-                $result['message'],
-            );
+            $this->mailtrap->send($email);
         } catch (Exception $exception) {
             throw new TransportException(
                 sprintf('Request to Mailtrap API failed. Reason: %s.', $exception->getMessage()),

--- a/src/Illuminate/Mail/Transport/MailtrapTransport.php
+++ b/src/Illuminate/Mail/Transport/MailtrapTransport.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Mail\Transport;
+
+use Exception;
+use Mailtrap\Api\EmailsSendApiInterface;
+use Mailtrap\Mime\MailtrapEmail;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\MessageConverter;
+
+class MailtrapTransport extends AbstractTransport
+{
+    /**
+     * Create a new Mailtrap transport instance.
+     */
+    public function __construct(protected EmailsSendApiInterface $mailtrap)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doSend(SentMessage $message): void
+    {
+        $email = MessageConverter::toEmail($message->getOriginalMessage());
+
+        $envelope = $message->getEnvelope();
+
+        $headers = [];
+
+        $headersToBypass = ['from', 'to', 'cc', 'bcc', 'reply-to', 'sender', 'subject', 'content-type'];
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if (in_array($name, $headersToBypass, true)) {
+                continue;
+            }
+
+            $headers[$header->getName()] = $header->getBodyAsString();
+        }
+
+        $attachments = [];
+
+        if ($email->getAttachments()) {
+            foreach ($email->getAttachments() as $attachment) {
+                $attachmentHeaders = $attachment->getPreparedHeaders();
+                $contentType = $attachmentHeaders->get('Content-Type')->getBody();
+                $disposition = $attachmentHeaders->getHeaderBody('Content-Disposition');
+                $filename = $attachmentHeaders->getHeaderParameter('Content-Disposition', 'filename');
+
+                if ($contentType == 'text/calendar') {
+                    $content = $attachment->getBody();
+                } else {
+                    $content = str_replace("\r\n", '', $attachment->bodyToString());
+                }
+
+                $item = [
+                    'content_type' => $contentType,
+                    'content' => $content,
+                    'filename' => $filename,
+                ];
+
+                if ($disposition === 'inline') {
+                    $item['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
+                }
+
+                $attachments[] = $item;
+            }
+        }
+
+        try {
+            // TODO Add headers.
+            // TODO Add attachments.
+            $email = (new MailtrapEmail)
+                ->from($envelope->getSender())
+                ->to(...$this->getRecipients($email, $envelope))
+                ->cc(...$email->getCc())
+                ->bcc(...$email->getBcc())
+                ->replyTo(...$email->getReplyTo())
+                ->subject($email->getSubject())
+                ->html($email->getHtmlBody())
+                ->text($email->getTextBody());
+
+            $this->mailtrap->send($email);
+
+            // TODO Update this exception to be correct
+            throw_if(
+                isset($result['statusCode']) && $result['statusCode'] != Response::HTTP_OK,
+                Exception::class,
+                $result['message'],
+            );
+        } catch (Exception $exception) {
+            throw new TransportException(
+                sprintf('Request to Mailtrap API failed. Reason: %s.', $exception->getMessage()),
+                is_int($exception->getCode()) ? $exception->getCode() : 0,
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Get the recipients without CC or BCC.
+     */
+    protected function getRecipients(Email $email, Envelope $envelope): array
+    {
+        return array_filter($envelope->getRecipients(), function (Address $address) use ($email): bool {
+            return in_array($address, array_merge($email->getCc(), $email->getBcc()), true) === false;
+        });
+    }
+
+    /**
+     * Get the string representation of the transport.
+     */
+    public function __toString(): string
+    {
+        return 'mailtrap';
+    }
+}

--- a/src/Illuminate/Mail/Transport/MailtrapTransport.php
+++ b/src/Illuminate/Mail/Transport/MailtrapTransport.php
@@ -4,7 +4,6 @@ namespace Illuminate\Mail\Transport;
 
 use Exception;
 use Mailtrap\Api\EmailsSendApiInterface;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;

--- a/src/Illuminate/Mail/Transport/MailtrapTransport.php
+++ b/src/Illuminate/Mail/Transport/MailtrapTransport.php
@@ -52,6 +52,16 @@ class MailtrapTransport extends AbstractTransport
         }
     }
 
+    /**
+     * Determine the attachments for the email.
+     *
+     * @return list<array{
+     *     content_type: string,
+     *     content: string,
+     *     filename: string|null,
+     *     content_id?: string
+     * }>
+     */
     protected function determineAttachments(Email $email): array
     {
         $attachments = [];
@@ -75,6 +85,7 @@ class MailtrapTransport extends AbstractTransport
                     'filename' => $filename,
                 ];
 
+                // TODO Is this needed?
                 if ($disposition === 'inline') {
                     $item['content_id'] = $attachment->hasContentId() ? $attachment->getContentId() : $filename;
                 }
@@ -86,6 +97,11 @@ class MailtrapTransport extends AbstractTransport
         return $attachments;
     }
 
+    /**
+     * Determine the headers for the email.
+     *
+     * @return array<string, string>
+     */
     protected function determineHeaders(Email $email): array
     {
         $headers = [];
@@ -103,6 +119,9 @@ class MailtrapTransport extends AbstractTransport
         return $headers;
     }
 
+    /**
+     * Build the Mailtrap email instance which will be sent.
+     */
     protected function prepareMailtrapEmail(Email $email, Envelope $envelope): MailtrapEmail
     {
         $mailtrapEmail = (new MailtrapEmail)


### PR DESCRIPTION
Hey! This PR proposes a new integration which allows developers to send transactional emails using Mailtrap's PHP library.

The idea behind this feature is that a developer can set these values in their `.env` file:

```dotenv
MAIL_MAILER=mailtrap
MAILTRAP_API_KEY=abc123
```

Then the dev will be able to use Mailtrap for sending their emails.

According to their site, Mailtrap has over 150k monthly active users. So I'd like to think there are plenty of Laravel developers in there (or budding Laravel developers) who might be able to make use of this integration 😄

## Installation

To use this integration, the official Mailtrap library is required (in a similar way that an extra library is required to use `mailgun` as the mailing driver). So it will need to be installed using Composer via the following command:

```text
composer require railsware/mailtrap-php
```

You'll then just need to add your API key and switch the mail driver in the `.env` file like shown above.

The integration _should_ now be set up and ready for sending transactional emails.

There are also some new config values (in `config/services.php` and `config/mail.php`) which can be set.

## Sandbox email testing

One of the really cool things I like about Mailtrap (and have been using for a few years myself) is the sandbox feature which captures emails you send from your app so you can preview them, rather than sending them to the intended recipient.

Usually, I'd need to configure my `.env` file with the correct SMTP credentials for sandbox testing. But for with these changes, I'd just need to set the `MAILTRAP_SANDBOX_ENABLED` to `true` and the `MAILTRAP_INBOX_ID` to the ID of my sandbox inbox ID like so:

```dotenv
MAIL_MAILER=mailtrap

MAILTRAP_API_KEY=abc123
MAILTRAP_SANDBOX_ENABLED=true
MAILTRAP_INBOX_ID=123456
```

So I think it's pretty cool that we can toggle the sandbox testing with just a single boolean in the environment 😄

## Further PRs

If this PR is merged, I'd love to make some more PRs to the application skeleton repo to add the config fields (`config/mail.php` and `config/services.php`).

I'm also more than happy to make any necessary PRs to the docs.

## Testing

I wasn't sure how to write automated tests for this, sorry. But I've manually tested different scenarios to check that the emails can be sent.

You may already have a Mailtrap account yourself. But just in case you don't, I'll email you (Taylor) some API credentials that I've set up on my Mailtrap account so you can test sending emails. I thought this would be useful so you don't have to start configuring DNS records and waiting for domain approval, etc.

Hopefully, this is something which you think is useful. Please give me a shout if you'd like anything changed at all 😄