### PR TITLE
[12.x] Fix: Drop indexes from failed_jobs

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -19,8 +19,6 @@ return new class extends Migration
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();
-
-            $table->index(['connection', 'queue', 'failed_at']);
         });
     }
 


### PR DESCRIPTION
This was added in the laravel repo [here](https://github.com/laravel/laravel/commit/36281b285a83c762446a9fe260ae95f76dfd35a6), so I moved it into the stubs in the framework

Butttt - it doesn't work for mysql databases, re: 

```
  SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'connection' used in key specification without a key length (Connection: mysql, Host: db, Port: 3306, Database: test, SQL: alter table `failed_jobs` add index `failed_jobs_connection_queue_failed_at_index`(`connection`, `queue`, `failed_at`))
```
  
  So reverted..
  
  
  Alternative is to use string() over text() which I'm assuming will work.. but up to you.