### PR TITLE
[12.x] Add TestResponse::assertHeaderContains assertion and tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -383,6 +383,29 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Asserts that the response contains the given header and that its value contains the given string.
+     *
+     * @param  string  $headerName
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertHeaderContains($headerName, $value)
+    {
+        PHPUnit::withResponse($this)->assertTrue(
+            $this->headers->has($headerName), "Header [{$headerName}] not present on response."
+        );
+
+        $actual = $this->headers->get($headerName, '');
+
+        PHPUnit::withResponse($this)->assertTrue(
+            Str::contains($actual, $value),
+            "Header [{$headerName}] was found, but [{$actual}] does not contain [{$value}]."
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response does not contain the given header.
      *
      * @param  string  $headerName

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2675,6 +2675,31 @@ class TestResponseTest extends TestCase
         $response->assertRedirectContains('url.net');
     }
 
+    public function testAssertHeaderContainsSuccess(): void
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->headers->set('X-Custom-Header', 'prefix-value-suffix');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertHeaderContains('X-Custom-Header', 'value');
+    }
+
+    public function testAssertHeaderContainsFailure(): void
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->headers->set('X-Custom-Header', 'unrelated');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Header [X-Custom-Header] was found, but [unrelated] does not contain [value].");
+
+        $response->assertHeaderContains('X-Custom-Header', 'value');
+    }
+
     public function testAssertRedirect(): void
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2695,7 +2695,7 @@ class TestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse($baseResponse);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage("Header [X-Custom-Header] was found, but [unrelated] does not contain [value].");
+        $this->expectExceptionMessage('Header [X-Custom-Header] was found, but [unrelated] does not contain [value].');
 
         $response->assertHeaderContains('X-Custom-Header', 'value');
     }


### PR DESCRIPTION
Adds a small test helper to improve HTTP response assertions: 
`TestResponse::assertHeaderContains($headerName, $value)`.
Also includes unit tests for assertion.

Added method: `src/Illuminate/Testing/TestResponse.php`
New: `public function assertHeaderContains($headerName, $value)`,  asserts header exists and that its value contains the given substring.
Tests: `tests/Testing/TestResponseTest.php`
New tests: `testAssertHeaderContainsSuccess, testAssertHeaderContainsFailure`.