### PR TITLE
[12.x] Fixup Eloquent `Collection` (param) docblocks

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -680,9 +680,8 @@ class Collection extends BaseCollection implements QueueableCollection
      */
 
     /**
-     * Count the number of items in the collection by a field or using a callback.
+     * {@inheritDoc}
      *
-     * @param  (callable(TModel, TKey): array-key)|string|null  $countBy
      * @return \Illuminate\Support\Collection<array-key, int>
      */
     public function countBy($countBy = null)
@@ -691,7 +690,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Collapse the collection of items into a single array.
+     * {@inheritDoc}
      *
      * @return \Illuminate\Support\Collection<int, mixed>
      */
@@ -701,9 +700,8 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get a flattened array of the items in the collection.
+     * {@inheritDoc}
      *
-     * @param  int  $depth
      * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function flatten($depth = INF)
@@ -712,7 +710,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Flip the items in the collection.
+     * {@inheritDoc}
      *
      * @return \Illuminate\Support\Collection<TModel, TKey>
      */
@@ -722,7 +720,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get the keys of the collection items.
+     * {@inheritDoc}
      *
      * @return \Illuminate\Support\Collection<int, TKey>
      */
@@ -732,12 +730,10 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Pad collection to the specified length with a value.
+     * {@inheritDoc}
      *
      * @template TPadValue
      *
-     * @param  int  $size
-     * @param  TPadValue  $value
      * @return \Illuminate\Support\Collection<int, TModel|TPadValue>
      */
     public function pad($size, $value)
@@ -746,11 +742,8 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Partition the collection into two arrays using the given callback or key.
+     * {@inheritDoc}
      *
-     * @param  (callable(TModel, TKey): bool)|TModel|string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
      * @return \Illuminate\Support\Collection<int<0, 1>, static<TKey, TModel>>
      */
     public function partition($key, $operator = null, $value = null)
@@ -759,10 +752,8 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get an array with the values of a given key.
+     * {@inheritDoc}
      *
-     * @param  string|array<array-key, string>|Closure|null  $value
-     * @param  string|Closure|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function pluck($value, $key = null)
@@ -771,11 +762,10 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Zip the collection together with one or more arrays.
+     * {@inheritDoc}
      *
      * @template TZipValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue>  ...$items
      * @return \Illuminate\Support\Collection<int, \Illuminate\Support\Collection<int, TModel|TZipValue>>
      */
     public function zip($items)
@@ -786,7 +776,6 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the comparison function to detect duplicates.
      *
-     * @param  bool  $strict
      * @return callable(TModel, TModel): bool
      */
     protected function duplicateComparator($strict)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -684,6 +684,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<array-key, int>
      */
+    #[\Override]
     public function countBy($countBy = null)
     {
         return $this->toBase()->countBy($countBy);
@@ -694,6 +695,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int, mixed>
      */
+    #[\Override]
     public function collapse()
     {
         return $this->toBase()->collapse();
@@ -704,6 +706,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int, mixed>
      */
+    #[\Override]
     public function flatten($depth = INF)
     {
         return $this->toBase()->flatten($depth);
@@ -714,6 +717,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<TModel, TKey>
      */
+    #[\Override]
     public function flip()
     {
         return $this->toBase()->flip();
@@ -724,6 +728,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int, TKey>
      */
+    #[\Override]
     public function keys()
     {
         return $this->toBase()->keys();
@@ -736,6 +741,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int, TModel|TPadValue>
      */
+    #[\Override]
     public function pad($size, $value)
     {
         return $this->toBase()->pad($size, $value);
@@ -746,6 +752,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int<0, 1>, static<TKey, TModel>>
      */
+    #[\Override]
     public function partition($key, $operator = null, $value = null)
     {
         return parent::partition(...func_get_args())->toBase();
@@ -756,6 +763,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
+    #[\Override]
     public function pluck($value, $key = null)
     {
         return $this->toBase()->pluck($value, $key);
@@ -768,6 +776,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return \Illuminate\Support\Collection<int, \Illuminate\Support\Collection<int, TModel|TZipValue>>
      */
+    #[\Override]
     public function zip($items)
     {
         return $this->toBase()->zip(...func_get_args());

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Closure;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -24,6 +24,7 @@
         "illuminate/macroable": "^12.0",
         "illuminate/support": "^12.0",
         "laravel/serializable-closure": "^1.3|^2.0",
+        "symfony/polyfill-php83": "^1.33",
         "symfony/polyfill-php85": "^1.33"
     },
     "autoload": {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When passing a callback returning an `UnitEnum` instance to an (Eloquent) `Collection@countBy` call, my static analyzer reported an issue due to this method not accepting this type. Upon inspection I figured this is due to a mismatch between param signatures between the Eloquent class and its parent.

To resolve this, rather than copy over the updated definition from there, I propose to inherit all this data for this method and all other methods that just explicitly 'defer' to the base class. This ensures that any future param docblock update on the base class will be properly inherited by the child. 

As an addition I've also added `Override` attributes to all calls to make this slightly more explicit.
