### PR TITLE
[12.x] Include JsonResource in `ModelInspector` result

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -17,13 +17,6 @@ use function Illuminate\Support\enum_value;
 class ModelInspector
 {
     /**
-     * The Laravel application instance.
-     *
-     * @var \Illuminate\Contracts\Foundation\Application
-     */
-    protected $app;
-
-    /**
      * The methods that can be called in a model to indicate a relation.
      *
      * @var array<int, string>
@@ -45,11 +38,10 @@ class ModelInspector
     /**
      * Create a new model inspector instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app  The Laravel application instance.
      */
-    public function __construct(Application $app)
+    public function __construct(protected Application $app)
     {
-        $this->app = $app;
     }
 
     /**
@@ -57,7 +49,7 @@ class ModelInspector
      *
      * @param  class-string<\Illuminate\Database\Eloquent\Model>|string  $model
      * @param  string|null  $connection
-     * @return array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: class-string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>>, builder: class-string<\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>>}
+     * @return array{"class": class-string<\Illuminate\Database\Eloquent\Model>, database: string, table: string, policy: class-string|null, attributes: \Illuminate\Support\Collection, relations: \Illuminate\Support\Collection, events: \Illuminate\Support\Collection, observers: \Illuminate\Support\Collection, collection: class-string<\Illuminate\Database\Eloquent\Collection<\Illuminate\Database\Eloquent\Model>>, builder: class-string<\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>>, "resource": class-string<\Illuminate\Http\Resources\Json\JsonResource>|null}
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -83,6 +75,7 @@ class ModelInspector
             'observers' => $this->getObservers($model),
             'collection' => $this->getCollectedBy($model),
             'builder' => $this->getBuilder($model),
+            'resource' => $this->getResource($model),
         ];
     }
 
@@ -294,6 +287,17 @@ class ModelInspector
     protected function getBuilder($model)
     {
         return $model->newQuery()::class;
+    }
+
+    /**
+     * Get the class used for JSON response transforming.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Http\Resources\Json\JsonResource|null
+     */
+    protected function getResource($model)
+    {
+        return rescue(static fn () => $model->toResource()::class, null, false);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -19,7 +19,7 @@ class ModelInspector
     /**
      * The methods that can be called in a model to indicate a relation.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $relationMethods = [
         'hasMany',

--- a/tests/Integration/Database/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspectorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -11,8 +12,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelInspector;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
+use Resend\Resource;
 
 class ModelInspectorTest extends DatabaseTestCase
 {
@@ -39,6 +42,7 @@ class ModelInspectorTest extends DatabaseTestCase
         $this->assertModelInfo($modelInfo);
         $this->assertSame(ModelInspectorTestModelEloquentCollection::class, $modelInfo['collection']);
         $this->assertSame(ModelInspectorTestModelBuilder::class, $modelInfo['builder']);
+        $this->assertSame(ModelInspectorTestModelResource::class, $modelInfo['resource']);
     }
 
     public function test_command_returns_json()
@@ -181,6 +185,7 @@ class ModelInspectorTest extends DatabaseTestCase
 
 #[ObservedBy(ModelInspectorTestModelObserver::class)]
 #[CollectedBy(ModelInspectorTestModelEloquentCollection::class)]
+#[UseResource(ModelInspectorTestModelResource::class)]
 class ModelInspectorTestModel extends Model
 {
     use HasUuids;
@@ -214,5 +219,9 @@ class ModelInspectorTestModelEloquentCollection extends Collection
 }
 
 class ModelInspectorTestModelBuilder extends Builder
+{
+}
+
+class ModelInspectorTestModelResource extends JsonResource
 {
 }

--- a/tests/Integration/Database/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspectorTest.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
-use Resend\Resource;
 
 class ModelInspectorTest extends DatabaseTestCase
 {


### PR DESCRIPTION
Include the JSON Resource class-string as one of the returned values of the `ModelInspector@inspect()`