### PR TITLE
fix(bus): execute callbacks for empty batches

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -193,7 +193,23 @@ class Batch implements Arrayable, JsonSerializable
             );
         });
 
-        return $this->fresh();
+        $batch = $this->fresh();
+
+        if ($count === 0 && $batch->pendingJobs === 0 && ! $batch->finished()) {
+            $this->repository->markAsFinished($this->id);
+
+            if ($this->hasThenCallbacks()) {
+                $this->invokeCallbacks('then');
+            }
+
+            if ($this->hasFinallyCallbacks()) {
+                $this->invokeCallbacks('finally');
+            }
+
+            $batch = $this->fresh();
+        }
+
+        return $batch;
     }
 
     /**

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -393,6 +393,29 @@ class BusBatchTest extends TestCase
         $this->assertEquals(2, $_SERVER['__failure3.param_count']);
     }
 
+    public function test_empty_batch_executes_callbacks()
+    {
+        $queue = m::mock(Factory::class);
+
+        $batch = $this->createTestBatch($queue);
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once()->with([], '', 'test-queue');
+
+        $batch = $batch->add([]);
+
+        $this->assertEquals(0, $batch->totalJobs);
+        $this->assertEquals(0, $batch->pendingJobs);
+        $this->assertTrue($batch->finished());
+        $this->assertInstanceOf(Batch::class, $_SERVER['__then.batch']);
+        $this->assertInstanceOf(Batch::class, $_SERVER['__finally.batch']);
+        $this->assertEquals(1, $_SERVER['__then.count']);
+        $this->assertEquals(1, $_SERVER['__finally.count']);
+    }
+
     public function test_batch_can_be_cancelled()
     {
         $queue = m::mock(Factory::class);


### PR DESCRIPTION
When Bus::batch([]) is called with an empty array, the then() and finally() callbacks were not being executed. This was counterintuitive as batches with zero jobs should logically complete immediately and trigger their completion callbacks.

This change detects when no jobs are added to a batch and immediately marks it as finished, executing the registered then() and finally() callbacks.

Fixes #58163