### PR TITLE
[12.x] Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/src/Illuminate/Foundation/resources/exceptions/renderer"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 2
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-    interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 2
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src/Illuminate/Foundation/resources/exceptions/renderer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+    interval: "weekly"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"


### PR DESCRIPTION
I believe Dependabot is currently [implicitly (run from repository settings).](https://github.com/laravel/framework/issues?q=is%3Apr%20author%3Aapp%2Fdependabot) , This PR adds an explicit `.github/dependabot.yml` to:

1) Improve visibility for contributors
2) Add GitHub Actions updates (currently not enabled)

I've set them to monthly for now, as not sure what it is behind the scenes, but thought this PR would be useful so actions etc are automatically updated and doesn't need any thought.

This can be tweaked more, but thought I'd open a basic idea to see what you think? 