### PR TITLE
[12.x] Feature: allow UnitEnum in has() method of Gate class

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
-use function Illuminate\Support\enum_value;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Auth\Access\Events\GateEvaluated;
@@ -18,6 +17,9 @@ use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 
 use Illuminate\Tests\JsonSchema\Fixtures\Enums\UnitEnum;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+
+use function Illuminate\Support\enum_value;
+
 
 class Gate implements GateContract
 {

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -15,10 +15,8 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;
-use UnitEnum;
 
 use function Illuminate\Support\enum_value;
-
 
 class Gate implements GateContract
 {
@@ -119,7 +117,7 @@ class Gate implements GateContract
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string|UnitEnum|array  $ability
+     * @param  string|\UnitEnum|array  $ability
      * @return bool
      */
     public function has($ability)

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -4,19 +4,20 @@ namespace Illuminate\Auth\Access;
 
 use Closure;
 use Exception;
-use Illuminate\Auth\Access\Events\GateEvaluated;
-use Illuminate\Contracts\Auth\Access\Gate as GateContract;
-use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Attributes\UsePolicy;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;
-
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Illuminate\Support\Collection;
 use function Illuminate\Support\enum_value;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Auth\Access\Events\GateEvaluated;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+
+use Illuminate\Tests\JsonSchema\Fixtures\Enums\UnitEnum;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 class Gate implements GateContract
 {
@@ -117,7 +118,7 @@ class Gate implements GateContract
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string|array  $ability
+     * @param  string|UnitEnum|array  $ability
      * @return bool
      */
     public function has($ability)
@@ -125,7 +126,7 @@ class Gate implements GateContract
         $abilities = is_array($ability) ? $ability : func_get_args();
 
         foreach ($abilities as $ability) {
-            if (! isset($this->abilities[$ability])) {
+            if (! isset($this->abilities[enum_value($ability)])) {
                 return false;
             }
         }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -117,7 +117,7 @@ class Gate implements GateContract
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string|\UnitEnum|array  $ability
+     * @param  \UnitEnum|array|string  $ability
      * @return bool
      */
     public function has($ability)

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -4,19 +4,17 @@ namespace Illuminate\Auth\Access;
 
 use Closure;
 use Exception;
-use ReflectionClass;
-use ReflectionFunction;
+use Illuminate\Auth\Access\Events\GateEvaluated;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Container\Container;
-use Illuminate\Auth\Access\Events\GateEvaluated;
-use Illuminate\Database\Eloquent\Attributes\UsePolicy;
-
-use Illuminate\Tests\JsonSchema\Fixtures\Enums\UnitEnum;
-use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use ReflectionClass;
+use ReflectionFunction;
 
 use function Illuminate\Support\enum_value;
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;
+use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -7,7 +7,7 @@ interface Gate
     /**
      * Determine if a given ability has been defined.
      *
-     * @param  string  $ability
+     * @param  \UnitEnum|string  $ability
      * @return bool
      */
     public function has($ability);

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 /**
- * @method static bool has(string|array $ability)
+ * @method static bool has(\UnitEnum|string|array $ability)
  * @method static \Illuminate\Auth\Access\Response allowIf(\Illuminate\Auth\Access\Response|\Closure|bool $condition, string|null $message = null, string|null $code = null)
  * @method static \Illuminate\Auth\Access\Response denyIf(\Illuminate\Auth\Access\Response|\Closure|bool $condition, string|null $message = null, string|null $code = null)
  * @method static \Illuminate\Auth\Access\Gate define(\UnitEnum|string $ability, callable|array|string $callback)


### PR DESCRIPTION
Since the [`Gate::define()`](https://github.com/laravel/framework/blob/379bf4247ddb2f5c6144475c3d07e2678d8b048f/src/Illuminate/Contracts/Auth/Access/Gate.php#L18) method allows the `$ability` argument to be an Enum, the [`Gate::has()`](https://github.com/laravel/framework/blob/379bf4247ddb2f5c6144475c3d07e2678d8b048f/src/Illuminate/Contracts/Auth/Access/Gate.php#L10) method should also accept an Enum.

This PR aligns both methods for consistency.