### PR TITLE
[12.x] Allow easier opting out of `DatabaseLock` prune lottery

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -28,7 +28,7 @@ class DatabaseLock extends Lock
     /**
      * The prune probability odds.
      *
-     * @var array
+     * @var array{int, int}|null
      */
     protected $lottery;
 
@@ -47,7 +47,7 @@ class DatabaseLock extends Lock
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
-     * @param  array  $lottery
+     * @param  array{int, int}|null  $lottery
      * @param  int  $defaultTimeoutInSeconds
      */
     public function __construct(Connection $connection, $table, $name, $seconds, $owner = null, $lottery = [2, 100], $defaultTimeoutInSeconds = 86400)
@@ -90,7 +90,7 @@ class DatabaseLock extends Lock
             $acquired = $updated >= 1;
         }
 
-        if (random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
+        if (count($this->lottery ?? []) === 2 && random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
             try {
                 $this->connection->table($this->table)
                     ->where('expiration', '<=', $this->currentTime())


### PR DESCRIPTION
As my colleague pointed out [here](https://github.com/laravel/framework/pull/57966), the database lock prune lottery can be an expensive footgun. The fact that it is non-deterministic means that extra queries are executed which, without Chris' index, may cause a request or queued job to choke.

In this PR, I have added an easy way to opt out of the lottery execution by allowing null to be passed. This shouldn't break any existing implementation, as it requires specifying the lottery parameter as null. Prior to this, in order to opt out of the lottery, you had to pass something like `[-1, 1]`. This isn't obvious or clear.

In our codebase, I'm writing a console command that prunes DB locks, which we will schedule to run every minute. If that's helpful, I can add the console command here as well.