### PR TITLE
[12.x] Fix Password::required() to fail when value is missing

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
@@ -12,7 +13,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 
-class Password implements Rule, DataAwareRule, ValidatorAwareRule
+class Password implements Rule, DataAwareRule, ValidatorAwareRule, ImplicitRule
 {
     use Conditionable;
 
@@ -330,6 +331,14 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     public function passes($attribute, $value)
     {
         $this->messages = [];
+
+        if (! $this->required && ! $this->sometimes && ($this->data === null || ! Arr::has($this->data, $attribute))) {
+            return true;
+        }
+
+        if ($value === null && ! $this->required && $this->validator && $this->validator->hasRule($attribute, ['Nullable'])) {
+            return true;
+        }
 
         $validator = Validator::make(
             $this->data,

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 
-class Password implements Rule, DataAwareRule, ValidatorAwareRule, ImplicitRule
+class Password implements Rule, DataAwareRule, ImplicitRule, ValidatorAwareRule
 {
     use Conditionable;
 

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -443,6 +443,28 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes([Password::sometimes()], ['Password123', 'password123']);
     }
 
+    public function testRequiredWithMissingValue()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [],
+            ['password' => [Password::required()]]
+        );
+
+        $this->assertFalse($v->passes());
+        $this->assertArrayHasKey('password', $v->messages()->toArray());
+        $this->assertStringContainsString('required', $v->messages()->first('password'));
+
+        $v = \Illuminate\Support\Facades\Validator::make(
+            [],
+            [
+                'password' => [\Illuminate\Validation\Rules\Password::required()],
+            ]
+        );
+
+        $this->assertFalse($v->passes());
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);


### PR DESCRIPTION
This PR fixes an issue where `Password::required()` validation incorrectly passes when the password field is missing from the request data.

Fixes #58112