### PR TITLE
[12.x] Add support for virtual JSON casts in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class AsJsonPath implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<mixed, mixed>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            public function __construct(protected array $arguments)
+            {
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                $targetColumn = $this->arguments[0] ?? null;
+                $jsonPath = $this->arguments[1] ?? null;
+                $type = $this->arguments[2] ?? null;
+
+                if (! $targetColumn || ! $jsonPath) {
+                    return null;
+                }
+
+                if (array_key_exists($key, $attributes)) {
+                    if ($type) {
+                        return $this->castValue($model, $key, $attributes[$key], $type);
+                    }
+                    return $attributes[$key];
+                }
+
+                if (! isset($attributes[$targetColumn])) {
+                    return null;
+                }
+
+                $rootValue = $attributes[$targetColumn];
+
+                if ($model->hasCast($targetColumn, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object'])) {
+                    $rootValue = $model->fromEncryptedString($rootValue);
+                }
+
+                $decoded = is_array($rootValue) ? $rootValue : $model->fromJson($rootValue);
+
+                if (! is_array($decoded)) {
+                    return null;
+                }
+
+                $extractedValue = data_get($decoded, $jsonPath);
+
+                if ($type && $extractedValue !== null) {
+                    return $this->castValue($model, $key, $extractedValue, $type);
+                }
+
+                return $extractedValue;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                $targetColumn = $this->arguments[0] ?? null;
+                $jsonPath = $this->arguments[1] ?? null;
+
+                if (! $targetColumn || ! $jsonPath) {
+                    return [];
+                }
+
+                if (array_key_exists($key, $attributes)) {
+                    return [$key => $value];
+                }
+
+                $path = str_replace('.', '->', $jsonPath);
+
+                return $model->fillJsonAttribute($targetColumn.'->'.$path, $value)->getAttributes();
+            }
+
+            protected function castValue($model, $key, $value, $type)
+            {
+                $castType = strtolower($type);
+
+                switch ($castType) {
+                    case 'int':
+                    case 'integer':
+                        return (int) $value;
+                    case 'real':
+                    case 'float':
+                    case 'double':
+                        return $model->fromFloat($value);
+                    case 'string':
+                        return (string) $value;
+                    case 'bool':
+                    case 'boolean':
+                        return (bool) $value;
+                    case 'array':
+                    case 'json':
+                        return is_array($value) ? $value : $model->fromJson($value);
+                    case 'object':
+                        return is_object($value) ? $value : $model->fromJson($value, true);
+                    case 'collection':
+                        return new \Illuminate\Support\Collection(is_array($value) ? $value : $model->fromJson($value));
+                    case 'date':
+                        return $model->asDate($value);
+                    case 'datetime':
+                        return $model->asDateTime($value);
+                    case 'timestamp':
+                        return $model->asTimestamp($value);
+                    default:
+                        if (str_starts_with($castType, 'decimal:')) {
+                            $decimals = (int) explode(':', $type, 2)[1];
+                            return $model->asDecimal($value, $decimals);
+                        }
+                        return $value;
+                }
+            }
+        };
+    }
+
+    /**
+     * Specify the target column, JSON path, and optional type for the cast.
+     *
+     * @param  string  $targetColumn
+     * @param  string  $jsonPath
+     * @param  string|null  $type
+     * @return string
+     */
+    public static function using($targetColumn, $jsonPath, $type = null)
+    {
+        $arguments = [$targetColumn, $jsonPath];
+
+        if ($type !== null) {
+            $arguments[] = $type;
+        }
+
+        return static::class.':'.implode(',', $arguments);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
@@ -18,7 +18,6 @@ class AsJsonPath implements Castable
         {
             public function __construct(protected array $arguments)
             {
-
             }
 
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
@@ -16,7 +16,10 @@ class AsJsonPath implements Castable
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments) {}
+            public function __construct(protected array $arguments)
+            {
+
+            }
 
             public function get($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsJsonPath.php
@@ -10,16 +10,13 @@ class AsJsonPath implements Castable
     /**
      * Get the caster class to use when casting from / to this cast target.
      *
-     * @param  array  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<mixed, mixed>
      */
     public static function castUsing(array $arguments)
     {
         return new class($arguments) implements CastsAttributes
         {
-            public function __construct(protected array $arguments)
-            {
-            }
+            public function __construct(protected array $arguments) {}
 
             public function get($model, $key, $value, $attributes)
             {
@@ -35,6 +32,7 @@ class AsJsonPath implements Castable
                     if ($type) {
                         return $this->castValue($model, $key, $attributes[$key], $type);
                     }
+
                     return $attributes[$key];
                 }
 
@@ -114,8 +112,10 @@ class AsJsonPath implements Castable
                     default:
                         if (str_starts_with($castType, 'decimal:')) {
                             $decimals = (int) explode(':', $type, 2)[1];
+
                             return $model->asDecimal($value, $decimals);
                         }
+
                         return $value;
                 }
             }
@@ -130,7 +130,7 @@ class AsJsonPath implements Castable
      * @param  string|null  $type
      * @return string
      */
-    public static function using($targetColumn, $jsonPath, $type = null)
+    public static function using($targetColumn, $jsonPath, $type = null): string
     {
         $arguments = [$targetColumn, $jsonPath];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2486,5 +2486,4 @@ trait HasAttributes
             return false;
         })->map->name->values()->all();
     }
