### PR TITLE
[12.x] Improve Blueprint docblocks with concrete value ranges for integer and text columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -725,7 +725,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing big integer (8-byte) column on the table.
+     * Create a new auto-incrementing big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -736,7 +736,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing integer (4-byte) column on the table.
+     * Create a new auto-incrementing integer column on the table (4-byte, 0 to 4,294,967,295).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -747,7 +747,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing integer (4-byte) column on the table.
+     * Create a new auto-incrementing integer column on the table (4-byte, 0 to 4,294,967,295).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -758,7 +758,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing tiny integer (1-byte) column on the table.
+     * Create a new auto-incrementing tiny integer column on the table (1-byte, 0 to 255).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -769,7 +769,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing small integer (2-byte) column on the table.
+     * Create a new auto-incrementing small integer column on the table (2-byte, 0 to 65,535).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -780,7 +780,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing medium integer (3-byte) column on the table.
+     * Create a new auto-incrementing medium integer column on the table (3-byte, 0 to 16,777,215).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -791,7 +791,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing big integer (8-byte) column on the table.
+     * Create a new auto-incrementing big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -830,7 +830,7 @@ class Blueprint
     }
 
     /**
-     * Create a new tiny text column on the table.
+     * Create a new tiny text column on the table (up to 255 characters).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -841,7 +841,7 @@ class Blueprint
     }
 
     /**
-     * Create a new text column on the table.
+     * Create a new text column on the table (up to 65,535 characters / ~64 KB).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -852,7 +852,7 @@ class Blueprint
     }
 
     /**
-     * Create a new medium text column on the table.
+     * Create a new medium text column on the table (up to 16,777,215 characters / ~16 MB).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -863,7 +863,7 @@ class Blueprint
     }
 
     /**
-     * Create a new long text column on the table.
+     * Create a new long text column on the table (up to 4,294,967,295 characters / ~4 GB).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
@@ -875,6 +875,7 @@ class Blueprint
 
     /**
      * Create a new integer (4-byte) column on the table.
+     * Range: -2,147,483,648 to 2,147,483,647 (signed) or 0 to 4,294,967,295 (unsigned).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -888,6 +889,7 @@ class Blueprint
 
     /**
      * Create a new tiny integer (1-byte) column on the table.
+     * Range: -128 to 127 (signed) or 0 to 255 (unsigned).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -901,6 +903,7 @@ class Blueprint
 
     /**
      * Create a new small integer (2-byte) column on the table.
+     * Range: -32,768 to 32,767 (signed) or 0 to 65,535 (unsigned).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -914,6 +917,7 @@ class Blueprint
 
     /**
      * Create a new medium integer (3-byte) column on the table.
+     * Range: -8,388,608 to 8,388,607 (signed) or 0 to 16,777,215 (unsigned).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -927,6 +931,7 @@ class Blueprint
 
     /**
      * Create a new big integer (8-byte) column on the table.
+     * Range: -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807 (signed) or 0 to 18,446,744,073,709,551,615 (unsigned).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -939,7 +944,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned integer (4-byte) column on the table.
+     * Create a new unsigned integer column on the table (4-byte, 0 to 4,294,967,295).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -951,7 +956,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned tiny integer (1-byte) column on the table.
+     * Create a new unsigned tiny integer column on the table (1-byte, 0 to 255).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -963,7 +968,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned small integer (2-byte) column on the table.
+     * Create a new unsigned small integer column on the table (2-byte, 0 to 65,535).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -975,7 +980,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned medium integer (3-byte) column on the table.
+     * Create a new unsigned medium integer column on the table (3-byte, 0 to 16,777,215).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -987,7 +992,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned big integer (8-byte) column on the table.
+     * Create a new unsigned big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
      *
      * @param  string  $column
      * @param  bool  $autoIncrement
@@ -999,7 +1004,7 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned big integer (8-byte) column on the table.
+     * Create a new unsigned big integer column on the table (8-byte, 0 to 18,446,744,073,709,551,615).
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition


### PR DESCRIPTION
## Motivation

Every time I create a migration, I get confused about the value ranges for different integer types. I have to remember or calculate what range a 1-byte, 2-byte, 3-byte, or 4-byte integer can hold. This mental overhead slows down development and can lead to choosing the wrong column type.

## Changes

This PR enhances the docblocks for integer and text column methods in the `Blueprint` class to include:

### Integer Columns
- **Concrete value ranges** for both signed and unsigned integers
- Examples:
  - `tinyInteger()`: -128 to 127 (signed) or 0 to 255 (unsigned)
  - `integer()`: -2,147,483,648 to 2,147,483,647 (signed) or 0 to 4,294,967,295 (unsigned)
  - `bigInteger()`: Full 64-bit ranges displayed

### Text Columns  
- **Maximum character limits** with size context
- Examples:
  - `tinyText()`: up to 255 characters
  - `text()`: up to 65,535 characters (~64 KB)
  - `mediumText()`: up to 16,777,215 characters (~16 MB)
  - `longText()`: up to 4,294,967,295 characters (~4 GB)

## Benefits

- **Faster development**: No need to look up or calculate ranges
- **Better column type selection**: Choose the right type at a glance
- **Reduced errors**: Less likely to pick an insufficient column type
- **Improved DX**: Information available right in IDE autocomplete/hover

## Example

Before:
```php
// Have to remember: "How big is a mediumInteger again?"
$table->mediumInteger('quantity');
```

After:
```php
// IDE shows: "3-byte, Range: -8,388,608 to 8,388,607 (signed)..."
$table->mediumInteger('quantity'); // Perfect for my use case!
```