### PR TITLE
feat: add --for option to queue:pause command for configurable pause …

### DIFF
--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -38,7 +38,13 @@ class PauseCommand extends Command
 
         $manager->pauseFor($connection, $queue, $this->option('for'));
 
-        $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused.");
+        $suffix = '';
+
+        if ($for = $this->option('for')) {
+            $suffix = " for {$for} seconds";
+        }
+
+        $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused {$suffix}.");
 
         return 0;
     }

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Illuminate\Queue\Console\Concerns\ParsesQueue;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'queue:pause')]
@@ -41,7 +42,7 @@ class PauseCommand extends Command
         $suffix = '';
 
         if ($for = $this->option('for')) {
-            $suffix = " for {$for} seconds";
+            $suffix = ' for '.Str::plural('second', $for, true);
         }
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused{$suffix}.");

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -17,7 +17,8 @@ class PauseCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:pause {queue : The name of the queue to pause}';
+    protected $signature = 'queue:pause {queue : The name of the queue to pause}
+                                    {--for= : The number of seconds to pause the queue}';
 
     /**
      * The console command description.
@@ -35,7 +36,7 @@ class PauseCommand extends Command
     {
         [$connection, $queue] = $this->parseQueue($this->argument('queue'));
 
-        $manager->pause($connection, $queue);
+        $manager->pauseFor($connection, $queue, $this->option('for'));
 
         $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused.");
 

--- a/src/Illuminate/Queue/Console/PauseCommand.php
+++ b/src/Illuminate/Queue/Console/PauseCommand.php
@@ -44,7 +44,7 @@ class PauseCommand extends Command
             $suffix = " for {$for} seconds";
         }
 
-        $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused {$suffix}.");
+        $this->components->info("Job processing on queue [{$connection}:{$queue}] has been paused{$suffix}.");
 
         return 0;
     }


### PR DESCRIPTION
This pull request updates the `PauseCommand` for Laravel queues to add support for pausing a queue for a specified duration. The command now accepts an optional `--for` parameter to indicate how many seconds the queue should be paused.

**Command signature and behavior changes:**

* Added a `--for` option to the `queue:pause` command, allowing users to specify the number of seconds to pause the queue.
* Updated the command logic to use the new `pauseFor` method on the `QueueManager`, passing the value of the `--for` option.

<img width="674" height="315" alt="image" src="https://github.com/user-attachments/assets/c6adccac-ab31-4b5c-a994-e8eabba6f908" />
