### PR TITLE
[12.x] Update setup-node action to v6

### DIFF
--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 


### PR DESCRIPTION
v4 is about 2 years old. [v6 is latest. ](https://github.com/actions/setup-node/releases/tag/v6.0.0) and is recommended by [the docs](https://github.com/actions/setup-node/blob/main/README.md#usage).

Just updated as all the other actions have now been updated, have ran the action to ensure it works via: 
https://github.com/jackbayliss/framework/actions/runs/20442769057/job/58739437230

