### PR TITLE
[12.x]  Introduce `ScopeAwareRule`  contract to provide relative contextual array item data to validation rules

### DIFF
--- a/src/Illuminate/Contracts/Validation/ScopeAwareRule.php
+++ b/src/Illuminate/Contracts/Validation/ScopeAwareRule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface ScopeAwareRule
+{
+    /**
+     * Set the scoped data (the current array item being validated).
+     *
+     * @param  array  $scope
+     * @return $this
+     */
+    public function setScope(array $scope);
+}

--- a/tests/Validation/ValidationScopeAwareRuleTest.php
+++ b/tests/Validation/ValidationScopeAwareRuleTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Closure;
+use Illuminate\Contracts\Validation\ScopeAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationScopeAwareRuleTest extends TestCase
+{
+    public function testScopeAwareRuleReceivesSiblingData()
+    {
+        $data = [
+            'products' => [
+                ['price' => 100, 'discount' => 150],
+                ['price' => 200, 'discount' => 50],
+                ['price' => 300, 'discount' => null],
+            ],
+        ];
+
+        $rules = [
+            'products.*.price' => 'required|numeric',
+            'products.*.discount' => ['nullable', 'numeric', new DiscountMustBeLessThanPrice()],
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'products.0.discount' => ['Discount cannot exceed the price.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    public function testScopeAwareRulePasses()
+    {
+        $data = [
+            'products' => [
+                ['price' => 100, 'discount' => 50],
+                ['price' => 200, 'discount' => 100],
+            ],
+        ];
+
+        $rules = [
+            'products.*.price' => 'required|numeric',
+            'products.*.discount' => ['nullable', 'numeric', new DiscountMustBeLessThanPrice()],
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testScopeAwareRuleWithDeeplyNestedWildcards()
+    {
+        $data = [
+            'orders' => [
+                [
+                    'items' => [
+                        ['price' => 50, 'quantity' => 2, 'max_quantity' => 1],
+                        ['price' => 30, 'quantity' => 1, 'max_quantity' => 5],
+                    ],
+                ],
+                [
+                    'items' => [
+                        ['price' => 100, 'quantity' => 3, 'max_quantity' => 10],
+                    ],
+                ],
+            ],
+        ];
+
+        $rules = [
+            'orders.*.items.*.quantity' => ['required', 'integer', new QuantityMustNotExceedMax()],
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'orders.0.items.0.quantity' => ['Quantity cannot exceed max quantity.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    public function testScopeAwareRuleWithConditionalLogic()
+    {
+        $data = [
+            'clients' => [
+                ['name' => 'John', 'state' => 'CA', 'tax_id' => null],
+                ['name' => 'Jane', 'state' => 'NY', 'tax_id' => null],
+                ['name' => 'Bob', 'state' => 'CA', 'tax_id' => '123-456'],
+            ],
+        ];
+
+        $rules = [
+            'clients.*.name' => 'required|string',
+            'clients.*.state' => 'required|string',
+            'clients.*.tax_id' => new RequiredIfState('state', 'CA'),
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'clients.0.tax_id' => ['The clients.0.tax_id field is required when state is CA.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    public function testScopeAwareRuleCanAccessNestedSiblingData()
+    {
+        $data = [
+            'orders' => [
+                [
+                    'type' => 'physical',
+                    'shipping' => ['method' => 'express', 'address' => null],
+                ],
+                [
+                    'type' => 'digital',
+                    'shipping' => ['method' => 'none', 'address' => null],
+                ],
+                [
+                    'type' => 'physical',
+                    'shipping' => ['method' => 'standard', 'address' => '123 Main St'],
+                ],
+            ],
+        ];
+
+        $rules = [
+            'orders.*.type' => 'required|in:physical,digital',
+            'orders.*.shipping.address' => new RequiredForPhysicalOrder(),
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'orders.0.shipping.address' => ['Shipping address is required for physical orders.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    public function testScopeAwareRuleWithMultipleRulesOnSameAttribute()
+    {
+        $data = [
+            'products' => [
+                ['price' => 100, 'discount' => 150, 'type' => 'sale'],
+                ['price' => 200, 'discount' => 50, 'type' => 'sale'],
+                ['price' => 300, 'discount' => null, 'type' => 'regular'],
+            ],
+        ];
+
+        $rules = [
+            'products.*.price' => 'required|numeric',
+            'products.*.discount' => [
+                'nullable',
+                'numeric',
+                new DiscountMustBeLessThanPrice(),
+            ],
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'products.0.discount' => ['Discount cannot exceed the price.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    public function testScopeAwareRuleWithoutWildcardReceivesFullData()
+    {
+        $data = [
+            'price' => 100,
+            'discount' => 150,
+        ];
+
+        $rules = [
+            'price' => 'required|numeric',
+            'discount' => ['nullable', 'numeric', new DiscountMustBeLessThanPrice()],
+        ];
+
+        $v = new Validator($this->getTranslator(), $data, $rules);
+
+        $this->assertFalse($v->passes());
+        $this->assertEquals([
+            'discount' => ['Discount cannot exceed the price.'],
+        ], $v->getMessageBag()->toArray());
+    }
+
+    protected function getTranslator()
+    {
+        return new Translator(
+            new ArrayLoader, 'en'
+        );
+    }
+}
+
+class RequiredIfState implements ValidationRule, ScopeAwareRule
+{
+    protected array $scope = [];
+
+    public function __construct(
+        protected string $field,
+        protected string $value
+    ) {
+    }
+
+    public function setScope(array $scope): static
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (($this->scope[$this->field] ?? null) === $this->value && empty($value)) {
+            $fail("The {$attribute} field is required when {$this->field} is {$this->value}.");
+        }
+    }
+}
+
+class RequiredForPhysicalOrder implements ValidationRule, ScopeAwareRule
+{
+    protected array $scope = [];
+
+    public function setScope(array $scope): static
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (($this->scope['type'] ?? null) === 'physical' && empty($value)) {
+            $fail('Shipping address is required for physical orders.');
+        }
+    }
+}
+
+class DiscountMustBeLessThanPrice implements ValidationRule, ScopeAwareRule
+{
+    protected array $scope = [];
+
+    public function setScope(array $scope): static
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value !== null && $value > ($this->scope['price'] ?? 0)) {
+            $fail('Discount cannot exceed the price.');
+        }
+    }
+}
+
+class QuantityMustNotExceedMax implements ValidationRule, ScopeAwareRule
+{
+    protected array $scope = [];
+
+    public function setScope(array $scope): static
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value > ($this->scope['max_quantity'] ?? PHP_INT_MAX)) {
+            $fail('Quantity cannot exceed max quantity.');
+        }
+    }
+}


### PR DESCRIPTION
When writing custom validation rules for array items, accessing sibling data requires manual path manipulation. Consider an API for bulk order creation:

```
{
    "orders": [
        {
            "customer_id": 123,
            "items": [
                {
                    "product_id": 1,
                    "quantity": 10,
                    "unit_price": 150.00,
                    "discount": 2000.00
                }
            ]
        }
    ]
}
  ```
  
  To validate that discount doesn't exceed the line total (quantity x unit_price), you currently need:
  
  ```php
  class DiscountMustNotExceedLineTotal implements ValidationRule, DataAwareRule
  {
      protected array $data = [];

      public function setData(array $data): static
      {
          $this->data = $data;
          return $this;
      }

      public function validate(string $attribute, mixed $value, Closure $fail): void
      {
          // $attribute = "orders.0.items.1.discount"
          // Need to extract indices and navigate the nested structure
          preg_match('/^orders\.(\d+)\.items\.(\d+)\./', $attribute, $matches);
          $orderIndex = $matches[1] ?? null;
          $itemIndex = $matches[2] ?? null;

          if ($orderIndex === null || $itemIndex === null) {
              return;
          }

          $item = $this->data['orders'][$orderIndex]['items'][$itemIndex] ?? [];
          $lineTotal = ($item['quantity'] ?? 0) * ($item['unit_price'] ?? 0);

          if ($value > $lineTotal) {
              $fail("The discount cannot exceed the line total of {$lineTotal}.");
          }
      }
  }
  ````
  
  We could make the experience much nicer with a new and more limited ScopeAwareRule interface that automatically receives the current array item's data:
  ```php
  class DiscountMustNotExceedLineTotal implements ValidationRule, ScopeAwareRule
  {
      protected array $scope = [];

      public function setScope(array $scope): static
      {
          $this->scope = $scope;
          return $this;
      }

      public function validate(string $attribute, mixed $value, Closure $fail): void
      {
          $lineTotal = ($this->scope['quantity'] ?? 0) * ($this->scope['unit_price'] ?? 0);

          if ($value > $lineTotal) {
              $fail("The discount cannot exceed the line total of {$lineTotal}.");
          }
      }
  }
  ```
  
  
  
  