### PR TITLE
[13.x] Defer resolving `Illuminate\Foundation\Exceptions\Handler` during

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -373,12 +373,16 @@ class ApplicationBuilder
             \Illuminate\Foundation\Exceptions\Handler::class
         );
 
+        $configureExceptions = new Exceptions;
+
         if ($using !== null) {
-            $this->app->afterResolving(
-                \Illuminate\Foundation\Exceptions\Handler::class,
-                fn ($handler) => $using(new Exceptions($handler)),
-            );
+            $using($configureExceptions);
         }
+
+        $this->app->afterResolving(
+            \Illuminate\Foundation\Exceptions\Handler::class,
+            fn ($handler) => $configureExceptions->handle($handler),
+        );
 
         return $this;
     }


### PR DESCRIPTION
application configuration.

This allows the following usage to work instead having to use https://github.com/laravel/docs/pull/10912

```php
use Illuminate\Foundation\Configuration\Exceptions;

->withExceptions(function (Exceptions $exceptions): void {
    // Truncate request exception messages to 240 characters...
    $exceptions->truncateRequestExceptionsAt(240);

    // Disable request exception message truncation...
    $exceptions->dontTruncateRequestExceptions();
})
```
