### PR TITLE
[12.x] Clean up `Builder` docblocks

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -351,7 +351,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw from clause to the query.
+     * Add a raw "from" clause to the query.
      *
      * @param  string  $expression
      * @param  mixed  $bindings
@@ -534,7 +534,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a join clause to the query.
+     * Add a "join" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $first
@@ -589,7 +589,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a subquery join clause to the query.
+     * Add a "subquery join" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
      * @param  string  $as
@@ -614,7 +614,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a lateral join clause to the query.
+     * Add a "lateral join" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|string  $query
      * @return $this
@@ -770,7 +770,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get a new join clause.
+     * Get a new "join" clause.
      *
      * @param  string  $type
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
@@ -782,7 +782,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get a new join lateral clause.
+     * Get a new "join lateral" clause.
      *
      * @param  string  $type
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
@@ -794,7 +794,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Merge an array of where clauses and bindings.
+     * Merge an array of "where" clauses and bindings.
      *
      * @param  array  $wheres
      * @param  array  $bindings
@@ -812,7 +812,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a basic where clause to the query.
+     * Add a basic "where" clause to the query.
      *
      * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
@@ -918,7 +918,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an array of where clauses to the query.
+     * Add an array of "where" clauses to the query.
      *
      * @param  array  $column
      * @param  string  $boolean
@@ -1099,7 +1099,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw where clause to the query.
+     * Add a raw "where" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $sql
      * @param  mixed  $bindings
@@ -1116,7 +1116,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw or where clause to the query.
+     * Add a raw "or where" clause to the query.
      *
      * @param  string  $sql
      * @param  mixed  $bindings
@@ -1382,7 +1382,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where between statement to the query.
+     * Add a "where between" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $boolean
@@ -1405,7 +1405,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where between statement using columns to the query.
+     * Add a "where between" statement using columns to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $boolean
@@ -1422,7 +1422,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where between statement to the query.
+     * Add an "or where between" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
@@ -1433,7 +1433,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where between statement using columns to the query.
+     * Add an "or where between" statement using columns to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
@@ -1444,7 +1444,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not between statement to the query.
+     * Add a "where not between" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $boolean
@@ -1456,7 +1456,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not between statement using columns to the query.
+     * Add a "where not between" statement using columns to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @param  string  $boolean
@@ -1468,7 +1468,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where not between statement to the query.
+     * Add an "or where not between" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
@@ -1479,7 +1479,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where not between statement using columns to the query.
+     * Add an "or where not between" statement using columns to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
      * @return $this
@@ -1490,7 +1490,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where between columns statement using a value to the query.
+     * Add a "where between columns" statement using a value to the query.
      *
      * @param  mixed  $value
      * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
@@ -1510,7 +1510,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where between columns statement using a value to the query.
+     * Add an "or where between columns" statement using a value to the query.
      *
      * @param  mixed  $value
      * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
@@ -1522,7 +1522,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not between columns statement using a value to the query.
+     * Add a "where not between columns" statement using a value to the query.
      *
      * @param  mixed  $value
      * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
@@ -1535,7 +1535,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or where not between columns statement using a value to the query.
+     * Add an "or where not between columns" statement using a value to the query.
      *
      * @param  mixed  $value
      * @param  array{\Illuminate\Contracts\Database\Query\Expression|string, \Illuminate\Contracts\Database\Query\Expression|string}  $columns
@@ -1827,7 +1827,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a nested where statement to the query.
+     * Add a nested "where" statement to the query.
      *
      * @param  string  $boolean
      * @return $this
@@ -1901,7 +1901,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an exists clause to the query.
+     * Add an "exists" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $callback
      * @param  string  $boolean
@@ -1925,7 +1925,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an or exists clause to the query.
+     * Add an "or where exists" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $callback
      * @param  bool  $not
@@ -1937,7 +1937,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not exists clause to the query.
+     * Add a "where not exists" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $callback
      * @param  string  $boolean
@@ -1949,7 +1949,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not exists clause to the query.
+     * Add an "or where not exists" clause to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $callback
      * @return $this
@@ -1960,7 +1960,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an exists clause to the query.
+     * Add an "exists" clause to the query.
      *
      * @param  string  $boolean
      * @param  bool  $not
@@ -2279,7 +2279,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a single dynamic where clause statement to the query.
+     * Add a single dynamic "where" clause statement to the query.
      *
      * @param  string  $segment
      * @param  string  $connector
@@ -2319,7 +2319,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "or where fulltext" clause to the query.
+     * Add an "or where fulltext" clause to the query.
      *
      * @param  string|string[]  $columns
      * @param  string  $value
@@ -2450,7 +2450,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw groupBy clause to the query.
+     * Add a raw "groupBy" clause to the query.
      *
      * @param  string  $sql
      * @return $this
@@ -2534,7 +2534,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a nested having statement to the query.
+     * Add a nested "having" statement to the query.
      *
      * @param  string  $boolean
      * @return $this
@@ -2620,7 +2620,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "having between " clause to the query.
+     * Add a "having between" clause to the query.
      *
      * @param  string  $column
      * @param  string  $boolean
@@ -2680,7 +2680,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw having clause to the query.
+     * Add a raw "having" clause to the query.
      *
      * @param  string  $sql
      * @param  string  $boolean
@@ -2698,7 +2698,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a raw or having clause to the query.
+     * Add a raw "or having" clause to the query.
      *
      * @param  string  $sql
      * @return $this
@@ -2976,7 +2976,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a union statement to the query.
+     * Add a "union" statement to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $query
      * @param  bool  $all
@@ -2996,7 +2996,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a union all statement to the query.
+     * Add a "union all" statement to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>  $query
      * @return $this
@@ -4151,7 +4151,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Run a truncate statement on the table.
+     * Run a "truncate" statement on the table.
      *
      * @return void
      */


### PR DESCRIPTION
Cleans up formatting inconsistencies in `Illuminate\Database\Query\Builder` docblocks, 
including:

- Adding suitable quotation marks where needed, like in other parts
- Removing extra space
- Replacing `a` with `an` where appropriate
- Correcting method names