### PR TITLE
[12.x] Remove useless use of `MockeryPHPUnitIntegration`

### DIFF
--- a/tests/Cache/CacheSpyMemoTest.php
+++ b/tests/Cache/CacheSpyMemoTest.php
@@ -8,15 +8,12 @@ use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Facade;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use Mockery\LegacyMockInterface;
 use PHPUnit\Framework\TestCase;
 
 class CacheSpyMemoTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
@@ -5,14 +5,11 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Foundation\CacheBasedMaintenanceMode;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class FoundationCacheBasedMaintenanceModeTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
     public function test_it_determines_whether_maintenance_mode_is_active()
     {
         $cache = m::mock(Factory::class, Repository::class);

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -28,7 +28,6 @@ use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use OutOfRangeException;
 use PHPUnit\Framework\AssertionFailedError;
@@ -44,7 +43,6 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
     use InteractsWithExceptionHandling;
 
     protected $config;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Remove useless use of `MockeryPHPUnitIntegration`
They are useless since the merge of https://github.com/laravel/framework/pull/58278
