### PR TITLE
[12.x] feat: add now methods to Date rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -185,6 +185,14 @@ class Rule
     }
 
     /**
+     * Get a datetime rule builder instance.
+     */
+    public static function dateTime(): Date
+    {
+        return (new Date)->format('Y-m-d H:i:s');
+    }
+
+    /**
      * Get an email rule builder instance.
      *
      * @return \Illuminate\Validation\Rules\Email

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -65,33 +65,33 @@ class Date implements Stringable
     }
 
     /**
-     * Ensure the date is before now.
+     * Ensure the date is in the past.
      */
-    public function beforeNow(): static
+    public function past(): static
     {
         return $this->before('now');
     }
 
     /**
-     * Ensure the date is after now.
+     * Ensure the date is in the future.
      */
-    public function afterNow(): static
+    public function future(): static
     {
         return $this->after('now');
     }
 
     /**
-     * Ensure the date is before or equal to now.
+     * Ensure the date is now or in the past.
      */
-    public function nowOrBefore(): static
+    public function nowOrPast(): static
     {
         return $this->beforeOrEqual('now');
     }
 
     /**
-     * Ensure the date is after or equal to now.
+     * Ensure the date is now or in the future.
      */
-    public function nowOrAfter(): static
+    public function nowOrFuture(): static
     {
         return $this->afterOrEqual('now');
     }

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -65,6 +65,38 @@ class Date implements Stringable
     }
 
     /**
+     * Ensure the date is before now.
+     */
+    public function beforeNow(): static
+    {
+        return $this->before('now');
+    }
+
+    /**
+     * Ensure the date is after now.
+     */
+    public function afterNow(): static
+    {
+        return $this->after('now');
+    }
+
+    /**
+     * Ensure the date is before or equal to now.
+     */
+    public function nowOrBefore(): static
+    {
+        return $this->beforeOrEqual('now');
+    }
+
+    /**
+     * Ensure the date is after or equal to now.
+     */
+    public function nowOrAfter(): static
+    {
+        return $this->afterOrEqual('now');
+    }
+
+    /**
      * Ensure the date is before the given date or date field.
      */
     public function before(DateTimeInterface|string $date): static


### PR DESCRIPTION
Hello!

### Motivation

I just had a bug in production where a developer (me :upside_down_face:) was validating a datetime with:

```php
'request_at'  => [Rule::date()->beforeOrEqual(now())],
```

However, this caused failures when the datetime was the current day and had a time component. The fix was:

```php
'request_at'  => [Rule::date()->beforeOrEqual('now')], // do not use now()
```

which is not very elegant and requires a comment to prevent future develepers from causing a regression. 

Additionally, we have a ton of datetime fields that need to be validated and don't want to have to repeatedly specify `->format('Y-m-d H:i:s')`

### Solution

What I would like is 

```php
'request_at'  => [Rule::date()->andTime()->nowOrBefore()],
```

This adds the following methods to the Date validation rule:
- `beforeNow`
- `afterNow`
- `nowOrBefore`
- `nowOrAfter`
- `andTime`


Thanks!