### PR TITLE
Do not swallow session write exceptions

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -5,7 +5,7 @@ namespace Illuminate\Session;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionInterface;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
@@ -155,7 +155,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
-        } catch (QueryException) {
+        } catch (UniqueConstraintViolationException) {
             $this->performUpdate($sessionId, $payload);
         }
     }


### PR DESCRIPTION
The database session driver tries to protect against race conditions when writing a session record into the database that doesn't already exist by wrapping the INSERT in a try-catch and if an exception is caught falling back to an update query rather than an insert. 

However, the exception that is caught is the rather generic QueryException which can be thrown for a wide variety of reasons (broken connection, column-type mismatch), most of which should not fallback to an update. Catching the QueryException and falling back to updating instead can hide actual problems with session writes by swallowing the exception. 

For example, if the `user_id` column on your `sessions` table does not match the type of the `id` field on your user record you get silent failures as the Query exception telling you of the column mismatch is swallowed by `performInsert()` and `performUpdate` fails silently because the record does not currently exist - again failing to throw the relevant exception. 

The attached PR updates `performInsert` to only fallback to `performUpdate` if the exception thrown is `UniqueConstraintViolationException`, allowing any other issues occurring on the insert to be surfaced properly. 