### PR TITLE
[12.x] Add `pausedUntil()` method for paused queues

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static void pauseFor(string $connection, string $queue, \DateTimeInterface|\DateInterval|int $ttl)
  * @method static void resume(string $connection, string $queue)
  * @method static bool isPaused(string $connection, string $queue)
+ * @method static \Illuminate\Support\Carbon|null pausedUntil(string $connection, string $queue)
  * @method static void withoutInterruptionPolling()
  * @method static void extend(string $driver, \Closure $resolver)
  * @method static void addConnector(string $driver, \Closure $resolver)


### PR DESCRIPTION
## Summary

This PR adds a new method `pausedUntil()` to the `QueueManager`. It allows retrieving the end time of a paused queue as a `Carbon` instance. If the queue is not paused or the pause is indefinite, the method returns `null`.

## Motivation

Currently, there is no way to programmatically determine how long a queue will remain paused.

- Developers and monitoring systems cannot access the pause TTL easily.
- Knowing when a pause ends can help with scheduling jobs or displaying queue status in dashboards.

## Consistency with Laravel Core

- This approach is similar to other Laravel components that expose metadata about temporary state, such as middleware throttling.
- It follows the framework’s philosophy of clear, expressive, and developer-friendly APIs.

## Example Usage

```php
Queue::pause('redis', 'default');

Queue::pausedUntil('redis', 'default'); // null

Queue::pauseFor('redis', 'emails', 60);

Queue::pausedUntil('redis', 'emails'); // A Carbon instance representing when the pause ends
```
