### PR TITLE
[12.x] Allow specifying that context should live under log's `context`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -25,6 +25,7 @@ use Illuminate\Http\Middleware\TrustHosts;
 use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Log\Context\Repository;
 use Illuminate\Mail\Markdown;
 use Illuminate\Queue\Console\WorkCommand;
 use Illuminate\Queue\Queue;
@@ -187,6 +188,7 @@ trait InteractsWithTestCaseLifecycle
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
+        Repository::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();
         TrustProxies::flushState();

--- a/src/Illuminate/Log/Context/ContextLogProcessor.php
+++ b/src/Illuminate/Log/Context/ContextLogProcessor.php
@@ -23,9 +23,17 @@ class ContextLogProcessor implements ContextLogProcessorContract
             return $record;
         }
 
-        return $record->with(extra: [
-            ...$record->extra,
-            ...$app->get(ContextRepository::class)->all(),
-        ]);
+        $repository = $app->get(ContextRepository::class);
+
+        return match ($repository->writesContextTo()) {
+            'extra' => $record->with(extra: [
+                ...$record->extra,
+                ...$repository->all(),
+            ]),
+            'context' => $record->with(context: [
+                ...$repository->all(),
+                ...$record->context,
+            ]),
+        };
     }
 }

--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -48,6 +48,13 @@ class Repository
     protected static $handleUnserializeExceptionsUsing;
 
     /**
+     * The structured log location to write repository data to.
+     *
+     * @var 'extra'|'context'
+     */
+    public static string $writeContextTo = 'extra';
+
+    /**
      * Create a new Context instance.
      */
     public function __construct(Dispatcher $events)
@@ -617,6 +624,14 @@ class Repository
     }
 
     /**
+     * @return 'context'|'extra'
+     */
+    public function writesContextTo()
+    {
+        return static::$writeContextTo;
+    }
+
+    /**
      * Flush all context data.
      *
      * @return $this
@@ -698,5 +713,13 @@ class Repository
         ));
 
         return $this;
+    }
+
+    /**
+     * Flush the state of the repository.
+     */
+    public static function flushState(): void
+    {
+        self::$writeContextTo = 'extra';
     }
 }

--- a/src/Illuminate/Support/Facades/Context.php
+++ b/src/Illuminate/Support/Facades/Context.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Log\Context\Repository;
+
 /**
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
@@ -17,30 +19,30 @@ namespace Illuminate\Support\Facades;
  * @method static array onlyHidden(array $keys)
  * @method static array except(array $keys)
  * @method static array exceptHidden(array $keys)
- * @method static \Illuminate\Log\Context\Repository add(string|array $key, mixed $value = null)
- * @method static \Illuminate\Log\Context\Repository addHidden(string|array $key, mixed $value = null)
+ * @method static Repository add(string|array $key, mixed $value = null)
+ * @method static Repository addHidden(string|array $key, mixed $value = null)
  * @method static mixed remember(string $key, mixed $value)
  * @method static mixed rememberHidden(string $key, mixed $value)
- * @method static \Illuminate\Log\Context\Repository forget(string|array $key)
- * @method static \Illuminate\Log\Context\Repository forgetHidden(string|array $key)
- * @method static \Illuminate\Log\Context\Repository addIf(string $key, mixed $value)
- * @method static \Illuminate\Log\Context\Repository addHiddenIf(string $key, mixed $value)
- * @method static \Illuminate\Log\Context\Repository push(string $key, mixed ...$values)
+ * @method static Repository forget(string|array $key)
+ * @method static Repository forgetHidden(string|array $key)
+ * @method static Repository addIf(string $key, mixed $value)
+ * @method static Repository addHiddenIf(string $key, mixed $value)
+ * @method static Repository push(string $key, mixed ...$values)
  * @method static mixed pop(string $key)
- * @method static \Illuminate\Log\Context\Repository pushHidden(string $key, mixed ...$values)
+ * @method static Repository pushHidden(string $key, mixed ...$values)
  * @method static mixed popHidden(string $key)
- * @method static \Illuminate\Log\Context\Repository increment(string $key, int $amount = 1)
- * @method static \Illuminate\Log\Context\Repository decrement(string $key, int $amount = 1)
+ * @method static Repository increment(string $key, int $amount = 1)
+ * @method static Repository decrement(string $key, int $amount = 1)
  * @method static bool stackContains(string $key, mixed $value, bool $strict = false)
  * @method static bool hiddenStackContains(string $key, mixed $value, bool $strict = false)
  * @method static mixed scope(callable $callback, array $data = [], array $hidden = [])
  * @method static bool isEmpty()
- * @method static \Illuminate\Log\Context\Repository dehydrating(callable $callback)
- * @method static \Illuminate\Log\Context\Repository hydrated(callable $callback)
- * @method static \Illuminate\Log\Context\Repository handleUnserializeExceptionsUsing(callable|null $callback)
- * @method static \Illuminate\Log\Context\Repository flush()
- * @method static \Illuminate\Log\Context\Repository|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
- * @method static \Illuminate\Log\Context\Repository|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static Repository dehydrating(callable $callback)
+ * @method static Repository hydrated(callable $callback)
+ * @method static Repository handleUnserializeExceptionsUsing(callable|null $callback)
+ * @method static Repository flush()
+ * @method static Repository|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static Repository|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)
@@ -58,6 +60,22 @@ class Context extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return \Illuminate\Log\Context\Repository::class;
+        return Repository::class;
+    }
+
+    /**
+     * Write context data under the structured log's "extra" key.
+     */
+    public static function writeContextToLogExtra(): void
+    {
+        Repository::$writeContextTo = 'extra';
+    }
+
+    /**
+     * Write context data under the structured log's "context" key.
+     */
+    public static function writeContextToLogContext(): void
+    {
+        Repository::$writeContextTo = 'context';
     }
 }

