### PR TITLE
[12.x] Fix MySQL port conflict in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: forge
         ports:
-          - 33306:3306
+          - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       redis:
         image: redis:7.0


### PR DESCRIPTION
Quite often the test containers will fail to bind the port as just some examples:

https://github.com/laravel/framework/actions/runs/20464378948/job/58804387410#step:2:115
https://github.com/laravel/framework/actions/runs/20938847798/job/60167800374#step:2:115
https://github.com/laravel/framework/actions/runs/20569775899/job/59074527901#step:2:115
https://github.com/laravel/framework/actions/runs/20557799282/job/59044372049#step:2:115
https://github.com/laravel/framework/actions/runs/20857540495/job/59928209267#step:2:115
https://github.com/laravel/framework/actions/runs/20464378948/job/58804387410#step:2:115


This causes failures, which mean PR's look like they have failing tests, and it's a bit of a pain.

This PR changes it so rather than bind the port to `33306` it does it dynamically, as it's set picked up via :

`DB_PORT: ${{ job.services.mysql.ports[3306] }}`

The reason it happens is because GitHub reuses runners between jobs afaik ie the "host" machine. Each test is still in its own environment, just means it'll ensure the port isn't used.

I've just done mysql for now, as that seems to be the one causing the issues from the actions above. 