### PR TITLE
[12.x] Add `Cache::withoutOverlapping()` to wrap `Cache::lock()->block()`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -539,7 +539,7 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Execute a callback within an atomic lock.
+     * Execute a callback while holding an atomic lock on a cache mutex to prevent overlapping calls.
      *
      * @template TReturn
      *
@@ -552,7 +552,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @throws \Illuminate\Contracts\Cache\LockTimeoutException
      */
-    public function atomic($key, callable $callback, $lockSeconds = 10, $waitSeconds = 10, $owner = null)
+    public function withoutOverlapping($key, callable $callback, $lockSeconds = 600, $waitSeconds = 10, $owner = null)
     {
         return $this->store->lock($key, $lockSeconds, $owner)->block($waitSeconds, $callback);
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -539,6 +539,25 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Execute a callback within an atomic lock.
+     *
+     * @template TReturn
+     *
+     * @param  string  $key
+     * @param  callable(): TReturn  $callback
+     * @param  int  $lockSeconds
+     * @param  int  $waitSeconds
+     * @param  string|null  $owner
+     * @return TReturn
+     *
+     * @throws \Illuminate\Contracts\Cache\LockTimeoutException
+     */
+    public function atomic($key, callable $callback, $lockSeconds = 10, $waitSeconds = 10, $owner = null)
+    {
+        return $this->store->lock($key, $lockSeconds, $owner)->block($waitSeconds, $callback);
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  \BackedEnum|\UnitEnum|array|string  $key

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -440,7 +440,7 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = new Repository(new ArrayStore);
 
-        $result = $repo->atomic('foo', function () {
+        $result = $repo->withoutOverlapping('foo', function () {
             return 'bar';
         });
 
@@ -458,7 +458,7 @@ class CacheRepositoryTest extends TestCase
             return $callback();
         });
 
-        $result = $repo->atomic('foo', function () {
+        $result = $repo->withoutOverlapping('foo', function () {
             return 'bar';
         }, 30, 15);
 
@@ -476,7 +476,7 @@ class CacheRepositoryTest extends TestCase
             return $callback();
         });
 
-        $result = $repo->atomic('foo', function () {
+        $result = $repo->withoutOverlapping('foo', function () {
             return 'bar';
         }, 10, 10, 'my-owner');
 
@@ -492,7 +492,7 @@ class CacheRepositoryTest extends TestCase
         $called = false;
 
         try {
-            $repo->atomic('foo', function () use (&$called) {
+            $repo->withoutOverlapping('foo', function () use (&$called) {
                 $called = true;
             }, 10, 0);
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -500,8 +500,6 @@ class CacheRepositoryTest extends TestCase
         } catch (LockTimeoutException) {
             $this->assertFalse($called);
         }
-
-
     }
 
     protected function getRepository()


### PR DESCRIPTION
## Add `Cache::withoutOverlapping()` method

### Description

This PR adds a new `atomic()` method to the Cache Repository that provides a cleaner API for executing callbacks within atomic locks.

### Before

```php
Cache::lock('my-lock-key', 600)->block(10, function () {
    // critical section
});
```

### After

```php
Cache::withoutOverlapping('my-lock-key', function () {
    // critical section
});
```

### Method Signature

```php
public function withoutOverlapping($key, callable $callback, $lockSeconds = 600, $waitSeconds = 10, $owner = null)
```

**Parameters:**
- `$key` - The lock key name
- `$callback` - The callback to execute within the lock
- `$lockSeconds` - How long the lock should be held (default: 600)
- `$waitSeconds` - How long to wait to acquire the lock (default: 10)
- `$owner` - Optional owner identifier for distributed lock restoration

**Throws:** `LockTimeoutException` if the lock cannot be acquired within `$waitSeconds`

### Default Values

~~The defaults of `10` seconds for both `$lockSeconds` and `$waitSeconds` match the existing session/route blocking defaults in the framework (`SessionManager::defaultRouteBlockLockSeconds()` and `Route::block()`).~~

