### PR TITLE
[12.x] Fix AppendableAttributeValue escape string value

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -237,6 +237,12 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
     public function merge(array $attributeDefaults = [], $escape = true)
     {
         $attributeDefaults = array_map(function ($value) use ($escape) {
+            if($value instanceof AppendableAttributeValue) {
+                return new AppendableAttributeValue(
+                    $this->resolveAppendableAttributeDefault([$value], 0, $escape)
+                );
+            }
+
             return $this->shouldEscapeAttributeValue($escape, $value)
                 ? e($value)
                 : $value;
@@ -251,9 +257,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
             });
 
         $attributes = $appendableAttributes->mapWithKeys(function ($value, $key) use ($attributeDefaults, $escape) {
-            $defaultsValue = isset($attributeDefaults[$key]) && $attributeDefaults[$key] instanceof AppendableAttributeValue
-                ? $this->resolveAppendableAttributeDefault($attributeDefaults, $key, $escape)
-                : ($attributeDefaults[$key] ?? '');
+            $defaultsValue = $attributeDefaults[$key] ?? '';
 
             if ($key === 'style') {
                 $value = Str::finish($value, ';');

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -237,7 +237,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
     public function merge(array $attributeDefaults = [], $escape = true)
     {
         $attributeDefaults = array_map(function ($value) use ($escape) {
-            if($value instanceof AppendableAttributeValue) {
+            if ($value instanceof AppendableAttributeValue) {
                 return new AppendableAttributeValue(
                     $this->resolveAppendableAttributeDefault([$value], 0, $escape)
                 );
@@ -256,7 +256,7 @@ class ComponentAttributeBag implements Arrayable, ArrayAccess, IteratorAggregate
                 );
             });
 
-        $attributes = $appendableAttributes->mapWithKeys(function ($value, $key) use ($attributeDefaults, $escape) {
+        $attributes = $appendableAttributes->mapWithKeys(function ($value, $key) use ($attributeDefaults) {
             $defaultsValue = $attributeDefaults[$key] ?? '';
 
             if ($key === 'style') {

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use Illuminate\View\AppendableAttributeValue;
 use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
 
@@ -62,6 +63,19 @@ class ViewComponentAttributeBagTest extends TestCase
             ]);
 
         $this->assertSame('test-escaped="&lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);
+
+        $bag = (new ComponentAttributeBag)
+            ->merge([
+                'test-escaped' => new AppendableAttributeValue('<tag attr="attr">'),
+            ]);
+
+        $this->assertSame('test-escaped="&lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);
+
+        $bag = $bag->merge([
+            'test-escaped' => $bag->prepends('<prefix>'),
+        ]);
+
+        $this->assertSame('test-escaped="&lt;prefix&gt; &lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);
 
         $bag = (new ComponentAttributeBag)
             ->merge([


### PR DESCRIPTION
Issue: AppendableAttributeValue did not escape the string value at first.

<img width="622" height="231" alt="image" src="https://github.com/user-attachments/assets/7a7ab045-c6ca-4d11-a48e-c263c6ab37ff" />

Fix: The fix is simple escape the string at the begining not while resolving.

    $attributeDefaults = array_map(function ($value) use ($escape) {
        if($value instanceof AppendableAttributeValue) {
            return new AppendableAttributeValue(
                $this->resolveAppendableAttributeDefault([$value], 0, $escape)
            );
        }

        return $this->shouldEscapeAttributeValue($escape, $value)
            ? e($value)
            : $value;
    });