### PR TITLE
[12.x] Allow BackedEnum for Cache keys

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -29,6 +29,7 @@ use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Traits\Macroable;
 
 use function Illuminate\Support\defer;
+use function Illuminate\Support\enum_value;
 
 /**
  * @mixin \Illuminate\Contracts\Cache\Store
@@ -82,7 +83,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item exists in the cache.
      *
-     * @param  array|string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function has($key): bool
@@ -93,7 +94,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item doesn't exist in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function missing($key)
@@ -104,7 +105,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  array|string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -113,6 +114,8 @@ class Repository implements ArrayAccess, CacheContract
         if (is_array($key)) {
             return $this->many($key);
         }
+
+        $key = enum_value($key);
 
         $this->event(new RetrievingKey($this->getName(), $key));
 
@@ -201,7 +204,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache and delete it.
      *
-     * @param  array|string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -215,7 +218,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache.
      *
-     * @param  array|string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -225,6 +228,8 @@ class Repository implements ArrayAccess, CacheContract
         if (is_array($key)) {
             return $this->putMany($key, $value);
         }
+
+        $key = enum_value($key);
 
         if ($ttl === null) {
             return $this->forever($key, $value);
@@ -250,8 +255,11 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * {@inheritdoc}
+     * Store an item in the cache.
      *
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
     public function set($key, $value, $ttl = null): bool
@@ -325,13 +333,15 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
     public function add($key, $value, $ttl = null)
     {
+        $key = enum_value($key);
+
         $seconds = null;
 
         if ($ttl !== null) {
@@ -364,36 +374,38 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
     {
-        return $this->store->increment($key, $value);
+        return $this->store->increment(enum_value($key), $value);
     }
 
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
-        return $this->store->decrement($key, $value);
+        return $this->store->decrement(enum_value($key), $value);
     }
 
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
+        $key = enum_value($key);
+
         $this->event(new WritingKey($this->getName(), $key, $value));
 
         $result = $this->store->forever($this->itemKey($key), $value);
@@ -412,7 +424,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
@@ -440,7 +452,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -454,7 +466,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -529,11 +541,13 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @return bool
      */
     public function forget($key)
     {
+        $key = enum_value($key);
+
         $this->event(new ForgettingKey($this->getName(), $key));
 
         return tap($this->store->forget($this->itemKey($key)), function ($result) use ($key) {
@@ -546,8 +560,9 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * {@inheritdoc}
+     * Remove an item from the cache.
      *
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @return bool
      */
     public function delete($key): bool
@@ -760,7 +775,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -771,7 +786,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache for the default time.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -83,7 +83,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item exists in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @return bool
      */
     public function has($key): bool

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -318,7 +318,6 @@ class RepositoryTest extends TestCase
         $this->assertTrue($cache->forget(TestCacheKey::FOO));
         $this->assertNull($cache->get(TestCacheKey::FOO));
     }
-
 }
 
 enum TestCacheKey: string
@@ -327,5 +326,4 @@ enum TestCacheKey: string
     case BAR = 'bar';
     case BAZ = 'baz';
     case QUX = 'qux';
-
 }


### PR DESCRIPTION
Since https://github.com/laravel/framework/pull/58241 enums are now available for the session keys this PR aligns it for the cache too.

I've done it this way via the Repository as we don't need to edit each store - and then update each store test - and its available on the Cache facade too.

I've added a test to cover the methods just to be sure,  the Cache facade will be updated if this is accepted / merged via the workflow.

We could edit the contract in 13.x and the other implementations perhaps. 

Just wanted to try this as a simpler way to get enums in, otherwise it'll have to be a full fat PR


This just means we can do:

```php

// Before 
Session::put(AnalyticalGraph::PROFILE, 'x'); // Session allows enums.
$result = Graphs::where('x', AnalyticalGraph::PROFILE)->first(); // we can already do it on the query builder.. :)
Cache::put(AnalyticalGraph::PROFILE->value, $result); // NO ENUM SUPPORT?


// After 
Session::put(AnalyticalGraph::PROFILE, 'x');
$result = Graphs::where('x', AnalyticalGraph::PROFILE)->first();
Cache::put(AnalyticalGraph::PROFILE, $result);
```
