### PR TITLE
[12.x] Add attachment helper method to add attachment from cloud storage

### DIFF
--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -99,7 +99,7 @@ class Attachment
     }
 
     /**
-     * Create a mail attachment from a file in the default storage disk.
+     * Create a mail attachment from a file on the default storage disk.
      *
      * @param  string  $path
      * @return static
@@ -110,7 +110,7 @@ class Attachment
     }
 
     /**
-     * Create a mail attachment from a file in the specified storage disk.
+     * Create a mail attachment from a file on the specified storage disk.
      *
      * @param  string|null  $disk
      * @param  string  $path
@@ -132,7 +132,7 @@ class Attachment
     }
 
     /**
-     * Create a mail attachment from a file in the cloud storage disk.
+     * Create a mail attachment from a file on the cloud storage disk.
      *
      * @param  string  $path
      * @return static

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
@@ -138,7 +139,7 @@ class Attachment
      */
     public static function fromCloudStorage($path)
     {
-        return self::fromStorageDisk(config('filesystems.cloud'), $path);
+        return self::fromStorageDisk(Storage::getDefaultCloudDriver(), $path);
     }
 
     /**

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -131,6 +131,17 @@ class Attachment
     }
 
     /**
+     * Create a mail attachment from a file in the cloud storage disk.
+     *
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromCloudStorage($path)
+    {
+        return self::fromStorageDisk(config('filesystems.cloud'), $path);
+    }
+
+    /**
      * Set the attached file's filename.
      *
      * @param  string|null  $name


### PR DESCRIPTION
Laravel already has a convenient helper like `Storage::cloud()` to have a simple and unified approach when dealing with the apps main cloud based file system. This PR adds a new addition to make it easier to add attachments to emails that are stored on the cloud.

```php
// Before:
Attachment::fromStorageDisk(Storage::getDefaultCloudDriver(), $attachment->path);

// After:
Attachment::fromCloudStorage($attachment->path);
```