### PR TITLE
[12.x] Fix `Validator::sometimes()` usage with attributes containing `.`

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1206,7 +1206,7 @@ class Validator implements ValidatorContract
     {
         return (new Collection($this->rules))
             ->mapWithKeys(fn ($value, $key) => [
-                static::encodeAttributeWithPlaceholder($key) => $value,
+                static::decodeAttributeWithPlaceholder($key) => $value,
             ])
             ->all();
     }
@@ -1704,7 +1704,7 @@ class Validator implements ValidatorContract
      */
     protected static function decodeAttributeWithPlaceholder(string $attribute)
     {
-        return str_replace('__dot__'.static::$placeholderHash, '\\.', $key);
+        return str_replace('__dot__'.static::$placeholderHash, '\\.', $attribute);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1235,7 +1235,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Append the validation rules.
+     * Append new validation rules to the validator.
      *
      * @param  array  $rules
      * @return $this
@@ -1676,17 +1676,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Flush the validator's global state.
-     *
-     * @return void
-     */
-    public static function flushState()
-    {
-        static::$placeholderHash = null;
-    }
-
-    /**
-     * Encode attribute with placeholder.
+     * Encode the attribute with the placeholder hash.
      *
      * @param  string  $attribute
      * @return string
@@ -1697,7 +1687,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Decode attribute with placeholder.
+     * Decode an attribute with a placeholder hash.
      *
      * @param  string  $attribute
      * @return string
@@ -1705,6 +1695,16 @@ class Validator implements ValidatorContract
     protected static function decodeAttributeWithPlaceholder(string $attribute)
     {
         return str_replace('__dot__'.static::$placeholderHash, '\\.', $attribute);
+    }
+
+    /**
+     * Flush the validator's global state.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$placeholderHash = null;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7396,6 +7396,17 @@ class ValidationValidatorTest extends TestCase
         // Interpreted dot followed by escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => [['bar.baz' => ''], ['bar.baz' => '']]], ['foo.*.bar\.baz' => 'required']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo.bar' => 'valid'], ['foo\.bar' => 'required']);
+        $this->assertFalse($v->fails());
+
+        $v = new Validator($trans, ['foo.bar' => 'valid'], []);
+        $v->appendRules(['foo\.bar' => 'required']);
+        $this->assertFalse($v->fails());
+
+        $v = new Validator($trans, ['foo.bar' => 'valid'], []);
+        $v->sometimes('foo\.bar', 'required', fn () => true);
+        $this->assertFalse($v->fails());
     }
 
     public function testParsingArrayKeysWithDotWhenTestingExistence()


### PR DESCRIPTION
This also add public API for dynamically adding rules using `appendRules()` instead of internal `addRules()` method.

fixes #58223

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
