### PR TITLE
Allow factory make() to build relationships in memory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -5,12 +5,17 @@ namespace Illuminate\Database\Eloquent\Factories;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @implements ChildRelationship<TModel>
+ */
 class BelongsToManyRelationship implements ChildRelationship
 {
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array
+     * @var \Illuminate\Database\Eloquent\Factories\Factory<TModel>|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array
      */
     protected $factory;
 
@@ -75,7 +80,7 @@ class BelongsToManyRelationship implements ChildRelationship
      * Make the attached relationship for the given model without persisting.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<array-key, TModel>
      */
     public function makeFor(Model $model)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -15,7 +15,7 @@ class BelongsToManyRelationship implements ChildRelationship
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory<TModel>|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array
+     * @var \Illuminate\Database\Eloquent\Factories\Factory<TModel>|\Illuminate\Support\Collection<int, TModel>|TModel|array<int, TModel>
      */
     protected $factory;
 
@@ -43,7 +43,7 @@ class BelongsToManyRelationship implements ChildRelationship
     /**
      * Create a new attached relationship definition.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory<TModel>|\Illuminate\Support\Collection<int, TModel>|TModel|array<int, TModel>  $factory
      * @param  callable|array  $pivot
      * @param  string  $relationship
      */

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -5,12 +5,15 @@ namespace Illuminate\Database\Eloquent\Factories;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 class BelongsToRelationship
 {
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Factories\Factory<TModel>|TModel
      */
     protected $factory;
 
@@ -31,7 +34,7 @@ class BelongsToRelationship
     /**
      * The cached, resolved parent model instance.
      *
-     * @var \Illuminate\Database\Eloquent\Model|null
+     * @var TModel|null
      */
     protected $resolvedModel;
 
@@ -45,7 +48,7 @@ class BelongsToRelationship
     /**
      * Create a new "belongs to" relationship definition.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory<TModel>|TModel  $factory
      * @param  string  $relationship
      */
     public function __construct($factory, $relationship)
@@ -99,7 +102,7 @@ class BelongsToRelationship
     /**
      * Get the resolved parent model instance.
      *
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return TModel|null
      */
     public function getResolvedModel()
     {

--- a/src/Illuminate/Database/Eloquent/Factories/ChildRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/ChildRelationship.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factories;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface ChildRelationship
+{
+    /**
+     * Create the child relationship for the given parent model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return void
+     */
+    public function createFor(Model $parent);
+
+    /**
+     * Make the child relationship for the given parent model without persisting.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
+     */
+    public function makeFor(Model $parent);
+
+    /**
+     * Get the relationship name.
+     *
+     * @return string
+     */
+    public function getRelationship();
+
+    /**
+     * Indicate that relationships should be created in-memory without persisting.
+     *
+     * @param  bool  $state
+     * @return $this
+     */
+    public function withInMemoryRelationships(bool $state = true);
+
+    /**
+     * Specify the model instances to always use when creating relationships.
+     *
+     * @param  \Illuminate\Support\Collection  $recycle
+     * @return $this
+     */
+    public function recycle($recycle);
+}

--- a/src/Illuminate/Database/Eloquent/Factories/ChildRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/ChildRelationship.php
@@ -4,6 +4,9 @@ namespace Illuminate\Database\Eloquent\Factories;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 interface ChildRelationship
 {
     /**
@@ -18,7 +21,7 @@ interface ChildRelationship
      * Make the child relationship for the given parent model without persisting.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|\Illuminate\Support\Collection
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<array-key, TModel>|\Illuminate\Support\Collection
      */
     public function makeFor(Model $parent);
 

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -83,17 +83,7 @@ class Relationship implements ChildRelationship
     {
         $relationship = $parent->{$this->relationship}();
 
-        if ($relationship instanceof MorphOneOrMany) {
-            return $this->factory
-                ->withInMemoryRelationships()
-                ->prependState($relationship->getQuery()->pendingAttributes)
-                ->make([], $parent);
-        } elseif ($relationship instanceof HasOneOrMany) {
-            return $this->factory
-                ->withInMemoryRelationships()
-                ->prependState($relationship->getQuery()->pendingAttributes)
-                ->make([], $parent);
-        } elseif ($relationship instanceof BelongsToMany) {
+        if ($relationship instanceof MorphOneOrMany || $relationship instanceof HasOneOrMany || $relationship instanceof BelongsToMany) {
             return $this->factory
                 ->withInMemoryRelationships()
                 ->prependState($relationship->getQuery()->pendingAttributes)

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -7,12 +7,17 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @implements ChildRelationship<TModel>
+ */
 class Relationship implements ChildRelationship
 {
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory
+     * @var \Illuminate\Database\Eloquent\Factories\Factory<TModel>
      */
     protected $factory;
 
@@ -72,7 +77,7 @@ class Relationship implements ChildRelationship
      * Make the child relationship for the given parent model without persisting.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return TModel|\Illuminate\Database\Eloquent\Collection<array-key, TModel>
      */
     public function makeFor(Model $parent)
     {

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -169,7 +169,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                 return 'taylor';
             },
             'options' => function ($attributes) {
-                return $attributes['name'] . '-options';
+                return $attributes['name'].'-options';
             },
         ]);
 
@@ -180,8 +180,8 @@ class DatabaseEloquentFactoryTest extends TestCase
     {
         $post = FactoryTestPostFactory::new()->create([
             'title' => 'post',
-            'user_id' => fn($attributes) => FactoryTestUserFactory::new([
-                'options' => $attributes['title'] . '-options',
+            'user_id' => fn ($attributes) => FactoryTestUserFactory::new([
+                'options' => $attributes['title'].'-options',
             ]),
         ]);
 
@@ -512,7 +512,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         }));
 
         $users = FactoryTestUserFactory::times(2)->sequence(function ($sequence) {
-            return ['name' => 'index: ' . $sequence->index];
+            return ['name' => 'index: '.$sequence->index];
         })->create();
 
         $this->assertSame('index: 0', $users[0]->name);
@@ -545,7 +545,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                 FactoryTestPostFactory::times(3)
                     ->state(['title' => 'Post'])
                     ->sequence(function ($sequence, $attributes, $user) {
-                        return ['title' => $user->name . ' ' . $attributes['title'] . ' ' . ($sequence->index % 3 + 1)];
+                        return ['title' => $user->name.' '.$attributes['title'].' '.($sequence->index % 3 + 1)];
                     }),
                 'posts'
             )
@@ -656,7 +656,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_model_has_factory()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $this->assertInstanceOf(FactoryTestUserFactory::class, FactoryTestUser::factory());
@@ -665,7 +665,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_dynamic_has_and_for_methods()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $user = FactoryTestUserFactory::new()->hasPosts(3)->create();
@@ -745,7 +745,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_model_instances_can_be_used_in_place_of_nested_factories()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $user = FactoryTestUserFactory::new()->create();
@@ -763,7 +763,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_for_method_recycles_models()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $user = FactoryTestUserFactory::new()->create();
@@ -778,7 +778,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_has_method_does_not_reassign_the_parent()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $post = FactoryTestPostFactory::new()->create();
@@ -794,7 +794,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_multiple_models_can_be_provided_to_recycle()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $users = FactoryTestUserFactory::new()->count(3)->create();
@@ -812,7 +812,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_recycled_models_can_be_combined_with_multiple_calls()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $users = FactoryTestUserFactory::new()
@@ -845,7 +845,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_no_models_can_be_provided_to_recycle()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model . 'Factory';
+            return $model.'Factory';
         });
 
         $posts = FactoryTestPostFactory::new()
@@ -917,7 +917,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_factory_global_model_resolver()
     {
         Factory::guessModelNamesUsing(function ($factory) {
-            return __NAMESPACE__ . '\\' . Str::replaceLast('Factory', '', class_basename($factory::class));
+            return __NAMESPACE__.'\\'.Str::replaceLast('Factory', '', class_basename($factory::class));
         });
 
         $this->assertEquals(FactoryTestGuessModel::factory()->modelName(), FactoryTestGuessModel::class);
@@ -1373,7 +1373,7 @@ class FactoryTestPost extends Eloquent
 
     public function upperCaseName(): Attribute
     {
-        return Attribute::get(fn($attr) => Str::upper($this->user->name));
+        return Attribute::get(fn ($attr) => Str::upper($this->user->name));
     }
 
     public function user()
@@ -1416,7 +1416,7 @@ class FactoryTestCommentFactory extends Factory
         return [
             'commentable_id' => FactoryTestPostFactory::new(),
             'commentable_type' => FactoryTestPost::class,
-            'user_id' => fn() => FactoryTestUserFactory::new(),
+            'user_id' => fn () => FactoryTestUserFactory::new(),
             'body' => $this->faker->name(),
         ];
     }
@@ -1474,7 +1474,7 @@ class FactoryTestGuessModelFactory extends Factory
 {
     protected static function appNamespace()
     {
-        return __NAMESPACE__ . '\\';
+        return __NAMESPACE__.'\\';
     }
 
     public function definition()


### PR DESCRIPTION
# Summary

Factories are great for unit tests, but `make()` becomes awkward as soon as a factory defines relationships: `for()` / `has()` may end up persisting related models in order to satisfy foreign keys. This PR introduces an **opt-in** mode that builds an **in-memory relationship graph** when using `make()`, without performing any database writes.

---

# The problem

When using `Factory::make()` in unit tests (where we intentionally avoid the database), relationship definitions can still trigger persistence. This makes `make()` unreliable for unit-test usage once relationships are involved.

---

# Existing alternatives

- `withoutParents()` and `dontExpandRelationshipsByDefault()` are great to *prevent* relationship expansion/persistence.
- However, they also mean you lose the ability to conveniently work with relationships in tests.

---

# Proposed solution

Add an opt-in mode for `make()` that:

- builds related models using `make()` as well
- attaches them to the root model via `setRelation()`
- never writes to the database

Example:

```php
$user = User::factory()
    ->withInMemoryRelationships()
    ->for(Company::factory())
    ->has(Post::factory()->count(2))
    ->make();

// $user->relationLoaded('company') === true
// $user->company is a Company model (in memory)
// $user->relationLoaded('posts') === true
// $user->posts is a Collection of Post models (in memory)
```

## Note on foreign keys

Foreign keys are set only when a key exists (e.g. recycled/persisted parent, UUID/ULID keys). Otherwise they may remain null, which is consistent with make() semantics.

---

# Scope / Non-goals

This is intentionally make-only. create() behaves as usual.

raw() / insert() are unaffected (no in-memory graph can be attached there).

Many-to-many pivot semantics (belongsToMany / hasAttached) are out of scope (can be discussed separately).

---

# Tests

This PR adds coverage to ensure:

make() + withInMemoryRelationships() does not create DB records

relationships are attached in-memory (relationLoaded() is true)

create() remains unchanged

---

# Backwards compatibility

```
No BC break. The feature is opt-in and defaults to the current behavior.
```