### PR TITLE
[12.x] Ability to access correct `->getOriginal()` values from -ed observer events while using `ShouldHandleEventsAfterCommit` alongside database transactions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2032,6 +2032,24 @@ trait HasAttributes
     }
 
     /**
+     * Set the array of model original attributes. No checking is done.
+     *
+     * @param  array  $original
+     * @return $this
+     */
+    public function setOriginalAttributes(array $original)
+    {
+        $this->original = $original;
+
+        // Original values influence cast resolution and attribute access,
+        // so clear caches to avoid stale casted values lingering.
+        $this->classCastCache = [];
+        $this->attributeCastCache = [];
+
+        return $this;
+    }
+
+    /**
      * Get the model's raw original attribute values.
      *
      * @param  string|null  $key
@@ -2252,6 +2270,19 @@ trait HasAttributes
     public function getChanges()
     {
         return $this->changes;
+    }
+
+    /**
+     * Set the changes to append to model's array.
+     *
+     * @param  array  $appends
+     * @return $this
+     */
+    public function setChanges(array $changes)
+    {
+        $this->changes = $changes;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -644,9 +644,8 @@ class Dispatcher implements DispatcherContract
      * Create a snapshot of the model's state at time of the event, allowing for changes to be viewed
      * despite model reference being already synced.
      *
-     * @param  mixed  $listener
-     * @param  string  $method
-     * @return \Closure
+     * @param  Model  $model
+     * @return Model
      */
     protected function snapshotModelForAfterCommit(Model $model): Model
     {

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -4,7 +4,6 @@ namespace Illuminate\Events;
 
 use Closure;
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
@@ -15,6 +14,7 @@ use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -603,7 +603,7 @@ class Dispatcher implements DispatcherContract
     /**
      * Create a callable for dispatching a listener after database transactions.
      * If triggered from a -ed event, generate a snapshot of the model state at time of event to capture
-     * original values
+     * original values.
      *
      * @param  mixed  $listener
      * @param  string  $method
@@ -616,14 +616,14 @@ class Dispatcher implements DispatcherContract
 
             // If called from a -ed event, snapshot the model to ensure we have access to
             // the changed values
-            if (!in_array($method, [
+            if (! in_array($method, [
                 'creating',
                 'updating',
                 'saving',
                 'restoring',
                 'replicating',
                 'deleting',
-                'forceDeleting'
+                'forceDeleting',
             ])) {
                 $payload = array_map(function ($arg) {
                     return $arg instanceof Model
@@ -642,7 +642,7 @@ class Dispatcher implements DispatcherContract
 
     /**
      * Create a snapshot of the model's state at time of the event, allowing for changes to be viewed
-     * despite model reference being already synced
+     * despite model reference being already synced.
      *
      * @param  mixed  $listener
      * @param  string  $method
@@ -663,7 +663,7 @@ class Dispatcher implements DispatcherContract
 
         // Preserve any already-loaded relations
         $relations = $model->getRelations();
-        if (!empty($relations)) {
+        if (! empty($relations)) {
             $clone->setRelations($relations);
         }
 


### PR DESCRIPTION
When an Observer implements the ShouldHandleEventsAfterCommit trait, all events being fired happen after changes have been committed to the database. This acts as expected when directly interacting with Eloquent models (and therefore provides correct data when using $model->getOriginal('field')), however if the Observer is fired from a Database Transaction all ->getOriginal() values are lost due to the model's object reference already being synced back.

This code change contains an additional check after confirming the Observer implements the ShouldHandleEventsAfterCommit trait; if the method being fired ends in "ed" (Updated / Saved / Restored, etc), create a copy of the model at invoke time and store all original values for reference after the commit has been made. 

This now allows you to utilize ->getOriginal('field') within these observer -ed methods while using transactions and no longer provides the updated value when requesting the original. This is useful when external actions need to happen on a model's value change (such as emails being delivered, jobs being queued, etc.) and you specifically need access to the original value, all while ensuring the actions aren't executed unless the database change has been officially committed. 

As an example,

```PHP
class UserObserver implements ShouldHandleEventsAfterCommit
{
    public function updated(User $user) : void
    {
        // This line returns true both before and after the changes made
        if ($user->wasChanged('address')) {
            // Below would previously have $originalAddress == $user->address
            // After change, $originalAddress is now the proper original value which triggered ->wasChanged() to fire in the first place.
            $originalAddress = $user->getOriginal('address');

            Mail::to([$user->email])->send(new AddressChangedEmail($user, $originalAddress));
        }
    }
}
```

These changes allow atomicity to be maintained on the database insertion side through the use of transactions as well as the observer side while still being able to access the original values.

Inspired from personal findings/pain points & [this thread](https://github.com/laravel/framework/discussions/52552).