### PR TITLE
[12.x] Fix transaction control in HTTP Tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use BackedEnum;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Uri;
@@ -365,7 +366,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        $testResponse = $this->call('GET', $uri, [], $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -378,7 +383,11 @@ trait MakesHttpRequests
      */
     public function getJson($uri, array $headers = [], $options = 0)
     {
-        return $this->json('GET', $uri, [], $headers, $options);
+        $testResponse = $this->json('GET', $uri, [], $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -394,7 +403,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('POST', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('POST', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -408,7 +421,11 @@ trait MakesHttpRequests
      */
     public function postJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('POST', $uri, $data, $headers, $options);
+        $testResponse = $this->json('POST', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -424,7 +441,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PUT', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('PUT', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -438,7 +459,11 @@ trait MakesHttpRequests
      */
     public function putJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PUT', $uri, $data, $headers, $options);
+        $testResponse = $this->json('PUT', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -454,7 +479,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PATCH', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('PATCH', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -468,7 +497,11 @@ trait MakesHttpRequests
      */
     public function patchJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PATCH', $uri, $data, $headers, $options);
+        $testResponse = $this->json('PATCH', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -484,7 +517,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('DELETE', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('DELETE', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -498,7 +535,11 @@ trait MakesHttpRequests
      */
     public function deleteJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('DELETE', $uri, $data, $headers, $options);
+        $testResponse = $this->json('DELETE', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -515,7 +556,11 @@ trait MakesHttpRequests
 
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -529,7 +574,11 @@ trait MakesHttpRequests
      */
     public function optionsJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('OPTIONS', $uri, $data, $headers, $options);
+        $testResponse = $this->json('OPTIONS', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -545,7 +594,11 @@ trait MakesHttpRequests
 
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('HEAD', $uri, [], $cookies, [], $server);
+        $testResponse = $this->call('HEAD', $uri, [], $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -762,5 +815,24 @@ trait MakesHttpRequests
                     : new LoggedExceptionCollection
             );
         });
+    }
+
+    protected function resetDatabaseTransactionLevelToOne()
+    {
+        $uses = $this->traitsUsedByTest ?? array_flip(class_uses_recursive(static::class));
+
+        if (! isset($uses[DatabaseTransactions::class])) {
+            return;
+        }
+
+        $databaseManager = $this->app['db'];
+
+        $connections = $this->connectionsToTransact();
+
+        foreach ($connections as $connectionName) {
+            if ($databaseManager->connection($connectionName)->transactionLevel() > 1) {
+                $databaseManager->connection($connectionName)->rollBack(1);
+            }
+        }
     }
 }

--- a/tests/Integration/Foundation/Testing/Concerns/MakeHttpRequestsWithDatabaseTransactionTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/MakeHttpRequestsWithDatabaseTransactionTest.php
@@ -1,0 +1,619 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Testing\Concerns;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class MakeHttpRequestsWithDatabaseTransactionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    public function test_it_can_make_get_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->get('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_get_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->get('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_get_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->getJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_get_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->getJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_post_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->post('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_post_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->post('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_post_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->postJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_post_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->postJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_put_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->put('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_put_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->put('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_put_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->putJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_put_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->putJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_patch_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->patch('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_patch_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->patch('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_patch_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->patchJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_patch_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->patchJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_delete_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->delete('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_delete_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->delete('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_delete_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->deleteJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_delete_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->deleteJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_options_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->options('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_options_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->options('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_options_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->optionsJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_options_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->optionsJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_head_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+        });
+
+        $testResponse = $this->head('test-route');
+
+        $testResponse->assertSuccessful();
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+}


### PR DESCRIPTION
# Transaction Control in HTTP Tests

## 📋 Overview

This feature adds automatic database transaction control during HTTP tests when the `DatabaseTransactions` trait is used. The implementation ensures that the transaction level is always reset to 1 after each HTTP request in tests, avoiding issues with uncommitted nested transactions.

## 🔧 Technical Changes

### Modified Files

#### 1. `src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php`

**New Method Added:**

```php
protected function resetDatabaseTransactionLevelToOne()
{
    $uses = $this->traitsUsedByTest ?? array_flip(class_uses_recursive(static::class));

    if (! isset($uses[DatabaseTransactions::class])) {
        return;
    }

    $databaseManager = $this->app['db'];
    $connections = $this->connectionsToTransact();

    foreach ($connections as $connectionName) {
        if ($databaseManager->connection($connectionName)->transactionLevel() > 1) {
            $databaseManager->connection($connectionName)->rollBack(1);
        }
    }
}
```

**Updated HTTP Methods:**

All HTTP methods in the trait have been updated to call `resetDatabaseTransactionLevelToOne()` after executing the request:

- `get()`
- `getJson()`
- `post()`
- `postJson()`
- `put()`
- `putJson()`
- `patch()`
- `patchJson()`
- `delete()`
- `deleteJson()`
- `options()`
- `optionsJson()`
- `head()`

**Implementation Example:**

```php
public function get($uri, array $headers = [])
{
    $server = $this->transformHeadersToServerVars($headers);
    $cookies = $this->prepareCookiesForRequest();

    $testResponse = $this->call('GET', $uri, [], $cookies, [], $server);

    $this->resetDatabaseTransactionLevelToOne();

    return $testResponse;
}
```

#### 2. `tests/Integration/Foundation/Testing/Concerns/MakeHttpRequestsWithDatabaseTransactionTest.php` (New File)

Complete test file with 620 lines containing 22 test scenarios covering:

- All HTTP methods (GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD)
- JSON variants of each method
- Scenarios with transaction without commit
- Scenarios with transaction with commit

## 🎯 Problem Solved

### Before Changes

When you used the `DatabaseTransactions` trait in your tests and made HTTP requests that started new transactions (with `DB::beginTransaction()`), the framework did not properly manage the nested transaction level. This caused:

1. **Uncommitted nested transactions:** If application code started a transaction but didn't commit or rollback, that transaction remained "hanging"
2. **Inconsistent state:** Transaction level remained greater than 1 after the request
3. **Unpredictable tests:** Depending on whether the code committed or not, data could be persisted unexpectedly

**Example of the Problem:**

```php
class UserTest extends TestCase
{
    use DatabaseTransactions;

    public function test_create_user()
    {
        Route::post('users', function () {
            DB::beginTransaction();  // Starts nested transaction (level 2)
            
            User::create(['name' => 'John']);
            
            // Forgot to commit or rollback!
            return response()->json(['success' => true]);
        });

        $response = $this->postJson('users');
        
        // Problem: transaction is still at level 2
        // User was not saved, but test may fail confusingly
        $this->assertDatabaseMissing('users', ['name' => 'John']); // ❌ Fails
    }
}
```

### After Changes

The framework now automatically detects and resets nested transactions to level 1 after each HTTP request, ensuring that:

1. **Uncommitted transactions are rolled back:** Automatic rollback to level 1
2. **Committed transactions persist:** If code committed, data is saved
3. **Predictable behavior:** Test always starts each request with clean transaction level

**Same Example, Now Working:**

```php
class UserTest extends TestCase
{
    use DatabaseTransactions;

    public function test_create_user_without_commit()
    {
        Route::post('users', function () {
            DB::beginTransaction();
            
            User::create(['name' => 'John']);
            
            // Did not commit
            return response()->json(['success' => true]);
        });

        $response = $this->postJson('users');
        
        // ✅ Transaction reset to level 1 automatically
        // ✅ Nested transaction rollback was executed
        $this->assertDatabaseMissing('users', ['name' => 'John']); // ✅ Passes
    }
}
```

## ✅ Why It Doesn't Break Existing Features

### 1. **Full Backward Compatibility**

The feature is **opt-in** through the `DatabaseTransactions` trait:

- **If you don't use `DatabaseTransactions`:** Nothing changes. Behavior is exactly the same.
- **If you use `DatabaseTransactions`:** Feature only adds additional behavior that improves transaction management.

```php
// Test WITHOUT DatabaseTransactions - no changes
class SimpleTest extends TestCase
{
    public function test_something()
    {
        $this->get('/'); // Behavior unchanged
    }
}

// Test WITH DatabaseTransactions - feature enabled
class TransactionalTest extends TestCase
{
    use DatabaseTransactions; // Feature enabled here
    
    public function test_something()
    {
        $this->get('/'); // Now with transaction management
    }
}
```

### 2. **Only Fixes Problematic Behavior**

The feature doesn't change expected behavior, it only fixes a bug where nested transactions weren't managed correctly. Previous behavior was inconsistent and caused hard-to-debug bugs.

### 3. **Respects Explicit Commits**

If application code explicitly commits, the feature respects that decision:

```php
// Commits still work normally
DB::beginTransaction();
User::create(['name' => 'Test']);
DB::commit(); // ✅ Respected - data is saved
```

### 4. **Doesn't Interfere with Level 1 Transactions**

Feature only acts when there are nested transactions (level > 1). The main transaction from `DatabaseTransactions` (level 1) remains intact:

```php
// Level 1: managed by DatabaseTransactions trait
// Level 2+: managed by new feature
```
