### PR TITLE
[12.x] Make `MessageSent::$message` a property hook

### DIFF
--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -5,12 +5,17 @@ namespace Illuminate\Mail\Events;
 use Exception;
 use Illuminate\Mail\SentMessage;
 use Illuminate\Support\Collection;
+use Symfony\Component\Mime\RawMessage;
 
 /**
  * @property \Symfony\Component\Mime\Email $message
  */
 class MessageSent
 {
+    public RawMessage $message {
+        get => $this->sent->getOriginalMessage();
+    }
+    
     /**
      * Create a new event instance.
      *
@@ -52,22 +57,5 @@ class MessageSent
         $this->data = (($data['hasAttachments'] ?? false) === true)
             ? unserialize(base64_decode($data['data']))
             : $data['data'];
-    }
-
-    /**
-     * Dynamically get the original message.
-     *
-     * @param  string  $key
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    public function __get($key)
-    {
-        if ($key === 'message') {
-            return $this->sent->getOriginalMessage();
-        }
-
-        throw new Exception('Unable to access undefined property on '.__CLASS__.': '.$key);
     }
 }

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -7,9 +7,6 @@ use Illuminate\Mail\SentMessage;
 use Illuminate\Support\Collection;
 use Symfony\Component\Mime\RawMessage;
 
-/**
- * @property \Symfony\Component\Mime\Email $message
- */
 class MessageSent
 {
     public RawMessage $message {


### PR DESCRIPTION
# Benefits
* ✅ Improved typing (`mixed` &rarr; `\Symfony\Component\Mime\RawMessage`)
* ✅ Better static analysis (property `$message` is now natively supported and doesn't have to be explicitly annotated)
* ✅ Increased readability (no more magic property names in `__get()`)
* ✅ State of the art code