### PR TITLE
[12.x] Add `Arr::onlyValues` and `Arr::exceptValues`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -220,14 +220,15 @@ class Arr
      *
      * @param  array  $array
      * @param  mixed  $values
+     * @param  bool  $strict
      * @return array
      */
-    public static function exceptValues($array, $values)
+    public static function exceptValues($array, $values, $strict = false)
     {
         $values = (array) $values;
 
-        return array_filter($array, function ($value) use ($values) {
-            return ! in_array($value, $values);
+        return array_filter($array, function ($value) use ($values, $strict) {
+            return ! in_array($value, $values, $strict);
         });
     }
 
@@ -710,14 +711,15 @@ class Arr
      *
      * @param  array  $array
      * @param  mixed  $values
+     * @param  bool  $strict
      * @return array
      */
-    public static function onlyValues($array, $values)
+    public static function onlyValues($array, $values, $strict = false)
     {
         $values = (array) $values;
 
-        return array_filter($array, function ($value) use ($values) {
-            return in_array($value, $values);
+        return array_filter($array, function ($value) use ($values, $strict) {
+            return in_array($value, $values, $strict);
         });
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -216,6 +216,22 @@ class Arr
     }
 
     /**
+     * Get all of the given array except for a specified array of values.
+     *
+     * @param  array  $array
+     * @param  mixed  $values
+     * @return array
+     */
+    public static function exceptValues($array, $values)
+    {
+        $values = (array) $values;
+
+        return array_filter($array, function ($value) use ($values) {
+            return ! in_array($value, $values);
+        });
+    }
+
+    /**
      * Determine if the given key exists in the provided array.
      *
      * @param  \ArrayAccess|array  $array
@@ -687,6 +703,22 @@ class Arr
     public static function only($array, $keys)
     {
         return array_intersect_key($array, array_flip((array) $keys));
+    }
+
+    /**
+     * Get a subset of the items from the given array by value.
+     *
+     * @param  array  $array
+     * @param  mixed  $values
+     * @return array
+     */
+    public static function onlyValues($array, $values)
+    {
+        $values = (array) $values;
+
+        return array_filter($array, function ($value) use ($values) {
+            return in_array($value, $values);
+        });
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -296,6 +296,34 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => 'hAz', 2 => [12 => 'baz']], Arr::except($array, 2.5));
     }
 
+    public function testExceptValues()
+    {
+        $array = ['name' => 'taylor', 'age' => 26, 'city' => 'austin'];
+        $this->assertEquals(['name' => 'taylor', 'city' => 'austin'], Arr::exceptValues($array, [26]));
+        $this->assertEquals(['name' => 'taylor', 'city' => 'austin'], Arr::exceptValues($array, 26));
+
+        $array = ['foo', 'bar', 'baz', 'qux'];
+        $this->assertEquals([1 => 'bar', 3 => 'qux'], Arr::exceptValues($array, ['foo', 'baz']));
+        $this->assertEquals([0 => 'foo', 1 => 'bar', 3 => 'qux'], Arr::exceptValues($array, 'baz'));
+
+        $array = [1, 2, 3, 4, 5];
+        $this->assertEquals([0 => 1, 1 => 2, 4 => 5], Arr::exceptValues($array, [3, 4]));
+
+        $array = ['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3];
+        $this->assertEquals(['b' => 2, 'd' => 3], Arr::exceptValues($array, 1));
+
+        $this->assertEquals([], Arr::exceptValues([], 'foo'));
+        $this->assertEquals(['foo', 'bar'], Arr::exceptValues(['foo', 'bar'], []));
+
+        $array = [1, '1', 2, '2', 3];
+        $this->assertEquals([1 => '1', 3 => '2'], Arr::exceptValues($array, [1, 2, 3], true));
+        $this->assertEquals([], Arr::exceptValues($array, [1, 2, 3]));
+
+        $array = ['a' => true, 'b' => false, 'c' => 1, 'd' => 0];
+        $this->assertEquals(['a' => true, 'b' => false], Arr::exceptValues($array, [1, 0], true));
+        $this->assertEquals([], Arr::exceptValues($array, [1, 0]));
+    }
+
     public function testExists()
     {
         $this->assertTrue(Arr::exists([1], 0));
@@ -856,6 +884,34 @@ class SupportArrTest extends TestCase
         // Test with array having numeric key and string key
         $this->assertEquals(['foo'], Arr::only(['foo', 'bar' => 'baz'], 0));
         $this->assertEquals(['bar' => 'baz'], Arr::only(['foo', 'bar' => 'baz'], 'bar'));
+    }
+
+    public function testOnlyValues()
+    {
+        $array = ['name' => 'taylor', 'age' => 26, 'city' => 'austin'];
+        $this->assertEquals(['age' => 26], Arr::onlyValues($array, [26]));
+        $this->assertEquals(['age' => 26], Arr::onlyValues($array, 26));
+
+        $array = ['foo', 'bar', 'baz', 'qux'];
+        $this->assertEquals([0 => 'foo', 2 => 'baz'], Arr::onlyValues($array, ['foo', 'baz']));
+        $this->assertEquals([2 => 'baz'], Arr::onlyValues($array, 'baz'));
+
+        $array = [1, 2, 3, 4, 5];
+        $this->assertEquals([2 => 3, 3 => 4], Arr::onlyValues($array, [3, 4]));
+
+        $array = ['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3];
+        $this->assertEquals(['a' => 1, 'c' => 1], Arr::onlyValues($array, 1));
+
+        $this->assertEquals([], Arr::onlyValues([], 'foo'));
+        $this->assertEquals([], Arr::onlyValues(['foo', 'bar'], []));
+
+        $array = [1, '1', 2, '2', 3];
+        $this->assertEquals([0 => 1, 2 => 2, 4 => 3], Arr::onlyValues($array, [1, 2, 3], true));
+        $this->assertEquals([0 => 1, 1 => '1', 2 => 2, 3 => '2', 4 => 3], Arr::onlyValues($array, [1, 2, 3]));
+
+        $array = ['a' => true, 'b' => false, 'c' => 1, 'd' => 0];
+        $this->assertEquals(['c' => 1, 'd' => 0], Arr::onlyValues($array, [1, 0], true));
+        $this->assertEquals(['a' => true, 'b' => false, 'c' => 1, 'd' => 0], Arr::onlyValues($array, [1, 0]));
     }
 
     public function testPluck()


### PR DESCRIPTION
### Description

This PR adds two new helper methods to the `Support\Arr` class to filter arrays by their values (complementing the existing `only()` and `except()` methods which filter by keys). This gives us a shorthand of `array_filter($array, fn () => in_array(...))`.

### Example

```php
//  Keep only specified values:
Arr::onlyValues(['foo', 'bar', 'baz', 'qux'], ['foo', 'baz']); // ['foo', 'baz']

// Remove specified values:
Arr::exceptValues(['foo', 'bar', 'baz', 'qux'], ['foo', 'baz']); // ['bar', 'qux']

// Strict type comparison:
Arr::onlyValues([1, '1', 2, '2'], [1, 2], strict: true); // [1, 2]
```