### PR TITLE
[12.x] Fix opened transaction in HTTP tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use BackedEnum;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Uri;
@@ -365,7 +366,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        $testResponse = $this->call('GET', $uri, [], $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -378,7 +383,11 @@ trait MakesHttpRequests
      */
     public function getJson($uri, array $headers = [], $options = 0)
     {
-        return $this->json('GET', $uri, [], $headers, $options);
+        $testResponse = $this->json('GET', $uri, [], $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -394,7 +403,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('POST', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('POST', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -408,7 +421,11 @@ trait MakesHttpRequests
      */
     public function postJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('POST', $uri, $data, $headers, $options);
+        $testResponse = $this->json('POST', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -424,7 +441,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PUT', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('PUT', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -438,7 +459,11 @@ trait MakesHttpRequests
      */
     public function putJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PUT', $uri, $data, $headers, $options);
+        $testResponse = $this->json('PUT', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -454,7 +479,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PATCH', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('PATCH', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -468,7 +497,11 @@ trait MakesHttpRequests
      */
     public function patchJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PATCH', $uri, $data, $headers, $options);
+        $testResponse = $this->json('PATCH', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -484,7 +517,11 @@ trait MakesHttpRequests
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('DELETE', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('DELETE', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -498,7 +535,11 @@ trait MakesHttpRequests
      */
     public function deleteJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('DELETE', $uri, $data, $headers, $options);
+        $testResponse = $this->json('DELETE', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -515,7 +556,11 @@ trait MakesHttpRequests
 
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
+        $testResponse = $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -529,7 +574,11 @@ trait MakesHttpRequests
      */
     public function optionsJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('OPTIONS', $uri, $data, $headers, $options);
+        $testResponse = $this->json('OPTIONS', $uri, $data, $headers, $options);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -545,7 +594,11 @@ trait MakesHttpRequests
 
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('HEAD', $uri, [], $cookies, [], $server);
+        $testResponse = $this->call('HEAD', $uri, [], $cookies, [], $server);
+
+        $this->resetDatabaseTransactionLevelToOne();
+
+        return $testResponse;
     }
 
     /**
@@ -762,5 +815,24 @@ trait MakesHttpRequests
                     : new LoggedExceptionCollection
             );
         });
+    }
+
+    protected function resetDatabaseTransactionLevelToOne()
+    {
+        $uses = $this->traitsUsedByTest ?? array_flip(class_uses_recursive(static::class));
+
+        if (! isset($uses[DatabaseTransactions::class])) {
+            return;
+        }
+
+        $databaseManager = $this->app['db'];
+
+        $connections = $this->connectionsToTransact();
+
+        foreach ($connections as $connectionName) {
+            if ($databaseManager->connection($connectionName)->transactionLevel() > 1) {
+                $databaseManager->connection($connectionName)->rollBack(1);
+            }
+        }
     }
 }

--- a/tests/Integration/Foundation/Testing/Concerns/MakeHttpRequestsWithDatabaseTransactionTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/MakeHttpRequestsWithDatabaseTransactionTest.php
@@ -1,0 +1,619 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Testing\Concerns;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class MakeHttpRequestsWithDatabaseTransactionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    public function test_it_can_make_get_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->get('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_get_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->get('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_get_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->getJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_get_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->getJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_post_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->post('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_post_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->post('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_post_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->postJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_post_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->post('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->postJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_put_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->put('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_put_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->put('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_put_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->putJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_put_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->put('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->putJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_patch_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->patch('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_patch_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->patch('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_patch_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->patchJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_patch_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->patch('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->patchJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_delete_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->delete('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_delete_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->delete('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_delete_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->deleteJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_delete_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->delete('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->deleteJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_options_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return 'ok';
+        });
+
+        $testResponse = $this->options('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_options_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return 'ok';
+        });
+
+        $testResponse = $this->options('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertSee('ok');
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_options_json_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->optionsJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+
+    public function test_it_can_make_options_json_method_request_with_database_transaction_and_commit()
+    {
+        $this->app['router']->options('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+
+            DB::commit();
+
+            return ['message' => 'ok'];
+        });
+
+        $testResponse = $this->optionsJson('test-route');
+
+        $testResponse
+            ->assertSuccessful()
+            ->assertJson(['message' => 'ok']);
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 1);
+    }
+
+    public function test_it_can_make_head_method_request_with_database_transaction_without_commit()
+    {
+        $this->app['router']->get('test-route', function () {
+            DB::beginTransaction();
+
+            DB::table('test_table')->insert([
+                'name' => 'test',
+            ]);
+        });
+
+        $testResponse = $this->head('test-route');
+
+        $testResponse->assertSuccessful();
+
+        $this->assertEquals(1, DB::transactionLevel());
+
+        $this->assertDatabaseCount('test_table', 0);
+    }
+}


### PR DESCRIPTION
## Overview

This pull request adds automatic database transaction control during HTTP tests when the `DatabaseTransactions` trait is used. The implementation ensures that the transaction level is always reset to 1 after each HTTP request in the tests, preventing issues with uncommitted nested transactions. This makes the test scenario more aligned with a real-world scenario where the transaction is rolled back when a "response" is returned.

## Before Changes

**api.php**
```php
Route::post('users', function () {
    DB::beginTransaction();  // Starts nested transaction (level 2)
    
    User::create(['name' => 'John']);
    
    // Forgot to commit or rollback!
    return response()->json(['success' => true]);
});
```

**UserTest.php**
```php
class UserTest extends TestCase
{
    use DatabaseTransactions;

    public function test_create_user()
    {
        $response = $this->postJson('/api/users');
        
        // Problem: transaction is still at level 2
        $this->assertDatabaseMissing('users', ['name' => 'John']); // Fails
    }
}
```

## After Changes

**api.php**
```php
Route::post('users', function () {
    DB::beginTransaction();  // Starts nested transaction (level 2)
    
    User::create(['name' => 'John']);
    
    // Forgot to commit or rollback!
    return response()->json(['success' => true]);
});
```

**UserTest.php**
```php
class UserTest extends TestCase
{
    use DatabaseTransactions;

    public function test_create_user_without_commit()
    {
        $response = $this->postJson('/api/users');
        
        // Transaction reset to level 1 automatically
        // Nested transaction rollback was executed
        $this->assertDatabaseMissing('users', ['name' => 'John']); // Passes
    }
}
```

## Reference links

[PHP documentation - PDO Transactions](https://www.php.net/manual/en/pdo.transactions.php)
