### PR TITLE
[12.x] Refactor `queuePaused` logic

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -418,9 +418,7 @@ class Worker
             return false;
         }
 
-        return $this->cache && (bool) $this->cache->get(
-            "illuminate:queue:paused:{$connectionName}:{$queue}", false
-        );
+        return $this->cache && $this->manager->isPaused($connectionName, $queue);
     }
 
     /**


### PR DESCRIPTION
Simplified queue paused state detection by using `QueueManager::isPaused` instead of direct cache access.