### PR TITLE
[12.x] Add --readable flag to env:encrypt for visible key names

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -93,30 +93,6 @@ class Encrypter implements EncrypterContract, StringEncrypter
     }
 
     /**
-     * Determine if the given value appears to be encrypted.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    public static function encrypted($value)
-    {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        $decoded = base64_decode($value, true);
-
-        if ($decoded === false) {
-            return false;
-        }
-
-        $payload = json_decode($decoded, true);
-
-        return is_array($payload)
-            && isset($payload['iv'], $payload['value'], $payload['mac']);
-    }
-
-    /**
      * Encrypt the given value.
      *
      * @param  mixed  $value
@@ -348,6 +324,30 @@ class Encrypter implements EncrypterContract, StringEncrypter
     protected function shouldValidateMac()
     {
         return ! self::$supportedCiphers[strtolower($this->cipher)]['aead'];
+    }
+
+    /**
+     * Determine if the given value appears to be encrypted by this encrypter.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function appearsEncrypted($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        $payload = json_decode($decoded, true);
+
+        return is_array($payload)
+            && isset($payload['iv'], $payload['value'], $payload['mac']);
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -93,6 +93,30 @@ class Encrypter implements EncrypterContract, StringEncrypter
     }
 
     /**
+     * Determine if the given value appears to be encrypted.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function encrypted($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        $payload = json_decode($decoded, true);
+
+        return is_array($payload)
+            && isset($payload['iv'], $payload['value'], $payload['mac']);
+    }
+
+    /**
      * Encrypt the given value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -153,18 +153,7 @@ class EnvironmentDecryptCommand extends Command
      */
     protected function isReadableFormat(string $contents): bool
     {
-        // Check if content is blob format (base64-encoded JSON with iv, value, mac keys)
-        $decoded = base64_decode($contents, true);
-
-        if ($decoded !== false) {
-            $payload = json_decode($decoded, true);
-
-            if (is_array($payload) && isset($payload['iv'], $payload['value'])) {
-                return false;
-            }
-        }
-
-        return true;
+        return ! Encrypter::encrypted($contents);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -168,5 +168,4 @@ class EnvironmentEncryptCommand extends Command
 
         return $result;
     }
