### PR TITLE
[12.x] Add BusBatchable tests

### DIFF
--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Bus;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Container\Container;
+use Illuminate\Support\Testing\Fakes\BatchFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -34,5 +35,40 @@ class BusBatchableTest extends TestCase
         $this->assertSame('test-batch', $class->batch());
 
         Container::setInstance(null);
+    }
+
+    public function test_with_fake_batch_sets_and_returns_fake()
+    {
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        [$self, $batch] = $job->withFakeBatch('test-batch-id', 'test-batch-name', 3, 3, 0, [], []);
+
+        $this->assertSame($job, $self);
+        $this->assertInstanceOf(BatchFake::class, $batch);
+        $this->assertSame($batch, $job->batch());
+        $this->assertSame('test-batch-id', $job->batch()->id);
+        $this->assertSame('test-batch-name', $job->batch()->name);
+        $this->assertSame(3, $job->batch()->totalJobs);
+    }
+
+
+    public function test_batching_reflects_cancelled_state()
+    {
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $job->withFakeBatch('test-batch-id', 'test-batch-name');
+
+        // Initially not cancelled
+        $this->assertTrue($job->batching());
+
+        // Cancel the batch and ensure batching() returns false
+        $job->batch()->cancel();
+        $this->assertFalse($job->batching());
     }
 }

--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -53,8 +53,7 @@ class BusBatchableTest extends TestCase
         $this->assertSame('test-batch-name', $job->batch()->name);
         $this->assertSame(3, $job->batch()->totalJobs);
     }
-
-
+    
     public function test_batching_reflects_cancelled_state()
     {
         $job = new class


### PR DESCRIPTION
Added tests
`test_with_fake_batch_sets_and_returns_fake`,  verifies `withFakeBatch` returns the job and sets a BatchFake with correct id, name and totalJobs.
`test_batching_reflects_cancelled_state`,  verifies `batching()` returns true initially and false after the batch is cancelled.

Purpose
improve test coverage for Batchable behavior and ensure batching state and fake batch functionality work as expected.