### PR TITLE
Improve type annotations of `$batchId` in `Batchable` trait

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -12,7 +12,7 @@ trait Batchable
     /**
      * The batch ID (if applicable).
      *
-     * @var string
+     * @var string|null
      */
     public $batchId;
 


### PR DESCRIPTION
This PR adjusts the type of `$batchId` in the `Batchable` trait.

Currently the type is `string`. It can be `null` when no batch is used. 

The `$batchId` type is incorrect. If no Batch is used the `$batchId` can be `null`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
