### PR TITLE
[12.x] Feat: pausable queue with callable

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -214,7 +214,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Indicate whether the queue workers should monitor for pause signals.
      *
-     * @param  bool|callable(string $connection, string $queue): void  $value
+     * @param  bool|callable(string $connection, string $queue): bool  $value
      * @return void
      */
     public function pausable($value = true)

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -212,6 +212,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Indicate whether the queue workers should monitor for pause signals.
+     *
+     * @param  bool|callable(string $connection, string $queue): void  $value
+     * @return void
+     */
+    public function pausable($value = true)
+    {
+        Worker::$pausable = $value;
+    }
+
+    /**
      * Pause a queue by its connection and name for a given amount of time.
      *
      * @param  string  $connection

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -420,7 +420,7 @@ class Worker
             $isPausable = $isPausable($connectionName, $queue);
         }
 
-        if (! $isPausable) {
+        if ($isPausable === false) {
             return false;
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -116,7 +116,7 @@ class Worker
     /**
      * Indicates if the worker should check for the paused signal in the cache.
      *
-     * @var bool|callable(string $connection, string $queue): bool
+     * @var bool|callable(string, string): bool
      */
     public static $pausable = true;
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -116,7 +116,7 @@ class Worker
     /**
      * Indicates if the worker should check for the paused signal in the cache.
      *
-     * @var bool
+     * @var bool|callable(string $connection, string $queue): bool
      */
     public static $pausable = true;
 
@@ -414,7 +414,13 @@ class Worker
      */
     protected function queuePaused($connectionName, $queue)
     {
-        if (! static::$pausable) {
+        $isPausable = static::$pausable;
+
+        if (is_callable($isPausable)) {
+            $isPausable = $isPausable($connectionName, $queue);
+        }
+
+        if (! $isPausable) {
             return false;
         }
 

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Queue\Worker;
 use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -108,6 +109,39 @@ class QueuePauseResumeTest extends TestCase
 
         $this->assertFalse($this->manager->isPaused('redis', 'emails'));
         $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
+    }
+
+    public function testPausableCanBeSetToTrue()
+    {
+        Worker::$pausable = false;
+        $this->manager->pausable(true);
+
+        $this->assertTrue(Worker::$pausable);
+    }
+
+    public function testPausableCanBeSetToFalse()
+    {
+        Worker::$pausable = true;
+        $this->manager->pausable(false);
+
+        $this->assertFalse(Worker::$pausable);
+    }
+
+    public function testPausableCanBeSetToCallable()
+    {
+        Worker::$pausable = true;
+        $callback = fn ($connection, $queue) => $connection === 'redis' && $queue === 'default';
+        $this->manager->pausable($callback);
+
+        $this->assertSame($callback, Worker::$pausable);
+    }
+
+    public function testPausableDefaultsToTrue()
+    {
+        Worker::$pausable = false;
+        $this->manager->pausable();
+
+        $this->assertTrue(Worker::$pausable);
     }
 
     public function testParsingQueueString()


### PR DESCRIPTION
## PR: Add pausable queue support with callable option

Summary
-------
- Adds configuration and runtime control to let workers optionally check the cache for per-queue pause signals.
- The change is small in code: expose `QueueManager::pausable()` and evaluate `Worker::$pausable` in `Worker::queuePaused()`.

Motivation
----------
Allow dynamic control over whether workers poll the cache for pause signals so you can reduce cache overhead, apply special rules to certain connections/queues, or disable pause-checking in non-production environments.

Usage examples
--------------
Enable globally (default):

```php
Queue::pausable(true);
```

Disable globally:

```php
Queue::pausable(false);
```

Conditional pause-checking per connection/queue:

```php
Queue::pausable(function (string $connection, string $queue) {
    // only check pause status for redis default queue
    return $connection === 'redis' && $queue === 'default';
});
```