### PR TITLE
Add allowed_classes => false to session unserialize for security

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -118,7 +118,7 @@ class Store implements Session
             if ($this->serialization === 'json') {
                 $data = json_decode($this->prepareForUnserialize($data), true);
             } else {
-                $data = @unserialize($this->prepareForUnserialize($data));
+                $data = @unserialize($this->prepareForUnserialize($data), ['allowed_classes' => false]);
             }
 
             if ($data !== false && is_array($data)) {

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -672,6 +672,21 @@ class SessionStoreTest extends TestCase
         $this->assertSame('macroable', $this->getSession()->foo());
     }
 
+    public function testUnserializeWithAllowedClassesFalsePreventsObjectInjection()
+    {
+        $session = $this->getSession();
+
+        $maliciousPayload = serialize(['foo' => 'bar', 'object' => new \stdClass]);
+
+        $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn($maliciousPayload);
+        $session->start();
+
+        $this->assertSame('bar', $session->get('foo'));
+
+        $object = $session->get('object');
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $object);
+    }
+
     public function getSession($serialization = 'php')
     {
         $reflection = new ReflectionClass(Store::class);


### PR DESCRIPTION
**Summary**
This PR adds `allowed_classes => false` to the `unserialize()` call in `Session\Store::readFromHandler()` to prevent PHP Object Injection attacks.

**Motivation:**
Session data is expected to contain only arrays and scalar values. By setting `allowed_classes => false`, any serialized objects in session data will be converted to `__PHP_Incomplete_Class`, preventing potential gadget chain exploitation.

**Changes:**
- Added `['allowed_classes' => false]` parameter to `unserialize()` in `Session/Store.php`
- Added test to verify object injection prevention

**Backward Compatibility:**
This change is backward compatible for the vast majority of applications since:
1. Session data should only contain arrays/scalars by design
2. Existing scalar and array data continues to work normally
3. Applications storing objects in sessions (rare edge case) will see objects as `__PHP_Incomplete_Class`