### PR TITLE
[12.x] Fix null array key deprecation in HasOneOrMany relation matching

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -54,7 +54,9 @@ class HasManyThrough extends HasOneOrManyThrough
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            $key = $this->getDictionaryKey($model->getAttribute($this->localKey));
+
+            if ($key !== null && isset($dictionary[$key])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -153,7 +153,9 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            $key = $this->getDictionaryKey($model->getAttribute($this->localKey));
+
+            if ($key !== null && isset($dictionary[$key])) {
                 $related = $this->getRelationValue($dictionary, $key, $type);
                 $model->setRelation($relation, $related);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -52,7 +52,9 @@ class HasOneThrough extends HasOneOrManyThrough implements SupportsPartialRelati
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            $key = $this->getDictionaryKey($model->getAttribute($this->localKey));
+
+            if ($key !== null && isset($dictionary[$key])) {
                 $value = $dictionary[$key];
                 $model->setRelation(
                     $relation, reset($value)

--- a/tests/Database/EloquentHasOneOrManyDeprecationTest.php
+++ b/tests/Database/EloquentHasOneOrManyDeprecationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class EloquentHasOneOrManyDeprecationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testHasManyMatchWithNullLocalKey(): void
+    {
+        $relation = $this->getHasManyRelation();
+
+        $result1 = new HasOneOrManyDeprecationModelStub;
+        $result1->foreign_key = 1;
+
+        $result2 = new HasOneOrManyDeprecationModelStub;
+        $result2->foreign_key = '';
+
+        $model1 = new HasOneOrManyDeprecationModelStub;
+        $model1->id = 1;
+        $model2 = new HasOneOrManyDeprecationModelStub;
+        $model2->id = null;
+
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array) {
+            return new Collection($array);
+        });
+
+        $models = $relation->match([$model1, $model2], new Collection([$result1, $result2]), 'foo');
+
+        $this->assertCount(1, $models[0]->foo);
+        $this->assertNull($models[1]->foo);
+    }
+
+    public function testHasOneMatchWithNullLocalKey(): void
+    {
+        $relation = $this->getHasOneRelation();
+
+        $result1 = new HasOneOrManyDeprecationModelStub;
+        $result1->foreign_key = 1;
+
+        $model1 = new HasOneOrManyDeprecationModelStub;
+        $model1->id = 1;
+        $model2 = new HasOneOrManyDeprecationModelStub;
+        $model2->id = null;
+
+        $models = $relation->match([$model1, $model2], new Collection([$result1]), 'foo');
+
+        $this->assertInstanceOf(HasOneOrManyDeprecationModelStub::class, $models[0]->foo);
+        $this->assertNull($models[1]->foo);
+    }
+
+    protected function getHasManyRelation(): HasMany
+    {
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
+        $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
+        $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+        return new HasMany($builder, $parent, 'table.foreign_key', 'id');
+    }
+
+    protected function getHasOneRelation(): HasOne
+    {
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $builder = m::mock(Builder::class, [$queryBuilder]);
+        $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
+        $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+        return new HasOne($builder, $parent, 'table.foreign_key', 'id');
+    }
+}
+
+class HasOneOrManyDeprecationModelStub extends Model
+{
+    public $foreign_key;
+}


### PR DESCRIPTION
## Summary

This PR fixes the PHP 8.5+ deprecation warning "Using null as an array offset is deprecated" in `HasOneOrMany`, `HasManyThrough`, and `HasOneThrough` relations.

**More importantly**, it fixes a **behavioral bug**: models with `null` local key values were incorrectly matching records with empty string (`''`) foreign keys due to PHP's implicit `null` → `''` conversion.

## Problem

```php
class Category extends Model
{
    public function children(): HasMany
    {
        return $this->hasMany(self::class, 'parent_guid', 'guid');
    }
}

// Categories with null guid incorrectly get children with '' parent_guid
Category::with('children')->get();

Solution

$key = $this->getDictionaryKey($model->getAttribute($this->localKey));

if ($key !== null && isset($dictionary[$key])) {

Skip dictionary lookup when key is null.

Test

Added test verifying models with null local key don't receive related records.

Fixes #58151