### PR TITLE
[12.x] fix invalid array doctypes for Str::replaceMatches in v12.47.0

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1350,9 +1350,9 @@ class Str
      *
      * @param  string|string[]  $pattern
      * @param  (\Closure(array): string)|string[]|string  $replace
-     * @param  array|string[]  $subject
+     * @param  string|string[]  $subject
      * @param  int  $limit
-     * @return ($subject is array ? string|null : string[]|null)
+     * @return ($subject is array ? string[]|null : string|null)
      */
     public static function replaceMatches($pattern, $replace, $subject, $limit = -1)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1350,7 +1350,7 @@ class Str
      *
      * @param  string|string[]  $pattern
      * @param  (\Closure(array): string)|string[]|string  $replace
-     * @param  string|string[]  $subject
+     * @param  string[]|string  $subject
      * @param  int  $limit
      * @return ($subject is array ? string[]|null : string|null)
      */


### PR DESCRIPTION
With release 12.47.0 the `Str::replaceMatches()` method does not accept simple strings as the subject anymore (checked by PHPStan) and pretends to return a nullable array with a simple string subject whereas it should return a nullable string instead and only a nullable array if the subject is an array as well.

<img width="522" height="95" alt="image" src="https://github.com/user-attachments/assets/11e92f03-10c5-4e14-816f-b12e657e2471" />

This PR fixes the doc types accordingly.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
