### PR TITLE
[12.x] Command typed arguments and options via service container contextual attribute dependency injection

### DIFF
--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -3,17 +3,16 @@
 namespace Illuminate\Console\Attributes;
 
 use Attribute;
-use InvalidArgumentException;
 use Illuminate\Console\Command;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Argument extends Input
 {
     /**
-     * @param \Illuminate\Console\Command $command
+     * @param  \Illuminate\Console\Command  $command
      *
      * @throws \InvalidArgumentException when neither an option nor an argument
-     *                                   with give key exists and no default value was given 
+     *                                   with give key exists and no default value was given
      */
     protected function getInput(Command $command, string $parameter)
     {

--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Console\Attributes;
 
+use Attribute;
 use InvalidArgumentException;
 use Illuminate\Console\Command;
 
+#[Attribute(Attribute::TARGET_PARAMETER)]
 class Argument extends Input
 {
     /**

--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -15,7 +15,7 @@ class Argument extends Input
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given 
      */
-    private function getInput(Command $command, string $parameter)
+    protected function getInput(Command $command, string $parameter)
     {
         return $command->argument($parameter);
     }

--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use InvalidArgumentException;
+use Illuminate\Console\Command;
+
+class Argument extends Input
+{
+    /**
+     * @param \Illuminate\Console\Command $command
+     *
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     */
+    private function getInput(Command $command, string $parameter)
+    {
+        return $command->argument($parameter);
+    }
+}

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Console\Attributes;
 
 use Illuminate\Console\Command;
-use ReflectionParameter;
 use ReflectionIntersectionType;
 use ReflectionNamedType;
+use ReflectionParameter;
 use ReflectionType;
 use ReflectionUnionType;
 use TypeError;
@@ -32,7 +32,7 @@ abstract class Input
         if (! $attribute->checkType($type, $input)) {
             throw new TypeError(sprintf('"%s" is not of type string. %s given', $attribute->parameter, get_debug_type($input)));
         }
-      
+
         return $input;
     }
 
@@ -46,7 +46,7 @@ abstract class Input
     }
 
     /**
-     * @param \Illuminate\Console\Command $command
+     * @param  \Illuminate\Console\Command  $command
      *
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use ReflectionParameter;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+abstract class Input
+{
+    public function __construct(public string $parameter)
+    {
+    }
+
+    /**
+     * Resolve the input.
+     *
+     * @param  self  $attribute
+     * @return mixed
+     *
+     * @throws \TypeError on type mismatch
+     */
+    public static function resolve(self $attribute, ReflectionParameter $parameter)
+    {
+        $input = $attribute->getInput();
+        $type = $parameter->getType();
+
+        if (! $this->checkType($type, $input)) {
+            throw new TypeError(sprintf('"%s" is not of type string. %s given', $attribute->parameter, get_debug_type($input)));
+        }
+      
+        return $input;
+    }
+
+    private function checkType(ReflectionType $expectedType, $actualValue): bool
+    {
+        return match (true) {
+            $expectedType instanceof ReflectionIntersectionType => array_all($expectedType->getTypes(), $this->checkType(...)),
+            $expectedType instanceof ReflectionUnionType => array_any($expectedType->getTypes(), $this->checkType(...)),
+            $expectedType instanceof ReflectionNamedType => class_exists($expectedType) ? $actualValue instanceof $expectedType : get_debug_type($actualValue) === $expectedType->getName(),
+        };
+    }
+
+    /**
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     */
+    abstract private function getInput();
+}

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -8,6 +8,7 @@ use ReflectionIntersectionType;
 use ReflectionNamedType;
 use ReflectionType;
 use ReflectionUnionType;
+use TypeError;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 abstract class Input

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Attributes;
 
-use Attribute;
 use Illuminate\Console\Command;
 use ReflectionParameter;
 use ReflectionIntersectionType;
