### PR TITLE
[12.x] Fix deadlock in cache_locks on cleanup

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -64,6 +64,7 @@ class DatabaseLock extends Lock
      * Attempt to acquire the lock.
      *
      * @return bool
+     *
      * @throws Throwable
      */
     public function acquire()

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
-use Orchestra\Testbench\Attributes\WithMigration;
 use Mockery as m;
+use Orchestra\Testbench\Attributes\WithMigration;
 use PDOException;
 use PHPUnit\Framework\Attributes\TestWith;
 

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Mockery as m;
+use PDOException;
 use PHPUnit\Framework\Attributes\TestWith;
 
 #[WithMigration('cache')]
@@ -87,11 +88,11 @@ class DatabaseLockTest extends DatabaseTestCase
 
         $deleteBuilder->shouldReceive('where')->with('expiration', '<=', m::any())->once()->andReturnSelf();
         $deleteBuilder->shouldReceive('delete')->once()->andThrow(
-            new \Illuminate\Database\QueryException(
+            new QueryException(
                 'mysql',
                 'delete from cache_locks where expiration <= ?',
                 [],
-                new \PDOException($message, $code)
+                new PDOException($message, $code)
             )
         );
 


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/57966

The addition of the index has caused the below in various environments for me  quite often, which I believe is down to using WithoutOverlapping middleware in high throughput queues: 
```
SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction (Connection: mysql, SQL: delete from `cache_locks` where `expiration` <= 1765344745)
```

The index seems to improve query performance, but changes the order it gets row locks - hence why this happens.

Since the cleanup is opportunistic (cause its using a lottery) this PR uses the existing `ConcurrencyErrorDetector` to identify and ignore concurrency failures, while continuing to throw any other errors. 

I've also added a test - which I think covers it - Any feedback or adjustments let me know 🫡 