### PR TITLE
[12.x] Prevent null reference in batch callback invocation

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -276,7 +276,6 @@ class Batch implements Arrayable, JsonSerializable
     {
         $batch = $this->fresh();
 
-        // Check if batch is null
         if (is_null($batch)) {
             return;
         }

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -276,6 +276,11 @@ class Batch implements Arrayable, JsonSerializable
     {
         $batch = $this->fresh();
 
+        // Check if batch is null
+        if (is_null($batch)) {
+            return;
+        }
+
         foreach ($this->options[$type] ?? [] as $handler) {
             $this->invokeHandlerCallback($handler, $batch, $e);
         }


### PR DESCRIPTION
This PR fixes a potential null reference error when invoking batch callbacks after the batch has been deleted from the repository.

With the null check in the `invokeCallbacks` method, callbacks are skipped when `fresh` returns null preventing an exception