### PR TITLE
[12.x] Add support for Enums in Translator replacements

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 class Translator extends NamespacedItemResolver implements TranslatorContract
 {
     use Macroable, ReflectsClosures;
@@ -285,8 +287,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 continue;
             }
 
-            if (is_object($value) && isset($this->stringableHandlers[get_class($value)])) {
-                $value = call_user_func($this->stringableHandlers[get_class($value)], $value);
+            if (is_object($value)) {
+                $value = isset($this->stringableHandlers[get_class($value)])
+                    ? call_user_func($this->stringableHandlers[get_class($value)], $value)
+                    : enum_value($value);
             }
 
             $shouldReplace[':'.Str::ucfirst($key)] = Str::ucfirst($value ?? '');

--- a/tests/Translation/Fixtures/Enums/Bar.php
+++ b/tests/Translation/Fixtures/Enums/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Translation\Fixtures\Enums;
+
+enum Bar: int
+{
+    case Thirteen = 13;
+}

--- a/tests/Translation/Fixtures/Enums/Baz.php
+++ b/tests/Translation/Fixtures/Enums/Baz.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Translation\Fixtures\Enums;
+
+enum Baz: string
+{
+    case February = 'February';
+}

--- a/tests/Translation/Fixtures/Enums/Foo.php
+++ b/tests/Translation/Fixtures/Enums/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Translation\Fixtures\Enums;
+
+enum Foo
+{
+    case Hosni;
+}

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -5,6 +5,9 @@ namespace Illuminate\Tests\Translation;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Tests\Translation\Fixtures\Enums\Bar;
+use Illuminate\Tests\Translation\Fixtures\Enums\Baz;
+use Illuminate\Tests\Translation\Fixtures\Enums\Foo;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use Mockery as m;
@@ -280,6 +283,35 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame(
             'the date is 1st Jan 1970',
             $t->get('test', ['date' => $date])
+        );
+    }
+
+    public function testGetJsonReplacesWithEnums()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()
+            ->shouldReceive('load')
+            ->once()
+            ->with('en', '*', '*')
+            ->andReturn([
+                'string_backed_enum' => 'Laravel 12 was released in :month 2025',
+                'int_backed_enum' => 'Stay tuned for Laravel v:version',
+                'unit_enum' => ':person gets excited about every new Laravel release',
+            ]);
+
+        $this->assertSame(
+            'Laravel 12 was released in February 2025',
+            $t->get('string_backed_enum', ['month' => Baz::February])
+        );
+
+        $this->assertSame(
+            'Stay tuned for Laravel v13',
+            $t->get('int_backed_enum', ['version' => Bar::Thirteen])
+        );
+
+        $this->assertSame(
+            'Hosni gets excited about every new Laravel release',
+            $t->get('unit_enum', ['person' => Foo::Hosni])
         );
     }
 


### PR DESCRIPTION
This PR adds support for using PHP Enums as values in the translator’s replacement array.

Right now, if an Enum is passed to the `replaces` array, the translator tries to treat the Enum object as a string. That causes a `TypeError` when `mb_substr()` is called. For example:

```
{
    "class": "TypeError",
    "message": "mb_substr(): Argument #1 ($string) must be of type string, App\\Enums\\UserStatus given",
    "file": "/vendor/laravel/framework/src/Illuminate/Support/Str.php:1718"
}
```
Because of:
https://github.com/laravel/framework/blob/eb1434958643431980547eb7eee0fa860d1cbac6/src/Illuminate/Translation/Translator.php#L292-L293


The change updates `Translator::makeReplacements()` so that Enum values are converted to their underlying value before the replacement logic runs. This brings Enum handling in line with how other simple value types are treated.

Tests are included for string-backed, int-backed, and unit Enums.

No breaking changes.
