### PR TITLE
[12.x] Add queue paused / resume events

### DIFF
--- a/src/Illuminate/Queue/Events/QueuePaused.php
+++ b/src/Illuminate/Queue/Events/QueuePaused.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class QueuePaused
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connection  The connection name.
+     * @param  string  $queue  The queue name.
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl  The TTL for the pause, if set.
+     */
+    public function __construct(
+        public $connection,
+        public $queue,
+        public $ttl = null,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/Events/QueuePaused.php
+++ b/src/Illuminate/Queue/Events/QueuePaused.php
@@ -9,7 +9,7 @@ class QueuePaused
      *
      * @param  string  $connection  The connection name.
      * @param  string  $queue  The queue name.
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl  The TTL for the pause, if set.
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      */
     public function __construct(
         public $connection,

--- a/src/Illuminate/Queue/Events/QueueResumed.php
+++ b/src/Illuminate/Queue/Events/QueueResumed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class QueueResumed
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connection  The connection name.
+     * @param  string  $queue  The queue name.
+     */
+    public function __construct(
+        public $connection,
+        public $queue,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -209,6 +209,10 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['cache']
             ->store()
             ->forever("illuminate:queue:paused:{$connection}:{$queue}", true);
+
+        $this->app['events']->dispatch(
+            new Events\QueuePaused($connection, $queue)
+        );
     }
 
     /**
@@ -224,6 +228,10 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['cache']
             ->store()
             ->put("illuminate:queue:paused:{$connection}:{$queue}", true, $ttl);
+
+        $this->app['events']->dispatch(
+            new Events\QueuePaused($connection, $queue, $ttl)
+        );
     }
 
     /**
@@ -238,6 +246,10 @@ class QueueManager implements FactoryContract, MonitorContract
         $this->app['cache']
             ->store()
             ->forget("illuminate:queue:paused:{$connection}:{$queue}");
+
+        $this->app['events']->dispatch(
+            new Events\QueueResumed($connection, $queue)
+        );
     }
 
     /**

--- a/tests/Queue/QueuePauseResumeTest.php
+++ b/tests/Queue/QueuePauseResumeTest.php
@@ -113,6 +113,7 @@ class QueuePauseResumeTest extends TestCase
         $this->assertFalse($this->manager->isPaused('redis', 'emails'));
         $this->assertTrue($this->manager->isPaused('redis', 'notifications'));
     }
+
     public function testPauseDispatchesQueuePausedEvent()
     {
         $dispatchedEvent = null;


### PR DESCRIPTION
This PR adds a `QueuePaused` and `QueueResumed` event that fire when queues are paused or resumed.

When queues are paused / resumed adding events provide visibility and means we can hook into the events for things like slack etc. [it's recommended in the docs to do it via the command](https://laravel.com/docs/12.x/queues#pausing-and-resuming-queue-workers) so thought this would be useful.


The tests are using the phpunit test case, so had to do it this way afaik, and didn't want to change it to the orchestra test case just incase 🤷🏻 