### PR TITLE
[13.x] Allow cache store keys to accept enums

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Cache;
 
+use function Illuminate\Support\enum_value;
+
 class ApcStore extends TaggableStore
 {
     use RetrievesMultipleKeys;
@@ -35,72 +37,74 @@ class ApcStore extends TaggableStore
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function get($key)
     {
-        return $this->apc->get($this->prefix.$key);
+        return $this->apc->get($this->prefix.enum_value($key));
     }
 
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
      */
     public function put($key, $value, $seconds)
     {
-        return $this->apc->put($this->prefix.$key, $value, $seconds);
+        return $this->apc->put($this->prefix.enum_value($key), $value, $seconds);
     }
 
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $value
      * @return int|false
      */
     public function increment($key, $value = 1)
     {
-        return $this->apc->increment($this->prefix.$key, $value);
+        return $this->apc->increment($this->prefix.enum_value($key), $value);
     }
 
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $value
      * @return int|false
      */
     public function decrement($key, $value = 1)
     {
-        return $this->apc->decrement($this->prefix.$key, $value);
+        return $this->apc->decrement($this->prefix.enum_value($key), $value);
     }
 
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
-        return $this->put($key, $value, 0);
+        return $this->put(enum_value($key), $value, 0);
     }
 
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $seconds
      * @return bool
      */
     public function touch($key, $seconds)
     {
+        $key = enum_value($key);
+
         $value = $this->apc->get($key = $this->getPrefix().$key);
 
         if (is_null($value)) {
@@ -113,12 +117,12 @@ class ApcStore extends TaggableStore
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key)
     {
-        return $this->apc->delete($this->prefix.$key);
+        return $this->apc->delete($this->prefix.enum_value($key));
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 
+use function Illuminate\Support\enum_value;
+
 class DatabaseStore implements LockProvider, Store
 {
     use InteractsWithTime;
@@ -97,11 +99,13 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function get($key)
     {
+        $key = enum_value($key);
+
         return $this->many([$key])[$key];
     }
 
@@ -157,14 +161,14 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
      */
     public function put($key, $value, $seconds)
     {
-        return $this->putMany([$key => $value], $seconds);
+        return $this->putMany([enum_value($key) => $value], $seconds);
     }
 
     /**
@@ -194,13 +198,15 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Store an item in the cache if the key doesn't exist.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
      */
     public function add($key, $value, $seconds)
     {
+        $key = enum_value($key);
+
         if (! is_null($this->get($key))) {
             return false;
         }
@@ -225,7 +231,7 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $value
      * @return int|false
      */
@@ -239,13 +245,13 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $value
      * @return int|false
      */
     public function decrement($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement(enum_value($key), $value, function ($current, $value) {
             return $current - $value;
         });
     }
@@ -310,13 +316,13 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
-        return $this->put($key, $value, 315360000);
+        return $this->put(enum_value($key), $value, 315360000);
     }
 
     /**
@@ -355,14 +361,14 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $seconds
      * @return bool
      */
     public function touch($key, $seconds)
     {
         return (bool) $this->table()
-            ->where('key', '=', $this->getPrefix().$key)
+            ->where('key', '=', $this->getPrefix().enum_value($key))
             ->where('expiration', '>', $now = $this->getTime())
             ->update(['expiration' => $now + $seconds]);
     }
@@ -370,23 +376,23 @@ class DatabaseStore implements LockProvider, Store
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key)
     {
-        return $this->forgetMany([$key]);
+        return $this->forgetMany([enum_value($key)]);
     }
 
     /**
      * Remove an item from the cache if it is expired.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forgetIfExpired($key)
     {
-        return $this->forgetManyIfExpired([$key]);
+        return $this->forgetManyIfExpired([enum_value($key)]);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -7,6 +7,8 @@ use Illuminate\Support\InteractsWithTime;
 use Memcached;
 use ReflectionMethod;
 
+use function Illuminate\Support\enum_value;
+
 class MemcachedStore extends TaggableStore implements LockProvider
 {
     use InteractsWithTime;
@@ -50,12 +52,12 @@ class MemcachedStore extends TaggableStore implements LockProvider
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @return mixed
      */
     public function get($key)
     {
-        $value = $this->memcached->get($this->prefix.$key);
+        $value = $this->memcached->get($this->prefix.enum_value($key));
 
         if ($this->memcached->getResultCode() == 0) {
             return $value;
@@ -94,7 +96,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
@@ -102,7 +104,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     public function put($key, $value, $seconds)
     {
         return $this->memcached->set(
-            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+            $this->prefix.enum_value($key), $value, $this->calculateExpiration($seconds)
         );
     }
 
@@ -129,7 +131,7 @@ class MemcachedStore extends TaggableStore implements LockProvider
     /**
      * Store an item in the cache if the key doesn't exist.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
@@ -137,44 +139,44 @@ class MemcachedStore extends TaggableStore implements LockProvider
     public function add($key, $value, $seconds)
     {
         return $this->memcached->add(
-            $this->prefix.$key, $value, $this->calculateExpiration($seconds)
+            $this->prefix.enum_value($key), $value, $this->calculateExpiration($seconds)
         );
     }
 
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  mixed  $value
      * @return int|false
      */
     public function increment($key, $value = 1)
     {
-        return $this->memcached->increment($this->prefix.$key, $value);
+        return $this->memcached->increment($this->prefix.enum_value($key), $value);
     }
 
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  mixed  $value
      * @return int|false
      */
     public function decrement($key, $value = 1)
     {
-        return $this->memcached->decrement($this->prefix.$key, $value);
+        return $this->memcached->decrement($this->prefix.enum_value($key), $value);
     }
 
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
-        return $this->put($key, $value, 0);
+        return $this->put(enum_value($key), $value, 0);
     }
 
     /**
@@ -205,24 +207,24 @@ class MemcachedStore extends TaggableStore implements LockProvider
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @param  int  $seconds
      * @return bool
      */
     public function touch($key, $seconds)
     {
-        return $this->memcached->touch($this->getPrefix().$key, $this->calculateExpiration($seconds));
+        return $this->memcached->touch($this->getPrefix().enum_value($key), $this->calculateExpiration($seconds));
     }
 
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string $key
      * @return bool
      */
     public function forget($key)
     {
-        return $this->memcached->delete($this->prefix.$key);
+        return $this->memcached->delete($this->prefix.enum_value($key));
     }
 
     /**

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -6,6 +6,8 @@ use BadMethodCallException;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 
+use function Illuminate\Support\enum_value;
+
 class MemoizedStore implements LockProvider, Store
 {
     /**
@@ -31,11 +33,13 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function get($key)
     {
+        $key = enum_value($key);
+
         $prefixedKey = $this->prefix($key);
 
         if (array_key_exists($prefixedKey, $this->cache)) {
@@ -90,13 +94,15 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
      */
     public function put($key, $value, $seconds)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->put($key, $value, $seconds);
@@ -121,12 +127,14 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->increment($key, $value);
@@ -135,12 +143,14 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->decrement($key, $value);
@@ -149,12 +159,14 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->forever($key, $value);
@@ -196,12 +208,14 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $seconds
      * @return bool
      */
     public function touch($key, $seconds)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->touch($key, $seconds);
@@ -210,11 +224,13 @@ class MemoizedStore implements LockProvider, Store
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key)
     {
+        $key = enum_value($key);
+
         unset($this->cache[$this->prefix($key)]);
 
         return $this->repository->forget($key);

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -11,7 +11,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return void
      */
     public function get($key)
@@ -22,7 +22,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
@@ -35,7 +35,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return false
      */
@@ -47,7 +47,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return false
      */
@@ -59,7 +59,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
@@ -96,7 +96,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|null  $key
      * @param  int  $seconds
      * @return bool
      */
@@ -108,7 +108,7 @@ class NullStore extends TaggableStore implements LockProvider
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -529,7 +529,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Set the expiration of a cached item; null TTL will retain the item forever.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */

--- a/src/Illuminate/Cache/SessionStore.php
+++ b/src/Illuminate/Cache/SessionStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 
+use function Illuminate\Support\enum_value;
+
 class SessionStore implements Store
 {
     use InteractsWithTime, RetrievesMultipleKeys;
@@ -49,11 +51,13 @@ class SessionStore implements Store
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function get($key)
     {
+        $key = enum_value($key);
+
         if (! $this->session->exists($this->itemKey($key))) {
             return;
         }
@@ -63,7 +67,7 @@ class SessionStore implements Store
         $expiresAt = $item['expiresAt'] ?? 0;
 
         if ($this->isExpired($expiresAt)) {
-            $this->forget($key);
+            $this->forget(enum_value($key));
 
             return;
         }
@@ -85,14 +89,14 @@ class SessionStore implements Store
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
      */
     public function put($key, $value, $seconds)
     {
-        $this->session->put($this->itemKey($key), [
+        $this->session->put($this->itemKey(enum_value($key)), [
             'value' => $value,
             'expiresAt' => $this->toTimestamp($seconds),
         ]);
@@ -114,12 +118,14 @@ class SessionStore implements Store
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
     {
+        $key = enum_value($key);
+
         if (! is_null($existing = $this->get($key))) {
             return tap(((int) $existing) + $value, function ($incremented) use ($key) {
                 $this->session->put($this->itemKey("{$key}.value"), $incremented);
@@ -134,7 +140,7 @@ class SessionStore implements Store
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int
      */
@@ -158,12 +164,14 @@ class SessionStore implements Store
     /**
      * Adjust the expiration time of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $seconds
      * @return bool
      */
     public function touch($key, $seconds)
     {
+        $key = enum_value($key);
+
         $value = $this->get($key);
 
         if (is_null($value)) {
@@ -178,11 +186,13 @@ class SessionStore implements Store
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key)
     {
+        $key = enum_value($key);
+
         if ($this->session->exists($this->itemKey($key))) {
             $this->session->forget($this->itemKey($key));
 

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -102,7 +102,7 @@ interface Repository extends CacheInterface
     /**
      * Set the expiration of a cached item; null TTL will retain the item forever.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -7,7 +7,7 @@ interface Store
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function get($key);
@@ -25,7 +25,7 @@ interface Store
     /**
      * Store an item in the cache for a given number of seconds.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
@@ -44,7 +44,7 @@ interface Store
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -53,7 +53,7 @@ interface Store
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -71,7 +71,7 @@ interface Store
     /**
      * Set the expiration of a cached item.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $seconds
      * @return bool
      */
@@ -80,7 +80,7 @@ interface Store
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key);

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -383,4 +383,21 @@ class CacheArrayStoreTest extends TestCase
             $store->all(false)['foo']['value']
         );
     }
+
+    public function testEnumsAreSupportedAsCacheKeys()
+    {
+        $store = new ArrayStore;
+
+        $store->put(BackedEnum::Foo, 'backed', 10);
+        $this->assertSame('backed', $store->get(BackedEnum::Foo));
+
+        $this->assertSame(1, $store->increment(BackedEnum::Foo));
+        $this->assertSame(0, $store->decrement(BackedEnum::Foo));
+
+        $this->assertTrue($store->forget(BackedEnum::Foo));
+        $this->assertNull($store->get(BackedEnum::Foo));
+
+        $this->assertTrue($store->forever(BackedEnum::Foo, 'forever'));
+        $this->assertSame('forever', $store->get(BackedEnum::Foo));
+    }
 }


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/58241 enums are now available for session keys  so I thought it would be nice to allow enums for the cache stores. 

I've targetted 13.x as I've made the contract changes, and feels like it's a big change so.. 

Opted to do it in one go to avoid PR spam.

Leaving this as draft as got a bunch of tests to sort out, but thought I'd open it for visibility.