### PR TITLE
[12.x] Add PHP 8.5 with Herd to passthrough variables in ServeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -82,6 +82,7 @@ class ServeCommand extends Command
         'HERD_PHP_82_INI_SCAN_DIR',
         'HERD_PHP_83_INI_SCAN_DIR',
         'HERD_PHP_84_INI_SCAN_DIR',
+        'HERD_PHP_85_INI_SCAN_DIR',
         'IGNITION_LOCAL_SITES_PATH',
         'LARAVEL_SAIL',
         'PATH',


### PR DESCRIPTION
This PR adds PHP 8.5 with herd to passthrough variables in ServeCommand.