### PR TITLE
[12.x] Feat(`MustVerifyEmail`): add `markEmailAsNotVerified()`

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -29,6 +29,19 @@ trait MustVerifyEmail
     }
 
     /**
+     * Mark the given user's email as not verified.
+     *
+     * @return bool
+     */
+    public function markEmailAsNotVerified()
+    {
+        return $this->forceFill([
+            'email_verified_at' => null,
+        ])->save();
+    }
+
+
+    /**
      * Send the email verification notification.
      *
      * @return void

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -40,7 +40,6 @@ trait MustVerifyEmail
         ])->save();
     }
 
-
     /**
      * Send the email verification notification.
      *

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -17,7 +17,7 @@ trait MustVerifyEmail
     }
 
     /**
-     * Mark the given user's email as verified.
+     * Mark the user's email as verified.
      *
      * @return bool
      */
@@ -29,11 +29,11 @@ trait MustVerifyEmail
     }
 
     /**
-     * Mark the given user's email as not verified.
+     * Mark the user's email as unverified.
      *
      * @return bool
      */
-    public function markEmailAsNotVerified()
+    public function markEmailAsUnverified()
     {
         return $this->forceFill([
             'email_verified_at' => null,


### PR DESCRIPTION
This method complements `markEmailAsVerified()` and provides a clean and explicit API for resetting email verification status, which is commonly needed when users update their email address, during administrative actions, or in automated tests.