### PR TITLE
[12.x] Fix QueryException showing wrong connection details for read PDO

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -50,6 +50,13 @@ class Connection implements ConnectionInterface
     protected $readPdo;
 
     /**
+     * The database connection configuration options for reading.
+     *
+     * @var array
+     */
+    protected $readPdoConfig = [];
+
+    /**
      * The name of the connected database.
      *
      * @var string
@@ -1327,6 +1334,19 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Set the read PDO connection configuration.
+     *
+     * @param  array  $config
+     * @return $this
+     */
+    public function setReadPdoConfig(array $config)
+    {
+        $this->readPdoConfig = $config;
+
+        return $this;
+    }
+
+    /**
      * Set the reconnect instance on the connection.
      *
      * @param  (callable(\Illuminate\Database\Connection): mixed)  $reconnector
@@ -1379,13 +1399,17 @@ class Connection implements ConnectionInterface
      */
     protected function getConnectionDetails()
     {
+        $config = $this->latestPdoTypeRetrieved === 'read'
+            ? $this->readPdoConfig
+            : $this->config;
+
         return [
             'driver' => $this->getDriverName(),
             'name' => $this->getNameWithReadWriteType(),
-            'host' => $this->getConfig('host'),
-            'port' => $this->getConfig('port'),
-            'database' => $this->getConfig('database'),
-            'unix_socket' => $this->getConfig('unix_socket'),
+            'host' => $config['host'] ?? null,
+            'port' => $config['port'] ?? null,
+            'database' => $config['database'] ?? null,
+            'unix_socket' => $config['unix_socket'] ?? null,
         ];
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1399,7 +1399,7 @@ class Connection implements ConnectionInterface
      */
     protected function getConnectionDetails()
     {
-        $config = $this->latestPdoTypeRetrieved === 'read'
+        $config = $this->latestReadWriteTypeUsed() === 'read'
             ? $this->readPdoConfig
             : $this->config;
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -87,7 +87,9 @@ class ConnectionFactory
     {
         $connection = $this->createSingleConnection($this->getWriteConfig($config));
 
-        return $connection->setReadPdo($this->createReadPdo($config));
+        return $connection
+            ->setReadPdo($this->createReadPdo($config))
+            ->setReadPdoConfig($this->getReadConfig($config));
     }
 
     /**

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -101,6 +101,19 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
     }
 
+    public function testReadWriteConnectionSetsReadPdoConfig()
+    {
+        $connection = $this->db->getConnection('read_write');
+
+        $readPdoConfig = new ReflectionProperty(get_class($connection), 'readPdoConfig');
+
+        $config = $readPdoConfig->getValue($connection);
+
+        $this->assertNotEmpty($config);
+        $this->assertArrayHasKey('database', $config);
+        $this->assertSame(':memory:', $config['database']);
+    }
+
     public function testIfDriverIsntSetExceptionIsThrown()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -535,6 +535,206 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(1.23, $log[0]['time']);
     }
 
+    public function testQueryExceptionContainsReadConnectionDetailsWhenUsingReadPdo()
+    {
+        // Create write PDO mock that will NOT be used for this query
+        $writePdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $writePdo->expects($this->never())->method('prepare');
+
+        // Create read PDO mock that throws an exception
+        $readPdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $readPdo->expects($this->once())
+            ->method('prepare')
+            ->willThrowException(new PDOException('Connection refused'));
+
+        // Write configuration (passed to constructor)
+        $writeConfig = [
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'host' => '192.168.1.10',
+            'port' => '3306',
+            'database' => 'write_db',
+        ];
+
+        // Create connection with write config
+        $connection = new Connection($writePdo, 'write_db', '', $writeConfig);
+        $connection->useDefaultQueryGrammar();
+        $connection->useDefaultPostProcessor();
+
+        // Read configuration (different from write)
+        $readConfig = [
+            'host' => '192.168.1.20',
+            'port' => '3307',
+            'database' => 'read_db',
+        ];
+
+        // Set read PDO and its config
+        $connection->setReadPdo($readPdo);
+        $connection->setReadPdoConfig($readConfig);
+
+        try {
+            $connection->select('SELECT * FROM users', useReadPdo: true);
+            $this->fail('Expected QueryException was not thrown');
+        } catch (QueryException $e) {
+            // Verify the readWriteType is correctly set to 'read'
+            $this->assertSame('read', $e->readWriteType);
+
+            // Verify connection details show READ config, not write config
+            $connectionDetails = $e->getConnectionDetails();
+            $this->assertSame('192.168.1.20', $connectionDetails['host']);
+            $this->assertSame('3307', $connectionDetails['port']);
+            $this->assertSame('read_db', $connectionDetails['database']);
+        }
+    }
+
+    public function testQueryExceptionContainsReadConnectionDetailsWhenReadPdoConnectionFails()
+    {
+        // Write PDO (won't be used)
+        $writePdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $writePdo->expects($this->never())->method('prepare');
+
+        // Write configuration
+        $writeConfig = [
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'host' => '192.168.1.10',
+            'port' => '3306',
+            'database' => 'write_db',
+        ];
+
+        $connection = new Connection($writePdo, 'write_db', '', $writeConfig);
+        $connection->useDefaultQueryGrammar();
+        $connection->useDefaultPostProcessor();
+
+        // Read config (different host)
+        $readConfig = [
+            'host' => '192.168.1.20',
+            'port' => '3307',
+            'database' => 'read_db',
+        ];
+
+        // Simulate lazy PDO that fails during connection (e.g., SET NAMES fails)
+        $connection->setReadPdo(function () {
+            throw new PDOException('SQLSTATE[HY000] SET NAMES failed');
+        });
+        $connection->setReadPdoConfig($readConfig);
+
+        try {
+            $connection->select('SELECT * FROM users', useReadPdo: true);
+            $this->fail('Expected QueryException was not thrown');
+        } catch (QueryException $e) {
+            $this->assertSame('read', $e->readWriteType);
+
+            // Verify connection details show READ config even for connection-time failures
+            $connectionDetails = $e->getConnectionDetails();
+            $this->assertSame('192.168.1.20', $connectionDetails['host']);
+            $this->assertSame('3307', $connectionDetails['port']);
+            $this->assertSame('read_db', $connectionDetails['database']);
+        }
+    }
+
+    public function testQueryExceptionContainsWriteConnectionDetailsWhenUsingWritePdo()
+    {
+        // Create write PDO mock that throws an exception
+        $writePdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $writePdo->expects($this->once())
+            ->method('prepare')
+            ->willThrowException(new PDOException('Connection refused'));
+
+        // Create read PDO mock that will NOT be used
+        $readPdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)
+            ->onlyMethods(['prepare'])
+            ->getMock();
+        $readPdo->expects($this->never())->method('prepare');
+
+        // Write configuration (passed to constructor)
+        $writeConfig = [
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'host' => '192.168.1.10',
+            'port' => '3306',
+            'database' => 'write_db',
+        ];
+
+        $connection = new Connection($writePdo, 'write_db', '', $writeConfig);
+        $connection->useDefaultQueryGrammar();
+        $connection->useDefaultPostProcessor();
+
+        // Read configuration (different from write)
+        $readConfig = [
+            'host' => '192.168.1.20',
+            'port' => '3307',
+            'database' => 'read_db',
+        ];
+
+        $connection->setReadPdo($readPdo);
+        $connection->setReadPdoConfig($readConfig);
+
+        try {
+            $connection->select('SELECT * FROM users', useReadPdo: false);
+            $this->fail('Expected QueryException was not thrown');
+        } catch (QueryException $e) {
+            // Verify the readWriteType is correctly set to 'write'
+            $this->assertSame('write', $e->readWriteType);
+
+            // Verify connection details show WRITE config, not read config
+            $connectionDetails = $e->getConnectionDetails();
+            $this->assertSame('192.168.1.10', $connectionDetails['host']);
+            $this->assertSame('3306', $connectionDetails['port']);
+            $this->assertSame('write_db', $connectionDetails['database']);
+        }
+    }
+
+    public function testQueryExceptionContainsWriteConnectionDetailsWhenWritePdoConnectionFails()
+    {
+        // Write configuration
+        $writeConfig = [
+            'driver' => 'mysql',
+            'name' => 'mysql',
+            'host' => '192.168.1.10',
+            'port' => '3306',
+            'database' => 'write_db',
+        ];
+
+        // Simulate lazy write PDO that fails during connection (e.g., SET NAMES fails)
+        $connection = new Connection(function () {
+            throw new PDOException('SQLSTATE[HY000] SET NAMES failed');
+        }, 'write_db', '', $writeConfig);
+        $connection->useDefaultQueryGrammar();
+        $connection->useDefaultPostProcessor();
+
+        // Read config (different host)
+        $readConfig = [
+            'host' => '192.168.1.20',
+            'port' => '3307',
+            'database' => 'read_db',
+        ];
+
+        $connection->setReadPdo(new DatabaseConnectionTestMockPDO);
+        $connection->setReadPdoConfig($readConfig);
+
+        try {
+            $connection->select('SELECT * FROM users', useReadPdo: false);
+            $this->fail('Expected QueryException was not thrown');
+        } catch (QueryException $e) {
+            $this->assertSame('write', $e->readWriteType);
+
+            // Verify connection details show WRITE config even for connection-time failures
+            $connectionDetails = $e->getConnectionDetails();
+            $this->assertSame('192.168.1.10', $connectionDetails['host']);
+            $this->assertSame('3306', $connectionDetails['port']);
+            $this->assertSame('write_db', $connectionDetails['database']);
+        }
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;


### PR DESCRIPTION
Previously on [this PR](https://github.com/laravel/framework/pull/58218) we added the connection details to the `QueryException`, however, it wasn't getting the correct host for the `readPdo`.

[This PR](https://github.com/laravel/framework/pull/58156) introduced the `latestReadWriteTypeUsed()` which allows us to know which connection was last used.

## This PR

- Fixes QueryException showing write connection details when a query fails on the read PDO connection
- Adds `$readPdoConfig` property and `setReadPdoConfig()` method to store read connection configuration
- Updates `getConnectionDetails()` to return read config when `latestReadWriteTypeUsed() === 'read'`

## Before
When `DB::connection('mysql')->select('...', useReadPdo: true)` failed, exception showed:
`Host: write.host.example` (incorrect)

## After 
Exception correctly shows:
`Host: read.host.example`

## How to reproduce

### Connection Error
1. Configure a read/write connection with different hosts in `config/database.php`:
```php
'mysql' => [
  'read' => ['host' => 'invalid.read.host'],
  'write' => ['host' => 'invalid.write.host'],
  'driver' => 'mysql',
  'database' => 'test_db',
  // ...
],
```

2. Run a query using the read connection:
```php
DB::connection('mysql')->select('SELECT 1', useReadPdo: true);
```

### Query Error
1. Configure the read connection with valid hosts/credentials and the write connection with invalid host/credentials in `config/database.php`:
```php
'mysql' => [
  'read' => ['host' => '127.0.0.1'], // valid
  'write' => ['host' => '127.0.0.2'], // invalid
  'driver' => 'mysql',
  'database' => 'test_db',
  // ...
],
```

2. Run a query using the read connection:
```php
DB::connection('mysql')->select('SELECTINVALID', useReadPdo: true);
```