### PR TITLE
[12.x] add `config()->int()` method

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -123,6 +123,20 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified integer configuration value.
+     *
+     * @param  string  $key
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function int(string $key, $default = null): int
+    {
+        return $this->integer($key, $default);
+    }
+
+    /**
      * Get the specified float configuration value.
      *
      * @param  string  $key


### PR DESCRIPTION
This adds `Config\Repository@int()`, which serves as an alias for `integer()`.

Why? My code failed earlier because I just assumed this method existed. I am sure I'm not the only dev who has done this, and it seems like good developer experience.