### PR TITLE
[12.x] Add Arr::mapKeys() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -794,6 +794,27 @@ class Arr
     }
 
     /**
+     * Map over an array's keys.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function mapKeys(array $array, callable $callback): array
+    {
+        $keys = array_keys($array);
+        $values = array_values($array);
+
+        try {
+            $newKeys = array_map($callback, $keys, $values);
+        } catch (ArgumentCountError) {
+            $newKeys = array_map($callback, $keys);
+        }
+
+        return array_combine($newKeys, $values);
+    }
+
+    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
@@ -991,6 +992,37 @@ class SupportArrTest extends TestCase
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
+    }
+
+    public function testMapKeys()
+    {
+        // Basic transformation
+        $array = ['first_name' => 'Taylor', 'last_name' => 'Otwell'];
+        $result = Arr::mapKeys($array, fn($key) => Str::camel($key));
+        $this->assertEquals(['firstName' => 'Taylor', 'lastName' => 'Otwell'], $result);
+
+        // With value parameter
+        $array = ['name' => 'Taylor', 'age' => 31];
+        $result = Arr::mapKeys($array, fn($key, $value) => is_numeric($value) ? "num_{$key}" : $key);
+        $this->assertEquals(['name' => 'Taylor', 'num_age' => 31], $result);
+
+        // Key collision - last wins
+        $array = ['name' => 'First', 'NAME' => 'Second'];
+        $result = Arr::mapKeys($array, fn($key) => strtolower($key));
+        $this->assertEquals(['name' => 'Second'], $result);
+
+        // Empty array
+        $this->assertEquals([], Arr::mapKeys([], fn($key) => $key));
+
+        // Numeric keys
+        $array = [1, 2, 3];
+        $result = Arr::mapKeys($array, fn($key) => "item_{$key}");
+        $this->assertEquals(['item_0' => 1, 'item_1' => 2, 'item_2' => 3], $result);
+
+        // Prefix example
+        $config = ['host' => 'localhost', 'port' => 3306, 'database' => 'app'];
+        $result = Arr::mapKeys($config, fn($key) => "db_{$key}");
+        $this->assertEquals(['db_host' => 'localhost', 'db_port' => 3306, 'db_database' => 'app'], $result);
     }
 
     public function testMapWithEmptyArray()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1012,7 +1012,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'Second'], $result);
 
         // Empty array
-        $this->assertEquals([], Arr::mapKeys([], fn($key) => $key));
+        $this->assertEquals([], Arr::mapKeys([], fn ($key) => $key));
 
         // Numeric keys
         $array = [1, 2, 3];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -998,17 +998,17 @@ class SupportArrTest extends TestCase
     {
         // Basic transformation
         $array = ['first_name' => 'Taylor', 'last_name' => 'Otwell'];
-        $result = Arr::mapKeys($array, fn($key) => Str::camel($key));
+        $result = Arr::mapKeys($array, fn ($key) => Str::camel($key));
         $this->assertEquals(['firstName' => 'Taylor', 'lastName' => 'Otwell'], $result);
 
         // With value parameter
         $array = ['name' => 'Taylor', 'age' => 31];
-        $result = Arr::mapKeys($array, fn($key, $value) => is_numeric($value) ? "num_{$key}" : $key);
+        $result = Arr::mapKeys($array, fn ($key, $value) => is_numeric($value) ? "num_{$key}" : $key);
         $this->assertEquals(['name' => 'Taylor', 'num_age' => 31], $result);
 
         // Key collision - last wins
         $array = ['name' => 'First', 'NAME' => 'Second'];
-        $result = Arr::mapKeys($array, fn($key) => strtolower($key));
+        $result = Arr::mapKeys($array, fn ($key) => strtolower($key));
         $this->assertEquals(['name' => 'Second'], $result);
 
         // Empty array
@@ -1016,12 +1016,12 @@ class SupportArrTest extends TestCase
 
         // Numeric keys
         $array = [1, 2, 3];
-        $result = Arr::mapKeys($array, fn($key) => "item_{$key}");
+        $result = Arr::mapKeys($array, fn ($key) => "item_{$key}");
         $this->assertEquals(['item_0' => 1, 'item_1' => 2, 'item_2' => 3], $result);
 
         // Prefix example
         $config = ['host' => 'localhost', 'port' => 3306, 'database' => 'app'];
-        $result = Arr::mapKeys($config, fn($key) => "db_{$key}");
+        $result = Arr::mapKeys($config, fn ($key) => "db_{$key}");
         $this->assertEquals(['db_host' => 'localhost', 'db_port' => 3306, 'db_database' => 'app'], $result);
     }
 


### PR DESCRIPTION
This PR adds an `Arr::mapKeys()` method to transform array keys while preserving values.

Common use case: transforming API response keys from snake_case to camelCase.
```php
// Transform keys
$data = ['first_name' => 'Taylor', 'last_name' => 'Otwell'];
$result = Arr::mapKeys($data, fn($key) => Str::camel($key));
// ['firstName' => 'Taylor', 'lastName' => 'Otwell']

// Prefix keys (My favorite)
$config = ['host' => 'localhost', 'port' => 3306];
$result = Arr::mapKeys($config, fn($key) => "db_{$key}");
// ['db_host' => 'localhost', 'db_port' => 3306]
```


The implementation follows the existing `Arr::map()` pattern, supporting callbacks with optional parameters (key only, or key with value).