### PR TITLE
Translation lines may contain square brackets and curly braces now

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -58,7 +58,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        preg_match('/^[\{\[]([\d,\.\*]*)[\}\]](.*)/s', $part, $matches);
+        preg_match('/^[\{\[]([\d,\.*]*)[\}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
             return null;
@@ -92,7 +92,7 @@ class MessageSelector
     private function stripConditions($segments)
     {
         return (new Collection($segments))
-            ->map(fn ($part) => preg_replace('/^[\{\[][\d,\,\*]*[\}\]]/', '', $part))
+            ->map(fn ($part) => preg_replace('/^[\{\[][\d,\.*]*[\}\]]/', '', $part))
             ->all();
     }
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -58,7 +58,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        preg_match('/^[\{\[]([^\[\]\{\}]*)[\}\]](.*)/s', $part, $matches);
+        preg_match('/^[\{\[]([\d,\.\*]*)[\}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
             return null;
@@ -92,7 +92,7 @@ class MessageSelector
     private function stripConditions($segments)
     {
         return (new Collection($segments))
-            ->map(fn ($part) => preg_replace('/^[\{\[]([^\[\]\{\}]*)[\}\]]/', '', $part))
+            ->map(fn ($part) => preg_replace('/^[\{\[][\d,\,\*]*[\}\]]/', '', $part))
             ->all();
     }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -33,6 +33,7 @@ class TranslationMessageSelectorTest extends TestCase
             ['first', '{9}first|{10}second', 1],
             ['', '{0}|{1}second', 0],
             ['', '{0}first|{1}', 1],
+            ['second', '{1.3}first|{2.3}second', .3],
             ['first', '{1.3}first|{2.3}second', 1.3],
             ['second', '{1.3}first|{2.3}second', 2.3],
             ['first
@@ -67,7 +68,13 @@ class TranslationMessageSelectorTest extends TestCase
             ['[first](//example.com)', '[first](//example.com)|[second](//test.com)', 1],
             ['[second](//test.com)', '[first](//example.com)|[second](//test.com)', 2],
             ['[first](//example.com)', '{0}[first](//example.com)|{1}[second](//test.com)', 0],
+            ['[second](//test.com)', '{0}[first](//example.com)|{1}[second](//test.com)', 1],
+            ['[first](//example.com)', '{0}[first](//example.com)|[2,*][second](//test.com)', 0],
+            ['[first](//example.com)', '{0}[first](//example.com)|[2,*][second](//test.com)', 1],
             ['[second](//test.com)', '{0}[first](//example.com)|[2,*][second](//test.com)', 10],
+            ['[first](//example.com)', '{0}[first](//example.com)|{2.3}[second](//test.com)', 0],
+            ['[first](//example.com)', '{0}[first](//example.com)|{2.3}[second](//test.com)', 1],
+            ['[second](//test.com)', '{0}[first](//example.com)|{2.3}[second](//test.com)', 2.3],
         ];
     }
 }

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -63,6 +63,11 @@ class TranslationMessageSelectorTest extends TestCase
 
             ['first', '{0}  first | { 1 } second', 0],
             ['first', '[4,*]first | [1,3]second', 100],
+
+            ['[first](//example.com)', '[first](//example.com)|[second](//test.com)', 1],
+            ['[second](//test.com)', '[first](//example.com)|[second](//test.com)', 2],
+            ['[first](//example.com)', '{0}[first](//example.com)|{1}[second](//test.com)', 0],
+            ['[second](//test.com)', '{0}[first](//example.com)|[2,*][second](//test.com)', 10],
         ];
     }
 }


### PR DESCRIPTION
Translation lines starting with brackets became unavailable due to a loose regex pattern.

We (also thanks to @RMJTromp) did an update on that, extended the tests, and find it all still working.

Thanks for merging, Keep up the good work 🙌 Laravel 🙌