### PR TITLE
[12.x] Fix inline mail embed replacement by Content-ID

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -270,7 +270,7 @@ class Mailer implements MailerContract, MailQueueContract
         if (preg_match_all('/<img.+?src=[\'"]cid:([^\'"]+)[\'"].*?>/is', $renderedView, $matches)) {
             foreach (array_unique($matches[1]) as $image) {
                 foreach ($attachments as $attachment) {
-                    if ($attachment->getFilename() === $image) {
+                    if ($attachment->getContentId() === $image || $attachment->getFilename() === $image) {
                         $renderedView = str_replace(
                             'cid:'.$image,
                             'data:'.$attachment->getContentType().';base64,'.$attachment->bodyToString(),

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -92,7 +92,18 @@ class SendingMarkdownMailTest extends TestCase
 
         $this->assertStringContainsString('Embed multiline content: <img', $html);
         $this->assertStringContainsString('alt="multiline image"', $html);
-        $this->assertStringContainsString('<img src="cid:', $html);
+        $this->assertStringContainsString('src="data:image/png;base64,', $html);
+        $this->assertStringNotContainsString('src="cid:', $html);
+    }
+
+    public function testEmbeddedImagesAreInlinedWhenRenderingMailable()
+    {
+        $html = app('mailer')->render('embed-image', [
+            'image' => __DIR__.'/Fixtures/empty_image.jpg',
+        ]);
+
+        $this->assertStringContainsString('src="data:image/jpeg;base64,', $html);
+        $this->assertStringNotContainsString('src="cid:', $html);
     }
 
     public function testMessageAsPublicPropertyMayBeDefinedAsViewData()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

#57726 switched `Message::embed()` to return Symfony's generated Content-ID (e.g. `...@symfony`). The HTML now uses that CID, not the filename.

`Mailer::replaceEmbeddedAttachments()` still matched on `$attachment->getFilename()`, so `Mail::render()` left `cid:` URLs in place instead of inlining base64 data.

The fix is matching embedded images by `getContentId()` (and falling back to the filename, for mailables that might be manually inlining a data part through `withSymfonyMessage()` + a hardcoded `cid:...` in a template) so the render path swaps `cid:` with `data:` URLs again.