### PR TITLE
[12.x] Fix unable to disable `created_at` or `updated_at` column when attaching models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1510,18 +1510,23 @@ class BelongsToMany extends Relation
     /**
      * Specify that the pivot table has creation and update timestamps.
      *
-     * @param  mixed  $createdAt
-     * @param  mixed  $updatedAt
+     * @param  string|null|false  $createdAt
+     * @param  string|null|false  $updatedAt
      * @return $this
      */
     public function withTimestamps($createdAt = null, $updatedAt = null)
     {
-        $this->withTimestamps = true;
+        $this->pivotCreatedAt = $createdAt !== false ? $createdAt : null;
+        $this->pivotUpdatedAt = $updatedAt !== false ? $updatedAt : null;
 
-        $this->pivotCreatedAt = $createdAt;
-        $this->pivotUpdatedAt = $updatedAt;
+        $pivots = array_filter([
+            $createdAt !== false ? $this->createdAt() : null,
+            $updatedAt !== false ? $this->updatedAt() : null,
+        ]);
 
-        return $this->withPivot($this->createdAt(), $this->updatedAt());
+        $this->withTimestamps = ! empty($pivots);
+
+        return $this->withTimestamps ? $this->withPivot($pivots) : $this;
     }
 
     /**

--- a/tests/Integration/Database/EloquentPivotWithoutTimestampTest.php
+++ b/tests/Integration/Database/EloquentPivotWithoutTimestampTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Tests\Integration\Database\EloquentPivotWithoutTimestamp as App;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithConfig('auth.providers.users.model', App\User::class)]
+#[WithMigration]
+class EloquentPivotWithoutTimestampTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        App\migrate();
+    }
+
+    public function testAttachingModelWithoutTimestamps()
+    {
+        $now = $this->freezeSecond();
+
+        $user = App\User::factory()->create();
+        $role = App\Role::factory()->create();
+
+        $user->roles()->attach($role->getKey(), ['notes' => 'Laravel']);
+
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $user->getKey(),
+            'role_id' => $role->getKey(),
+            'notes' => 'Laravel',
+            'created_at' => $now,
+        ]);
+    }
+}
+
+namespace Illuminate\Tests\Integration\Database\EloquentPivotWithoutTimestamp;
+
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Factories\UserFactory;
+
+#[UseFactory(UserFactory::class)]
+class User extends Authenticatable
+{
+    use HasFactory;
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)
+            ->withPivot('notes')
+            ->using(UserRole::class)
+            ->withTimestamps(updatedAt: false);
+    }
+}
+
+#[UseFactory(RoleFactory::class)]
+class Role extends Model
+{
+    use HasFactory;
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)
+            ->withPivot('notes')
+            ->using(UserRole::class);
+    }
+}
+
+class RoleFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+        ];
+    }
+}
+
+class UserRole extends Pivot
+{
+    public $table = 'role_user';
+
+    public function getUpdatedAtColumn()
+    {
+        return null;
+    }
+}
+
+function migrate()
+{
+    Schema::create('roles', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->timestamps();
+    });
+
+    Schema::create('role_user', function (Blueprint $table) {
+        $table->foreignId('user_id');
+        $table->foreignId('role_id');
+        $table->text('notes');
+        $table->timestamp('created_at')->nullable();
+    });
+}


### PR DESCRIPTION
fix #56893

This PR allows developer to disable either `created_at` or `updated_at` on pivot relationships.

### Before

Using `->withTimestamps()` will always enable both `created_at` and `updated_at`.

### After

You can use `->withTimestamps(createdAt: false)` or `->withTimestamps(updatedAt: false)` to just disable the field you need.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
