### PR TITLE
[12.x] Fix passing `null` to `array_key_exists` in `Builder` class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1363,7 +1363,7 @@ class Builder implements BuilderContract
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (! array_key_exists($column, $values)) {
+        if (! is_null($column) && ! array_key_exists($column, $values)) {
             $timestamp = $this->model->freshTimestampString();
 
             if (


### PR DESCRIPTION
based on https://github.com/laravel/framework/pull/58073