### PR TITLE
[12.x] Prevent make:exception from overwriting existing files

### DIFF
--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -60,7 +60,8 @@ class ExceptionMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($this->rootNamespace().'Exceptions\\'.$rawName);
+        return class_exists($rawName) ||
+            $this->files->exists($this->getPath($this->qualifyClass($rawName)));
     }
 
     /**


### PR DESCRIPTION
## Description
The `make:exception` command currently overwrites existing exception classes without warning or checking if the file already exists. This is inconsistent with other `make:*` commands, which protect against accidental overwrites.