### PR TITLE
[12.x] Make the Client Response class tappable

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
 use LogicException;
 use Stringable;
 
@@ -15,7 +16,7 @@ use Stringable;
  */
 class Response implements ArrayAccess, Stringable
 {
-    use Concerns\DeterminesStatusCode, Macroable {
+    use Concerns\DeterminesStatusCode, Tappable, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -406,7 +406,7 @@ class HttpClientTest extends TestCase
     {
         Response::macro('movieFields', function () {
             return $this->collect()
-                ->mapWithKeys(fn($field, $key) => [strtolower($key) => $field])
+                ->mapWithKeys(fn ($field, $key) => [strtolower($key) => $field])
                 ->toArray();
         });
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -387,6 +387,51 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $response->object()->result->foo);
     }
 
+    public function testResponseObjectIsTappable()
+    {
+        $bar = null;
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
+
+        $this->factory->get('http://foo.com/api')
+            ->tap(function (Response $response) use (&$bar) {
+                $bar = $response['result']['foo'];
+            });
+
+        $this->assertSame('bar', $bar);
+    }
+
+    public function testResponseObjectIsMacroable()
+    {
+        Response::macro('movieFields', function () {
+            return $this->collect()
+                ->mapWithKeys(fn($field, $key) => [strtolower($key) => $field])
+                ->toArray();
+        });
+
+        $response = $this->factory->fake([
+            '*' => [
+                'Title' => 'The Godfather',
+                'Year' => 1972,
+                'Rated' => 'R',
+                'Runtime' => '175 min',
+                'Director' => 'Francis Ford Coppola',
+            ],
+        ]);
+
+        $response = $this->factory->get('http://www.omdbapi.com/?apikey=test_api_key&i=test_imdb_id');
+
+        $this->assertIsArray($response->movieFields());
+        $this->assertSame([
+            'title' => 'The Godfather',
+            'year' => 1972,
+            'rated' => 'R',
+            'runtime' => '175 min',
+            'director' => 'Francis Ford Coppola',
+        ], $response->movieFields());
+    }
+
     public function testResponseCanBeReturnedAsResource()
     {
         $this->factory->fake([


### PR DESCRIPTION
When sending API requests to external services, we always have to assign the response to a temporary variable before working on that. making the `Illuminate\Http\Client\Response` class tappable will remove that hassle.

For example, I have a side project about movies. It is a good idea to only save IMDB id in the DB first, and then use it to retrieve the remaining data of a movie later.

Using `tap` in combination with `macro`, the code will be a lot cleaner.

```php
use Illuminate\Http\Client\Response;

Response::macro(
    'movieFields',
    fn () => $this->collect()->only('title', 'year', 'runtime', 'director', 'plot')
);

class MoviesController extends Controller
{
    public function show(Movie $movie)
    {
        if ($movie->missingInformation()) {
            Http::post("http://www.omdbapi.com/?apikey=test_api_key&i={$movie->imdb_id}")
                ->throw()
                ->tap(fn (Response $response) => $movie->update($response->movieFields()));
        }

        return view('movies.show', compact('movie'));
    }
}
```
I also add a test case for adding macros to that Client Response class.