### PR TITLE
[12.x] Specify that the query builder returns instances of `stdClass`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -34,7 +34,7 @@ use function Illuminate\Support\enum_value;
 
 class Builder implements BuilderContract
 {
-    /** @use \Illuminate\Database\Concerns\BuildsQueries<object> */
+    /** @use \Illuminate\Database\Concerns\BuildsQueries<\stdClass> */
     use BuildsWhereDateClauses, BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
@@ -3088,7 +3088,7 @@ class Builder implements BuilderContract
      *
      * @param  int|string  $id
      * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
-     * @return object|null
+     * @return \stdClass|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -3103,7 +3103,7 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @param  (\Closure(): TValue)|string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @return object|TValue
+     * @return \stdClass|TValue
      */
     public function findOr($id, $columns = ['*'], ?Closure $callback = null)
     {

--- a/types/Database/Query/Builder.php
+++ b/types/Database/Query/Builder.php
@@ -10,10 +10,10 @@ use function PHPStan\Testing\assertType;
 /** @param \Illuminate\Database\Eloquent\Builder<\User> $userQuery */
 function test(Builder $query, EloquentBuilder $userQuery): void
 {
-    assertType('object|null', $query->first());
-    assertType('object|null', $query->find(1));
-    assertType('42|object', $query->findOr(1, fn () => 42));
-    assertType('42|object', $query->findOr(1, callback: fn () => 42));
+    assertType('stdClass|null', $query->first());
+    assertType('stdClass|null', $query->find(1));
+    assertType('42|stdClass', $query->findOr(1, fn () => 42));
+    assertType('42|stdClass', $query->findOr(1, callback: fn () => 42));
     assertType('Illuminate\Database\Query\Builder', $query->selectSub($userQuery, 'alias'));
     assertType('Illuminate\Database\Query\Builder', $query->fromSub($userQuery, 'alias'));
     assertType('Illuminate\Database\Query\Builder', $query->from($userQuery, 'alias'));
@@ -33,31 +33,31 @@ function test(Builder $query, EloquentBuilder $userQuery): void
     assertType('Illuminate\Database\Query\Builder', $query->unionAll($userQuery));
     assertType('int', $query->insertUsing([], $userQuery));
     assertType('int', $query->insertOrIgnoreUsing([], $userQuery));
-    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazy());
-    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyById());
-    assertType('Illuminate\Support\LazyCollection<int, object>', $query->lazyByIdDesc());
+    assertType('Illuminate\Support\LazyCollection<int, stdClass>', $query->lazy());
+    assertType('Illuminate\Support\LazyCollection<int, stdClass>', $query->lazyById());
+    assertType('Illuminate\Support\LazyCollection<int, stdClass>', $query->lazyByIdDesc());
 
     $query->chunk(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, stdClass>', $users);
         assertType('int', $page);
     });
     $query->chunkById(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, stdClass>', $users);
         assertType('int', $page);
     });
     $query->chunkMap(function ($users) {
-        assertType('object', $users);
+        assertType('stdClass', $users);
     });
     $query->chunkByIdDesc(1, function ($users, $page) {
-        assertType('Illuminate\Support\Collection<int, object>', $users);
+        assertType('Illuminate\Support\Collection<int, stdClass>', $users);
         assertType('int', $page);
     });
     $query->each(function ($users, $page) {
-        assertType('object', $users);
+        assertType('stdClass', $users);
         assertType('int', $page);
     });
     $query->eachById(function ($users, $page) {
-        assertType('object', $users);
+        assertType('stdClass', $users);
         assertType('int', $page);
     });
     assertType('Illuminate\Database\Query\Builder', $query->pipe(function () {


### PR DESCRIPTION
The query builder returns query results as instances of `stdClass`, however currently it is documented as if it can return any `object`. This PR narrows the type to more accurately reflect what is being returned. This doesn't affect calling code, editors, etc. but it does change something for PHPStan.

PHPStan has a special list of classes on which it assumes any property can exist, it calls this universal object crates, `stdClass` is one of these classes, this means that:

Before:

```php
$result = $query->find($id); // <- object|null

if (is_null($result)) {
    return;
}

echo "Hello, $result->first_name"; // <- PHPStan error, first_name might not exist on 'object'
```

After:


```php
$result = $query->find($id); // <- stdClass|null

if (is_null($result)) {
    return;
}

echo "Hello, $result->first_name"; // <- OK
```



Relevant PHPStan docs: https://phpstan.org/config-reference#universal-object-crates

**Note**: Some query builder methods (get, cursor) already use `stdClass`