### PR TITLE
[12.x] Add support as a depdency for container

### DIFF
--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^12.0",
+        "illuminate/support": "^12.0",
         "psr/container": "^1.1.1|^2.0.1",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33"


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I ran into an issue installing Valet today and tracked it down to this [PR](https://github.com/laravel/framework/pull/57831) using Support, without having it as a dependency.

Here was the install output:

```
./composer.json has been created
Running composer update laravel/valet
Loading composer repositories with package information
Updating dependencies
Lock file operations: 31 installs, 0 updates, 0 removals
  - Locking guzzlehttp/guzzle (7.10.0)
  - Locking guzzlehttp/promises (2.3.0)
  - Locking guzzlehttp/psr7 (2.8.0)
  - Locking illuminate/collections (v12.41.1)
  - Locking illuminate/conditionable (v12.41.1)
  - Locking illuminate/container (v12.41.1)
  - Locking illuminate/contracts (v12.41.1)
  - Locking illuminate/macroable (v12.41.1)
  - Locking laravel/valet (v4.11.0)
  - Locking mnapoli/silly (1.9.1)
  - Locking php-di/invoker (2.3.7)
  - Locking psr/container (2.0.2)
  - Locking psr/event-dispatcher (1.0.0)
  - Locking psr/http-client (1.0.3)
  - Locking psr/http-factory (1.1.0)
  - Locking psr/http-message (2.0)
  - Locking psr/simple-cache (3.0.0)
  - Locking ralouphie/getallheaders (3.0.3)
  - Locking symfony/console (v7.4.0)
  - Locking symfony/deprecation-contracts (v3.6.0)
  - Locking symfony/event-dispatcher (v7.4.0)
  - Locking symfony/event-dispatcher-contracts (v3.6.0)
  - Locking symfony/polyfill-ctype (v1.33.0)
  - Locking symfony/polyfill-intl-grapheme (v1.33.0)
  - Locking symfony/polyfill-intl-normalizer (v1.33.0)
  - Locking symfony/polyfill-mbstring (v1.33.0)
  - Locking symfony/polyfill-php84 (v1.33.0)
  - Locking symfony/polyfill-php85 (v1.33.0)
  - Locking symfony/process (v7.4.0)
  - Locking symfony/service-contracts (v3.6.1)
  - Locking symfony/string (v7.4.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 31 installs, 0 updates, 0 removals
  - Downloading guzzlehttp/promises (2.3.0)
  - Downloading ralouphie/getallheaders (3.0.3)
  - Downloading psr/http-message (2.0)
  - Downloading psr/http-factory (1.1.0)
  - Downloading guzzlehttp/psr7 (2.8.0)
  - Downloading illuminate/conditionable (v12.41.1)
  - Downloading psr/simple-cache (3.0.0)
  - Downloading psr/container (2.0.2)
  - Downloading illuminate/contracts (v12.41.1)
  - Downloading illuminate/macroable (v12.41.1)
  - Downloading symfony/process (v7.4.0)
  - Downloading psr/event-dispatcher (1.0.0)
  - Downloading symfony/event-dispatcher-contracts (v3.6.0)
  - Downloading symfony/event-dispatcher (v7.4.0)
  - Downloading symfony/polyfill-mbstring (v1.33.0)
  - Downloading symfony/polyfill-intl-normalizer (v1.33.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.33.0)
  - Downloading symfony/polyfill-ctype (v1.33.0)
  - Downloading symfony/deprecation-contracts (v3.6.0)
  - Downloading symfony/string (v7.4.0)
  - Downloading symfony/service-contracts (v3.6.1)
  - Downloading symfony/console (v7.4.0)
  - Downloading php-di/invoker (2.3.7)
  - Downloading mnapoli/silly (1.9.1)
  - Downloading symfony/polyfill-php85 (v1.33.0)
  - Downloading symfony/polyfill-php84 (v1.33.0)
  - Downloading illuminate/container (v12.41.1)
  - Downloading illuminate/collections (v12.41.1)
  - Downloading psr/http-client (1.0.3)
  - Downloading guzzlehttp/guzzle (7.10.0)
  - Downloading laravel/valet (v4.11.0)
  0/31 [>---------------------------]   0%
 12/31 [==========>-----------------]  38%
 22/31 [===================>--------]  70%
 27/31 [========================>---]  87%
 30/31 [===========================>]  96%
 31/31 [============================] 100%
  - Installing guzzlehttp/promises (2.3.0): Extracting archive
  - Installing ralouphie/getallheaders (3.0.3): Extracting archive
  - Installing psr/http-message (2.0): Extracting archive
  - Installing psr/http-factory (1.1.0): Extracting archive
  - Installing guzzlehttp/psr7 (2.8.0): Extracting archive
  - Installing illuminate/conditionable (v12.41.1): Extracting archive
  - Installing psr/simple-cache (3.0.0): Extracting archive
  - Installing psr/container (2.0.2): Extracting archive
  - Installing illuminate/contracts (v12.41.1): Extracting archive
  - Installing illuminate/macroable (v12.41.1): Extracting archive
  - Installing symfony/process (v7.4.0): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v3.6.0): Extracting archive
  - Installing symfony/event-dispatcher (v7.4.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.33.0): Extracting archive
  - Installing symfony/polyfill-intl-grapheme (v1.33.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.33.0): Extracting archive
  - Installing symfony/deprecation-contracts (v3.6.0): Extracting archive
  - Installing symfony/string (v7.4.0): Extracting archive
  - Installing symfony/service-contracts (v3.6.1): Extracting archive
  - Installing symfony/console (v7.4.0): Extracting archive
  - Installing php-di/invoker (2.3.7): Extracting archive
  - Installing mnapoli/silly (1.9.1): Extracting archive
  - Installing symfony/polyfill-php85 (v1.33.0): Extracting archive
  - Installing symfony/polyfill-php84 (v1.33.0): Extracting archive
  - Installing illuminate/container (v12.41.1): Extracting archive
  - Installing illuminate/collections (v12.41.1): Extracting archive
  - Installing psr/http-client (1.0.3): Extracting archive
  - Installing guzzlehttp/guzzle (7.10.0): Extracting archive
  - Installing laravel/valet (v4.11.0): Extracting archive
  0/31 [>---------------------------]   0%
 29/31 [==========================>-]  93%
 31/31 [============================] 100%
10 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
18 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
Using version ^4.11 for laravel/valet
PHP Fatal error:  Trait "Illuminate\Support\Traits\ReflectsClosures" not found in /Users/austin/.composer/vendor/illuminate/container/Container.php on line 25
```