### PR TITLE
[12.x] JSON API: Deduplicate circular references 

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -332,13 +332,15 @@ trait ResolvesJsonApiElements
         $relations = new Collection;
         $index = 0;
 
-        // Track visited objects by instance + type to prevent infinite loops from circular references
-        // created by chaperone(). We use object instances rather than type+id to preserve legitimate
-        // cases like BelongsToMany with different pivot data where multiple distinct instances may
-        // share the same model ID. We also track by type to allow the same model to appear with
-        // different resource types (e.g., User as both "users" and "authors").
+        // Track visited objects by instance + type to prevent infinite loops from circular
+        // references created by "chaperone()". We use object instances rather than type
+        // and ID for any possible cases like BelongsToMany with different pivot data.
+        // We'll track types to allow the same models with different resource types.
         $visitedObjects = new WeakMap;
-        $visitedObjects[$this->resource] = [$this->resolveResourceType($request) => true];
+
+        $visitedObjects[$this->resource] = [
+            $this->resolveResourceType($request) => true
+        ];
 
         while ($index < count($this->loadedRelationshipsMap)) {
             [$resourceInstance, $type, $id, $isUnique] = $this->loadedRelationshipsMap[$index];
@@ -348,7 +350,6 @@ trait ResolvesJsonApiElements
             if (is_object($underlyingResource)) {
                 if (isset($visitedObjects[$underlyingResource][$type])) {
                     $index++;
-
                     continue;
                 }
 

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/ArrayBackedJsonApiResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/ArrayBackedJsonApiResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class ArrayBackedJsonApiResource extends JsonApiResource
+{
+    public function toId(Request $request)
+    {
+        return (string) $this->resource['id'];
+    }
+
+    public function toType(Request $request)
+    {
+        return 'things';
+    }
+
+    public function toAttributes(Request $request)
+    {
+        return ['name' => $this->resource['name']];
+    }
+}

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/User.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/User.php
@@ -24,6 +24,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function chaperonePosts()
+    {
+        return $this->hasMany(Post::class)->chaperone('author');
+    }
+
     public function comments()
     {
         return $this->hasMany(Comment::class);

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/UserResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/UserResource.php
@@ -12,6 +12,7 @@ class UserResource extends JsonApiResource
         'profile',
         'posts',
         'teams',
+        'chaperonePosts' => PostResource::class,
     ];
 
     #[\Override]

--- a/tests/Integration/Http/Resources/JsonApi/Fixtures/UserWithArrayRelationshipResource.php
+++ b/tests/Integration/Http/Resources/JsonApi/Fixtures/UserWithArrayRelationshipResource.php
@@ -5,15 +5,13 @@ namespace Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
 
-class AuthorResource extends JsonApiResource
+class UserWithArrayRelationshipResource extends JsonApiResource
 {
-    protected array $relationships = [
-        'comments',
-        'profile',
-        'chaperonePosts' => PostResource::class,
-    ];
+    public function toType(Request $request)
+    {
+        return 'users';
+    }
 
-    #[\Override]
     public function toAttributes(Request $request)
     {
         return [

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -604,4 +604,119 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonCount(1, 'included')
             ->assertJsonMissing(['jsonapi']);
     }
+
+    public function testItHandlesBidirectionalRelationshipsWithChaperoneWithoutInfiniteLoop()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        // The /with-chaperone-posts route loads chaperonePosts which uses chaperone()
+        // to automatically set the inverse 'author' relationship on each Post,
+        // creating circular object references (User -> Post -> User same instance).
+        // Without the fix, this would hang forever due to infinite loop.
+        // The same User model appears twice in included: once as "posts" (the Post)
+        // and once as "authors" (Post's author via chaperone) - this is correct
+        // because different resource types should not be deduplicated.
+        $this->getJson("/users/{$user->getKey()}/with-chaperone-posts?".http_build_query(['include' => 'chaperonePosts']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $user->getKey())
+            ->assertJsonPath('data.type', 'users')
+            ->assertJsonPath('data.relationships.chaperonePosts.data.0.type', 'posts')
+            ->assertJsonPath('data.relationships.chaperonePosts.data.0.id', (string) $post->getKey())
+            ->assertJsonPath('included.0.type', 'posts')
+            ->assertJsonPath('included.1.type', 'authors')
+            ->assertJsonCount(2, 'included');
+    }
+
+    public function testIncludedResourcesCanBeArrayBackedCustomResources()
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/users/{$user->getKey()}/with-array-relationship")
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $user->getKey())
+            ->assertJsonPath('data.type', 'users')
+            ->assertJsonPath('included.0.id', '99')
+            ->assertJsonPath('included.0.type', 'things')
+            ->assertJsonPath('included.0.attributes.name', 'test')
+            ->assertJsonCount(1, 'included');
+    }
+
+    public function testSameModelWithTheSameResourceTypeIsDeduplicated()
+    {
+        $user = User::factory()->create();
+
+        $post1 = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        $post2 = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        Comment::factory()->create([
+            'post_id' => $post1->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        Comment::factory()->create([
+            'post_id' => $post2->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        // Both comments have the same commenter (User). Per the JSON:API spec, the same
+        // type+id pair should only appear once in included, even when referenced by
+        // multiple relationships. We expect 3 items: 2 comments + 1 user (deduped).
+        $response = $this->getJson('/posts?'.http_build_query(['include' => 'comments.commenter']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonCount(3, 'included');
+
+        $included = $response->json('included');
+        $types = array_column($included, 'type');
+
+        $this->assertCount(2, array_filter($types, fn (string $t) => $t === 'comments'));
+        $this->assertCount(1, array_filter($types, fn (string $t) => $t === 'users'));
+    }
+
+    public function testDifferentModelInstancesWithSameTypeAndIdAreDeduplicated()
+    {
+        $user = User::factory()->create();
+
+        // This route manually creates two different User model instances with the same ID and
+        // adds them both to the loadedRelationshipsMap. Per the JSON:API spec, they should
+        // be deduplicated since they have the same type+id, even though they're different object instances.
+        $response = $this->getJson("/users/{$user->getKey()}/with-duplicate-instances")
+            ->assertHeader('Content-type', 'application/vnd.api+json');
+
+        $included = $response->json('included');
+
+        $this->assertCount(1, $included);
+        $this->assertSame('users', $included[0]['type']);
+        $this->assertSame((string) $user->getKey(), $included[0]['id']);
+    }
+
+    public function testSameModelOnDifferentResourcesIsNotDeduplicated()
+    {
+        $user = User::factory()->create();
+
+        $post = Post::factory()->create([
+            'user_id' => $user->getKey(),
+        ]);
+
+        // Post's author uses AuthorResource ("authors"), root uses UserResource ("users").
+        // We don't want to deduplicate them, as even though the underlying model is the
+        // same, they are different resource types, so they have different identity.
+        $this->getJson("/users/{$user->getKey()}/with-chaperone-posts?".http_build_query(['include' => 'chaperonePosts.author']))
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertJsonPath('data.id', (string) $user->getKey())
+            ->assertJsonPath('data.type', 'users')
+            ->assertJsonPath('included.0.type', 'posts')
+            ->assertJsonPath('included.0.id', (string) $post->getKey())
+            ->assertJsonPath('included.1.type', 'authors')
+            ->assertJsonPath('included.1.id', (string) $user->getKey())
+            ->assertJsonCount(2, 'included');
+    }
 }

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -6,8 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\ArrayBackedJsonApiResource;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\User;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserResource;
+use Illuminate\Tests\Integration\Http\Resources\JsonApi\Fixtures\UserWithArrayRelationshipResource;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\Attributes\WithMigration;
 
@@ -48,12 +51,38 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return User::find($userId)->toResource();
         });
 
+        $router->get('users/{userId}/with-chaperone-posts', function ($userId) {
+            return User::find($userId)->load('chaperonePosts')->toResource();
+        });
+
         $router->get('posts', function () {
             return Post::paginate(5)->toResourceCollection();
         });
 
         $router->get('posts/{postId}', function ($postId) {
             return Post::find($postId)->toResource();
+        });
+
+        $router->get('users/{userId}/with-array-relationship', function ($userId) {
+            $resource = new UserWithArrayRelationshipResource(User::find($userId));
+            $resource->loadedRelationshipsMap = [
+                [new ArrayBackedJsonApiResource(['id' => 99, 'name' => 'test']), 'things', '99', true],
+            ];
+
+            return $resource;
+        });
+
+        $router->get('users/{userId}/with-duplicate-instances', function ($userId) {
+            $instance1 = User::find($userId);
+            $instance2 = User::find($userId);
+
+            $resource = new UserWithArrayRelationshipResource(User::find($userId));
+            $resource->loadedRelationshipsMap = [
+                [new UserResource($instance1), 'users', (string) $instance1->getKey(), true],
+                [new UserResource($instance2), 'users', (string) $instance2->getKey(), true],
+            ];
+
+            return $resource;
         });
     }
 


### PR DESCRIPTION
Branching off of https://github.com/laravel/framework/pull/58329 
The previous PR went a bit astray so I wanted to keep this one focused.  

The problem: When using things like `chaperone`, where two models reference themselves, `compileResourceRelationships` will turn into an infinite loop as it adds the available relationships into the resource map. For example:  

```php

class User extends Model
{
    public function posts()
    {
        return $this->hasMany(Post::class)->chaperone();
    }
}

class Post extends Model
{
    public function author()
    {
        return $this->belongsTo(User::class);
    }
}


class UserResource extends JsonApiResource
{
    protected array $relationships = [
        'posts' => PostResource::class,
    ];
}

class PostResource extends JsonApiResource
{
    protected array $relationships = [
        'author' => UserResource::class,
    ];
}
```

The following hangs:
```php
return User::with('posts')->find(1)->toResource();
``` 


This PR fixes that by using a `WeakMap` to track visited object instances along with their resource type, preventing the same object from being processed multiple times. It does not handle any additional deduplication we discussed/implemented on https://github.com/laravel/framework/pull/58329