### PR TITLE
[12.x] Add `@includeIsolated` directive for isolated Blade includes

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -79,4 +79,17 @@ trait CompilesIncludes
 
         return "<?php echo \$__env->first({$expression}, array_diff_key(get_defined_vars(), ['__data' => 1, '__path' => 1]))->render(); ?>";
     }
+
+    /**
+     * Compile the include-scoped statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeScoped($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->make({$expression}, [])->render(); ?>";
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -90,6 +90,6 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->make({$expression}, [])->render(); ?>";
+        return "<?php echo \$__env->make({$expression})->render(); ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -81,12 +81,12 @@ trait CompilesIncludes
     }
 
     /**
-     * Compile the include-scoped statements into valid PHP.
+     * Compile the include-isolated statements into valid PHP.
      *
      * @param  string  $expression
      * @return string
      */
-    protected function compileIncludeScoped($expression)
+    protected function compileIncludeIsolated($expression)
     {
         $expression = $this->stripParentheses($expression);
 

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -235,7 +235,7 @@ class BladeTest extends TestCase
 
         $this->assertSame('Parent: parent-value, Explicit: explicit-value', trim($regularInclude));
 
-        // @includeScoped does NOT pass parent scope variables
+        // @includeIsolated does NOT pass parent scope variables
         $scopedInclude = View::make('uses-include-scoped', [
             'parentVar' => 'parent-value',
             'explicitVar' => 'explicit-value',

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -225,6 +225,25 @@ class BladeTest extends TestCase
         $this->assertTrue($found);
     }
 
+    public function test_include_scoped_does_not_inherit_parent_scope()
+    {
+        // Regular @include passes parent scope variables
+        $regularInclude = View::make('uses-include-regular', [
+            'parentVar' => 'parent-value',
+            'explicitVar' => 'explicit-value',
+        ])->render();
+
+        $this->assertSame('Parent: parent-value, Explicit: explicit-value', trim($regularInclude));
+
+        // @includeScoped does NOT pass parent scope variables
+        $scopedInclude = View::make('uses-include-scoped', [
+            'parentVar' => 'parent-value',
+            'explicitVar' => 'explicit-value',
+        ])->render();
+
+        $this->assertSame('Parent: undefined, Explicit: explicit-value', trim($scopedInclude));
+    }
+
     /** {@inheritdoc} */
     #[\Override]
     protected function defineEnvironment($app)

--- a/tests/Integration/View/templates/partials/scoped-partial.blade.php
+++ b/tests/Integration/View/templates/partials/scoped-partial.blade.php
@@ -1,0 +1,1 @@
+Parent: {{ $parentVar ?? 'undefined' }}, Explicit: {{ $explicitVar }}

--- a/tests/Integration/View/templates/uses-include-regular.blade.php
+++ b/tests/Integration/View/templates/uses-include-regular.blade.php
@@ -1,0 +1,1 @@
+@include('partials.scoped-partial', ['explicitVar' => $explicitVar])

--- a/tests/Integration/View/templates/uses-include-scoped.blade.php
+++ b/tests/Integration/View/templates/uses-include-scoped.blade.php
@@ -1,0 +1,1 @@
+@includeScoped('partials.scoped-partial', ['explicitVar' => $explicitVar])

--- a/tests/Integration/View/templates/uses-include-scoped.blade.php
+++ b/tests/Integration/View/templates/uses-include-scoped.blade.php
@@ -1,1 +1,1 @@
-@includeScoped('partials.scoped-partial', ['explicitVar' => $explicitVar])
+@includeIsolated('partials.scoped-partial', ['explicitVar' => $explicitVar])

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -49,9 +49,9 @@ class BladeIncludesTest extends AbstractBladeTestCase
 
     public function testIncludeScopedsAreCompiled()
     {
-        $this->assertSame('<?php echo $__env->make(\'foo\')->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\')'));
-        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((\'])'));
-        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((a)\' => \'((a)\'])'));
-        $this->assertSame('<?php echo $__env->make(name(foo))->render(); ?>', $this->compiler->compileString('@includeScoped(name(foo))'));
+        $this->assertSame('<?php echo $__env->make(\'foo\')->render(); ?>', $this->compiler->compileString('@includeIsolated(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'])->render(); ?>', $this->compiler->compileString('@includeIsolated(\'foo\', [\'((\'])'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'])->render(); ?>', $this->compiler->compileString('@includeIsolated(\'foo\', [\'((a)\' => \'((a)\'])'));
+        $this->assertSame('<?php echo $__env->make(name(foo))->render(); ?>', $this->compiler->compileString('@includeIsolated(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -46,4 +46,12 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], ["foo" => "bar(-(("], array_diff_key(get_defined_vars(), [\'__data\' => 1, \'__path\' => 1]))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], ["foo" => "bar(-(("])'));
         $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], [(string) "foo()" => "bar(-(("], array_diff_key(get_defined_vars(), [\'__data\' => 1, \'__path\' => 1]))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], [(string) "foo()" => "bar(-(("])'));
     }
