### PR TITLE
[12.x] Ensure Bus::chain filters out falsy items

### DIFF
--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -59,8 +59,7 @@ class ChainedBatch implements ShouldQueue
      */
     public static function prepareNestedBatches(Collection $jobs): Collection
     {
-        return $jobs->filter()->values()
-            ->map(fn ($job) => match (true) {
+        return $jobs->filter()->values()->map(fn ($job) => match (true) {
             is_array($job) => static::prepareNestedBatches(new Collection($job))->all(),
             $job instanceof Collection => static::prepareNestedBatches($job),
             $job instanceof PendingBatch => new ChainedBatch($job),

--- a/src/Illuminate/Bus/ChainedBatch.php
+++ b/src/Illuminate/Bus/ChainedBatch.php
@@ -59,7 +59,8 @@ class ChainedBatch implements ShouldQueue
      */
     public static function prepareNestedBatches(Collection $jobs): Collection
     {
-        return $jobs->map(fn ($job) => match (true) {
+        return $jobs->filter()->values()
+            ->map(fn ($job) => match (true) {
             is_array($job) => static::prepareNestedBatches(new Collection($job))->all(),
             $job instanceof Collection => static::prepareNestedBatches($job),
             $job instanceof PendingBatch => new ChainedBatch($job),

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -258,7 +258,7 @@ class JobChainingTest extends QueueTestCase
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
 
-    public function testChainJobRemovesFalsyValues()
+    public function testChainJobRemovesFalsy()
     {
         $job = (new JobChainingTestFirstJob)->chain([
             new JobChainingTestSecondJob,
@@ -369,7 +369,7 @@ class JobChainingTest extends QueueTestCase
         $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
     }
 
-    public function testChainRemovesFalsyValues()
+    public function testChainRemovesFalsy()
     {
         $chain = Bus::chain([
             $firstJob = new JobChainingTestFirstJob,

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -369,6 +369,21 @@ class JobChainingTest extends QueueTestCase
         $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
     }
 
+    public function testChainRemovesFalsyValues()
+    {
+        $chain = Bus::chain([
+            $firstJob = new JobChainingTestFirstJob,
+            $secondJob = new JobChainingTestSecondJob,
+            null,
+            '',
+            0,
+            [],
+        ]);
+
+        $this->assertEquals($firstJob, $chain->job);
+        $this->assertEquals([$secondJob], $chain->chain);
+    }
+
     public function testChainAppendRemovesFalsy()
     {
         $chain = Bus::chain([

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -258,6 +258,26 @@ class JobChainingTest extends QueueTestCase
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
 
+    public function testChainRemovesFalsyValues()
+    {
+        $job = (new JobChainingTestFirstJob)->chain([
+            new JobChainingTestSecondJob,
+            null,
+            '',
+            0,
+            [],
+        ]);
+
+        $this->assertCount(1, $job->chained);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        Queue::push($job);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
     public function testChainJobsCanBePrepended()
     {
         JobChainAddingPrependingJob::withChain([new JobChainAddingExistingJob])->dispatch();
@@ -349,6 +369,25 @@ class JobChainingTest extends QueueTestCase
         $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
     }
 
+    public function testChainAppendRemovesFalsy()
+    {
+        $chain = Bus::chain([
+            $firstJob = new JobChainingNamedTestJob('j1'),
+        ]);
+
+        $chain->append([
+            $secondJob = new JobChainingNamedTestJob('j2'),
+            $thirdJob = new JobChainingNamedTestJob('j3'),
+            null,
+            '',
+            0,
+            [],
+        ]);
+
+        $this->assertEquals($firstJob, $chain->job);
+        $this->assertEquals([$secondJob, $thirdJob], $chain->chain);
+    }
+
     public function testChainCanBePrepended()
     {
         $chain = Bus::chain();
@@ -371,6 +410,26 @@ class JobChainingTest extends QueueTestCase
             $secondJob = new JobChainingNamedTestJob('j1'),
             $thirdJob = new JobChainingNamedTestJob('j2'),
             $fourthJob = new JobChainingNamedTestJob('j3'),
+        ]);
+
+        $this->assertEquals($secondJob, $chain->job);
+        $this->assertEquals([$thirdJob, $fourthJob, $firstJob], $chain->chain);
+    }
+
+    public function testChainPrependRemovesFalsy()
+    {
+        $chain = Bus::chain([
+            $firstJob = new JobChainingNamedTestJob('j4'),
+        ]);
+
+        $chain->prepend([
+            $secondJob = new JobChainingNamedTestJob('j1'),
+            $thirdJob = new JobChainingNamedTestJob('j2'),
+            $fourthJob = new JobChainingNamedTestJob('j3'),
+            null,
+            '',
+            0,
+            [],
         ]);
 
         $this->assertEquals($secondJob, $chain->job);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -270,9 +270,9 @@ class JobChainingTest extends QueueTestCase
 
         $this->assertCount(1, $job->chained);
 
-        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
-
         Queue::push($job);
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
         $this->assertTrue(JobChainingTestSecondJob::$ran);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -258,7 +258,7 @@ class JobChainingTest extends QueueTestCase
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
 
-    public function testChainRemovesFalsyValues()
+    public function testChainJobRemovesFalsyValues()
     {
         $job = (new JobChainingTestFirstJob)->chain([
             new JobChainingTestSecondJob,


### PR DESCRIPTION
[`Bus::batch()` does this ](https://github.com/laravel/framework/blob/136332ccdf99fd3aa1da05b417e82a4a63f7f220/src/Illuminate/Bus/PendingBatch.php#L68)- so feels natural (to me) that chain should too.. as it feels pointless keeping any null or empty values in the chain. 

When it's serialized this should also help reduce the size - if anyone is currently doing this.

I've done this in `prepareNestedBatches` as it keeps the logic centralised. it also means append / prepend benefit from it too.

This means we can now do an inline chain like.. 

```php

Bus::chain([
    new ProcessOrder($order),
    $order->needsShipping() ? new ShipOrder($order) : null,
    $order->isGift() ? new SendGiftMessage($order) : null,
    new SendConfirmationEmail($order),
])->dispatch();


Bus::assertChained(function (PendingChain $chain) {
    $jobs = array_filter($chain->jobs); // won't need to do this anymore.
    return count($jobs) === 2;
});
```

I think I've covered it in tests, but happy to target 13.x if this is a bit risky for 12.x