### PR TITLE
[12.x] Require `illuminate/support` for `illuminate/container`

### DIFF
--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^12.0",
+        "illuminate/support": "^12.0",
         "psr/container": "^1.1.1|^2.0.1",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33"


### PR DESCRIPTION
Fixes this error after Laravel Valet install:
```
PHP Fatal error:  Trait "Illuminate\Support\Traits\ReflectsClosures" not found in /Users/james/.composer/vendor/illuminate/container/Container.php on line 25

Fatal error: Trait "Illuminate\Support\Traits\ReflectsClosures" not found in /Users/james/.composer/vendor/illuminate/container/Container.php on line 25
```

[First discovered on StackOverflow.]( https://stackoverflow.com/questions/79838053/laravel-valet-fails-to-install-via-composer-on-mac-apple-silicon)
