### PR TITLE
[12.x] Allow ignoring notifications inside closure

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -41,7 +41,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @return void
      */
     public function send($notifiables, $notification)
-    {   
+    {
         if (empty($notifiables = $this->filterNotifiables($notifiables, $notification))) {
             return;
         }
@@ -60,7 +60,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @return void
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
-    {   
+    {
         if (empty($notifiables = $this->filterNotifiables($notifiables, $notification))) {
             return;
         }
@@ -207,16 +207,13 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
         if ($when === false) {
             return $notifiables;
-
         } elseif ($when === true) {
             return [];
         }
 
         if ($notifiables instanceof Collection) {
             return $notifiables->filter(fn ($notifiable) => ! $when($notification, $notifiable));
-        
         } elseif (is_array($notifiables)) {
-
             return array_filter($notifiables, fn ($notifiable) => ! $when($notification, $notifiable));
         }
 

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -41,7 +41,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @return void
      */
     public function send($notifiables, $notification)
-    {
+    {   
         if (empty($notifiables = $this->filterNotifiables($notifiables, $notification))) {
             return;
         }
@@ -178,9 +178,9 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
     /**
      * Execute a callback without sending notifications.
-     * 
-     * @param \Closure  $callback
-     * @param bool|\Closure
+     *
+     * @param  \Closure  $callback
+     * @param  bool|\Closure  $when
      * @return mixed
      */
     public static function withoutNotifications($callback, $when = true)
@@ -196,7 +196,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
     /**
      * Filter notifiables before they are sent a notification.
-     * 
+     *
      * @param  \Illuminate\Support\Collection|mixed  $notifiables
      * @param  mixed  $notification
      * @return \Illuminate\Support\Collection|mixed
@@ -207,17 +207,17 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
         if ($when === false) {
             return $notifiables;
-        
-        } else if ($when === true) {
+
+        } elseif ($when === true) {
             return [];
         }
 
         if ($notifiables instanceof Collection) {
-            return $notifiables->filter(fn($notifiable) => ! $when($notification, $notifiable));
+            return $notifiables->filter(fn ($notifiable) => ! $when($notification, $notifiable));
         
         } elseif (is_array($notifiables)) {
 
-            return array_filter($notifiables, fn($notifiable) => ! $when($notification, $notifiable));
+            return array_filter($notifiables, fn ($notifiable) => ! $when($notification, $notifiable));
         }
 
         return $when($notification, $notifiables) ? $notifiables : null;

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -217,6 +217,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             return array_filter($notifiables, fn ($notifiable) => ! $when($notification, $notifiable));
         }
 
-        return $when($notification, $notifiables) ? $notifiables : null;
+        return $when($notification, $notifiables) ? null : $notifiables;
     }
 }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -18,7 +18,6 @@ use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Notification as FacadesNotification;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -371,7 +370,6 @@ class NotificationChannelManagerTest extends TestCase
 
     public function testWithoutNotificationsPreventsSending()
     {
-
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
         $container->instance(Bus::class, $bus = m::mock());
@@ -384,7 +382,7 @@ class NotificationChannelManagerTest extends TestCase
         $driver->shouldReceive('send')->never();
         $events->shouldReceive('dispatch')->never();
 
-        ChannelManager::withoutNotifications(function() use ($manager) {
+        ChannelManager::withoutNotifications(function () use ($manager) {
             $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
         });
     }
@@ -393,7 +391,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $notifiables = collect([
             new NotificationChannelManagerTestNotifiable,
-            new NotificationChannelManagerTestNotifiable
+            new NotificationChannelManagerTestNotifiable,
         ]);
 
         $notification = new NotificationChannelManagerTestNotification;
@@ -413,10 +411,10 @@ class NotificationChannelManagerTest extends TestCase
         });
         $events->shouldReceive('dispatch')->with(m::type(NotificationSent::class));
 
-        ChannelManager::withoutNotifications(function() use ($manager, $notification, $notifiables) {
+        ChannelManager::withoutNotifications(function () use ($manager, $notification, $notifiables) {
             $manager->send($notifiables, $notification);
 
-        }, when: function($notification, $notifiable) use ($notifiables) {
+        }, when: function ($notification, $notifiable) use ($notifiables) {
             return $notifiable === $notifiables->last();
         });
     }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -415,7 +415,6 @@ class NotificationChannelManagerTest extends TestCase
 
         ChannelManager::withoutNotifications(function () use ($manager, $notification, $notifiables) {
             $manager->send($notifiables, $notification);
-
         }, when: function ($notification, $notifiable) use ($notifiables) {
             return $notifiable === $notifiables->last();
         });

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -405,9 +405,11 @@ class NotificationChannelManagerTest extends TestCase
         $manager->shouldReceive('driver')->andReturn($driver = m::mock());
         $events->shouldReceive('listen')->once();
         $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
-        $driver->shouldReceive('send')->once()->withArgs(function($recipient, $notif) use ($notifiables) {
-            return $recipient === $notifiables->first()
-                && $notif instanceof NotificationChannelManagerTestNotification;
+        $driver->shouldReceive('send')->once()->withArgs(function ($recipient, $notification) use ($notifiables) {
+            $this->assertEquals($recipient, $notifiables->first());
+            $this->assertInstanceOf(NotificationChannelManagerTestNotification::class, $notification);
+
+            return true;
         });
         $events->shouldReceive('dispatch')->with(m::type(NotificationSent::class));
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -403,7 +403,7 @@ class NotificationChannelManagerTest extends TestCase
 
         ChannelManager::withoutNotifications(function () use ($manager) {
             $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
-        }, when: fn() => true);
+        }, when: fn () => true);
     }
 
     public function testWithoutNotificationsConditionallyPreventsSendingToMultipleNotifiables()


### PR DESCRIPTION
This PR makes it possible to execute a closure without sending any notifications.

**Use-case:** an e-commerce application where marking an order as dispatched sends a dispatch email. For various reasons, we may want to mark the order as dispatched without actually notifying the customer. This is currently non-trivial to achieve when sending is decoupled from other logic, e.g.

- the notification is sent by listening to an event
- the notification is queued

The existing ways to prevent sending (via the cancelable `NotificationSending` event, or the `shouldSend()` method) do not help here because they may be called from within a queued job, without access to the context in which it was dispatched.

**Approach**: The PR adds a new `withoutNotifications()` method to the `ChannelManager` class, which is typically accessed via the Notification facade. (This was chosen to mirror the similar `Model::withoutEvents()` method).

The first argument is a closure which, when called, will not trigger any notifications:

```
use Illuminate\Support\Facades\Notification;

Notification::withoutNotifications(function() {
    $order
        ->fill($request->validated())
        ->save();
});
```

A second, optional, argument gives finer control over when notifications should be ignored:

```
Notification::withoutNotifications(function() {
    $order
        ->fill($request->validated())
        ->save();

}, when: function($notification, $notifiable) {
    return $notifiable->isCustomer();
});
```

This gives developers a way to prevent notifications under different circumstances, while utilising traditional Laravel features like events and queues.

Am not sure about the naming and whether it is clear enough that the 2nd callback should return `true` to skip the notification, so any feedback welcome.