### PR TITLE
[12.x] Simplify `LazyCollection` `passthru` calls and docblocks

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -303,17 +303,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Cross join the given iterables, returning all possible permutations.
-     *
-     * @template TCrossJoinKey
-     * @template TCrossJoinValue
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TCrossJoinKey, TCrossJoinValue>|iterable<TCrossJoinKey, TCrossJoinValue>  ...$arrays
-     * @return static<int, array<int, TValue|TCrossJoinValue>>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function crossJoin(...$arrays)
     {
-        return $this->passthru('crossJoin', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -346,110 +341,84 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the items that are not present in the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @return static<TKey, TValue>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diff($items)
     {
-        return $this->passthru('diff', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get the items that are not present in the given items, using the callback.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @param  callable(TValue, TValue): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diffUsing($items, callable $callback)
     {
-        return $this->passthru('diffUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get the items whose keys and values are not present in the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diffAssoc($items)
     {
-        return $this->passthru('diffAssoc', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get the items whose keys and values are not present in the given items, using the callback.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @param  callable(TKey, TKey): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diffAssocUsing($items, callable $callback)
     {
-        return $this->passthru('diffAssocUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get the items whose keys are not present in the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, mixed>|iterable<TKey, mixed>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diffKeys($items)
     {
-        return $this->passthru('diffKeys', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get the items whose keys are not present in the given items, using the callback.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, mixed>|iterable<TKey, mixed>  $items
-     * @param  callable(TKey, TKey): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function diffKeysUsing($items, callable $callback)
     {
-        return $this->passthru('diffKeysUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Retrieve duplicate items.
-     *
-     * @template TMapValue
-     *
-     * @param  (callable(TValue): TMapValue)|string|null  $callback
-     * @param  bool  $strict
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function duplicates($callback = null, $strict = false)
     {
-        return $this->passthru('duplicates', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Retrieve duplicate items using strict comparison.
-     *
-     * @template TMapValue
-     *
-     * @param  (callable(TValue): TMapValue)|string|null  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function duplicatesStrict($callback = null)
     {
-        return $this->passthru('duplicatesStrict', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Get all items except for those with the specified keys.
-     *
-     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function except($keys)
     {
-        return $this->passthru('except', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -565,17 +534,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Group an associative array by a field or using a callback.
-     *
-     * @template TGroupKey of array-key
-     *
-     * @param  (callable(TValue, TKey): TGroupKey)|array|string  $groupBy
-     * @param  bool  $preserveKeys
-     * @return static<($groupBy is string ? array-key : ($groupBy is array ? array-key : TGroupKey)), static<($preserveKeys is true ? TKey : int), ($groupBy is array ? mixed : TValue)>>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function groupBy($groupBy, $preserveKeys = false)
     {
-        return $this->passthru('groupBy', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -655,60 +619,48 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Intersect the collection with the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function intersect($items)
     {
-        return $this->passthru('intersect', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Intersect the collection with the given items, using the callback.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @param  callable(TValue, TValue): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function intersectUsing($items, callable $callback)
     {
-        return $this->passthru('intersectUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Intersect the collection with the given items with additional index check.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function intersectAssoc($items)
     {
-        return $this->passthru('intersectAssoc', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Intersect the collection with the given items with additional index check, using the callback.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @param  callable(TValue, TValue): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function intersectAssocUsing($items, callable $callback)
     {
-        return $this->passthru('intersectAssocUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Intersect the collection with the given items by key.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, mixed>|iterable<TKey, mixed>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function intersectByKeys($items)
     {
-        return $this->passthru('intersectByKeys', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -831,19 +783,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Run a dictionary map over the items.
-     *
-     * The callback should return an associative array with a single key/value pair.
-     *
-     * @template TMapToDictionaryKey of array-key
-     * @template TMapToDictionaryValue
-     *
-     * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>  $callback
-     * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function mapToDictionary(callable $callback)
     {
-        return $this->passthru('mapToDictionary', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -867,27 +812,21 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Merge the collection with the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function merge($items)
     {
-        return $this->passthru('merge', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Recursively merge the collection with the given items.
-     *
-     * @template TMergeRecursiveValue
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TMergeRecursiveValue>|iterable<TKey, TMergeRecursiveValue>  $items
-     * @return static<TKey, TValue|TMergeRecursiveValue>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function mergeRecursive($items)
     {
-        return $this->passthru('mergeRecursive', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -898,7 +837,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function multiply(int $multiplier)
     {
-        return $this->passthru('multiply', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -935,14 +874,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Union the collection with the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function union($items)
     {
-        return $this->passthru('union', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -1097,24 +1034,21 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Recursively replace the collection items with the given items.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function replaceRecursive($items)
     {
-        return $this->passthru('replaceRecursive', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Reverse items order.
-     *
-     * @return static<TKey, TValue>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function reverse()
     {
-        return $this->passthru('reverse', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -1203,13 +1137,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Shuffle the items in the collection.
-     *
-     * @return static<TKey, TValue>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function shuffle()
     {
-        return $this->passthru('shuffle', []);
+        return $this->passthru(__FUNCTION__, []);
     }
 
     /**
@@ -1321,16 +1254,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get a slice of items from the enumerable.
-     *
-     * @param  int  $offset
-     * @param  int|null  $length
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function slice($offset, $length = null)
     {
         if ($offset < 0 || $length < 0) {
-            return $this->passthru('slice', func_get_args());
+            return $this->passthru(__FUNCTION__, func_get_args());
         }
 
         $instance = $this->skip($offset);
@@ -1339,14 +1269,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Split a collection into a certain number of groups.
-     *
-     * @param  int  $numberOfGroups
-     * @return static<int, static>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function split($numberOfGroups)
     {
-        return $this->passthru('split', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -1492,84 +1420,66 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Sort through each item with a callback.
-     *
-     * @param  (callable(TValue, TValue): int)|null|int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sort($callback = null)
     {
-        return $this->passthru('sort', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort items in descending order.
-     *
-     * @param  int  $options
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortDesc($options = SORT_REGULAR)
     {
-        return $this->passthru('sortDesc', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort the collection using the given callback.
-     *
-     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback
-     * @param  int  $options
-     * @param  bool  $descending
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
-        return $this->passthru('sortBy', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort the collection in descending order using the given callback.
-     *
-     * @param  array<array-key, (callable(TValue, TValue): mixed)|(callable(TValue, TKey): mixed)|string|array{string, string}>|(callable(TValue, TKey): mixed)|string  $callback
-     * @param  int  $options
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
-        return $this->passthru('sortByDesc', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort the collection keys.
-     *
-     * @param  int  $options
-     * @param  bool  $descending
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
-        return $this->passthru('sortKeys', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort the collection keys in descending order.
-     *
-     * @param  int  $options
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortKeysDesc($options = SORT_REGULAR)
     {
-        return $this->passthru('sortKeysDesc', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
-     * Sort the collection keys using a callback.
-     *
-     * @param  callable(TKey, TKey): int  $callback
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function sortKeysUsing(callable $callback)
     {
-        return $this->passthru('sortKeysUsing', func_get_args());
+        return $this->passthru(__FUNCTION__, func_get_args());
     }
 
     /**
@@ -1731,17 +1641,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function dot()
     {
-        return $this->passthru('dot', []);
+        return $this->passthru(__FUNCTION__, []);
     }
 
     /**
-     * Convert a flatten "dot" notation array into an expanded array.
-     *
-     * @return static
+     * {@inheritDoc}
      */
+    #[\Override]
     public function undot()
     {
-        return $this->passthru('undot', []);
+        return $this->passthru(__FUNCTION__, []);
     }
 
     /**
@@ -1847,18 +1756,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Pad collection to the specified length with a value.
-     *
-     * @template TPadValue
-     *
-     * @param  int  $size
-     * @param  TPadValue  $value
-     * @return static<int, TValue|TPadValue>
+     * {@inheritDoc}
      */
+    #[\Override]
     public function pad($size, $value)
     {
         if ($size < 0) {
-            return $this->passthru('pad', func_get_args());
+            return $this->passthru(__FUNCTION__, func_get_args());
         }
 
         return new static(function () use ($size, $value) {

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -18,6 +18,7 @@
         "illuminate/conditionable": "^12.0",
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
+        "symfony/polyfill-php83": "^1.33",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33"
     },


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
For all `passthru` calls we use the magic [`__FUNCTION__` constant](https://www.php.net/manual/en/language.constants.magic.php#constant.function) for a more consistent forwarding pattern. Moreover for all methods which are part of the `Enumerable` interface we inherit the docblock and add an `Override` attribute.