### PR TITLE
[12.x] Feat: add `havingNotBetween()` && `orHavingBetween()` && `orHavingNotBetween()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2643,6 +2643,43 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "having not between" clause to the query.
+     *
+     * @param  string  $column
+     * @param  iterable  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function havingNotBetween($column, iterable $values, $boolean = 'and')
+    {
+        return $this->havingBetween($column, $values, $boolean, true);
+    }
+
+    /**
+     * Add an "or having between" clause to the query.
+     *
+     * @param  string  $column
+     * @param  iterable  $values
+     * @return $this
+     */
+    public function orHavingBetween($column, iterable $values)
+    {
+        return $this->havingBetween($column, $values, 'or');
+    }
+
+    /**
+     * Add an "or having not between" clause to the query.
+     *
+     * @param  string  $column
+     * @param  iterable  $values
+     * @return $this
+     */
+    public function orHavingNotBetween($column, iterable $values)
+    {
+        return $this->havingBetween($column, $values, 'or', true);
+    }
+
+    /**
      * Add a raw having clause to the query.
      *
      * @param  string  $sql


### PR DESCRIPTION
Add havingBetween variants (NOT / OR)

In this PR, missing HAVING BETWEEN variants were added to the query builder to align with Laravel’s existing `whereBetween` API.

Added methods

`havingNotBetween`

`orHavingBetween`

`orHavingNotBetween`

 Implementation details

All methods delegate to `havingBetween` to avoid logic duplication

Boolean (and / or) and negation (not) are handled consistently

Fully compatible with existing bindings and grammar compilation

 Result

Improves query builder completeness and provides a more expressive and consistent HAVING API.