### PR TITLE
[12.x] Add --table option to make:model for explicit table control

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -92,7 +92,7 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Get the table name
+     * Get the table name.
      */
     protected function getTableName()
     {
@@ -235,7 +235,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return is_dir(app_path('Models')) ? $rootNamespace . '\\Models' : $rootNamespace;
+        return is_dir(app_path('Models')) ? $rootNamespace.'\\Models' : $rootNamespace;
     }
 
     /**
@@ -272,7 +272,6 @@ class ModelMakeCommand extends GeneratorCommand
         );
     }
 
-
     /**
      * Build the replacements for a factory.
      *
@@ -285,7 +284,7 @@ class ModelMakeCommand extends GeneratorCommand
         if ($this->option('factory') || $this->option('all')) {
             $modelPath = Str::of($this->argument('name'))->studly()->replace('/', '\\')->toString();
 
-            $factoryNamespace = '\\Database\\Factories\\' . $modelPath . 'Factory';
+            $factoryNamespace = '\\Database\\Factories\\'.$modelPath.'Factory';
 
             $factoryCode = <<<EOT
             /** @use HasFactory<$factoryNamespace> */
@@ -335,7 +334,6 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function buildTableReplacements(): array
     {
-        // If a custom table was provided, inject the property block.
         if (! blank($this->option('table'))) {
             $table = $this->getTableName();
 
@@ -353,8 +351,6 @@ class ModelMakeCommand extends GeneratorCommand
             ];
         }
 
-        // No table option passed...
-        // For pivot & morph-pivot: keep placeholder but replace with comment.
         if ($this->option('pivot') || $this->option('morph-pivot')) {
             return [
                 '{{ table }}' => '//',
@@ -362,11 +358,11 @@ class ModelMakeCommand extends GeneratorCommand
         }
 
         return [
-            "    {{ table }}\n"   => '',
+            "    {{ table }}\n" => '',
             "    {{ table }}\r\n" => '',
-            "{{ table }}\n"       => '',
-            "{{ table }}\r\n"     => '',
-            '{{ table }}'         => '',
+            "{{ table }}\n" => '',
+            "{{ table }}\r\n" => '',
+            '{{ table }}' => '',
         ];
     }
 
@@ -414,6 +410,6 @@ class ModelMakeCommand extends GeneratorCommand
             'migration' => 'Migration',
             'policy' => 'Policy',
             'resource' => 'Resource Controller',
-        ])))->each(fn($option) => $input->setOption($option, true));
+        ])))->each(fn ($option) => $input->setOption($option, true));
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.morph-pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.morph-pivot.stub
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Relations\MorphPivot;
 
 class {{ class }} extends MorphPivot
 {
-    //
+    {{ table }}
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class {{ class }} extends Pivot
 {
-    //
+    {{ table }}
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -8,4 +8,5 @@ use Illuminate\Database\Eloquent\Model;
 class {{ class }} extends Model
 {
     {{ factory }}
+    {{ table }}
 }


### PR DESCRIPTION

### Why this change is needed

Laravel’s `make:model` command currently assumes Eloquent’s default table naming convention and does not provide a way to define a custom table name at generation time. When working with legacy databases, shared schemas, reporting tables, or unconventional pivot tables, developers must manually edit the generated model (and often its migration) after generation.

This PR introduces a `--table` option to `make:model`, allowing the table name to be defined explicitly during generation and keeping model intent and database structure aligned from the start.

---

### What this PR solves

#### Explicit table definition at generation time

```bash
php artisan make:model Invoice --table=custom_invoices
```

Generates:

```php
class Invoice extends Model
{
    protected $table = 'custom_invoices';
}
```

This removes a common manual step and makes the table mapping explicit and self-documenting.

---

#### Migration consistency

When used with `--migration`, the custom table name is also applied to:

- Migration file name
- `Schema::create(...)`
- `Schema::dropIfExists(...)`

This ensures the generated migration matches the model configuration without additional edits.

---

#### Better pivot and morph-pivot ergonomics

Pivot and morph-pivot models frequently rely on non-conventional table names. This change supports that use case while preserving defaults:

- The `$table` property is only generated when `--table` is explicitly provided
- Pivot and morph-pivot models remain clean when no override is needed
- No implicit behavior changes to Eloquent’s default conventions

---

#### Stub-based and backwards compatible

This change introduces a `{{ table }}` placeholder to the model stubs and replaces it during generation:

- When `--table` is provided, the placeholder is replaced with a `$table` property
- When not provided:
  - For normal models, the placeholder is removed entirely
  - For pivot and morph-pivot models, it is replaced with a comment to preserve formatting

All existing behavior remains unchanged unless the new option is explicitly used.

---

### Why this belongs in core

- Custom table names are a common real-world requirement
- The feature integrates naturally with existing generator options
- It removes repetitive manual edits after model generation
- The implementation is minimal, explicit, and fully backwards compatible

---

### Tests

The PR includes integration tests covering:

- Models generated with and without `--table`
- Pivot and morph-pivot models
- Migration generation with custom table names
- Ensuring stub placeholders are correctly removed or replaced

---

### Summary

This PR makes `make:model` more expressive without adding complexity, improves correctness for non-standard schemas, and preserves Laravel’s conventions by default.
