### PR TITLE
[12.x] Adds 'required_unless_accepted' validation rule

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -146,6 +146,7 @@ return [
     'required_if_accepted' => 'The :attribute field is required when :other is accepted.',
     'required_if_declined' => 'The :attribute field is required when :other is declined.',
     'required_unless' => 'The :attribute field is required unless :other is in :values.',
+    'required_unless_accepted' => 'The :attribute field is required unless :other is accepted.',
     'required_with' => 'The :attribute field is required when :values is present.',
     'required_with_all' => 'The :attribute field is required when :values are present.',
     'required_without' => 'The :attribute field is required when :values is not present.',

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -653,6 +653,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the required_unless_accepted rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceRequiredUnlessAccepted($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceRequiredIfAccepted($message, $attribute, $rule, $parameters);
+    }
+
+    /**
      * Replace all place-holders for the required_unless rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2370,6 +2370,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute exists when another attribute was not "accepted".
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateRequiredUnlessAccepted($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'required_unless_accepted');
+
+        if (! $this->validateAccepted($parameters[0], $this->getValue($parameters[0]))) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
      * Indicate that an attribute should be excluded when another attribute presents.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -257,6 +257,7 @@ class Validator implements ValidatorContract
         'RequiredIfAccepted',
         'RequiredIfDeclined',
         'RequiredUnless',
+        'RequiredUnlessAccepted',
         'RequiredWith',
         'RequiredWithAll',
         'RequiredWithout',

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -225,6 +225,7 @@ class Validator implements ValidatorContract
         'RequiredIfAccepted',
         'RequiredIfDeclined',
         'RequiredUnless',
+        'RequiredUnlessAccepted',
         'RequiredWith',
         'RequiredWithAll',
         'RequiredWithout',

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -771,6 +771,21 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:hTtp,hTtps']);
         $this->assertFalse($v->passes());
         $this->assertSame('The url must start with one of the following values hTtp, hTtps', $v->messages()->first('url'));
+
+        // required_unless_accepted
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'yes', 'bar' => ''], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_unless_accepted' => 'The :attribute field is required unless :other is accepted.'], 'en');
+        $v = new Validator($trans, ['foo' => 'no', 'bar' => ''], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The bar field is required unless foo is accepted.', $v->messages()->first('bar'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'no', 'bar' => 'something'], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertTrue($v->passes());
     }
 
     public function testInputIsReplacedByItsDisplayableValue()
@@ -2716,6 +2731,19 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 'yes', 'bar' => ''], ['bar' => 'required_if_accepted:foo']);
         $this->assertFalse($v->passes());
+    }
+
+    public function testValidateRequiredUnlessAccepted()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'no', 'bar' => ''], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'yes', 'bar' => ''], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'no', 'bar' => 'baz'], ['bar' => 'required_unless_accepted:foo']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateAcceptedIf()


### PR DESCRIPTION
This PR adds a new `required_unless_accepted` validation rule to Laravel's validation system. This rule makes a field required unless another specified field has been accepted (checked).

## What was added

- **New validation method**: `validateRequiredUnlessAccepted()` in `Illuminate\Validation\Concerns\ValidatesAttributes`
- **Comprehensive tests**: Added test coverage in `ValidationValidatorTest.php` to ensure the rule works correctly in various scenarios
- **Validation message**: Added default error message for the new rule in `resources/lang/en/validation.php`
- **Replace place-holder**: Added `replaceRequiredUnlessAccepted()` method in `Illuminate\Validation\Concerns\ReplacesAttributes`
- **Dependent and Implicit Rules**: Added `RequiredUnlessAccepted` to dependentRules and implicitRules in `src\Illuminate\Validator`

## How it works

The `required_unless_accepted` rule validates that a field is required when another field is **not** accepted. If the other field is accepted (e.g., a checkbox is checked), the field becomes optional.

**Syntax:**
```php
'field' => 'required_unless_accepted:other_field'
```

**Implementation details:**
- Checks if the specified field is accepted using the existing `validateAccepted()` method
- If the field is **not** accepted, validates that the current field is required
- If the field **is** accepted, the validation passes (field is optional)
- Follows the same pattern as existing conditional validation rules like `required_if_accepted` and `required_unless`

## Use cases

This rule is particularly useful for forms where certain fields become optional based on user consent or acceptance:

### 1. **Contact preferences with opt-out**
```php
'contact_preferences' => 'required_unless_accepted:use_default_preferences'
```
User must specify contact preferences unless they check "use default preferences"

### 2. **Custom data with template option**
```php
'custom_message' => 'required_unless_accepted:use_template'
```
User must provide a custom message unless they opt to use a template

### 3. **Tier require prices**
```php
'tier.prices' => 'required_unless_accepted:is_parent'
```
Here tier prices is required unless address is required unless 'is_parent' is checked

### 4. **Conditional opt-out scenarios**
```php
'reason' => 'required_unless_accepted:no_reason_needed'
```
User must provide a reason unless they explicitly indicate no reason is needed

## Why this is useful

This rule complements the existing `required_if_accepted` rule by providing the inverse logic:
- `required_if_accepted`: Field required **when** another field is accepted
- `required_unless_accepted`: Field required **unless** another field is accepted

This gives developers more flexibility in building intuitive forms where acceptance/consent checkboxes control field requirements, improving the user experience by reducing unnecessary required fields when users opt into simplified flows.

## Consistency with existing rules

This implementation follows the established patterns in Laravel's validation system:
- Mirrors the structure of `required_if_accepted`
- Uses existing helper methods (`validateAccepted`, `validateRequired`, `getValue`)
- Follows naming conventions consistent with `required_unless` and other conditional rules
- Includes proper parameter validation with `requireParameterCount`