-
 }

--- a/tests/Database/DatabaseEloquentVirtualJsonCastTest.php
+++ b/tests/Database/DatabaseEloquentVirtualJsonCastTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\AsJsonPath;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
@@ -316,29 +317,16 @@ class VirtualCastTestModel extends Model
     protected $table = 'test_models';
     protected $guarded = [];
 
-    protected function virtualJsonAttributes(): array
-    {
-        return [
-            'meta->settings->volume' => 'volume',
-            'meta->settings->title' => 'title',
-            'meta->settings->enabled' => 'enabled',
-            'meta->settings->rating' => 'rating',
-            'meta->settings->tags' => 'tags',
-            'options->ui->theme->color' => 'color',
-            'options->ui->theme->mode' => 'mode',
-        ];
-    }
-
     protected function casts(): array
     {
         return [
-            'volume' => 'integer',
-            'title' => 'string',
-            'enabled' => 'boolean',
-            'rating' => 'float',
-            'tags' => 'array',
-            'color' => 'string',
-            'mode' => 'string',
+            'volume' => AsJsonPath::using('meta', 'settings.volume', 'int'),
+            'title' => AsJsonPath::using('meta', 'settings.title', 'string'),
+            'enabled' => AsJsonPath::using('meta', 'settings.enabled', 'bool'),
+            'rating' => AsJsonPath::using('meta', 'settings.rating', 'float'),
+            'tags' => AsJsonPath::using('meta', 'settings.tags', 'array'),
+            'color' => AsJsonPath::using('options', 'ui.theme.color', 'string'),
+            'mode' => AsJsonPath::using('options', 'ui.theme.mode', 'string'),
         ];
     }
 }
@@ -348,19 +336,11 @@ class AliasingTestModel extends Model
     protected $table = 'test_models';
     protected $guarded = [];
 
-    protected function virtualJsonAttributes(): array
-    {
-        return [
-            'meta->name' => 'meta_name',
-            'meta->organization->name' => 'organization_name',
-        ];
-    }
-
     protected function casts(): array
     {
         return [
-            'meta_name' => 'string',
-            'organization_name' => 'string',
+            'meta_name' => AsJsonPath::using('meta', 'name', 'string'),
+            'organization_name' => AsJsonPath::using('meta', 'organization.name', 'string'),
         ];
     }
 }