@@ -11,7 +10,6 @@ use ReflectionType;
 use ReflectionUnionType;
 use TypeError;
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
 abstract class Input
 {
     public function __construct(public string $parameter)

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -28,7 +28,7 @@ abstract class Input
      */
     public static function resolve(self $attribute, Command $command, ReflectionParameter $parameter)
     {
-        $input = $attribute->getInput($command);
+        $input = $attribute->getInput($command, $attribute->parameter);
         $type = $parameter->getType();
 
         if (! $this->checkType($type, $input)) {
@@ -53,5 +53,5 @@ abstract class Input
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given
      */
-    abstract private function getInput(Command $command);
+    abstract private function getInput(Command $command, string $parameter);
 }

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -29,7 +29,7 @@ abstract class Input
         $input = $attribute->getInput($command, $attribute->parameter);
         $type = $parameter->getType();
 
-        if (! $this->checkType($type, $input)) {
+        if (! $attribute->checkType($type, $input)) {
             throw new TypeError(sprintf('"%s" is not of type string. %s given', $attribute->parameter, get_debug_type($input)));
         }
       

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Attributes;
 
 use Attribute;
+use Illuminate\Console\Command;
 use ReflectionParameter;
 use ReflectionIntersectionType;
 use ReflectionNamedType;
@@ -25,9 +26,9 @@ abstract class Input
      *
      * @throws \TypeError on type mismatch
      */
-    public static function resolve(self $attribute, ReflectionParameter $parameter)
+    public static function resolve(self $attribute, Command $command, ReflectionParameter $parameter)
     {
-        $input = $attribute->getInput();
+        $input = $attribute->getInput($command);
         $type = $parameter->getType();
 
         if (! $this->checkType($type, $input)) {
@@ -47,8 +48,10 @@ abstract class Input
     }
 
     /**
+     * @param \Illuminate\Console\Command $command
+     *
      * @throws \InvalidArgumentException when neither an option nor an argument
-     *                                   with give key exists and no default value was given 
+     *                                   with give key exists and no default value was given
      */
-    abstract private function getInput();
+    abstract private function getInput(Command $command);
 }

--- a/src/Illuminate/Console/Attributes/Input.php
+++ b/src/Illuminate/Console/Attributes/Input.php
@@ -51,5 +51,5 @@ abstract class Input
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given
      */
-    abstract private function getInput(Command $command, string $parameter);
+    abstract protected function getInput(Command $command, string $parameter);
 }

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use InvalidArgumentException;
+use Illuminate\Console\Command;
+
+class Option extends Input
+{
+    /**
+     * @param \Illuminate\Console\Command $command
+     *
+     * @throws \InvalidArgumentException when neither an option nor an argument
+     *                                   with give key exists and no default value was given 
+     */
+    private function getInput(Command $command, string $parameter)
+    {
+        return $command->option($parameter);
+    }
+}

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -3,17 +3,16 @@
 namespace Illuminate\Console\Attributes;
 
 use Attribute;
-use InvalidArgumentException;
 use Illuminate\Console\Command;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Option extends Input
 {
     /**
-     * @param \Illuminate\Console\Command $command
+     * @param  \Illuminate\Console\Command  $command
      *
      * @throws \InvalidArgumentException when neither an option nor an argument
-     *                                   with give key exists and no default value was given 
+     *                                   with give key exists and no default value was given
      */
     protected function getInput(Command $command, string $parameter)
     {

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Console\Attributes;
 
+use Attribute;
 use InvalidArgumentException;
 use Illuminate\Console\Command;
 
+#[Attribute(Attribute::TARGET_PARAMETER)]
 class Option extends Input
 {
     /**

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -15,7 +15,7 @@ class Option extends Input
      * @throws \InvalidArgumentException when neither an option nor an argument
      *                                   with give key exists and no default value was given 
      */
-    private function getInput(Command $command, string $parameter)
+    protected function getInput(Command $command, string $parameter)
     {
         return $command->option($parameter);
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Attributes\Input;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Traits\Macroable;
+use ReflectionAttribute;
 use ReflectionMethod;
 use ReflectionParameter;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -218,8 +219,16 @@ class Command extends SymfonyCommand
                     return $carry;
                 }
 
-                $instance = $attributes->newInstance();
-                return [ ...$carry, $parameter->getName() => $instance::resolve($instance, $this, $parameter) ];
+                return [
+                    ...$carry,
+                    array_reduce(
+                        $attributes,
+                        fn (array $carry, ReflectionAttribute $attribute) => [
+                            ...$carry,
+                            $parameter->getName() => ($instance = $attribute->newInstance())::resolve($instance, $this, $parameter),
+                        ],
+                    ),
+                ];
             },
             [],
         );        

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -227,6 +227,7 @@ class Command extends SymfonyCommand
                             ...$carry,
                             $parameter->getName() => ($instance = $attribute->newInstance())::resolve($instance, $this, $parameter),
                         ],
+                        [],
                     ),
                 ];
             },

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -231,7 +231,7 @@ class Command extends SymfonyCommand
                 ];
             },
             [],
