### PR TITLE
[12.x] Add BackedEnum support for session keys

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -17,6 +17,8 @@ use RuntimeException;
 use SessionHandlerInterface;
 use stdClass;
 
+use function Illuminate\Support\enum_value;
+
 class Store implements Session
 {
     use Macroable;
@@ -322,25 +324,25 @@ class Store implements Session
     /**
      * Get an item from the session.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
     {
-        return Arr::get($this->attributes, $key, $default);
+        return Arr::get($this->attributes, enum_value($key), $default);
     }
 
     /**
      * Get the value of a given key and then forget it.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null)
     {
-        return Arr::pull($this->attributes, $key, $default);
+        return Arr::pull($this->attributes, enum_value($key), $default);
     }
 
     /**
@@ -382,25 +384,25 @@ class Store implements Session
     /**
      * Put a key / value pair or array of key / value pairs in the session.
      *
-     * @param  string|array  $key
+     * @param  \BackedEnum|\UnitEnum|string|array  $key
      * @param  mixed  $value
      * @return void
      */
     public function put($key, $value = null)
     {
         if (! is_array($key)) {
-            $key = [$key => $value];
+            $key = [enum_value($key) => $value];
         }
 
         foreach ($key as $arrayKey => $arrayValue) {
-            Arr::set($this->attributes, $arrayKey, $arrayValue);
+            Arr::set($this->attributes, enum_value($arrayKey), $arrayValue);
         }
     }
 
     /**
      * Get an item from the session, or store the default value.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -418,7 +420,7 @@ class Store implements Session
     /**
      * Push a value onto a session array.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */
@@ -434,7 +436,7 @@ class Store implements Session
     /**
      * Increment the value of an item in the session.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $amount
      * @return mixed
      */
@@ -448,7 +450,7 @@ class Store implements Session
     /**
      * Decrement the value of an item in the session.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $amount
      * @return int
      */
@@ -560,23 +562,23 @@ class Store implements Session
     /**
      * Remove an item from the session, returning its value.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function remove($key)
     {
-        return Arr::pull($this->attributes, $key);
+        return Arr::pull($this->attributes, enum_value($key));
     }
 
     /**
      * Remove one or many items from the session.
      *
-     * @param  string|array  $keys
+     * @param  \BackedEnum|\UnitEnum|string|array  $keys
      * @return void
      */
     public function forget($keys)
     {
-        Arr::forget($this->attributes, $keys);
+        Arr::forget($this->attributes, collect((array) $keys)->map(fn ($key) => enum_value($key))->all());
     }
 
     /**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -571,6 +571,112 @@ class SessionStoreTest extends TestCase
         $this->assertTrue($session->missing(['hulk.two']));
     }
 
+    public function testBackedEnumKeyPut()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+
+        $this->assertSame('Taylor', $session->get('user'));
+        $this->assertSame('Taylor', $session->get(SessionTestKey::User));
+    }
+
+    public function testBackedEnumKeyGet()
+    {
+        $session = $this->getSession();
+        $session->put('user', 'Taylor');
+
+        $this->assertSame('Taylor', $session->get(SessionTestKey::User));
+        $this->assertSame('default', $session->get(SessionTestKey::Settings, 'default'));
+    }
+
+    public function testBackedEnumKeyHas()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+        $session->put(SessionTestKey::Settings, 'dark-mode');
+
+        $this->assertTrue($session->has(SessionTestKey::User));
+        $this->assertTrue($session->has(SessionTestKey::User, SessionTestKey::Settings));
+        $this->assertTrue($session->has([SessionTestKey::User, SessionTestKey::Settings]));
+        $this->assertFalse($session->has(SessionTestKey::Preference));
+    }
+
+    public function testBackedEnumKeyForget()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+        $this->assertTrue($session->has('user'));
+
+        $session->forget(SessionTestKey::User);
+        $this->assertFalse($session->has('user'));
+
+        $session->put(SessionTestKey::User, 'Taylor');
+        $session->put(SessionTestKey::Settings, 'dark-mode');
+        $session->forget([SessionTestKey::User, SessionTestKey::Settings]);
+        $this->assertFalse($session->has('user'));
+        $this->assertFalse($session->has('settings'));
+    }
+
+    public function testBackedEnumKeyPull()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+
+        $this->assertSame('Taylor', $session->pull(SessionTestKey::User));
+        $this->assertNull($session->pull(SessionTestKey::User));
+        $this->assertSame('default', $session->pull(SessionTestKey::User, 'default'));
+    }
+
+    public function testBackedEnumKeyRemember()
+    {
+        $session = $this->getSession();
+
+        $result = $session->remember(SessionTestKey::User, fn () => 'Taylor');
+
+        $this->assertSame('Taylor', $result);
+        $this->assertSame('Taylor', $session->get('user'));
+        $this->assertSame('Taylor', $session->remember(SessionTestKey::User, fn () => 'Otwell'));
+    }
+
+    public function testBackedEnumKeyPush()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, ['Taylor']);
+        $session->push(SessionTestKey::User, 'Otwell');
+
+        $this->assertSame(['Taylor', 'Otwell'], $session->get('user'));
+    }
+
+    public function testBackedEnumKeyIncrement()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 5);
+
+        $this->assertSame(6, $session->increment(SessionTestKey::User));
+        $this->assertSame(6, $session->get('user'));
+
+        $this->assertSame(10, $session->increment(SessionTestKey::User, 4));
+        $this->assertSame(10, $session->get('user'));
+    }
+
+    public function testBackedEnumKeyDecrement()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 5);
+
+        $this->assertSame(4, $session->decrement(SessionTestKey::User));
+        $this->assertSame(4, $session->get('user'));
+    }
+
+    public function testBackedEnumKeyRemove()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+
+        $this->assertSame('Taylor', $session->remove(SessionTestKey::User));
+        $this->assertFalse($session->has('user'));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $session = $this->getSession();
@@ -698,4 +804,11 @@ class SessionStoreTest extends TestCase
     {
         return 'name';
     }
+}
+
+enum SessionTestKey: string
+{
+    case User = 'user';
+    case Settings = 'settings';
+    case Preference = 'preference';
 }


### PR DESCRIPTION
This PR adds enum support for Session keys. Laravel already handles BackedEnums gracefully in Gate, Queue, Cache, RateLimiter, and elsewhere - this pattern follows the same.

If you're managing a multi-step checkout flow across several components, you probably have something like:
```php
enum CheckoutSession: string
{
    case Cart = 'checkout.cart';
    case ShippingAddress = 'checkout.shipping_address';
    case PaymentMethod = 'checkout.payment_method';
}
```

Right now you have to do `->value` everywhere:

```php
session()->put(CheckoutSession::Cart->value, $items);
session()->get(CheckoutSession::Cart->value);
```

This PR lets you drop the `->value`:

```php
session()->put(CheckoutSession::Cart, $items);
session()->get(CheckoutSession::Cart);
```

Uses `enum_value()` to normalize keys, same pattern as the rest of the framework.