### PR TITLE
[12.x] Alias and extend route

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -286,9 +286,9 @@ class Router implements BindingRegistrar, RegistrarContract
         $canonicalRoute = $this->routes->getByName($name);
 
         if ($canonicalRoute === null) {
-            throw new InvalidArgumentException('No route found by name to alias, "' . $name . '" given.');
+            throw new InvalidArgumentException('No route found by name to alias, "'.$name.'" given.');
         }
-        
+
         $newRoute = clone $canonicalRoute;
         $canonicalRoute->uri = $uri;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -275,6 +275,20 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new route alias.
+     *
+     * @param  string  $uri
+     * @param  string  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function alias(string $uri, string $name)
+    {
+        $canonicalRoute = (clone) $this->routes->getByName($name);
+        $canonicalRoute->uri = $uri;
+        return $this->routes->add($canonicalRoute);
+    }
+
+    /**
      * Register a new route that returns a view.
      *
      * @param  string  $uri

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -283,7 +283,13 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function alias(string $uri, string $name)
     {
-        $canonicalRoute = clone $this->routes->getByName($name);
+        $canonicalRoute = $this->routes->getByName($name);
+
+        if ($canonicalRoute === null) {
+            throw new InvalidArgumentException('No route found by name to alias, "' . $name . '" given.');
+        }
+        
+        $newRoute = clone $canonicalRoute;
         $canonicalRoute->uri = $uri;
 
         return $this->routes->add($canonicalRoute);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -283,7 +283,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function alias(string $uri, string $name)
     {
-        $canonicalRoute = (clone) $this->routes->getByName($name);
+        $canonicalRoute = clone $this->routes->getByName($name);
         $canonicalRoute->uri = $uri;
         return $this->routes->add($canonicalRoute);
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -285,6 +285,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $canonicalRoute = clone $this->routes->getByName($name);
         $canonicalRoute->uri = $uri;
+
         return $this->routes->add($canonicalRoute);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use ReflectionClass;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -38,6 +38,7 @@ use Illuminate\Routing\RouteGroup;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -2272,6 +2273,14 @@ class RoutingRouteTest extends TestCase
         })->name('foo.bar');
         $router->alias('foo/baz', 'foo.bar');
         $this->assertSame('hello', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
+    }
+
+    public function testRouteAliasNameNotFound()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No route found by name to alias, "foo.bar" given.');
+        $router = $this->getRouter();
+        $router->alias('foo/baz', 'foo.bar');
     }
 
     protected function getRouter($container = null)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2268,9 +2268,9 @@ class RoutingRouteTest extends TestCase
     public function testRouteAlias()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->name('foo.bar')->get('foo/bar', function () {
             return 'hello';
-        })->name('foo.bar');
+        });
         $router->alias('foo/baz', 'foo.bar');
         $this->assertSame('hello', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2264,6 +2264,16 @@ class RoutingRouteTest extends TestCase
         $this->assertSame($response, $prepared[1]->response);
     }
 
+    public function testRouteAlias()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', function () {
+            return 'hello';
+        })->name('foo.bar');
+        $router->alias('foo/bar', 'foo.bar');
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
+    }
+
     protected function getRouter($container = null)
     {
         $container ??= new Container;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2270,7 +2270,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', function () {
             return 'hello';
         })->name('foo.bar');
-        $router->alias('foo/bar', 'foo.bar');
+        $router->alias('foo/baz', 'foo.bar');
         $this->assertSame('hello', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
     }
 


### PR DESCRIPTION
Sometimes, you want to offer multiple ways to access a page:
```php
Route::domain('foo.example.com')->group(function () {
    Route::get('/bar', fn () => view('bar'));
});

Route::prefix('foo')->group(function () {
    Route::get('/bar', fn () => view('bar'));
});
```
Currently, you have to options:
* redirect
* copy and paste

|                    | Pro                       | Contra |
| ------------------ | ------------------------- | -------------------- |
| **Redirect**       | only one canonical source | sometimes not wanted |
| **Copy and paste** | no accidental change of multiple routes when you only want to change one | forgetting to change the other routes when changing one |

With this PR, you can get multiple of these routes in sync:
```php
Route::domain('foo.example.com')->group(function () {
    Route::get('/bar', fn () => view('bar'))->name('foo.bar');
});

Route::prefix('foo')->group(function () {
    Route::alias('/bar', 'foo.bar');
});
```