### PR TITLE
[12.x] Add indexes to failed_jobs stub

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -19,6 +19,8 @@ return new class extends Migration
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
+
+            $table->index(['connection', 'queue', 'failed_at']);
         });
     }
 


### PR DESCRIPTION
I noticed these indexes were added in the [laravel repo](https://github.com/laravel/laravel/commit/36281b285a83c762446a9fe260ae95f76dfd35a6) so thought it be good to have here too - just consistent across the board then.

Just means everyone who generates the migration going forward gets the performance benefit automatically too.

Feel free to close if no use 🫡  (hyb)