### PR TITLE
[12.x] Adjust AuthDatabaseTokenRepositoryTest

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -104,6 +104,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
 
     public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
@@ -113,10 +115,14 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertTrue($repo->recentlyCreatedToken($user));
+
+        Carbon::setTestNow();
     }
 
     public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
@@ -126,6 +132,8 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
 
         $this->assertFalse($repo->recentlyCreatedToken($user));
+
+        Carbon::setTestNow();
     }
 
     public function testDeleteMethodDeletesByToken()


### PR DESCRIPTION
Noticed it flaked here: 
https://github.com/laravel/framework/actions/runs/20490793252/job/58882488454

This fixes potential race conditions  by freezing time where it was 59 / 60 seconds etc.

Did these two methods as seemed to make the most sense.