### PR TITLE
[12.x] Ensure `Bus::batch` filters out falsy items

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -64,7 +64,7 @@ class PendingBatch
     {
         $this->container = $container;
 
-        $this->jobs = $jobs->filter()->each(function (object|array $job) {
+        $this->jobs = $jobs->filter()->values()->each(function (object|array $job) {
             $this->ensureJobIsBatchable($job);
         });
     }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -64,7 +64,7 @@ class PendingBatch
     {
         $this->container = $container;
 
-        $this->jobs = $jobs->each(function (object|array $job) {
+        $this->jobs = $jobs->filter()->each(function (object|array $job) {
             $this->ensureJobIsBatchable($job);
         });
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -336,6 +336,27 @@ class BusBatchTest extends TestCase
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
+    public function test_pending_batch_filters_out_falsy_jobs()
+    {
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $secondJob = new class
+        {
+            use Batchable;
+        };
+
+        $jobsWithNulls = collect([$job, null, $secondJob, [], 0, '', false]);
+
+        $batch = new PendingBatch(new Container, $jobsWithNulls);
+
+        $this->assertCount(2, $batch->jobs);
+        $this->assertTrue($batch->jobs->contains($job));
+        $this->assertTrue($batch->jobs->contains($secondJob));
+    }
+
     public function test_failure_callbacks_execute_correctly(): void
     {
         $queue = m::mock(Factory::class);


### PR DESCRIPTION
it would be nice for `Bus::batch` to ignore falsy items which means we wouldn't have to filter ourselves when creating a batch.

Imagine the following usage: 

```php
$jobs = $users->map(function (User $user) {
    return $user->hasValidData() ? new ProcessFinancialInformation($user) : null;
}); 


// Rather than ..
Bus::batch(array_filter($jobs)); 

// We can do this
Bus::batch($jobs);

// Currently, we have to filter or tests like this fail.. 
 Bus::assertBatched(function (PendingBatchFake $batch) use ($autoRule) {
    return count($batch->jobs) === 0;
 });
``` 

I don't believe it's a B/C, but happy to target 13.x if I'm missing something! Thanks.

I went for filter() as I don't think accepting `[],false,0 or ''` is needed.
 