### PR TITLE
fix(migration): safely drop a column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -418,6 +418,20 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given columns should be dropped if they exist.
+     *
+     * @param  mixed  $columns
+     * @return \Illuminate\Support\Fluent
+     */
+
+    public function dropColumnIfExists($columns)
+    {
+        $columns = is_array($columns) ? $columns : func_get_args();
+
+        return $this->addCommand('dropColumnIfExists', compact('columns'));
+    }
+
+    /**
      * Indicate that the given columns should be renamed.
      *
      * @param  string  $from

--- a/src/Illuminate/Database/Schema/BlueprintState.php
+++ b/src/Illuminate/Database/Schema/BlueprintState.php
@@ -201,6 +201,13 @@ class BlueprintState
 
                 break;
 
+            case 'dropColumnIfExists':
+                $this->columns = array_values(
+                    array_filter($this->columns, fn ($column) => ! in_array($column->name, $command->columns))
+                );
+
+                break;
+
             case 'primary':
                 $this->primaryKey = $command;
                 break;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -549,6 +549,21 @@ class Builder
     }
 
     /**
+     * Drop columns from a table schema if they exist.
+     *
+     * @param  string  $table
+     * @param  string|array<string>  $columns
+     * @return void
+     */
+
+    public function dropColumnsIfExists($table, $columns)
+    {
+        $this->table($table, function (Blueprint $blueprint) use ($columns) {
+            $blueprint->dropColumnIfExists($columns);
+        });
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -535,6 +535,20 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a drop column command if exists.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function compileDropColumnIfExists(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('This database driver does not support drop column if exists.');
+    }
+
+    /**
      * Compile a drop primary key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -571,6 +571,20 @@ class PostgresGrammar extends Grammar
         return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }
 
+     /**
+     * Compile a drop column command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropColumnIfExists(Blueprint $blueprint, Fluent $command)
+    {
+        $columns = $this->prefixArray('drop column if exists ', $this->wrapArray($command->columns));
+
+        return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
+    }
+
     /**
      * Compile a drop primary key command.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -538,6 +538,20 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a drop column command if exists.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function compileDropColumnIfExists(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('This database driver does not support drop column if exists.');
+    }
+
+    /**
      * Compile a drop primary key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use RuntimeException;
 
 class SqlServerGrammar extends Grammar
 {
@@ -383,6 +384,21 @@ class SqlServerGrammar extends Grammar
 
         return $dropExistingConstraintsSql.'alter table '.$this->wrapTable($blueprint).' drop column '.implode(', ', $columns);
     }
+
+    /**
+     * Compile a drop column command if exists.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function compileDropColumnIfExists(Blueprint $blueprint, Fluent $command)
+    {
+        throw new RuntimeException('This database driver does not support drop column if exists.');
+    }
+
 
     /**
      * Compile a drop default constraint command.


### PR DESCRIPTION
Uses dropColumnIfExists , which is supported only on PostgreSQL, to avoid migration failures when the column is missing.Example:  Schema::table('table_name', function (Blueprint $table) {
            $table->dropColumnIfExists('column_name');
        });

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
