### PR TITLE
[12.x] Add CommandFailed event and listenForFailures() for Redis connections

### DIFF
--- a/src/Illuminate/Redis/Events/CommandFailed.php
+++ b/src/Illuminate/Redis/Events/CommandFailed.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Redis\Events;
+
+use Throwable;
+
+class CommandFailed
+{
+    /**
+     * The Redis command that failed.
+     *
+     * @var string
+     */
+    public $command;
+
+    /**
+     * The array of command parameters.
+     *
+     * @var array
+     */
+    public $parameters;
+
+    /**
+     * The exception that was thrown.
+     *
+     * @var \Throwable
+     */
+    public $exception;
+
+    /**
+     * The Redis connection instance.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    public $connection;
+
+    /**
+     * The Redis connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $command
+     * @param  array  $parameters
+     * @param  \Throwable  $exception
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     */
+    public function __construct($command, $parameters, Throwable $exception, $connection)
+    {
+        $this->command = $command;
+        $this->parameters = $parameters;
+        $this->exception = $exception;
+        $this->connection = $connection;
+        $this->connectionName = $connection->getName();
+    }
+}
+

--- a/tests/Redis/RedisEventsTest.php
+++ b/tests/Redis/RedisEventsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Exception;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Redis\Events\CommandExecuted;
+use Illuminate\Redis\Events\CommandFailed;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Redis;
+
+class RedisEventsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCommandFailedEventIsDispatched()
+    {
+        $exception = new Exception('Test exception');
+
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->with('key')->andThrow($exception);
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($exception) {
+            return $event instanceof CommandFailed
+                && $event->command === 'get'
+                && $event->parameters === ['key']
+                && $event->exception === $exception;
+        }));
+
+        $connection = new PhpRedisConnection($client);
+        $connection->setEventDispatcher($events);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $connection->command('get', ['key']);
+    }
+
+    public function testCommandExecutedEventIsNotDispatchedWhenCommandFails()
+    {
+        $exception = new Exception('Test exception');
+
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->with('key')->andThrow($exception);
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(CommandFailed::class));
+        $events->shouldNotReceive('dispatch')->with(m::type(CommandExecuted::class));
+
+        $connection = new PhpRedisConnection($client);
+        $connection->setEventDispatcher($events);
+
+        try {
+            $connection->command('get', ['key']);
+        } catch (Exception $e) {
+            // Expected exception
+        }
+    }
+
+    public function testCommandFailedEventContainsConnectionName()
+    {
+        $exception = new Exception('Test exception');
+
+        $client = m::mock(Redis::class);
+        $client->shouldReceive('get')->with('key')->andThrow($exception);
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
+            return $event instanceof CommandFailed
+                && $event->connectionName === 'test-connection';
+        }));
+
+        $connection = new PhpRedisConnection($client);
+        $connection->setName('test-connection');
+        $connection->setEventDispatcher($events);
+
+        try {
+            $connection->command('get', ['key']);
+        } catch (Exception $e) {
+            // Expected exception
+        }
+    }
+
+    public function testListenForFailuresRegistersCallback()
+    {
+        $client = m::mock(Redis::class);
+
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('listen')->once()->with(CommandFailed::class, m::type('Closure'));
+
+        $connection = new PhpRedisConnection($client);
+        $connection->setEventDispatcher($events);
+
+        $connection->listenForFailures(function () {
+            // callback
+        });
+    }
+}
+


### PR DESCRIPTION
This PR adds a `CommandFailed` event and `listenForFailures()` method to Redis connections, providing observability for failed Redis commands.

## Motivation

Currently, Laravel's Redis implementation dispatches `CommandExecuted` events for successful commands, but there's no clean way to monitor failed commands without wrapping every Redis call in try/catch blocks. The database layer has similar observability patterns, and Redis should follow suit.

## Changes

- Added `CommandFailed` event class with command, parameters, exception, connection, and connectionName properties
- Added `listenForFailures()` method to `Connection` class
- Dispatch `CommandFailed` event when a Redis command throws an exception (before re-throwing)

## Usage Example

```php
use Illuminate\Redis\Events\CommandFailed;
use Illuminate\Support\Facades\Redis;

// Register a failure listener
Redis::connection()->listenForFailures(function (CommandFailed $event) {
    Log::error('Redis command failed', [
        'connection' => $event->connectionName,
        'command' => $event->command,
        'parameters' => $event->parameters,
        'exception' => $event->exception->getMessage(),
    ]);
    
    // Send to monitoring service
    Metrics::increment('redis.failures', ['command' => $event->command]);
});
