### PR TITLE
Change Pusher host prefix from 'api-' to 'ws-'

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -53,7 +53,7 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'host' => env('PUSHER_HOST') ?: 'ws-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),
                 'encrypted' => true,


### PR DESCRIPTION
As far as I can tell based on the Pusher documentation, the host should start with "ws-" and not "api-". 

When set to "api-", Echo fails to connect to Pusher's server. Changing this value to "ws-" fixes the issue and allows Echo to connect.

https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/
