### PR TITLE
Add connection details to QueryException error messages

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -819,12 +819,12 @@ class Connection implements ConnectionInterface
         catch (Exception $e) {
             if ($this->isUniqueConstraintError($e)) {
                 throw new UniqueConstraintViolationException(
-                    $this->getName(), $query, $this->prepareBindings($bindings), $e
+                    $this->getNameWithReadWriteType(), $query, $this->prepareBindings($bindings), $e, $this->getConnectionInfo()
                 );
             }
 
             throw new QueryException(
-                $this->getName(), $query, $this->prepareBindings($bindings), $e
+                $this->getNameWithReadWriteType(), $query, $this->prepareBindings($bindings), $e, $this->getConnectionInfo()
             );
         }
     }
@@ -1352,6 +1352,23 @@ class Connection implements ConnectionInterface
     public function getConfig($option = null)
     {
         return Arr::get($this->config, $option);
+    }
+
+    /**
+     * Get the connection info as an array.
+     *
+     * @return array
+     */
+    protected function getConnectionInfo()
+    {
+        return [
+            'driver' => $this->getDriverName(),
+            'name' => $this->getNameWithReadWriteType(),
+            'host' => $this->getConfig('host'),
+            'port' => $this->getConfig('port'),
+            'database' => $this->getConfig('database'),
+            'unix_socket' => $this->getConfig('unix_socket'),
+        ];
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -31,11 +31,11 @@ class QueryException extends PDOException
     protected $bindings;
 
     /**
-     * The connection info for the query.
+     * The connection details for the query (host, port, database, etc.).
      *
      * @var array
      */
-    protected $connectionInfo = [];
+    protected $connectionDetails = [];
 
     /**
      * Create a new query exception instance.
@@ -44,16 +44,16 @@ class QueryException extends PDOException
      * @param  string  $sql
      * @param  array  $bindings
      * @param  \Throwable  $previous
-     * @param  array  $connectionInfo
+     * @param  array  $connectionDetails
      */
-    public function __construct($connectionName, $sql, array $bindings, Throwable $previous, array $connectionInfo = [])
+    public function __construct($connectionName, $sql, array $bindings, Throwable $previous, array $connectionDetails = [])
     {
         parent::__construct('', 0, $previous);
 
         $this->connectionName = $connectionName;
         $this->sql = $sql;
         $this->bindings = $bindings;
-        $this->connectionInfo = $connectionInfo;
+        $this->connectionDetails = $connectionDetails;
         $this->code = $previous->getCode();
         $this->message = $this->formatMessage($connectionName, $sql, $bindings, $previous);
 
@@ -85,27 +85,28 @@ class QueryException extends PDOException
      */
     protected function formatConnectionDetails()
     {
-        if (empty($this->connectionInfo)) {
+        if (empty($this->connectionDetails)) {
             return '';
         }
 
-        $driver = $this->connectionInfo['driver'] ?? '';
+        $driver = $this->connectionDetails['driver'] ?? '';
 
-        $parts = [];
+        $segments = [];
 
         if ($driver !== 'sqlite') {
-            if (! empty($this->connectionInfo['unix_socket'])) {
-                $parts[] = 'Socket: '.$this->connectionInfo['unix_socket'];
+            if (! empty($this->connectionDetails['unix_socket'])) {
+                $segments[] = 'Socket: '.$this->connectionDetails['unix_socket'];
             } else {
-                $host = $this->connectionInfo['host'] ?? '';
-                $parts[] = 'Host: '.(is_array($host) ? implode(', ', $host) : $host);
-                $parts[] = 'Port: '.($this->connectionInfo['port'] ?? '');
+                $host = $this->connectionDetails['host'] ?? '';
+
+                $segments[] = 'Host: '.(is_array($host) ? implode(', ', $host) : $host);
+                $segments[] = 'Port: '.($this->connectionDetails['port'] ?? '');
             }
         }
 
-        $parts[] = 'Database: '.($this->connectionInfo['database'] ?? '');
+        $segments[] = 'Database: '.($this->connectionDetails['database'] ?? '');
 
-        return ', '.implode(', ', $parts);
+        return ', '.implode(', ', $segments);
     }
 
     /**
@@ -149,12 +150,12 @@ class QueryException extends PDOException
     }
 
     /**
-     * Get the connection info for the query.
+     * Get information about the connection such as host, port, database, etc.
      *
      * @return array
      */
-    public function getConnectionInfo()
+    public function getConnectionDetails()
     {
-        return $this->connectionInfo;
+        return $this->connectionDetails;
     }
 }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -373,7 +373,7 @@ class DatabaseConnectionTest extends TestCase
     public function testOnLostConnectionPDOIsNotSwappedWithinATransaction()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('server has gone away (Connection: , SQL: foo)');
+        $this->expectExceptionMessage('server has gone away (Connection: , Host: , Port: , Database: , SQL: foo)');
 
         $pdo = m::mock(PDO::class);
         $pdo->shouldReceive('beginTransaction')->once();
@@ -425,7 +425,7 @@ class DatabaseConnectionTest extends TestCase
     public function testRunMethodNeverRetriesIfWithinTransaction()
     {
         $this->expectException(QueryException::class);
-        $this->expectExceptionMessage('(Connection: conn, SQL: ) (Connection: , SQL: )');
+        $this->expectExceptionMessage('(Connection: conn, SQL: ) (Connection: , Host: , Port: , Database: , SQL: )');
 
         $method = (new ReflectionClass(Connection::class))->getMethod('run');
 

--- a/tests/Database/DatabaseQueryExceptionTest.php
+++ b/tests/Database/DatabaseQueryExceptionTest.php
@@ -137,7 +137,7 @@ class DatabaseQueryExceptionTest extends TestCase
         ];
         $exception = new QueryException('mysql::read', 'SELECT * FROM users', [], $pdoException, $connectionInfo);
 
-        $this->assertSame($connectionInfo, $exception->getConnectionInfo());
+        $this->assertSame($connectionInfo, $exception->getConnectionDetails());
     }
 
     public function testBackwardCompatibilityWithoutConnectionInfo()
@@ -146,7 +146,7 @@ class DatabaseQueryExceptionTest extends TestCase
         $exception = new QueryException('mysql', 'SELECT * FROM users WHERE id = ?', [1], $pdoException);
 
         $this->assertSame('Mock SQL error (Connection: mysql, SQL: SELECT * FROM users WHERE id = 1)', $exception->getMessage());
-        $this->assertSame([], $exception->getConnectionInfo());
+        $this->assertSame([], $exception->getConnectionDetails());
     }
 
     protected function getConnection()


### PR DESCRIPTION
This helps diagnose connection issues, especially with read/write configurations where hosts may differ from `DB_HOST`.

Empty values are shown explicitly to make misconfiguration obvious.

## Before:
> SQLSTATE[HY000] [2002] No such file or directory (Connection: mysql, SQL: select ...)

## After (MySQL with host/port):
> SQLSTATE[HY000] [2002] No such file or directory (Connection: mysql, Host: 192.168.1.10, Port: 3306, Database: laravel, SQL: select ...)

## After (MySQL with host/port for read and write connection): 
> SQLSTATE[HY000] [2002] No such file or directory (Connection: mysql::read, Host: 192.168.1.10, Port: 3306, Database: laravel, SQL: select ...)

## After (misconfigured - empty host):
SQLSTATE[HY000] [2002] No such file or directory (Connection: mysql, Host: , Port: 3306, Database: laravel, SQL: select ...)

## After (misconfigured - empty host for read and write connection): 
> SQLSTATE[HY000] [2002] No such file or directory (Connection: mysql::read, Host: , Port: 3306, Database: laravel, SQL: select ...)

## After (SQLite):
> SQLSTATE[HY000] [2002] No such file or directory (Connection: sqlite, Database: /path/to/db.sqlite, SQL: select ...)


