### PR TITLE
[12.x] Make the assertQueuedTimes method public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -225,7 +225,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
      * @param  int  $times
      * @return void
      */
-    protected function assertQueuedTimes($mailable, $times = 1)
+    public function assertQueuedTimes($mailable, $times = 1)
     {
         $count = $this->queued($mailable)->count();
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -186,6 +186,7 @@ class SupportTestingMailFakeTest extends TestCase
         }
 
         $this->fake->assertSent(MailableStub::class, 2);
+        $this->fake->assertSentTimes(MailableStub::class, 2);
     }
 
     public function testAssertSentCount()
@@ -258,6 +259,7 @@ class SupportTestingMailFakeTest extends TestCase
         }
 
         $this->fake->assertQueued(MailableStub::class, 2);
+        $this->fake->assertQueuedTimes(MailableStub::class, 2);
     }
 
     public function testAssertNotQueuedWithString()


### PR DESCRIPTION
Guided by [this PR](https://github.com/laravel/docs/pull/10949) to docs.

I notice the `assertSentTimes` method has been made public. It's counterpart should be probably made public too.