### PR TITLE
Add strict/non-strict Base64 validation to Str

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -382,6 +382,17 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if the string is valid Base64.
+     *
+     * @param  bool  $strict
+     * @return bool
+     */
+    public function isBase64(bool $strict = true): bool
+    {
+        return Str::isBase64($this->value, $strict);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -719,6 +719,34 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isJson([]));
     }
 
+    public function testIsBase64()
+    {
+        $padded = base64_encode('Laravel');
+        $unpadded = rtrim($padded, '=');
+
+        $this->assertTrue(Str::isBase64($padded));
+        $this->assertFalse(Str::isBase64($unpadded));
+        $this->assertTrue(Str::isBase64($unpadded, strict: false));
+
+        $binary = "\x00\x01\x02\xff";
+        $binaryEncoded = base64_encode($binary);
+        $this->assertTrue(Str::isBase64($binaryEncoded));
+
+        $urlsafe = rtrim(strtr($binaryEncoded, '+/', '-_'), '=');
+        $this->assertFalse(Str::isBase64($urlsafe));
+        $this->assertTrue(Str::isBase64($urlsafe, strict: false));
+
+        $this->assertFalse(Str::isBase64(''));
+        $this->assertFalse(Str::isBase64('!!!!'));
+        $this->assertFalse(Str::isBase64('YWJj#A=='));
+        $this->assertFalse(Str::isBase64('TQ==='));
+        $this->assertFalse(Str::isBase64('TQ=', strict: false));
+
+        $this->assertSame(Str::isBase64($padded), Str::of($padded)->isBase64());
+        $this->assertSame(Str::isBase64($unpadded, strict: false), Str::of($unpadded)->isBase64(strict: false));
+        $this->assertSame(Str::isBase64($urlsafe, strict: false), Str::of($urlsafe)->isBase64(strict: false));
+    }
+
     public function testIsMatch()
     {
         $this->assertTrue(Str::isMatch('/.*,.*!/', 'Hello, Laravel!'));


### PR DESCRIPTION
This PR introduces a new helper for safely determining whether a string is valid Base64.

## Why

Laravel has helpers like `Str::isJson()` and `Str::isUrl()` for common “is this valid?” checks, but there’s no built-in, predictable Base64 validator. In userland this often turns into a mix of regexes and `base64_decode()` usage that’s inconsistent and easy to get wrong.

`Str::isBase64()` provides a clear, conservative default, aligned with Laravel’s existing validation-style helpers.

## What’s Included

- `Illuminate\Support\Str::isBase64(string $value, bool $strict = true): bool`
- `Illuminate\Support\Stringable::isBase64(bool $strict = true): bool`  
  For fluent usage: `str($value)->isBase64()`

## Behavior

### `strict = true` (default)

- RFC 4648 Base64 alphabet only (`A–Z a–z 0–9 + /`)
- Padding allowed only at the end (maximum 2 `=` characters)
- Length must be a multiple of 4
- Uses `base64_decode($value, true)` for strict character validation

### `strict = false`

- Accepts unpadded Base64
- Accepts URL-safe Base64 (`-` and `_`)
- Normalizes URL-safe input and, when needed, adds padding before validation

### General Rules

- Empty string always returns `false`
- No exceptions are thrown
- Input is never mutated

## Examples

```php
Str::isBase64('Zm9vYg=='); // true
Str::isBase64('Zm9vYg'); // false
Str::isBase64('Zm9vYg', strict: false); // true
Str::isBase64('____', strict: false); // true (URL-safe variant)

str($value)->isBase64(); // mirrors Str::isBase64($value)
```

Tests

Added testIsBase64() to SupportStrTest.php, covering:

valid padded Base64

valid unpadded Base64 (non-strict)

valid URL-safe Base64 (non-strict)

invalid characters

incorrect padding

empty string

binary data encoded to Base64

symmetry between Str and Stringable

Compatibility

Additive API only

No new dependencies

O(n) validation
