### PR TITLE
[12.x] Fix RateLimiter remaining() to handle negative maxAttempts values

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -232,7 +232,9 @@ class RateLimiter
 
         $attempts = $this->attempts($key);
 
-        return max(0, $maxAttempts - $attempts);
+        return $maxAttempts >= 0
+            ? max(0, $maxAttempts - $attempts)
+            : -1;
     }
 
     /**

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -88,6 +88,18 @@ class CacheRateLimiterTest extends TestCase
         $this->assertSame(0, $rateLimiter->retriesLeft('key', 3));
     }
 
+    public function testRemainingReturnsNegativeOneForNegativeMaxAttempts(): void
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->with('key', 0)->andReturn(5);
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertSame(-1, $rateLimiter->remaining('key', -1));
+        $this->assertSame(-1, $rateLimiter->retriesLeft('key', -1));
+    }
+
     public function testRetriesLeftReturnsCorrectCount()
     {
         $cache = m::mock(Cache::class);


### PR DESCRIPTION
Fixes #58014.

PR #57851 changed RateLimiter::remaining() to use max(0, $maxAttempts - $attempts) to prevent negative values when attempts exceed the limit. This broke cases where $maxAttempts is negative.
Before PR #57851, remaining('key', -1) returned a negative number, so !remaining('key', -1) was false. After the change, it returned 0, so !remaining('key', -1) became true, which is incorrect.
This fix checks if $maxAttempts >= 0 before applying the max() clamp. For negative values, it returns -1 to indicate unlimited attempts, restoring the previous behavior while keeping the fix for non-negative values.
The change preserves PR #57851's behavior for normal cases and restores the ability to disable rate limiting with negative values.