### PR TITLE
Enhances loadMissing method on eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -48,7 +48,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->whereIn($this->first()->getKeyName(), $key);
         }
 
-        return Arr::first($this->items, fn($model) => $model->getKey() == $key, $default);
+        return Arr::first($this->items, fn ($model) => $model->getKey() == $key, $default);
     }
 
     /**
@@ -232,7 +232,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $segments = explode('.', $parts[0]);
 
             if (isset($parts[1])) {
-                $segments[count($segments) - 1] .= ':' . $parts[1];
+                $segments[count($segments) - 1] .= ':'.$parts[1];
             }
 
             $path = [];
@@ -298,7 +298,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $relation = reset($relation);
         }
 
-        $models->filter(fn($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
+        $models->filter(fn ($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
 
         if (empty($path)) {
             return;
@@ -324,8 +324,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn($model) => get_class($model))
-            ->each(fn($models, $className) => static::make($models)->load($relations[$className] ?? []));
+            ->groupBy(fn ($model) => get_class($model))
+            ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
 
         return $this;
     }
@@ -341,8 +341,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn($model) => get_class($model))
-            ->each(fn($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
+            ->groupBy(fn ($model) => get_class($model))
+            ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
 
         return $this;
     }
@@ -362,10 +362,10 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         if ($key instanceof Model) {
-            return parent::contains(fn($model) => $model->is($key));
+            return parent::contains(fn ($model) => $model->is($key));
         }
 
-        return parent::contains(fn($model) => $model->getKey() == $key);
+        return parent::contains(fn ($model) => $model->getKey() == $key);
     }
 
     /**
@@ -388,7 +388,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_map(fn($model) => $model->getKey(), $this->items);
+        return array_map(fn ($model) => $model->getKey(), $this->items);
     }
 
     /**
@@ -420,7 +420,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        return $result->contains(fn($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -438,7 +438,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::mapWithKeys($callback);
 
-        return $result->contains(fn($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -461,8 +461,8 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return $this->filter(fn($model) => $model->exists && isset($freshModels[$model->getKey()]))
-            ->map(fn($model) => $freshModels[$model->getKey()]);
+        return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))
+            ->map(fn ($model) => $freshModels[$model->getKey()]);
     }
 
     /**
@@ -794,7 +794,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function duplicateComparator($strict)
     {
-        return fn($a, $b) => $a->is($b);
+        return fn ($a, $b) => $a->is($b);
     }
 
     /**
@@ -804,7 +804,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function withRelationshipAutoloading()
     {
-        $callback = fn($tuples) => $this->loadMissingRelationshipChain($tuples);
+        $callback = fn ($tuples) => $this->loadMissingRelationshipChain($tuples);
 
         foreach ($this as $model) {
             if (! $model->hasRelationAutoloadCallback()) {
@@ -931,7 +931,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($model);
 
-        if ($this->reject(fn($model) => $model instanceof $class)->isNotEmpty()) {
+        if ($this->reject(fn ($model) => $model instanceof $class)->isNotEmpty()) {
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -216,10 +216,10 @@ class Collection extends BaseCollection implements QueueableCollection
      * @param  array<array-key, array|(callable(\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|string>|string  $relations
      * @return $this
      */
