### PR TITLE
[12.x] add MigrationSkipped event

### DIFF
--- a/src/Illuminate/Database/Events/MigrationSkipped.php
+++ b/src/Illuminate/Database/Events/MigrationSkipped.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Contracts\Database\Events\MigrationEvent;
+
+class MigrationSkipped implements MigrationEvent
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $migrationName  The migration name that was skipped.
+     */
+    public function __construct(
+        public $migrationName,
+    ) {
+    }
+}

--- a/src/Illuminate/Database/Events/MigrationSkipped.php
+++ b/src/Illuminate/Database/Events/MigrationSkipped.php
@@ -9,7 +9,7 @@ class MigrationSkipped implements MigrationEvent
     /**
      * Create a new event instance.
      *
-     * @param  string  $migrationName  The migration name that was skipped.
+     * @param  string  $migrationName  The name of the migration that was skipped.
      */
     public function __construct(
         public $migrationName,

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Events\MigrationEnded;
 use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Database\Events\MigrationSkipped;
 use Illuminate\Database\Events\MigrationsStarted;
 use Illuminate\Database\Events\MigrationStarted;
 use Illuminate\Database\Events\NoPendingMigrations;
@@ -245,6 +246,8 @@ class Migrator
             : true;
 
         if (! $shouldRunMigration) {
+            $this->fireMigrationEvent(new MigrationSkipped($name));
+
             $this->write(Task::class, $name, fn () => MigrationResult::Skipped->value);
         } else {
             $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -4,10 +4,10 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Events\MigrationEnded;
 use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Database\Events\MigrationSkipped;
 use Illuminate\Database\Events\MigrationsStarted;
 use Illuminate\Database\Events\MigrationStarted;
 use Illuminate\Database\Events\NoPendingMigrations;
-use Illuminate\Database\Events\MigrationSkipped;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\MigrationsStarted;
 use Illuminate\Database\Events\MigrationStarted;
 use Illuminate\Database\Events\NoPendingMigrations;
+use Illuminate\Database\Events\MigrationSkipped;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
@@ -32,6 +33,7 @@ class MigratorEventsTest extends TestCase
         Event::assertDispatched(MigrationsEnded::class, 2);
         Event::assertDispatched(MigrationStarted::class, 2);
         Event::assertDispatched(MigrationEnded::class, 2);
+        Event::assertDispatched(MigrationSkipped::class, 1);
     }
 
     public function testMigrationEventsContainTheOptionsAndPretendFalse()

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -139,4 +139,18 @@ class MigratorEventsTest extends TestCase
             return $event->method === 'down';
         });
     }
+
+    public function testMigrationSkippedEventIsFired()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', [
+            '--path' => realpath(__DIR__.'/stubs/2014_10_13_000000_skipped_migration.php'),
+            '--realpath' => true,
+        ]);
+
+        Event::assertDispatched(MigrationSkipped::class, function ($event) {
+            return $event->migrationName === '2014_10_13_000000_skipped_migration';
+        });
+    }
 }

--- a/tests/Integration/Database/stubs/2014_10_13_000000_skipped_migration.php
+++ b/tests/Integration/Database/stubs/2014_10_13_000000_skipped_migration.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function shouldRun(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('skipped_table', function (Blueprint $table) {
+            $table->id();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skipped_table');
+    }
+};


### PR DESCRIPTION
This PR adds a `MigrationSkipped` event that fires when a migration is pending but skipped.

Laravel fires various events for migrations, but not when a pending migration is skipped. 

This allows us to track it for monitoring for things such as conditional migration behavior across environments.

When running migrations silently in deployment pipelines, events provide the only way to observe what occurred - so useful for logging tools etc.