### PR TITLE
[12.x] Fix typo in BelongsToMany::createOrFirst method name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -659,7 +659,7 @@ class BelongsToMany extends Relation
     public function createOrFirst(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
         try {
-            return $this->getQuery()->withSavePointIfNeeded(fn () => $this->create(array_merge($attributes, $values), $joining, $touch));
+            return $this->getQuery()->withSavepointIfNeeded(fn () => $this->create(array_merge($attributes, $values), $joining, $touch));
         } catch (UniqueConstraintViolationException $e) {
             // ...
         }


### PR DESCRIPTION
Fixed `withSavePointIfNeeded` to `withSavepointIfNeeded` (lowercase 'p' in 'point').

The method `withSavepointIfNeeded` exists on `Builder`, but line 662 was calling `withSavePointIfNeeded` (capital P), causing it to fall through to `__call` instead of the intended method.

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says) 🤠

> "Consistency matters. One capital letter breaks the chain."