### PR TITLE
[12.x] Add shorthand aliases for validation rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1943,18 +1943,6 @@ trait ValidatesAttributes
     }
 
     /**
-     * "Indicate" validation should pass if value is null.
-     *
-     * Always returns true, just lets us put "null" in rules.
-     *
-     * @return bool
-     */
-    public function validateNull()
-    {
-        return true;
-    }
-
-    /**
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1943,6 +1943,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * "Indicate" validation should pass if value is null.
+     *
+     * Always returns true, just lets us put "null" in rules.
+     *
+     * @return bool
+     */
+    public function validateNull()
+    {
+        return true;
+    }
+
+    /**
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -320,6 +320,10 @@ class ValidationRuleParser
         return match ($rule) {
             'Int' => 'Integer',
             'Bool' => 'Boolean',
+            'Str' => 'String',
+            'Arr' => 'Array',
+            'Null' => 'Nullable',
+            'Num' => 'Numeric',
             default => $rule,
         };
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1253,7 +1253,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Arr']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => new File('/tmp/foo', false)], ['foo' => 'Array']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => new File('/tmp/foo', false)], ['foo' => 'Arr']);
         $this->assertFalse($v->passes());
     }
 
@@ -3227,7 +3233,15 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'str']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ['blah' => 'test']], ['x' => 'string']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => ['blah' => 'test']], ['x' => 'str']);
         $this->assertFalse($v->passes());
     }
 
@@ -3421,6 +3435,19 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Numeric']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Num']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Num']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '-1'], ['foo' => 'Num']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Num']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -332,6 +332,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [
             'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
         ], [
+            'x' => 'string|null', 'y' => 'integer|null', 'z' => 'numeric|null', 'a' => 'array|null', 'b' => 'bool|null',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
+        ], [
             'x' => 'string', 'y' => 'integer', 'z' => 'numeric', 'a' => 'array', 'b' => 'bool',
         ]);
         $this->assertTrue($v->fails());


### PR DESCRIPTION
## Description

This PR adds shorthand aliases for common validation rules to match PHP's native type naming conventions and complete the existing pattern established with `Int` and `Bool`.

## Motivation

Laravel already normalizes `Int` → `Integer` and `Bool` → `Boolean` in the `normalizeRule` method. This PR completes that pattern by adding aliases for other common validation rules, making them more concise and aligned with PHP's type system.

**Benefits:**
- **Consistency with PHP types**: Developers can use the same short forms they use in type hints (`string`, `array`, `int`, etc.)
- **Improved readability**: Shorter validation rules are easier to scan
- **Completes existing pattern**: Builds on the established normalization approach

## Usage Examples

**Before:**
```php
$request->validate([
    'name' => 'required|string|max:50',
    'tags' => 'nullable|array',
    'age' => 'required|integer|numeric',
    'active' => 'required|boolean',
]);
```

**After (both forms work):**
```php
$request->validate([
    'name' => 'required|str|max:50',
    'tags' => 'null|arr',
    'age' => 'required|int|num',
    'active' => 'required|bool',
]);
```

## Backward Compatibility

Fully backward compatible - existing code continues to work unchanged.