### PR TITLE
Add SSL certificate/key support for MySQL schema dumps (MariaDB safe)

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -151,7 +151,7 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
-            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound,
+            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound
             'LARAVEL_LOAD_SSL_CERT' => $config['options'][\PDO::MYSQL_ATTR_SSL_CERT] ?? '',
             'LARAVEL_LOAD_SSL_KEY' => $config['options'][\PDO::MYSQL_ATTR_SSL_KEY] ?? '',
         ];

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,10 +116,20 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
-        // if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
-        //     $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-        //     $value .= ' --ssl=off';
-        // }
+        if (!$this->connection->isMaria()) {
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CERT])) {
+                $value .= ' --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}"';
+            }
+
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_KEY])) {
+                $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
+            }
+
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
+                $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
+                $value .= ' --ssl-verify-server-cert=OFF';
+            }
+        }
 
         return $value;
     }
@@ -141,7 +151,9 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
-            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound
+            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound,
+            'LARAVEL_LOAD_SSL_CERT' => $config['options'][\PDO::MYSQL_ATTR_SSL_CERT] ?? '',
+            'LARAVEL_LOAD_SSL_KEY' => $config['options'][\PDO::MYSQL_ATTR_SSL_KEY] ?? '',
         ];
     }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,10 +116,20 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
-        // if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
-        //     $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-        //     $value .= ' --ssl=off';
-        // }
+        if (! $this->connection->isMaria()) {
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CERT])) {
+                $value .= ' --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}"';
+            }
+
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_KEY])) {
+                $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
+            }
+
+            if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
+                $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
+                $value .= ' --ssl-verify-server-cert=OFF';
+            }
+        }
 
         return $value;
     }
@@ -141,7 +151,9 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
-            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound
+            'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound,
+            'LARAVEL_LOAD_SSL_CERT' => $config['options'][\PDO::MYSQL_ATTR_SSL_CERT] ?? '',
+            'LARAVEL_LOAD_SSL_KEY' => $config['options'][\PDO::MYSQL_ATTR_SSL_KEY] ?? '',
         ];
     }
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -45,6 +45,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -53,7 +55,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         ];
 
         yield 'ssl_ca' => [
-            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"', [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}" --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}" --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"', [
                 'LARAVEL_LOAD_SOCKET' => '',
                 'LARAVEL_LOAD_HOST' => '',
                 'LARAVEL_LOAD_PORT' => '',
@@ -61,32 +63,38 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+                'LARAVEL_LOAD_SSL_CERT' => 'cert.pem',
+                'LARAVEL_LOAD_SSL_KEY' => 'key.pem',
             ], [
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    \PDO::MYSQL_ATTR_SSL_CERT => 'cert.pem',
+                    \PDO::MYSQL_ATTR_SSL_KEY => 'key.pem',
                 ],
             ],
         ];
 
-        // yield 'no_ssl' => [
-        //     ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl=off', [
-        //         'LARAVEL_LOAD_SOCKET' => '',
-        //         'LARAVEL_LOAD_HOST' => '',
-        //         'LARAVEL_LOAD_PORT' => '',
-        //         'LARAVEL_LOAD_USER' => 'root',
-        //         'LARAVEL_LOAD_PASSWORD' => '',
-        //         'LARAVEL_LOAD_DATABASE' => 'forge',
-        //         'LARAVEL_LOAD_SSL_CA' => '',
-        //     ], [
-        //         'username' => 'root',
-        //         'database' => 'forge',
-        //         'options' => [
-        //             \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
-        //         ],
-        //     ],
-        // ];
+        yield 'no_ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-verify-server-cert=OFF', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                ],
+            ],
+        ];
 
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
@@ -97,6 +105,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',


### PR DESCRIPTION
This PR adds optional SSL support to MySqlSchemaState when dumping schema via mysqldump.
The following improvements are included:

- SSL CERT, KEY support

Values defined in PDO options are now passed through to the dump command.

- MariaDB compatibility

MariaDB clients do not universally support --ssl-cert, --ssl-key, or --ssl-verify-server-cert.
These options are now applied only when the connection is not MariaDB.
