### PR TITLE
[12.x] Allow PendingBatch `onConnection` to use Enum

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -299,7 +299,7 @@ class PendingBatch
     /**
      * Specify the queue connection that the batched jobs should run on.
      *
-     * @param string|\UnitEnum $connection
+     * @param \UnitEnum|string $connection
      * @return $this
      */
     public function onConnection(string|\UnitEnum $connection)

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -302,7 +302,7 @@ class PendingBatch
      * @param  \UnitEnum|string  $connection
      * @return $this
      */
-    public function onConnection(string|\UnitEnum $connection)
+    public function onConnection(\UnitEnum|string $connection)
     {
         $this->options['connection'] = enum_value($connection);
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -299,12 +299,12 @@ class PendingBatch
     /**
      * Specify the queue connection that the batched jobs should run on.
      *
-     * @param  string  $connection
+     * @param string|\UnitEnum $connection
      * @return $this
      */
-    public function onConnection(string $connection)
+    public function onConnection(string|\UnitEnum $connection)
     {
-        $this->options['connection'] = $connection;
+        $this->options['connection'] = enum_value($connection);
 
         return $this;
     }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -299,7 +299,7 @@ class PendingBatch
     /**
      * Specify the queue connection that the batched jobs should run on.
      *
-     * @param \UnitEnum|string $connection
+     * @param  \UnitEnum|string  $connection
      * @return $this
      */
     public function onConnection(string|\UnitEnum $connection)


### PR DESCRIPTION
This aligns with the onQueue method, and aligns with [all of the other onConnection methods](https://github.com/search?q=repo%3Alaravel%2Fframework%20public%20function%20onConnection&type=code) 

This means we can do:

```php
$batch = Bus::batch([
    // ...
})->onConnection(Connections::Replica)
)->onQueue(Queues::Finance)->dispatch();

```

Rather than..

```php
$batch = Bus::batch([
    // ...
})->onConnection('replica') // string!?
)->onQueue(Queues::Finance)->dispatch();

```

Kept as UnitEnum to follow the others, had to type the method as it was typed as a string.

