### PR TITLE
[12.x] Allow float values in duration helpers for CarbonInterval

### DIFF
--- a/src/Illuminate/Support/functions.php
+++ b/src/Illuminate/Support/functions.php
@@ -70,7 +70,7 @@ if (! function_exists('Illuminate\Support\microseconds')) {
     /**
      * Get the current date / time plus the given number of microseconds.
      */
-    function microseconds(int $microseconds): CarbonInterval
+    function microseconds(int|float $microseconds): CarbonInterval
     {
         return CarbonInterval::microseconds($microseconds);
     }
@@ -80,7 +80,7 @@ if (! function_exists('Illuminate\Support\milliseconds')) {
     /**
      * Get the current date / time plus the given number of milliseconds.
      */
-    function milliseconds(int $milliseconds): CarbonInterval
+    function milliseconds(int|float $milliseconds): CarbonInterval
     {
         return CarbonInterval::milliseconds($milliseconds);
     }
@@ -90,7 +90,7 @@ if (! function_exists('Illuminate\Support\seconds')) {
     /**
      * Get the current date / time plus the given number of seconds.
      */
-    function seconds(int $seconds): CarbonInterval
+    function seconds(int|float $seconds): CarbonInterval
     {
         return CarbonInterval::seconds($seconds);
     }
@@ -100,7 +100,7 @@ if (! function_exists('Illuminate\Support\minutes')) {
     /**
      * Get the current date / time plus the given number of minutes.
      */
-    function minutes(int $minutes): CarbonInterval
+    function minutes(int|float $minutes): CarbonInterval
     {
         return CarbonInterval::minutes($minutes);
     }
@@ -110,7 +110,7 @@ if (! function_exists('Illuminate\Support\hours')) {
     /**
      * Get the current date / time plus the given number of hours.
      */
-    function hours(int $hours): CarbonInterval
+    function hours(int|float $hours): CarbonInterval
     {
         return CarbonInterval::hours($hours);
     }
@@ -120,7 +120,7 @@ if (! function_exists('Illuminate\Support\days')) {
     /**
      * Get the current date / time plus the given number of days.
      */
-    function days(int $days): CarbonInterval
+    function days(int|float $days): CarbonInterval
     {
         return CarbonInterval::days($days);
     }


### PR DESCRIPTION
This PR updates the duration helpers (`microseconds`, `milliseconds`, `seconds`, `minutes`, `hours`, `days`) to accept `int|float` values.  

CarbonInterval natively supports fractional values for all of these units (as reflected in its docblock for the corresponding `add{Unit}` methods), and the conversion is internally handled through microseconds. Updating the helpers aligns Laravel’s type signatures with Carbon’s documented behavior.

### Why?
Developers often work with derived or calculated durations, for example:

```php
milliseconds($expectedSeconds * 1000)
```

Without float support, this requires extra casting:

```php
milliseconds((int) ($expectedSeconds * 1000))
```

Allowing floats removes unnecessary boilerplate and matches the actual capabilities of CarbonInterval.

### Benefits
- Better alignment with CarbonInterval’s documented API
- Cleaner, more natural usage when dealing with computed durations
- No breaking changes: existing code continues to work, and Carbon gracefully handles floats
