### PR TITLE
[12.x] Add assertions for "Content Too Large" & "URI Too Long"

### DIFF
--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -212,6 +212,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 414 "URI Too Long" status code.
+     *
+     * @return $this
+     */
+    public function assertUriTooLong()
+    {
+        return $this->assertStatus(414);
+    }
+
+    /**
      * Assert that the response has a 415 "Unsupported Media Type" status code.
      *
      * @return $this

--- a/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
+++ b/src/Illuminate/Testing/Concerns/AssertsStatusCodes.php
@@ -202,6 +202,16 @@ trait AssertsStatusCodes
     }
 
     /**
+     * Assert that the response has a 413 "Content Too Large" status code.
+     *
+     * @return $this
+     */
+    public function assertContentTooLarge()
+    {
+        return $this->assertStatus(413);
+    }
+
+    /**
      * Assert that the response has a 415 "Unsupported Media Type" status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1051,6 +1051,24 @@ class TestResponseTest extends TestCase
         $response->assertContentTooLarge();
     }
 
+    public function testAssertUriTooLong(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_REQUEST_URI_TOO_LONG)
+        );
+
+        $response->assertUriTooLong();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [414] but received 200.\nFailed asserting that 200 is identical to 414.");
+
+        $response->assertUriTooLong();
+    }
+
     public function testAssertTooManyRequests(): void
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1033,6 +1033,24 @@ class TestResponseTest extends TestCase
         $response->assertGone();
     }
 
+    public function testAssertContentTooLarge(): void
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_REQUEST_ENTITY_TOO_LARGE)
+        );
+
+        $response->assertContentTooLarge();
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setStatusCode(Response::HTTP_OK)
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Expected response status code [413] but received 200.\nFailed asserting that 200 is identical to 413.");
+
+        $response->assertContentTooLarge();
+    }
+
     public function testAssertTooManyRequests(): void
     {
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
Adds assertions for [413 Content Too Large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/413) and [414 URI Too Long](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/414).

Maintains consistency with the other status assertions.
