### PR TITLE
[12.x] Add enum to `persistentFake()`- and add tests

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -118,13 +118,13 @@ class Storage extends Facade
     /**
      * Replace the given disk with a persistent local testing disk.
      *
-     * @param  string|null  $disk
+     * @param  \UnitEnum|string|null  $disk
      * @param  array  $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null, array $config = [])
     {
-        $disk = $disk ?: static::$app['config']->get('filesystems.default');
+        $disk = enum_value($disk) ?: static::$app['config']->get('filesystems.default');
 
         static::set($disk, $fake = static::createLocalDriver(
             self::buildDiskConfiguration($disk, $config, root: self::getRootPath($disk))

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -60,7 +60,6 @@ class StorageFacadeTest extends TestCase
         $this->assertNull(Storage::persistentFake(StorageDisk::Test)->get('nonExistentFile'));
         $this->assertNull(Storage::fake(StorageDisk::Public)->get('nonExistentFile'));
     }
-
 }
 
 enum StorageDisk: string

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -54,4 +54,17 @@ class StorageFacadeTest extends TestCase
         $result = Storage::persistentFake('test', ['throw' => false])->get('nonExistentFile');
         $this->assertNull($result);
     }
+
+    public function testStorageFakeWithEnums()
+    {
+        $this->assertNull(Storage::persistentFake(StorageDisk::Test)->get('nonExistentFile'));
+        $this->assertNull(Storage::fake(StorageDisk::Public)->get('nonExistentFile'));
+    }
+
+}
+
+enum StorageDisk: string
+{
+    case Test = 'test';
+    case Public = 'public';
 }

--- a/tests/Support/StorageFacadeTest.php
+++ b/tests/Support/StorageFacadeTest.php
@@ -55,7 +55,7 @@ class StorageFacadeTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testStorageFakeWithEnums()
+    public function testStorageFakeMethodsWithEnums()
     {
         $this->assertNull(Storage::persistentFake(StorageDisk::Test)->get('nonExistentFile'));
         $this->assertNull(Storage::fake(StorageDisk::Public)->get('nonExistentFile'));


### PR DESCRIPTION
https://github.com/laravel/framework/pull/58076 added enums to the `fake()` method. 

I noticed this ideally should also be on the `persistentFake` method too just to keep consistency - as both are documented

I've also added a simple test to prevent any regression - as noticed there wasnt any.

Thank you!