### PR TITLE
Change the remember cookie to store a MAC of the users password hash instead of their real password hash

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -127,6 +127,7 @@ class AuthManager implements FactoryContract
             $this->app['session.store'],
             rehashOnLogin: $this->app['config']->get('hashing.rehash_on_login', true),
             timeboxDuration: $this->app['config']->get('auth.timebox_duration', 200000),
+            hashKey: $this->app['config']->get('app.key'),
         );
 
         // When using the remember me functionality of the authentication services we

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -10,6 +10,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\OtherDeviceLogout;
 use Illuminate\Auth\Events\Validated;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Auth\SupportsBasicAuth;
@@ -623,7 +624,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function hashPasswordForCookie($passwordHash)
     {
-        return hash_hmac('sha256', $passwordHash, config('app.key'));
+        $container = Container::getInstance();
+
+        if ($container && $container->bound('config')) {
+            $key = $container->make('config')->get('app.key');
+        } else {
+            $key = 'base-key-for-password-hash-mac';
+        }
+
+        return hash_hmac('sha256', $passwordHash, $key);
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -600,7 +600,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function queueRecallerCookie(AuthenticatableContract $user)
     {
         $this->getCookieJar()->queue($this->createRecaller(
-            $user->getAuthIdentifier().'|'.$user->getRememberToken().'|'.$user->getAuthPassword()
+            $user->getAuthIdentifier().'|'.$user->getRememberToken().'|'.$this->hashPasswordForCookie($user->getAuthPassword())
         ));
     }
 
@@ -613,6 +613,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected function createRecaller($value)
     {
         return $this->getCookieJar()->make($this->getRecallerName(), $value, $this->getRememberDuration());
+    }
+
+    /**
+     * Create a HMAC of the password hash for storage in cookies.
+     *
+     * @param  string  $passwordHash
+     * @return string
+     */
+    public function hashPasswordForCookie($passwordHash)
+    {
+        return hash_hmac('sha256', $passwordHash, config('app.key'));
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -48,9 +48,9 @@ class AuthenticateSession implements AuthenticatesSessions
         }
 
         if ($this->guard()->viaRemember()) {
-            $passwordHash = explode('|', $request->cookies->get($this->guard()->getRecallerName()))[2] ?? null;
+            $passwordHashMac = explode('|', $request->cookies->get($this->guard()->getRecallerName()))[2] ?? null;
 
-            if (! $passwordHash || ! hash_equals($request->user()->getAuthPassword(), $passwordHash)) {
+            if (! $passwordHashMac || ! hash_equals($this->guard()->hashPasswordForCookie($request->user()->getAuthPassword()), $passwordHashMac)) {
                 $this->logout($request);
             }
         }
@@ -59,7 +59,7 @@ class AuthenticateSession implements AuthenticatesSessions
             $this->storePasswordHashInSession($request);
         }
 
-        if (! hash_equals($request->session()->get('password_hash_'.$this->auth->getDefaultDriver()), $request->user()->getAuthPassword())) {
+        if (! hash_equals($request->session()->get('password_hash_'.$this->auth->getDefaultDriver()), $this->guard()->hashPasswordForCookie($request->user()->getAuthPassword()))) {
             $this->logout($request);
         }
 
@@ -83,7 +83,7 @@ class AuthenticateSession implements AuthenticatesSessions
         }
 
         $request->session()->put([
-            'password_hash_'.$this->auth->getDefaultDriver() => $request->user()->getAuthPassword(),
+            'password_hash_'.$this->auth->getDefaultDriver() => $this->guard()->hashPasswordForCookie($request->user()->getAuthPassword()),
         ]);
     }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -498,7 +498,8 @@ class AuthGuardTest extends TestCase
         $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
         $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
