### PR TITLE
Respect --quiet and --silent in queue:work command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -214,6 +214,10 @@ class WorkCommand extends Command
      */
     protected function writeOutput(Job $job, $status, ?Throwable $exception = null)
     {
+        if ($this->output->isQuiet() || $this->output->isSilent()) {
+            return;
+        }
+
         $this->outputUsingJson()
             ? $this->writeOutputAsJson($job, $status, $exception)
             : $this->writeOutputForCli($job, $status);


### PR DESCRIPTION
This PR modifies output writing in the `queue:work` command to respect the `-q|--quiet` and `--silent` options, so that it does not output hard-coded messages.

### Motivation

In containerized environments (Docker, Kubernetes, etc.), it's common to run `queue:work` processes under process managers like Supervisor or as long-running containers, with all output redirected to a centralized logging system. This means that standardized logging to stdout/stderr needs to be addressed.