### PR TITLE
[12.x] Align Listener docblock and add unit test for query shape

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
@@ -44,7 +44,7 @@ class Listener
     /**
      * Returns the queries that have been executed.
      *
-     * @return array<int, array{sql: string, time: float}>
+     * @return array<int, array{connectionName: string, time: float, sql: string, bindings: array}>
      */
     public function queries()
     {

--- a/tests/Foundation/Exceptions/Renderer/ListenerTest.php
+++ b/tests/Foundation/Exceptions/Renderer/ListenerTest.php
@@ -45,4 +45,3 @@ class ListenerTest extends TestCase
         $this->assertEquals(['foo'], $query['bindings']);
     }
 }
-

--- a/tests/Foundation/Exceptions/Renderer/ListenerTest.php
+++ b/tests/Foundation/Exceptions/Renderer/ListenerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Exceptions\Renderer;
+
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Exceptions\Renderer\Listener;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ListenerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function test_queries_returns_expected_shape_after_query_executed()
+    {
+        $connection = m::mock();
+
+        $connection->shouldReceive('getName')->andReturn('testing');
+        $connection->shouldReceive('prepareBindings')->with(['foo'])->andReturn(['foo']);
+
+        $event = new QueryExecuted('select * from users where id = ?', ['foo'], 5.2, $connection);
+
+        $listener = new Listener();
+
+        $listener->onQueryExecuted($event);
+
+        $queries = $listener->queries();
+
+        $this->assertIsArray($queries);
+        $this->assertCount(1, $queries);
+
+        $query = $queries[0];
+
+        $this->assertArrayHasKey('connectionName', $query);
+        $this->assertArrayHasKey('time', $query);
+        $this->assertArrayHasKey('sql', $query);
+        $this->assertArrayHasKey('bindings', $query);
+
+        $this->assertEquals('testing', $query['connectionName']);
+        $this->assertEquals(5.2, $query['time']);
+        $this->assertEquals('select * from users where id = ?', $query['sql']);
+        $this->assertEquals(['foo'], $query['bindings']);
+    }
+}
+


### PR DESCRIPTION
Update `src/Illuminate/Foundation/Exceptions/Renderer/Listener.php` docblock for `queries()` to reflect actual stored keys (connectionName, time, sql, bindings).

Add `tests/Foundation/Exceptions/Renderer/ListenerTest.php` to assert the queries array shape and values after handling a QueryExecuted event.

improves type documentation and adds minimal test coverage.
