### PR TITLE
Replace mb_split with preg_split in Str helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1437,7 +1437,7 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = mb_split('\s+', $value);
+        $parts = preg_split('/\s+/u', $value);
 
         $parts = count($parts) > 1
             ? array_map(static::title(...), $parts)
@@ -1470,7 +1470,7 @@ class Str
 
         $endPunctuation = ['.', '!', '?', ':', '—', ','];
 
-        $words = mb_split('\s+', $value);
+        $words = preg_split('/\s+/u', $value);
         $wordCount = count($words);
 
         for ($i = 0; $i < $wordCount; $i++) {
@@ -1686,7 +1686,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $words = mb_split('\s+', static::replace(['-', '_'], ' ', $value));
+        $words = preg_split('/\s+/u', static::replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(fn ($word) => static::ucfirst($word), $words);
 


### PR DESCRIPTION
## Description
This PR replaces usages of `mb_split` with `preg_split` in the `Illuminate\Support\Str` class.
### Motivation
The `mb_split` function is part of the `mbstring` extension's regex module (`mbregex`). While `mbstring` is a requirement for Laravel, it is possible to compile `mbstring` without `mbregex` support (using `--disable-mbregex`). In such environments, or in certain PHP runtime configurations (e.g., specific MCP server environments), `mb_split` may be undefined even if `mbstring` is loaded.
`preg_split` is part of the PCRE extension, which is a core requirement of PHP and is always available. Using `preg_split` with the `u` (Unicode) modifier achieves the same result as `mb_split` for splitting strings by whitespace, making the framework more robust across different PHP builds.
### Changes
- Replaced `mb_split('\s+', $value)` with `preg_split('/\s+/u', $value)` in:
    - `Str::headline()`
    - `Str::apa()`
    - `Str::studly()`
### Verification
I have verified that `preg_split('/\s+/u', ...)` correctly splits strings containing Unicode characters by whitespace, identical to `mb_split('\s+', ...)`.
```php
// Test script
$value = 'Application Info';
$parts = preg_split('/\s+/u', $value);
// Result: ['Application', 'Info']