### PR TITLE
Add `skip`, `first` and `last` helpers to Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1802,24 +1802,24 @@ class Str
      * Get the first N characters of a string.
      *
      * @param  string  $string
-     * @param  int  $characters
+     * @param  int  $limit
      * @return string
      */
-    public static function first($string, int $characters = 1): string
+    public static function first($string, int $limit = 1): string
     {
-        return static::take($string, $characters);
+        return static::take($string, $limit);
     }
 
     /**
      * Get the last N characters of a string.
      *
      * @param  string  $string
-     * @param  int  $characters
+     * @param  int  $limit
      * @return string
      */
-    public static function last($string, int $characters = 1): string
+    public static function last($string, int $limit = 1): string
     {
-        return static::take($string, $characters * -1);
+        return static::take($string, $limit * -1);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1767,6 +1767,22 @@ class Str
     }
 
     /**
+     * Skip the first or last {$skip} characters of a string.
+     *
+     * @param  string  $string
+     * @param  int  $skip
+     * @return string
+     */
+    public static function skip($string, int $skip): string
+    {
+        if($skip <= 0) {
+            return $string;
+        }
+
+        return static::substr($string, $skip);
+    }
+
+    /**
      * Take the first or last {$limit} characters of a string.
      *
      * @param  string  $string
@@ -1780,6 +1796,30 @@ class Str
         }
 
         return static::substr($string, 0, $limit);
+    }
+
+    /**
+     * Get the first N characters of a string.
+     *
+     * @param  string  $string
+     * @param  int  $characters
+     * @return string
+     */
+    public static function first($string, int $characters = 1): string
+    {
+        return static::take($string, $characters);
+    }
+
+    /**
+     * Get the last N characters of a string.
+     *
+     * @param  string  $string
+     * @param  int  $characters
+     * @return string
+     */
+    public static function last($string, int $characters = 1): string
+    {
+        return static::take($string, $characters * -1);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1040,6 +1040,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Skip the first or last {$skip} characters.
+     *
+     * @param  int  $skip
+     * @return static
+     */
+    public function skip(int $skip)
+    {
+        return new static(Str::skip($this->value, $skip));
+    }
+
+    /**
      * Take the first or last {$limit} characters.
      *
      * @param  int  $limit
@@ -1052,6 +1063,28 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
         }
 
         return $this->substr(0, $limit);
+    }
+
+    /**
+     * Get the first {$limit} characters.
+     *
+     * @param  int  $limit
+     * @return static
+     */
+    public function first(int $limit = 1)
+    {
+        return new static(Str::first($this->value, $limit));
+    }
+
+    /**
+     * Get the last {$limit} characters.
+     *
+     * @param  int  $limit
+     * @return static
+     */
+    public function last(int $limit = 1)
+    {
+        return new static(Str::last($this->value, $limit));
     }
 
     /**
@@ -1493,7 +1526,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function toFloat()
     {
-        return floatval($this->value);
+        return (float) ($this->value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1275,6 +1275,17 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
     }
 
+    public function testSkip()
+    {
+        $this->assertSame('cdef', Str::skip('abcdef', 2));
+        $this->assertSame('abcdef', Str::skip('abcdef', -2));
+        $this->assertSame('abcdef', Str::skip('abcdef', 0));
+        $this->assertSame('', Str::skip('', 2));
+        $this->assertSame('', Str::skip('abcdef', 10));
+        $this->assertSame('', Str::skip('abcdef', 6));
+        $this->assertSame('öä', Str::skip('üöä', 1));
+    }
+
     public function testTake()
     {
         $this->assertSame('ab', Str::take('abcdef', 2));
@@ -1284,6 +1295,28 @@ class SupportStrTest extends TestCase
         $this->assertSame('abcdef', Str::take('abcdef', 10));
         $this->assertSame('abcdef', Str::take('abcdef', 6));
         $this->assertSame('ü', Str::take('üöä', 1));
+    }
+
+    public function testFirst()
+    {
+        $this->assertSame('ab', Str::first('abcdef', 2));
+        $this->assertSame('ef', Str::first('abcdef', -2));
+        $this->assertSame('', Str::first('abcdef', 0));
+        $this->assertSame('', Str::first('', 2));
+        $this->assertSame('abcdef', Str::first('abcdef', 10));
+        $this->assertSame('abcdef', Str::first('abcdef', 6));
+        $this->assertSame('ü', Str::first('üöä', 1));
+    }
+
+    public function testLast()
+    {
+        $this->assertSame('ef', Str::last('abcdef', 2));
+        $this->assertSame('ab', Str::last('abcdef', -2));
+        $this->assertSame('', Str::last('abcdef', 0));
+        $this->assertSame('', Str::last('', 2));
+        $this->assertSame('abcdef', Str::last('abcdef', 10));
+        $this->assertSame('abcdef', Str::last('abcdef', 6));
+        $this->assertSame('ä', Str::last('üöä', 1));
     }
 
     public function testLcfirst()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -150,6 +150,24 @@ class SupportStringableTest extends TestCase
         $this->assertSame('ef', (string) $this->stringable('abcdef')->take(-2));
     }
 
+    public function testSkip()
+    {
+        $this->assertSame('cdef', (string) $this->stringable('abcdef')->skip(2));
+        $this->assertSame('abcdef', (string) $this->stringable('abcdef')->skip(-2));
+    }
+
+    public function testFirst()
+    {
+        $this->assertSame('ab', (string) $this->stringable('abcdef')->first(2));
+        $this->assertSame('ef', (string) $this->stringable('abcdef')->first(-2));
+    }
+
+    public function testLast()
+    {
+        $this->assertSame('ef', (string) $this->stringable('abcdef')->last(2));
+        $this->assertSame('ab', (string) $this->stringable('abcdef')->last(-2));
+    }
+
     public function testTest()
     {
         $stringable = $this->stringable('foo bar');


### PR DESCRIPTION
I find myself using `skip()`, `first()` and `last()` on a `Illuminate\Support\Collection` object and often enough try the same methods on strings using `Illuminate\Support\Str`. This PR adds these methods to `Str` to make this possible.

Note: `take()` already exists on both `Illuminate\Support\Str` and `Illuminate\Support\Collection`.

## Added Methods
- `Str::skip($string, $count)`: Skip the first or last `$count` characters.
- `Str::first($string, $count = 1)`: Get the first `$count` characters.
- `Str::last($string, $count = 1)`: Get the last `$count` characters.

## Example Usage

```php
use Illuminate\Support\Str;

// Skip
Str::skip('https://laravel.com', 8); // 'laravel.com'
Str::skip('...Start', 3); // 'Start'

// First
Str::first('a0b1c2d3e4f5', 7); // 'a0b1c2d'
Str::first('https://laravel.com', 5); // 'https'

// Last
Str::last('image.jpg', 3); // 'jpg'
Str::last('1234-5678-9012-3456', 4); // '3456'
```
