### PR TITLE
[12.x] Add missing return type to Arr::array()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,11 +64,9 @@ class Arr
     /**
      * Get an array item from an array using "dot" notation.
      *
-     * @return array
-     *
      * @throws \InvalidArgumentException
      */
-    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null)
+    public static function array(ArrayAccess|array $array, string|int|null $key, ?array $default = null): array
     {
         $value = Arr::get($array, $key, $default);
 


### PR DESCRIPTION
This PR adds the missing native return type to `Arr::array()` and removes the redundant `@return` docblock to match the pattern used by its sibling methods:

- `Arr::boolean()` 
- `Arr::float()`
- `Arr::integer()`
- `Arr::string()`

All of these have native return types with only `@throws` in their docblocks.

---

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says) 🤠