### PR TITLE
feat: fire JobAttempted for sync jobs too

### DIFF
--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
@@ -131,7 +132,13 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
+            $exceptionOccurred = true;
             $this->handleException($queueJob, $e);
+        } finally {
+            if ($this->container->bound('events')) {
+                $this->container['events']->dispatch(new JobAttempted($this->connectionName, $queueJob, $exceptionOccurred ?? false));
+
+            }
         }
 
         return 0;

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -136,8 +136,9 @@ class SyncQueue extends Queue implements QueueContract
             $this->handleException($queueJob, $e);
         } finally {
             if ($this->container->bound('events')) {
-                $this->container['events']->dispatch(new JobAttempted($this->connectionName, $queueJob, $exceptionOccurred ?? false));
-
+                $this->container['events']->dispatch(
+                    new JobAttempted($this->connectionName, $queueJob, $exceptionOccurred ?? false)
+                );
             }
         }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -133,6 +133,7 @@ class SyncQueue extends Queue implements QueueContract
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
             $exceptionOccurred = true;
+
             $this->handleException($queueJob, $e);
         } finally {
             if ($this->container->bound('events')) {

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -47,7 +47,7 @@ class QueueSyncQueueTest extends TestCase
         $container = new Container;
         Container::setInstance($container);
         $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->times(3);
+        $events->shouldReceive('dispatch')->times(4);
         $container->instance('events', $events);
         $container->instance(Dispatcher::class, $events);
         $sync->setContainer($container);


### PR DESCRIPTION
Currently, there is no consistent way to fire an event both before and after a job.
On a regular queue, you can do so by hooking the BeforeJob event and the JobAttempted event. This event if fired both if 
the job finishes and if it throws an exception.

However, the sync queue does not have a JobAttempted event, so if you are running a sync job and it fires and throws an exception, you get no event after it finishes.

This PR simply implements the JobAttempted event for sync jobs. I don't foresee a case where that would cause breakage.