-        );        
+        );
 
         try {
             return (int) $this->laravel->call([$this, $method], $arguments);

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Console\Attributes\Input;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -5,6 +5,8 @@ namespace Illuminate\Console;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Traits\Macroable;
+use ReflectionMethod;
+use ReflectionParameter;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -232,7 +232,7 @@ class CommandTest extends TestCase
             protected function getArguments()
             {
                 return [
-                    new InputArgument('argument-one', 'o', InputArgument::REQUIRED, 'first test argument'),
+                    new InputArgument('argument-one', InputArgument::REQUIRED, 'first test argument'),
                 ];
             }
         };

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Application;
+use Illuminate\Console\Attributes\Argument;
+use Illuminate\Console\Attributes\Option;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
@@ -214,5 +216,63 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
+    }
+
+    public function testGetArgument()
+    {
+        $command = new class extends Command
+        {
+            public function handle(#[Argument('argument-one')] public int $argumentOne)
+            {
+            }
+
+            protected function getArguments()
+            {
+                return [
+                    new InputArgument('argument-one', 'o', InputArgument::REQUIRED, 'first test argument'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            'argument-one' => 42,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $this->assertSame(42, $command->argumentOne);
+    }
+
+    public function testGetOption()
+    {
+        $command = new class extends Command
+        {
+            public function handle(#[Option('option-one')] public int $optionOne)
+            {
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            '--option-one' => 42,
+        ]);
+        $output = new NullOutput;
+
+        $command->run($input, $output);
+
+        $this->assertSame(42, $command->optionOne);
     }
 }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -222,8 +222,11 @@ class CommandTest extends TestCase
     {
         $command = new class extends Command
         {
-            public function handle(#[Argument('argument-one')] public int $argumentOne)
+            public int $argumentOne;
+
+            public function handle(#[Argument('argument-one')] int $argumentOne)
             {
+                $this->argumentOne = $argumentOne;
             }
 
             protected function getArguments()
@@ -251,8 +254,11 @@ class CommandTest extends TestCase
     {
         $command = new class extends Command
         {
-            public function handle(#[Option('option-one')] public int $optionOne)
+            public int $optionOne;
+
+            public function handle(#[Option('option-one')] int $optionOne)
             {
+                $this->optionOne = $optionOne;
             }
 
             protected function getOptions()


### PR DESCRIPTION
like, for example, with `\Illuminate\Support\Facades\Config` (#50140) and `\Illuminate\Support\Arr` (#55567)

# Enhancements
* return value is typed
* when value has unexpected type, an exception is thrown

# Example
```php
<?php

namespace App\Console\Commands;

use App\Models\User;
use App\Support\DripEmailer;
use Illuminate\Console\Command;
 
class SendEmails extends Command
{
    protected $signature = 'mail:send {user} {--flag} {--subject=} {--cc=*}';
    protected $description = 'Send a marketing email to a user';
 
    /**
     * Execute the console command.
     * 
     * @param int[] $cc
     */
    public function handle(
        #[Argument('user')] int $userId,
        #[Option('flag') bool $flag,
        #[Option('cc') array $cc,
        #[Option('subject') string $subject = 'Default subject',
        DripEmailer $drip,
    ): void {
        $user = User::find($userId);
        $cc = User::whereIn('id', $cc)->get();

        if ($flag) {
            // do something
        }

        $drip->send($user, $cc, $subject);
    }
}
```