-
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -25,7 +25,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
-                    {--readable : Encrypt in a readable format with plain-text variable names}
+                    {--readable : Encrypt each variable individually with readable, plain-text variable names}
                     {--prune : Delete the original environment file}
                     {--force : Overwrite the existing encrypted environment file}';
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Dotenv\Parser\Lines;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
@@ -151,145 +152,21 @@ class EnvironmentEncryptCommand extends Command
      */
     protected function encryptReadableFormat(string $contents, Encrypter $encrypter): string
     {
-        $lines = preg_split('/\r\n|\r|\n/', $contents);
-        $result = [];
-        $multilineBuffer = null;
-        $multilineKey = null;
+        $result = '';
 
-        foreach ($lines as $line) {
-            // Handle multiline continuation
-            if ($multilineBuffer !== null) {
-                $multilineBuffer .= "\n".$line;
+        foreach (Lines::process(preg_split('/\r\n|\r|\n/', $contents)) as $entry) {
+            $pos = strpos($entry, '=');
 
-                if ($this->isMultilineEnd($line)) {
-                    $result[] = $multilineKey.'='.$encrypter->encryptString($multilineBuffer);
-                    $multilineBuffer = null;
-                    $multilineKey = null;
-                }
-
+            if ($pos === false) {
                 continue;
             }
 
-            // Preserve blank lines
-            if (trim($line) === '') {
-                $result[] = '';
-                continue;
-            }
-
-            // Handle comments - encrypt with #: prefix
-            if ($this->isComment($line)) {
-                $result[] = '#:'.$encrypter->encryptString($line);
-                continue;
-            }
-
-            // Parse variable line
-            $parsed = $this->parseEnvLine($line);
-
-            if ($parsed === null) {
-                // Invalid line - encrypt as comment
-                $result[] = '#:'.$encrypter->encryptString($line);
-                continue;
-            }
-
-            [$key, $value, $isMultilineStart] = $parsed;
-
-            if ($isMultilineStart) {
-                $multilineBuffer = $value;
-                $multilineKey = $key;
-                continue;
-            }
-
-            $result[] = $key.'='.$encrypter->encryptString($value);
+            $name = substr($entry, 0, $pos);
+            $value = substr($entry, $pos + 1);
+            $result .= $name.'='.$encrypter->encryptString($value)."\n";
         }
 
-        // Handle unterminated multiline (edge case)
-        if ($multilineBuffer !== null) {
-            $result[] = $multilineKey.'='.$encrypter->encryptString($multilineBuffer);
-        }
-
-        return implode("\n", $result);
+        return $result;
     }
 
-    /**
-     * Determine if a line is a comment.
-     *
-     * @param  string  $line
-     * @return bool
-     */
-    protected function isComment(string $line): bool
-    {
-        $trimmed = ltrim($line);
-
-        return str_starts_with($trimmed, '#');
-    }
-
-    /**
-     * Parse an environment variable line.
-     *
-     * Returns [key, value, isMultilineStart] or null if invalid.
-     *
-     * @param  string  $line
-     * @return array|null
-     */
-    protected function parseEnvLine(string $line): ?array
-    {
-        // Handle export prefix
-        $line = preg_replace('/^export\s+/', '', ltrim($line));
-
-        // Find the = separator
-        $pos = strpos($line, '=');
-
-        if ($pos === false) {
-            return null;
-        }
-
-        $key = substr($line, 0, $pos);
-        $value = substr($line, $pos + 1);
-
-        // Validate key (alphanumeric, underscore, starts with letter or underscore)
-        if (! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $key)) {
-            return null;
-        }
-
-        // Check for multiline start (value starts with " but doesn't end with ")
-        $isMultilineStart = $this->isMultilineStart($value);
-
-        return [$key, $value, $isMultilineStart];
-    }
-
-    /**
-     * Determine if a value starts a multiline string.
-     *
-     * @param  string  $value
-     * @return bool
-     */
-    protected function isMultilineStart(string $value): bool
-    {
-        $trimmed = ltrim($value);
-
-        if (! str_starts_with($trimmed, '"')) {
-            return false;
-        }
-
-        // Count unescaped quotes
-        $unescaped = str_replace('\\\\', '', $trimmed);
-        $unescaped = str_replace('\\"', '', $unescaped);
-
-        return substr_count($unescaped, '"') === 1;
-    }
-
-    /**
-     * Determine if a line ends a multiline string.
-     *
-     * @param  string  $line
-     * @return bool
-     */
-    protected function isMultilineEnd(string $line): bool
-    {
-        $unescaped = str_replace('\\\\', '', $line);
-        $unescaped = str_replace('\\"', '', $unescaped);
-
-        // Line ends with unescaped quote
-        return str_ends_with(rtrim($unescaped), '"');
-    }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -25,7 +25,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
-                    {--readable : Encrypt in readable format with visible keys}
+                    {--readable : Encrypt in a readable format with plain-text variable names}
                     {--prune : Delete the original environment file}
                     {--force : Overwrite the existing encrypted environment file}';
 
@@ -129,21 +129,6 @@ class EnvironmentEncryptCommand extends Command
     }
 
     /**
-     * Parse the encryption key.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function parseKey(string $key)
-    {
-        if (Str::startsWith($key, $prefix = 'base64:')) {
-            $key = base64_decode(Str::after($key, $prefix));
-        }
-
-        return $key;
-    }
-
-    /**
      * Encrypt the environment file in readable format.
      *
      * @param  string  $contents
@@ -163,9 +148,25 @@ class EnvironmentEncryptCommand extends Command
 
             $name = substr($entry, 0, $pos);
             $value = substr($entry, $pos + 1);
+
             $result .= $name.'='.$encrypter->encryptString($value)."\n";
         }
 
         return $result;
+    }
+
+    /**
+     * Parse the encryption key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function parseKey(string $key)
+    {
+        if (Str::startsWith($key, $prefix = 'base64:')) {
+            $key = base64_decode(Str::after($key, $prefix));
+        }
+
+        return $key;
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -269,4 +269,34 @@ class EncrypterTest extends TestCase
         $enc = new Encrypter(str_repeat('x', 16));
         $enc->decrypt(base64_encode(json_encode($payload)));
     }
+
+    public function testEncryptedReturnsTrueForEncryptedValue()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+
+        $this->assertTrue(Encrypter::encrypted($encrypted));
+    }
+
+    public function testEncryptedReturnsTrueForEncryptedArray()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt(['foo' => 'bar']);
+
+        $this->assertTrue(Encrypter::encrypted($encrypted));
+    }
+
+    public function testEncryptedReturnsFalseForPlainText()
+    {
+        $this->assertFalse(Encrypter::encrypted('foo'));
+        $this->assertFalse(Encrypter::encrypted('APP_NAME=Laravel'));
+        $this->assertFalse(Encrypter::encrypted("APP_NAME=Laravel\nAPP_ENV=local"));
+    }
+
+    public function testEncryptedReturnsFalseForNonString()
+    {
+        $this->assertFalse(Encrypter::encrypted(123));
+        $this->assertFalse(Encrypter::encrypted(['foo' => 'bar']));
+        $this->assertFalse(Encrypter::encrypted(null));
+    }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -275,7 +275,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo');
 
-        $this->assertTrue(Encrypter::encrypted($encrypted));
+        $this->assertTrue(Encrypter::appearsEncrypted($encrypted));
     }
 
     public function testEncryptedReturnsTrueForEncryptedArray()
@@ -283,20 +283,20 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt(['foo' => 'bar']);
 
-        $this->assertTrue(Encrypter::encrypted($encrypted));
+        $this->assertTrue(Encrypter::appearsEncrypted($encrypted));
     }
 
     public function testEncryptedReturnsFalseForPlainText()
     {
-        $this->assertFalse(Encrypter::encrypted('foo'));
-        $this->assertFalse(Encrypter::encrypted('APP_NAME=Laravel'));
-        $this->assertFalse(Encrypter::encrypted("APP_NAME=Laravel\nAPP_ENV=local"));
+        $this->assertFalse(Encrypter::appearsEncrypted('foo'));
+        $this->assertFalse(Encrypter::appearsEncrypted('APP_NAME=Laravel'));
+        $this->assertFalse(Encrypter::appearsEncrypted("APP_NAME=Laravel\nAPP_ENV=local"));
     }
 
     public function testEncryptedReturnsFalseForNonString()
     {
-        $this->assertFalse(Encrypter::encrypted(123));
-        $this->assertFalse(Encrypter::encrypted(['foo' => 'bar']));
-        $this->assertFalse(Encrypter::encrypted(null));
+        $this->assertFalse(Encrypter::appearsEncrypted(123));
+        $this->assertFalse(Encrypter::appearsEncrypted(['foo' => 'bar']));
+        $this->assertFalse(Encrypter::appearsEncrypted(null));
     }
 }

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -336,7 +336,6 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->with(base_path('.env'), "APP_NAME=Laravel\nAPP_ENV=local\n");
     }
 
-
     public function testItStillDecryptsBlobFormat(): void
     {
         $key = 'abcdefghijklmnopabcdefghijklmnop';

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -333,63 +333,9 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.env'), "APP_NAME=Laravel\nAPP_ENV=local");
+            ->with(base_path('.env'), "APP_NAME=Laravel\nAPP_ENV=local\n");
     }
 
-    public function testItDecryptsReadableFormatWithBlankLines(): void
-    {
-        $key = 'abcdefghijklmnopabcdefghijklmnop';
-        $encrypter = new Encrypter($key, 'AES-256-CBC');
-
-        // Create readable format with blank line
-        $encryptedContent = 'APP_NAME='.$encrypter->encryptString('Laravel')."\n".
-                           "\n".
-                           'APP_ENV='.$encrypter->encryptString('local');
-
-        $this->filesystem->shouldReceive('exists')
-            ->once()
-            ->andReturn(true)
-            ->shouldReceive('exists')
-            ->once()
-            ->andReturn(false)
-            ->shouldReceive('get')
-            ->once()
-            ->andReturn($encryptedContent);
-
-        $this->artisan('env:decrypt', ['--key' => $key])
-            ->expectsOutputToContain('Environment successfully decrypted.')
-            ->assertExitCode(0);
-
-        $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.env'), "APP_NAME=Laravel\n\nAPP_ENV=local");
-    }
-
-    public function testItDecryptsReadableFormatWithComments(): void
-    {
-        $key = 'abcdefghijklmnopabcdefghijklmnop';
-        $encrypter = new Encrypter($key, 'AES-256-CBC');
-
-        // Create readable format with encrypted comment
-        $encryptedContent = '#:'.$encrypter->encryptString('# This is a comment')."\n".
-                           'APP_NAME='.$encrypter->encryptString('Laravel');
-
-        $this->filesystem->shouldReceive('exists')
-            ->once()
-            ->andReturn(true)
-            ->shouldReceive('exists')
-            ->once()
-            ->andReturn(false)
-            ->shouldReceive('get')
-            ->once()
-            ->andReturn($encryptedContent);
-
-        $this->artisan('env:decrypt', ['--key' => $key])
-            ->expectsOutputToContain('Environment successfully decrypted.')
-            ->assertExitCode(0);
-
-        $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.env'), "# This is a comment\nAPP_NAME=Laravel");
-    }
 
     public function testItStillDecryptsBlobFormat(): void
     {
@@ -418,14 +364,13 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->with(base_path('.env'), $originalContent);
     }
 
-    public function testItDecryptsLinesWithoutEqualsPreservingOriginal(): void
+    public function testItDecryptsReadableFormatWithBase64Values(): void
     {
         $key = 'abcdefghijklmnopabcdefghijklmnop';
         $encrypter = new Encrypter($key, 'AES-256-CBC');
 
-        // Create readable format with a line that was encrypted as comment (no = sign)
-        $encryptedContent = 'APP_NAME='.$encrypter->encryptString('Laravel')."\n".
-                           '#:'.$encrypter->encryptString('MY_ENV_WITHOUT_EQUALS')."\n".
+        // Create readable format with base64 value containing = signs
+        $encryptedContent = 'APP_KEY='.$encrypter->encryptString('base64:Ge+W23u+VZI2tbrp5QCGWrsUuxgcD65i7jtTRR2ZqfY=')."\n".
                            'APP_ENV='.$encrypter->encryptString('local');
 
         $this->filesystem->shouldReceive('exists')
@@ -443,6 +388,6 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with(base_path('.env'), "APP_NAME=Laravel\nMY_ENV_WITHOUT_EQUALS\nAPP_ENV=local");
+            ->with(base_path('.env'), "APP_KEY=base64:Ge+W23u+VZI2tbrp5QCGWrsUuxgcD65i7jtTRR2ZqfY=\nAPP_ENV=local\n");
     }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -180,7 +180,7 @@ class EnvironmentEncryptCommandTest extends TestCase
         $filesystem->shouldReceive('put')
             ->once()
             ->with(base_path('.env.encrypted'), m::on(function ($content) {
-                $lines = explode("\n", $content);
+                $lines = explode("\n", rtrim($content));
 
                 return count($lines) === 2
                     && str_starts_with($lines[0], 'APP_NAME=')
@@ -194,7 +194,7 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function testItPreservesBlankLinesInReadableFormat(): void
+    public function testItSkipsCommentsAndBlankLinesInReadableFormat(): void
     {
         $filesystem = m::mock(Filesystem::class);
         $filesystem->shouldReceive('exists')
@@ -208,81 +208,16 @@ class EnvironmentEncryptCommandTest extends TestCase
         $filesystem->shouldReceive('get')
             ->with(base_path('.env'))
             ->once()
-            ->andReturn("APP_NAME=Laravel\n\nAPP_ENV=local");
+            ->andReturn("# Comment\nAPP_NAME=Laravel\n\nAPP_ENV=local");
         $filesystem->shouldReceive('put')
             ->once()
             ->with(base_path('.env.encrypted'), m::on(function ($content) {
-                $lines = explode("\n", $content);
+                $lines = explode("\n", rtrim($content));
 
-                return count($lines) === 3
-                    && str_starts_with($lines[0], 'APP_NAME=')
-                    && $lines[1] === ''
-                    && str_starts_with($lines[2], 'APP_ENV=');
-            }))
-            ->andReturn(true);
-        File::swap($filesystem);
-
-        $this->artisan('env:encrypt', ['--readable' => true, '--key' => 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
-            ->expectsOutputToContain('Environment successfully encrypted')
-            ->assertExitCode(0);
-    }
-
-    public function testItEncryptsCommentsInReadableFormat(): void
-    {
-        $filesystem = m::mock(Filesystem::class);
-        $filesystem->shouldReceive('exists')
-            ->with(base_path('.env'))
-            ->once()
-            ->andReturn(true);
-        $filesystem->shouldReceive('exists')
-            ->with(base_path('.env.encrypted'))
-            ->once()
-            ->andReturn(false);
-        $filesystem->shouldReceive('get')
-            ->with(base_path('.env'))
-            ->once()
-            ->andReturn("# This is a comment\nAPP_NAME=Laravel");
-        $filesystem->shouldReceive('put')
-            ->once()
-            ->with(base_path('.env.encrypted'), m::on(function ($content) {
-                $lines = explode("\n", $content);
-
+                // Comments and blank lines are skipped
                 return count($lines) === 2
-                    && str_starts_with($lines[0], '#:')
-                    && str_starts_with($lines[1], 'APP_NAME=');
-            }))
-            ->andReturn(true);
-        File::swap($filesystem);
-
-        $this->artisan('env:encrypt', ['--readable' => true, '--key' => 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
-            ->expectsOutputToContain('Environment successfully encrypted')
-            ->assertExitCode(0);
-    }
-
-    public function testItEncryptsLinesWithoutEqualsAsComments(): void
-    {
-        $filesystem = m::mock(Filesystem::class);
-        $filesystem->shouldReceive('exists')
-            ->with(base_path('.env'))
-            ->once()
-            ->andReturn(true);
-        $filesystem->shouldReceive('exists')
-            ->with(base_path('.env.encrypted'))
-            ->once()
-            ->andReturn(false);
-        $filesystem->shouldReceive('get')
-            ->with(base_path('.env'))
-            ->once()
-            ->andReturn("APP_NAME=Laravel\nMY_ENV_WITHOUT_EQUALS\nAPP_ENV=local");
-        $filesystem->shouldReceive('put')
-            ->once()
-            ->with(base_path('.env.encrypted'), m::on(function ($content) {
-                $lines = explode("\n", $content);
-
-                return count($lines) === 3
                     && str_starts_with($lines[0], 'APP_NAME=')
-                    && str_starts_with($lines[1], '#:')  // Line without = encrypted as comment
-                    && str_starts_with($lines[2], 'APP_ENV=');
+                    && str_starts_with($lines[1], 'APP_ENV=');
             }))
             ->andReturn(true);
         File::swap($filesystem);

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -227,6 +227,230 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function testItEncryptsMultiLineValuesInReadableFormat(): void
+    {
+        $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+        $encrypter = new Encrypter($key, 'AES-256-CBC');
+
+        $originalContent = <<<'ENV'
+APP_TEST_1="line1
+line2
+line3"
+APP_TEST_2="línea1
+lìnea2
+lïne3"
+ENV;
+
+        $encryptedOutput = null;
+
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn(true);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env.encrypted'))
+            ->once()
+            ->andReturn(false);
+        $filesystem->shouldReceive('get')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn($originalContent);
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with(base_path('.env.encrypted'), m::on(function ($content) use (&$encryptedOutput) {
+                $encryptedOutput = $content;
+
+                return true;
+            }))
+            ->andReturn(true);
+        File::swap($filesystem);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->assertExitCode(0);
+
+        // Verify structure
+        $lines = explode("\n", rtrim($encryptedOutput));
+        $this->assertCount(2, $lines);
+        $this->assertTrue(str_starts_with($lines[0], 'APP_TEST_1='));
+        $this->assertTrue(str_starts_with($lines[1], 'APP_TEST_2='));
+
+        // Round-trip: decrypt and verify original values
+        $encryptedValue1 = substr($lines[0], strlen('APP_TEST_1='));
+        $encryptedValue2 = substr($lines[1], strlen('APP_TEST_2='));
+
+        // Quotes are preserved, accented characters are preserved
+        $this->assertSame("\"line1\nline2\nline3\"", $encrypter->decryptString($encryptedValue1));
+        $this->assertSame("\"línea1\nlìnea2\nlïne3\"", $encrypter->decryptString($encryptedValue2));
+    }
+
+    public function testItEncryptsVariableReferencesInReadableFormat(): void
+    {
+        $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+        $encrypter = new Encrypter($key, 'AES-256-CBC');
+
+        $originalContent = <<<'ENV'
+APP_TEST_1=${APP_TEST}
+APP_TEST_2="${APP_TEST}"
+ENV;
+
+        $encryptedOutput = null;
+
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn(true);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env.encrypted'))
+            ->once()
+            ->andReturn(false);
+        $filesystem->shouldReceive('get')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn($originalContent);
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with(base_path('.env.encrypted'), m::on(function ($content) use (&$encryptedOutput) {
+                $encryptedOutput = $content;
+
+                return true;
+            }))
+            ->andReturn(true);
+        File::swap($filesystem);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->assertExitCode(0);
+
+        // Verify structure
+        $lines = explode("\n", rtrim($encryptedOutput));
+        $this->assertCount(2, $lines);
+        $this->assertTrue(str_starts_with($lines[0], 'APP_TEST_1='));
+        $this->assertTrue(str_starts_with($lines[1], 'APP_TEST_2='));
+
+        // Round-trip: decrypt and verify values preserve variable reference syntax
+        $encryptedValue1 = substr($lines[0], strlen('APP_TEST_1='));
+        $encryptedValue2 = substr($lines[1], strlen('APP_TEST_2='));
+
+        // Unquoted value preserved as-is, quoted value includes quotes
+        $this->assertSame('${APP_TEST}', $encrypter->decryptString($encryptedValue1));
+        $this->assertSame('"${APP_TEST}"', $encrypter->decryptString($encryptedValue2));
+    }
+
+    public function testItSkipsInvalidEnvLinesInReadableFormat(): void
+    {
+        $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+        $encrypter = new Encrypter($key, 'AES-256-CBC');
+
+        $originalContent = <<<'ENV'
+APP_TEST_1=valid
+APP_TEST_2
+APP_TEST_3=also_valid
+ENV;
+
+        $encryptedOutput = null;
+
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn(true);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env.encrypted'))
+            ->once()
+            ->andReturn(false);
+        $filesystem->shouldReceive('get')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn($originalContent);
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with(base_path('.env.encrypted'), m::on(function ($content) use (&$encryptedOutput) {
+                $encryptedOutput = $content;
+
+                return true;
+            }))
+            ->andReturn(true);
+        File::swap($filesystem);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->assertExitCode(0);
+
+        // Verify structure - invalid line (APP_TEST_2 without =) is skipped
+        $lines = explode("\n", rtrim($encryptedOutput));
+        $this->assertCount(2, $lines);
+        $this->assertTrue(str_starts_with($lines[0], 'APP_TEST_1='));
+        $this->assertTrue(str_starts_with($lines[1], 'APP_TEST_3='));
+
+        // Round-trip: decrypt and verify values
+        $encryptedValue1 = substr($lines[0], strlen('APP_TEST_1='));
+        $encryptedValue3 = substr($lines[1], strlen('APP_TEST_3='));
+
+        $this->assertSame('valid', $encrypter->decryptString($encryptedValue1));
+        $this->assertSame('also_valid', $encrypter->decryptString($encryptedValue3));
+    }
+
+    public function testItEncryptsSpecialCharactersInReadableFormat(): void
+    {
+        $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP';
+        $encrypter = new Encrypter($key, 'AES-256-CBC');
+
+        $originalContent = <<<'ENV'
+NAME_1="Máximus"
+NAME_2=M'aximus
+NAME_3="M'aximus Decimus Meridius"
+ENV;
+
+        $encryptedOutput = null;
+
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn(true);
+        $filesystem->shouldReceive('exists')
+            ->with(base_path('.env.encrypted'))
+            ->once()
+            ->andReturn(false);
+        $filesystem->shouldReceive('get')
+            ->with(base_path('.env'))
+            ->once()
+            ->andReturn($originalContent);
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with(base_path('.env.encrypted'), m::on(function ($content) use (&$encryptedOutput) {
+                $encryptedOutput = $content;
+
+                return true;
+            }))
+            ->andReturn(true);
+        File::swap($filesystem);
+
+        $this->artisan('env:encrypt', ['--readable' => true, '--key' => $key])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->assertExitCode(0);
+
+        // Verify structure
+        $lines = explode("\n", rtrim($encryptedOutput));
+        $this->assertCount(3, $lines);
+        $this->assertTrue(str_starts_with($lines[0], 'NAME_1='));
+        $this->assertTrue(str_starts_with($lines[1], 'NAME_2='));
+        $this->assertTrue(str_starts_with($lines[2], 'NAME_3='));
+
+        // Round-trip: decrypt and verify special characters are preserved
+        $encryptedValue1 = substr($lines[0], strlen('NAME_1='));
+        $encryptedValue2 = substr($lines[1], strlen('NAME_2='));
+        $encryptedValue3 = substr($lines[2], strlen('NAME_3='));
+
+        // Quoted values include the quotes, unquoted values are as-is
+        $this->assertSame('"Máximus"', $encrypter->decryptString($encryptedValue1));
+        $this->assertSame("M'aximus", $encrypter->decryptString($encryptedValue2));
+        $this->assertSame("\"M'aximus Decimus Meridius\"", $encrypter->decryptString($encryptedValue3));
+    }
+
     public function testItCanRemoveTheOriginalFile(): void
     {
         $this->filesystem->shouldReceive('exists')


### PR DESCRIPTION
This adds a new `--readable` flag to the `env:encrypt` command that produces a line-by-line encrypted format where variable names remain visible but values are encrypted. This allows developers to see what environment variables exist without exposing sensitive data, and makes pull requests easier to review since reviewers can see which variables were added, removed, or renamed without needing to decrypt the file.

## Format example:
APP_NAME=eyJpdiI6...
DB_HOST=eyJpdiI6...

## Features:
- Variable names visible, values encrypted as base64 JSON
- Comments skipped (removed)
- Blank lines skipped (removed)
- Multiline values supported
- Auto-detection during decryption (backward compatible)
- Existing blob format continues to work unchanged

## Encrypter changes
- Add static encrypted() method to Encrypter

## Notes
For context, inspired by [Ansible's Vault Multiple Passwords](https://docs.ansible.com/projects/ansible/latest/vault_guide/vault_managing_passwords.html#managing-multiple-passwords-with-vault-ids)