### PR TITLE
[12.x] `PendingRequest@withAttributes()`

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -27,6 +27,13 @@ class Request implements ArrayAccess
     protected $data;
 
     /**
+     * The contextual data passed when building the PendingRequest.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected $requestContext = [];
+
+    /**
      * Create a new request instance.
      *
      * @param  \Psr\Http\Message\RequestInterface  $request
@@ -242,6 +249,29 @@ class Request implements ArrayAccess
         $this->data = $data;
 
         return $this;
+    }
+
+    /**
+     * Set the request's context data.
+     *
+     * @param  array<array-key, mixed>  $context
+     * @return $this
+     */
+    public function setRequestContext($context)
+    {
+        $this->requestContext = $context;
+
+        return $this;
+    }
+
+    /**
+     * Get the contextual data from the request.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function requestContext()
+    {
+        return $this->requestContext;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -27,11 +27,11 @@ class Request implements ArrayAccess
     protected $data;
 
     /**
-     * The contextual data passed when building the PendingRequest.
+     * The attribute data passed when building the PendingRequest.
      *
      * @var array<array-key, mixed>
      */
-    protected $requestContext = [];
+    protected $attributes = [];
 
     /**
      * Create a new request instance.
@@ -252,26 +252,26 @@ class Request implements ArrayAccess
     }
 
     /**
-     * Set the request's context data.
-     *
-     * @param  array<array-key, mixed>  $context
-     * @return $this
-     */
-    public function setRequestContext($context)
-    {
-        $this->requestContext = $context;
-
-        return $this;
-    }
-
-    /**
-     * Get the contextual data from the request.
+     * Get the attribute data from the request.
      *
      * @return array<array-key, mixed>
      */
-    public function requestContext()
+    public function attributes()
     {
-        return $this->requestContext;
+        return $this->attributes;
+    }
+
+    /**
+     * Set the request's attribute data.
+     *
+     * @param  array<array-key, mixed>  $attributes
+     * @return $this
+     */
+    public function setRequestAttributes($attributes)
+    {
+        $this->attributes = $attributes;
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Http/HttpClientTest.php
+++ b/tests/Integration/Http/HttpClientTest.php
@@ -89,20 +89,20 @@ class HttpClientTest extends TestCase
         $this->assertEquals('stub', $r);
     }
 
-    public function testCanSetRequestContext()
+    public function testCanSetRequestAttributes()
     {
         Http::fake([
-            '*' => fn (Request $request) => match($request->requestContext()['name'] ?? null) {
+            '*' => fn (Request $request) => match($request->attributes()['name'] ?? null) {
                 'first' => Http::response('first response'),
                 'second' => Http::response('second response'),
                 default => Http::response('unnamed')
             }
         ]);
 
-        $response1 = Http::withRequestContext(['name' => 'first'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
-        $response2 = Http::withRequestContext(['name' => 'second'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
+        $response1 = Http::withAttributes(['name' => 'first'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
+        $response2 = Http::withAttributes(['name' => 'second'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
         $response3 = Http::get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
-        $response4 = Http::withRequestContext(['name' => 'fourth'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
+        $response4 = Http::withAttributes(['name' => 'fourth'])->get('https://some-store.myshopify.com/admin/api/2025-10/graphql.json');
 
         $this->assertEquals('first response', $response1->body());
         $this->assertEquals('second response', $response2->body());


### PR DESCRIPTION
I had tried this previously in https://github.com/laravel/framework/pull/57944 but now I have a slightly different reason for needing it. Here we are just passing it to the Request object, and my vision is that we would use this for essentially naming the call.

## Why
The company I work for integrates with Shopify's GraphQL API. Every request [hits the same endpoint](https://shopify.dev/docs/api/admin-graphql/latest#endpoints-and-queries), and as such, writing unit tests with stubbed HTTP responses is no fun, because your best bet is to compare against a string that's in the request... but you sort of have to know what's the most unique string in the GraphQL query. 😿 

### An example
```php
public function test_it_fetches_shops_and_scopes()
{
    Http::fake(['*graphql.json' => function (Request $request) {
            // This is real, real ugly
            $queryPayload = $request->data()['query'] ?? '';
            if (str_contains($queryPayload, 'publicDisplayName')) {
                return Http::response(self::getGetShopQueryResponse());
            }
            if (str_contains($queryPayload, 'currentAppInstallation')) {
                return Http::response(self::getGetShopScopesResponse());
            }
    }]);
    $merchant = new Merchant(
        'domain' => 'my-shop',
        'api-token' => 'top-secret',
    );
    $this->app->make(MyService::class)->handle($merchant);
}
```

Instead, it would be great if we could just kind of "name" our requests, like this:

```php
Http::withAttributes(['name' => 'get_shop'])
    ->post('https://some-store.myshopify.com/admin/api/2025-10/graphql.json', $data);
```

and then inside of the test:

```php
    Http::fake(['*graphql.json' => function (Request $request) {
            // This is less ugly
            $requestContext = $request->attributes()['name'] ?? '';
            if ($requestContext === 'get_shop') {
                return Http::response(self::getGetShopQueryResponse());
            }
            // ...
    }]);
```

## Alternatives
Just create a `requestName` string property. That definitely fits my use case most narrowly, but also, how soon before someone wants to store something else in there? Though that would be really nice because when calling `$pool->as('get_shop')`, that could also set the requestName. 🤷 