### PR TITLE
[12.x] Fix backward compatibility with third-party guards

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -85,8 +85,13 @@ class AuthenticateSession implements AuthenticatesSessions
             return;
         }
 
+        $passwordHash = $request->user()->getAuthPassword();
+        if (method_exists($this->guard(), 'hashPasswordForCookie')) {
+            $passwordHash = $this->guard()->hashPasswordForCookie($passwordHash);
+        }
+
         $request->session()->put([
-            'password_hash_'.$this->auth->getDefaultDriver() => $this->guard()->hashPasswordForCookie($request->user()->getAuthPassword()),
+            'password_hash_'.$this->auth->getDefaultDriver() => $passwordHash,
         ]);
     }
 
@@ -100,7 +105,10 @@ class AuthenticateSession implements AuthenticatesSessions
     protected function validatePasswordHash($passwordHash, $storedValue)
     {
         // Try new HMAC format first...
-        if (hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)) {
+        if (
+            method_exists($this->guard(), 'hashPasswordForCookie') &&
+            hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)
+        ) {
             return true;
         }
 

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -86,6 +86,7 @@ class AuthenticateSession implements AuthenticatesSessions
         }
 
         $passwordHash = $request->user()->getAuthPassword();
+
         if (is_callable([$this->guard(), 'hashPasswordForCookie'])) {
             $passwordHash = $this->guard()->hashPasswordForCookie($passwordHash);
         }

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -106,10 +106,8 @@ class AuthenticateSession implements AuthenticatesSessions
     protected function validatePasswordHash($passwordHash, $storedValue)
     {
         // Try new HMAC format first...
-        if (
-            is_callable([$this->guard(), 'hashPasswordForCookie']) &&
-            hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)
-        ) {
+        if (is_callable([$this->guard(), 'hashPasswordForCookie']) &&
+            hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)) {
             return true;
         }
 

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -86,7 +86,7 @@ class AuthenticateSession implements AuthenticatesSessions
         }
 
         $passwordHash = $request->user()->getAuthPassword();
-        if (method_exists($this->guard(), 'hashPasswordForCookie')) {
+        if (is_callable([$this->guard(), 'hashPasswordForCookie'])) {
             $passwordHash = $this->guard()->hashPasswordForCookie($passwordHash);
         }
 
@@ -106,7 +106,7 @@ class AuthenticateSession implements AuthenticatesSessions
     {
         // Try new HMAC format first...
         if (
-            method_exists($this->guard(), 'hashPasswordForCookie') &&
+            is_callable([$this->guard(), 'hashPasswordForCookie']) &&
             hash_equals($this->guard()->hashPasswordForCookie($passwordHash), $storedValue)
         ) {
             return true;


### PR DESCRIPTION
PR #58107 introduced BC break with third-party guards which doesn't implement `hashPasswordForCookie` method.
This PR adds graceful fallback for those legacy guards.

If necessary, I follow up with another PR for next major Laravel version which will add `hashPasswordForCookie` to the interface and remove this temporary code.