### PR TITLE
[12.x] Support "where subquery between values" 

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1393,6 +1393,13 @@ class Builder implements BuilderContract
     {
         $type = 'between';
 
+        if ($this->isQueryable($column)) {
+            [$sub, $bindings] = $this->createSub($column);
+
+            return $this->addBinding($bindings, 'where')
+                ->whereBetween(new Expression('('.$sub.')'), $values, $boolean, $not);
+        }
+
         if ($values instanceof CarbonPeriod) {
             $values = [$values->getStartDate(), $values->getEndDate()];
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1062,6 +1062,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
         $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $subqueryBuilder = $this->getBuilder();
+        $subqueryBuilder->select('id')->from('posts')->where('status', 'published')->orderByDesc('created_at')->limit(1);
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereBetween($subqueryBuilder, collect([1, 2]));
+        $this->assertSame('select * from "users" where (select "id" from "posts" where "status" = ? order by "created_at" desc limit 1) between ? and ?', $builder->toSql());
+        $this->assertEquals([0 => 'published', 1 => 1, 2 => 2], $builder->getBindings());
     }
 
     public function testOrWhereBetween()


### PR DESCRIPTION
This PR adds the ability to add "where subquery between values" clauses to the query builder.

It is already possible to add a "where subquery value" clause to a query builder, so I assumed this also worked on 'where between' clauses but that is not the case.

```php
$query->whereBetween($subquery, [$minValue, $maxValue])
```

Why would this be needed? Well, let's say you have users and users have posts. Let's say you need to query users whose _latest_ post was created between one and two months ago. Eloquent currently does not provide a way to write that query without having to resort to the "whereRaw" method, but this PR fixes that so you can write the following query:
```php
$users = User::query()
	->whereBetween(
		Post::query()
			->select('created_at')
			->whereColumn('posts.user_id', 'users.id')
			->latest()
			->limit(1),
		[now()->subMonths(2), now()->subMonth()],
	)
	->get();
```

