### PR TITLE
[12.x] Added MySQL DDL locking options to MySQL grammar

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -15,15 +15,15 @@ use Illuminate\Support\Fluent;
  * @method $this default(mixed $value) Specify a "default" value for the column
  * @method $this first() Place the column "first" in the table (MySQL)
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
- * @method $this instant() Specify that algorithm=instant should be used for the column operation (MySQL)
- * @method $this lock(string $value) Specify the DDL lock mode for the column operation (MySQL)
+ * @method $this fulltext(bool|string $indexName = null) Add a fulltext index
  * @method $this generatedAs(string|\Illuminate\Contracts\Database\Query\Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(bool|string $indexName = null) Add an index
+ * @method $this instant() Specify that algorithm=instant should be used for the column operation (MySQL)
  * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
+ * @method $this lock(string $value) Specify the DDL lock mode for the column operation (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary(bool $value = true) Add a primary index
- * @method $this fulltext(bool|string $indexName = null) Add a fulltext index
  * @method $this spatialIndex(bool|string $indexName = null) Add a spatial index
  * @method $this startingValue(int $startingValue) Set the starting value of an auto-incrementing field (MySQL/PostgreSQL)
  * @method $this storedAs(string|\Illuminate\Contracts\Database\Query\Expression $expression) Create a stored generated column (MySQL/PostgreSQL/SQLite)

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Fluent;
  * @method $this first() Place the column "first" in the table (MySQL)
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
  * @method $this instant() Specify that algorithm=instant should be used for the column operation (MySQL)
+ * @method $this lock(string $value) Specify the DDL lock mode for the column operation (MySQL)
  * @method $this generatedAs(string|\Illuminate\Contracts\Database\Query\Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(bool|string $indexName = null) Add an index
  * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Fluent;
  * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
  * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action
  * @method ForeignKeyDefinition references(string|array $columns) Specify the referenced column(s)
+ * @method ForeignKeyDefinition lock(string $value) Specify the DDL lock mode for the foreign key operation (MySQL)
  */
 class ForeignKeyDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -7,11 +7,11 @@ use Illuminate\Support\Fluent;
 /**
  * @method ForeignKeyDefinition deferrable(bool $value = true) Set the foreign key as deferrable (PostgreSQL)
  * @method ForeignKeyDefinition initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
+ * @method ForeignKeyDefinition lock(string $value) Specify the DDL lock mode for the foreign key operation (MySQL)
  * @method ForeignKeyDefinition on(string $table) Specify the referenced table
  * @method ForeignKeyDefinition onDelete(string $action) Add an ON DELETE action
  * @method ForeignKeyDefinition onUpdate(string $action) Add an ON UPDATE action
  * @method ForeignKeyDefinition references(string|array $columns) Specify the referenced column(s)
- * @method ForeignKeyDefinition lock(string $value) Specify the DDL lock mode for the foreign key operation (MySQL)
  */
 class ForeignKeyDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Fluent;
 
 /**
  * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
- * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
+ * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
+ * @method $this lock(string $value) Specify the DDL lock mode for the index operation (MySQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
- * @method $this lock(string $value) Specify the DDL lock mode for the index operation (MySQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Fluent;
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
+ * @method $this lock(string $value) Specify the DDL lock mode for the index operation (MySQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1629,6 +1629,116 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` drop `name`, algorithm=instant', $statements[0]);
     }
 
+    public function testAddingColumnWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('name')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null, lock=none', $statements[0]);
+    }
+
+    public function testChangingColumnWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('name', 100)->change()->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` modify `name` varchar(100) not null, lock=none', $statements[0]);
+    }
+
+    public function testDroppingColumnWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->dropColumn('name')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` drop `name`, lock=none', $statements[0]);
+    }
+
+    public function testColumnWithBothAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->string('name')->instant()->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null, algorithm=instant, lock=none', $statements[0]);
+    }
+
+    public function testAddingIndexWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('name')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `users_name_index`(`name`), lock=none', $statements[0]);
+    }
+
+    public function testAddingUniqueIndexWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->lock('shared');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add unique `users_email_unique`(`email`), lock=shared', $statements[0]);
+    }
+
+    public function testAddingPrimaryKeyWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->primary('id')->lock('exclusive');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add primary key (`id`), lock=exclusive', $statements[0]);
+    }
+
+    public function testAddingForeignKeyWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->foreign('user_id')->references('id')->on('accounts')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_user_id_foreign` foreign key (`user_id`) references `accounts` (`id`), lock=none', $statements[0]);
+    }
+
+    public function testAddingFullTextIndexWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fullText('content')->lock('shared');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add fulltext `users_content_fulltext`(`content`), lock=shared', $statements[0]);
+    }
+
+    public function testAddingSpatialIndexWithLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->spatialIndex('location')->lock('default');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add spatial index `users_location_spatialindex`(`location`), lock=default', $statements[0]);
+    }
+
+    public function testIndexWithAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('name', 'custom_idx')->algorithm('btree')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `custom_idx` using btree(`name`), lock=none', $statements[0]);
+    }
+
     public function getGrammar(?Connection $connection = null)
     {
         return new MySqlGrammar($connection ?? $this->getConnection());


### PR DESCRIPTION
### Problem
Right now when writing [MySQL DDL Operations](https://dev.mysql.com/doc/refman/8.4/en/innodb-online-ddl-operations.html) in migrations it is not possible to define what locking mechanism to use for the statement. 

This makes it possible to define what locks to use for altering tables.

Usage example:
```php
    Schema::table('students', function (Blueprint $table) {
        $table->index('email')->lock('none');
    });
```

As opposed to previously needing something like this
```php
    if (DB::getDriverName() === 'mysql') {
          DB::statement('
              ALTER TABLE `students`
              ADD INDEX `students_email_index` (`email`),
              LOCK = NONE
          ');
    } else {
          Schema::table('students', function (Blueprint $table) {
              $table->index('email');
          });
    }
```