### PR TITLE
[12.x] Add dumpCurl methods to Http client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1820,4 +1820,30 @@ class PendingRequest
     {
         return $this->options;
     }
+
+    /**
+     * Dump the execution as a cURL command.
+     */
+    public function dumpCurl(): self
+    {
+        return $this->beforeSending(function (Request $request) {
+            $body = $request->isJson()
+                ? json_encode($request->data(), JSON_THROW_ON_ERROR)
+                : $request->body();
+
+            $command = sprintf('curl -X %s %s', $request->method(), escapeshellarg($request->url()));
+
+            foreach ($request->headers() as $key => $values) {
+                foreach ($values as $value) {
+                    $command .= sprintf(' -H %s', escapeshellarg("{$key}: {$value}"));
+                }
+            }
+
+            if ($body) {
+                $command .= sprintf(' -d %s', escapeshellarg($body));
+            }
+
+            dump($command);
+        });
+    }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -814,7 +814,7 @@ class PendingRequest
                 $command .= sprintf(' -d %s', escapeshellarg($body));
             }
 
-            VarDumper::dump($value);
+            VarDumper::dump($command);
         });
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -791,6 +791,34 @@ class PendingRequest
     }
 
     /**
+     * Dump the execution as a cURL command before sending.
+     *
+     * @return $this
+     */
+    public function dumpCurl()
+    {
+        return $this->beforeSending(function (Request $request) {
+            $body = $request->isJson()
+                ? json_encode($request->data(), JSON_THROW_ON_ERROR)
+                : $request->body();
+
+            $command = sprintf('curl -X %s %s', $request->method(), escapeshellarg($request->url()));
+
+            foreach ($request->headers() as $key => $values) {
+                foreach ($values as $value) {
+                    $command .= sprintf(' -H %s', escapeshellarg("{$key}: {$value}"));
+                }
+            }
+
+            if ($body) {
+                $command .= sprintf(' -d %s', escapeshellarg($body));
+            }
+
+            VarDumper::dump($value);
+        });
+    }
+
+    /**
      * Dump the request before sending and end the script.
      *
      * @return $this
@@ -1819,31 +1847,5 @@ class PendingRequest
     public function getOptions()
     {
         return $this->options;
-    }
-
-    /**
-     * Dump the execution as a cURL command.
-     */
-    public function dumpCurl(): self
-    {
-        return $this->beforeSending(function (Request $request) {
-            $body = $request->isJson()
-                ? json_encode($request->data(), JSON_THROW_ON_ERROR)
-                : $request->body();
-
-            $command = sprintf('curl -X %s %s', $request->method(), escapeshellarg($request->url()));
-
-            foreach ($request->headers() as $key => $values) {
-                foreach ($values as $value) {
-                    $command .= sprintf(' -H %s', escapeshellarg("{$key}: {$value}"));
-                }
-            }
-
-            if ($body) {
-                $command .= sprintf(' -d %s', escapeshellarg($body));
-            }
-
-            dump($command);
-        });
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4194,6 +4194,27 @@ class HttpClientTest extends TestCase
             'delete' => ['delete'],
         ];
     }
+
+    public function testDumpCurl(): void
+    {
+        $dumped = null;
+
+        VarDumper::setHandler(function ($value) use (&$dumped) {
+            $dumped = $value;
+        });
+
+        $this->factory->fake()
+            ->dumpCurl()
+            ->withHeaders(['X-Test' => 'foo'])
+            ->post('https://laravel.com/api/test', ['name' => 'Taylor']);
+
+        VarDumper::setHandler(null);
+
+        $this->assertStringContainsString('curl -X POST', $dumped);
+        $this->assertStringContainsString(escapeshellarg('https://laravel.com/api/test'), $dumped);
+        $this->assertStringContainsString('-H '.escapeshellarg('X-Test: foo'), $dumped);
+        $this->assertStringContainsString('-d '.escapeshellarg(json_encode(['name' => 'Taylor'])), $dumped);
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Description**
This PR adds `dumpCurl()` method to the `Illuminate\Http\Client\PendingRequest` class.

While `dump()` are excellent for inspecting PHP arrays/objects, debugging HTTP requests often requires reproducing the request in a terminal context or sharing it with third-party API support.

These new methods output the outgoing request as a fully valid, shell-safe cURL command string, including:
- HTTP Method
- URL
- All Headers
- Request Body (JSON or raw)

**Benefit to End Users**
Developers working with third-party APIs often struggle to debug why a request fails.
- **Current workflow:** Manually inspect `dump()`, then painstakingly reconstruct a cURL command by copying headers and formatting the JSON body manually to test in the terminal.
- **New workflow:** Simply chain `->dumpCurl()`. The developer gets a copy-paste ready command immediately.

**Implementation Details**
- Uses `escapeshellarg()` strictly for all user inputs (URL, headers, body) to ensure the command is safe to execute and handles special characters correctly across different operating systems.
- Fully typed (PHP 8 strict types).
- Includes unit tests ensuring correct formatting for headers and JSON bodies.

**Example Usage**

```php
Http::withToken('token')
    ->asJson()
    ->dumpCurl()
    ->post('https://example.com/api', ['foo' => 'bar']);

// Output:
curl -X POST 'https://example.com/api' -H 'Authorization: Bearer token' -H 'Content-Type: application/json' -d '{"foo":"bar"}'
```

**Breaking Changes:**
None. This adds new public methods to the PendingRequest class and does not modify existing behavior.