### PR TITLE
[12.x] Remove calls to `optional()`

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -137,7 +137,7 @@ class DatabaseLock extends Lock
     /**
      * Returns the owner value written into the driver for this lock.
      *
-     * @return string
+     * @return string|null
      */
     protected function getCurrentOwner()
     {

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -141,7 +141,7 @@ class DatabaseLock extends Lock
      */
     protected function getCurrentOwner()
     {
-        return optional($this->connection->table($this->table)->where('key', $this->name)->first())->owner;
+        return $this->connection->table($this->table)->where('key', $this->name)->first()?->owner;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -28,7 +28,13 @@ class PaginatedResourceResponse extends ResourceResponse
             $this->resource->jsonOptions()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->map(function ($item) {
-                return is_array($item) ? Arr::get($item, 'resource') : optional($item)->resource;
+                if (is_array($item)) {
+                    return Arr::get($item, 'resource');
+                } elseif (is_object($item)) {
+                    return $item->resource ?? null;
+                }
+
+                return null;
             });
 
             $this->resource->withResponse($request, $response);

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -837,7 +837,7 @@ class UrlGenerator implements UrlGeneratorContract
         $this->cachedRoot = null;
         $this->cachedScheme = null;
 
-        tap($this->routeGenerator?->defaultParameters ?? [], function ($defaults) {
+        tap($this->routeGenerator?->defaultParameters ?: [], function ($defaults) {
             $this->routeGenerator = null;
 
             if (! empty($defaults)) {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -837,7 +837,7 @@ class UrlGenerator implements UrlGeneratorContract
         $this->cachedRoot = null;
         $this->cachedScheme = null;
 
-        tap(optional($this->routeGenerator)->defaultParameters ?: [], function ($defaults) {
+        tap($this->routeGenerator?->defaultParameters ?? [], function ($defaults) {
             $this->routeGenerator = null;
 
             if (! empty($defaults)) {


### PR DESCRIPTION
Saying goodbye to a relic from a bygone era.

We will always remember the good times we shared with `optional()`, the laughs and the tears. Listening to tunes on our iPods, drinking Four Lokos, and reaching for values which may or may not exist on a mixed type variable.