### PR TITLE
[12.x] Add option to get typed command input

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -612,14 +612,4 @@ trait InteractsWithIO
 
         return $value;
     }
-
-    /**
-     * @throws \InvalidArgumentException when neither an option nor an argument
-     *                                   with give key exists and no default value was given 
-     * @throws \TypeError on type mismatch
-     */
-    public function collection(string $key, $default = null): Collection
-    {
-        return new Collection($this->array($key, $default));
-    }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -5,7 +5,6 @@ namespace Illuminate\Console\Concerns;
 use Closure;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -593,6 +593,7 @@ trait InteractsWithIO
 
     /**
      * @return array<array-key, mixed>
+     *
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given 
      * @throws \TypeError on type mismatch

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -492,7 +492,7 @@ trait InteractsWithIO
         $value = match (true) {
             $this->hasArgument($key) => $this->getArgument($key),
             $this->hasOption($key) => $this->getOption($key),
-            default => $default ??  throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
         if (! is_int($value)) {

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -469,8 +469,8 @@ trait InteractsWithIO
     public function string(string $key, ?string $default = null): string
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
@@ -489,8 +489,8 @@ trait InteractsWithIO
     public function integer(string $key, ?int $default = null): int
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
@@ -519,8 +519,8 @@ trait InteractsWithIO
     public function float(string $key, ?float $default = null): float
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
@@ -549,8 +549,8 @@ trait InteractsWithIO
     public function number(string $key, int|float|null $default = null): int|float
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
@@ -569,8 +569,8 @@ trait InteractsWithIO
     public function boolean(string $key, int|float|null $default = null): bool
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 
@@ -601,8 +601,8 @@ trait InteractsWithIO
     public function array(string $key, ?array $default = null): array
     {
         $value = match (true) {
-            $this->hasArgument($key) => $this->getArgument($key),
-            $this->hasOption($key) => $this->getOption($key),
+            $this->hasArgument($key) => $this->argument($key),
+            $this->hasOption($key) => $this->option($key),
             default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
         };
 

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Concerns;
 use Closure;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
@@ -459,5 +460,166 @@ trait InteractsWithIO
     public function outputComponents()
     {
         return $this->components;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function string(string $key, ?string $default = null): string
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_string($value)) {
+            throw new TypeError(sprintf('"%s" is not of type string. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function integer(string $key, ?int $default = null): int
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ??  throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_int($value)) {
+            throw new TypeError(sprintf('"%s" is not of type integer. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function int(string $key, $default): int
+    {
+        return $this->integer($key, $default);
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function float(string $key, ?float $default = null): float
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_float($value)) {
+            throw new TypeError(sprintf('"%s" is not of type float. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function double(string $key, $default): float
+    {
+        return $this->float($key, $default);
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function number(string $key, int|float|null $default = null): int|float
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_int($value) && ! is_float($value)) {
+            throw new TypeError(sprintf('"%s" is neither of type float nor integer. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function boolean(string $key, int|float|null $default = null): bool
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_bool($value)) {
+            throw new TypeError(sprintf('"%s" is not of type boolean. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function bool(string $key, $default): bool
+    {
+        return $this->boolean($key, $default);
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function array(string $key, ?array $default = null): array
+    {
+        $value = match (true) {
+            $this->hasArgument($key) => $this->getArgument($key),
+            $this->hasOption($key) => $this->getOption($key),
+            default => $default ?? throw new InvalidArgumentException(sprintf('"%s" is neither an option nor an argument of this command', $key)),
+        };
+
+        if (! is_array($value)) {
+            throw new TypeError(sprintf('"%s" is not of type array. %s given', $key, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     * @throws \TypeError on type mismatch
+     */
+    public function collection(string $key, $default = null): Collection
+    {
+        return new Collection($this->array($key, $default));
     }
 }

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use InvalidArgumentException;
+use TypeError;
 
 trait InteractsWithIO
 {

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -293,9 +293,7 @@ class CommandTest extends TestCase
         $application = app();
         $command->setLaravel($application);
 
-        $input = new ArrayInput([
-            '--option-one' => 'test-first-option',
-        ]);
+        $input = new ArrayInput();
         $output = new NullOutput;
 
         $command->run($input, $output);
@@ -311,6 +309,13 @@ class CommandTest extends TestCase
         {
             public function handle()
             {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
             }
         };
 

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -215,4 +215,68 @@ class CommandTest extends TestCase
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
     }
