### PR TITLE
[12.x] Add the firstKey and lastKey methods to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -279,6 +279,43 @@ class Arr
     }
 
     /**
+     * Return the key of the first element in an iterable passing a given truth test.
+     *
+     * @template TKey
+     * @template TValue
+     * @template TFirstDefault
+     *
+     * @param  iterable<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
+     * @return TValue|TFirstDefault
+     */
+    public static function firstKey($array, ?callable $callback = null, $default = null)
+    {
+        if (is_null($callback)) {
+            if (empty($array)) {
+                return value($default);
+            }
+
+            if (is_array($array)) {
+                return array_key_first($array);
+            }
+
+            foreach ($array as $key => $item) {
+                return $key;
+            }
+
+            return value($default);
+        }
+
+        $array = static::from($array);
+
+        $key = array_find_key($array, $callback);
+
+        return $key !== null ? $key : value($default);
+    }
+
+    /**
      * Return the last element in an array passing a given truth test.
      *
      * @template TKey

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -337,6 +337,27 @@ class Arr
     }
 
     /**
+     * Return the key of the last element in an array passing a given truth test.
+     *
+     * @template TKey
+     * @template TValue
+     * @template TLastDefault
+     *
+     * @param  iterable<TKey, TValue>  $array
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TLastDefault|(\Closure(): TLastDefault)  $default
+     * @return TValue|TLastDefault
+     */
+    public static function lastKey($array, ?callable $callback = null, $default = null)
+    {
+        if (is_null($callback)) {
+            return empty($array) ? value($default) : array_key_last($array);
+        }
+
+        return static::firstKey(array_reverse($array, true), $callback, $default);
+    }
+
+    /**
      * Take the first or last {$limit} items from an array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -457,6 +457,30 @@ class SupportArrTest extends TestCase
         $this->assertEquals(200, $value5);
     }
 
+    public function testLastKey()
+    {
+        $this->assertSame(null, Arr::lastKey([]));
+
+        $array = [
+            'foo_key_1' => 'foo',
+            'foo_key_2' => 'foo',
+            'foo_key_3' => 'foo',
+            'bar_key_1' => 'bar',
+            'bar_key_2' => 'bar',
+            'bar_key_3' => 'bar',
+            'baz_key_1' => 'baz',
+            'baz_key_2' => 'baz',
+            'baz_key_3' => 'baz',
+        ];
+
+        $this->assertSame('baz_key_3', Arr::lastKey($array));
+        $this->assertSame('bar_key_3', Arr::lastKey($array, fn ($item) => $item === 'bar'));
+        $this->assertSame(2, Arr::lastKey(array_values($array), fn ($item) => $item === 'foo'));
+        $this->assertSame(null, Arr::lastKey($array, fn ($item) => $item === 'boo'));
+        $this->assertSame('last_boo_key', Arr::lastKey($array, fn ($item) => $item === 'boo', 'last_boo_key'));
+        $this->assertSame('last_boo_key', Arr::lastKey($array, fn ($item) => $item === 'boo', fn () => 'last_boo_key'));
+    }
+
     public function testFlatten()
     {
         // Flat arrays are unaffected

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -376,6 +376,24 @@ class SupportArrTest extends TestCase
         $this->assertNull(Arr::first($cursor));
     }
 
+    public function testFirstKey()
+    {
+        $this->assertSame(null, Arr::firstKey([]));
+
+        $array = [
+            'foo_key' => 'foo',
+            'bar_key' => 'bar',
+            'baz_key' => 'baz',
+        ];
+
+        $this->assertSame('foo_key', Arr::firstKey($array));
+        $this->assertSame('baz_key', Arr::firstKey($array, fn ($item) => $item === 'baz'));
+        $this->assertSame(1, Arr::firstKey(array_values($array), fn ($item) => $item === 'bar'));
+        $this->assertSame(null, Arr::firstKey($array, fn ($item) => $item === 'boo'));
+        $this->assertSame('boo_key', Arr::firstKey($array, fn ($item) => $item === 'boo', 'boo_key'));
+        $this->assertSame('boo_key', Arr::firstKey($array, fn ($item) => $item === 'boo', fn () => 'boo_key'));
+    }
+
     public function testFirstWorksWithArrayObject()
     {
         $arrayObject = new ArrayObject([0, 10, 20]);


### PR DESCRIPTION
In a number of scenarios, I am interested in not the first element, but the key of the first element.

Currently I believe there is no straightforward or dynamic enough ways to do so:

```php
$collection
    ->filter(...)
    ->keys()
    ->first()

// This is a good approach, but not dynamic enough.
array_find_key($array, $callback);
```

I got an example.

```php
// an API response
$ladder = [
    'Detroit Pistons',
    'New York Knicks',
    'Boston Celtics',
    'Philadelphia 76ers',
    'Orlando Magics',
    // ...
];

$rank = Arr::firstKey($ladder, 'Detroit Pistons') + 1;
```

And a realistic example that I work on.

```php
$myMainAddress = '1EpJefk6p4KhKm5oU5RsfgYBaN16T3MFmt';

// an API response contains all my Bitcoin accounts.
$myBitcoinAddresses = [
    '1Fi47w4JoEWJ4stdC13bXbc7awtLLLvygZ' => 0,
    '15NZY7PuuTy6tpvL3xp9PWDxFPyyygptPd' => 0,
    '1AyTZjo2YksAqh2Vf8Je6RM2RfSxnhsEox' => 0.1,
    '1BtUZ5bJTa5tGqf9GkVRXomBmp9nNmwYp4' => 0.2,
    '1PWx9SpZxRArXAFbdD3QWY6G2Fs1QMuEpm' => 0.3,
];

$toBeTransfer = 0.11;

$addressToBeUsed = Arr::firstKey($myBitcoinAddresses, fn ($balance) => $balance >= $toBeTransfer, $myMainAddress);
```

I don't have much use for the `lastKey` method, but I implemented that anyway.

If you don't find this persuasive enough, that is totally fine. I can always add those as macros.

