### PR TITLE
[12.x]Feature: add query to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1942,4 +1942,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Convert the collection into a query string.
+     *
+     * @return static
+     */
+    public function query(): static
+    {
+        return new static(Arr::query($this->all()));
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5912,7 +5912,7 @@ class SupportCollectionTest extends TestCase
     {
         $collection = new Collection([
             'name' => 'Ali',
-            'age' => 17,
+            'age' => 18,
             'skills' => ['php', 'laravel'],
         ]);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -9,6 +9,7 @@ use CachingIterator;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\ItemNotFoundException;
@@ -5905,6 +5906,44 @@ class SupportCollectionTest extends TestCase
         $collection = new $collection([]);
 
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
+    }
+
+    public function testConvertsCollectionToQueryString()
+    {
+        $collection = new Collection([
+            'name' => 'Ali',
+            'age' => 17,
+            'skills' => ['php', 'laravel'],
+        ]);
+
+        $query = $collection->query();
+
+        $this->assertInstanceOf(Collection::class, $query);
+
+        $this->assertEquals(
+            Arr::query($collection->all()),
+            $query->first(),
+        );
+    }
+
+    public function testDoesNotMutateOriginalCollection()
+    {
+        $collection = new Collection(['a' => 1, 'b' => 2]);
+
+        $originalArray = $collection->all();
+
+        $collection->query();
+
+        $this->assertEquals($originalArray, $collection->all());
+    }
+
+    public function testReturnsNewInstance()
+    {
+        $collection = new Collection(['foo' => 'bar']);
+
+        $queryCollection = $collection->query();
+
+        $this->assertNotSame($collection, $queryCollection);
     }
 
     /**


### PR DESCRIPTION
Add `query()` method to Collection

This PR adds a `query()` method to the Collection class, allowing the collection data to be converted into a query string using `Arr::query()`. The method returns a new instance and does not modify the original collection.

Changes

Added `query()` method

Converts the collection’s contents into a query string in a new instance

Tests

Ensures the output matches `Arr::query()`

Confirms the original collection remains unchanged

Verifies a new instance is returned