### PR TITLE
[12.x] Add ability to run callbacks after building an Http response

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1544,9 +1544,9 @@ class PendingRequest
     /**
      * Execute the "before sending" callbacks.
      *
-     * @param  \GuzzleHttp\Psr7\RequestInterface  $request
+     * @param  \Psr\Http\Message\RequestInterface  $request
      * @param  array  $options
-     * @return \GuzzleHttp\Psr7\RequestInterface
+     * @return \Psr\Http\Message\RequestInterface
      */
     public function runBeforeSendingCallbacks($request, array $options)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -168,7 +168,7 @@ class PendingRequest
     /**
      * The callbacks that should execute after the Laravel Response is built.
      *
-     * @var \Illuminate\Support\Collection<int, (callable(\Illuminate\Http\Client\Response))>
+     * @var \Illuminate\Support\Collection<int, (callable(\Illuminate\Http\Client\Response): void)>
      */
     protected $afterResponseCallbacks;
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -167,7 +167,7 @@ class PendingRequest
 
     /**
      * The callbacks that should execute after the Laravel Response is built.
-     * 
+     *
      * @var \Illuminate\Support\Collection<int, (callable(\Illuminate\Http\Client\Response))>
      */
     protected $afterResponseCallbacks;
@@ -749,7 +749,8 @@ class PendingRequest
 
     /**
      * Add a new callback to execute after the response is built.
-     * @param  callable(\Illuminate\Http\Client\Response)  $callback
+     *
+     * @param  (callable(\Illuminate\Http\Client\Response): void)  $callback
      * @return $this
      */
     public function afterResponse(callable $callback)
@@ -1602,6 +1603,12 @@ class PendingRequest
         });
     }
 
+    /**
+     * Execute the "after response" callbacks.
+     *
+     * @param  Response  $response
+     * @return void
+     */
     protected function runAfterResponseCallbacks(Response $response)
     {
         $this->afterResponseCallbacks->each(static fn (callable $callback) => $callback($response));

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -754,7 +754,7 @@ class PendingRequest
      */
     public function afterResponse(callable $callback)
     {
-        $this->$afterResponseCallbacks[] = $callback;
+        $this->afterResponseCallbacks[] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1174,6 +1174,7 @@ class PendingRequest
         return $this->promise = $this->sendRequest($method, $url, $options)
             ->then(function (MessageInterface $message) {
                 $response = $this->newResponse($message);
+
                 $this->populateResponse($response);
                 $this->dispatchResponseReceivedEvent($response);
 
@@ -1613,6 +1614,7 @@ class PendingRequest
     {
         foreach ($this->afterResponseCallbacks as $callback) {
             $returnedResponse = $callback($response);
+
             if ($returnedResponse instanceof Response) {
                 $response = $returnedResponse;
             }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3567,6 +3567,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
+        //
         $this->factory->beforeSending(function (Request $request) {
             $requestLine = sprintf(
                 '%s %s HTTP/%s',
@@ -4193,6 +4194,60 @@ class HttpClientTest extends TestCase
             'post' => ['post'],
             'delete' => ['delete'],
         ];
+    }
+
+    public function testAfterResponse()
+    {
+        $this->factory->fake([
+            'http://200.com*' => $this->factory::response('OK'),
+        ]);
+
+        $response = $this->factory
+            ->afterResponse(fn (Response $response): TestResponse => new TestResponse($response->toPsrResponse()))
+            ->afterResponse(fn () => 'abc')
+            ->afterResponse(function ($r) {
+                $this->assertInstanceOf(TestResponse::class, $r);
+            })
+            ->afterResponse(fn (Response $r) => new Response($r->toPsrResponse()->withBody(Utils::streamFor(strtolower($r->body())))))
+            ->get('http://200.com');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('ok', $response->body());
+    }
+
+    public function testAfterResponseWithThrows()
+    {
+        $this->factory->fake([
+            'http://500.com*' => $this->factory::response('oh no', 500),
+        ]);
+
+        try {
+            $this->factory->throw()
+                ->afterResponse(fn ($response) => new TestResponse($response->toPsrResponse()))
+                ->post('http://500.com');
+        } catch (RequestException $e) {
+            $this->assertInstanceOf(TestResponse::class, $e->response);
+        }
+    }
+
+    public function testAfterResponseWithAsync()
+    {
+        $this->factory->fake([
+            'http://200.com*' => $this->factory::response('OK', 200),
+            'http://401.com*' => $this->factory::response('Unauthorized.', 401),
+        ]);
+
+        $o = $this->factory->pool(function (Pool $pool): void {
+            $pool->as('200')->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()))->get('http://200.com');
+            $pool->as('401-throwing')->throw()->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()))->get('http://401.com');
+            $pool->as('401-response')->afterResponse(fn (Response $response) => new TestResponse($response->toPsrResponse()->withBody(Utils::streamFor('different'))))->get('http://401.com');
+        }, 0);
+
+        $this->assertInstanceOf(TestResponse::class, $o['200']);
+        $this->assertInstanceOf(TestResponse::class, $o['401-response']);
+        $this->assertEquals('different', $o['401-response']->body());
+        $this->assertInstanceOf(RequestException::class, $o['401-throwing']);
+        $this->assertInstanceOf(TestResponse::class, $o['401-throwing']->response);
     }
 }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3567,7 +3567,6 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        //
         $this->factory->beforeSending(function (Request $request) {
             $requestLine = sprintf(
                 '%s %s HTTP/%s',


### PR DESCRIPTION
While we can add middleware to the Guzzle stack, it doesn't actually build the Response object, which I would like to inspect and mutate.

1. I want to record GraphQL query costs only for Shopify requests. I could add a listener for this, but then it's an extra function call for requests which are not for Shopify.
2. I want to be able to leverage macros and all of the other niceties offered by the Illuminate Client\Request object, rather than mucking with the Guzzle handler.

## An Example
```php
class ShopifyResponse extends Response
{
    public function __construct($response)
    {
        $this->response = $response;
        $this->decoded = json_decode($this->body(), true, flags: JSON_THROW_ON_ERROR);
    }

    public function getQueryCost(): array {
        // ...
    }
}

Http::macro('shopifyRequest', function (ShopCredentials $shopCreds) {
    return Http::acceptJson()
        ->withHeader('X-Shopify-Access-Token', $shopCreds->token)
        ->baseUrl("https://{$shopCreds->shop_domain}.myshopify.com/admin/api/2025-10/")
        ->afterResponse(
            // Report any deprecation notices that were in the header
            function (Response $response) use ($shopCreds) {
                $header = $response->header('X-Shopify-API-Deprecated-Reason');
                if ($header) {
                    event(new ShopifyDeprecationNotice($shopCreds->shop, $header);
                }
         })
        ->afterResponse(
            // Map the response into our own custom response class
            fn (Response $response) => new ShopifyResponse($response->toPsrResponse())
        )
        ->afterResponse(
            // Report the cost of the query
            static fn (ShopifyResponse $response) => QueryCostResponse::report(
                $response->getQueryCost(),
                $shopCreds->shop
            )
        )
});

$r = Http::shopifyRequest($someShopCredentials)->post('graphql.json', ['query' => 'some graphql query']);
```

While obviously all of this can be done currently, it requires every developer to remember to run that pipeline on their response. We _could_ make a macro that actually posts the response and maps it, however, that doesn't allow for mutating on a per request basis before sending (such as adding an additional header or setting throws() or a timeout).