### PR TITLE
[12.x] Fix Password::required() missing value validation and nullable empty …

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -332,14 +332,12 @@ class Password implements Rule, DataAwareRule, ImplicitRule, ValidatorAwareRule
     {
         $this->messages = [];
 
-        if (! $this->required && ! $this->sometimes && ($this->data === null || ! Arr::has($this->data, $attribute))) {
+        if (! $this->required && ! $this->sometimes && ! Arr::has($this->data ?? [], $attribute)) {
             return true;
         }
 
-        if ($this->validator && $this->validator->hasRule($attribute, ['Nullable'])) {
-            if ($value === null || (is_string($value) && trim($value) === '')) {
-                return true;
-            }
+        if (blank($value) && ! $this->required && $this->validator?->hasRule($attribute, ['Nullable'])) {
+            return true;
         }
 
         $validator = Validator::make(

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -336,8 +336,10 @@ class Password implements Rule, DataAwareRule, ImplicitRule, ValidatorAwareRule
             return true;
         }
 
-        if ($value === null && ! $this->required && $this->validator && $this->validator->hasRule($attribute, ['Nullable'])) {
-            return true;
+        if ($this->validator && $this->validator->hasRule($attribute, ['Nullable'])) {
+            if ($value === null || (is_string($value) && trim($value) === '')) {
+                return true;
+            }
         }
 
         $validator = Validator::make(

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -465,6 +465,33 @@ class ValidationPasswordRuleTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testNullableWithEmptyString()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            ['password' => ''],
+            ['password' => ['nullable', Password::min(8)->letters()->numbers()]]
+        );
+
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            resolve('translator'),
+            ['password' => null],
+            ['password' => ['nullable', Password::min(8)->letters()->numbers()]]
+        );
+
+        $this->assertTrue($v->passes());
+
+        $v = new Validator(
+            resolve('translator'),
+            ['password' => ''],
+            ['password' => ['nullable', Password::sometimes()->min(8)->letters()->numbers()]]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);


### PR DESCRIPTION
…strings

This PR fixes an issue where `Password::required()` validation incorrectly passes when the password field is missing from the request data. It also fixes a regression where password validation fails when using `nullable` with empty strings.

Addresses issues reported in https://github.com/laravel/framework/pull/58125#issuecomment-3667308751