### PR TITLE
[12.x] Fix escaping of AppendableAttributeValue

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -278,6 +278,10 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
             return false;
         }
 
+        if ($value instanceof AppendableAttributeValue) {
+            return $this->shouldEscapeAttributeValue($escape, $value->value);
+        }
+        
         return ! is_object($value) &&
                ! is_null($value) &&
                ! is_bool($value);

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -281,7 +281,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
         if ($value instanceof AppendableAttributeValue) {
             return $this->shouldEscapeAttributeValue($escape, $value->value);
         }
-        
+
         return ! is_object($value) &&
                ! is_null($value) &&
                ! is_bool($value);

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View;
 
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\AppendableAttributeValue;
 use PHPUnit\Framework\TestCase;
 
 class ViewComponentAttributeBagTest extends TestCase

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -65,6 +65,19 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $bag = (new ComponentAttributeBag)
             ->merge([
+                'data-bs-tooltip' => new AppendableAttributeValue('<strong>Sample Title</strong>'),
+            ]);
+
+        $this->assertSame('data-bs-tooltip="&lt;strong&gt;Sample Title&lt;/strong&gt;"', (string) $bag);
+
+        $bag->merge([
+            'data-bs-tooltip' => new AppendableAttributeValue('<em>First Text</em>'),
+        ]);
+
+        $this->assertSame('data-bs-tooltip="&lt;em&gt;First Text&lt;/em&gt; &lt;strong&gt;Sample Title&lt;/strong&gt;"', (string) $bag);
+
+        $bag = (new ComponentAttributeBag)
+            ->merge([
                 'test-string' => 'ok',
                 'test-null' => null,
                 'test-false' => false,

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -71,7 +71,7 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('data-bs-tooltip="&lt;strong&gt;Sample Title&lt;/strong&gt;"', (string) $bag);
 
-        $bag->merge([
+        $bag = $bag->merge([
             'data-bs-tooltip' => new AppendableAttributeValue('<em>First Text</em>'),
         ]);
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\View;
 
-use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\AppendableAttributeValue;
+use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
 
 class ViewComponentAttributeBagTest extends TestCase


### PR DESCRIPTION
I recently ran into a problem where appendable attribute does not escape it's value AppendableAttributeValue cause the function shouldEscapeAttributeValue returns false if it is an object. So, checked the value if it is an instance of AppendableAttributeValue and then get the actual value for escaping.

    if ($value instanceof AppendableAttributeValue) {
        return $this->shouldEscapeAttributeValue($escape, $value->value);
    }