### PR TITLE
Feature disable route

### DIFF
--- a/src/Illuminate/Routing/Middleware/DisabledRoute.php
+++ b/src/Illuminate/Routing/Middleware/DisabledRoute.php
@@ -19,13 +19,25 @@ class DisabledRoute
     {
         $route = $request->route();
 
-        if ($route && ($message = $route->getAction('disabled')) !== null) {
-            $response = is_callable($message) ? $message($request) : null;
+        if ($route && ($message = $route->getDisabled()) !== null) {
+            // If it's a callback, execute it
+            if (is_callable($message)) {
+                $response = $message($request);
 
-            if ($response !== null) {
+                // If callback returns null or false, allow the route to proceed
+                if ($response === null || $response === false) {
+                    return $next($request);
+                }
+
                 return $response;
             }
 
+            // For boolean false, allow the route to proceed
+            if ($message === false) {
+                return $next($request);
+            }
+
+            // For boolean true or non-empty string, disable the route
             $message = is_string($message) && ! empty($message)
                 ? $message
                 : 'This route is temporarily disabled.';

--- a/src/Illuminate/Routing/Middleware/DisabledRoute.php
+++ b/src/Illuminate/Routing/Middleware/DisabledRoute.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DisabledRoute
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $route = $request->route();
+
+        if ($route && ($message = $route->getAction('disabled')) !== null) {
+            $response = is_callable($message) ? $message($request) : null;
+
+            if ($response !== null) {
+                return $response;
+            }
+
+            $message = is_string($message) && ! empty($message)
+                ? $message
+                : 'This route is temporarily disabled.';
+
+            return response($message, 503);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1165,6 +1165,26 @@ class Route
     }
 
     /**
+     * Get the disabled status or callback for the route.
+     *
+     * @return \Closure|string|bool|null
+     */
+    public function getDisabled()
+    {
+        $disabled = $this->action['disabled'] ?? null;
+
+        if (is_string($disabled) &&
+            Str::startsWith($disabled, [
+                'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
+                'O:55:"Laravel\\SerializableClosure\\UnsignedSerializableClosure',
+            ])) {
+            return unserialize($disabled)->getClosure();
+        }
+
+        return $disabled;
+    }
+
+    /**
      * Mark this route as temporarily disabled.
      *
      * @param  \Closure|string|bool  $messageOrCallback
@@ -1407,6 +1427,12 @@ class Route
         if (isset($this->action['missing']) && $this->action['missing'] instanceof Closure) {
             $this->action['missing'] = serialize(
                 SerializableClosure::unsigned($this->action['missing'])
+            );
+        }
+
+        if (isset($this->action['disabled']) && $this->action['disabled'] instanceof Closure) {
+            $this->action['disabled'] = serialize(
+                SerializableClosure::unsigned($this->action['disabled'])
             );
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1165,6 +1165,19 @@ class Route
     }
 
     /**
+     * Mark this route as temporarily disabled.
+     *
+     * @param  \Closure|string|bool  $messageOrCallback
+     * @return $this
+     */
+    public function disabled($messageOrCallback = true)
+    {
+        $this->action['disabled'] = $messageOrCallback;
+
+        return $this->middleware(\Illuminate\Routing\Middleware\DisabledRoute::class);
+    }
+
+    /**
      * Specify middleware that should be removed from the given route.
      *
      * @param  array|string  $middleware

--- a/tests/Integration/Routing/DisabledRouteTest.php
+++ b/tests/Integration/Routing/DisabledRouteTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class DisabledRouteTest extends TestCase
+{
+    public function testRouteCanBeDisabledWithDefaultMessage()
+    {
+        Route::get('/disabled', function () {
+            return 'This should not be returned';
+        })->disabled();
+
+        $response = $this->get('/disabled');
+
+        $response->assertStatus(503);
+        $this->assertSame('This route is temporarily disabled.', $response->content());
+    }
+
+    public function testRouteCanBeDisabledWithCustomMessage()
+    {
+        Route::get('/custom-disabled', function () {
+            return 'This should not be returned';
+        })->disabled('Feature is under maintenance');
+
+        $response = $this->get('/custom-disabled');
+
+        $response->assertStatus(503);
+        $this->assertSame('Feature is under maintenance', $response->content());
+    }
+
+    public function testRouteCanBeDisabledWithCallback()
+    {
+        Route::get('/callback-disabled', function () {
+            return 'This should not be returned';
+        })->disabled(function ($request) {
+            return response()->json([
+                'message' => 'Route disabled',
+                'path' => $request->path(),
+            ], 503);
+        });
+
+        $response = $this->get('/callback-disabled');
+
+        $response->assertStatus(503);
+        $response->assertJson([
+            'message' => 'Route disabled',
+            'path' => 'callback-disabled',
+        ]);
+    }
+
+    public function testEnabledRouteWorksNormally()
+    {
+        Route::get('/enabled', function () {
+            return 'This should work';
+        });
+
+        $response = $this->get('/enabled');
+
+        $response->assertStatus(200);
+        $this->assertSame('This should work', $response->content());
+    }
+
+    public function testDisabledRouteWithPostMethod()
+    {
+        Route::post('/post-disabled', function () {
+            return 'This should not be returned';
+        })->disabled('POST endpoint disabled');
+
+        $response = $this->post('/post-disabled');
+
+        $response->assertStatus(503);
+        $this->assertSame('POST endpoint disabled', $response->content());
+    }
+
+    public function testDisabledRouteWithEmptyStringUsesDefaultMessage()
+    {
+        Route::get('/empty-message', function () {
+            return 'This should not be returned';
+        })->disabled('');
+
+        $response = $this->get('/empty-message');
+
+        $response->assertStatus(503);
+        $this->assertSame('This route is temporarily disabled.', $response->content());
+    }
+
+    public function testDisabledRouteWorksWithRouteGroups()
+    {
+        Route::prefix('admin')->group(function () {
+            Route::get('/users', function () {
+                return 'User list';
+            })->disabled('Admin area under maintenance');
+
+            Route::get('/posts', function () {
+                return 'Post list';
+            });
+        });
+
+        $disabledResponse = $this->get('/admin/users');
+        $disabledResponse->assertStatus(503);
+        $this->assertSame('Admin area under maintenance', $disabledResponse->content());
+
+        $enabledResponse = $this->get('/admin/posts');
+        $enabledResponse->assertStatus(200);
+        $this->assertSame('Post list', $enabledResponse->content());
+    }
+}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2230,6 +2230,34 @@ class RoutingRouteTest extends TestCase
         ], $route->middleware());
     }
 
+    public function testRouteCanBeDisabled()
+    {
+        $route = new Route(['GET'], '/', []);
+        $route->disabled();
+
+        $this->assertTrue($route->getAction('disabled'));
+        $this->assertContains(\Illuminate\Routing\Middleware\DisabledRoute::class, $route->middleware());
+    }
+
+    public function testRouteCanBeDisabledWithCustomMessage()
+    {
+        $route = new Route(['GET'], '/', []);
+        $route->disabled('Custom message');
+
+        $this->assertEquals('Custom message', $route->getAction('disabled'));
+        $this->assertContains(\Illuminate\Routing\Middleware\DisabledRoute::class, $route->middleware());
+    }
+
+    public function testRouteCanBeDisabledWithCallback()
+    {
+        $callback = fn ($request) => response('Disabled', 503);
+        $route = new Route(['GET'], '/', []);
+        $route->disabled($callback);
+
+        $this->assertSame($callback, $route->getAction('disabled'));
+        $this->assertContains(\Illuminate\Routing\Middleware\DisabledRoute::class, $route->middleware());
+    }
+
     public function testItDispatchesEventsWhilePreparingRequest()
     {
         $events = new Dispatcher;


### PR DESCRIPTION
# Add Route Disabling Feature

This PR introduces the ability to temporarily disable routes without removing them from the codebase. This feature is useful for maintenance mode, feature flags, A/B testing, gradual rollouts, and emergency response scenarios.

## Usage

### Basic Usage - Default Message
```php
Route::get('/users', [UserController::class, 'index'])->disabled();
// Returns: "This route is temporarily disabled." with 503 status
```

### Custom Message
```php
Route::get('/users', [UserController::class, 'index'])
    ->disabled('User management is under maintenance');
// Returns: "User management is under maintenance" with 503 status
```

### Custom Response with Callback
```php
Route::get('/users', [UserController::class, 'index'])
    ->disabled(function ($request) {
        return response()->json([
            'message' => 'This feature is temporarily unavailable',
            'retry_after' => now()->addHours(2)->timestamp,
        ], 503);
    });
```

### Conditional Disabling
```php
Route::get('/beta-feature', [BetaController::class, 'index'])
    ->disabled(config('features.beta_disabled') ? 'Beta features are disabled' : false);
```

## Implementation Details

### Files Added
- `src/Illuminate/Routing/Middleware/DisabledRoute.php` - Middleware that handles disabled routes
- `tests/Integration/Routing/DisabledRouteTest.php` - Integration tests (7 tests, 16 assertions)

### Files Modified
- `src/Illuminate/Routing/Route.php` - Added `disabled()` method (13 lines)
- `tests/Routing/RoutingRouteTest.php` - Added unit tests (3 tests, 6 assertions)

### How It Works
1. The `disabled()` method on the Route class:
   - Accepts optional message (string), boolean, or callback (Closure)
   - Stores the value in the route action array under the 'disabled' key
   - Automatically registers the `DisabledRoute` middleware to the route

2. The `DisabledRoute` middleware:
   - Checks if the current route has a 'disabled' action
   - If a callback is provided, executes it and returns the response
   - If a string message is provided, returns it with 503 status
   - If true or empty string, returns default message: "This route is temporarily disabled."
   - If false or null (from callback), allows the request to proceed normally

## Use Cases

1. **Selective Maintenance Mode** - Disable specific routes without putting the entire application in maintenance mode
2. **Feature Flags** - Easily toggle features on/off based on configuration or environment
3. **Time-Based Availability** - Enable routes only during specific time periods or business hours
4. **A/B Testing** - Conditionally disable routes for specific user segments
5. **Gradual Rollouts** - Keep new features disabled until ready, then enable for percentage of users
6. **Emergency Response** - Quickly disable problematic endpoints in production

## Real-World Examples

### Feature Flags
```php
Route::get('/new-feature', [FeatureController::class, 'index'])
    ->disabled(!config('features.new_feature_enabled'));
```

### Time-Based Availability
```php
Route::get('/christmas-sale', [SaleController::class, 'christmas'])
    ->disabled(function ($request) {
        $now = now();
        if ($now->between('2025-12-24', '2025-12-26')) {
            return null; // Enable during Christmas
        }
        return 'Christmas sale is only available December 24-26';
    });
```

### Business Hours
```php
Route::post('/trading/execute', [TradingController::class, 'execute'])
    ->disabled(function ($request) {
        if (now()->isWeekend() || now()->hour < 9 || now()->hour >= 17) {
            return response()->json([
                'message' => 'Trading is only available 9 AM - 5 PM on weekdays',
            ], 503);
        }
        return null; // Enable during business hours
    });
```

### Gradual Rollout
```php
Route::get('/new-dashboard', [DashboardController::class, 'new'])
    ->disabled(function ($request) {
        // Enable for 20% of users
        if (($request->user()->id % 5) === 0) {
            return null;
        }
        return 'New dashboard coming soon!';
    });
```

## Testing

All tests pass successfully:
  - 7 integration tests covering:
  - Default disabled message
  - Custom disabled message
  - Callback-based disabling
  - Enabled routes (verification)
  - POST method routes
  - Empty string handling
  - Route groups compatibility

  -3 unit tests covering:
  - Middleware registration
  - Action array storage
  - Different parameter types (boolean, string, callback)

  - Total: 10 tests, 22 assertions

## Backward Compatibility

This is a **non-breaking change**. It only adds new functionality without modifying any existing behavior. All existing routes continue to work exactly as before.

## API Design Considerations

The `disabled()` method accepts three types of values:
- **Boolean** (`true`/`false`) - Simple on/off switch
- **String** - Custom message with automatic 503 response
- **Closure** - Full control over the response logic

Returning `null` from a callback means "do not disable" - allowing dynamic enabling/disabling based on complex conditions.

Default HTTP status is **503 Service Unavailable**, which is semantically correct for temporary unavailability scenarios.
