### PR TITLE
[12.x] Add notNull method to Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1669,7 +1669,7 @@ class Blueprint
     /**
      * Indicate that the column should not be nullable.
      *
-     * @return $this
+     * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function notNull()
     {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1667,6 +1667,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the column should not be nullable.
+     *
+     * @return $this
+     */
+    public function notNull()
+    {
+        return $this->nullable(false);
+    }
+
+    /**
      * Create a new custom column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Fluent;
  * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
  * @method $this lock(string $value) Specify the DDL lock mode for the column operation (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
+ * @method $this notNull() Mark column and NOT NULL
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary(bool $value = true) Add a primary index
  * @method $this spatialIndex(bool|string $indexName = null) Add a spatial index

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -656,6 +656,14 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `posts` add `note` tinytext not null default \'this\'\'ll work too\''], $getSql('MySql'));
     }
 
+    public function testNotNullMethodSetsNullableToFalse()
+    {
+        $blueprint = new Blueprint('users');
+        $column = $blueprint->string('email')->notNull();
+    
+        $this->assertFalse($column->get('nullable'));
+    }
+
     protected function getConnection(?string $grammar = null, string $prefix = '')
     {
         $connection = m::mock(Connection::class)

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -660,7 +660,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $column = $blueprint->string('email')->notNull();
-    
+        
         $this->assertFalse($column->get('nullable'));
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -666,8 +666,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
         });
 
         $this->assertEquals([
-            "alter table `users` add `name` varchar(255) null",
-            "alter table `users` modify `name` varchar(255) not null",
+            'alter table `users` add `name` varchar(255) null',
+            'alter table `users` modify `name` varchar(255) not null',
         ], $blueprint->toSql());
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -658,9 +658,17 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testNotNullMethodSetsNullableToFalse()
     {
-        $blueprint = new Blueprint('users');
-        $column = $blueprint->string('email')->notNull();
-        $this->assertFalse($column->get('nullable'));
+        $connection = $this->getConnection('MySql');
+
+        $blueprint = new Blueprint($connection, 'users', function ($table) {
+            $table->string('name')->nullable();
+            $table->string('name')->notNull()->change();
+        });
+
+        $this->assertEquals([
+            "alter table `users` add `name` varchar(255) null",
+            "alter table `users` modify `name` varchar(255) not null",
+        ], $blueprint->toSql());
     }
 
     protected function getConnection(?string $grammar = null, string $prefix = '')

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -660,7 +660,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $column = $blueprint->string('email')->notNull();
-        
         $this->assertFalse($column->get('nullable'));
     }
 


### PR DESCRIPTION
Benefit to end users: This PR adds a notNull() method to the Illuminate\Database\Schema\Blueprint class. Currently, to explicitly define a column as not nullable (especially when using the change() method to modify existing columns), developers have to use nullable(false).

The new notNull() method provides a more fluent and readable API, making migrations feel more like natural English.

Example usage: Instead of:
`$table->string('email')->nullable(false)->change();`

Developers can now write:
`$table->string('email')->notNull()->change();`

Reasons it does not break any existing features: This is a purely additive change. It acts as a wrapper/proxy for the existing nullable(false) method and does not modify any existing logic or behavior in the schema builder.

How it makes building web applications easier: It improves code readability and discoverability. When a developer wants to make a column "not null", their first instinct is often to look for a notNull() or notNullable() method rather than passing a boolean to nullable().