### PR TITLE
Add whenTableHasIndex and whenTableDoesntHaveIndex to Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -327,17 +327,12 @@ class Builder
      *
      * @param  string  $table
      * @param  string|array  $index
-     * @param  \Closure|string|null  $type
-     * @param  \Closure|null  $callback
+     * @param  \Closure  $callback
+     * @param string|null $type
      * @return void
      */
-    public function whenTableHasIndex(string $table, string|array $index, Closure|string|null $type = null, ?Closure $callback = null)
+    public function whenTableHasIndex(string $table, string|array $index, Closure $callback, string|null $type = null)
     {
-        if ($type instanceof Closure) {
-            $callback = $type;
-            $type = null;
-        }
-
         if ($this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
         }
@@ -348,17 +343,12 @@ class Builder
      *
      * @param  string  $table
      * @param  string|array  $index
-     * @param  \Closure|string|null  $type
-     * @param  \Closure|null  $callback
+     * @param \Closure $callback
+     * @param string|null $type
      * @return void
      */
-    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure|string|null $type = null, ?Closure $callback = null)
+    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, string|null $type = null)
     {
-        if ($type instanceof Closure) {
-            $callback = $type;
-            $type = null;
-        }
-
         if (! $this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
         }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -328,10 +328,10 @@ class Builder
      * @param  string  $table
      * @param  string|array  $index
      * @param  \Closure  $callback
-     * @param string|null $type
+     * @param  string|null  $type
      * @return void
      */
-    public function whenTableHasIndex(string $table, string|array $index, Closure $callback, string|null $type = null)
+    public function whenTableHasIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
     {
         if ($this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));
@@ -343,11 +343,11 @@ class Builder
      *
      * @param  string  $table
      * @param  string|array  $index
-     * @param \Closure $callback
-     * @param string|null $type
+     * @param  \Closure  $callback
+     * @param  string|null  $type
      * @return void
      */
-    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, string|null $type = null)
+    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure $callback, ?string $type = null)
     {
         if (! $this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -323,6 +323,48 @@ class Builder
     }
 
     /**
+     * Execute a table builder callback if the given table has a given index.
+     *
+     * @param  string  $table
+     * @param  string|array  $index
+     * @param  \Closure|string|null  $type
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public function whenTableHasIndex(string $table, string|array $index, Closure|string|null $type = null, ?Closure $callback = null)
+    {
+        if ($type instanceof Closure) {
+            $callback = $type;
+            $type = null;
+        }
+
+        if ($this->hasIndex($table, $index, $type)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
+     * Execute a table builder callback if the given table doesn't have a given index.
+     *
+     * @param  string  $table
+     * @param  string|array  $index
+     * @param  \Closure|string|null  $type
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public function whenTableDoesntHaveIndex(string $table, string|array $index, Closure|string|null $type = null, ?Closure $callback = null)
+    {
+        if ($type instanceof Closure) {
+            $callback = $type;
+            $type = null;
+        }
+
+        if (! $this->hasIndex($table, $index, $type)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
      * Get the data type for the given column name.
      *
      * @param  string  $table


### PR DESCRIPTION
I reached for these but only found the `whenTableHasColumn` ones

This PR adds `whenTableHasIndex` and `whenTableDoesntHaveIndex` to align with `whenTableHasColumn`.

Not sure if you're keen on these, but thought i'd give it a go to help dx

I don't see any tests for `whenTableHasColumn` - so have left these out for now. Let me know if you want some tests? I can have a go later on.

Before you'd have to use the Schema again:
```php
<?php

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Migrations\Migration;

return new class extends Migration
{

    public function up(): void
    {
        if (! Schema::hasIndex('product', 'name')) {
            Schema::table('product', function (Blueprint $table) {
                $table->index('name', 'index_name');
            });
        }
    }
};

```
Now you can just do the below:

```php
<?php

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Migrations\Migration;

return new class extends Migration
{
    public function up(): void
    {
        Schema::whenTableDoesntHaveIndex('product', 'name', function (Blueprint $table) {
            $table->index('name', 'index_name');
        });

        // You can also pass the index type...
        Schema::whenTableDoesntHaveIndex('product', 'name', function (Blueprint $table) {
            $table->index('name', 'index_name');
        },  'unique');
    }
};

```
