### PR TITLE
[12.x] Add PHPDoc callable types for BusFake methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -488,7 +488,7 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Create a new assertion about a chained batch.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(\Illuminate\Bus\PendingBatch): bool  $callback
      * @return \Illuminate\Support\Testing\Fakes\ChainedBatchTruthTest
      */
     public function chainedBatch(Closure $callback)
@@ -499,7 +499,7 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Assert if a batch was dispatched based on a truth-test callback.
      *
-     * @param  callable  $callback
+     * @param  callable(\Illuminate\Bus\PendingBatch): bool  $callback
      * @return void
      */
     public function assertBatched(callable $callback)
@@ -606,8 +606,8 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Get all of the pending batches matching a truth-test callback.
      *
-     * @param  callable  $callback
-     * @return \Illuminate\Support\Collection
+     * @param  callable(\Illuminate\Bus\PendingBatch): bool  $callback
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Bus\PendingBatch>
      */
     public function batched(callable $callback)
     {

--- a/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
+++ b/src/Illuminate/Support/Testing/Fakes/ChainedBatchTruthTest.php
@@ -9,14 +9,14 @@ class ChainedBatchTruthTest
     /**
      * The underlying truth test.
      *
-     * @var \Closure
+     * @var \Closure(\Illuminate\Bus\PendingBatch): bool
      */
     protected $callback;
 
     /**
      * Create a new truth test instance.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure(\Illuminate\Bus\PendingBatch): bool  $callback
      */
     public function __construct(Closure $callback)
     {


### PR DESCRIPTION
Add proper callable type hints that document the callback signatures for batch-related methods in `BusFake` and `ChainedBatchTruthTest`.

**Changes:**
- `BusFake::chainedBatch()` - `@param \Closure(\Illuminate\Bus\PendingBatch): bool`
- `BusFake::assertBatched()` - `@param callable(\Illuminate\Bus\PendingBatch): bool`
- `BusFake::batched()` - `@param callable(\Illuminate\Bus\PendingBatch): bool` and `@return \Illuminate\Support\Collection<int, \Illuminate\Bus\PendingBatch>`
- `ChainedBatchTruthTest::$callback` and constructor - `@var/@param \Closure(\Illuminate\Bus\PendingBatch): bool`

This improves IDE autocompletion and static analysis support when using these testing methods.