### PR TITLE
[12.x] Only exclude Command ending with `Test` isn't an instance of `Command`

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Throwable;
+use WeakMap;
 
 class Kernel implements KernelContract
 {
@@ -366,15 +367,24 @@ class Kernel implements KernelContract
 
         $namespace = $this->app->getNamespace();
 
-        foreach ($this->findCommands($paths) as $file) {
-            $command = $this->commandClassFromFile($file, $namespace);
+        $possibleCommands = new WeakMap;
 
-            if (is_subclass_of($command, Command::class) &&
-                ! (new ReflectionClass($command))->isAbstract()) {
-                Artisan::starting(function ($artisan) use ($command) {
-                    $artisan->resolve($command);
-                });
-            }
+        $filterCommands = function (SplFileInfo $file) use ($namespace, &$possibleCommands) {
+            $commandClassName = $this->commandClassFromFile($file, $namespace);
+
+            $possibleCommands[$file] = $commandClassName;
+
+            $command = rescue(fn () => new ReflectionClass($commandClassName), null, false);
+
+            return $command instanceof ReflectionClass
+                && $command->isSubClassOf(Command::class)
+                && ! $command->isAbstract();
+        };
+
+        foreach ($this->findCommands($paths)->filter($filterCommands) as $file) {
+            Artisan::starting(function ($artisan) use ($file, $possibleCommands) {
+                $artisan->resolve($possibleCommands[$file]);
+            });
         }
     }
 
@@ -386,7 +396,7 @@ class Kernel implements KernelContract
      */
     protected function findCommands(array $paths)
     {
-        return Finder::create()->in($paths)->notName('*Test.php')->files();
+        return Finder::create()->in($paths)->name('*.php')->files();
     }
 
     /**

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -337,8 +337,6 @@ class TestKernel extends Kernel
     public function loadFrom($paths)
     {
         $this->load($paths);
-
-        $this->bootstrap();
     }
 
     #[\Override]

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -2,27 +2,36 @@
 
 namespace Illuminate\Tests\Console;
 
+use Composer\Autoload\ClassLoader;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application as FoundationApplication;
 use Illuminate\Foundation\Console\Kernel;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithArrayInputPrompting;
 use Illuminate\Tests\Console\Fixtures\FakeCommandWithInputPrompting;
 use Mockery as m;
+use Orchestra\Testbench\Concerns\InteractsWithMockery;
+use Orchestra\Testbench\Foundation\Application as Testbench;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Throwable;
 
+use function Illuminate\Filesystem\join_paths;
+use function Orchestra\Testbench\default_skeleton_path;
+
 class ConsoleApplicationTest extends TestCase
 {
+    use InteractsWithMockery;
+
     protected function tearDown(): void
     {
-        m::close();
+        $this->tearDownTheTestEnvironmentUsingMockery();
     }
 
     public function testAddSetsLaravelInstance()
@@ -150,7 +159,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputPromptsWhenRequiredArgumentIsMissing()
     {
         $artisan = new Application(
-            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $laravel = new FoundationApplication(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
@@ -169,7 +178,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputDoesntPromptWhenRequiredArgumentIsPassed()
     {
         $artisan = new Application(
-            new \Illuminate\Foundation\Application(__DIR__),
+            new FoundationApplication(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
@@ -188,7 +197,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputPromptsWhenRequiredArgumentsAreMissing()
     {
         $artisan = new Application(
-            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $laravel = new FoundationApplication(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
@@ -207,7 +216,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCommandInputDoesntPromptWhenRequiredArgumentsArePassed()
     {
         $artisan = new Application(
-            new \Illuminate\Foundation\Application(__DIR__),
+            new FoundationApplication(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
@@ -226,7 +235,7 @@ class ConsoleApplicationTest extends TestCase
     public function testCallMethodCanCallArtisanCommandUsingCommandClassObject()
     {
         $artisan = new Application(
-            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            $laravel = new FoundationApplication(__DIR__),
             m::mock(Dispatcher::class, ['dispatch' => null]),
             'testing'
         );
@@ -244,30 +253,45 @@ class ConsoleApplicationTest extends TestCase
 
     public function testLoadIgnoresTestFiles()
     {
-        $dir = __DIR__.'/laravel';
-        @mkdir($dir.'/app/Console/Commands', 0755, true);
-        file_put_contents($dir.'/composer.json', json_encode(['autoload' => ['psr-4' => ['App\\' => 'app/']]]));
-        file_put_contents($dir.'/app/Console/Commands/ExampleCommand.php', '<?php namespace App\Console\Commands; class ExampleCommand extends \Illuminate\Console\Command { protected $signature = "example"; public function handle() {} }');
-        file_put_contents($dir.'/app/Console/Commands/ExampleCommandTest.php', '<?php namespace App\Console\Commands; class ExampleCommandTest extends \Illuminate\Console\Command { protected $signature = "example-test"; public function handle() {} }');
+        $files = new Filesystem;
+
+        $files->ensureDirectoryExists(join_paths(default_skeleton_path(), 'app', 'Console', 'Commands'), 0755, true);
 
         try {
-            $app = new FoundationApplication($dir);
+            $files->put(
+                join_paths(default_skeleton_path(), 'app', 'Console', 'Commands', 'ExampleCommand.php'),
+                '<?php namespace App\Console\Commands; class ExampleCommand extends \Illuminate\Console\Command { protected $signature = "example"; public function handle() {} }'
+            );
+
+            $files->put(
+                join_paths(default_skeleton_path(), 'app', 'Console', 'Commands', 'ExampleCommandTest.php'),
+                '<?php namespace App\Console\Commands; class ExampleCommandTest extends \Illuminate\Console\Command { protected $signature = "example-test"; public function handle() {} }'
+            );
+
+            $files->put(
+                join_paths(default_skeleton_path(), 'app', 'Console', 'Commands', 'ExampleCommandUnitTest.php'),
+                '<?php namespace App\Console\Commands; class ExampleCommandUnitTest extends \PHPUnit\Framework\TestCase { public function test_command() { $this->assertTrue(true); } }'
+            );
+
+            foreach (ClassLoader::getRegisteredLoaders() as $loader) {
+                $loader->addPsr4('App\\', [default_skeleton_path('app')]);
+            }
+
+            $app = Testbench::create(default_skeleton_path());
             $events = new EventsDispatcher($app);
             $app->instance('events', $events);
 
             $kernel = new TestKernel($app, $events);
-            $kernel->loadFrom([$dir.'/app/Console/Commands']);
 
-            $this->assertContains('App\Console\Commands\ExampleCommand', $kernel->loadedCommands);
-            $this->assertNotContains('App\Console\Commands\ExampleCommandTest', $kernel->loadedCommands);
+            $commands = collect($kernel->getResolvedArtisan()->all())->values()->transform(fn ($command) => $command::class);
+
+            $this->assertContains('App\Console\Commands\ExampleCommand', $commands);
+            $this->assertContains('App\Console\Commands\ExampleCommandTest', $commands);
+            $this->assertNotContains('App\Console\Commands\ExampleCommandUnitTest', $commands);
+
+            Testbench::flushState($this);
         } finally {
-            @unlink($dir.'/app/Console/Commands/ExampleCommand.php');
-            @unlink($dir.'/app/Console/Commands/ExampleCommandTest.php');
-            @unlink($dir.'/composer.json');
-            @rmdir($dir.'/app/Console/Commands');
-            @rmdir($dir.'/app/Console');
-            @rmdir($dir.'/app');
-            @rmdir($dir);
+            $files->cleanDirectory(default_skeleton_path('app', 'Console', 'Commands'));
         }
     }
 
@@ -311,10 +335,17 @@ class TestKernel extends Kernel
     public function loadFrom($paths)
     {
         $this->load($paths);
+
+        $this->bootstrap();
     }
 
     protected function commandClassFromFile(\SplFileInfo $file, string $namespace): string
     {
         return tap(parent::commandClassFromFile($file, $namespace), fn ($command) => $this->loadedCommands[] = $command);
+    }
+
+    public function getResolvedArtisan()
+    {
+        return $this->getArtisan();
     }
 }


### PR DESCRIPTION
fix #58106
