### PR TITLE
[12.x] Fix `required` and `sometimes` validation of `Password` rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -45,6 +45,20 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $max;
 
     /**
+     * If the password is required.
+     *
+     * @var bool
+     */
+    protected $required = false;
+
+    /**
+     * If the password should only be validated when present.
+     *
+     * @var bool
+     */
+    protected $sometimes = false;
+
+    /**
      * If the password requires at least one uppercase and one lowercase letter.
      *
      * @var bool
@@ -155,21 +169,29 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Get the default configuration of the password rule and mark the field as required.
      *
-     * @return array
+     * @return static
      */
     public static function required()
     {
-        return ['required', static::default()];
+        $password = static::default();
+
+        $password->required = true;
+
+        return $password;
     }
 
     /**
      * Get the default configuration of the password rule and mark the field as sometimes being required.
      *
-     * @return array
+     * @return static
      */
     public static function sometimes()
     {
-        return ['sometimes', static::default()];
+        $password = static::default();
+
+        $password->sometimes = true;
+
+        return $password;
     }
 
     /**
@@ -312,6 +334,8 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         $validator = Validator::make(
             $this->data,
             [$attribute => [
+                ...($this->required ? ['required'] : []),
+                ...($this->sometimes ? ['sometimes'] : []),
                 'string',
                 'min:'.$this->min,
                 ...($this->max ? ['max:'.$this->max] : []),

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -377,44 +377,42 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testRequired()
     {
-        $this->fails(Password::required(), [null, ''], [
+        $this->fails(Password::required(), [null], [
             'validation.required',
         ]);
 
         $this->passes(Password::required(), ['12345678', 'password123']);
 
-        $this->fails([Password::required()], ['12345'], [
-            'validation.min.string'
+        $this->fails([Password::required()], ['short'], [
+            'validation.min.string',
         ]);
 
         $this->passes(Password::required()->mixedCase()->numbers(), ['Password1']);
 
-        # Ensure it still work when using array
+        // Ensure it still correct when using array
         $this->passes([Password::required()], ['12345678', 'password123']);
 
-        $this->fails([Password::required()], ['12345'], [
-            'validation.min.string'
+        $this->fails([Password::required()], ['short'], [
+            'validation.min.string',
         ]);
 
         $this->passes(['string', Password::required()], ['12345678', 'password123']);
 
         $this->passes([Password::required()->mixedCase()->numbers()], ['Password1']);
 
-        # Test with custom defaults
+        // Test with custom defaults
         Password::defaults(Password::min(6)->letters());
 
-        $this->fails(Password::required(), [null, ''], [
+        $this->fails(Password::required(), [null], [
             'validation.required',
         ]);
 
-        $this->passes(Password::required(), ['12345678', 'password123']);
-        $this->passes([Password::required()], ['12345678', 'password123']);
+        $this->passes(Password::required(), ['Password123', 'password123']);
+        $this->passes([Password::required()], ['Password123', 'password123']);
     }
 
     public function testSometimes()
     {
-        $this->passes(Password::sometimes(), [null, '']);
-
         $this->fails(Password::sometimes(), ['short'], [
             'validation.min.string',
         ]);
@@ -422,29 +420,27 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(Password::sometimes(), ['12345678', 'password123']);
 
         $this->fails([Password::sometimes()], ['12345'], [
-            'validation.min.string'
+            'validation.min.string',
         ]);
 
         $this->passes(Password::sometimes()->mixedCase()->numbers(), ['Password1']);
 
-        # Ensure it still work when using array
+        // Ensure it still correct when using array
         $this->passes([Password::sometimes()], ['12345678', 'password123']);
 
         $this->fails([Password::sometimes()], ['12345'], [
-            'validation.min.string'
+            'validation.min.string',
         ]);
 
         $this->passes(['string', Password::sometimes()], ['12345678', 'password123']);
 
         $this->passes([Password::sometimes()->mixedCase()->numbers()], ['Password1']);
 
-        # Test with custom defaults
+        // Test with custom defaults
         Password::defaults(Password::min(6)->letters());
 
-        $this->passes(Password::sometimes(), [null, '']);
-
-        $this->passes(Password::sometimes(), ['12345678', 'password123']);
-        $this->passes([Password::sometimes()], ['12345678', 'password123']);
+        $this->passes(Password::sometimes(), ['Password123', 'password123']);
+        $this->passes([Password::sometimes()], ['Password123', 'password123']);
     }
 
     protected function passes($rule, $values)

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -237,14 +237,14 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->passes(Password::default(), ['abcd', '454qb^', '接2133手田']);
         $this->assertSame($password, Password::default());
-        $this->assertSame(['required', $password], Password::required());
-        $this->assertSame(['sometimes', $password], Password::sometimes());
+        $this->assertInstanceOf(Password::class, Password::required());
+        $this->assertInstanceOf(Password::class, Password::sometimes());
 
         Password::defaults($password2);
         $this->passes(Password::default(), ['Nn', 'Mn', 'âA']);
         $this->assertSame($password2, Password::default());
-        $this->assertSame(['required', $password2], Password::required());
-        $this->assertSame(['sometimes', $password2], Password::sometimes());
+        $this->assertInstanceOf(Password::class, Password::required());
+        $this->assertInstanceOf(Password::class, Password::sometimes());
     }
 
     public function testItCannotSetDefaultUsingGivenString()
@@ -373,6 +373,78 @@ class ValidationPasswordRuleTest extends TestCase
             'compromisedThreshold' => 0,
             'customRules' => [],
         ]);
+    }
+
+    public function testRequired()
+    {
+        $this->fails(Password::required(), [null, ''], [
+            'validation.required',
+        ]);
+
+        $this->passes(Password::required(), ['12345678', 'password123']);
+
+        $this->fails([Password::required()], ['12345'], [
+            'validation.min.string'
+        ]);
+
+        $this->passes(Password::required()->mixedCase()->numbers(), ['Password1']);
+
+        # Ensure it still work when using array
+        $this->passes([Password::required()], ['12345678', 'password123']);
+
+        $this->fails([Password::required()], ['12345'], [
+            'validation.min.string'
+        ]);
+
+        $this->passes(['string', Password::required()], ['12345678', 'password123']);
+
+        $this->passes([Password::required()->mixedCase()->numbers()], ['Password1']);
+
+        # Test with custom defaults
+        Password::defaults(Password::min(6)->letters());
+
+        $this->fails(Password::required(), [null, ''], [
+            'validation.required',
+        ]);
+
+        $this->passes(Password::required(), ['12345678', 'password123']);
+        $this->passes([Password::required()], ['12345678', 'password123']);
+    }
+
+    public function testSometimes()
+    {
+        $this->passes(Password::sometimes(), [null, '']);
+
+        $this->fails(Password::sometimes(), ['short'], [
+            'validation.min.string',
+        ]);
+
+        $this->passes(Password::sometimes(), ['12345678', 'password123']);
+
+        $this->fails([Password::sometimes()], ['12345'], [
+            'validation.min.string'
+        ]);
+
+        $this->passes(Password::sometimes()->mixedCase()->numbers(), ['Password1']);
+
+        # Ensure it still work when using array
+        $this->passes([Password::sometimes()], ['12345678', 'password123']);
+
+        $this->fails([Password::sometimes()], ['12345'], [
+            'validation.min.string'
+        ]);
+
+        $this->passes(['string', Password::sometimes()], ['12345678', 'password123']);
+
+        $this->passes([Password::sometimes()->mixedCase()->numbers()], ['Password1']);
+
+        # Test with custom defaults
+        Password::defaults(Password::min(6)->letters());
+
+        $this->passes(Password::sometimes(), [null, '']);
+
+        $this->passes(Password::sometimes(), ['12345678', 'password123']);
+        $this->passes([Password::sometimes()], ['12345678', 'password123']);
     }
 
     protected function passes($rule, $values)


### PR DESCRIPTION
This PR fixes an issue where using `Password::required()` or `Password::sometimes(`) inside an array of rules results in incorrect validation behavior.

When defining validation rules like:
```
$request->validate([
    'password' => ['confirmed', Password::required()],
]);
```
with the following payload:
```
{
    "password": "123",
    "password_confirmation": "123"
}
```
the validation does not work as expected.
The root cause is that Password::required() returns an array, which conflicts when it is placed inside another rule array.

This PR updated `Password::required()` so that it returns the rule instance instead of an array. This ensures the rule works correctly when used inside array-based validation.