### PR TITLE
[12.x] Add `doesntHaveArgument` and `doesntHaveOption` helpers to console commands

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -68,6 +68,17 @@ trait InteractsWithIO
     }
 
     /**
+     * Determine if the given argument is not present.
+     *
+     * @param  string|int  $name
+     * @return bool
+     */
+    public function doesntHaveArgument($name)
+    {
+        return ! $this->input->hasArgument($name);
+    }
+
+    /**
      * Get the value of a command argument.
      *
      * @param  string|null  $key
@@ -101,6 +112,17 @@ trait InteractsWithIO
     public function hasOption($name)
     {
         return $this->input->hasOption($name);
+    }
+
+    /**
+     * Determine whether the option is not defined in the command signature.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function doesntHaveOption($name)
+    {
+        return ! $this->input->hasOption($name);
     }
 
     /**


### PR DESCRIPTION
This PR adds `doesntHaveArgument` and `doesntHaveOption` helper methods to the `InteractsWithIO` trait.

They improve readability and intent, especially in negative conditions, and are consistent with existing Laravel conventions in other parts of the framework.
