### PR TITLE
[12.x] Fix circular references support on JSON:API component

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Resources\JsonApi\Concerns;
 
 use Generator;
 use Illuminate\Contracts\Support\Arrayable;
-use WeakMap;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\AsPivot;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -21,6 +20,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use JsonSerializable;
+use WeakMap;
 
 trait ResolvesJsonApiElements
 {

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -3,11 +3,7 @@
 namespace Illuminate\Tests\Http\Resources\JsonApi;
 
 use BadMethodCallException;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Http\Resources\JsonApi\Exceptions\ResourceIdentificationException;
-use Illuminate\Http\Resources\JsonApi\JsonApiRequest;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 use PHPUnit\Framework\TestCase;
 
@@ -42,50 +38,5 @@ class JsonApiResourceTest extends TestCase
         $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.');
 
         JsonApiResource::withoutWrapping();
-    }
-
-    public function testPlainJsonResourceWithArrayCannotBeIncluded()
-    {
-        $this->expectException(ResourceIdentificationException::class);
-
-        $model = new class extends Model {};
-        $model->id = 1;
-
-        $resource = new JsonApiResource($model);
-        $resource->loadedRelationshipsMap = [
-            [new JsonResource(['id' => 1, 'name' => 'test']), 'things', '1', true],
-        ];
-
-        $resource->resolveIncludedResourceObjects(new JsonApiRequest);
-    }
-
-    public function testIncludedResourcesCanBeArrayBackedCustomResources()
-    {
-        $model = new class extends Model {};
-        $model->id = 1;
-
-        $resource = new JsonApiResource($model);
-        $resource->loadedRelationshipsMap = [
-            [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
-        ];
-
-        $included = $resource->resolveIncludedResourceObjects(new JsonApiRequest);
-
-        $this->assertCount(1, $included);
-        $this->assertSame('99', $included[0]['id']);
-        $this->assertSame('things', $included[0]['type']);
-    }
-}
-
-class ArrayBackedJsonApiResource extends JsonApiResource
-{
-    public function toId(Request $request)
-    {
-        return (string) $this->resource['id'];
-    }
-
-    public function toAttributes(Request $request)
-    {
-        return ['name' => $this->resource['name']];
     }
 }

--- a/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -3,7 +3,11 @@
 namespace Illuminate\Tests\Http\Resources\JsonApi;
 
 use BadMethodCallException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\JsonApi\Exceptions\ResourceIdentificationException;
+use Illuminate\Http\Resources\JsonApi\JsonApiRequest;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 use PHPUnit\Framework\TestCase;
 
@@ -38,5 +42,50 @@ class JsonApiResourceTest extends TestCase
         $this->expectExceptionMessage('Using Illuminate\Http\Resources\JsonApi\JsonApiResource::withoutWrapping() method is not allowed.');
 
         JsonApiResource::withoutWrapping();
