### PR TITLE
[12.x] Add native types to Arr foundational methods

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -219,12 +219,8 @@ class Arr
 
     /**
      * Determine if the given key exists in the provided array.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|float  $key
-     * @return bool
      */
-    public static function exists($array, $key)
+    public static function exists(ArrayAccess|array $array, string|int|float|null $key): bool
     {
         if ($array instanceof Enumerable) {
             return $array->has($key);
@@ -435,13 +431,8 @@ class Arr
 
     /**
      * Get an item from an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
-     * @param  mixed  $default
-     * @return mixed
      */
-    public static function get($array, $key, $default = null)
+    public static function get(mixed $array, string|int|null $key, mixed $default = null): mixed
     {
         if (! static::accessible($array)) {
             return value($default);
@@ -472,12 +463,8 @@ class Arr
 
     /**
      * Check if an item or items exist in an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
-     * @return bool
      */
-    public static function has($array, $keys)
+    public static function has(mixed $array, string|array|null $keys): bool
     {
         $keys = (array) $keys;
 
@@ -506,12 +493,8 @@ class Arr
 
     /**
      * Determine if all keys exist in an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
-     * @return bool
      */
-    public static function hasAll($array, $keys)
+    public static function hasAll(ArrayAccess|array|null $array, string|array|null $keys): bool
     {
         $keys = (array) $keys;
 
@@ -530,12 +513,8 @@ class Arr
 
     /**
      * Determine if any of the keys exist in an array using "dot" notation.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|array  $keys
-     * @return bool
      */
-    public static function hasAny($array, $keys)
+    public static function hasAny(ArrayAccess|array|null $array, string|array|null $keys): bool
     {
         if (is_null($keys)) {
             return false;


### PR DESCRIPTION
Adds native type declarations to the foundational `Arr` methods, aligning them with the newer typed accessor methods (`boolean`, `float`, `integer`, `string`):

- `Arr::exists()`
- `Arr::get()`
- `Arr::has()`
- `Arr::hasAll()`
- `Arr::hasAny()`

Also removes redundant `@param`/`@return` docblocks since native types now express this. Keeps only the description and `@throws` annotations where applicable.

---

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says) 🤠

> "The typed accessor methods are the correct pattern — native types, no redundant `@param`/`@return`, just the description and `@throws`. The `push` PR (#56632) kept its docblocks but shouldn't have. Don't match its mistake — match the typed accessors."