### PR TITLE
[12.x] use process to trigger package uninstall event

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -6,6 +6,7 @@ use Composer\Installer\PackageEvent;
 use Composer\Script\Event;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Concurrency;
 
 class ComposerScripts
 {
@@ -77,7 +78,12 @@ class ComposerScripts
         /** @var \Composer\DependencyResolver\Operation\UninstallOperation $uninstallOperation */
         $uninstallOperation = $event->getOperation()->getPackage();
 
-        $app['events']->dispatch('composer_package.'.$uninstallOperation->getName().':pre_uninstall');
+        Concurrency::createProcessDriver([])->run(
+            fn () => Container::getInstance()['events']->dispatch(
+                'composer_package.'.$uninstallOperation->getName().':pre_uninstall'
+            )
+        );
+
     }
 
     /**

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -61,15 +61,17 @@ class ComposerScripts
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
         $laravel = new Application(getcwd());
+
         $laravel->bootstrapWith([
             LoadEnvironmentVariables::class,
             LoadConfiguration::class,
         ]);
 
-        // To ensure we can encrypt our serializable closure
+        // Ensure we can encrypt our serializable closure...
         (new EncryptionServiceProvider($laravel))->register();
 
         $name = $event->getOperation()->getPackage()->getName();
+
         $laravel->make(ProcessDriver::class)->run(
             static fn () => app()['events']->dispatch("composer_package.{$name}:pre_uninstall")
         );

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -83,7 +83,6 @@ class ComposerScripts
                 'composer_package.'.$uninstallOperation->getName().':pre_uninstall'
             )
         );
-
     }
 
     /**


### PR DESCRIPTION
To close https://github.com/laravel/framework/issues/57780

# Problem
Composer uses a different version of PSR-3 logger than what Laravel provides. While running the uninstall composer script, it's possible that composer has already booted with the old PSR log definition, but some part of the Kernel booting will attempt to log something.

# Solution
Fire this in a sub-process via the Concurrency/ProcessDriver. This guarantees we're in a fresh Laravel instance without the baggage of old composer owned dependencies.

Unfortunately, this isn't cleanly done. We have to boot a version of the application with only env/config, boot the encryption service provider (so we can serialize the closure) and then run the ProcessDriver. Other options I tried all ran the risk of hitting something that would trigger logs.