### PR TITLE
[12.x] Feat: add `notTrashed()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -206,6 +206,16 @@ trait SoftDeletes
     }
 
     /**
+     * Determine if the model instance has not been soft-deleted.
+     *
+     * @return bool
+     */
+    public function notTrashed()
+    {
+        return is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
      * Register a "softDeleted" model event callback with the dispatcher.
      *
      * @param  \Illuminate\Events\QueuedClosure|callable|class-string  $callback


### PR DESCRIPTION
🔹 Add `notTrashed()` helper method to SoftDeletes

This PR introduces a `notTrashed()` method as the semantic opposite of trashed().

Benefits:

Improves readability and expressiveness in conditions

Avoids negating `trashed()` (!$model->trashed())

Aligns with Laravel’s fluent and intention-revealing API style

No behavior change, just a clean and clearer alternative for checking non–soft-deleted models.