### PR TITLE
[12.x] Allow for enum keys in additional Session Store methods

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -272,7 +272,7 @@ class Store implements Session
     /**
      * Checks if a key exists.
      *
-     * @param  string|array  $key
+     * @param  \BackedEnum|\UnitEnum|string|array  $key
      * @return bool
      */
     public function exists($key)
@@ -287,7 +287,7 @@ class Store implements Session
     /**
      * Determine if the given key is missing from the session data.
      *
-     * @param  string|array  $key
+     * @param  \BackedEnum|\UnitEnum|string|array  $key
      * @return bool
      */
     public function missing($key)
@@ -298,7 +298,7 @@ class Store implements Session
     /**
      * Determine if a key is present and not null.
      *
-     * @param  string|array  $key
+     * @param  \BackedEnum|\UnitEnum|string|array  $key
      * @return bool
      */
     public function has($key)
@@ -311,7 +311,7 @@ class Store implements Session
     /**
      * Determine if any of the given keys are present and not null.
      *
-     * @param  string|array  $key
+     * @param  \BackedEnum|\UnitEnum|string|array  $key
      * @return bool
      */
     public function hasAny($key)

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -596,6 +596,51 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->has(SessionTestKey::Preference));
     }
 
+    public function testBackedEnumKeyHasAny()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+        $session->put(SessionTestKey::Settings, 'dark-mode');
+
+        $this->assertTrue($session->hasAny(SessionTestKey::User));
+        $this->assertTrue($session->hasAny('user'));
+        $this->assertTrue($session->hasAny(SessionTestKey::User, SessionTestKey::Preference, 'foo'));
+        $this->assertTrue($session->hasAny([SessionTestKey::User, SessionTestKey::Preference, 'foo']));
+
+        $this->assertFalse($session->hasAny(SessionTestKey::Preference));
+        $this->assertFalse($session->hasAny('preference'));
+        $this->assertFalse($session->hasAny(SessionTestKey::Preference, 'foo'));
+        $this->assertFalse($session->hasAny([SessionTestKey::Preference, 'foo']));
+    }
+
+    public function testBackedEnumKeyExists()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+        $session->put(SessionTestKey::Settings, null);
+
+        $this->assertTrue($session->exists(SessionTestKey::User));
+        $this->assertTrue($session->exists(SessionTestKey::Settings));
+        $this->assertFalse($session->exists(SessionTestKey::Preference));
+
+        $this->assertTrue($session->exists('user'));
+        $this->assertFalse($session->exists('preference'));
+    }
+
+    public function testBackedEnumKeyMissing()
+    {
+        $session = $this->getSession();
+        $session->put(SessionTestKey::User, 'Taylor');
+        $session->put(SessionTestKey::Settings, null);
+
+        $this->assertFalse($session->missing(SessionTestKey::User));
+        $this->assertFalse($session->missing(SessionTestKey::Settings));
+        $this->assertTrue($session->missing(SessionTestKey::Preference));
+
+        $this->assertFalse($session->missing('user'));
+        $this->assertTrue($session->missing('preference'));
+    }
+
     public function testBackedEnumKeyForget()
     {
         $session = $this->getSession();


### PR DESCRIPTION
Follow-up on #58241 for:
- `Illuminate\Session\Store::has()`
- `Illuminate\Session\Store::hasAny()`
- `Illuminate\Session\Store::exists()`
- `Illuminate\Session\Store::missing()`