### PR TITLE
[12.x] Make Model Macroable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable as SupportStringable;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Macroable;
 use JsonException;
 use JsonSerializable;
 use LogicException;
@@ -50,6 +51,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
+    
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The connection name for the model.
@@ -2524,6 +2529,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+        
         if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly'])) {
             return $this->$method(...$parameters);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -51,7 +51,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
     /** @use HasCollection<\Illuminate\Database\Eloquent\Collection<array-key, static & self>> */
     use HasCollection;
-    
     use Macroable {
         __call as macroCall;
     }
@@ -2532,7 +2531,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
         }
-        
+
         if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly'])) {
             return $this->$method(...$parameters);
         }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -152,6 +152,7 @@ class EloquentModelTest extends DatabaseTestCase
         };
 
         $this->assertSame('test', $model->test());
+        $this->assertSame('test', $model::test());
     }
 }
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -135,6 +135,24 @@ class EloquentModelTest extends DatabaseTestCase
             'analyze' => true,
         ]);
     }
+
+    public function testMacroable()
+    {
+        Model::macro('test', function () {
+            return 'test';
+        });
+
+        $model = new class extends Model
+        {
+            protected $table = 'actions';
+
+            protected $guarded = ['id'];
+
+            public $timestamps = false;
+        };
+
+        $this->assertSame('test', $model->test());
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
I have a replica database and I'd like to macro the following: 

```php
        Model::macro('replica', function () {
            return (new static)->setConnection('mysql-replica')->newQuery();
        });
```

I want specific queries on my replica.

Meaning I can do: 

```php

User::replica()->where(...
Documents::replica()->where(...
Analytics::replica()->where(...

vs 

User::on('mysql-replica')->where(...
Documents::on('mysql-replica')->where(...
Analytics::on('mysql-replica')->where(...

```

Just a bit of DX, but perhaps good reason why its not been done before?  Added a test to prove it works. 

Thanks Taylor.