-    public function loadMissing(array|string $relations): static
+    public function loadMissing(array|string ...$relations): static
     {
-        if (is_string($relations)) {
-            $relations = func_get_args();
+        if (isset($relations[0]) && is_array($relations[0])) {
+            $relations = $relations[0];
         }
 
         if ($this->isNotEmpty()) {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -48,7 +48,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->whereIn($this->first()->getKeyName(), $key);
         }
 
-        return Arr::first($this->items, fn ($model) => $model->getKey() == $key, $default);
+        return Arr::first($this->items, fn($model) => $model->getKey() == $key, $default);
     }
 
     /**
@@ -216,7 +216,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * @param  array<array-key, array|(callable(\Illuminate\Database\Eloquent\Relations\Relation<*, *, *>): mixed)|string>|string  $relations
      * @return $this
      */
-    public function loadMissing($relations)
+    public function loadMissing(array|string $relations): static
     {
         if (is_string($relations)) {
             $relations = func_get_args();
@@ -229,7 +229,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 $segments = explode('.', explode(':', $key)[0]);
 
                 if (str_contains($key, ':')) {
-                    $segments[count($segments) - 1] .= ':'.explode(':', $key)[1];
+                    $segments[count($segments) - 1] .= ':' . explode(':', $key)[1];
                 }
 
                 $path = [];
@@ -295,7 +295,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $relation = reset($relation);
         }
 
-        $models->filter(fn ($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
+        $models->filter(fn($model) => ! is_null($model) && ! $model->relationLoaded($name))->load($relation);
 
         if (empty($path)) {
             return;
@@ -321,8 +321,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
-            ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
+            ->groupBy(fn($model) => get_class($model))
+            ->each(fn($models, $className) => static::make($models)->load($relations[$className] ?? []));
 
         return $this;
     }
@@ -338,8 +338,8 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
-            ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
+            ->groupBy(fn($model) => get_class($model))
+            ->each(fn($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
 
         return $this;
     }
@@ -359,10 +359,10 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         if ($key instanceof Model) {
-            return parent::contains(fn ($model) => $model->is($key));
+            return parent::contains(fn($model) => $model->is($key));
         }
 
-        return parent::contains(fn ($model) => $model->getKey() == $key);
+        return parent::contains(fn($model) => $model->getKey() == $key);
     }
 
     /**
@@ -385,7 +385,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_map(fn ($model) => $model->getKey(), $this->items);
+        return array_map(fn($model) => $model->getKey(), $this->items);
     }
 
     /**
@@ -417,7 +417,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -435,7 +435,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::mapWithKeys($callback);
 
-        return $result->contains(fn ($item) => ! $item instanceof Model) ? $result->toBase() : $result;
+        return $result->contains(fn($item) => ! $item instanceof Model) ? $result->toBase() : $result;
     }
 
     /**
@@ -458,8 +458,8 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return $this->filter(fn ($model) => $model->exists && isset($freshModels[$model->getKey()]))
-            ->map(fn ($model) => $freshModels[$model->getKey()]);
+        return $this->filter(fn($model) => $model->exists && isset($freshModels[$model->getKey()]))
+            ->map(fn($model) => $freshModels[$model->getKey()]);
     }
 
     /**
@@ -791,7 +791,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function duplicateComparator($strict)
     {
-        return fn ($a, $b) => $a->is($b);
+        return fn($a, $b) => $a->is($b);
     }
 
     /**
@@ -801,7 +801,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function withRelationshipAutoloading()
     {
-        $callback = fn ($tuples) => $this->loadMissingRelationshipChain($tuples);
+        $callback = fn($tuples) => $this->loadMissingRelationshipChain($tuples);
 
         foreach ($this as $model) {
             if (! $model->hasRelationAutoloadCallback()) {
@@ -928,7 +928,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($model);
 
-        if ($this->reject(fn ($model) => $model instanceof $class)->isNotEmpty()) {
+        if ($this->reject(fn($model) => $model instanceof $class)->isNotEmpty()) {
             throw new LogicException('Unable to create query for collection with mixed types.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -222,28 +222,30 @@ class Collection extends BaseCollection implements QueueableCollection
             $relations = $relations[0];
         }
 
-        if ($this->isNotEmpty()) {
-            $query = $this->first()->newQueryWithoutRelationships()->with($relations);
+        if ($this->isEmpty()) {
+            return $this;
+        }
 
-            foreach ($query->getEagerLoads() as $key => $value) {
-                $segments = explode('.', explode(':', $key)[0]);
+        $query = $this->first()->newQueryWithoutRelationships()->with($relations);
 
-                if (str_contains($key, ':')) {
-                    $segments[count($segments) - 1] .= ':' . explode(':', $key)[1];
-                }
+        foreach ($query->getEagerLoads() as $key => $value) {
+            $segments = explode('.', explode(':', $key)[0]);
 
-                $path = [];
-
-                foreach ($segments as $segment) {
-                    $path[] = [$segment => $segment];
-                }
-
-                if (is_callable($value)) {
-                    $path[count($segments) - 1][array_last($segments)] = $value;
-                }
-
-                $this->loadMissingRelation($this, $path);
+            if (str_contains($key, ':')) {
+                $segments[count($segments) - 1] .= ':' . explode(':', $key)[1];
             }
+
+            $path = [];
+
+            foreach ($segments as $segment) {
+                $path[] = [$segment => $segment];
+            }
+
+            if (is_callable($value)) {
+                $path[count($segments) - 1][array_last($segments)] = $value;
+            }
+
+            $this->loadMissingRelation($this, $path);
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -226,13 +226,13 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this;
         }
 
-        $query = $this->first()->newQueryWithoutRelationships()->with($relations);
+        $eagerLoads = $this->first()->newQueryWithoutRelationships()->with($relations)->getEagerLoads();
+        foreach ($eagerLoads as $key => $value) {
+            $parts = explode(':', $key, 2);
+            $segments = explode('.', $parts[0]);
 
-        foreach ($query->getEagerLoads() as $key => $value) {
-            $segments = explode('.', explode(':', $key)[0]);
-
-            if (str_contains($key, ':')) {
-                $segments[count($segments) - 1] .= ':' . explode(':', $key)[1];
+            if (isset($parts[1])) {
+                $segments[count($segments) - 1] .= ':' . $parts[1];
             }
 
             $path = [];
@@ -242,7 +242,8 @@ class Collection extends BaseCollection implements QueueableCollection
             }
 
             if (is_callable($value)) {
-                $path[count($segments) - 1][array_last($segments)] = $value;
+                $lastIndex = count($path) - 1;
+                $path[$lastIndex][end($segments)] = $value;
             }
 
             $this->loadMissingRelation($this, $path);


### PR DESCRIPTION
The following changes were made to the original method.

- Type hints were added
- Used the spread operator instead of func_get_args, which is slightly older and slower
- Used native, faster methods.