### PR TITLE
Add type guard for ChainedBatch/Queueable chained property before array_shift

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -118,7 +118,7 @@ class ChainedBatch implements ShouldQueue
      */
     protected function attachRemainderOfChainToEndOfBatch(PendingBatch $batch)
     {
-        if (! empty($this->chained)) {
+        if (is_array($this->chained) && ! empty($this->chained)) {
             $next = unserialize(array_shift($this->chained));
 
             $next->chained = $this->chained;

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -322,7 +322,7 @@ trait Queueable
      */
     public function dispatchNextJobInChain()
     {
-        if (! empty($this->chained)) {
+        if (is_array($this->chained) && ! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
                 $next->chained = $this->chained;
 


### PR DESCRIPTION
## Summary

Adds `is_array()` type guard before `array_shift()` on the `$chained` property in:
- `Queueable::dispatchNextJobInChain()`
- `ChainedBatch::attachRemainderOfChainToEndOfBatch()`

## Problem

The `$chained` property is typed as `array` but is public and can become corrupted during serialization/deserialization cycles—particularly with certain Redis queue driver configurations. When this happens, `array_shift()` throws a `TypeError`.

```
Job 'ChainedBatch' on queue 'default' failed on attempt 10 of not set due to TypeError: 'array_shift(): Argument #1 ($array) must be of type array, int given' in vendor/laravel/framework/src/Illuminate/Bus/ChainedBatch.php:122
````

It does not happen very often, and I dont have been able to make it reproducible. 
But it happens for us in production once in a while for 1+ year.  

So my thinking is that as it already checks for empty() it should be safe to also make sure its array as the code below depends on it.

## Solution

```php
// Before
if (! empty($this->chained)) {

// After  
if (is_array($this->chained) && ! empty($this->chained)) {
```

This defensive check:
- Preserves existing behavior for valid arrays
- Prevents `TypeError` crashes on corrupted job data
- Treats non-array values as empty chains (safe default)