### PR TITLE
[12.x] Add Conditionable trait to Schedule

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ProcessUtils;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -27,7 +28,7 @@ use function Illuminate\Support\enum_value;
  */
 class Schedule
 {
-    use Macroable {
+    use Conditionable, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Console/Scheduling/SchedulingConditionableTest.php
+++ b/tests/Console/Scheduling/SchedulingConditionableTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class SchedulingConditionableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup the Container and bind mocks for the Mutexes
+        $container = Container::getInstance();
+        $container->instance(EventMutex::class, m::mock(EventMutex::class));
+        $container->instance(SchedulingMutex::class, m::mock(SchedulingMutex::class));
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+        Container::setInstance(null); // Clear the container
+        parent::tearDown();
+    }
+
+    public function test_schedule_can_use_conditionable_when()
+    {
+        $schedule = new Schedule;
+
+        $schedule->when(true, function ($s) {
+            $s->command('test:true')->daily();
+        });
+
+        $schedule->when(false, function ($s) {
+            $s->command('test:false')->daily();
+        });
+
+        $events = $schedule->events();
+
+        $this->assertCount(1, $events);
+        // Use contains instead of equals
+        $this->assertStringContainsString('test:true', $events[0]->command);
+    }
+
+    public function test_schedule_can_use_conditionable_unless()
+    {
+        $schedule = new Schedule;
+
+        $schedule->unless(true, function ($s) {
+            $s->command('test:unless-true')->daily();
+        });
+
+        $schedule->unless(false, function ($s) {
+            $s->command('test:unless-false')->daily();
+        });
+
+        $events = $schedule->events();
+
+        $this->assertCount(1, $events);
+        // Use contains instead of equals
+        $this->assertStringContainsString('test:unless-false', $events[0]->command);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the `Illuminate\Support\Traits\Conditionable` trait to the `Illuminate\Console\Scheduling\Schedule` class.

## Motivation
Currently, many core Laravel classes—such as Eloquent Query Builder, the HTTP Client, Collections, and Carbon—utilize the `Conditionable` trait to allow for fluent `when()` and `unless()` calls. 

Adding this trait to the `Schedule` class allows developers to conditionally register groups of scheduled tasks in a way that is consistent with the rest of the framework. This provides a more "Laravel-esque" and fluent alternative to wrapping task registrations in manual `if` or `unless` blocks.

## Example Usage

Instead of using raw PHP logic:

```php
if ($shouldScheduleBackup) {
    Schedule::command('backup:run')->daily();
    Schedule::command('backup:clean')->weekly();
}
```

Developers can now use the fluent API:
```php
Schedule::when($shouldScheduleBackup, function ($schedule) {
    $schedule->command('backup:run')->daily();
    $schedule->command('backup:clean')->weekly();
});
```

Comparison with ```group()```
While the scheduler already has a ```group() ```method, it is designed for sharing attributes (like ```daily()```, ```onOneServer()```, or ```environments()```) across multiple tasks.

In contrast, the ```when()``` method from the ```Conditionable``` trait is used to decide if the registration of those tasks should happen at all. This makes ```Conditionable``` a perfect complement to the existing ```group()``` functionality.