### PR TITLE
[12.x] Add `mergeHidden` and `mergeVisible` methods to Collection class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -581,6 +581,28 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Merge the given, typically visible, attributes hidden across the entire collection.
+     *
+     * @param  array<array-key, string>|string  $attributes
+     * @return $this
+     */
+    public function mergeHidden($attributes)
+    {
+        return $this->each->mergeHidden($attributes);
+    }
+
+    /**
+     * Merge the given, typically hidden, attributes visible across the entire collection.
+     *
+     * @param  array<array-key, string>|string  $attributes
+     * @return $this
+     */
+    public function mergeVisible($attributes)
+    {
+        return $this->each->mergeVisible($attributes);
+    }
+
+    /**
      * Set the visible attributes across the entire collection.
      *
      * @param  array<int, string>  $visible

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -545,6 +545,22 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
+    public function testMergeHiddenAddsHiddenOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->mergeHidden(['merged']);
+
+        $this->assertEquals(['hidden', 'merged'], $c[0]->getHidden());
+    }
+
+    public function testMergeVisibleRemovesHiddenFromEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->mergeVisible(['merged']);
+
+        $this->assertEquals(['visible', 'merged'], $c[0]->getVisible());
+    }
+
     public function testSetVisibleReplacesVisibleOnEntireCollection()
     {
         $c = new Collection([new TestEloquentCollectionModel]);


### PR DESCRIPTION
This PR extends the `mergeHidden` and `mergeVisible` methods to **Eloquent Collections**, allowing you to adjust attribute visibility across an entire collection—not just individual models.

```php
// App\Models\User

use Illuminate\Foundation\Auth\User as Authenticatable;

class User extends Authenticatable
{
    /**
     * The attributes that are mass assignable.
     *
     * @var array<int, string>
     */
    protected $fillable = [
        'name',
        'email',
        'password',
        'last_login_at',
    ];

    /**
     * The attributes that should be hidden for serialization.
     *
     * @var array<string>
     */
    protected $hidden = [
        'password',
        'remember_token',
    ];

    /**
     * The attributes that should be visible in serialization.
     *
     * @var array<string>
     */
    protected $visible = [
        'name',
    ];
}
```

Runtime Usage

```php
use App\Models\User;

$users = User::withWhereHas('comments')->get();

// Temporarily expose hidden attributes for all models in the collection
$users->mergeVisible(['email']);

// Temporarily hide attributes across the collection
$users->mergeHidden(['last_login_at']);
```