### PR TITLE
[12.x] Fixed phpdoc of `Container::buildSelfBuildingInstance`, to prevent psalm from erroring when parsing the class

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1180,7 +1180,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @template TClass of object
      *
-     * @param object{'newInstance': \Closure(static, array): TClass|class-string<TClass>} $concrete
+     * @param  object{'newInstance': \Closure(static, array): TClass|class-string<TClass>} $concrete
      *
      * @param  \ReflectionClass  $reflector
      * @return TClass

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1178,7 +1178,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Instantiate a concrete instance of the given self building type.
      *
-     * @param  \Closure(static, array): TClass|class-string<TClass>  $concrete
+     * @template TClass of object
+     *
+     * @param object{'newInstance': \Closure(static, array): TClass|class-string<TClass>} $concrete
+     *
      * @param  \ReflectionClass  $reflector
      * @return TClass
      *

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1181,7 +1181,6 @@ class Container implements ArrayAccess, ContainerContract
      * @template TClass of object
      *
      * @param  object{'newInstance': \Closure(static, array): TClass|class-string<TClass>}  $concrete
-     *
      * @param  \ReflectionClass  $reflector
      * @return TClass
      *

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1180,7 +1180,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @template TClass of object
      *
-     * @param  object{'newInstance': \Closure(static, array): TClass|class-string<TClass>} $concrete
+     * @param  object{'newInstance': \Closure(static, array): TClass|class-string<TClass>}  $concrete
      *
      * @param  \ReflectionClass  $reflector
      * @return TClass


### PR DESCRIPTION
Fixed the phpdoc of the `buildSelfBuildingInstance` function, in the `Container` class, to fix an error when attempting to analyze the class using psalm version 6.14.3 and up. 

Fixes https://github.com/laravel/framework/issues/58313 
