### PR TITLE
[12.x] Only fire composer uninstall events when removing dev packages

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -58,7 +58,7 @@ class ComposerScripts
      */
     public static function prePackageUninstall(PackageEvent $event)
     {
-        // Package uninstall events are only applicable when uninstalling packages in dev environments.
+        // Package uninstall events are only applicable when uninstalling packages in dev environments...
         if (! $event->isDevMode()) {
             return;
         }

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -58,6 +58,11 @@ class ComposerScripts
      */
     public static function prePackageUninstall(PackageEvent $event)
     {
+        // Package uninstall events are only applicable when uninstalling packages in dev environments.
+        if (! $event->isDevMode()) {
+            return;
+        }
+
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
         $laravel = new Application(getcwd());


### PR DESCRIPTION
To close: https://github.com/laravel/framework/issues/57613

There have been so many problems with this feature 😢 I hope that this clears up the last of them.

If we are uninstalling packages with the `--no-dev` flag, then we do not want to fire events. Why? Because it fixes a problem. Thinking further though, we wouldn't want these things to fire on production environments. That's not the intended use of this pattern. I misunderstood the naming of this event `prePackageUninstall` thinking that it meant "when a package is requested to be removed from composer.json" instead of what it is, which is "when a package is being removed from your composer.lock"