### PR TITLE
[12.x] Update git-auto-commit action

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -91,7 +91,7 @@ jobs:
             Illuminate\\Support\\Facades\\Vite
 
       - name: Commit facade docblocks
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Update facade docblocks
           file_pattern: src/

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -61,7 +61,7 @@ jobs:
         run: sed -i "s/const VERSION = '.*';/const VERSION = '${{ steps.version.outputs.version }}';/g" src/Illuminate/Foundation/Application.php
 
       - name: Commit version change
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Update version to v${{ steps.version.outputs.version }}"
 

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -34,6 +34,6 @@ jobs:
           npm run build --prefix "./src/Illuminate/Foundation/resources/exceptions/renderer"
 
       - name: Commit Compiled Files
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Update Assets


### PR DESCRIPTION
v5 is quite outdated now (by 2 years) , v7 is the latest : https://github.com/stefanzweifel/git-auto-commit-action/releases

I've tested it to make sure it works as expected see : https://github.com/jackbayliss/framework/actions/runs/20200818805/job/57991732460#step:7:1

Cheers