### PR TITLE
[12.x] Fix Postgres sequence starting value for custom schemas/connections

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -269,11 +269,12 @@ class PostgresGrammar extends Grammar
     {
         if ($command->column->autoIncrement
             && $value = $command->column->get('startingValue', $command->column->get('from'))) {
-            [$schema, $table] = $this->connection->getSchemaBuilder()->parseSchemaAndTable($blueprint->getTable());
-
-            $table = ($schema ? $schema.'.' : '').$this->connection->getTablePrefix().$table;
-
-            return 'alter sequence '.$table.'_'.$command->column->name.'_seq restart with '.$value;
+            return sprintf(
+                'select setval(pg_get_serial_sequence(%s, %s), %s, false)',
+                $this->quoteString($this->wrapTable($blueprint)),
+                $this->quoteString($command->column->name),
+                $value
+            );
         }
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -70,7 +70,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
-        $this->assertSame('alter sequence users_id_seq restart with 1000', $statements[1]);
+        $this->assertSame("select setval(pg_get_serial_sequence('\"users\"', 'id'), 1000, false)", $statements[1]);
     }
 
     public function testAddColumnsWithMultipleAutoIncrementStartingValue()
@@ -88,8 +88,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
             'alter table "users" add column "id" bigserial not null primary key',
             'alter table "users" add column "code" serial not null primary key',
             'alter table "users" add column "name" varchar(255) not null',
-            'alter sequence users_id_seq restart with 100',
-            'alter sequence users_code_seq restart with 200',
+            "select setval(pg_get_serial_sequence('\"users\"', 'id'), 100, false)",
+            "select setval(pg_get_serial_sequence('\"users\"', 'code'), 200, false)",
         ], $statements);
     }
 

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -77,8 +77,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-                . 'alter column "code" type integer, '
-                . 'alter column "code" set not null',
+                .'alter column "code" type integer, '
+                .'alter column "code" set not null',
             'select setval(pg_get_serial_sequence(\'"users"\', \'code\'), 10, false)',
             'comment on column "users"."code" is \'my comment\'',
         ], $blueprint->toSql());
@@ -89,10 +89,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-                . 'alter column "name" type char(40) collate "unicode", '
-                . 'alter column "name" drop not null, '
-                . 'alter column "name" set default \'easy\', '
-                . 'alter column "name" drop identity if exists',
+                .'alter column "name" type char(40) collate "unicode", '
+                .'alter column "name" drop not null, '
+                .'alter column "name" set default \'easy\', '
+                .'alter column "name" drop identity if exists',
             'comment on column "users"."name" is NULL',
         ], $blueprint->toSql());
 
@@ -102,11 +102,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-                . 'alter column "foo" type integer, '
-                . 'alter column "foo" set not null, '
-                . 'alter column "foo" drop default, '
-                . 'alter column "foo" drop identity if exists, '
-                . 'alter column "foo" add  generated always as identity (expression)',
+                .'alter column "foo" type integer, '
+                .'alter column "foo" set not null, '
+                .'alter column "foo" drop default, '
+                .'alter column "foo" drop identity if exists, '
+                .'alter column "foo" add  generated always as identity (expression)',
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
@@ -116,10 +116,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-                . 'alter column "foo" type geometry(point,1234), '
-                . 'alter column "foo" set not null, '
-                . 'alter column "foo" drop default, '
-                . 'alter column "foo" drop identity if exists',
+                .'alter column "foo" type geometry(point,1234), '
+                .'alter column "foo" set not null, '
+                .'alter column "foo" drop default, '
+                .'alter column "foo" drop identity if exists',
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
@@ -129,11 +129,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-                . 'alter column "added_at" type timestamp(2) without time zone, '
-                . 'alter column "added_at" set not null, '
-                . 'alter column "added_at" set default CURRENT_TIMESTAMP, '
-                . 'alter column "added_at" drop expression if exists, '
-                . 'alter column "added_at" drop identity if exists',
+                .'alter column "added_at" type timestamp(2) without time zone, '
+                .'alter column "added_at" set not null, '
+                .'alter column "added_at" set default CURRENT_TIMESTAMP, '
+                .'alter column "added_at" drop expression if exists, '
+                .'alter column "added_at" drop identity if exists',
             'comment on column "users"."added_at" is NULL',
         ], $blueprint->toSql());
     }
@@ -495,7 +495,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             // Expecting something similar to:
             // Illuminate\Database\QueryException
             //   SQLSTATE[42000]: Syntax error or access violation: 1426 Too big precision 10 specified for 'my_timestamp'. Maximum is 6....
-            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: ' . $e->getMessage());
+            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: '.$e->getMessage());
         }
     }
 
