### PR TITLE
[12.x] Add `--for` option to `queue:pause` command

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -17,7 +17,9 @@ class PauseCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:pause {queue : The name of the queue to pause}';
+    protected $signature = 'queue:pause
+                {queue : The name of the queue to pause}
+                {--for= : Pause the queue for the given number of seconds}';
 
     /**
      * The console command description.
@@ -34,6 +36,24 @@ class PauseCommand extends Command
     public function handle(QueueManager $manager)
     {
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
+
+        $seconds = $this->option('for');
+
+        if ($seconds !== null) {
+            $seconds = filter_var($seconds, FILTER_VALIDATE_INT);
+
+            if (! is_int($seconds) || $seconds <= 0) {
+                $this->components->error('The --for option must be a positive integer.');
+
+                return 1;
+            }
+
+            $manager->pauseFor($connection, $queue, $seconds);
+
+            $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused for {$seconds} seconds.");
+
+            return 0;
+        }
 
         $manager->pause($connection, $queue);
 


### PR DESCRIPTION
## Description

This PR adds an optional `--for` flag to the `queue:pause` Artisan command, allowing a queue to be paused for a fixed number of seconds.

This builds on the existing `pauseFor()` method already available on the queue manager, making it accessible via the CLI in a consistent and user-friendly way.

## Usage

```shell
php artisan queue:pause redis:emails --for=300
```

Without the option, the command behaves exactly as before.