### PR TITLE
[12.x] Fix docblock for Failovers

### DIFF
--- a/src/Illuminate/Cache/FailoverStore.php
+++ b/src/Illuminate/Cache/FailoverStore.php
@@ -202,7 +202,7 @@ class FailoverStore extends TaggableStore implements LockProvider
      *
      * @return mixed
      *
-     * @throws \RuntimeException
+     * @throws \Throwable
      */
     protected function attemptOnAllStores(string $method, array $arguments)
     {

--- a/src/Illuminate/Queue/FailoverQueue.php
+++ b/src/Illuminate/Queue/FailoverQueue.php
@@ -140,7 +140,7 @@ class FailoverQueue extends Queue implements QueueContract
      * @param  mixed  $job
      * @return mixed
      *
-     * @throws \RuntimeException
+     * @throws \Throwable
      */
     protected function attemptOnAllConnections(string $method, array $arguments, $job = null)
     {


### PR DESCRIPTION
I wasn't thinking about the fact that it could throw any exception, not just a runtimeexception here.