### PR TITLE
Fix @JSON Blade directive parsing with nested structures

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -15,6 +15,7 @@ trait CompilesJson
      * Compile the JSON statement into valid PHP.
      *
      * @param  string  $expression
+     *
      * @return string
      */
     protected function compileJson($expression)
@@ -38,17 +39,18 @@ trait CompilesJson
      * and other nested structures by using PHP's tokenizer.
      *
      * @param  string  $expression
+     *
      * @return array
      */
     protected function parseArguments($expression)
     {
-        if (trim($expression) === '') {
+        if ('' === trim($expression)) {
             return [];
         }
 
-        $tokens = @token_get_all('<?php '.$expression);
+        $tokens = @token_get_all('<?php ' . $expression);
 
-        if ($tokens === false) {
+        if (false === $tokens) {
             // Fallback to simple explode if tokenization fails
             return array_map('trim', explode(',', $expression));
         }
@@ -59,7 +61,7 @@ trait CompilesJson
 
         foreach ($tokens as $index => $token) {
             // Skip the initial <?php token
-            if ($index === 0 && is_array($token) && $token[0] === T_OPEN_TAG) {
+            if (0 === $index && is_array($token) && T_OPEN_TAG === $token[0]) {
                 continue;
             }
 
@@ -73,7 +75,7 @@ trait CompilesJson
                 }
 
                 // Handle whitespace at top level when $current is empty (can be ignored)
-                if ($id === T_WHITESPACE && $depth === 0 && $current === '') {
+                if (T_WHITESPACE === $id && 0 === $depth && '' === $current) {
                     continue;
                 }
 
@@ -82,13 +84,13 @@ trait CompilesJson
                 $char = $token;
 
                 // Track nesting depth for parentheses, brackets, and braces
-                if ($char === '(' || $char === '[' || $char === '{') {
-                    $depth++;
+                if ('(' === $char || '[' === $char || '{' === $char) {
+                    ++$depth;
                     $current .= $char;
-                } elseif ($char === ')' || $char === ']' || $char === '}') {
-                    $depth--;
+                } elseif (')' === $char || ']' === $char || '}' === $char) {
+                    --$depth;
                     $current .= $char;
-                } elseif ($char === ',' && $depth === 0) {
+                } elseif (',' === $char && 0 === $depth) {
                     // Only split on commas at the top level
                     $parts[] = trim($current);
                     $current = '';
@@ -99,7 +101,7 @@ trait CompilesJson
         }
 
         // Add the last part
-        if ($current !== '') {
+        if ('' !== $current) {
             $parts[] = trim($current);
         }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -15,7 +15,6 @@ trait CompilesJson
      * Compile the JSON statement into valid PHP.
      *
      * @param  string  $expression
-     *
      * @return string
      */
     protected function compileJson($expression)
@@ -39,7 +38,6 @@ trait CompilesJson
      * and other nested structures by using PHP's tokenizer.
      *
      * @param  string  $expression
-     *
      * @return array
      */
     protected function parseArguments($expression)
@@ -48,7 +46,7 @@ trait CompilesJson
             return [];
         }
 
-        $tokens = @token_get_all('<?php ' . $expression);
+        $tokens = @token_get_all('<?php '.$expression);
 
         if (false === $tokens) {
             // Fallback to simple explode if tokenization fails
@@ -85,10 +83,10 @@ trait CompilesJson
 
                 // Track nesting depth for parentheses, brackets, and braces
                 if ('(' === $char || '[' === $char || '{' === $char) {
-                    ++$depth;
+                    $depth++;
                     $current .= $char;
                 } elseif (')' === $char || ']' === $char || '}' === $char) {
-                    --$depth;
+                    $depth--;
                     $current .= $char;
                 } elseif (',' === $char && 0 === $depth) {
                     // Only split on commas at the top level

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,14 +19,7 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        $parts = $this->parseArguments($this->stripParentheses($expression));
-
-        $options = isset($parts[1]) ? trim($parts[1]) : $this->encodingOptions;
-
-        $depth = isset($parts[2]) ? trim($parts[2]) : 512;
-
-        // Ensure we have at least one argument, default to null if empty
-        $data = $parts[0] ?? 'null';
+        [$data, $options, $depth] = $this->parseArguments($this->stripParenthesis($expression)) + ['null', $this->encodingOptions, 512];
 
         return "<?php echo json_encode($data, $options, $depth) ?>";
     }
@@ -38,7 +31,7 @@ trait CompilesJson
      * and other nested structures by using PHP's tokenizer.
      *
      * @param  string  $expression
-     * @return array
+     * @return array{0?: string, 1?: string, 2?: string}
      */
     protected function parseArguments($expression)
     {

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -19,7 +19,7 @@ trait CompilesJson
      */
     protected function compileJson($expression)
     {
-        [$data, $options, $depth] = $this->parseArguments($this->stripParenthesis($expression)) + ['null', $this->encodingOptions, 512];
+        [$data, $options, $depth] = $this->parseArguments($this->stripParentheses($expression)) + ['null', $this->encodingOptions, 512];
 
         return "<?php echo json_encode($data, $options, $depth) ?>";
     }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -19,4 +19,53 @@ class BladeJsonTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testJsonWithComplexArrayContainingNestedStructures()
+    {
+        $string = '@json([\'items\' => collect([1, 2, 3])->map(fn($x) => [\'id\' => $x, \'name\' => "test"]), \'translation\' => \'%:booking.benefits%\'])';
+        $expected = '<?php echo json_encode([\'items\' => collect([1, 2, 3])->map(fn($x) => [\'id\' => $x, \'name\' => "test"]), \'translation\' => \'%:booking.benefits%\'], 15, 512) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonWithArrayContainingMultipleCommas()
+    {
+        $string = '@json([\'a\' => 1, \'b\' => 2, \'c\' => 3], JSON_PRETTY_PRINT)';
+        $expected = '<?php echo json_encode([\'a\' => 1, \'b\' => 2, \'c\' => 3], JSON_PRETTY_PRINT, 512) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonWithClosureContainingCommas()
+    {
+        $string = '@json($items->map(fn($item) => [\'icon\' => $item->icon, \'title\' => (string)$item->title, \'description\' => (string)$item->description]))';
+        $expected = '<?php echo json_encode($items->map(fn($item) => [\'icon\' => $item->icon, \'title\' => (string)$item->title, \'description\' => (string)$item->description]), 15, 512) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonWithAllThreeArguments()
+    {
+        $string = '@json($data, JSON_PRETTY_PRINT, 256)';
+        $expected = '<?php echo json_encode($data, JSON_PRETTY_PRINT, 256) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonWithEmptyExpressionDefaultsToNull()
+    {
+        $string = '@json()';
+        $expected = '<?php echo json_encode(null, 15, 512) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonWithIssue56331ExactCase()
+    {
+        // This is the exact case from GitHub issue #56331
+        $string = '@json([\'items\' => $helpers[\'benefit\'][\'getAll\']()->map(fn($item) => [\'icon\' => $item->icon, \'title\' => (string)$item->title, \'description\' => (string)$item->description]), \'translation\' => \'%:booking.benefits%\'])';
+        $expected = '<?php echo json_encode([\'items\' => $helpers[\'benefit\'][\'getAll\']()->map(fn($item) => [\'icon\' => $item->icon, \'title\' => (string)$item->title, \'description\' => (string)$item->description]), \'translation\' => \'%:booking.benefits%\'], 15, 512) ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
## Description

Fixes `@json` Blade directive incorrectly parsing complex expressions with nested structures.  Replaces `explode()` with tokenizer-based parser that respects nesting depth.

## Problem

The directive would split on commas inside nested arrays, closures, and method calls, causing parse errors.

**Example** (from original issue):

```php
@json([
    'items' => $helpers['benefit']['getAll']()->map(fn($item) => [
        'icon' => $item->icon,
        'title' => (string)$item->title,
        'description' => (string)$item->description
    ]),
    'translation' => '%:booking.benefits%'
])
```

would incorrectly split on the comma inside the closure.

## Solution

- Added `parseArguments()` method using PHP's tokenizer
- Tracks nesting depth (parentheses, brackets, braces)
- Only splits on commas at top level (`depth === 0`)
- Handles empty expressions (defaults to `null`)

Fully backwards compatible - defaults to same behavior as before.

Fixes #56331