### PR TITLE
[12.x] Adjust testCanRetrieveAllFailedJobs

### DIFF
--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -41,9 +41,9 @@ class FileFailedJobProviderTest extends TestCase
 
     public function testCanRetrieveAllFailedJobs()
     {
-        Carbon::setTestNow(now());
-
         try {
+            Carbon::setTestNow(now());
+
             [$uuidOne, $exceptionOne] = $this->logFailedJob();
             [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
 

--- a/tests/Queue/FileFailedJobProviderTest.php
+++ b/tests/Queue/FileFailedJobProviderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Queue;
 
 use Exception;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -40,31 +41,37 @@ class FileFailedJobProviderTest extends TestCase
 
     public function testCanRetrieveAllFailedJobs()
     {
-        [$uuidOne, $exceptionOne] = $this->logFailedJob();
-        [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
+        Carbon::setTestNow(now());
 
-        $failedJobs = $this->provider->all();
+        try {
+            [$uuidOne, $exceptionOne] = $this->logFailedJob();
+            [$uuidTwo, $exceptionTwo] = $this->logFailedJob();
 
-        $this->assertEquals([
-            (object) [
-                'id' => $uuidTwo,
-                'connection' => 'connection',
-                'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuidTwo]),
-                'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
-                'failed_at' => $failedJobs[1]->failed_at,
-                'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
-            ],
-            (object) [
-                'id' => $uuidOne,
-                'connection' => 'connection',
-                'queue' => 'queue',
-                'payload' => json_encode(['uuid' => $uuidOne]),
-                'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
-                'failed_at' => $failedJobs[0]->failed_at,
-                'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
-            ],
-        ], $failedJobs);
+            $failedJobs = $this->provider->all();
+
+            $this->assertEquals([
+                (object) [
+                    'id' => $uuidTwo,
+                    'connection' => 'connection',
+                    'queue' => 'queue',
+                    'payload' => json_encode(['uuid' => $uuidTwo]),
+                    'exception' => (string) mb_convert_encoding($exceptionTwo, 'UTF-8'),
+                    'failed_at' => $failedJobs[1]->failed_at,
+                    'failed_at_timestamp' => $failedJobs[1]->failed_at_timestamp,
+                ],
+                (object) [
+                    'id' => $uuidOne,
+                    'connection' => 'connection',
+                    'queue' => 'queue',
+                    'payload' => json_encode(['uuid' => $uuidOne]),
+                    'exception' => (string) mb_convert_encoding($exceptionOne, 'UTF-8'),
+                    'failed_at' => $failedJobs[0]->failed_at,
+                    'failed_at_timestamp' => $failedJobs[0]->failed_at_timestamp,
+                ],
+            ], $failedJobs);
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     public function testCanFindFailedJobs()


### PR DESCRIPTION
This test seems to be flaky quite often in CI see :
 https://github.com/laravel/framework/actions/runs/20151806630/job/57846064726
https://github.com/laravel/framework/actions/runs/20151281269/job/57844394190

I believe its due to race conditions with timestamps. When the two jobs are logged in quick succession, they occasionally get timestamps one second apart meaning the order is wrong.

This PR freezes the time as the test is more interested in the fact there's two jobs.