+
+    public function testGetStringArgument()
+    {
+        
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getArguments()
+            {
+                return [
+                    new InputArgument('argument-one', InputArgument::REQUIRED, 'first test argument'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            'argument-one' => 'test-first-argument',
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->string('argument-one');
+        $this->assertSame('test-first-argument', $value);
+        $this->assertTrue(is_string($value));
+    }
+
+    public function testGetStringOption()
+    {
+        
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => 'test-first-option',
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->string('option-one');
+        $this->assertSame('test-first-option', $value);
+        $this->assertTrue(is_string($value));
+    }
 }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -288,12 +288,21 @@ class CommandTest extends TestCase
             public function handle()
             {
             }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-two', 'o', InputOption::VALUE_OPTIONAL, 'second test option'),
+                ];
+            }
         };
 
         $application = app();
         $command->setLaravel($application);
 
-        $input = new ArrayInput();
+        $input = new ArrayInput([
+            '--option-two' => ['foo', 'bar'],
+        ]);
         $output = new NullOutput;
 
         $command->run($input, $output);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -246,7 +246,6 @@ class CommandTest extends TestCase
 
         $value = $command->string('argument-one');
         $this->assertSame('test-first-argument', $value);
-        $this->assertTrue(is_string($value));
     }
 
     public function testGetStringOption()
@@ -277,7 +276,6 @@ class CommandTest extends TestCase
 
         $value = $command->string('option-one');
         $this->assertSame('test-first-option', $value);
-        $this->assertTrue(is_string($value));
     }
 
     public function testAttemptToGetNotDefinedInput()
@@ -326,5 +324,155 @@ class CommandTest extends TestCase
 
         $command->run($input, $output);
         $command->string('option-one');
+    }
+
+    public function testGetIntegerOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => 42,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->integer('option-one');
+        $this->assertSame(42, $value);
+    }
+
+    public function testGetFloatOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => 0.42,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->float('option-one');
+        $this->assertSame(0.42, $value);
+    }
+
+    public function testGetNumberOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => 42,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->number('option-one');
+        $this->assertSame(42, $value);
+    }
+
+    public function testGetBooleanOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => true,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->boolean('option-one');
+        $this->assertSame(true, $value);
+    }
+
+    public function testGetArrayOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle()
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => ['foo', 'bar'],
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $value = $command->array('option-one');
+        $this->assertSame(['foo', 'bar'], $value);
     }
 }


### PR DESCRIPTION
and input validation

like, for example, with `\Illuminate\Support\Facades\Config` (#50140) and `\Illuminate\Support\Arr` (#55567)

# Enhancements
* return value is typed
* optionally provide a default value, otherwise, an exception is thrown if not found
* when value has unexpected type, an exception is thrown

# Example
```php
<?php

namespace App\Console\Commands;

use App\Models\User;
use App\Support\DripEmailer;
use Illuminate\Console\Command;
 
class SendEmails extends Command
{
    protected $signature = 'mail:send {user} {--flag} {--subject=} {--cc=*}';
    protected $description = 'Send a marketing email to a user';
 
    /**
     * Execute the console command.
     */
    public function handle(DripEmailer $drip): void
    {
        $user = User::find($this->integer('user')); // argument typed as int, alternatively, you can use $this->int() or $this->number()
        $flag = $this->boolean('flag'); // flag typed as bool, there's also the alias $this->bool()
        $subject = $this->string('subject', 'Default subject'); // option typed as string with default value
        $cc = User::whereIn('id', $this->array('cc'))->get(); // option typed as array

        if ($flag) {
            // do something
        }

        $drip->send($user, $cc, $subject);
    }
}
```