### PR TITLE
[12.x] Fix: add `@throws \InvalidArgumentException` to some dock block

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -938,6 +938,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  int  $step
      * @param  int  $offset
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
     public function nth($step, $offset = 0)
     {
@@ -1360,6 +1362,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function split($numberOfGroups)
     {
@@ -1401,6 +1405,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function splitIn($numberOfGroups)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -898,6 +898,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  int  $step
      * @param  int  $offset
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
     public function nth($step, $offset = 0)
     {
@@ -1284,6 +1286,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 
     /**
      * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
      */
     #[\Override]
     public function split($numberOfGroups)
@@ -1394,6 +1398,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $numberOfGroups
      * @return static<int, static>
+     *
+     * @throws \InvalidArgumentException
      */
     public function splitIn($numberOfGroups)
     {


### PR DESCRIPTION
continuation of #58283

add `@throws \InvalidArgumentException` to dock blocks