### PR TITLE
Add previous locale to LocaleUpdated event

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1595,7 +1595,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function setLocale($locale)
     {
-        $previous = $this->getLocale();
+        $previous = $this['config']->get('app.locale');
 
         $this['config']->set('app.locale', $locale);
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1595,11 +1595,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function setLocale($locale)
     {
+        $previous = $this->getLocale();
+
         $this['config']->set('app.locale', $locale);
 
         $this['translator']->setLocale($locale);
 
-        $this['events']->dispatch(new LocaleUpdated($locale));
+        $this['events']->dispatch(new LocaleUpdated($locale, $previous));
     }
 
     /**

--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -22,6 +22,7 @@ class LocaleUpdated
      * Create a new event instance.
      *
      * @param  string  $locale
+     * @param  ?string  $previous
      */
     public function __construct($locale, $previous = null)
     {

--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -12,12 +12,21 @@ class LocaleUpdated
     public $locale;
 
     /**
+     * The previous locale.
+     *
+     * @var ?string
+     */
+    public $previous;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $locale
      */
-    public function __construct($locale)
+    public function __construct($locale, $previous = null)
     {
         $this->locale = $locale;
+
+        $this->previous = $previous;
     }
 }

--- a/src/Illuminate/Foundation/Events/LocaleUpdated.php
+++ b/src/Illuminate/Foundation/Events/LocaleUpdated.php
@@ -16,18 +16,18 @@ class LocaleUpdated
      *
      * @var ?string
      */
-    public $previous;
+    public $previousLocale;
 
     /**
      * Create a new event instance.
      *
      * @param  string  $locale
-     * @param  ?string  $previous
+     * @param  ?string  $previousLocale
      */
-    public function __construct($locale, $previous = null)
+    public function __construct($locale, $previousLocale = null)
     {
         $this->locale = $locale;
 
-        $this->previous = $previous;
+        $this->previousLocale = $previousLocale;
     }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -24,12 +24,16 @@ class FoundationApplicationTest extends TestCase
     public function testSetLocaleSetsLocaleAndFiresLocaleChangedEvent()
     {
         $app = new Application;
+
         $app['config'] = $config = m::mock(stdClass::class);
+        $config->shouldReceive('get')->once()->with('app.locale')->andReturn('bar');
         $config->shouldReceive('set')->once()->with('app.locale', 'foo');
         $app['translator'] = $trans = m::mock(stdClass::class);
         $trans->shouldReceive('setLocale')->once()->with('foo');
         $app['events'] = $events = m::mock(stdClass::class);
-        $events->shouldReceive('dispatch')->once()->with(m::type(LocaleUpdated::class));
+        $events->shouldReceive('dispatch')->once()->with(m::on(function (LocaleUpdated $event) {
+            return $event->locale === 'foo' && $event->previous === 'bar';
+        }));
 
         $app->setLocale('foo');
     }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -32,7 +32,7 @@ class FoundationApplicationTest extends TestCase
         $trans->shouldReceive('setLocale')->once()->with('foo');
         $app['events'] = $events = m::mock(stdClass::class);
         $events->shouldReceive('dispatch')->once()->with(m::on(function (LocaleUpdated $event) {
-            return $event->locale === 'foo' && $event->previous === 'bar';
+            return $event->locale === 'foo' && $event->previousLocale === 'bar';
         }));
 
         $app->setLocale('foo');


### PR DESCRIPTION
Ciao!

This PR adds a `$previous` property to the `LocaleUpdated` event, containing the locale value before the change.

Currently, the event only provides the new locale, which is redundant since it can be retrieved via `app()->getLocale()` at any point after the event is dispatched. The previous locale, however, is lost once `setLocale()` is called.

The `$previous` property is nullable and defaults to `null` for backward compatibility.
