### PR TITLE
[12.x] Only fire `CacheFailedOver` and `QueueFailedOver` on first failure

### DIFF
--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -11,13 +11,22 @@ use Throwable;
 class FailoverStore extends TaggableStore implements LockProvider
 {
     /**
+     * The caches which failed on the last action.
+     *
+     * @var list<string>
+     */
+    protected array $failingCaches = [];
+
+    /**
      * Create a new failover store.
+     *
+     * @param  array<int, string>  $stores
      */
     public function __construct(
         protected CacheManager $cache,
         protected Dispatcher $events,
-        protected array $stores)
-    {
+        protected array $stores
+    ) {
     }
 
     /**
@@ -190,19 +199,31 @@ class FailoverStore extends TaggableStore implements LockProvider
 
     /**
      * Attempt the given method on all stores.
+     *
+     * @return mixed
+     *
+     * @throws \RuntimeException
      */
     protected function attemptOnAllStores(string $method, array $arguments)
     {
         $lastException = null;
 
-        foreach ($this->stores as $store) {
-            try {
-                return $this->store($store)->{$method}(...$arguments);
-            } catch (Throwable $e) {
-                $lastException = $e;
+        $failedCaches = [];
+        try {
+            foreach ($this->stores as $store) {
+                try {
+                    return $this->store($store)->{$method}(...$arguments);
+                } catch (Throwable $e) {
+                    $lastException = $e;
 
-                $this->events->dispatch(new CacheFailedOver($store, $e));
+                    $failedCaches[] = $store;
+                    if (! in_array($store, $this->failingCaches)) {
+                        $this->events->dispatch(new CacheFailedOver($store, $e));
+                    }
+                }
             }
+        } finally {
+            $this->failingCaches = $failedCaches;
         }
 
         throw $lastException ?? new RuntimeException('All failover cache stores failed.');

--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -206,9 +206,8 @@ class FailoverStore extends TaggableStore implements LockProvider
      */
     protected function attemptOnAllStores(string $method, array $arguments)
     {
-        $lastException = null;
+        [$lastException, $failedCaches] = [null, []];
 
-        $failedCaches = [];
         try {
             foreach ($this->stores as $store) {
                 try {
@@ -217,6 +216,7 @@ class FailoverStore extends TaggableStore implements LockProvider
                     $lastException = $e;
 
                     $failedCaches[] = $store;
+
                     if (! in_array($store, $this->failingCaches)) {
                         $this->events->dispatch(new CacheFailedOver($store, $e));
                     }

--- a/tests/Integration/Cache/FailoverStoreTest.php
+++ b/tests/Integration/Cache/FailoverStoreTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Cache\Events\CacheFailedOver;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+
+#[WithConfig('cache.default', 'failover')]
+#[WithConfig('cache.stores.array.serialize', false)]
+class FailoverStoreTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        CantSerialize::$throwException = true;
+    }
+
+    public function testFailoverCacheDispatchesEventOnlyOnce()
+    {
+        config([
+            'cache.stores.failing_array' => array_merge(config('cache.stores.array'), ['serialize' => true]),
+        ]);
+
+        config([
+            'cache.stores.failover.stores' => ['failing_array', 'array'],
+        ]);
+
+        Event::fake();
+
+        Cache::put('irrelevant', new CantSerialize());
+
+        Event::assertDispatched(CacheFailedOver::class, function (CacheFailedOver $event) {
+            return $event->storeName === 'failing_array';
+        });
+        $this->assertInstanceOf(CantSerialize::class, Cache::store('array')->get('irrelevant'));
+
+        Cache::put('irrelevant2', new CantSerialize());
+        Event::assertDispatchedTimes(CacheFailedOver::class, 1);
+        CantSerialize::$throwException = false;
+        Cache::put('irrelevant3', new CantSerialize());
+        Event::assertDispatchedTimes(CacheFailedOver::class, 1);
+        CantSerialize::$throwException = true;
+        Cache::put('irrelevant4', new CantSerialize());
+        Event::assertDispatchedTimes(CacheFailedOver::class, 2);
+    }
+}
+
+class CantSerialize
+{
+    public static bool $throwException = true;
+
+    public function __serialize()
+    {
+        if (self::$throwException) {
+            throw new \Exception('You cannot serialize this.');
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
To partially resolve https://github.com/laravel/framework/issues/57762

Only fire a CacheFailedOver event when there's a "new" failover. This is either the first time it failed, or if there was a success after a failure, and then another failure. (so fail -> success -> fail will emit this event twice, while fail -> fail -> fail will emit only once).

**Note:** This is marked a bug and I wanted to write some code. I personally find this behavior a _little bit_ unusual, though I have not used this feature yet. Almost feels like there should be a different event, but I have no idea what it would be named.