### PR TITLE
[12.x] Add withEncodingOption and withoutEncodingOption methods to JsonResponse

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -135,4 +135,30 @@ class JsonResponse extends BaseJsonResponse
     {
         return (bool) ($this->encodingOptions & $option);
     }
+
+    /**
+     * Add a JSON encoding option.
+     *
+     * @param  int  $option
+     * @return $this
+     */
+    public function withEncodingOption($option)
+    {
+        $this->encodingOptions |= $option;
+
+        return $this->setData($this->getData());
+    }
+
+    /**
+     * Remove a JSON encoding option.
+     *
+     * @param  int  $option
+     * @return $this
+     */
+    public function withoutEncodingOption($option)
+    {
+        $this->encodingOptions &= ~$option;
+
+        return $this->setData($this->getData());
+    }
 }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -108,6 +108,47 @@ class HttpJsonResponseTest extends TestCase
 
         $this->assertSame('bar', $response->getData()->foo);
     }
+
+    public function testHasEncodingOption()
+    {
+        $response = new JsonResponse(['foo' => 'bar'], 200, [], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        $this->assertTrue($response->hasEncodingOption(JSON_PRETTY_PRINT));
+        $this->assertTrue($response->hasEncodingOption(JSON_UNESCAPED_UNICODE));
+        $this->assertFalse($response->hasEncodingOption(JSON_UNESCAPED_SLASHES));
+    }
+
+    public function testWithEncodingOption()
+    {
+        $response = new JsonResponse(['foo' => 'bar']);
+        $this->assertFalse($response->hasEncodingOption(JSON_PRETTY_PRINT));
+
+        $result = $response->withEncodingOption(JSON_PRETTY_PRINT);
+
+        $this->assertSame($response, $result);
+        $this->assertTrue($response->hasEncodingOption(JSON_PRETTY_PRINT));
+    }
+
+    public function testWithoutEncodingOption()
+    {
+        $response = new JsonResponse(['foo' => 'bar'], 200, [], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        $this->assertTrue($response->hasEncodingOption(JSON_PRETTY_PRINT));
+
+        $result = $response->withoutEncodingOption(JSON_PRETTY_PRINT);
+
+        $this->assertSame($response, $result);
+        $this->assertFalse($response->hasEncodingOption(JSON_PRETTY_PRINT));
+        $this->assertTrue($response->hasEncodingOption(JSON_UNESCAPED_UNICODE));
+    }
+
+    public function testWithCallback()
+    {
+        $response = new JsonResponse(['foo' => 'bar']);
+        $result = $response->withCallback('myCallback');
+
+        $this->assertSame($response, $result);
+        $this->assertStringContainsString('myCallback', $response->getContent());
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable


### PR DESCRIPTION
add new fluent methods to `JsonResponse` for manipulating encoding options and improves test coverage.

## New Methods

- `withEncodingOption(int $option)` - Fluently adds an encoding option
- `withoutEncodingOption(int $option)` - Fluently removes an encoding option 

## Added Tests

- `testHasEncodingOption` - Verifies `hasEncodingOption()` correctly identifies set encoding options
- `testWithEncodingOption` - Verifies the new `withEncodingOption()` method
- `testWithoutEncodingOption` - Verifies the new `withoutEncodingOption()` method
- `testWithCallback` - Verifies `withCallback()` JSONP callback support
