### PR TITLE
[13.x] Remove `Illuminate\Http\Request::get()` override.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -425,21 +425,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
-     *
-     * Instead, you may use the "input" method.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    #[\Override]
-    public function get(string $key, mixed $default = null): mixed
-    {
-        return parent::get($key, $default);
-    }
-
-    /**
      * Get the JSON payload for the request.
      *
      * @param  string|null  $key

--- a/tests/Foundation/Configuration/MiddlewareTest.php
+++ b/tests/Foundation/Configuration/MiddlewareTest.php
@@ -55,8 +55,8 @@ class MiddlewareTest extends TestCase
 
         $request = $middleware->handle($request, fn (Request $request) => $request);
 
-        $this->assertSame('  123  ', $request->get('aaa'));
-        $this->assertNull($request->get('bbb'));
+        $this->assertSame('  123  ', $request->input('aaa'));
+        $this->assertNull($request->input('bbb'));
 
         $symfonyRequest = new SymfonyRequest([
             'aaa' => '  123  ',
@@ -68,8 +68,8 @@ class MiddlewareTest extends TestCase
 
         $request = $middleware->handle($request, fn (Request $request) => $request);
 
-        $this->assertSame('  123  ', $request->get('aaa'));
-        $this->assertSame('', $request->get('bbb'));
+        $this->assertSame('  123  ', $request->input('aaa'));
+        $this->assertSame('', $request->input('bbb'));
 
         $symfonyRequest = new SymfonyRequest([
             'aaa' => '  123  ',
@@ -81,8 +81,8 @@ class MiddlewareTest extends TestCase
 
         $request = $middleware->handle($request, fn (Request $request) => $request);
 
-        $this->assertSame('  123  ', $request->get('aaa'));
-        $this->assertSame('', $request->get('bbb'));
+        $this->assertSame('  123  ', $request->input('aaa'));
+        $this->assertSame('', $request->input('bbb'));
     }
 
     public function testTrimStrings()
@@ -105,9 +105,9 @@ class MiddlewareTest extends TestCase
 
         $request = $middleware->handle($request, fn (Request $request) => $request);
 
-        $this->assertSame('  123  ', $request->get('aaa'));
-        $this->assertSame('456', $request->get('bbb'));
-        $this->assertSame('789', $request->get('ccc'));
+        $this->assertSame('  123  ', $request->input('aaa'));
+        $this->assertSame('456', $request->input('bbb'));
+        $this->assertSame('789', $request->input('ccc'));
 
         $symfonyRequest = new SymfonyRequest([
             'aaa' => '  123  ',
@@ -120,9 +120,9 @@ class MiddlewareTest extends TestCase
 
         $request = $middleware->handle($request, fn (Request $request) => $request);
 
-        $this->assertSame('  123  ', $request->get('aaa'));
-        $this->assertSame('  456  ', $request->get('bbb'));
-        $this->assertSame('  789  ', $request->get('ccc'));
+        $this->assertSame('  123  ', $request->input('aaa'));
+        $this->assertSame('  456  ', $request->input('bbb'));
+        $this->assertSame('  789  ', $request->input('ccc'));
     }
 
     public function testTrustProxies()

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -20,8 +20,8 @@ class ConvertEmptyStringsToNullTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('bar', $request->get('foo'));
-            $this->assertNull($request->get('baz'));
+            $this->assertSame('bar', $request->input('foo'));
+            $this->assertNull($request->input('baz'));
         });
     }
 
@@ -37,8 +37,8 @@ class ConvertEmptyStringsToNullTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('bar', $request->get('foo'));
-            $this->assertSame('', $request->get('baz'));
+            $this->assertSame('bar', $request->input('foo'));
+            $this->assertSame('', $request->input('baz'));
         });
     }
 }

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -20,8 +20,8 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('12', $request->get('bar'));
-            $this->assertSame('ab', $request->get('baz'));
+            $this->assertSame('12', $request->input('bar'));
+            $this->assertSame('ab', $request->input('baz'));
         });
     }
 
@@ -39,9 +39,9 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('Damian', $request->get('name'));
-            $this->assertEquals(27, $request->get('age'));
-            $this->assertEquals(5, $request->get('beers'));
+            $this->assertSame('Damian', $request->input('name'));
+            $this->assertEquals(27, $request->input('age'));
+            $this->assertEquals(5, $request->input('beers'));
         });
     }
 
@@ -61,9 +61,9 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('Damian', $request->get('name'));
-            $this->assertEquals([27, 55, 83], $request->get('age'));
-            $this->assertEquals([5, 9, 13], $request->get('beers'));
+            $this->assertSame('Damian', $request->input('name'));
+            $this->assertEquals([27, 55, 83], $request->input('age'));
+            $this->assertEquals([5, 9, 13], $request->input('beers'));
         });
     }
 

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -22,10 +22,10 @@ class TrimStringsTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('123', $request->get('abc'));
-            $this->assertSame('456', $request->get('xyz'));
-            $this->assertSame('  789  ', $request->get('foo'));
-            $this->assertSame('  010  ', $request->get('bar'));
+            $this->assertSame('123', $request->input('abc'));
+            $this->assertSame('456', $request->input('xyz'));
+            $this->assertSame('  789  ', $request->input('foo'));
+            $this->assertSame('  010  ', $request->input('bar'));
         });
     }
 
@@ -47,13 +47,13 @@ class TrimStringsTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertSame('123', $request->get('abc'));
-            $this->assertSame('ha', $request->get('zwnbsp'));
-            $this->assertSame('だ', $request->get('xyz'));
-            $this->assertSame('ム', $request->get('foo'));
-            $this->assertSame('だ', $request->get('bar'));
-            $this->assertSame('ム', $request->get('baz'));
-            $this->assertSame("\xE9", $request->get('binary'));
+            $this->assertSame('123', $request->input('abc'));
+            $this->assertSame('ha', $request->input('zwnbsp'));
+            $this->assertSame('だ', $request->input('xyz'));
+            $this->assertSame('ム', $request->input('foo'));
+            $this->assertSame('だ', $request->input('bar'));
+            $this->assertSame('ム', $request->input('baz'));
+            $this->assertSame("\xE9", $request->input('binary'));
         });
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1777,10 +1777,10 @@ class HttpRequestTest extends TestCase
         $request = Request::createFromBase($base);
 
         $request->merge([
-            'name' => $request->get('first').' '.$request->get('last'),
+            'name' => $request->input('first').' '.$request->input('last'),
         ]);
 
-        $this->assertSame('Taylor Otwell', $request->get('name'));
+        $this->assertSame('Taylor Otwell', $request->input('name'));
     }
 
     public function testItCanHaveObjectsInJsonPayload()
@@ -1792,9 +1792,9 @@ class HttpRequestTest extends TestCase
         $base = SymfonyRequest::create('/', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: '{"framework":{"name":"Laravel"}}');
         $request = Request::createFromBase($base);
 
-        $value = $request->get('framework');
+        $value = $request->input('framework');
 
-        $this->assertSame(['name' => 'Laravel'], $request->get('framework'));
+        $this->assertSame(['name' => 'Laravel'], $request->input('framework'));
     }
 
     public function testItDoesNotGenerateJsonErrorsForEmptyContent()


### PR DESCRIPTION
The parent method was removed in Symfony 8 via https://github.com/symfony/symfony/pull/61983

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
