### PR TITLE
[12.x] Add `forEachCrossJoinSequence()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -654,6 +654,17 @@ abstract class Factory
     }
 
     /**
+     * Add a new cross joined sequenced state transformation to the model definition and update the pending creation count to the size of the sequence.
+     *
+     * @param  array  ...$sequence
+     * @return static
+     */
+    public function forEachCrossJoinSequence(...$sequence)
+    {
+        return $this->state(new CrossJoinSequence(...$sequence))->count(array_product(array_map('count', [...$sequence])));
+    }
+
+    /**
      * Define a child relationship for the model.
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -606,6 +606,39 @@ class DatabaseEloquentFactoryTest extends TestCase
         $assert($usersByMethod);
     }
 
+    public function test_counted_cross_join_sequences()
+    {
+        $assert = function ($users) {
+            $assertions = [
+                ['first_name' => 'Thomas', 'last_name' => 'Anderson', 'options' => ['Red Pill']],
+                ['first_name' => 'Thomas', 'last_name' => 'Anderson', 'options' => ['Blue Pill']],
+                ['first_name' => 'Thomas', 'last_name' => 'Smith', 'options' => ['Red Pill']],
+                ['first_name' => 'Thomas', 'last_name' => 'Smith', 'options' => ['Blue Pill']],
+                ['first_name' => 'Agent', 'last_name' => 'Anderson', 'options' => ['Red Pill']],
+                ['first_name' => 'Agent', 'last_name' => 'Anderson', 'options' => ['Blue Pill']],
+                ['first_name' => 'Agent', 'last_name' => 'Smith', 'options' => ['Red Pill']],
+                ['first_name' => 'Agent', 'last_name' => 'Smith', 'options' => ['Blue Pill']],
+            ];
+
+            foreach ($assertions as $key => $assertion) {
+                $this->assertSame(
+                    $assertion,
+                    $users[$key]->only('first_name', 'last_name', 'options'),
+                );
+            }
+        };
+
+        $users = FactoryTestUserFactory::new()
+            ->forEachCrossJoinSequence(
+                [['first_name' => 'Thomas'], ['first_name' => 'Agent']],
+                [['last_name' => 'Anderson'], ['last_name' => 'Smith']],
+                [['options' => ['Red Pill']], ['options' => ['Blue Pill']]],
+            )
+            ->make();
+
+        $assert($users);
+    }
+
     public function test_resolve_nested_model_factories()
     {
         Factory::useNamespace('Factories\\');


### PR DESCRIPTION
## Description

- This is a combination of `crossJoinSequence()` and `forEachSequence()` eloquent factory helpers
- Aim is to remove the need for the developer to calculate and supply the number of models expected to be created

## Example

I recently wrote a test using `crossJoinSequence()` in which a colleague rightly pointed out that I'd over-complicated it. That led to re-writing it in a much more readable way (likely the intended use of the method tbf) but it still seemed like there was a next logical step missing, which I hope this PR will provide.

```php
// Initial horror show

        $attributes = Attribute::factory()
            ->times(15)
            ->crossJoinSequence(
                collect(['', '', 'Beta', 'Alpha', 'Victor'])
                    ->map(fn (string $g, int $i) => ['group' => $g]),
                array_map(fn ($n) => ['name' => $n], ['Bongo', 'Apple', 'Elephant']),
            )
            ->create();

// Improved readability version, still with crossJoinSequence()

        $groups = [
            ['group' => ''],
            ['group' => ''],
            ['group' => 'Beta'],
            ['group' => 'Alpha'],
            ['group' => 'Victor'],
        ];

        $names = [
            ['name' => 'Bongo'],
            ['name' => 'Apple'],
            ['name' => 'Elephant'],
        ];

        $attributes = Attribute::factory()
            ->times(count($groups) * count($names))
            ->crossJoinSequence($groups, $names)
            ->create();

// Intended usage of this method

        $groups = [
            ['group' => ''],
            ['group' => ''],
            ['group' => 'Beta'],
            ['group' => 'Alpha'],
            ['group' => 'Victor'],
        ];

        $names = [
            ['name' => 'Bongo'],
            ['name' => 'Apple'],
            ['name' => 'Elephant'],
        ];

        $attributes = Attribute::factory()
            ->forEachCrossJoinSequence($groups, $names)
            ->create();
```
