### PR TITLE
[12.x] Improve types in `\Illuminate\Support\Str` helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -221,7 +221,7 @@ class Str
      * Convert a value to camel case.
      *
      * @param  string  $value
-     * @return string
+     * @return ($value is '' ? '' : string)
      */
     public static function camel($value)
     {
@@ -254,7 +254,7 @@ class Str
      * Remove the given string(s) if it exists at the start of the haystack.
      *
      * @param  string  $subject
-     * @param  string|array  $needle
+     * @param  string|string[]  $needle
      * @return string
      */
     public static function chopStart($subject, $needle)
@@ -272,7 +272,7 @@ class Str
      * Remove the given string(s) if it exists at the end of the haystack.
      *
      * @param  string  $subject
-     * @param  string|array  $needle
+     * @param  string|string[]  $needle
      * @return string
      */
     public static function chopEnd($subject, $needle)
@@ -292,7 +292,7 @@ class Str
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
      * @param  bool  $ignoreCase
-     * @return bool
+     * @return ($needles is array{} ? false : ($haystack is non-empty-string ? bool : false))
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
@@ -327,7 +327,7 @@ class Str
      * @param  string  $haystack
      * @param  iterable<string>  $needles
      * @param  bool  $ignoreCase
-     * @return bool
+     * @return ($needles is array{} ? false : ($haystack is non-empty-string ? bool : false))
      */
     public static function containsAll($haystack, $needles, $ignoreCase = false)
     {
@@ -346,7 +346,7 @@ class Str
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
      * @param  bool  $ignoreCase
-     * @return bool
+     * @return ($needles is array{} ? true : ($haystack is non-empty-string ? bool : true))
      */
     public static function doesntContain($haystack, $needles, $ignoreCase = false)
     {
@@ -357,9 +357,9 @@ class Str
      * Convert the case of a string.
      *
      * @param  string  $string
-     * @param  int  $mode
+     * @param  MB_CASE_UPPER|MB_CASE_LOWER|MB_CASE_TITLE|MB_CASE_FOLD|MB_CASE_UPPER_SIMPLE|MB_CASE_LOWER_SIMPLE|MB_CASE_TITLE_SIMPLE|MB_CASE_FOLD_SIMPLE  $mode
      * @param  string|null  $encoding
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function convertCase(string $string, int $mode = MB_CASE_FOLD, ?string $encoding = 'UTF-8')
     {
@@ -371,7 +371,7 @@ class Str
      *
      * @param  string  $string
      * @param  array<string>|string  $characters
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function deduplicate(string $string, array|string $characters = ' ')
     {
@@ -391,7 +391,7 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
-     * @return bool
+     * @return ($needles is array{} ? false : ($haystack is non-empty-string ? bool : false))
      */
     public static function endsWith($haystack, $needles)
     {
@@ -417,7 +417,7 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
-     * @return bool
+     * @return ($needles is array{} ? true : ($haystack is non-empty-string ? bool : true))
      */
     public static function doesntEndWith($haystack, $needles)
     {
@@ -429,7 +429,7 @@ class Str
      *
      * @param  string  $text
      * @param  string  $phrase
-     * @param  array  $options
+     * @param  array{radius?: int|float, omission?: string}  $options
      * @return string|null
      */
     public static function excerpt($text, $phrase = '', $options = [])
@@ -585,7 +585,7 @@ class Str
      * Determine if a given value is a valid URL.
      *
      * @param  mixed  $value
-     * @param  array  $protocols
+     * @param  string[]  $protocols
      * @return bool
      *
      * @phpstan-assert-if-true =non-empty-string $value
@@ -691,7 +691,7 @@ class Str
      * Convert a string to kebab case.
      *
      * @param  string  $value
-     * @return string
+     * @return ($value is '' ? '' : string)
      */
     public static function kebab($value)
     {
@@ -703,7 +703,7 @@ class Str
      *
      * @param  string  $value
      * @param  string|null  $encoding
-     * @return int
+     * @return non-negative-int
      */
     public static function length($value, $encoding = null)
     {
@@ -744,7 +744,7 @@ class Str
      * Convert the given string to lower-case.
      *
      * @param  string  $value
-     * @return string
+     * @return lowercase-string
      */
     public static function lower($value)
     {
@@ -775,8 +775,8 @@ class Str
      *
      * @param  string  $string
      * @param  array  $options
-     * @param  array  $extensions
-     * @return string
+     * @param  \League\CommonMark\Extension\ExtensionInterface[]  $extensions
+     * @return ($string is '' ? '' : string)
      */
     public static function markdown($string, array $options = [], array $extensions = [])
     {
@@ -796,8 +796,8 @@ class Str
      *
      * @param  string  $string
      * @param  array  $options
-     * @param  array  $extensions
-     * @return string
+     * @param  \League\CommonMark\Extension\ExtensionInterface[]  $extensions
+     * @return ($string is '' ? '' : string)
      */
     public static function inlineMarkdown($string, array $options = [], array $extensions = [])
     {
@@ -874,7 +874,7 @@ class Str
      *
      * @param  string|iterable<string>  $pattern
      * @param  string  $value
-     * @return bool
+     * @return ($pattern is array{} ? false : bool)
      */
     public static function isMatch($pattern, $value)
     {
@@ -1039,7 +1039,7 @@ class Str
      * @param  bool  $numbers
      * @param  bool  $symbols
      * @param  bool  $spaces
-     * @return string
+     * @return ($letters is false ? ($numbers is true ? ($symbols is false ? ($spaces is false ? numeric-string : string) : string) : string) : string)
      */
     public static function password($length = 32, $letters = true, $numbers = true, $symbols = true, $spaces = false)
     {
@@ -1081,7 +1081,7 @@ class Str
      * @param  string  $needle
      * @param  int  $offset
      * @param  string|null  $encoding
-     * @return int|false
+     * @return ($haystack is '' ? false : ($needle is '' ? false : int|false) : int|false)
      */
     public static function position($haystack, $needle, $offset = 0, $encoding = null)
     {
@@ -1127,8 +1127,8 @@ class Str
     /**
      * Set the sequence that will be used to generate random strings.
      *
-     * @param  array  $sequence
-     * @param  callable|null  $whenMissing
+     * @param  string[]  $sequence
+     * @param  (callable(int): string)|null  $whenMissing
      * @return void
      */
     public static function createRandomStringsUsingSequence(array $sequence, $whenMissing = null)
@@ -1348,11 +1348,11 @@ class Str
     /**
      * Replace the patterns matching the given regular expression.
      *
-     * @param  array|string  $pattern
-     * @param  \Closure|string[]|string  $replace
-     * @param  array|string  $subject
+     * @param  string|string[]  $pattern
+     * @param  (\Closure(array): string)|string[]|string  $replace
+     * @param  array|string[]  $subject
      * @param  int  $limit
-     * @return string|string[]|null
+     * @return ($subject is array ? string|null : string[]|null)
      */
     public static function replaceMatches($pattern, $replace, $subject, $limit = -1)
     {
@@ -1411,7 +1411,7 @@ class Str
      * Convert the given string to upper-case.
      *
      * @param  string  $value
-     * @return string
+     * @return uppercase-string
      */
     public static function upper($value)
     {
@@ -1639,7 +1639,9 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
-     * @return bool
+     * @return ($needles is array{} ? false : ($haystack is non-empty-string ? bool : false))
+     *
+     * @phpstan-assert-if-true =non-empty-string $haystack
      */
     public static function startsWith($haystack, $needles)
     {
@@ -1665,7 +1667,9 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|iterable<string>  $needles
-     * @return bool
+     * @return ($needles is array{} ? true : ($haystack is non-empty-string ? bool : true))
+     *
+     * @phpstan-assert-if-false =non-empty-string $haystack
      */
     public static function doesntStartWith($haystack, $needles)
     {
@@ -1676,7 +1680,7 @@ class Str
      * Convert a value to studly caps case.
      *
      * @param  string  $value
-     * @return string
+     * @return ($value is '' ? '' : string)
      */
     public static function studly($value)
     {
@@ -1697,7 +1701,7 @@ class Str
      * Convert a value to Pascal case.
      *
      * @param  string  $value
-     * @return string
+     * @return ($value is '' ? '' : string)
      */
     public static function pascal($value)
     {
@@ -1759,7 +1763,7 @@ class Str
     /**
      * Swap multiple keywords in a string with other keywords.
      *
-     * @param  array  $map
+     * @param  array<string, string>  $map
      * @param  string  $subject
      * @return string
      */
@@ -1788,7 +1792,7 @@ class Str
      * Convert the given string to Base64 encoding.
      *
      * @param  string  $string
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function toBase64($string): string
     {
@@ -1800,7 +1804,7 @@ class Str
      *
      * @param  string  $string
      * @param  bool  $strict
-     * @return string|false
+     * @return ($strict is true ? string|false : string)
      */
     public static function fromBase64($string, $strict = false)
     {
@@ -1811,7 +1815,7 @@ class Str
      * Make a string's first character lowercase.
      *
      * @param  string  $string
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function lcfirst($string)
     {
@@ -1822,7 +1826,7 @@ class Str
      * Make a string's first character uppercase.
      *
      * @param  string  $string
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function ucfirst($string)
     {
@@ -1834,7 +1838,7 @@ class Str
      *
      * @param  string  $string
      * @param  string  $separators
-     * @return string
+     * @return ($string is '' ? '' : string)
      */
     public static function ucwords($string, $separators = " \t\r\n\f\v")
     {
@@ -1849,7 +1853,7 @@ class Str
      * Split a string into pieces by uppercase characters.
      *
      * @param  string  $string
-     * @return string[]
+     * @return ($string is '' ? array{} : string[])
      */
     public static function ucsplit($string)
     {
@@ -1861,7 +1865,7 @@ class Str
      *
      * @param  string  $string
      * @param  string|null  $characters
-     * @return int
+     * @return non-negative-int
      */
     public static function wordCount($string, $characters = null)
     {
@@ -1946,7 +1950,7 @@ class Str
     /**
      * Set the sequence that will be used to generate UUIDs.
      *
-     * @param  array  $sequence
+     * @param  \Ramsey\Uuid\UuidInterface[]  $sequence
      * @param  (callable(): \Ramsey\Uuid\UuidInterface)|null  $whenMissing
      * @return void
      */
@@ -1980,7 +1984,7 @@ class Str
     /**
      * Always return the same UUID when generating new UUIDs.
      *
-     * @param  \Closure|null  $callback
+     * @param  (\Closure(\Ramsey\Uuid\UuidInterface): mixed)|null  $callback
      * @return \Ramsey\Uuid\UuidInterface
      */
     public static function freezeUuids(?Closure $callback = null)
@@ -2053,7 +2057,7 @@ class Str
     /**
      * Set the sequence that will be used to generate ULIDs.
      *
-     * @param  array  $sequence
+     * @param  \Symfony\Component\Uid\Ulid[]  $sequence
      * @param  (callable(): \Symfony\Component\Uid\Ulid)|null  $whenMissing
      * @return void
      */
@@ -2087,7 +2091,7 @@ class Str
     /**
      * Always return the same ULID when generating new ULIDs.
      *
-     * @param  Closure|null  $callback
+     * @param  (Closure(Ulid): mixed)|null  $callback
      * @return Ulid
      */
     public static function freezeUlids(?Closure $callback = null)


### PR DESCRIPTION
# Benefits
✅ Improved static analysis
✅ Improved type inference
✅ Increased type coverage

# Highlights
* Closure/callable parameter and return types
* array type narrowing
* number narrowing
* more precise return type when input strings are empty
* `non-empty-string` assertions
* string narrowing