### PR TITLE
[12.x] Fix TypeError when validation rule has empty parameters

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -748,7 +748,7 @@ class Validator implements ValidatorContract
     protected function replaceDotInParameters(array $parameters)
     {
         return array_map(function ($field) {
-            return static::encodeAttributeWithPlaceholder($field);
+            return static::encodeAttributeWithPlaceholder((string) ($field ?? ''));
         }, $parameters);
     }
 


### PR DESCRIPTION
Fixes #58371

What is the problem?
Since the introduction of stricter type-hinting in recent versions, certain validation rules (specifically date comparison rules like after_or_equal:) throw a TypeError if the parameter is missing or empty.

Previously, an empty parameter would be handled gracefully (usually resulting in a validation failure). Currently, it triggers: Illuminate\Validation\Validator::encodeAttributeWithPlaceholder(): Argument # 1 ($attribute) must be of type string, null given

What is the fix?
I have updated the Validator to ensure that parameters passed to encodeAttributeWithPlaceholder are cast to strings or handled as empty strings when null. This prevents the application from crashing when a dynamic or malformed rule is encountered.

How to reproduce?
```php
$trans = $this->getIlluminateArrayTranslator();
$data = ['start_date' => '2025-01-01'];
$rules = ['start_date' => 'date|after_or_equal:'];

$validator = new Validator($trans, $data, $rules);

// This should not throw a TypeError
$this->assertFalse($validator->passes());
```
