### PR TITLE
[12.x] Fix `Validator::appendRules()` with pipe-separated rule strings

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1242,6 +1242,12 @@ class Validator implements ValidatorContract
      */
     public function appendRules(array $rules)
     {
+        $rules = (new Collection($rules))
+            ->map(function ($value) {
+                return is_string($value) ? explode('|', $value) : $value;
+            })
+            ->toArray();
+
         return $this->setRules(array_merge_recursive($this->getRulesWithoutPlaceholders(), $rules));
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1246,7 +1246,7 @@ class Validator implements ValidatorContract
             ->map(function ($value) {
                 return is_string($value) ? explode('|', $value) : $value;
             })
-            ->toArray();
+            ->all();
 
         return $this->setRules(array_merge_recursive($this->getRulesWithoutPlaceholders(), $rules));
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7407,6 +7407,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo.bar' => 'valid'], []);
         $v->sometimes('foo\.bar', 'required', fn () => true);
         $this->assertFalse($v->fails());
+
+        $v = new Validator($trans, ['name' => 'ab'], ['name' => 'required']);
+        $v->appendRules(['name' => 'string']);
+        $v->appendRules(['name' => 'min:5|max:255']);
+        $this->assertTrue($v->fails());
     }
 
     public function testParsingArrayKeysWithDotWhenTestingExistence()


### PR DESCRIPTION
## Summary

Fixes a bug where `Validator::appendRules()` throws exception when new rules use pipe-separated strings (e.g., `'required|string|min:5'`). The issue occurs because `array_merge_recursive()` merges already-parsed arrays with unparsed strings.

## Step to reproduce

When using `appendRules()` with pipe-separated rules:

```php
$validator = new Validator($trans, ['name' => 'ab'], ['name' => 'required']);
$validator->appendRules(['name' => 'string|min:5']);
$validator->fails(); // Throws: Method validateString|min does not exist
```

## Solution

Modified `Validator::appendRules()` to pre-process the new rules by exploding pipe-separated strings into arrays before calling array_merge_recursive().