### PR TITLE
[12.x] Run `ConnectionEstablished` event on database reconnection

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -330,7 +330,9 @@ class DatabaseManager implements ConnectionResolverInterface
             return $this->connection($name);
         }
 
-        return $this->refreshPdoConnections($name);
+        return tap($this->refreshPdoConnections($name), function ($connection) {
+            $this->dispatchConnectionEstablishedEvent($connection);
+        });
     }
 
     /**

--- a/tests/Integration/Database/EventConnectionEstablishedTest.php
+++ b/tests/Integration/Database/EventConnectionEstablishedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Events\ConnectionEstablished;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\Attributes\WithMigration;
+use Orchestra\Testbench\TestCase;
+
+use function Orchestra\Testbench\artisan;
+
+class EventConnectionEstablishedTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    #[WithMigration]
+    public function testItListenToEstablishedConnectionOnReconnect()
+    {
+        Event::fake([ConnectionEstablished::class]);
+
+        Event::assertNotDispatched(ConnectionEstablished::class);
+
+        artisan($this, 'migrate:fresh');
+
+        Event::assertDispatched(ConnectionEstablished::class);
+    }
+}


### PR DESCRIPTION
This allows application to register custom function etc to PDO such as #57602 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
