### PR TITLE
fix autoloading StringableObjectStub class in tests/Support/SupportStringableTest.php

### DIFF
--- a/tests/Support/Fixtures/StringableObjectStub.php
+++ b/tests/Support/Fixtures/StringableObjectStub.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+class StringableObjectStub
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Exception;
 use Illuminate\Support\Str;
+use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -1925,20 +1926,5 @@ class SupportStrTest extends TestCase
         };
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
-    }
-}
-
-class StringableObjectStub
-{
-    private $value;
-
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
-    public function __toString()
-    {
-        return $this->value;
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Uri;
+use Illuminate\Tests\Support\Fixtures\StringableObjectStub;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Extension\ExtensionInterface;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
When running `vendor/bin/phpunit ./tests/Support/SupportStringableTest.php` it will fail with the following error.

```
Error: Class "Illuminate\Tests\Support\StringableObjectStub" not found
tests/Support/SupportStringableTest.php:980
```

This PR moves the class from the bottom of the `tests/Support/SupportStrTest.php` to it's own file in `tests/Support/Fixtures/StringableObjectStub.php` which follows the PSR-4 autoloading standards.