### PR TITLE
[12.x] Simplify clearing resolved instances for `Facade` classes

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\InteractsWithTime;
 use InvalidArgumentException;
 use Throwable;
@@ -165,7 +165,7 @@ class Kernel implements KernelContract
     {
         $this->app->instance('request', $request);
 
-        Facade::clearResolvedInstance('request');
+        Request::clearResolvedInstance();
 
         $this->bootstrap();
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -6,7 +6,7 @@ use Closure;
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
-use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Vite as ViteFacade;
 use Illuminate\Support\HtmlString;
 use Mockery;
 
@@ -123,7 +123,7 @@ trait InteractsWithContainer
             $this->originalVite = app(Vite::class);
         }
 
-        Facade::clearResolvedInstance(Vite::class);
+        ViteFacade::clearResolvedInstance();
 
         $this->swap(Vite::class, new class extends Vite
         {

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -247,12 +247,12 @@ abstract class Facade
     /**
      * Clear a resolved facade instance.
      *
-     * @param  string  $name
+     * @param  ?string  $name
      * @return void
      */
-    public static function clearResolvedInstance($name)
+    public static function clearResolvedInstance($name = null)
     {
-        unset(static::$resolvedInstance[$name]);
+        unset(static::$resolvedInstance[$name ?? static::getFacadeAccessor()]);
     }
 
     /**

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -80,6 +80,40 @@ class SupportFacadeTest extends TestCase
         $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
+
+    public function testFacadeResolvesAgainAfterClearingSpecific()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => $mock = m::mock(stdClass::class)]);
+        $mock->shouldReceive('bar')->times(3)->andReturn('baz');
+
+        // Resolve for the first time
+        FacadeStub::setFacadeApplication($app);
+        $this->assertSame('baz', FacadeStub::bar());
+
+        // Clear resolved instance and resolve the second time
+        FacadeStub::clearResolvedInstance();
+        $this->assertSame('baz', FacadeStub::bar());
+
+        // Clear resolved instance through parent and resolve the third time
+        Facade::clearResolvedInstance('foo');
+        $this->assertSame('baz', FacadeStub::bar());
+    }
+
+    public function testFacadeResolvesAgainAfterClearingAll()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => $mock = m::mock(stdClass::class)]);
+        $mock->shouldReceive('bar')->times(2)->andReturn('baz');
+
+        // Resolve for the first time
+        FacadeStub::setFacadeApplication($app);
+        $this->assertSame('baz', FacadeStub::bar());
+
+        // Clear all resolved instances and resolve a second time
+        Facade::clearResolvedInstances();
+        $this->assertSame('baz', FacadeStub::bar());
+    }
 }
 
 class FacadeStub extends Facade

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -40,8 +40,8 @@ class SupportFacadesEventTest extends TestCase
 
     protected function tearDown(): void
     {
-        Event::clearResolvedInstances();
-        Event::setFacadeApplication(null);
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
 
         m::close();
     }

--- a/tests/Support/SupportFacadesQueueTest.php
+++ b/tests/Support/SupportFacadesQueueTest.php
@@ -30,7 +30,7 @@ class SupportFacadesQueueTest extends TestCase
 
     protected function tearDown(): void
     {
-        Queue::clearResolvedInstances();
+        Queue::clearResolvedInstance();
         Queue::setFacadeApplication(null);
 
         m::close();

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -101,7 +101,7 @@ class TestDatabasesTest extends TestCase
         parent::tearDown();
 
         Container::setInstance(null);
-        DB::clearResolvedInstances();
+        DB::clearResolvedInstance();
         DB::setFacadeApplication(null);
 
         unset($_SERVER['LARAVEL_PARALLEL_TESTING']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If one currently wants to clear the resolved instance for a `Facade` class, there are two possibilities:
- Find out (through the implementing code) what the value of `getFacadeAccessor` for the particular class is, then pass this to `Facade::clearResolvedInstance`
- Clear all instances with `clearResolvedInstances`

Given the first is somewhat cumbersome and the second a bit too much of a shotgun approach for some usecases, this PR propose to rework the `clearResolvedInstance` instance method in such a way that it allows calling it without any arguments, defaulting to the value obtained from `getFacadeAccessor`. This allows one to simply call `ChildFacade::clearResolvedInstance()` without requiring any knowledge about the underlying accessor implementation.

For 'stylistic' reasons, I've opted to change relevant calls to:
- `Facade::clearResolvedInstances` to signify all instances will be cleared, regardless of class
- `ChildFacade::clearResolvedInstance` to signify which particular instance will be cleared