### PR TITLE
Add RequestException handling in PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1180,7 +1180,7 @@ class PendingRequest
 
                 return $this->runAfterResponseCallbacks($response);
             })
-            ->otherwise(function (OutOfBoundsException|TransferException|StrayRequestException $e) {
+            ->otherwise(function (OutOfBoundsException|TransferException|StrayRequestException|\Illuminate\Http\Client\RequestException $e) {
                 if ($e instanceof StrayRequestException) {
                     throw $e;
                 }


### PR DESCRIPTION
I received this error message:

`Argument #1 ($e) must be of type OutOfBoundsException|GuzzleHttp\Exception\TransferException|Illuminate\Http\Client\StrayRequestException, Illuminate\Http\Client\RequestException given, called in /srv/vendor/guzzlehttp/promises/src/Promise.php on line 209`

Reproducible by doing
```php
// AppServiceProvider.php
Event::listen(function (ResponseReceived $event) {
            $event->response->throwIf(true);
        });

// Service class
Http::pool(function ($pool) {
  return [
     $pool->get('https://laravel.com/404');
  ];
});
```