### PR TITLE
[12.x] Add missing docblock param in FailedOver event docblocks

### DIFF
--- a/src/Illuminate/Cache/Events/CacheFailedOver.php
+++ b/src/Illuminate/Cache/Events/CacheFailedOver.php
@@ -9,7 +9,8 @@ class CacheFailedOver
     /**
      * Create a new event instance.
      *
-     * @param  string  $storeName  The name of the cache store that failed.
+     * @param  string|null  $storeName  The name of the cache store that failed.
+     * @param  Throwable  $exception  The exception that was thrown.
      */
     public function __construct(
         public ?string $storeName,

--- a/src/Illuminate/Queue/Events/QueueFailedOver.php
+++ b/src/Illuminate/Queue/Events/QueueFailedOver.php
@@ -9,8 +9,9 @@ class QueueFailedOver
     /**
      * Create a new event instance.
      *
-     * @param  string  $connectionName  The queue connection that failed.
-     * @param  \Closure|string|object  $job  The job instance.
+     * @param  string|null  $connectionName  The queue connection that failed.
+     * @param  \Closure|string|object  $command  The job instance.
+     * @param  Throwable  $exception  The exception that was thrown.
      */
     public function __construct(
         public ?string $connectionName,


### PR DESCRIPTION
I was poking about thinking about a new Failover class for something👀  but noticed these. 

Just for clarity, tooling, and static analysis / aligns with everywhere else.