### PR TITLE
feat: implement 'assertFailedDependency' response assertion

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -222,6 +222,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 424 "Failed Dependency" status code.
+     *
+     * @return $this
+     */
+    public function assertFailedDependency()
+    {
+        return $this->assertStatus(424);
+    }
+
+    /**
      * Assert that the response has a 429 "Too Many Requests" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1087,6 +1087,25 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertFailedDependency(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_FAILED_DEPENDENCY)
+        );
+
+        $response->assertFailedDependency();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [424] but received 200.\nFailed asserting that 200 is identical to 424.");
+
+        $response->assertFailedDependency();
+        $this->fail();
+    }
+
     public function testAssertClientError(): void
     {
         $statusCode = 400;


### PR DESCRIPTION
Introduces an assertion for `HTTP 424` to maintain consistency with existing `TestResponse` status assertion helpers.

