### PR TITLE
[12.x] Make PendingDispatch::afterResponse conditional

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -184,11 +184,12 @@ class PendingDispatch
     /**
      * Indicate that the job should be dispatched after the response is sent to the browser.
      *
+     * @param  bool  $afterResponse
      * @return $this
      */
-    public function afterResponse()
+    public function afterResponse($afterResponse = true)
     {
-        $this->afterResponse = true;
+        $this->afterResponse = $afterResponse;
 
         return $this;
     }


### PR DESCRIPTION
A quality of life improvement that allows the afterResponse option to be set conditionally, to simplify call site code.

A boolean `$afterResponse` parameter has been added to the `PendingDispatch::afterResponse()` method with a default value of `true` which ensures backwards compatibility.

This change can improve call site code by no longer requiring an if-test when the PendingDispatch should not always be executed after the response has been sent to the client.

Before:
```
if (env('APP_ENV') === 'local') {
    MyJob::dispatch($myData)
         ->afterResponse();
} else {
    MyJob::dispatch($myData);
}
```

After:
```
MyJob::dispatch($myData)
     ->afterResponse(env('APP_ENV') === 'local');
```
