### PR TITLE
[12.x] Modernize typecasting

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1595,7 +1595,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                         }
                     } else {
                         $result = match ($options) {
-                            SORT_NUMERIC => (int) ($values[0]) <=> (int) ($values[1]),
+                            SORT_NUMERIC => (int) $values[0] <=> (int) $values[1],
                             SORT_STRING => strcmp($values[0], $values[1]),
                             SORT_NATURAL => strnatcmp((string) $values[0], (string) $values[1]),
                             SORT_LOCALE_STRING => strcoll($values[0], $values[1]),

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1595,7 +1595,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                         }
                     } else {
                         $result = match ($options) {
-                            SORT_NUMERIC => intval($values[0]) <=> intval($values[1]),
+                            SORT_NUMERIC => (int) ($values[0]) <=> (int) ($values[1]),
                             SORT_STRING => strcmp($values[0], $values[1]),
                             SORT_NATURAL => strnatcmp((string) $values[0], (string) $values[1]),
                             SORT_LOCALE_STRING => strcoll($values[0], $values[1]),

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -45,7 +45,7 @@ trait BuildsQueries
         $page = 1;
 
         do {
-            $offset = (($page - 1) * $count) + intval($skip);
+            $offset = (($page - 1) * $count) + (int) $skip;
 
             $limit = is_null($remaining) ? $count : min($count, $remaining);
 

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -79,7 +79,7 @@ class MySqlConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return boolval(preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage()));
+        return (bool) (preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage()));
     }
 
     /**

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -79,7 +79,7 @@ class MySqlConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return (bool) (preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage()));
+        return (bool) preg_match('#Integrity constraint violation: 1062#i', $exception->getMessage());
     }
 
     /**

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -59,7 +59,7 @@ class SQLiteConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return (bool) (preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
+        return (bool) preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage());
     }
 
     /**

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -59,7 +59,7 @@ class SQLiteConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return boolval(preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
+        return (bool) (preg_match('#(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)#i', $exception->getMessage()));
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -83,7 +83,7 @@ class SqlServerConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return (bool) (preg_match('#Cannot insert duplicate key row in object#i', $exception->getMessage()));
+        return (bool) preg_match('#Cannot insert duplicate key row in object#i', $exception->getMessage());
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -83,7 +83,7 @@ class SqlServerConnection extends Connection
      */
     protected function isUniqueConstraintError(Exception $exception)
     {
-        return boolval(preg_match('#Cannot insert duplicate key row in object#i', $exception->getMessage()));
+        return (bool) (preg_match('#Cannot insert duplicate key row in object#i', $exception->getMessage()));
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -234,7 +234,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
             return $options;
         }
 
-        $transformToString = fn ($value) => strval($value);
+        $transformToString = fn ($value) => (string) $value;
 
         // The message group ID is required for FIFO queues and is optional for
         // standard queues. Job objects contain a group ID. With string jobs

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -277,7 +277,7 @@ class Number
         }
 
         switch (true) {
-            case floatval($number) === 0.0:
+            case (float) $number === 0.0:
                 return $precision > 0 ? static::format(0, $precision, $maxPrecision) : '0';
             case $number < 0:
                 return sprintf('-%s', static::summarize(abs($number), $precision, $maxPrecision, $units));

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1493,7 +1493,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function toFloat()
     {
-        return floatval($this->value);
+        return (float) ($this->value);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1493,7 +1493,7 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
      */
     public function toFloat()
     {
-        return (float) ($this->value);
+        return (float) $this->value;
     }
 
     /**

--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -36,7 +36,7 @@ class Timebox
             $exception = $caught;
         }
 
-        $remainder = intval($microseconds - ((microtime(true) - $start) * 1000000));
+        $remainder = (int) ($microseconds - ((microtime(true) - $start) * 1000000));
 
         if (! $this->earlyReturn && $remainder > 0) {
             $this->usleep($remainder);

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -269,7 +269,7 @@ trait InteractsWithData
      */
     public function integer($key, $default = 0)
     {
-        return intval($this->data($key, $default));
+        return (int) ($this->data($key, $default));
     }
 
     /**
@@ -281,7 +281,7 @@ trait InteractsWithData
      */
     public function float($key, $default = 0.0)
     {
-        return floatval($this->data($key, $default));
+        return (float) ($this->data($key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -269,7 +269,7 @@ trait InteractsWithData
      */
     public function integer($key, $default = 0)
     {
-        return (int) ($this->data($key, $default));
+        return (int) $this->data($key, $default);
     }
 
     /**
@@ -281,7 +281,7 @@ trait InteractsWithData
      */
     public function float($key, $default = 0.0)
     {
-        return (float) ($this->data($key, $default));
+        return (float) $this->data($key, $default);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -239,7 +239,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
 
         $size = strtolower(trim($size));
 
-        $value = floatval($size);
+        $value = (float) $size;
 
         return round(match (true) {
             Str::endsWith($size, 'kb') => $value * 1,

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -142,7 +142,7 @@ class UrlSigningTest extends TestCase
     {
         Route::get('/foo/{id}', function (Request $request, $id) {
             return $request->hasValidSignature()
-                && intval($id) === 1
+                && (int) $id === 1
                 && $request->has('paramEmpty')
                 && $request->has('paramEmptyString')
                 && $request->query('paramWithValue') === 'value'

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -258,7 +258,7 @@ class SleepTest extends TestCase
         Sleep::fake();
         Carbon::setTestNow(now()->startOfDay());
 
-        Sleep::until((string) (now()->addMinute()->timestamp));
+        Sleep::until((string) now()->addMinute()->timestamp);
 
         Sleep::assertSequence([
             Sleep::for(60)->seconds(),

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -258,7 +258,7 @@ class SleepTest extends TestCase
         Sleep::fake();
         Carbon::setTestNow(now()->startOfDay());
 
-        Sleep::until(strval(now()->addMinute()->timestamp));
+        Sleep::until((string) (now()->addMinute()->timestamp));
 
         Sleep::assertSequence([
             Sleep::for(60)->seconds(),


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/57914, modernize_types_casting was set to true in pint, but it was never run against the codebase.

In order to facilitate this, I modified the app's pint.json file so it only included this rule:

<details>
<summary>Pint.json</summary>

```json
{
    "preset": "empty",
    "rules": {
        "modernize_types_casting": true
    },
    "notPath": [
        "tests/Foundation/fixtures/bad-syntax-strategy.php"
    ]
}

```

</details>

and then ran `vendor/bin/pint --parallel` to apply just these changes.