### PR TITLE
Fix queue:listen timeout false positives after system sleep/wake

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -85,9 +85,8 @@ class Listener
      */
     public function listen($connection, $queue, ListenerOptions $options)
     {
-        $process = $this->makeProcess($connection, $queue, $options);
-
         while (true) {
+            $process = $this->makeProcess($connection, $queue, $options);
             $this->runProcess($process, $options->memory);
 
             if ($options->rest) {

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -87,6 +87,7 @@ class Listener
     {
         while (true) {
             $process = $this->makeProcess($connection, $queue, $options);
+
             $this->runProcess($process, $options->memory);
 
             if ($options->rest) {


### PR DESCRIPTION
## Description

Fixes issue where `queue:listen` command crashes with a timeout error after the system wakes from sleep, even when no jobs are running.

**Related Issue:** #58178

## Problem

The `queue:listen` command was creating a single `Process` object outside the loop and reusing it for each iteration. When the system goes to sleep:

1. Wall-clock time (`microtime(true)`) continues to advance
2. The process is suspended
3. When the system wakes up, Symfony Process checks if `microtime(true) - starttime > timeout`
4. It sees too much wall-clock time has passed and throws a `ProcessTimedOutException`, even though the process was suspended

This caused false timeout errors after system sleep/wake cycles, crashing `composer run dev` after a few hours.

## Solution

Moved the `Process` object creation inside the `listen()` method's loop, ensuring each iteration creates a fresh `Process` instance with a clean timeout state.

**Before:**
```php
public function listen($connection, $queue, ListenerOptions $options)
{
    $process = $this->makeProcess($connection, $queue, $options); // Created once
    
    while (true) {
        $this->runProcess($process, $options->memory); // Reused
        // ...
    }
}
```
**After:**
```php
public function listen($connection, $queue, ListenerOptions $options)
{
    while (true) {
        $process = $this->makeProcess($connection, $queue, $options); // Fresh each iteration
        $this->runProcess($process, $options->memory);
        // ...
    }
}
```
## Impact

- ✅ Prevents false timeout errors after system sleep/wake cycles
- ✅ Each `queue:work --once` invocation gets a fresh Process with clean timeout state
- ✅ Timeout protection still works correctly for actually stuck processes
- ✅ No breaking changes - maintains existing behavior and API

## Testing

- ✅ Existing tests pass
- ✅ Verified that `makeProcess()` creates new Process instances each call
- ✅ Confirmed timeout values are correctly set on each Process instance

## Notes

This fix ensures that the timeout counter starts fresh for each subprocess invocation, preventing accumulated wall-clock time during system sleep from causing false positives.