### PR TITLE
[12.x] Fix: Handle `ParseError` in `hasEvenNumberOfParentheses` when Xdebug is active

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -635,9 +635,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $closing = 0;
 
         foreach ($tokens as $token) {
-            if ($token === ')') {
+            if ($token == ')') {
                 $closing++;
-            } elseif ($token === '(') {
+            } elseif ($token == '(') {
                 $opening++;
             }
         }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\View\Component;
 use InvalidArgumentException;
+use ParseError;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -620,7 +621,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function hasEvenNumberOfParentheses(string $expression)
     {
-        $tokens = token_get_all('<?php '.$expression);
+        try {
+            $tokens = token_get_all('<?php '.$expression);
+        } catch (ParseError) {
+            return false;
+        }
 
         if (Arr::last($tokens) !== ')') {
             return false;
@@ -630,9 +635,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $closing = 0;
 
         foreach ($tokens as $token) {
-            if ($token == ')') {
+            if ($token === ')') {
                 $closing++;
-            } elseif ($token == '(') {
+            } elseif ($token === '(') {
                 $opening++;
             }
         }


### PR DESCRIPTION
fix #57472

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
