### PR TITLE
[12.x] Extract `JobAttempted` event dispatch to a separate method in `SyncQueue`

### DIFF
--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -136,11 +136,7 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->handleException($queueJob, $e);
         } finally {
-            if ($this->container->bound('events')) {
-                $this->container['events']->dispatch(
-                    new JobAttempted($this->connectionName, $queueJob, $exceptionOccurred ?? false)
-                );
-            }
+            $this->raiseJobAttemptedEvent($queueJob, $exceptionOccurred ?? false);
         }
 
         return 0;
@@ -181,6 +177,20 @@ class SyncQueue extends Queue implements QueueContract
     {
         if ($this->container->bound('events')) {
             $this->container['events']->dispatch(new JobProcessed($this->connectionName, $job));
+        }
+    }
+
+    /**
+     * Raise the job attempted event.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  bool  $exceptionOccurred
+     * @return void
+     */
+    protected function raiseJobAttemptedEvent(Job $job, bool $exceptionOccurred = false)
+    {
+        if ($this->container->bound('events')) {
+            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exceptionOccurred));
         }
     }
 


### PR DESCRIPTION
This PR refactors the `SyncQueue` class to move the dispatching of the `JobAttempted` event into its own protected method, `raiseJobAttemptedEvent`. This aligns with the existing pattern of `raiseBeforeJobEvent` and `raiseAfterJobEvent`, improving code readability and maintainability.

Continuation of #58228