### PR TITLE
[12.x] Fix: Change BackedEnum to UnitEnum in Authorizable trait

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -9,7 +9,7 @@ trait Authorizable
     /**
      * Determine if the entity has the given abilities.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  mixed  $arguments
      * @return bool
      */
@@ -21,7 +21,7 @@ trait Authorizable
     /**
      * Determine if the entity has any of the given abilities.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  mixed  $arguments
      * @return bool
      */
@@ -33,7 +33,7 @@ trait Authorizable
     /**
      * Determine if the entity does not have the given abilities.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  mixed  $arguments
      * @return bool
      */
@@ -45,7 +45,7 @@ trait Authorizable
     /**
      * Determine if the entity does not have the given abilities.
      *
-     * @param  iterable|\BackedEnum|string  $abilities
+     * @param  iterable|\UnitEnum|string  $abilities
      * @param  mixed  $arguments
      * @return bool
      */


### PR DESCRIPTION
The [Gate class](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Contracts/Auth/Access/Gate.php)  uses UnitEnum to describe the `$abilities` argument, but the [Authorizable trait](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Auth/Access/Authorizable.php), which calls Gate methods, defines $abilities as BackedEnum.

This PR standardizes the type across both.
