### PR TITLE
[12.x] Fix deprecated usage of passing `null` to `array_key_exists` in `Builder` class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1363,7 +1363,7 @@ class Builder implements BuilderContract
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (! array_key_exists($column, $values)) {
+        if (! is_null($column) && ! array_key_exists($column, $values)) {
             $timestamp = $this->model->freshTimestampString();
 
             if (

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -724,7 +724,7 @@ trait QueriesRelationships
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
-    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
+    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and', $not = false)
     {
         if (! $related instanceof EloquentCollection) {
             $relatedCollection = $related->newCollection([$related]);
@@ -756,6 +756,7 @@ trait QueriesRelationships
             $relationship->getQualifiedForeignKeyName(),
             $relatedCollection->pluck($relationship->getOwnerKeyName())->toArray(),
             $boolean,
+            $not
         );
 
         return $this;
@@ -773,6 +774,33 @@ trait QueriesRelationships
     public function orWhereBelongsTo($related, $relationshipName = null)
     {
         return $this->whereBelongsTo($related, $relationshipName, 'or');
+    }
+
+    /**
+     * Add a "BelongsTo" relationship with a "where not" clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string|null  $relationshipName
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotBelongsTo($related, $relationshipName = null, $boolean = 'and')
+    {
+        return $this->whereBelongsTo($related, $relationshipName, $boolean, true);
+    }
+
+    /**
+     * Add a "BelongsTo" relationship with a "where not" clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string|null  $relationshipName
+     * @return $this
+     * 
+     * @throws \RuntimeException
+     */
+    public function orWhereNotBelongsTo($related, $relationshipName = null)
+    {
+        return $this->whereNotBelongsTo($related, $relationshipName, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -796,7 +796,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @param  string|null  $relationshipName
      * @return $this
-     * 
+     *
      * @throws \RuntimeException
      */
     public function orWhereNotBelongsTo($related, $relationshipName = null)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -720,6 +720,7 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>  $related
      * @param  string|null  $relationshipName
      * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
@@ -790,7 +791,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a "BelongsTo" relationship with a "where not" clause to the query.
+     * Add a "BelongsTo" relationship with an "or where not" clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @param  string|null  $relationshipName

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1240,7 +1240,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and', false);
 
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
@@ -1248,7 +1248,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and', false);
 
         $result = $builder->whereBelongsTo($parent, 'parent');
         $this->assertEquals($result, $builder);
@@ -1264,7 +1264,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and', false);
 
         $result = $builder->whereBelongsTo($parents);
         $this->assertEquals($result, $builder);
@@ -1272,7 +1272,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and', false);
 
         $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);


### PR DESCRIPTION
based on https://github.com/laravel/framework/pull/58073