--- a/tests/Log/ContextTest.php
+++ b/tests/Log/ContextTest.php
@@ -632,6 +632,21 @@ class ContextTest extends TestCase
         file_put_contents($path, '');
     }
 
+    public function test_can_set_the_context_output_location()
+    {
+        $path = storage_path('logs/laravel.log');
+        file_put_contents($path, '');
+        Context::writeContextToLogContext();
+
+        Context::add(['value_from_context' => 'hello', 'tim' => 'macdonald']);
+
+        Log::info('This is an info log.', ['value_from_context' => 'bye']);
+        $log = Str::after(file_get_contents($path), '] ');
+        $this->assertSame('testing.INFO: This is an info log. {"value_from_context":"bye","tim":"macdonald"}', Str::trim($log));
+
+        file_put_contents($path, '');
+    }
+
     public function test_it_increments_a_counter()
     {
         Context::increment('foo');


### PR DESCRIPTION
Imagine you're embarking on a legacy codebase started on Laravel 5. The engineers were adding lots and lots of log statements, but because something like Context didn't exist, they were repeatedly writing logs like this:

```php
logs()->info('Return in progress', [
    'shopId' => $shop->id,
    'returnId' => $return->id,
]);
// ...
logs()->info('Return completed', [
    'shopId' => $shop->id,
    'returnId' => $return->id,
]);
```

Obviously duplicating these contextual pieces of data is arduous and error-prone. Along comes the Context facade and this can be simplified to:

```php
Context::add([
    'shopId' => $shop->id,
    'returnId' => $return->id,
]);

logs()->info('Return in progress');
// ...
logs()->info('Return completed');
```

But for keen observers, they'll realize these two snippets of code actually function differently. In the first, the data lives under the log's context, whereas in the second, the data now lives under extra. For DataDog queries that search for logs based on contextual data, the first goes from `@context.shopId=123` to `@context.extra.shopId=123`

This can be changed, of course, by binding our own log processor. However, I have done this on the last 3 projects I have worked on, so I figured it may be helpful to others.

With this MR, a developer would simply add something like this to their AppServiceProvider@boot():

```php
Context::writeContextToLogContext();
```

**Note**: This gives the values set in the log method precedence over what is stored in the Context repository.