### PR TITLE
[12.x] feat(seeders): autoload traits

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -5,8 +5,8 @@ namespace Illuminate\Database;
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 abstract class Seeder

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -186,8 +186,10 @@ abstract class Seeder
 
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[WithoutModelEvents::class])) {
-            $callback = $this->withoutModelEvents($callback);
+        foreach ($uses as $trait) {
+            if (method_exists($this, $method = Str::camel(class_basename($trait)))) {
+                $callback = $this->{$method}($callback);
+            }
         }
 
         return $callback();

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -26,6 +26,30 @@ class TestDepsSeeder extends Seeder
     }
 }
 
+trait SomeTrait
+{
+    public $someTraitCalled = false;
+
+    public function someTrait(callable $callback): callable
+    {
+        $this->someTraitCalled = true;
+
+        return $callback;
+    }
+}
+
+class TestSeederWithAutoLoadedTraits extends Seeder
+{
+    use SomeTrait;
+
+    public $runCalled = false;
+
+    public function run()
+    {
+        $this->runCalled = true;
+    }
+}
+
 class DatabaseSeederTest extends TestCase
 {
     protected function tearDown(): void
@@ -88,5 +112,14 @@ class DatabaseSeederTest extends TestCase
         $seeder->__invoke(['test1', 'test2']);
 
         $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], ['test1', 'test2']);
+    }
+
+    public function testAutoLoadedTraitsOnRunMethod()
+    {
+        $seeder = new TestSeederWithAutoLoadedTraits;
+        $seeder->__invoke();
+
+        $this->assertTrue($seeder->someTraitCalled);
+        $this->assertTrue($seeder->runCalled);
     }
 }


### PR DESCRIPTION
In a similar fashion to what we already have for TestCase traits (`setUpTraitName`, `tearDownTraitName`) or Model traits (`bootTraitName`), it would be interesting to be able to automatically load and wrap Seeder runs with additional traits.

This would allow us to be able to hook into the existing chain and add wrap the execution of `run()` with additional functionalities if need be.

This is not a breaking change as executing `withoutModelEvents()` for the trait called the same way `WithoutModelEvents` would still happen, but if let's say we need some sort of "fail-safe" to wrap the seeder for example (or whatever other logic), this would also now allow us to have something like:

```php
class UserSeeder extends Seeder
{
    use WithoutModelEvents;
    use WithFailSafe;
    use WithWhatever;
}
```

Now if our trait `WithFailSafe` defines a `withFailSafe(callable $callback): callable` method, just how `WithoutModelEvents` does with `withoutModelEvents()` - it will wrap the execution of the seeder.