### PR TITLE
[12.x] Adds object decorator utility

### DIFF
--- a/src/Illuminate/Support/Wrap.php
+++ b/src/Illuminate/Support/Wrap.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\ForwardsCalls;
-use ValueError;
 
 /**
  * @template TObject
@@ -14,7 +13,7 @@ class Wrap
     use ForwardsCalls;
 
     /**
-     * Create a new Proxyable instance.
+     * Create a new Wrap instance.
      *
      * @param  TObject  $object
      * @param  array<string, \Closure>  $methods
@@ -25,13 +24,13 @@ class Wrap
     }
 
     /**
-     * Captures a method call and executes a callback with the arguments and object.
+     * Registers a temporary macro to execute for the wrapped object method call.
      *
      * @param  string  $method
      * @param  \Closure  $callback
      * @return  $this
      */
-    public function capture($method, Closure $callback)
+    public function macro($method, Closure $callback)
     {
         $this->methods[$method] = $callback;
 
@@ -62,7 +61,7 @@ class Wrap
     }
 
     /**
-     * Dynamically handle removing a property value
+     * Dynamically handle removing a property value.
      *
      * @param  string  $name
      * @return void
@@ -73,7 +72,7 @@ class Wrap
     }
 
     /**
-     * Dynamically handle removing a property value
+     * Dynamically handle checking a property value.
      *
      * @param  string  $name
      * @return bool
@@ -102,14 +101,14 @@ class Wrap
     }
 
     /**
-     * Create a new Proxyable instance using an object.
+     * Create a new Wrap instance using an object.
      *
      * @template TProxied of object
      *
      * @param  TProxied  $object
      * @return static<TProxied>
      */
-    public static function object(object $object): static
+    public static function instance($object): static
     {
         return new static($object);
     }

--- a/src/Illuminate/Support/Wrap.php
+++ b/src/Illuminate/Support/Wrap.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Closure;
+use Illuminate\Support\Traits\ForwardsCalls;
+use ValueError;
+
+/**
+ * @template TObject
+ */
+class Wrap
+{
+    use ForwardsCalls;
+
+    /**
+     * Create a new Proxyable instance.
+     *
+     * @param  TObject  $object
+     * @param  array<string, \Closure>  $methods
+     */
+    public function __construct(protected $object, protected $methods = [])
+    {
+        //
+    }
+
+    /**
+     * Captures a method call and executes a callback with the arguments and object.
+     *
+     * @param  string  $method
+     * @param  \Closure  $callback
+     * @return  $this
+     */
+    public function capture($method, Closure $callback)
+    {
+        $this->methods[$method] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically handle accessing the object properties.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->object->{$name};
+    }
+
+    /**
+     * Dynamically handle setting the object properties.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($name, $value)
+    {
+        $this->object->{$name} = $value;
+    }
+
+    /**
+     * Dynamically handle removing a property value
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function __unset($name)
+    {
+        unset($this->object->{$name});
+    }
+
+    /**
+     * Dynamically handle removing a property value
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function __isset($name): bool
+    {
+        return isset($this->object->{$name});
+    }
+
+    /**
+     * Dynamically handle calling the object methods.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        if (isset($this->methods[$name])) {
+            $result = $this->methods[$name]?->call($this->object, ...$arguments);
+
+            return $result === $this->object ? $this : $result;
+        }
+
+        return $this->forwardDecoratedCallTo($this->object, $name, $arguments);
+    }
+
+    /**
+     * Create a new Proxyable instance using an object.
+     *
+     * @template TProxied of object
+     *
+     * @param  TProxied  $object
+     * @return static<TProxied>
+     */
+    public static function object(object $object): static
+    {
+        return new static($object);
+    }
+}

--- a/tests/Support/WrapTest.php
+++ b/tests/Support/WrapTest.php
@@ -20,7 +20,7 @@ class WrapTest extends TestCase
         $object = m::mock(Fluent::class);
         $object->expects('get')->with('foo')->andReturn('bar');
 
-        $wrap = Wrap::object($object);
+        $wrap = Wrap::instance($object);
 
         $this->assertSame('bar', $wrap->get('foo'));
     }
@@ -30,8 +30,8 @@ class WrapTest extends TestCase
         $object = m::mock(Fluent::class);
         $object->expects('get')->never();
 
