### PR TITLE
[12.x] Adds callback debounce to Rate Limiter.

### DIFF
--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -17,6 +17,7 @@ namespace Illuminate\Support\Facades;
  * @method static void clear(string $key)
  * @method static int availableIn(string $key)
  * @method static string cleanRateLimiterKey(string $key)
+ * @method static mixed debounce(string $key, \DateTimeInterface|\DateInterval|int $decaySeconds, \Closure $callback)
  *
  * @see \Illuminate\Cache\RateLimiter
  */

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Exception;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Cache\Repository as Cache;
@@ -218,5 +219,45 @@ class CacheRateLimiterTest extends TestCase
         $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
 
         $this->assertTrue($rateLimiter->tooManyAttempts($key, 1));
+    }
+
+    public function testDebounceCallback()
+    {
+        $key = 'debounced';
+
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('add')->once()->with("$key:timer", m::type('int'), 30)->andReturnTrue();
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $cache->shouldReceive('add')->once()->with("$key:timer", m::type('int'), 30)->andReturnTrue();
+        $cache->shouldReceive('add')->once()->with($key, 0, 30)->andReturnTrue();
+        $cache->shouldReceive('increment')->once()->with($key, 1)->andReturnTrue();
+
+        $this->assertSame('foo', $rateLimiter->debounce($key, 30, fn() => 'foo'));
+
+        $cache->shouldReceive('add')->once()->with("$key:timer", m::type('int'), 30)->andReturnFalse();
+
+        $this->assertFalse($rateLimiter->debounce($key, 30, fn() => 'foo'));
+    }
+
+    public function testDebounceExceptionsClearsAttempts()
+    {
+        $key = 'debounced';
+
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('add')->once()->with("$key:timer", m::type('int'), 30)->andReturnTrue();
+        $cache->shouldReceive('getStore')->andReturn(new ArrayStore);
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $cache->shouldReceive('forget')->once()->with($key)->andReturnTrue();
+        $cache->shouldReceive('forget')->once()->with("$key:timer")->andReturnTrue();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Thrown by debounce');
+
+        $this->assertSame('foo', $rateLimiter->debounce($key, 30, fn() => throw new Exception('Thrown by debounce')));
     }
 }


### PR DESCRIPTION
# What?

This introduces the `attemptOnce` to the Rate Limiter helper, which is just syntax sugar for `attempt()` with 1 retry while being atomic _without the need of atomic locks_. It uses the same syntax style that `attempt()`, with a 60 second default.

The idea is to tun a callback **only once** inside a given window of time, sharing it execution state across multiple app instances and checkable across the whole app. This also allows to clear the debounce data manually or on failure.

```php
use Illuminate\Support\Facades\Cache;
use App\Alerts\SystemAlert;

// 1. Somewhat irresponsable but works
if (Cache::add('send-sms', true, 60)) {
    SystemAlert::send('Something happened');
}

// 2. Alternative using atomic locks
$lock = Cache::lock('send-sms', 60);

if ($lock->get()) {
    try {
        SystemAlert::send('Something happened');
    } catch (Throwable $throwable) {
    
        $lock->release();
        
        throw $throwable;
    } finally {
        // Do not release the lock on success so the debounce works.
    }
}}

// Much simpler and without atomic locks.
use Illuminate\Support\Facades\RateLimiter;

RateLimiter::attemptOnce('send-sms', fn () => SystemAlert::send('Something happened'));
```

When the debounced callback is executed, its original result will be returned, otherwise `false` is returned.

```php
use Illuminate\Support\Facades\RateLimiter;

$result = RateLimiter::attemptOnce('computed', fn () => /* ... */));

if ($result === false) {
    $seconds = RateLimiter::availableIn('computed');
    
    return "The computation was already done, wait $seconds seconds."
}

return 'Compute done!'
```

Since it uses the Rate Limiter, the status of the key can be checked elsewhere.

```php
use Illuminate\Support\Facades\RateLimiter;

public function form()
{
    return view('sms.send', [
        'remaining' => RateLimiter::availableIn('send-sms'),
    ]);
}

public function send()
{
    RateLimiter::attemptOnce('send-sms', function () {
        // ...
    });
    
    return to_route('sms.send');
}
```

## Caveats

1. Does not cache the result

This is made to avoid serializing a result, or making the developer mistakenly not returning anything (`null` of `void`. I assume the developer will also want the fresh result of the callback instead of stale data, otherwise he would use `Cache::remember()` or have more control with an Atomic Lock.

2. Attempt is cleared on exception

If the callback fails, the attempt is cleared. If the developer requires to **not** do so, catching the exception inside the function is required, like using with `rescue()`.

```php
use App\Alerts\SystemAlert;
use App\Alerts\Exceptions\ThrottledException;
use Illuminate\Support\Facades\RateLimiter;

RateLimiter::attemptOnce('computed', function () {
    rescue(fn () => SystemAlert::send('Something happened'));
});
```