### PR TITLE
[12.x] Fix Str::chopStart() and Str::chopEnd() returning empty string when given empty needle

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -260,7 +260,7 @@ class Str
     public static function chopStart($subject, $needle)
     {
         foreach ((array) $needle as $n) {
-            if (str_starts_with($subject, $n)) {
+            if ($n !== '' && str_starts_with($subject, $n)) {
                 return mb_substr($subject, mb_strlen($n));
             }
         }
@@ -278,7 +278,7 @@ class Str
     public static function chopEnd($subject, $needle)
     {
         foreach ((array) $needle as $n) {
-            if (str_ends_with($subject, $n)) {
+            if ($n !== '' && str_ends_with($subject, $n)) {
                 return mb_substr($subject, 0, -mb_strlen($n));
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1826,6 +1826,9 @@ class SupportStrTest extends TestCase
     public function testChopStart()
     {
         foreach ([
+            '' => ['', ''],
+            'Laravel' => ['', 'Laravel'],
+            'Ship it' => [['', 'Ship '], 'it'],
             'http://laravel.com' => ['http://', 'laravel.com'],
             'http://-http://' => ['http://', '-http://'],
             'http://laravel.com' => ['htp:/', 'http://laravel.com'],
@@ -1859,6 +1862,9 @@ class SupportStrTest extends TestCase
     public function testChopEnd()
     {
         foreach ([
+            '' => ['', ''],
+            'Laravel' => ['', 'Laravel'],
+            'Ship it' => [['', ' it'], 'Ship'],
             'path/to/file.php' => ['.php', 'path/to/file'],
             '.php-.php' => ['.php', '.php-'],
             'path/to/file.php' => ['.ph', 'path/to/file.php'],


### PR DESCRIPTION
Both `Str::chopStart()` and `Str::chopEnd()` incorrectly handle empty string needles.

**The bug:**

```php
Str::chopEnd('Laravel', '');  // Returns '' instead of 'Laravel'
Str::chopStart('Laravel', ''); // Returns '' instead of 'Laravel'
```

**Root cause:**

- `str_ends_with('Laravel', '')` returns `true` (any string ends with empty string)
- `mb_strlen('')` returns `0`
- `mb_substr('Laravel', 0, -0)` returns `''` because `-0` equals `0` in PHP

Same issue affects `chopStart()` when an empty string is first in an array of needles.

**Fix:**

Skip empty strings in the needle array by adding `$n !== ''` guard before the `str_starts_with`/`str_ends_with` check.

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says) 🤠

> "When `mb_substr` gets `-0` as the length, it truncates everything because `-0 === 0`. The empty-string needle is a trap that makes any input vanish."