--- a/tests/Database/DatabaseEloquentVirtualJsonCastTest.php
+++ b/tests/Database/DatabaseEloquentVirtualJsonCastTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentVirtualJsonCastTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('test_models', function ($table) {
+            $table->increments('id');
+            $table->json('meta')->nullable();
+            $table->json('options')->nullable();
+            $table->integer('volume')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('test_models');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    public function testVirtualCastRetrievesValueFromJsonColumn()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'id' => 1,
+            'meta' => json_encode(['settings' => ['volume' => '75']]),
+        ]);
+
+        $this->assertSame(75, $model->volume);
+        $this->assertIsInt($model->volume);
+    }
+
+    public function testVirtualCastSetsValueInJsonColumn()
+    {
+        $model = new VirtualCastTestModel;
+        $model->volume = 100;
+
+        $this->assertIsString($model->getAttributes()['meta']);
+        $metaData = json_decode($model->getAttributes()['meta'], true);
+        $this->assertSame(100, $metaData['settings']['volume']);
+    }
+
+    public function testVirtualCastSetAndRetrieve()
+    {
+        $model = new VirtualCastTestModel;
+        $model->volume = '50';
+
+        $this->assertSame(50, $model->volume);
+        $this->assertIsInt($model->volume);
+    }
+
+    public function testVirtualCastWorksWithStringType()
+    {
+        $model = new VirtualCastTestModel;
+        $model->title = 'Test Title';
+
+        $this->assertSame('Test Title', $model->title);
+        $this->assertIsString($model->title);
+
+        $metaData = json_decode($model->getAttributes()['meta'], true);
+        $this->assertSame('Test Title', $metaData['settings']['title']);
+    }
+
+    public function testVirtualCastWorksWithBooleanType()
+    {
+        $model = new VirtualCastTestModel;
+        $model->enabled = 1;
+
+        $this->assertTrue($model->enabled);
+        $this->assertIsBool($model->enabled);
+
+        $metaData = json_decode($model->getAttributes()['meta'], true);
+        $this->assertSame(1, $metaData['settings']['enabled']);
+    }
+
+    public function testRealColumnTakesPriorityOverVirtualCast()
+    {
+        $model = new VirtualCastTestModel;
+
+        // Set the real column directly
+        $model->setRawAttributes([
+            'volume' => 200,
+            'meta' => json_encode(['settings' => ['volume' => '75']]),
+        ]);
+
+        // The real column should take priority
+        $this->assertSame(200, $model->volume);
+    }
+
+    public function testRealColumnTakesPriorityWhenSettingValue()
+    {
+        $model = new VirtualCastTestModel;
+
+        // First, set the real column
+        $model->setRawAttributes(['volume' => 150]);
+
+        // Now try to set via attribute
+        $model->volume = 100;
+
+        // It should update the real column, not the JSON
+        $this->assertSame(100, $model->getAttributes()['volume']);
+        $this->assertFalse(isset($model->getAttributes()['meta']));
+    }
+
+    public function testDeepNestedVirtualCast()
+    {
+        $model = new VirtualCastTestModel;
+        $model->color = 'blue';
+
+        $this->assertSame('blue', $model->color);
+        $this->assertIsString($model->color);
+
+        $optionsData = json_decode($model->getAttributes()['options'], true);
+        $this->assertSame('blue', $optionsData['ui']['theme']['color']);
+    }
+
+    public function testDeepNestedVirtualCastRetrieval()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'id' => 1,
+            'options' => json_encode(['ui' => ['theme' => ['color' => 'red', 'mode' => 'dark']]]),
+        ]);
+
+        $this->assertSame('red', $model->color);
+        $this->assertSame('dark', $model->mode);
+    }
+
+    public function testVirtualCastWithNullValue()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'id' => 1,
+            'meta' => null,
+        ]);
+
+        $this->assertNull($model->volume);
+    }
+
+    public function testVirtualCastWithEmptyJson()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'id' => 1,
+            'meta' => json_encode([]),
+        ]);
+
+        $this->assertNull($model->volume);
+    }
+
+    public function testVirtualCastPreservesExistingJsonData()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'meta' => json_encode(['settings' => ['volume' => '30', 'other' => 'value']]),
+        ]);
+
+        $model->volume = 60;
+
+        $metaData = json_decode($model->getAttributes()['meta'], true);
+        $this->assertSame(60, $metaData['settings']['volume']);
+        $this->assertSame('value', $metaData['settings']['other']);
+    }
+
+    public function testVirtualCastWithDatabasePersistence()
+    {
+        VirtualCastTestModel::create([
+            'color' => 'green',
+            'mode' => 'light',
+        ]);
+
+        $model = VirtualCastTestModel::first();
+
+        $this->assertSame('green', $model->color);
+        $this->assertSame('light', $model->mode);
+        $this->assertIsString($model->color);
+        $this->assertIsString($model->mode);
+    }
+
+    public function testVirtualCastUpdatesPersisted()
+    {
+        $model = VirtualCastTestModel::create(['color' => 'yellow']);
+
+        $model->color = 'purple';
+        $model->save();
+
+        $freshModel = VirtualCastTestModel::find($model->id);
+        $this->assertSame('purple', $freshModel->color);
+    }
+
+    public function testMultipleVirtualCastsOnSameJsonColumn()
+    {
+        $model = new VirtualCastTestModel;
+        $model->volume = 70;
+        $model->title = 'Multiple Casts';
+        $model->enabled = true;
+
+        $this->assertSame(70, $model->volume);
+        $this->assertSame('Multiple Casts', $model->title);
+        $this->assertTrue($model->enabled);
+
+        $metaData = json_decode($model->getAttributes()['meta'], true);
+        $this->assertSame(70, $metaData['settings']['volume']);
+        $this->assertSame('Multiple Casts', $metaData['settings']['title']);
+        $this->assertTrue($metaData['settings']['enabled']);
+    }
+
+    public function testVirtualCastWithFloatType()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'meta' => json_encode(['settings' => ['rating' => '4.5']]),
+        ]);
+
+        $this->assertSame(4.5, $model->rating);
+        $this->assertIsFloat($model->rating);
+    }
+
+    public function testVirtualCastIsDirtyDetection()
+    {
+        $model = VirtualCastTestModel::create(['volume' => 50]);
+
+        $this->assertFalse($model->isDirty('meta'));
+
+        $model->volume = 60;
+
+        $this->assertTrue($model->isDirty('meta'));
+    }
+
+    public function testVirtualCastWithArrayType()
+    {
+        $model = new VirtualCastTestModel;
+        $model->setRawAttributes([
+            'meta' => json_encode(['settings' => ['tags' => ['php', 'laravel', 'testing']]]),
+        ]);
+
+        $this->assertIsArray($model->tags);
+        $this->assertSame(['php', 'laravel', 'testing'], $model->tags);
+    }
+}
+
+class VirtualCastTestModel extends Model
+{
+    protected $table = 'test_models';
+    protected $guarded = [];
+
+    protected $casts = [
+        'meta->settings->volume' => 'integer',
+        'meta->settings->title' => 'string',
+        'meta->settings->enabled' => 'boolean',
+        'meta->settings->rating' => 'float',
+        'meta->settings->tags' => 'array',
+        'options->ui->theme->color' => 'string',
+        'options->ui->theme->mode' => 'string',
+    ];
+}


### PR DESCRIPTION
This PR introduces Virtual JSON Casting to Eloquent models. It allows developers to map nested JSON keys directly to model attributes using the $casts array.

Currently, to treat a nested JSON value as a first-class attribute with proper type casting, developers often have to define repetitive accessors and mutators. This PR enables a declarative approach using the familiar -> syntax within the $casts property, consistent with how we query JSON columns in the Query Builder.

Example Usage

Imagine a User model with a JSON meta column. You can now define nested casts directly:

```
class User extends Model
{
    protected $casts = [
        'meta->settings->threshold' => 'integer',
        'meta->notifications->enabled' => 'boolean',
        'meta->last_login_at' => 'datetime',
    ];
}

// Interacting with the model
$user->threshold = "100"; // Automatically cast to (int) and stored in 'meta'
$user->enabled = 1;       // Automatically cast to (bool) and stored in 'meta'

dump($user->threshold); // 100 (int)
dump($user->enabled);   // true (bool)

// The parent JSON column is updated automatically
dump($user->getAttributes()['meta']); // '{"settings":{"threshold":100},"notifications":{"enabled":true}}'
```