### PR TITLE
[12.x] `JsonResource@toArray()` maps items to array

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -158,7 +158,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray(Request $request)
     {
-        return match(true) {
+        return match (true) {
             is_null($this->resource) => [],
             is_array($this->resource) => $this->resource,
             $this->resource instanceof Collection => $this->resource->map(fn ($val) => $val instanceof JsonResource ? $val->resolve($request) : $val)->toArray(),

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -158,13 +158,12 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray(Request $request)
     {
-        if (is_null($this->resource)) {
-            return [];
-        }
-
-        return is_array($this->resource)
-            ? $this->resource
-            : $this->resource->map(fn ($val) => $val instanceof JsonResource ? $val->resolve($request) : $val)->toArray();
+        return match(true) {
+            is_null($this->resource) => [],
+            is_array($this->resource) => $this->resource,
+            $this->resource instanceof Collection => $this->resource->map(fn ($val) => $val instanceof JsonResource ? $val->resolve($request) : $val)->toArray(),
+            default => $this->resource->toArray($request),
+        };
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -164,7 +164,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
 
         return is_array($this->resource)
             ? $this->resource
-            : $this->resource->toArray();
+            : $this->resource->map(fn ($val) => $val instanceof JsonResource ? $val->resolve($request) : $val)->toArray();
     }
 
     /**


### PR DESCRIPTION
To close: https://github.com/laravel/framework/issues/58300

For whatever reason, we have tests in our test suite that perform assertions against a `JsonResource` class. They would call `toArray()` on an instance, and then manually call `toArray()` on `AnonymousResourceCollection`s returned.

It's always uncomfortable to change tests to accommodate a framework change. This change gives developers back that confidence without breaking the new functionality introduced in 12.45.0