### PR TITLE
[12.x] Migration Ensure replaceMigrationPlaceholders fails clearly if stub is missing

### DIFF
--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -102,7 +102,6 @@ abstract class MigrationGeneratorCommand extends Command
         $this->files->put($path, $stub);
     }
 
-
     /**
      * Determine whether a migration for the table already exists.
      *

--- a/src/Illuminate/Console/MigrationGeneratorCommand.php
+++ b/src/Illuminate/Console/MigrationGeneratorCommand.php
@@ -84,15 +84,24 @@ abstract class MigrationGeneratorCommand extends Command
      * @param  string  $path
      * @param  string  $table
      * @return void
+     *
+     * @throws \RuntimeException if the stub file does not exist
      */
     protected function replaceMigrationPlaceholders($path, $table)
     {
+        $stubPath = $this->migrationStubFile();
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \RuntimeException("Migration stub file does not exist: {$stubPath}");
+        }
+
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get($this->migrationStubFile())
+            '{{table}}', $table, $this->files->get($stubPath)
         );
 
         $this->files->put($path, $stub);
     }
+
 
     /**
      * Determine whether a migration for the table already exists.


### PR DESCRIPTION
This change improves the replaceMigrationPlaceholders() method in
MigrationGeneratorCommand to throw a clear RuntimeException when the 
migration stub file does not exist.

Previously, if the stub was missing, the method would crash or fail
silently, causing confusing errors. This update ensures that developers
receive a clear and immediate error message when the stub file is missing.

No existing functionality is broken, and the return types remain unchanged.