-        $wrap = Wrap::object($object);
-        $wrap->capture('get', fn ($name) => $name . 'baz');
+        $wrap = Wrap::instance($object);
+        $wrap->macro('get', fn ($name) => $name . 'baz');
 
         $this->assertSame('foobaz', $wrap->get('foo'));
     }
@@ -41,8 +41,8 @@ class WrapTest extends TestCase
         $object = m::mock(Fluent::class);
         $object->expects('invalid')->never();
 
-        $wrap = Wrap::object($object);
-        $wrap->capture('invalid', fn ($name) => $name . 'baz');
+        $wrap = Wrap::instance($object);
+        $wrap->macro('invalid', fn ($name) => $name . 'baz');
 
         $this->assertSame('foobaz', $wrap->invalid('foo'));
     }
@@ -51,7 +51,7 @@ class WrapTest extends TestCase
     {
         $object = new Fluent(['foo' => 'bar']);
 
-        $wrap = Wrap::object($object);
+        $wrap = Wrap::instance($object);
 
         $this->assertSame('bar', $wrap->foo);
         $this->assertTrue(isset($wrap->foo));

--- a/tests/Support/WrapTest.php
+++ b/tests/Support/WrapTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Wrap;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class WrapTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCallsOriginalObject()
+    {
+        $object = m::mock(Fluent::class);
+        $object->expects('get')->with('foo')->andReturn('bar');
+
+        $wrap = Wrap::object($object);
+
+        $this->assertSame('bar', $wrap->get('foo'));
+    }
+
+    public function testCallsCapturedMethod()
+    {
+        $object = m::mock(Fluent::class);
+        $object->expects('get')->never();
+
+        $wrap = Wrap::object($object);
+        $wrap->capture('get', fn ($name) => $name . 'baz');
+
+        $this->assertSame('foobaz', $wrap->get('foo'));
+    }
+
+    public function testCallsNonExistingCapturedMethod()
+    {
+        $object = m::mock(Fluent::class);
+        $object->expects('invalid')->never();
+
+        $wrap = Wrap::object($object);
+        $wrap->capture('invalid', fn ($name) => $name . 'baz');
+
+        $this->assertSame('foobaz', $wrap->invalid('foo'));
+    }
+
+    public function testPassesThroughProperties()
+    {
+        $object = new Fluent(['foo' => 'bar']);
+
+        $wrap = Wrap::object($object);
+
+        $this->assertSame('bar', $wrap->foo);
+        $this->assertTrue(isset($wrap->foo));
+
+        unset($wrap->foo);
+
+        $this->assertNull($wrap->foo);
+        $this->assertFalse(isset($wrap->foo));
+
+        $wrap->foo = 'baz';
+
+        $this->assertSame('baz', $wrap->foo);
+    }
+}


### PR DESCRIPTION
# What?

It's a convenience class to wrap objects while capturing method calls. For example, this can be used to alter services without having to extending them or registering macros, especially when you want to test something or run something only local.

```php
use Illuminate\Support\Decorator;
use Illuminate\Support\Fluent;

$fluent = app(Fluent::class);

$decorator = Decorator::of($fluent)->intercept(
    'get', fn () => 'something else'
);
```

I use this when third-party packages lack something, and waiting for the developers to implement that may take weeks or months, or even creating a fork somewhere.

- Adding development/local switches
- Logging
- Adding insightful exceptions
- Executing something while keeping the original method accessible.

For example, let's imagine we have a package that offers the `RadioSignal` class. It does will always send a signal regardless of the environment. Instead of creating a decorator or editing code everywhere is used, we can just _wrap_ it and capture the problematic call.

```php
use Illuminate\Support\Decorator;
use Radio\Laravel\RadioSignal;
use Illuminate\Support\Facades\Log;

$this->app->extend(RadioSignal::class, function ($radio, $app) {
    if ($app->isLocal()) {
        return Decorator::of($radio)->intercept('send', function ($frequency, $data) {
            Log::info('Radio Signal', ['frequency' => $frequency, 'data' => $data]);
        });
    }

    return $channel;
});
```

The "wrapper" is non-invasive. For example, the developer can change something and then call the original intended method, because the callback is bound to the original object.

```php
use Illuminate\Support\Decorator;

Decorator::of($radio)->intercept('setFrequency', function ($frequency) {
    /** @var \Radio\Laravel\RadioSignal $this */
    return $this->setFrequency(max(0, $frequency));
})
```