+    }
+
+    public function testPlainJsonResourceWithArrayCannotBeIncluded()
+    {
+        $this->expectException(ResourceIdentificationException::class);
+
+        $model = new class extends Model {};
+        $model->id = 1;
+
+        $resource = new JsonApiResource($model);
+        $resource->loadedRelationshipsMap = [
+            [new JsonResource(['id' => 1, 'name' => 'test']), 'things', '1', true],
+        ];
+
+        $resource->resolveIncludedResourceObjects(new JsonApiRequest);
+    }
+
+    public function testIncludedResourcesCanBeArrayBackedCustomResources()
+    {
+        $model = new class extends Model {};
+        $model->id = 1;
+
+        $resource = new JsonApiResource($model);
+        $resource->loadedRelationshipsMap = [
+            [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
+        ];
+
+        $included = $resource->resolveIncludedResourceObjects(new JsonApiRequest);
+
+        $this->assertCount(1, $included);
+        $this->assertSame('99', $included[0]['id']);
+        $this->assertSame('things', $included[0]['type']);
+    }
+}
+
+class ArrayBackedJsonApiResource extends JsonApiResource
+{
+    public function toId(Request $request)
+    {
+        return (string) $this->resource['id'];
+    }
+
+    public function toAttributes(Request $request)
+    {
+        return ['name' => $this->resource['name']];
     }
 }

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ArrayBackedJsonApiResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ArrayBackedJsonApiResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class ArrayBackedJsonApiResource extends JsonApiResource
+{
+    public function toId(Request $request)
+    {
+        return (string) $this->resource['id'];
+    }
+
+    public function toType(Request $request)
+    {
+        return 'things';
+    }
+
+    public function toAttributes(Request $request)
+    {
+        return ['name' => $this->resource['name']];
+    }
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/AuthorResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/AuthorResource.php
@@ -10,6 +10,7 @@ class AuthorResource extends JsonApiResource
     protected array $relationships = [
         'comments',
         'profile',
+        'chaperonePosts' => PostResource::class,
     ];
 
     #[\Override]

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/User.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/User.php
@@ -24,6 +24,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function chaperonePosts()
+    {
+        return $this->hasMany(Post::class)->chaperone('author');
+    }
+
     public function comments()
     {
         return $this->hasMany(Comment::class);

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/UserResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/UserResource.php
@@ -12,6 +12,7 @@ class UserResource extends JsonApiResource
         'profile',
         'posts',
         'teams',
+        'chaperonePosts' => PostResource::class,
     ];
 
     #[\Override]

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/UserWithArrayRelationshipResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/UserWithArrayRelationshipResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class UserWithArrayRelationshipResource extends JsonApiResource
+{
+    public function toType(Request $request)
+    {
+        return 'users';
+    }
+
+    public function toAttributes(Request $request)
+    {
+        return [
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiCollectionTest.php
@@ -88,7 +88,6 @@ class JsonApiCollectionTest extends TestCase
         ]);
 
         $user->teams()->attach($team, ['role' => 'Admin']);
-        $user->teams()->attach($team, ['role' => 'Member']);
 
         $posts = Post::factory()->times(2)->create([
             'user_id' => $user->getKey(),
@@ -135,7 +134,6 @@ class JsonApiCollectionTest extends TestCase
                             'teams' => [
                                 'data' => [
                                     ['id' => (string) $team->getKey(), 'type' => 'teams'],
-                                    ['id' => (string) $team->getKey(), 'type' => 'teams'],
                                 ],
                             ],
                         ],
@@ -180,23 +178,6 @@ class JsonApiCollectionTest extends TestCase
                                 'user_id' => $user->getKey(),
                                 'team_id' => $team->getKey(),
                                 'role' => 'Admin',
-                                'created_at' => $now->toISOString(),
-                                'updated_at' => $now->toISOString(),
-                            ],
-                        ],
-                    ],
-                    [
-                        'id' => (string) $team->getKey(),
-                        'type' => 'teams',
-                        'attributes' => [
-                            'id' => $team->getKey(),
-                            'user_id' => $team->user_id,
-                            'name' => 'Laravel Team',
-                            'personal_team' => true,
-                            'membership' => [
-                                'user_id' => $user->getKey(),
-                                'team_id' => $team->getKey(),
-                                'role' => 'Member',
                                 'created_at' => $now->toISOString(),
                                 'updated_at' => $now->toISOString(),
                             ],

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -625,4 +625,19 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonPath('data.relationships.chaperonePosts.data.0.id', (string) $post->getKey())
             ->assertJsonCount(1, 'included');
     }
+
+    public function testIncludedResourcesCanBeArrayBackedCustomResources()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/users/{$user->getKey()}/with-array-relationship")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $user->getKey())
+            ->assertJsonPath('data.type', 'users')
+            ->assertJsonPath('included.0.id', '99')
+            ->assertJsonPath('included.0.type', 'things')
+            ->assertJsonPath('included.0.attributes.name', 'test')
+            ->assertJsonCount(1, 'included');
+    }
+
 }

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -639,5 +639,4 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonPath('included.0.attributes.name', 'test')
             ->assertJsonCount(1, 'included');
     }
-
 }

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -6,8 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ArrayBackedJsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserWithArrayRelationshipResource;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 
@@ -58,6 +60,15 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $router->get('posts/{postId}', function ($postId) {
             return Post::find($postId)->toResource();
+        });
+
+        $router->get('users/{userId}/with-array-relationship', function ($userId) {
+            $resource = new UserWithArrayRelationshipResource(User::find($userId));
+            $resource->loadedRelationshipsMap = [
+                [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
+            ];
+
+            return $resource;
         });
     }
 

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -48,6 +48,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return User::find($userId)->toResource();
         });
 
