### PR TITLE
[12.x] Set default max bytes to prevent password collision via bcrypt truncation

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -43,7 +43,7 @@ class Password implements Rule, DataAwareRule, ImplicitRule, ValidatorAwareRule
      *
      * @var int
      */
-    protected $max;
+    protected $max = 72;
 
     /**
      * If the password is required.

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -364,7 +364,7 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->assertSame($password->appliedRules(), [
             'min' => 2,
-            'max' => null,
+            'max' => 72,
             'mixedCase' => false,
             'letters' => false,
             'numbers' => false,

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -139,7 +139,7 @@ class ValidationPasswordRuleTest extends TestCase
             '%HurHUnw7zM!',
             'rundeliekend',
             '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
-            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwS',
         ]);
     }
 


### PR DESCRIPTION
 **Summary**

  - Added default max(72) validation to the Password rule to prevent bcrypt truncation vulnerabilities
  - Updated test expectations to reflect the new default

  **Problem**
Laravel uses bcrypt for password hashing by default, which only processes the first 72 bytes of a password. Passwords longer than 72 characters are silently truncated, meaning two different passwords with the same first 72 bytes will authenticate identically:
```php
  $password1 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'; // 73 chars
  $password2 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2'; // 73 chars

  $hash = bcrypt($password1);

  Hash::check($password1, $hash); // TRUE
  Hash::check($password2, $hash); // TRUE
```
This allows users with passwords sharing the same first 72 bytes to authenticate into each other's accounts.

**Proposed Solution**

The Password validation rule now enforces a default max(72) limit, preventing users from creating passwords that exceed bcrypt's effective length.

**References**
- https://www.php.net/manual/en/function.password-hash.php#refsect1-function.password-hash-parameters
- https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length
- https://www.usenix.org/legacy/events/usenix99/provos/provos_html/node4.html

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
