### PR TITLE
[12.x] Fix missing variable reassignment

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2896,7 +2896,7 @@ class Builder implements BuilderContract
         $this->ensureConnectionSupportsVectors();
 
         if (is_string($vector)) {
-            Str::of($vector)->toEmbeddings();
+            $vector = Str::of($vector)->toEmbeddings(cache: true);
         }
 
         $this->addBinding(


### PR DESCRIPTION
hey buddy, looks like this `$vector` variable is missing the re-assignment here. Thanks @nuernbergerA for reporting this.
