### PR TITLE
[12.x] Add `Bus::dispatchPending()` method for feature parity with `dispatch` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
-use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cookie\Factory as CookieFactory;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Routing\ResponseFactory;
@@ -28,11 +27,11 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Log\LogManager;
-use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Defer\DeferredCallback;
 use Illuminate\Support\Defer\DeferredCallbackCollection;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\HtmlString;
@@ -456,9 +455,7 @@ if (! function_exists('dispatch')) {
      */
     function dispatch($job): PendingDispatch|PendingClosureDispatch
     {
-        return $job instanceof Closure
-            ? new PendingClosureDispatch(CallQueuedClosure::create($job))
-            : new PendingDispatch($job);
+        return Bus::dispatchPending($job);
     }
 }
 
@@ -474,7 +471,7 @@ if (! function_exists('dispatch_sync')) {
      */
     function dispatch_sync($job, $handler = null)
     {
-        return app(Dispatcher::class)->dispatchSync($job, $handler);
+        return Bus::dispatchSync($job, $handler);
     }
 }
 

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -2,9 +2,13 @@
 
 namespace Illuminate\Support\Facades;
 
+use Closure;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Foundation\Bus\PendingChain;
+use Illuminate\Foundation\Bus\PendingClosureDispatch;
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Testing\Fakes\BusFake;
 
 /**
@@ -89,6 +93,19 @@ class Bus extends Facade
 
         return (new PendingChain(array_shift($jobs), $jobs))
             ->dispatch();
+    }
+
+    /**
+     * Dispatch a job to its appropriate handler.
+     *
+     * @param  mixed  $job
+     * @return ($job is \Closure ? \Illuminate\Foundation\Bus\PendingClosureDispatch : \Illuminate\Foundation\Bus\PendingDispatch)
+     */
+    public static function dispatchPending($job): PendingDispatch|PendingClosureDispatch
+    {
+        return $job instanceof Closure
+            ? new PendingClosureDispatch(CallQueuedClosure::create($job))
+            : new PendingDispatch($job);
     }
 
     /**

--- a/tests/Support/SupportFacadesBusTest.php
+++ b/tests/Support/SupportFacadesBusTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\PendingClosureDispatch;
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Support\Facades\Bus;
+use Orchestra\Testbench\TestCase;
+
+class SupportFacadesBusTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Bus::fake();
+    }
+
+    public function testDispatchPendingReturnsCorrectTypeForJob()
+    {
+        $result = Bus::dispatchPending(new BusFacadeJobStub);
+
+        $this->assertInstanceOf(PendingDispatch::class, $result);
+    }
+
+    public function testDispatchPendingReturnsCorrectTypeForClosure()
+    {
+        $result = Bus::dispatchPending(function () {
+            return 'test';
+        });
+
+        $this->assertInstanceOf(PendingClosureDispatch::class, $result);
+    }
+
+    public function testDispatchPendingReturnsPendingDispatchWithCorrectJob()
+    {
+        $job = new BusFacadeJobStub;
+
+        $result = Bus::dispatchPending($job);
+
+        $this->assertSame($job, $result->getJob());
+    }
+
+    public function testDispatchPendingDispatchesJob()
+    {
+        Bus::dispatchPending(new BusFacadeJobStub);
+
+        Bus::assertDispatched(BusFacadeJobStub::class);
+    }
+}
+
+class BusFacadeJobStub implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Summary

Add `Bus::dispatchPending()` method that returns a `PendingDispatch` instance, matching the behavior of the global `dispatch()` helper function.

Unlike `Bus::dispatch()`, this method respects the `ShouldBeUnique` contract by returning a `PendingDispatch` that checks uniqueness in its destructor.

This provides facade users with parity to the `dispatch()` helper while maintaining backward compatibility with the existing `Bus::dispatch()` method.

Related issues:
 - #45781
 - #39113
 - #42297
 - #51798

## API Overview

| Helper | Bus Facade | Dispatcher | Returns | `ShouldBeUnique` |
|--------|------------|------------|---------|------------------|
| `dispatch($job)` | `Bus::dispatchPending($job)` ✨ | — | `PendingDispatch` | ✅ Respected |
| — | `Bus::dispatch($job)` | `dispatch($job)` | `mixed` | ❌ Bypassed |
| `dispatch_sync($job)` | `Bus::dispatchSync($job)` | `dispatchSync($job)` | `mixed` | N/A |
| — | `Bus::dispatchNow($job)` | `dispatchNow($job)` | `mixed` | N/A |
| — | `Bus::dispatchAfterResponse($job)` | `dispatchAfterResponse($job)` | `void` | N/A |
| — | `Bus::dispatchToQueue($job)` | `dispatchToQueue($job)` | `mixed` | ❌ Bypassed |

✨ Added in this PR

## Benefit to End Users

Developers who prefer using facades over helper functions can now dispatch unique jobs correctly. Previously, `Bus::dispatch()` would bypass the `ShouldBeUnique` contract entirely, causing duplicate jobs to be dispatched even when the job implemented `ShouldBeUnique`.

## Why a New Method?

Changing `Bus::dispatch()` to return `PendingDispatch` would be a breaking change:

1. Return type changes from `mixed` to `PendingDispatch|PendingClosureDispatch`
2. Existing code relying on immediate dispatch would break
3. Code expecting return values from `dispatch()` would break

## Why on the Facade Instead of Dispatcher?

`PendingDispatch` lives in `Illuminate\Foundation\Bus`, which is NOT a split package. The `illuminate/bus` split package doesn't depend on Foundation, so adding this to `Dispatcher` would break standalone usage of the bus package.

## How It Makes Building Web Applications Easier

Developers can now use the Bus facade consistently with the same uniqueness guarantees as the `dispatch()` helper:

```php
// Before: ShouldBeUnique was ignored
Bus::dispatch(new UniqueJob()); // Duplicates could be dispatched

// After: ShouldBeUnique is respected
Bus::dispatchPending(new UniqueJob()); // Uniqueness enforced
```

## Future Consideration

I considered adding a `dispatch_pending()` helper as an alias for `dispatch()` to maintain consistent naming across helpers and facades, but kept it out of this PR as it's worth discussing separately.
