### PR TITLE
[12.x] Introduce method `lastOrFail` to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -781,6 +781,27 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the last item from the collection but throw exception if no matching item exists.
+     *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrFail(?callable $callback = null)
+    {
+        $placeholder = new stdClass();
+
+        $item = $this->last($callback, $placeholder);
+
+        if ($item === $placeholder) {
+            throw new ItemNotFoundException;
+        }
+
+        return $item;
+    }
+
+    /**
      * Get the last item from the collection.
      *
      * @template TLastDefault

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -644,6 +644,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the last item from the collection.
      *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrfail(?callable $callback = null);
+
+    /**
+     * Get the last item from the collection.
+     *
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -642,7 +642,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function keys();
 
     /**
-     * Get the last item from the collection.
+     * Get the last item from the collection but throw exception if no matching item exists.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return TValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -720,7 +720,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Get the last item from the collection.
+     * Get the last item from the collection but throw exception if no matching item exists.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return TValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -729,19 +729,15 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function lastOrfail(?callable $callback = null)
     {
-        $needle = $placeholder = new stdClass;
+        $placeholder = new stdClass();
 
-        foreach ($this as $key => $value) {
-            if (is_null($callback) || $callback($value, $key)) {
-                $needle = $value;
-            }
+        $item = $this->last($callback, $placeholder);
+
+        if ($item === $placeholder) {
+            throw new ItemNotFoundException;
         }
 
-        if ($needle === $placeholder) {
-            throw new ItemNotFoundException();
-        }
-
-        return $needle;
+        return $item;
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -722,6 +722,31 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the last item from the collection.
      *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function lastOrfail(?callable $callback = null)
+    {
+        $needle = $placeholder = new stdClass;
+
+        foreach ($this as $key => $value) {
+            if (is_null($callback) || $callback($value, $key)) {
+                $needle = $value;
+            }
+        }
+
+        if ($needle === $placeholder) {
+            throw new ItemNotFoundException();
+        }
+
+        return $needle;
+    }
+
+    /**
+     * Get the last item from the collection.
+     *
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -273,6 +273,68 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailReturnsLastItemInCollection($collection)
+    {
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $this->assertSame(['name' => 'bar'], $collection->lastOrFail());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailThrowsExceptionOnEmptyCollection($collection)
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        $collection = new $collection();
+
+        $collection->lastOrFail();
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailDoesntThrowExceptionIfMoreThanOneItemExists($collection)
+    {
+        $collection = new $collection([
+            ['name' => 'foo'],
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $this->assertSame(['name' => 'foo'], $collection->lastOrfail());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailReturnsLastItemInCollectionIfOnlyOneExistsWithCallback($collection)
+    {
+        $data = new $collection(['foo', 'bar', 'baz']);
+        $result = $data->lastOrFail(static fn (string $value) => $value === 'bar');
+        $this->assertSame('bar', $result);
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailThrowsExceptionIfNoItemsExistWithCallback($collection)
+    {
+        $this->expectException(ItemNotFoundException::class);
+
+        $data = new $collection(['foo', 'bar', 'baz']);
+
+        $data->lastOrFail(static fn (string $value) => $value === 'invalid');
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLastOrFailDoesntThrowExceptionIfMoreThanOneItemExistsWithCallback($collection)
+    {
+        $data = new $collection(['foo', 'bar', 'bar']);
+
+        $this->assertSame(
+            'bar',
+            $data->lastOrFail(static fn (string $value) => $value === 'bar')
+        );
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testLastReturnsLastItemInCollection($collection)
     {
         $c = new $collection(['foo', 'bar']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -302,7 +302,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'bar'],
         ]);
 
-        $this->assertSame(['name' => 'foo'], $collection->lastOrfail());
+        $this->assertSame(['name' => 'bar'], $collection->lastOrfail());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -298,7 +298,7 @@ class SupportCollectionTest extends TestCase
     {
         $collection = new $collection([
             ['name' => 'foo'],
-            ['name' => 'foo'],
+            ['name' => 'bar'],
             ['name' => 'bar'],
         ]);
 


### PR DESCRIPTION
This PR introduces a new collection method `lastOrFail`.

This method works similarly to the `firstOrFail` method, except for the last match - returns the last matching item in the collection or throws an `ItemNotFoundException` when a match is not found.

Due to how the `last` method is implemented, I've decided to base this on it's parameters, which have already been a bit different from the `first` and `firstOrFail` methods.
