### PR TITLE
Add forceTruncate to bypass foreign key constraints

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4157,6 +4157,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Truncate the table even if foreign key constraints exist.
+     *
+     * @return void
+     */
+    public function forceTruncate()
+    {
+        $this->connection->getSchemaBuilder()->withoutForeignKeyConstraints(function () {
+            $this->truncate();
+        });
+    }
+
+    /**
      * Get a new instance of the query builder.
      *
      * @return \Illuminate\Database\Query\Builder


### PR DESCRIPTION
Currently, truncating a table with foreign keys requires manually disabling and re-enabling checks. This PR adds a single-line, database-agnostic way to do this:

`
// Before
Schema::disableForeignKeyConstraints();
User::truncate();
Schema::enableForeignKeyConstraints();

// After
User::forceTruncate();
`