### PR TITLE
[12.x] Update fake method parameter type for disk

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -92,7 +92,7 @@ class Storage extends Facade
     /**
      * Replace the given disk with a local testing disk.
      *
-     * @param  string|null  $disk
+     * @param  \UnitEnum|string|null  $disk
      * @param  array  $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */


### PR DESCRIPTION
This PR (https://github.com/laravel/framework/pull/58076) introduced support for using Enums as the disk parameter in the Storage::fake() method. However, the PHPDoc for this method was not updated accordingly. As a result, when an Enum is passed as the parameter, IDEs such as VS Code incorrectly report a type error, since Enums are not listed as a valid parameter type in the documentation.
`Argument '1' passed to fake() is expected to be of type string|null, App\Enums\FileSystemDiskEnum given`