### PR TITLE
[12.x] Add `Collection::containsManyItems()` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -743,11 +743,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function containsManyItems(?callable $callback = null): bool
     {
-        if ($callback) {
-            return $this->filter($callback)->count() > 1;
+        if (! $callback) {
+            return $this->count() > 1;
         }
 
-        return $this->count() > 1;
+        $count = 0;
+
+        foreach ($this as $key => $item) {
+            if ($callback($item, $key)) {
+                $count++;
+            }
+
+            if ($count > 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -736,6 +736,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection contains multiple items. If a callback is provided, determine if multiple items match the condition.
+     *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @return bool
+     */
+    public function containsManyItems(?callable $callback = null): bool
+    {
+        if ($callback) {
+            return $this->filter($callback)->count() > 1;
+        }
+
+        return $this->count() > 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -627,6 +627,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
 
     /**
      * Determine if the collection contains multiple items.
+     *
      * @return bool
      */
     public function containsManyItems();

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -626,6 +626,12 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function containsOneItem();
 
     /**
+     * Determine if the collection contains multiple items.
+     * @return bool
+     */
+    public function containsManyItems();
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -732,6 +732,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection contains multiple items.
+     *
+     * @return bool
+     */
+    public function containsManyItems(): bool
+    {
+        return $this->take(2)->count() > 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -900,6 +900,20 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) > 4));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testContainsManyItems($collection)
+    {
+        $this->assertFalse((new $collection([]))->containsManyItems());
+        $this->assertFalse((new $collection([1]))->containsManyItems());
+        $this->assertTrue((new $collection([1, 2]))->containsManyItems());
+        $this->assertTrue((new $collection([1, 2, 3]))->containsManyItems());
+
+        $this->assertTrue(collect([1, 2, 2])->containsManyItems(fn ($number) => $number === 2));
+        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 4));
+        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) > 4));
+        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 3));
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -392,6 +392,21 @@ class SupportLazyCollectionTest extends TestCase
         $this->assertFalse($multipleCollection->containsOneItem());
     }
 
+    public function testContainsManyItems()
+    {
+        $emptyCollection = new LazyCollection([]);
+        $this->assertFalse($emptyCollection->containsManyItems());
+
+        $singleCollection = new LazyCollection([1]);
+        $this->assertFalse($singleCollection->containsManyItems());
+
+        $multipleCollection = new LazyCollection([1, 2]);
+        $this->assertTrue($multipleCollection->containsManyItems());
+
+        $manyCollection = new LazyCollection([1, 2, 3]);
+        $this->assertTrue($manyCollection->containsManyItems());
+    }
+
     public function testDoesntContain()
     {
         $collection = new LazyCollection([1, 2, 3, 4, 5]);


### PR DESCRIPTION
This PR adds the `containsManyItems` method to collections, like the `containsOneItem` method that already exists.

This assists in keeping a uniform syntax in situations where you need to take a code path depending on the collection being empty, having one item, or having many:

```php
match (true) {
    $collection->isEmpty() => '...',
    $collection->containsOneItem() => '...',
    $collection->containsManyItems() => '...',
};
```