### PR TITLE
[12.x] Fix flatten() with depth of 0

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -322,6 +322,10 @@ class Arr
      */
     public static function flatten($array, $depth = INF)
     {
+        if ($depth < 1) {
+            return array_values(static::from($array));
+        }
+
         $result = [];
 
         foreach ($array as $item) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -480,6 +480,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function flatten($depth = INF)
     {
+        if ($depth < 1) {
+            return $this->values();
+        }
+
         $instance = new static(function () use ($depth) {
             foreach ($this as $item) {
                 if (! is_array($item) && ! $item instanceof Enumerable) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -490,6 +490,10 @@ class SupportArrTest extends TestCase
 
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
+
+        // Depth of 0 returns array unchanged (as values)
+        $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
+        $this->assertEquals([['#foo', ['#bar', ['#baz']]], '#zap'], Arr::flatten($array, 0));
     }
 
     public function testGet()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1329,6 +1329,10 @@ class SupportCollectionTest extends TestCase
 
         $c = new $collection([['#foo', ['#bar', ['#baz']]], '#zap']);
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
+
+        // Depth of 0 returns collection unchanged (as values)
+        $c = new $collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $this->assertEquals([['#foo', ['#bar', ['#baz']]], '#zap'], $c->flatten(0)->all());
     }
 
     #[DataProvider('collectionClassProvider')]


### PR DESCRIPTION
When `flatten(0)` is called, it should return the array unchanged since zero levels of flattening means no flattening. Instead, the current implementation fully flattens the array because the `$depth === 1` check fails and recursion continues with negative values (-1, -2, etc.) which never equal 1.

```php
// Before: flatten(0) fully flattens (bug)
Arr::flatten([[1, [2, 3]], [4, [5]]], 0);
// [1, 2, 3, 4, 5]

// After: flatten(0) returns unchanged
Arr::flatten([[1, [2, 3]], [4, [5]]], 0);
// [[1, [2, 3]], [4, [5]]]
```

Fixes `Arr::flatten()`, `Collection::flatten()`, and `LazyCollection::flatten()`.

---

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says) 🤠

> "The implementation is clean. Both correctly handle 0 and negative depths, return values (re-indexed) which is consistent with what flatten does at any depth, and use existing Laravel methods. Minimal fix, no over-engineering."