### PR TITLE
[12.x] Add `class()` to config repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -201,6 +201,28 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified class-string configuration value.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(class-string|null))|class-string|null  $default
+     * @return class-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function class(string $key, $default = null): string
+    {
+        $value = $this->string($key, $default);
+
+        if (! class_exists($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a class-string, %s given.', $key, gettype($value))
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Set a given configuration value.
      *
      * @param  array|string  $key

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -372,4 +372,28 @@ class RepositoryTest extends TestCase
 
         $this->repository->float('a.b');
     }
+
+    public function testItGetsAsClassString(): void
+    {
+        $this->repository->set([
+            'class' => \stdClass::class,
+            'class-as-string' => 'stdClass',
+        ]);
+
+        $this->assertSame(
+            $this->repository->class('class'), \stdClass::class
+        );
+
+        $this->assertSame(
+            $this->repository->class('class-as-string'), \stdClass::class
+        );
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonClassStringValueAsClassString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#Configuration value for key \[foo\] must be a class-string, (.*) given.#');
+
+        $this->repository->class('foo');
+    }
 }


### PR DESCRIPTION
Adds the `class()` helper to the config repository, which validates using `class_exists()`.

Omitted trait/interface checks intentionally, since it’s not that common to reference interfaces or traits in configuration.
