### PR TITLE
[12.x] ValidationException: update redirectTo property definition to include null

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -39,7 +39,7 @@ class ValidationException extends Exception
     /**
      * The path the client should be redirected to.
      *
-     * @var string
+     * @var string|null
      */
     public $redirectTo;
 


### PR DESCRIPTION
Update the `$redirectTo` property type in `ValidationException` to allow `null`. This resolves the static analysis errors, for example, PHPStan flags the property as non-nullable when used with the ?? operator:
```php
$exception->redirectTo ?? url()->previous();
```