### PR TITLE
[12.x] Adjust PendingBatchFake to filter

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -23,7 +23,7 @@ class PendingBatchFake extends PendingBatch
     public function __construct(BusFake $bus, Collection $jobs)
     {
         $this->bus = $bus;
-        $this->jobs = $jobs;
+        $this->jobs = $jobs->filter()->values();
     }
 
     /**


### PR DESCRIPTION
This fake extends PendingBatch, but has its own __construct.. so this makes sure it filters etc too, to [replicate the intended behaviour.](https://github.com/laravel/framework/blob/136332ccdf99fd3aa1da05b417e82a4a63f7f220/src/Illuminate/Bus/PendingBatch.php#L68)

(Sorry, I'm using this locally and just keep noticing stuff)

This fixes assertions where they should be empty, but contains nulls etc.