### PR TITLE
Improve Model::is() to support Stringable value-object keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1919,8 +1919,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function is($model)
     {
-        return ! is_null($model) &&
-            $this->getKey() === $model->getKey() &&
+        if (is_null($model)) {
+            return false;
+        }
+
+        $modelAKey = $this->getKey();
+        $modelBKey = $model->getKey();
+
+        $normalizedAKey = $modelAKey instanceof Stringable ? (string) $modelAKey : $modelAKey;
+        $normalizedBKey = $modelBKey instanceof Stringable ? (string) $modelBKey : $modelBKey;
+
+        return $normalizedAKey === $normalizedBKey &&
             $this->getTable() === $model->getTable() &&
             $this->getConnectionName() === $model->getConnectionName();
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1923,13 +1923,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        $modelAKey = $this->getKey();
-        $modelBKey = $model->getKey();
+        $firstModelKey = $this->getKey();
+        $secondModelKey = $model->getKey();
 
-        $normalizedAKey = $modelAKey instanceof Stringable ? (string) $modelAKey : $modelAKey;
-        $normalizedBKey = $modelBKey instanceof Stringable ? (string) $modelBKey : $modelBKey;
+        $firstModelKey = $firstModelKey instanceof Stringable ? (string) $firstModelKey : $firstModelKey;
+        $secondModelKey = $secondModelKey instanceof Stringable ? (string) $secondModelKey : $secondModelKey;
 
-        return $normalizedAKey === $normalizedBKey &&
+        return $firstModelKey === $secondModelKey &&
             $this->getTable() === $model->getTable() &&
             $this->getConnectionName() === $model->getConnectionName();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3041,6 +3041,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testIsWithStringableKey()
+    {
+        $firstInstance = new EloquentModelStub(['id' => new Stringable('1')]);
+        $secondInstance = new EloquentModelStub(['id' => new Stringable('1')]);
+        $result = $firstInstance->is($secondInstance);
+        $this->assertTrue($result);
+    }
+
     public function testWithoutTouchingCallback()
     {
         new EloquentModelStub(['id' => 1]);


### PR DESCRIPTION
This PR updates `Model::is()` to correctly compare models that use value objects as primary keys.

The current implementation relies on strict identity (`===`) for key comparison, which works for scalar keys but fails when `getKey()` returns an object. Two value-object keys representing the same identifier may not be the same instance, causing `is()` to return `false`.

This change normalizes model keys before comparison:
- Keys implementing PHP’s `Stringable` interface are compared by their string value
- All other keys continue to be compared strictly

#### Benefits
- Ensures `Model::is()` behaves correctly for value-based identifiers

#### Backward compatibility
- Scalar keys remain strictly compared
- Non-stringable objects still require strict identity
- No loose comparisons or behavior changes for existing applications