### PR TITLE
[12.x] Adjust getEventDispatcher docblock to allow null return

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1467,7 +1467,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the event dispatcher used by the connection.
      *
-     * @return \Illuminate\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public function getEventDispatcher()
     {

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -289,7 +289,7 @@ class Logger implements LoggerInterface
     /**
      * Get the event dispatcher instance.
      *
-     * @return \Illuminate\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public function getEventDispatcher()
     {

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -185,7 +185,7 @@ abstract class Connection
     /**
      * Get the event dispatcher used by the connection.
      *
-     * @return \Illuminate\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public function getEventDispatcher()
     {


### PR DESCRIPTION
I noticed the `getEventDispatcher()` method can actually return `null`.  I realised after playing with: 
```php 

    DB::connection()->unsetEventDispatcher();
    dd(DB::connection()->getEventDispatcher());
```  

I've adjusted the docblocks for all three classes missing it based on the fact the properties can actually be null:

- [Connection](https://github.com/laravel/framework/blob/6ad8cc987ca9fd2b0402f820b27926464194708a/src/Illuminate/Database/Connection.php#L108-L113)
- [Redis Connection](https://github.com/laravel/framework/blob/6ad8cc987ca9fd2b0402f820b27926464194708a/src/Illuminate/Redis/Connections/Connection.php#L32-L37)
- [Logger ](https://github.com/laravel/framework/blob/6ad8cc987ca9fd2b0402f820b27926464194708a/src/Illuminate/Log/Logger.php#L26-L30) & [Logger allows dispatcher to be null](https://github.com/laravel/framework/blob/6ad8cc987ca9fd2b0402f820b27926464194708a/src/Illuminate/Log/Logger.php#L45) 

This ensures the docblock matches the actual implementation

