### PR TITLE
[12.x] Table prefix not applied when cloning connections

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -243,8 +243,6 @@ class Connection implements ConnectionInterface
         // so they reference the cloned connection instead of the original.
         $this->useDefaultQueryGrammar();
 
-        $this->useDefaultPostProcessor();
-
         if (! is_null($this->schemaGrammar)) {
             $this->useDefaultSchemaGrammar();
         }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -233,6 +233,24 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        // When cloning, we need to re-initialize the grammars and post processor
+        // so they reference the cloned connection instead of the original.
+        $this->queryGrammar = $this->getDefaultQueryGrammar();
+
+        $this->postProcessor = $this->getDefaultPostProcessor();
+
+        if (! is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
+    }
+
+    /**
      * Set the query grammar to the default implementation.
      *
      * @return void

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -233,22 +233,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Prepare the instance for cloning.
-     *
-     * @return void
-     */
-    public function __clone()
-    {
-        // When cloning, we need to re-initialize the grammars so they
-        // reference the cloned connection instead of the original.
-        $this->useDefaultQueryGrammar();
-
-        if (! is_null($this->schemaGrammar)) {
-            $this->useDefaultSchemaGrammar();
-        }
-    }
-
-    /**
      * Set the query grammar to the default implementation.
      *
      * @return void
@@ -1731,5 +1715,20 @@ class Connection implements ConnectionInterface
     public static function getResolver($driver)
     {
         return static::$resolvers[$driver] ?? null;
+    }
+
+    /**
+     * Prepare the instance for cloning.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        // When cloning, re-initialize grammars to reference cloned connection...
+        $this->useDefaultQueryGrammar();
+
+        if (! is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -241,9 +241,9 @@ class Connection implements ConnectionInterface
     {
         // When cloning, we need to re-initialize the grammars and post processor
         // so they reference the cloned connection instead of the original.
-        $this->queryGrammar = $this->getDefaultQueryGrammar();
+        $this->useDefaultQueryGrammar();
 
-        $this->postProcessor = $this->getDefaultPostProcessor();
+        $this->useDefaultPostProcessor();
 
         if (! is_null($this->schemaGrammar)) {
             $this->useDefaultSchemaGrammar();

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -239,8 +239,8 @@ class Connection implements ConnectionInterface
      */
     public function __clone()
     {
-        // When cloning, we need to re-initialize the grammars and post processor
-        // so they reference the cloned connection instead of the original.
+        // When cloning, we need to re-initialize the grammars so they
+        // reference the cloned connection instead of the original.
         $this->useDefaultQueryGrammar();
 
         if (! is_null($this->schemaGrammar)) {

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -164,9 +164,3 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
         return $this->connection($connection)->getSchemaBuilder();
     }
 }
-
-class EloquentTestUser extends Eloquent
-{
-    protected $table = 'users';
-    protected $guarded = [];
-}


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/56902

## Problem

When cloning a database connection and setting a different table prefix, the prefix is not applied correctly.

```php
$original = DB::connection('mysql');
$cloned = clone $original;
$cloned->setTablePrefix('foo_');

// Laravel 11.x - appeared to work, but affected BOTH connections
$cloned->table('contacts')->get();  // Queries: foo_contacts
$original->table('contacts')->get(); // Also queries: foo_contacts (not intentional)

// Laravel 12.x - broken, prefix ignored entirely
$cloned->table('contacts')->get();  // Queries: contacts (prefix ignored)
$original->table('contacts')->get(); // Queries: contacts
```

## Root Cause

c78fa3d refactored how grammars access table prefixes. Previously, grammars stored their own `$tablePrefix` property. Now they dynamically retrieve it from their connection reference.

Laravel 11 behavior (before c78fa3d):
```php
// Connection.php
public function setTablePrefix($prefix)
{
    $this->tablePrefix = $prefix;
    $this->getQueryGrammar()->setTablePrefix($prefix); // grammar also updated
    return $this;
}

// Grammar.php
protected $tablePrefix = '';

public function wrapTable($table) {
    return $this->wrapValue($this->tablePrefix . $table);
}
```

When cloning, the grammar object was shallow-copied. Calling `setTablePrefix()` on the clone updated the shared grammar, affecting both connections.

Laravel 12 behavior (after c78fa3d):
```php
// Connection.php
public function setTablePrefix($prefix)
{
    $this->tablePrefix = $prefix;
    // Grammar is no longer updated and read dynamically
    return $this;
}

// Grammar.php
public function wrapTable($table) {
    $prefix = $this->connection->getTablePrefix();  // reads from connection
    return $this->wrapValue($prefix . $table);
}
```

When cloning, the grammar's `$connection` reference still points to the original connection. Calling `setTablePrefix()` on the clone only updates the clone's prefix, but the grammar still reads from the original connection, ignoring the new prefix.

## Solution

Added `__clone()` to the `Connection` class to re-initialize grammars with the cloned connection.