### PR TITLE
Add `Str::limitExact()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -741,6 +741,23 @@ class Str
     }
 
     /**
+     * Limit the number of characters in a string, including the ending.
+     *
+     * @param  string  $value
+     * @param  int  $limit
+     * @param  string  $end
+     * @return string
+     */
+    public static function limitExact($value, $limit = 100, $end = '...')
+    {
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+            return $value;
+        }
+
+        return mb_strimwidth($value, 0, $limit, $end, 'UTF-8');
+    }
+
+    /**
      * Convert the given string to lower-case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -478,6 +478,18 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Limit the number of characters in a string, including the ending.
+     *
+     * @param  int  $limit
+     * @param  string  $end
+     * @return static
+     */
+    public function limitExact($limit = 100, $end = '...')
+    {
+        return new static(Str::limitExact($this->value, $limit, $end));
+    }
+
+    /**
      * Convert the given string to lower-case.
      *
      * @return static
@@ -1493,7 +1505,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function toFloat()
     {
-        return floatval($this->value);
+        return (float) ($this->value);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1505,7 +1505,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function toFloat()
     {
-        return (float) ($this->value);
+        return floatval($this->value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -779,6 +779,16 @@ class SupportStrTest extends TestCase
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', true));
     }
 
+    public function testLimitExact()
+    {
+        $this->assertSame('Laravel...', Str::limitExact('Laravel is a free, open source PHP web application framework.', 10));
+        $this->assertSame('Laravel', Str::limitExact('Laravel', 10));
+        $this->assertSame('Laravel___', Str::limitExact('Laravel is a free, open source PHP web application framework.', 10, '___'));
+        $this->assertSame('这...', Str::limitExact('这是一段中文', 6));
+        $this->assertSame('这是...', Str::limitExact('这是一段中文', 7));
+        $this->assertSame('这是一', Str::limitExact('这是一段中文', 6, ''));
+    }
+
     public function testLength()
     {
         $this->assertEquals(11, Str::length('foo bar baz'));


### PR DESCRIPTION
This PR introduces a new method `Str::limitExact` (and its `Stringable` counterpart) to handle string truncation where the final string length **must** include the separator (e.g., `...`).

### The Problem
The existing `Str::limit($limit)` method truncates the string to the `$limit`, and *then* appends the separator. This results in a final string length of `$limit + strlen($separator)`.

This behavior has often caught me out when using it to adhere to API paramter character length limits.

**Example of current behavior:**
```php
// Limit is 5, but result is 8 characters long
Str::limit('123456789', 5); // "12345..."
```

### The Solution
The new limitExact method utilizes PHP's native mb_strimwidth to ensure the resulting string (separator included) never exceeds the specified limit.

**Example of new behavior:**
```php
// Limit is 5, result is strictly 5 characters long
Str::limitExact('123456789', 5); // "12..."
```