### PR TITLE
Prevent Attribute accessors from running for non-arrayable attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -696,6 +696,7 @@ trait HasAttributes
         // Lazy evaluation: only now do we resolve and inspect the Attribute
         try {
             $attribute = $this->{Str::camel($key)}();
+
             return static::$getAttributeMutatorCache[$class][$key] = is_callable($attribute->get);
         } catch (\Throwable $e) {
             return static::$getAttributeMutatorCache[$class][$key] = false;
@@ -2484,7 +2485,7 @@ trait HasAttributes
         // in hasAttributeGetMutator() when the attribute is actually accessed.
         static::$getAttributeMutatorCache[$class] = (new Collection($attributeMutatorMethods))
             ->mapWithKeys(fn ($match) => [
-                lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => null
+                lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => null,
             ])
             ->all();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2507,6 +2507,4 @@ trait HasAttributes
             ->values()
             ->all();
     }
-
-
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -222,10 +222,15 @@ trait HasAttributes
             $attributes = $this->getArrayableAttributes()
         );
 
-        // IMPORTANT: only derive mutated attributes from the *arrayable* keys
+        $mutatedAttributes = array_values(
+            array_filter(array_keys($attributes), function ($key) {
+                return $this->hasAnyGetMutator($key);
+            })
+        );
+
         $attributes = $this->addMutatedAttributesToArray(
             $attributes,
-            $mutatedAttributes = $this->getArrayableMutatedAttributes($attributes)
+            $mutatedAttributes,
         );
 
         // Next we will handle any casts that have been setup for this model and cast
@@ -294,29 +299,6 @@ trait HasAttributes
 
         return $attributes;
     }
