### PR TITLE
[12.x] Add native JSON column type support for SQL Server 2025+

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -749,6 +749,12 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
+        $version = $this->connection->getServerVersion();
+
+        if (version_compare($version, '2025', '>=')) {
+            return 'json';
+        }
+
         return 'nvarchar(max)';
     }
 
@@ -760,7 +766,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'nvarchar(max)';
+        return $this->typeJson($column);
     }
 
     /**


### PR DESCRIPTION
Fixes #57965
This PR implements version detection in SqlServerGrammar to utilize the native JSON datatype for SQL Server 2025+ while maintaining the nvarchar(max) fallback for older versions, as requested in the issue.
