### PR TITLE
APP_KEY cant be set with key:generate when APP_KEY is already set in the environment

### DIFF
--- a/tests/Foundation/Console/KeyGenerateCommandTest.php
+++ b/tests/Foundation/Console/KeyGenerateCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Orchestra\Testbench\TestCase;
+
+class KeyGenerateCommandTest extends TestCase
+{
+    protected string $envFilePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->envFilePath = $this->app->environmentFilePath();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up any environment variables we set
+        putenv('APP_KEY');
+        $_ENV['APP_KEY'] = '';
+        $_SERVER['APP_KEY'] = '';
+
+        parent::tearDown();
+    }
+
+    public function test_key_generate_updates_env_file()
+    {
+        // Create .env file with empty APP_KEY
+        file_put_contents($this->envFilePath, 'APP_KEY=');
+
+        $this->artisan('key:generate')
+            ->expectsOutputToContain('Application key set successfully')
+            ->assertExitCode(0);
+
+        $envContent = file_get_contents($this->envFilePath);
+        $this->assertMatchesRegularExpression('/^APP_KEY=base64:.+$/m', $envContent);
+    }
+
+    /**
+     * Test that key:generate writes to .env even when APP_KEY is set in environment.
+     *
+     * This can happen when:
+     * - A parent process (like Laravel Horizon) has APP_KEY set in its environment
+     * - The user has APP_KEY exported in their shell profile
+     * - Running in a container with APP_KEY set as an environment variable
+     *
+     * The key:generate command should always write to .env when explicitly called,
+     * regardless of whether APP_KEY exists in the environment.
+     */
+    public function test_key_generate_updates_env_file_even_when_app_key_exists_in_environment()
+    {
+        // Create .env file with empty APP_KEY
+        file_put_contents($this->envFilePath, 'APP_KEY=');
+
+        // Set APP_KEY in environment (simulating inheritance from parent process like Horizon)
+        $existingKey = 'base64:'.base64_encode(Encrypter::generateKey($this->app['config']['app.cipher']));
+        putenv("APP_KEY={$existingKey}");
+        $_ENV['APP_KEY'] = $existingKey;
+        $_SERVER['APP_KEY'] = $existingKey;
+
+        // Force config to reload with the environment variable
+        $this->app['config']->set('app.key', $existingKey);
+
+        // Run key:generate --force
+        // Expected: should update .env file with a new key
+        // Current bug: command builds regex using env var value, which doesn't match .env content
+        $this->artisan('key:generate', ['--force' => true])
+            ->expectsOutputToContain('Application key set successfully')
+            ->assertExitCode(0);
+
+        $envContent = file_get_contents($this->envFilePath);
+
+        // The .env file should have a new key written to it
+        $this->assertMatchesRegularExpression('/^APP_KEY=base64:.+$/m', $envContent);
+    }
+
+    public function test_key_generate_shows_helpful_error_when_app_key_line_missing_from_env()
+    {
+        // Create .env file WITHOUT APP_KEY line at all
+        file_put_contents($this->envFilePath, 'APP_NAME=Laravel');
+
+        $this->artisan('key:generate')
+            ->expectsOutputToContain('No APP_KEY variable was found')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
Consider this PR a bug report. I'm unsure yet what an elegant fix would be or if its intended behavior.

When running `php artisan key:generate` while `APP_KEY` has already been set in the environment the `APP_KEY` won't be set and a misleading error message "Unable to set application key. No APP_KEY variable was found in the .env file." will be shown.

You can also reproduce this on a mac or linux machine:
1. Clone and set up a new vanilla Laravel application.
2. Run `export APP_KEY=abc` on the command line.
3. Run `php artisan key:generate` inside the application.
4.  Message "Unable to set application key. No APP_KEY variable was found in the .env file." will be shown.
5. Clear the environment APP_KEY with `unset APP_KEY` on the command line, and the `key:generate` command will succeed.

This issue also occurs when generating Laravel apps through jobs with Horizon as the `APP_KEY` will be set in the environment when jobs are being processed.

If this is expected behavior then at least a proper error message should be shown. Especially for LLMs this would be helpful.

I provided a couple of tests where `test_key_generate_updates_env_file_even_when_app_key_exists_in_environment` demonstrates the the current behavior and fails.