+
+    public function testIncludeScopedsAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->make(\'foo\', [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'], [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((\'])'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'], [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((a)\' => \'((a)\'])'));
+        $this->assertSame('<?php echo $__env->make(name(foo), [])->render(); ?>', $this->compiler->compileString('@includeScoped(name(foo))'));
+    }
 }

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -49,9 +49,9 @@ class BladeIncludesTest extends AbstractBladeTestCase
 
     public function testIncludeScopedsAreCompiled()
     {
-        $this->assertSame('<?php echo $__env->make(\'foo\', [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\')'));
-        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'], [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((\'])'));
-        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'], [])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((a)\' => \'((a)\'])'));
-        $this->assertSame('<?php echo $__env->make(name(foo), [])->render(); ?>', $this->compiler->compileString('@includeScoped(name(foo))'));
+        $this->assertSame('<?php echo $__env->make(\'foo\')->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((\'])'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'])->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\', [\'((a)\' => \'((a)\'])'));
+        $this->assertSame('<?php echo $__env->make(name(foo))->render(); ?>', $this->compiler->compileString('@includeScoped(name(foo))'));
     }
 }


### PR DESCRIPTION
This PR introduces a new `@includeIsolated` Blade directive that includes a view without inheriting the parent scope's variables.

I work in a codebase where we use `<x-component>` for reusable components and `@component()` for partials (because we like variable isolation). However, `@component()` brings overhead we don't need: slot management, the opening/closing tag ceremony, and component lifecycle logic.

`@includeIsolated` would give us the best of both worlds: the simplicity of `@include` with the isolation of `@component`.

This PR is another shot of: https://github.com/laravel/framework/pull/45616

## Motivation

Currently, `@include` passes all parent scope variables via `get_defined_vars()`:

```blade
{{-- Parent view has $user, $errors, $config, etc. --}}

@include('partials.hero', ['message' => $error])
{{-- hero.blade.php receives $message + ALL parent variables --}}
```

This implicit inheritance can lead to:

- Variable collisions in nested partials
- Unpredictable behavior when partials accidentally depend on the parent scope
- Harder debugging when variables "magically" appear

The recommended workaround is Blade components (`<x-partials.hero />`), but components come with overhead 
(slots, validation, class resolution) that isn't always needed for simple partials.

### Proposed Solution

`@includeIsolated()` provides explicit-only data passing where "explicit > implicit":

```blade
@includeIsolated('partials.hero', ['message' => $error])
{{-- hero.blade.php receives ONLY $message --}}
```

**Benefits:**

- Cleaner syntax for isolated partials (no closing tag needed)
- Lighter than `@component` (no slot/component machinery)
- Consistent with existing `@includeIf`, `@includeWhen`, `@includeFirst` patterns
- Prevents accidental variable leakage and naming collisions


