### PR TITLE
[12.x] Add `failIf` method to InteractsWithQueue

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -68,7 +68,7 @@ trait InteractsWithQueue
     /**
      * Fail the job from the queue when the boolean is true.
      *
-     * @param  bool $boolean
+     * @param  bool  $boolean
      * @param  \Throwable|string|null  $exception
      * @return void
      */

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -66,6 +66,20 @@ trait InteractsWithQueue
     }
 
     /**
+     * Fail the job from the queue when the boolean is true.
+     *
+     * @param  boolean $boolean
+     * @param  \Throwable|string|null  $exception
+     * @return void
+     */
+    public function failIf(bool $boolean, $exception = null)
+    {
+        if ($boolean) {
+            $this->fail($exception);
+        }
+    }
+
+    /**
      * Release the job back into the queue after (n) seconds.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -68,7 +68,7 @@ trait InteractsWithQueue
     /**
      * Fail the job from the queue when the boolean is true.
      *
-     * @param  boolean $boolean
+     * @param  bool $boolean
      * @param  \Throwable|string|null  $exception
      * @return void
      */

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -56,7 +56,7 @@ class InteractsWithQueueTest extends TestCase
         $queueJob->mockery_verify();
     }
 
-    public function testDoesntCreateAnExceptionWhenBooleanIsFalse()
+    public function testDoesNotFailJobWhenConditionIsFalse()
     {
         $queueJob = m::mock(Job::class);
         $queueJob->shouldNotReceive('fail');

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -33,7 +33,7 @@ class InteractsWithQueueTest extends TestCase
         $queueJob->mockery_verify();
     }
 
-    public function testCreatesAnExceptionWhenBooleanIsTrue()
+    public function testFailsJobWhenConditionIsTrue()
     {
         $queueJob = m::mock(Job::class);
         $queueJob->shouldReceive('fail')->once()->withArgs(function ($e) {

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -13,7 +13,7 @@ class InteractsWithQueueTest extends TestCase
     public function testCreatesAnExceptionFromString()
     {
         $queueJob = m::mock(Job::class);
-        $queueJob->shouldReceive('fail')->withArgs(function ($e) {
+        $queueJob->shouldReceive('fail')->once()->withArgs(function ($e) {
             $this->assertInstanceOf(Exception::class, $e);
             $this->assertEquals('Whoops!', $e->getMessage());
 
@@ -29,5 +29,48 @@ class InteractsWithQueueTest extends TestCase
 
         $job->job = $queueJob;
         $job->fail('Whoops!');
+
+        $queueJob->mockery_verify();
+    }
+
+    public function testCreatesAnExceptionWhenBooleanIsTrue()
+    {
+        $queueJob = m::mock(Job::class);
+        $queueJob->shouldReceive('fail')->once()->withArgs(function ($e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Whoops!', $e->getMessage());
+
+            return true;
+        });
+
+        $job = new class
+        {
+            use InteractsWithQueue;
+
+            public $job;
+        };
+
+        $job->job = $queueJob;
+        $job->failIf(true, 'Whoops!');
+
+        $queueJob->mockery_verify();
+    }
+
+    public function testDoesntCreateAnExceptionWhenBooleanIsFalse()
+    {
+        $queueJob = m::mock(Job::class);
+        $queueJob->shouldNotReceive('fail');
+
+        $job = new class
+        {
+            use InteractsWithQueue;
+
+            public $job;
+        };
+
+        $job->job = $queueJob;
+        $job->failIf(false, 'Whoops!');
+
+        $queueJob->mockery_verify();
     }
 }


### PR DESCRIPTION
This PR adds a `failIf` method to the InteractsWithQueue class. With this method, a job can be failed based on a condition. 

## Example 

When working with queues, I often add a condition around the fail method. For example, when a HTTP Request fails, I want to fail the job:

```
if (!$request->successful()) {
    $this->fail($request->toException());
}
```

With this change, this can be done in a single line:

````
$this->failIf(!$request->successful(), $request->toException())
````