### PR TITLE
Add `route:conflicts` Command to Detect Route Conflicts

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteConflictsCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteConflictsCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'route:conflicts')]
+class RouteConflictsCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'route:conflicts {--json : Output in JSON format}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Detect route conflicts where multiple routes could match the same request';
+
+    /**
+     * The router instance.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected Router $router;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    public function __construct(Router $router)
+    {
+        parent::__construct();
+
+        $this->router = $router;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $routes = collect($this->router->getRoutes()->getRoutes());
+        $conflicts = $this->findConflicts($routes);
+
+        if ($conflicts->isEmpty()) {
+            $this->info('No route conflicts detected.');
+
+            return self::SUCCESS;
+        }
+
+        $this->error('Route conflicts found:');
+
+        $this->line($this->option('json') ? $this->asJson($conflicts) : $this->forCli($conflicts));
+
+        return self::FAILURE;
+    }
+
+    /**
+     * Find route conflicts from a collection of routes.
+     *
+     * @param  \Illuminate\Support\Collection  $routes
+     * @return \Illuminate\Support\Collection
+     */
+    protected function findConflicts(Collection $routes): Collection
+    {
+        $conflicts = collect();
+
+        $routes->each(function (Route $earlier, $i) use ($routes, $conflicts) {
+            $routes->slice($i + 1)->each(function (Route $later) use ($earlier, $conflicts) {
+                if (! array_intersect($earlier->methods(), $later->methods())) {
+                    return;
+                }
+
+                if ($this->routesConflict($earlier, $later)) {
+                    $conflicts->push([
+                        'methods' => implode(',', $earlier->methods()),
+                        'earlier' => $this->routeDetails($earlier),
+                        'later' => $this->routeDetails($later),
+                    ]);
+                }
+            });
+        });
+
+        return $conflicts;
+    }
+
+    /**
+     * Determine if two routes conflict.
+     *
+     * @param  \Illuminate\Routing\Route  $earlier
+     * @param  \Illuminate\Routing\Route  $later
+     * @return bool
+     */
+    protected function routesConflict(Route $earlier, Route $later): bool
+    {
+        $aParts = explode('/', $earlier->uri());
+        $bParts = explode('/', $later->uri());
+
+        if (count($aParts) !== count($bParts)) {
+            return false;
+        }
+
+        foreach ($aParts as $i => $segmentA) {
+            $segmentB = $bParts[$i];
+
+            if (! $this->isParameter($segmentA) && ! $this->isParameter($segmentB) && $segmentA !== $segmentB) {
+                return false;
+            }
+
+            if ($this->isParameter($segmentA) && ! $this->isParameter($segmentB)) {
+                if (! $this->parameterMatchesLiteral($earlier, $segmentA, $segmentB)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (! $this->isParameter($segmentA) && $this->isParameter($segmentB)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a route parameter matches a literal segment.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  string  $parameter
+     * @param  string  $literal
+     * @return bool
+     */
+    protected function parameterMatchesLiteral(Route $route, string $parameter, string $literal): bool
+    {
+        $paramName = trim($parameter, '{}');
+        $regex = $route->wheres[$paramName] ?? null;
+
+        if (! $regex) {
+            return true;
+        }
+
+        return preg_match('/^'.$regex.'$/', $literal) === 1;
+    }
+
+    /**
+     * Determine if a segment is a route parameter.
+     *
+     * @param  string  $segment
+     * @return bool
+     */
+    protected function isParameter(string $segment): bool
+    {
+        return preg_match('/^\{[^}]+\}$/', $segment) === 1;
+    }
+
+    /**
+     * Get detailed route information.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return array
+     */
+    protected function routeDetails(Route $route): array
+    {
+        return [
+            'uri' => $route->uri(),
+            'name' => $route->getName(),
+            'action' => $route->getActionName(),
+        ];
+    }
+
+    /**
+     * Convert conflicts to JSON format.
+     *
+     * @param  \Illuminate\Support\Collection  $conflicts
+     * @return string
+     */
+    protected function asJson(Collection $conflicts): string
+    {
+        return $conflicts->values()->toJson(JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * Format conflicts for CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $conflicts
+     * @return string
+     */
+    protected function forCli(Collection $conflicts): string
+    {
+        return $conflicts->map(function ($c) {
+            return "[{$c['methods']}]\n"
+                ."  Earlier: {$c['earlier']['uri']} ({$c['earlier']['action']})\n"
+                ."  Later:   {$c['later']['uri']} ({$c['later']['action']})";
+        })->implode("\n\n");
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -75,6 +75,7 @@ use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
+use Illuminate\Foundation\Console\RouteConflictsCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ScopeMakeCommand;
@@ -165,6 +166,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'RouteCache' => RouteCacheCommand::class,
         'RouteClear' => RouteClearCommand::class,
         'RouteList' => RouteListCommand::class,
+        'RouteConflict' => RouteConflictsCommand::class,
         'SchemaDump' => DumpCommand::class,
         'Seed' => SeedCommand::class,
         'ScheduleFinish' => ScheduleFinishCommand::class,

--- a/tests/Foundation/Console/RouteConflictsCommandTest.php
+++ b/tests/Foundation/Console/RouteConflictsCommandTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Console\Application;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Console\RouteConflictsCommand;
+use Illuminate\Routing\Router;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RouteConflictsCommandTest extends TestCase
+{
+    protected Application $app;
+
+    protected Router $router;
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app = new Application(
+            $laravel = new \Illuminate\Foundation\Application(__DIR__),
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing',
+        );
+
+        $this->router = new Router(m::mock('Illuminate\Events\Dispatcher'));
+
+        $command = new RouteConflictsCommand($this->router);
+        $command->setLaravel($laravel);
+
+        $this->app->addCommands([$command]);
+    }
+
+    public function testNoConflictsDetected()
+    {
+        $this->router->get('/users', fn () => 'Users list');
+        $this->router->get('/posts', fn () => 'Posts list');
+        $this->router->post('/comments', fn () => 'Create comment');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+
+    public function testDetectsParameterVsLiteralConflict()
+    {
+        $this->router->get('/users/{id}', fn () => 'Show user');
+        $this->router->get('/users/admin', fn () => 'Admin panel');
+
+        $exitCode = $this->app->call('route:conflicts');
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Route conflicts found', $output);
+        $this->assertStringContainsString('users/{id}', $output);
+        $this->assertStringContainsString('users/admin', $output);
+    }
+
+    public function testNoConflictWithParameterConstraints()
+    {
+        $this->router->get('/users/{id}', fn () => 'Show user')->where('id', '[0-9]+');
+        $this->router->get('/users/admin', fn () => 'Admin panel');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+
+    public function testDetectsParameterVsParameterConflict()
+    {
+        $this->router->get('/posts/{slug}', fn () => 'Show post by slug');
+        $this->router->get('/posts/{id}', fn () => 'Show post by id');
+
+        $exitCode = $this->app->call('route:conflicts');
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Route conflicts found', $output);
+        $this->assertStringContainsString('posts/{slug}', $output);
+        $this->assertStringContainsString('posts/{id}', $output);
+    }
+
+    public function testNoConflictWithDifferentHttpMethods()
+    {
+        $this->router->get('/users/{id}', fn () => 'Show user');
+        $this->router->post('/users/{id}', fn () => 'Update user');
+        $this->router->delete('/users/{id}', fn () => 'Delete user');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+
+    public function testDetectsConflictWithSharedHttpMethods()
+    {
+        $this->router->match(['GET', 'POST'], '/users/{id}', fn () => 'User action');
+        $this->router->post('/users/admin', fn () => 'Admin action');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('Route conflicts found', $this->app->output());
+    }
+
+    public function testNoConflictWithDifferentSegmentCounts()
+    {
+        $this->router->get('/users', fn () => 'Users list');
+        $this->router->get('/users/{id}', fn () => 'Show user');
+        $this->router->get('/users/{id}/posts', fn () => 'User posts');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+
+    public function testJsonOutputFormat()
+    {
+        $this->router->get('/products/{id}', fn () => 'Show product')->name('products.show');
+        $this->router->get('/products/featured', fn () => 'Featured products')->name('products.featured');
+
+        $exitCode = $this->app->call('route:conflicts', ['--json' => true]);
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+
+        preg_match('/(\[.*\])/s', $output, $matches);
+        $json = json_decode($matches[1], true);
+
+        $this->assertIsArray($json);
+        $this->assertNotEmpty($json);
+        $this->assertArrayHasKey('methods', $json[0]);
+        $this->assertArrayHasKey('earlier', $json[0]);
+        $this->assertArrayHasKey('later', $json[0]);
+        $this->assertEquals('products/{id}', $json[0]['earlier']['uri']);
+        $this->assertEquals('products/featured', $json[0]['later']['uri']);
+        $this->assertEquals('products.show', $json[0]['earlier']['name']);
+        $this->assertEquals('products.featured', $json[0]['later']['name']);
+    }
+
+    public function testCliOutputFormat()
+    {
+        $this->router->get('/articles/{slug}', fn () => 'Show article');
+        $this->router->get('/articles/latest', fn () => 'Latest articles');
+
+        $exitCode = $this->app->call('route:conflicts');
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('[GET,HEAD]', $output);
+        $this->assertStringContainsString('Earlier:', $output);
+        $this->assertStringContainsString('Later:', $output);
+        $this->assertStringContainsString('articles/{slug}', $output);
+        $this->assertStringContainsString('articles/latest', $output);
+        $this->assertStringContainsString('Closure', $output);
+    }
+
+    public function testDetectsMultipleConflicts()
+    {
+        $this->router->get('/users/{id}', fn () => 'User');
+        $this->router->get('/users/admin', fn () => 'Admin');
+        $this->router->get('/posts/{slug}', fn () => 'Post');
+        $this->router->get('/posts/featured', fn () => 'Featured');
+
+        $exitCode = $this->app->call('route:conflicts', ['--json' => true]);
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+
+        preg_match('/(\[.*\])/s', $output, $matches);
+        $json = json_decode($matches[1], true);
+
+        $this->assertCount(2, $json);
+
+        $uris = array_column($json, 'earlier');
+        $uris = array_column($uris, 'uri');
+
+        $this->assertContains('users/{id}', $uris);
+        $this->assertContains('posts/{slug}', $uris);
+    }
+
+    public function testConflictDetectionWithNamedRoutes()
+    {
+        $this->router->get('/api/users/{id}', fn () => 'API user')->name('api.users.show');
+        $this->router->get('/api/users/me', fn () => 'Current user')->name('api.users.me');
+
+        $exitCode = $this->app->call('route:conflicts', ['--json' => true]);
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+
+        preg_match('/(\[.*\])/s', $output, $matches);
+        $json = json_decode($matches[1], true);
+
+        $this->assertEquals('api.users.show', $json[0]['earlier']['name']);
+        $this->assertEquals('api.users.me', $json[0]['later']['name']);
+    }
+
+    public function testNoConflictWithComplexNonOverlappingUris()
+    {
+        $this->router->get('/users/{userId}/posts/{postId}', fn () => 'User post');
+        $this->router->get('/users/{userId}/comments/{commentId}', fn () => 'User comment');
+        $this->router->get('/admin/{adminId}/posts/{postId}', fn () => 'Admin post');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+
+    public function testConflictWithControllerRoutes()
+    {
+        $this->router->get('/dashboard/{section}', 'DashboardController@show');
+        $this->router->get('/dashboard/overview', 'DashboardController@overview');
+
+        $exitCode = $this->app->call('route:conflicts');
+        $output = $this->app->output();
+
+        $this->assertEquals(1, $exitCode);
+        $this->assertStringContainsString('DashboardController', $output);
+        $this->assertStringContainsString('dashboard/{section}', $output);
+        $this->assertStringContainsString('dashboard/overview', $output);
+    }
+
+    public function testLiteralRouteFirstNoConflict()
+    {
+        $this->router->get('/users/admin', fn () => 'Admin panel');
+        $this->router->get('/users/{id}', fn () => 'Show user');
+
+        $exitCode = $this->app->call('route:conflicts');
+
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('No route conflicts detected', $this->app->output());
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new Artisan command `php artisan route:conflicts` that analyzes registered routes and detects potential routing conflicts where two routes could match the same incoming request.

### The Problem

Route conflicts are a common source of subtle bugs in Laravel applications. When a parameterized route is defined before a literal route, the parameter route may "shadow" the literal one:

```php
// This route will match /users/admin with id="admin"
Route::get('/users/{id}', [UserController::class, 'show']);

// This route will NEVER be reached!
Route::get('/users/admin', [AdminController::class, 'dashboard']);
```

These conflicts are difficult to detect manually in large applications with hundreds of routes, and often only surface in production when users report unexpected behavior.

### The Solution

The new `route:conflicts` command provides:

- **Automatic conflict detection** - Scans all routes and identifies potential conflicts
- **Constraint awareness** - Respects `where()` constraints (e.g., `->where('id', '[0-9]+')` won't conflict with `/users/admin`)
- **HTTP method checking** - Only flags routes that share HTTP methods
- **Detailed output** - Shows URIs, route names, and controller actions for each conflict
- **JSON output** - `--json` flag for CI/CD pipeline integration
- **Proper exit codes** - Returns `0` for no conflicts, `1` when conflicts are found

### Usage

```bash
# Basic usage - human-readable output
php artisan route:conflicts

# JSON output for CI/CD pipelines
php artisan route:conflicts --json
```

### Example Output

**CLI format:**
```
🚨 Route conflicts found:
[GET,HEAD]
  Earlier: users/{id} (App\Http\Controllers\UserController@show)
  Later:   users/admin (App\Http\Controllers\AdminController@dashboard)
```

**JSON format:**
```json
[
  {
    "methods": "GET,HEAD",
    "earlier": {
      "uri": "users/{id}",
      "name": "users.show",
      "action": "App\\Http\\Controllers\\UserController@show"
    },
    "later": {
      "uri": "users/admin",
      "name": "admin.dashboard",
      "action": "App\\Http\\Controllers\\AdminController@dashboard"
    }
  }
]
```

### Conflict Detection Logic

The command detects conflicts when:

1. Two routes share at least one HTTP method
2. Routes have the same number of URI segments
3. For each segment position:
   - Both are literals and match, OR
   - At least one is a parameter that could match the other's value

The command correctly handles:
- Parameter constraints via `where()` clauses
- Multiple HTTP methods on a single route
- Closure and controller-based routes
- Named and unnamed routes

### Why This Matters

- **Development** - Catch routing issues early during development
- **Code Review** - Quickly audit route files for potential problems
- **CI/CD** - Integrate into pipelines to prevent deployment of conflicting routes
- **Debugging** - Diagnose unexpected routing behavior in existing applications

## Test Plan

- [x] Test no conflicts detected with non-overlapping routes
- [x] Test parameter vs literal conflict detection (`/users/{id}` vs `/users/admin`)
- [x] Test parameter constraints prevent false positives
- [x] Test parameter vs parameter conflict detection (`/posts/{slug}` vs `/posts/{id}`)
- [x] Test different HTTP methods don't conflict
- [x] Test shared HTTP methods trigger conflict detection
- [x] Test different segment counts don't conflict
- [x] Test JSON output format and structure
- [x] Test CLI output format
- [x] Test multiple conflicts detection
- [x] Test named routes included in output
- [x] Test complex non-overlapping URIs
- [x] Test controller-based routes
- [x] Test literal-first ordering doesn't report false conflicts

## Files Changed

- `src/Illuminate/Foundation/Console/RouteConflictsCommand.php` - New command implementation
- `src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php` - Command registration
- `tests/Foundation/Console/RouteConflictsCommandTest.php` - Comprehensive test suite


Now developers can also verify route integrity with `route:conflicts`.