-        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 576000)->andReturn($foreverCookie);
+        $expectedHash = hash_hmac('sha256', 'bar', 'base-key-for-password-hash-mac');
+        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|'.$expectedHash, 576000)->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('regenerate')->once();
@@ -518,7 +519,8 @@ class AuthGuardTest extends TestCase
         $guard->setRememberDuration(5000);
         $guard->setCookieJar($cookie);
         $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
-        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 5000)->andReturn($foreverCookie);
+        $expectedHash = hash_hmac('sha256', 'bar', 'base-key-for-password-hash-mac');
+        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|'.$expectedHash, 5000)->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('regenerate')->once();

--- a/tests/Session/Middleware/AuthenticateSessionTest.php
+++ b/tests/Session/Middleware/AuthenticateSessionTest.php
@@ -281,4 +281,44 @@ class AuthenticateSessionTest extends TestCase
         $this->assertEquals('1', $session->get('a'));
         $this->assertEquals('2', $session->get('b'));
     }
+
+    public function test_handle_with_old_format_cookie_for_backward_compatibility()
+    {
+        $user = new class
+        {
+            public function getAuthPassword()
+            {
+                return 'my-pass-(*&^%$#!@';
+            }
+        };
+
+        // Cookie contains OLD format (raw password hash, not HMAC)
+        $request = new Request(cookies: ['recaller-name' => 'a|b|my-pass-(*&^%$#!@']);
+        $request->setUserResolver(fn () => $user);
+
+        $session = new Store('name', new ArraySessionHandler(1));
+        $session->put('a', '1');
+        $session->put('b', '2');
+        // Session also contains old format for this test
+        $session->put('password_hash_web', 'my-pass-(*&^%$#!@');
+        $request->setLaravelSession($session);
+
+        $authFactory = Mockery::mock(AuthFactory::class);
+        $authFactory->shouldReceive('viaRemember')->andReturn(true);
+        $authFactory->shouldReceive('getRecallerName')->once()->andReturn('recaller-name');
+        $authFactory->shouldReceive('getDefaultDriver')->andReturn('web');
+        $authFactory->shouldReceive('user')->andReturn($user);
+        // The HMAC won't match the old format, but fallback to raw hash should work
+        $authFactory->shouldReceive('hashPasswordForCookie')->with('my-pass-(*&^%$#!@')->andReturn('mac:my-pass-(*&^%$#!@');
+
+        $middleware = new AuthenticateSession($authFactory);
+        $response = $middleware->handle($request, fn () => 'next-9');
+
+        // Should succeed because of backward compatibility fallback
+        $this->assertEquals('next-9', $response);
+        // Session should be updated to new format (HMAC)
+        $this->assertEquals('mac:my-pass-(*&^%$#!@', $session->get('password_hash_web'));
+        $this->assertEquals('1', $session->get('a'));
+        $this->assertEquals('2', $session->get('b'));
+    }
 }


### PR DESCRIPTION
During a pentest of a customer's deployed app, I inspected the `remember_web_*` cookie that it had set. It contained an encoded string, which I decoded and was shocked to find that it contained the real server-side bcrypt hash of the user's password. I set up the hash for offline cracking, which succeeded after only about 2 hours due to a lax password policy.

Looking at the SessionGuard history, it seems that the hash was included to provide a means for these session tokens to be invalidated automatically if the user changes their password (thus changing the hash). I can see that being useful, but it comes at the price of introducing an unnecessary security risk. Cookie encryption (which I gather is enabled by default, but in this case it had been disabled) does avoid the risk, but defence in depth applies; the same functionality can be implemented without any such risk.

The right way to do this is not to use the password hash directly, but a MAC derived from it (a hash is not good enough), keyed using the app's secret. It uses the app secret instead of a session fingerprint because we want it to match all active sessions. This retains all the same useful automatic invalidation if the password changes, but without exposing anything of use to an attacker, even if cookie encryption is disabled.

This PR introduces one new public method to provide the MAC, and then uses it in the cookie creation and session checking code, and includes updated tests to match.