+        $router->get('users/{userId}/with-chaperone-posts', function ($userId) {
+            return User::find($userId)->load('chaperonePosts')->toResource();
+        });
+
         $router->get('posts', function () {
             return Post::paginate(5)->toResourceCollection();
         });

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ArrayBackedJsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
-use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserWithArrayRelationshipResource;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -67,19 +66,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $resource = new UserWithArrayRelationshipResource(User::find($userId));
             $resource->loadedRelationshipsMap = [
                 [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
-            ];
-
-            return $resource;
-        });
-
-        $router->get('users/{userId}/with-duplicate-instances', function ($userId) {
-            $instance1 = User::find($userId);
-            $instance2 = User::find($userId);
-
-            $resource = new UserWithArrayRelationshipResource(User::find($userId));
-            $resource->loadedRelationshipsMap = [
-                [new UserResource($instance1), 'users', (string) $instance1->getKey(), true],
-                [new UserResource($instance2), 'users', (string) $instance2->getKey(), true],
             ];
 
             return $resource;

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ArrayBackedJsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserWithArrayRelationshipResource;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
@@ -66,6 +67,19 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $resource = new UserWithArrayRelationshipResource(User::find($userId));
             $resource->loadedRelationshipsMap = [
                 [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
+            ];
+
+            return $resource;
+        });
+
+        $router->get('users/{userId}/with-duplicate-instances', function ($userId) {
+            $instance1 = User::find($userId);
+            $instance2 = User::find($userId);
+
+            $resource = new UserWithArrayRelationshipResource(User::find($userId));
+            $resource->loadedRelationshipsMap = [
+                [new UserResource($instance1), 'users', (string) $instance1->getKey(), true],
+                [new UserResource($instance2), 'users', (string) $instance2->getKey(), true],
             ];
 
             return $resource;


### PR DESCRIPTION
Right now, `JsonApiResource` enters an infinite loop when serializing models with bidirectional Eloquent relationships that use `chaperone()`.   

For example, imagine you have:
```php

class User extends Model
{
    public function posts()
    {
        return $this->hasMany(Post::class)->chaperone();
    }
}

class Post extends Model
{
    public function author()
    {
        return $this->belongsTo(User::class);
    }
}


class UserResource extends JsonApiResource
{
    protected array $relationships = [
        'posts' => PostResource::class,
    ];
}

class PostResource extends JsonApiResource
{
    protected array $relationships = [
        'author' => UserResource::class,
    ];
}
```

The following hangs:
```php
return User::with('posts')->find(1)->toResource();
``` 

This happens because on `resolveIncludedResourceObjects` we call `includePreviouslyLoadedRelationships`, which includes all available relations for a model on `compileResourceRelationships`.  

So, essentially:
1. `User` resource adds `Post` to the map
2. `Post` resource calls `includePreviouslyLoadedRelationships` -> sees `author` is loaded (via chaperone) → adds the same `User` instance back to the map
3. That `User` is processed again -> adds the same` Post` back -> infinite loop


We can't remove `includePreviouslyLoadedRelationships`, as it'd break nested relationships (I think, pretty tired, might need to revisit this), so my fix involves tracking which objects we have visited on `resolveIncludedResourceObjects`, which is only invoked for the "root" resource/model.  
My first approach tracked `{type}-{id}`, but it breaks some use cases (and tests), e.g. `BelongsToMany` where you have e.g. the same model attached to another model but with different pivot data, for example `testItCanGenerateJsonApiResponseWithRelationshipsUsingSparseIncluded` where it expects two teams, but it'd only give one back.  Tracking the object itself with `spl_object_id` handles that. 

There are some edge cases I can think of that this solution does not support:
- If you want the same object legitimately included twice: e.g. `/users/1?include=posts.user` — I don't see when this would be useful tbh but it'd not work. 
- Wanting the chaperoned relation to show up as a different resource type in included: e.g. `Post` author uses `AuthorResource` (type: authors) while the root uses `UserResource` (type: users). The `Post` relationship identifier would reference authors/1, but there'd be no matching entry in included since we skip the same object. Bit of a weird setup though. 

2 is a bit hard to understand, here's some Claude art:
```
User (root, type: users)
  └── Post
        └── author (chaperone) → AuthorResource (type: authors)
```  

I'd prefer to avoid tracking objects tbh. I can revisit this tomorrow and go through the code more carefully to see if there's a better option, but wanted to at least get a failing test in place.