### PR TITLE
[12.x] Add FileFactory::fromPath (and File::fromPath) to create fakes from filesystem path

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -76,6 +76,19 @@ class File extends UploadedFile
     }
 
     /**
+     * Create a new fake file from an existing path.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  string|null  $mimeType
+     * @return \Illuminate\Http\Testing\File
+     */
+    public static function fromPath($path, $name = null, $mimeType = null)
+    {
+        return (new FileFactory)->fromPath($path, $name, $mimeType);
+    }
+
+    /**
      * Create a new fake image.
      *
      * @param  string  $name

--- a/tests/Http/HttpTestingFileFromPathTest.php
+++ b/tests/Http/HttpTestingFileFromPathTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use Illuminate\Http\Testing\File as TestingFile;
+use Illuminate\Http\Testing\FileFactory;
+use PHPUnit\Framework\TestCase;
+
+class HttpTestingFileFromPathTest extends TestCase
+{
+    public function testFromPathCreatesFileWithBasenameSizeAndMime()
+    {
+        $path = __DIR__.'/fixtures/test.txt';
+
+        $file = (new FileFactory)->fromPath($path);
+
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame(filesize($path), $file->getSize());
+        $this->assertSame('text/plain', $file->getMimeType());
+    }
+
+    public function testFromPathAllowsOverridingNameAndMime()
+    {
+        $path = __DIR__.'/fixtures/test.txt';
+
+        $file = (new FileFactory)->fromPath($path, 'custom.bin', 'application/octet-stream');
+
+        $this->assertSame('custom.bin', $file->getClientOriginalName());
+        $this->assertSame('application/octet-stream', $file->getMimeType());
+    }
+
+    public function testStaticFileFromPathConvenience()
+    {
+        $path = __DIR__.'/fixtures/test.txt';
+
+        $file = TestingFile::fromPath($path);
+
+        $this->assertSame('test.txt', $file->getClientOriginalName());
+        $this->assertSame(filesize($path), $file->getSize());
+        $this->assertSame('text/plain', $file->getMimeType());
+    }
+
+    public function testFromPathThrowsOnMissingFile()
+    {
+        $this->expectException(\LogicException::class);
+
+        (new FileFactory)->fromPath(__DIR__.'/fixtures/does-not-exist.txt');
+    }
+}
+


### PR DESCRIPTION
Introduces a convenient way to create fake uploaded files from an existing file on disk:
`Illuminate\Http\Testing\FileFactory::fromPath(<span>path,</span>name = null, $mimeType = null)`
`Illuminate\Http\Testing\File::fromPath(<span>path,</span>name = null, $mimeType = null)`

### Motivation

When tests depend on pre-existing fixture files saved on disk, it’s cumbersome to manually handle temp streams or load entire contents into memory. This provides a simple, expressive helper, consistent with other factory methods like create, createWithContent, and image. Naming aligns with existing conventions such as Mail `Attachment::fromPath`.


### Tests

`tests/Http/HttpTestingFileFromPathTest.php`:
Ensures basename, size, and inferred MIME are correct.
Verifies name and MIME can be overridden.
Covers the static convenience File::fromPath.
Asserts an exception is thrown for missing files.