### PR TITLE
[12.x] Fix Blade compilation race conditions during parallel testing

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -196,7 +196,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             );
 
             if (! $this->files->exists($compiledPath)) {
-                $this->files->put($compiledPath, $contents);
+                $this->files->replace($compiledPath, $contents);
 
                 return;
             }
@@ -204,7 +204,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $compiledHash = $this->files->hash($compiledPath, 'xxh128');
 
             if ($compiledHash !== hash('xxh128', $contents)) {
-                $this->files->put($compiledPath, $contents);
+                $this->files->replace($compiledPath, $contents);
             }
         }
     }

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -75,11 +75,7 @@ class CompilerEngine extends PhpEngine
         try {
             $results = $this->evaluatePath($this->compiler->getCompiledPath($path), $data);
         } catch (ViewException $e) {
-            if (! Str::of($e->getMessage())->contains(['No such file or directory', 'File does not exist at path'])) {
-                throw $e;
-            }
-
-            if (! isset($this->compiledOrNotExpired[$path])) {
+            if (! Str::of($e->getMessage())->contains(['No such file or directory', 'File does not exist at path', 'Failed opening required'])) {
                 throw $e;
             }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -315,7 +315,7 @@ class ViewBladeCompilerTest extends TestCase
         $result = 1;
         $pids = [];
 
-        for ($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < 10; $i++) {
             $pid = pcntl_fork();
             if ($pid === 0) {
                 try {


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/58378

## Problem

When multiple processes compile the same Blade view simultaneously (common in parallel testing), two race conditions can occur:

1. `ParseError` from truncated files

`file_put_contents()` truncates the target file before writing, creating a window where the file is incomplete:

Process A: `put()` → truncates file to 0 bytes
Process A: `put()` → begins writing content
Process B: `require($compiled)` → includes partial/empty file → `ParseError`

2. `FileNotFoundException` on first render

The existing retry logic in `CompilerEngine::get()` only worked on subsequent renders (when `compiledOrNotExpired` was already set). On first access, if the compiled file disappeared between `isExpired()` and `evaluatePath()`, the exception was thrown without retry:

Process A: `compile()` creates file
Process B: `isExpired()` → file exists, returns false
Process A: `replace()` overwrites file (brief window)
Process B: `evaluatePath()` → `FileNotFoundException` (no retry on first access)

## Fix

1. Atomic writes in `BladeCompiler`

Replaced `Filesystem::put()` with `Filesystem::replace()` in `BladeCompiler::compile()`. The `replace()` method uses a temp file, then uses `rename()` which is atomic. The compiled path instantly switched from the old to new complete file.

2. Always retry on file not found errors in `CompilerEngine`

Removed the `compiledOrNotExpired` check so retry logic works on first render, not just subsequent renders. Also added `'Failed opening required'` to the error patterns that trigger a retry.

The atomic write scenario is tested in `testCompiledFileIsWrittenAtomic`, and it will intermittently fail without the changes in `BladeCompiler`:

```bash
for i in {1..50}; do vendor/bin/phpunit --filter testCompiledFileIsWrittenAtomic &>/dev/null && echo "Run $i: OK" || echo "Run $i: FAIL"; done
```