### PR TITLE
Make \Illuminate\Testing\TestResponse::assertHeader() case insensitive

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -373,7 +373,7 @@ class TestResponse implements ArrayAccess
         $actual = $this->headers->get($headerName);
 
         if (! is_null($value)) {
-            PHPUnit::withResponse($this)->assertEquals(
+            PHPUnit::withResponse($this)->assertEqualsIgnoringCase(
                 $value, $this->headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
             );


### PR DESCRIPTION
I bumped into a PhpUnit error today when asserting the response has the correct header:

```php
$response->assertHeader('content-type', 'text/html; charset=UTF-8');
```

PhpUnit error:

```
Header [content-type] was found, but value [text/html; charset=utf-8] does not match [text/html; charset=UTF-8].
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'text/html; charset=UTF-8'
+'text/html; charset=utf-8'

[..paths omitted..]
```

It might be that `redirect('/some/path')` fairly recently changed from UTF-8 to utf-8 due to HPACK/QPACK normalisation rules. But it broke some of my tests.

In principle these HTTP headers are case-insensitive, so this change to `\Illuminate\Testing\TestResponse::assertHeader()` makes sense.

Let me know if you agree, or you want it fixed in another way.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
