### PR TITLE
[12.x] Add commandFileFinder method and exclude test files from command discovery

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -366,7 +366,7 @@ class Kernel implements KernelContract
 
         $namespace = $this->app->getNamespace();
 
-        foreach (Finder::create()->in($paths)->files() as $file) {
+        foreach ($this->commandFileFinder($paths) as $file) {
             $command = $this->commandClassFromFile($file, $namespace);
 
             if (is_subclass_of($command, Command::class) &&
@@ -376,6 +376,17 @@ class Kernel implements KernelContract
                 });
             }
         }
+    }
+
+    /**
+     * Get the Finder instance for discovering command files.
+     *
+     * @param  array  $paths
+     * @return \Symfony\Component\Finder\Finder
+     */
+    protected function commandFileFinder(array $paths)
+    {
+        return Finder::create()->in($paths)->notName('*Test.php')->files();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -366,7 +366,7 @@ class Kernel implements KernelContract
 
         $namespace = $this->app->getNamespace();
 
-        foreach ($this->commandFileFinder($paths) as $file) {
+        foreach ($this->findCommands($paths) as $file) {
             $command = $this->commandClassFromFile($file, $namespace);
 
             if (is_subclass_of($command, Command::class) &&
@@ -384,7 +384,7 @@ class Kernel implements KernelContract
      * @param  array  $paths
      * @return \Symfony\Component\Finder\Finder
      */
-    protected function commandFileFinder(array $paths)
+    protected function findCommands(array $paths)
     {
         return Finder::create()->in($paths)->notName('*Test.php')->files();
     }


### PR DESCRIPTION
This PR introduces a new `commandFileFinder` method to the console Kernel and updates the command discovery logic to exclude test files by default.

### Changes

- Added a new protected `commandFileFinder(array $paths)` method that returns the `Finder` instance used for discovering command files
- Updated the `load` method to use `$this->commandFileFinder($paths)` instead of directly instantiating the Finder
- Test files matching `*Test.php` are now excluded from command auto-discovery by default

### Benefits to End Users

1. **Fixes PHPUnit ignoring co-located test files** - When developers co-locate PHPUnit test files alongside their command classes in the `Commands` folder, the command discovery mechanism autoloads these test files before PHPUnit runs. This causes PHPUnit to skip them entirely since the classes are already loaded. By excluding `*Test.php` files from command discovery, tests are properly executed by PHPUnit.

2. **Extensibility** - Developers can now override `commandFileFinder()` in their application's Kernel to customize which files are discovered (e.g., exclude additional patterns, include specific directories, etc.)