### PR TITLE
[12.x] Add `cancelPendingDispatch` and `flushPendingDispatch` methods to PendingDispatch

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Queue\InteractsWithUniqueJobs;
-use RuntimeException;
 
 class PendingDispatch
 {
@@ -206,15 +205,9 @@ class PendingDispatch
      * Cancel the pending dispatch of the job.
      *
      * @return $this
-     *
-     * @throws RuntimeException
      */
     public function cancelPendingDispatch()
     {
-        if (! $this->pendingDispatch) {
-            throw new RuntimeException('Cannot cancel a pending dispatch that has already been dispatched.');
-        }
-
         $this->pendingDispatch = false;
 
         return $this;

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -224,13 +224,11 @@ class PendingDispatch
      * Dispatch the job immediately.
      *
      * @return mixed
-     *
-     * @throws RuntimeException
      */
     public function flushPendingDispatch()
     {
         if (! $this->pendingDispatch) {
-            throw new RuntimeException('Cannot flush a pending dispatch that has already been dispatched.');
+            return null;
         }
 
         $this->pendingDispatch = false;

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -165,15 +165,14 @@ class BusPendingDispatchTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testCancelPendingDispatchThrowsExceptionIfAlreadyDispatched()
+    public function testCancelPendingDispatchAfterFlushReturnsEarly()
     {
         $this->dispatcher->shouldReceive('dispatch')->once()->with($this->job);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot cancel a pending dispatch that has already been dispatched.');
-
         $this->pendingDispatch->flushPendingDispatch();
-        $this->pendingDispatch->cancelPendingDispatch();
+        $result = $this->pendingDispatch->cancelPendingDispatch();
+
+        $this->assertSame($this->pendingDispatch, $result);
     }
 
     public function testFlushPendingDispatchWithDelay()

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -134,13 +134,14 @@ class BusPendingDispatchTest extends TestCase
         );
     }
 
-    public function testFlushPendingDispatchAfterCancelThrowsException()
+    public function testFlushPendingDispatchAfterCancelReturnsEarly()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot flush a pending dispatch that has already been dispatched.');
+        $this->dispatcher->shouldNotReceive('dispatch');
 
         $this->pendingDispatch->cancelPendingDispatch();
-        $this->pendingDispatch->flushPendingDispatch();
+        $result = $this->pendingDispatch->flushPendingDispatch();
+
+        $this->assertNull($result);
     }
 
     public function testFlushPendingDispatchSetsPendingDispatchToFalse()
@@ -154,15 +155,14 @@ class BusPendingDispatchTest extends TestCase
         );
     }
 
-    public function testFlushPendingDispatchThrowsExceptionIfAlreadyDispatched()
+    public function testFlushPendingDispatchReturnsEarlyIfAlreadyDispatched()
     {
         $this->dispatcher->shouldReceive('dispatch')->once()->with($this->job);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot flush a pending dispatch that has already been dispatched.');
+        $this->pendingDispatch->flushPendingDispatch();
+        $result = $this->pendingDispatch->flushPendingDispatch();
 
-        $this->pendingDispatch->flushPendingDispatch();
-        $this->pendingDispatch->flushPendingDispatch();
+        $this->assertNull($result);
     }
 
     public function testCancelPendingDispatchThrowsExceptionIfAlreadyDispatched()


### PR DESCRIPTION
 This PR adds explicit control over job dispatch timing with two new methods on PendingDispatch:

- `flushPendingDispatch()`: Immediately dispatches the job instead of waiting for the destructor. Safe to call multiple times.
- `cancelPendingDispatch()`: Prevents the job from being dispatched in the destructor. Safe to call multiple times.

## Example

`flushPendingDispatch()` - Ensure dispatch before risky operations

When performing operations that might terminate the process, you may want to ensure a job is dispatched before the operation rather than relying on the destructor:

```php
// Schedule a cleanup job with a delay before uploading to S3
// If the server crashes during upload, the cleanup job is already queued
$pending = CleanupOrphanedFile::dispatch($path)->delay(60);
$pending->flushPendingDispatch();

// This operation might fail or kill the process while receiving the response from S3
Storage::disk('s3')->put($path, $contents);

// If we get here, the upload succeeded - the delayed cleanup job
// will check if the file should be kept or removed
```

Previously, if the server died during `Storage::disk('s3')->put()`, the job would never be dispatched since the destructor wouldn't run and potentially ophan resources would be created on the external target.

I did not have any use case for the `cancelPendingDispatch` but might be worth adding.  Up to you.