### PR TITLE
[12.x] Improve the return types for `Number::with*()` helpers

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -345,9 +345,11 @@ class Number
     /**
      * Execute the given callback using the given locale.
      *
+     * @template TReturn
+     *
      * @param  string  $locale
-     * @param  callable  $callback
-     * @return mixed
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function withLocale(string $locale, callable $callback)
     {
@@ -365,9 +367,11 @@ class Number
     /**
      * Execute the given callback using the given currency.
      *
+     * @template TReturn
+     *
      * @param  string  $currency
-     * @param  callable  $callback
-     * @return mixed
+     * @param  callable(): TReturn  $callback
+     * @return TReturn
      */
     public static function withCurrency(string $currency, callable $callback)
     {


### PR DESCRIPTION
This PR narrows the return type of the `Number::with*()` functions to the return type of the callback for better IDE autocompletion.