### PR TITLE
[12.x] Allow Factory connection method to accept null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -842,10 +842,10 @@ abstract class Factory
     /**
      * Specify the database connection that should be used to generate models.
      *
-     * @param  \UnitEnum|string  $connection
+     * @param  \UnitEnum|string|null  $connection
      * @return static
      */
-    public function connection(UnitEnum|string $connection)
+    public function connection(UnitEnum|string|null $connection)
     {
         return $this->newInstance(['connection' => $connection]);
     }


### PR DESCRIPTION
In some of my factories I pass in the connection such as: 

``` php
Product::connection('replica-1')->factory()->create(); 
```
However, the definition references another factory ie: 

```php
    public function definition(): array
    {
        return [
            'user_id'  => User::factory(),
        ];
    }
``` 

I want to pass the connection through ie `User::factory()->connection($this->connection)` 

but, the connection can be null - as i'm not setting a connection in every test so I end up having to do: 

```php 
// Before
    public function definition(): array
    {
        return [
             'user_id'  => $this->connection ? User::factory()->connection($this->connection) : User::factory()
        ];
    }

// After
    public function definition(): array
    {
        return [
             'user_id'  => User::factory()->connection($this->connection);
        ];
    }
```

This is just a bit of DX, as the connection property can be null.

Thanks