### PR TITLE
[12.x] Add static constructor to guest middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
+++ b/src/Illuminate/Auth/Middleware/RedirectIfAuthenticated.php
@@ -18,6 +18,18 @@ class RedirectIfAuthenticated
     protected static $redirectToCallback;
 
     /**
+     * Specify the guards for the middleware.
+     *
+     * @param  string  $guard
+     * @param  string  $others
+     * @return string
+     */
+    public static function using($guard, ...$others)
+    {
+        return static::class.':'.implode(',', [$guard, ...$others]);
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next

--- a/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
+++ b/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Auth;
+
+use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
+use PHPUnit\Framework\TestCase;
+
+class RedirectIfAuthenticatedMiddlewareTest extends TestCase
+{
+    public function testItCanGenerateDefinitionViaStaticMethod()
+    {
+        $signature = (string) RedirectIfAuthenticated::using('foo');
+        $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo', $signature);
+
+        $signature = (string) RedirectIfAuthenticated::using('foo', 'bar');
+        $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo,bar', $signature);
+
+        $signature = (string) RedirectIfAuthenticated::using('foo', 'bar', 'baz');
+        $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo,bar,baz', $signature);
+    }
+}


### PR DESCRIPTION
From the default aliased middleware that takes parameters, `Illuminate\Auth\Middleware\RedirectIfAuthenticated` was the only one missing a static constructor.

Reference:

https://github.com/laravel/framework/blob/2f309363193371fc1ac338d171a5b92be9976de5/src/Illuminate/Foundation/Configuration/Middleware.php#L779-L802

As such, in codebases that avoid using middleware aliases (preferring to use their FQCN), one would need to manually concatenate a custom guard to the `Illuminate\Auth\Middleware\RedirectIfAuthenticated` middleware class name, while all others provide a static constructor.

Usage example:

```php
use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
use Illuminate\Routing\Controllers\HasMiddleware;

class ForgotPasswordController implements HasMiddleware
{
    public static function middleware(): array
    {
        return [
            // 'guest:app', // before
            RedirectIfAuthenticated::using('app'), // after
        ];
    }
}
```

**This PR:**

- Adds a static constructor to the `Illuminate\Auth\Middleware\RedirectIfAuthenticated` middleware.
- Adds a related test case (based on the analog `Illuminate\Auth\Middleware\Authenticate` static constructor's test).