### PR TITLE
Add JSON serialization option for file and database cache stores

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -50,12 +50,14 @@ return [
             'table' => env('DB_CACHE_TABLE', 'cache'),
             'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),
             'lock_table' => env('DB_CACHE_LOCK_TABLE'),
+            'serialization' => env('CACHE_SERIALIZATION', 'php'),
         ],
 
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
             'lock_path' => storage_path('framework/cache/data'),
+            'serialization' => env('CACHE_SERIALIZATION', 'php'),
         ],
 
         'memcached' => [

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -194,6 +194,7 @@ class CacheManager implements FactoryContract
             $config['lock_table'] ?? 'cache_locks',
             $config['lock_lottery'] ?? [2, 100],
             $config['lock_timeout'] ?? 86400,
+            $config['serialization'] ?? 'php',
         );
 
         return $this->repository(
@@ -277,7 +278,7 @@ class CacheManager implements FactoryContract
     protected function createFileDriver(array $config)
     {
         return $this->repository(
-            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null))
+            (new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null, $config['serialization'] ?? 'php'))
                 ->setLockDirectory($config['lock_path'] ?? null),
             $config
         );

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -49,7 +49,7 @@ class FileStore implements Store, LockProvider
      */
     protected $serialization = 'php';
 
-    ص    /**
+    /**
      * Create a new file cache store instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -228,8 +228,8 @@ class FileStore implements Store, LockProvider
         $this->ensureCacheDirectoryExists($this->lockDirectory ?? $this->directory);
 
         return new FileLock(
-            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission),
-            "file-store-lock:{$name}",
+            new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission, $this->serialization),
+            $name,
             $seconds,
             $owner
         );

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -229,7 +229,7 @@ class FileStore implements Store, LockProvider
 
         return new FileLock(
             new static($this->files, $this->lockDirectory ?? $this->directory, $this->filePermission, $this->serialization),
-            $name,
+            "file-store-lock:{$name}",
             $seconds,
             $owner
         );


### PR DESCRIPTION
**Summary**
This PR adds JSON serialization support for file and database cache stores, similar to what's already available for sessions.

**Motivation:**
Using JSON serialization instead of PHP `serialize()` provides:
- **Security**: JSON cannot deserialize PHP objects, preventing PHP Object Injection attacks
- **Interoperability**: JSON cached data can be read by other languages/services
- **Debugging**: JSON is human-readable and easier to debug

**Changes:**
- Added `serialization` option to `FileStore` and `DatabaseStore` constructors
- Added `setSerialization()` method for runtime configuration
- Updated `CacheManager` to pass serialization config to stores
- Added `serialization` option to `config/cache.php` for file and database stores
- Default remains `'php'` for backward compatibility

**Usage:**

// config/cache.php
```php
'file' => [
    'driver' => 'file',
    'path' => storage_path('framework/cache/data'),
    'serialization' => 'json', // or 'php' (default)
],
```
```php
// or via environment variable
CACHE_SERIALIZATION=json 
```

This change is fully backward compatible:
- Default serialization remains `'php'`
- Existing cached data continues to work
- All existing tests pass