### PR TITLE
[12.x] Let Storage::fake() accept enum as disk name

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -4,6 +4,8 @@ namespace Illuminate\Support\Facades;
 
 use Illuminate\Filesystem\Filesystem;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @method static \Illuminate\Contracts\Filesystem\Filesystem drive(string|null $name = null)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(\UnitEnum|string|null $name = null)
@@ -96,7 +98,7 @@ class Storage extends Facade
      */
     public static function fake($disk = null, array $config = [])
     {
-        $root = self::getRootPath($disk = $disk ?: static::$app['config']->get('filesystems.default'));
+        $root = self::getRootPath($disk = enum_value($disk) ?: static::$app['config']->get('filesystems.default'));
 
         if ($token = ParallelTesting::token()) {
             $root = "{$root}_test_{$token}";


### PR DESCRIPTION
## Current
Currently, `Storage::fake()` only accepts a string.

## New
This update allows `Storage::fake()` to accept backed Enums for the disk name, aligning its behavior with `Storage::disk()`.

`Storage::disk(Disk::Local)` ✅
`Storage::fake(Disk::Local)` ✅