-
-    /**
-     * Get the mutated attributes that are actually arrayable.
-     *
-     * This ensures that Attribute-based and classic get mutators are only
-     * invoked during serialization for attributes that are visible /
-     * not hidden on the model.
-     *
-     * @param  array  $attributes
-     * @return array
-     */
-    protected function getArrayableMutatedAttributes(array $attributes)
-    {
-        return array_values(
-            array_filter(
-                array_keys($attributes),
-                function ($key) {
-                    return $this->hasAnyGetMutator($key);
-                }
-            )
-        );
-    }
-
 
     /**
      * Add the casted attributes to the attributes array.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3560,6 +3560,7 @@ class DatabaseEloquentModelTest extends TestCase
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
+
                 return Attribute::make(
                     get: fn () => 'Paris',
                 );
@@ -3568,6 +3569,7 @@ class DatabaseEloquentModelTest extends TestCase
             protected function timezone(): Attribute
             {
                 $this->timezoneAccessorCalled = true;
+
                 return Attribute::make(
                     get: fn () => 'Europe/Paris',
                 );
@@ -3595,6 +3597,7 @@ class DatabaseEloquentModelTest extends TestCase
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
+
                 return Attribute::make(
                     get: fn ($value) => 'Paris',
                 );
@@ -3621,6 +3624,7 @@ class DatabaseEloquentModelTest extends TestCase
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
+
                 return Attribute::make(
                     get: fn ($value) => 'Paris',
                 );
@@ -3634,7 +3638,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['id' => 1, 'name' => 'Test'], $array);
     }
 
-    public function testSetOnlyAttributeMutatorDoesNotBreakSerialization() 
+    public function testSetOnlyAttributeMutatorDoesNotBreakSerialization()
     {
         $model = new class extends Model
         {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3549,14 +3549,14 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsNotCalledForNonVisibleAttributes()
     {
-        $model = new class extends Model 
+        $model = new class extends Model
         {
             protected $visible = ['id', 'name'];
             protected $attributes = ['id' => 1, 'name' => 'Test'];
-            
+
             public $locationAccessorCalled = false;
             public $timezoneAccessorCalled = false;
-            
+
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
@@ -3564,7 +3564,7 @@ class DatabaseEloquentModelTest extends TestCase
                     get: fn () => 'Paris',
                 );
             }
-            
+
             protected function timezone(): Attribute
             {
                 $this->timezoneAccessorCalled = true;
@@ -3573,9 +3573,9 @@ class DatabaseEloquentModelTest extends TestCase
                 );
             }
         };
-        
+
         $array = $model->toArray();
-        
+
         $this->assertFalse($model->locationAccessorCalled, 'Location accessor should not be called for non-visible attributes');
         $this->assertFalse($model->timezoneAccessorCalled, 'Timezone accessor should not be called for non-visible attributes');
         $this->assertArrayNotHasKey('location', $array);
@@ -3585,13 +3585,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsCalledForVisibleAttributes()
     {
-        $model = new class extends Model 
+        $model = new class extends Model
         {
             protected $visible = ['id', 'name', 'location'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'location' => 'original'];
-            
+
             public $locationAccessorCalled = false;
-            
+
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
@@ -3600,9 +3600,9 @@ class DatabaseEloquentModelTest extends TestCase
                 );
             }
         };
-        
+
         $array = $model->toArray();
-        
+
         $this->assertTrue($model->locationAccessorCalled, 'Location accessor should be called for visible attributes');
         $this->assertArrayHasKey('location', $array);
         $this->assertEquals('Paris', $array['location']);
@@ -3611,13 +3611,13 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsNotCalledForHiddenAttributes()
     {
-        $model = new class extends Model 
+        $model = new class extends Model
         {
             protected $hidden = ['location'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'location' => 'original'];
-            
+
             public $locationAccessorCalled = false;
-            
+
             protected function location(): Attribute
             {
                 $this->locationAccessorCalled = true;
@@ -3626,9 +3626,9 @@ class DatabaseEloquentModelTest extends TestCase
                 );
             }
         };
-        
+
         $array = $model->toArray();
-        
+
         $this->assertFalse($model->locationAccessorCalled, 'Location accessor should not be called for hidden attributes');
         $this->assertArrayNotHasKey('location', $array);
         $this->assertEquals(['id' => 1, 'name' => 'Test'], $array);
@@ -3636,7 +3636,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testSetOnlyAttributeMutatorDoesNotBreakSerialization() 
     {
-        $model = new class extends Model 
+        $model = new class extends Model
         {
             protected $visible = ['id', 'name', 'foo'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'foo' => 'ORIGINAL'];

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3663,6 +3663,27 @@ class DatabaseEloquentModelTest extends TestCase
         // Should not crash and should still include the "foo" attribute.
         $this->assertArrayHasKey('foo', $array);
     }
+
+    public function testHiddenAttributeAccessorIsNotInvokedDuringSerialization()
+    {
+        $model = new class extends Model
+        {
+            protected $hidden = ['dangerous'];
+
+            protected function dangerous(): Attribute
+            {
+                return Attribute::make(
+                    get: function () {
+                        throw new \RuntimeException('Hidden attribute accessor should not be invoked');
+                    }
+                );
+            }
+        };
+
+        $array = $model->toArray();
+
+        $this->assertArrayNotHasKey('dangerous', $array);
+    }
 }
 
 class CustomBuilder extends Builder

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3549,7 +3549,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsNotCalledForNonVisibleAttributes()
     {
-        $model = new class extends Model {
+        $model = new class extends Model 
+        {
             protected $visible = ['id', 'name'];
             protected $attributes = ['id' => 1, 'name' => 'Test'];
             
@@ -3584,7 +3585,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsCalledForVisibleAttributes()
     {
-        $model = new class extends Model {
+        $model = new class extends Model 
+        {
             protected $visible = ['id', 'name', 'location'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'location' => 'original'];
             
@@ -3609,7 +3611,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testAccessorsNotCalledForHiddenAttributes()
     {
-        $model = new class extends Model {
+        $model = new class extends Model 
+        {
             protected $hidden = ['location'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'location' => 'original'];
             
@@ -3633,7 +3636,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testSetOnlyAttributeMutatorDoesNotBreakSerialization() 
     {
-        $model = new class extends Model {
+        $model = new class extends Model 
+        {
             protected $visible = ['id', 'name', 'foo'];
             protected $attributes = ['id' => 1, 'name' => 'Test', 'foo' => 'ORIGINAL'];
 


### PR DESCRIPTION
When serializing models to arrays/JSON, Eloquent currently considers _all_ Attribute-based accessors via `getMutatedAttributes()`, even for attributes that are not arrayable (hidden or not visible).

This can:

- Invoke accessors that will never appear in the serialized output,
- Trigger unnecessary work, and
- Cause unexpected exceptions when those accessors touch unloaded relationships or other states.

### Changes

- `attributesToArray()` now derives mutated attributes only from the model's **arrayable** attributes via a new helper:

```php
protected function getArrayableMutatedAttributes(array $attributes): array
{
	return array_values(array_filter(array_keys($attributes), function ($key) {
		return $this->hasAnyGetMutator($key);
	}));
}
```
- `mutateAttributeForArray()`:
    - Applies class casts first,
    - Uses `Attribute`-based get mutators when `hasAttributeGetMutator()` is true (and serializes `DateTimeInterface` values),
    - Falls back to legacy `getFooAttribute` mutators.
- `getAttributeMarkedMutatorMethods()` no longer invokes Attribute methods; it only inspects their return types to see if they return `Attribute`.
- `hasAttributeGetMutator()` now lazily resolves and caches the presence of a `get` closure, and only invokes the underlying method when required.

### Behavior
- `toArray()`/`toJson()` now invoke Attribute accessors **only** for attributes that:
    - are arrayable for that instance, and
    - define a get mutator (legacy or Attribute-based)
- Hidden / non-visible Attribute accessors are no longer executed as a side-effect of serialization.
- Set-only `Attribute` mutators (no `get`) continue to work as before and are not treated as get mutators.

### Tests
Added tests to `DatabaseEloquentModelTest`:
- 	`testAccessorsNotCalledForNonVisibleAttributes`
- `testAccessorsCalledForVisibleAttributes`
- `testAccessorsNotCalledForHiddenAttributes`
- `testSetOnlyAttributeMutatorDoesNotBreakSerialization`

These ensure that only visible/arrayable attributes trigger Attribute accessors during `toArray()`.

Fixes #55067 