@@ -514,7 +514,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         string $table,
         Closure $callback,
     ): Blueprint {
-        $grammarClass = 'Illuminate\Database\Schema\Grammars\\' . $grammar . 'Grammar';
+        $grammarClass = 'Illuminate\Database\Schema\Grammars\\'.$grammar.'Grammar';
 
         $connection = DB::connection();
         $connection->setSchemaGrammar(new $grammarClass($connection));

--- a/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSchemaBlueprintTest.php
@@ -77,9 +77,9 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "code" type integer, '
-            .'alter column "code" set not null',
-            'alter sequence users_code_seq restart with 10',
+                . 'alter column "code" type integer, '
+                . 'alter column "code" set not null',
+            'select setval(pg_get_serial_sequence(\'"users"\', \'code\'), 10, false)',
             'comment on column "users"."code" is \'my comment\'',
         ], $blueprint->toSql());
 
@@ -89,10 +89,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "name" type char(40) collate "unicode", '
-            .'alter column "name" drop not null, '
-            .'alter column "name" set default \'easy\', '
-            .'alter column "name" drop identity if exists',
+                . 'alter column "name" type char(40) collate "unicode", '
+                . 'alter column "name" drop not null, '
+                . 'alter column "name" set default \'easy\', '
+                . 'alter column "name" drop identity if exists',
             'comment on column "users"."name" is NULL',
         ], $blueprint->toSql());
 
@@ -102,11 +102,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "foo" type integer, '
-            .'alter column "foo" set not null, '
-            .'alter column "foo" drop default, '
-            .'alter column "foo" drop identity if exists, '
-            .'alter column "foo" add  generated always as identity (expression)',
+                . 'alter column "foo" type integer, '
+                . 'alter column "foo" set not null, '
+                . 'alter column "foo" drop default, '
+                . 'alter column "foo" drop identity if exists, '
+                . 'alter column "foo" add  generated always as identity (expression)',
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
@@ -116,10 +116,10 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "foo" type geometry(point,1234), '
-            .'alter column "foo" set not null, '
-            .'alter column "foo" drop default, '
-            .'alter column "foo" drop identity if exists',
+                . 'alter column "foo" type geometry(point,1234), '
+                . 'alter column "foo" set not null, '
+                . 'alter column "foo" drop default, '
+                . 'alter column "foo" drop identity if exists',
             'comment on column "users"."foo" is NULL',
         ], $blueprint->toSql());
 
@@ -129,11 +129,11 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table "users" '
-            .'alter column "added_at" type timestamp(2) without time zone, '
-            .'alter column "added_at" set not null, '
-            .'alter column "added_at" set default CURRENT_TIMESTAMP, '
-            .'alter column "added_at" drop expression if exists, '
-            .'alter column "added_at" drop identity if exists',
+                . 'alter column "added_at" type timestamp(2) without time zone, '
+                . 'alter column "added_at" set not null, '
+                . 'alter column "added_at" set default CURRENT_TIMESTAMP, '
+                . 'alter column "added_at" drop expression if exists, '
+                . 'alter column "added_at" drop identity if exists',
             'comment on column "users"."added_at" is NULL',
         ], $blueprint->toSql());
     }
@@ -495,7 +495,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             // Expecting something similar to:
             // Illuminate\Database\QueryException
             //   SQLSTATE[42000]: Syntax error or access violation: 1426 Too big precision 10 specified for 'my_timestamp'. Maximum is 6....
-            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: '.$e->getMessage());
+            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: ' . $e->getMessage());
         }
     }
 
@@ -514,7 +514,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         string $table,
         Closure $callback,
     ): Blueprint {
-        $grammarClass = 'Illuminate\Database\Schema\Grammars\\'.$grammar.'Grammar';
+        $grammarClass = 'Illuminate\Database\Schema\Grammars\\' . $grammar . 'Grammar';
 
         $connection = DB::connection();
         $connection->setSchemaGrammar(new $grammarClass($connection));


### PR DESCRIPTION
### Description
This PR fixes an issue where the `from()` / `startingValue()` method was ignored when using PostgreSQL with secondary database connections or custom schemas (Issue #58095).

The previous implementation manually constructed the sequence name string (e.g., `{$table}_{$column}_seq`), which fails if the actual sequence name differs due to schemas or connection configurations.

This PR updates the grammar to use the native `pg_get_serial_sequence` function, which correctly resolves the sequence name regardless of the schema or connection.

### Fixed Issue
Fixes #58095

### Verification
I have added unit tests to ensure the correct SQL is generated (`select setval(...)`).
I have also manually verified this against a running PostgreSQL container to confirm that the `setval` statement correctly sets the auto-increment starting value without errors.
