### PR TITLE
[12.x] Normalize APP_URL when generating filesystem URLs

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,7 +41,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => rtrim(env('APP_URL'), '/').'/storage',
+            'url' => rtrim(env('APP_URL', ''), '/').'/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,7 +41,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => rtrim(env('APP_URL'), '/').'/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,7 +41,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => rtrim(env('APP_URL', ''), '/').'/storage',
+            'url' => rtrim((string) env('APP_URL'), '/').'/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,


### PR DESCRIPTION
This PR fixes an issue where a trailing slash in APP_URL could result in
malformed public filesystem URLs containing double slashes.

The base URL is now normalized before concatenating paths, preventing
the generation of URLs with "//".