### PR TITLE
[12.x] Adjust README test status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400"></a></p>
 
 <p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
+<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/actions/workflows/tests.yml/badge.svg" alt="Build Status"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>


### PR DESCRIPTION
I noticed in the readme it kept saying the tests were failing: 

<img width="982" height="476" alt="image" src="https://github.com/user-attachments/assets/9300baf0-0c92-4df7-b5b1-c555953888c8" />

I think this was because it was looking at all the tests, not just the default branch (currently 12.x) / may be legacy.


The new badge defaults (heh) to the default branch, rather than all the tests - which means it should no longer show failing.

I got the badge via the "create status badge" option in the test action. 

<details> 

<img width="721" height="510" alt="image" src="https://github.com/user-attachments/assets/8775ffa4-2605-4d37-bf9e-c42774d6c18c" />


</details>

I've just adjusted the image for now.