### PR TITLE
[12.x] Add `newRequest()` to Pool and Batch

### DIFF
--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -42,6 +42,16 @@ class Pool
     }
 
     /**
+     * Add a request to the pool with a numeric index.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest|\GuzzleHttp\Promise\Promise
+     */
+    public function newRequest()
+    {
+        return $this->pool[] = $this->asyncRequest();
+    }
+
+    /**
      * Add a request to the pool with a key.
      *
      * @param  string  $key
@@ -73,7 +83,7 @@ class Pool
     }
 
     /**
-     * Add a request to the pool with a numeric index.
+     * Add a request to the pool with a numeric index and forward the method call to the request.
      *
      * @param  string  $method
      * @param  array  $parameters
@@ -81,6 +91,6 @@ class Pool
      */
     public function __call($method, $parameters)
     {
-        return $this->pool[] = $this->asyncRequest()->$method(...$parameters);
+        return $this->newRequest()->{$method}(...$parameters);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1906,10 +1906,12 @@ class HttpClientTest extends TestCase
                 $pool->as('test200')->get('200.com'),
                 $pool->as('test400')->get('400.com'),
                 $pool->as('test500')->get('500.com'),
+                $pool->newRequest()->get('200.com'),
             ];
         });
 
         $this->assertSame(200, $responses['test200']->status());
+        $this->assertSame(200, $responses[0]->status());
         $this->assertSame(400, $responses['test400']->status());
         $this->assertSame(500, $responses['test500']->status());
     }


### PR DESCRIPTION
This adds convenience for folks who want to create a new request without having to name it.

```php
function addPromiseMapping($promise) {
    $promise->get('https://laravel.com/careers')
        ->then(fn ($response) => str_contains($response->body(), 'software engineer'));
}

Http::pool(function (Pool $pool) {
    addPromiseMapping($pool->newRequest());
    addPromiseMapping($pool->newRequest());
});
```

Prior to this, you would have to name the request (via `Pool@as()`) even if that wasn't convenient for the use case.