### PR TITLE
Add optional $otherwise callback to whenTableHas and whenIndexHas methods

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -293,7 +293,8 @@ class Builder
     }
 
     /**
-     * Execute a table builder callback if the given table has a given column.
+     * Execute a table builder callback if the given table has a given column
+     * Optionally execute a separate callback if the column does not exist
      *
      * @param  string  $table
      * @param  string  $column
@@ -312,6 +313,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table doesn't have a given column.
+     * Optionally execute a separate callback if the column exists
      *
      * @param  string  $table
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -332,7 +332,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table has a given index.
-     * Optionally execute a separate callback if the column does not exist.
+     * Optionally execute a separate callback if the index does not exist.
      *
      * @param  string  $table
      * @param  string|array  $index
@@ -352,7 +352,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table doesn't have a given index.
-     * Optionally execute a separate callback if the column exists.
+     * Optionally execute a separate callback if the index exists.
      *
      * @param  string  $table
      * @param  string|array  $index

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -294,7 +294,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table has a given column
-     * Optionally execute a separate callback if the column does not exist
+     * Optionally execute a separate callback if the column does not exist.
      *
      * @param  string  $table
      * @param  string  $column
@@ -313,7 +313,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table doesn't have a given column.
-     * Optionally execute a separate callback if the column exists
+     * Optionally execute a separate callback if the column exists.
      *
      * @param  string  $table
      * @param  string  $column
@@ -332,7 +332,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table has a given index.
-     * Optionally execute a separate callback if the column does not exist
+     * Optionally execute a separate callback if the column does not exist.
      *
      * @param  string  $table
      * @param  string|array  $index
@@ -352,7 +352,7 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table doesn't have a given index.
-     * Optionally execute a separate callback if the column exists
+     * Optionally execute a separate callback if the column exists.
      *
      * @param  string  $table
      * @param  string|array  $index

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -332,33 +332,41 @@ class Builder
 
     /**
      * Execute a table builder callback if the given table has a given index.
+     * Optionally execute a separate callback if the column does not exist
      *
      * @param  string  $table
      * @param  string|array  $index
      * @param  \Closure  $callback
      * @param  string|null  $type
+     * @param  \Closure|null  $otherwise
      * @return void
      */
-    public function whenTableHasIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
+    public function whenTableHasIndex(string $table, string|array $index, Closure $callback, ?string $type = null, ?Closure $otherwise = null)
     {
         if ($this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
+        } elseif ($otherwise) {
+            $this->table($table, fn (Blueprint $table) => $otherwise($table));
         }
     }
 
     /**
      * Execute a table builder callback if the given table doesn't have a given index.
+     * Optionally execute a separate callback if the column exists
      *
      * @param  string  $table
      * @param  string|array  $index
      * @param  \Closure  $callback
      * @param  string|null  $type
+     * @param  \Closure|null  $otherwise
      * @return void
      */
-    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
+    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, ?string $type = null, ?Closure $otherwise = null)
     {
         if (! $this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
+        } elseif ($otherwise) {
+            $this->table($table, fn (Blueprint $table) => $otherwise($table));
         }
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -298,12 +298,15 @@ class Builder
      * @param  string  $table
      * @param  string  $column
      * @param  \Closure  $callback
+     * @param  \Closure|null  $fail
      * @return void
      */
-    public function whenTableHasColumn(string $table, string $column, Closure $callback)
+    public function whenTableHasColumn(string $table, string $column, Closure $callback, ?Closure $fail = null)
     {
         if ($this->hasColumn($table, $column)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
+        } elseif ($fail) {
+            $this->table($table, fn (Blueprint $table) => $fail($table));
         }
     }
 
@@ -313,12 +316,15 @@ class Builder
      * @param  string  $table
      * @param  string  $column
      * @param  \Closure  $callback
+     * @param  \Closure|null  $fail
      * @return void
      */
-    public function whenTableDoesntHaveColumn(string $table, string $column, Closure $callback)
+    public function whenTableDoesntHaveColumn(string $table, string $column, Closure $callback, ?Closure $fail = null)
     {
         if (! $this->hasColumn($table, $column)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
+        } elseif ($fail) {
+            $this->table($table, fn (Blueprint $table) => $fail($table));
         }
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -298,15 +298,15 @@ class Builder
      * @param  string  $table
      * @param  string  $column
      * @param  \Closure  $callback
-     * @param  \Closure|null  $fail
+     * @param  \Closure|null  $otherwise
      * @return void
      */
-    public function whenTableHasColumn(string $table, string $column, Closure $callback, ?Closure $fail = null)
+    public function whenTableHasColumn(string $table, string $column, Closure $callback, ?Closure $otherwise = null)
     {
         if ($this->hasColumn($table, $column)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
-        } elseif ($fail) {
-            $this->table($table, fn (Blueprint $table) => $fail($table));
+        } elseif ($otherwise) {
+            $this->table($table, fn (Blueprint $table) => $otherwise($table));
         }
     }
 
@@ -316,15 +316,15 @@ class Builder
      * @param  string  $table
      * @param  string  $column
      * @param  \Closure  $callback
-     * @param  \Closure|null  $fail
+     * @param  \Closure|null  $otherwise
      * @return void
      */
-    public function whenTableDoesntHaveColumn(string $table, string $column, Closure $callback, ?Closure $fail = null)
+    public function whenTableDoesntHaveColumn(string $table, string $column, Closure $callback, ?Closure $otherwise = null)
     {
         if (! $this->hasColumn($table, $column)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
-        } elseif ($fail) {
-            $this->table($table, fn (Blueprint $table) => $fail($table));
+        } elseif ($otherwise) {
+            $this->table($table, fn (Blueprint $table) => $otherwise($table));
         }
     }
 


### PR DESCRIPTION
Previously, these methods only executed a callback when a column existed or did not exist. Since they return void, it wasn’t possible to wrap them in an if or do any logic on em.

This  PR adds an optional $otherwise callback so you can handle the opposite case directly. For example:

```php
$this->whenTableHasColumn(
    'users',
    'nickname',
    fn ($table) => $table->dropColumn('nickname'),
    fn ($table) => $table->string('nickname')->nullable()
);
```
Without this, the same logic requires calling Schema multiple times:

```php

if (Schema::hasColumn('users', 'nickname')) {
    Schema::table('users', function (Blueprint $table) {
        $table->dropColumn('nickname');
    });
} else {
    Schema::table('users', function (Blueprint $table) {
        $table->string('nickname')->nullable();
    });
}


// or... repeat the when columns, which feels funky

$this->whenTableHasColumn(
    'users',
    'nickname',
    fn ($table) => $table->dropColumn('nickname')
);


$this->whenTableDoesnthaveColumn(
    'users',
    'nickname',
    fn ($table) => $table->string('nickname')->nullable()
);
```

This makes it more expressive, especially when dealing with evolving schemas across environments where columns are different in each.

In my day to day, I often need conditional logic in migrations to ensure they are safe to run repeatedly across multiple envs, so thought I'd give this PR a go.

The "when" naming makes it feel like a natural fit to me, but happy to adjust if you have feedback - thank you!