### PR TITLE
[12.x] Adds `findOnce` and `findOrFailOnce` methods for Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -569,6 +569,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Find a model once by its primary key.
+     *
+     * @param  mixed  $id
+     * @param  array|string  $columns
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TModel> : TModel|null)
+     */
+    public function findOnce($id, $columns = ['*'])
+    {
+        return once(fn () => $this->find($id, $columns));
+    }
+
+    /**
      * Find a sole model by its primary key.
      *
      * @param  mixed  $id
@@ -633,6 +645,20 @@ class Builder implements BuilderContract
         }
 
         return $result;
+    }
+
+    /**
+     * Find a model by its primary key once or throw an exception.
+     *
+     * @param  mixed  $id
+     * @param  array|string  $columns
+     * @return ($id is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? \Illuminate\Database\Eloquent\Collection<int, TModel> : TModel)
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<TModel>
+     */
+    public function findOrFailOnce($id, $columns = ['*'])
+    {
+        return once(fn () => $this->findOrFail($id, $columns));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -49,6 +49,20 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('baz', $result);
     }
 
+    public function testFindOnceMethod()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
+
+        $result = $builder->findOnce('bar', ['column']);
+        $this->assertSame('baz', $result);
+        $this->assertSame('baz', $builder->findOnce('bar', ['column']));
+    }
+
     public function testFindSoleMethod()
     {
         $builder = m::mock(Builder::class.'[sole]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
Hi team,

It is quite a normal use case that we use `find` or `findOrFail` multiple times within the same request - which results in multiple queries to the database.

The usual workaround is to cache the result via static properties or a Context, but that adds another unnecessary layer in userland.

So this PR introduces the `findOnce` and `findOrFailOnce` methods. Both are nice-to-have and provide a small performance improvement per request.

Personal taste: I did add these methods using `macro`, but I don't really like `macro`. Extending Builder is fine, but then I’d have to create a new `BaseModel` to use that extended `Builder` class, etc.

(If this gets accepted, I’ll open a PR to update the docs.)