### PR TITLE
[12.x] Reset additional state in Vite flush method

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -1043,6 +1043,10 @@ class Vite implements Htmlable
      */
     public function flush()
     {
+        $this->nonce = null;
         $this->preloadedAssets = [];
+        $this->scriptTagAttributesResolvers = [];
+        $this->styleTagAttributesResolvers = [];
+        $this->preloadTagAttributesResolvers = [];
     }
 }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1714,12 +1714,20 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        app(Vite::class)('resources/js/app.js');
+        $vite = app(Vite::class);
+        $vite('resources/js/app.js');
+        $vite->useCspNonce('test-nonce');
+        $vite->useScriptTagAttributes(['data-turbo-track' => 'reload']);
+        $vite->useStyleTagAttributes(['data-turbo-track' => 'reload']);
+        $vite->usePreloadTagAttributes(['data-turbo-track' => 'reload']);
+
         app()->forgetScopedInstances();
         $this->assertCount(1, app(Vite::class)->preloadedAssets());
+        $this->assertSame('test-nonce', app(Vite::class)->cspNonce());
 
         app(Vite::class)->flush();
         $this->assertCount(0, app(Vite::class)->preloadedAssets());
+        $this->assertNull(app(Vite::class)->cspNonce());
     }
 
     protected function cleanViteManifest($path = 'build')


### PR DESCRIPTION
The `flush()` method added in #55228 resets `$preloadedAssets` but leaves other per-request state intact. In Octane environments, this causes:

- CSP nonce persisting across requests
- Tag attribute resolvers accumulating unbounded

This PR resets the nonce and resolver arrays alongside `$preloadedAssets`.

---

Found by [taylor-says](https://github.com/mischasigtermans/taylor-says)

> "The flush() method should reset ALL request-specific state, not just preloadedAssets. The nonce is security-sensitive and the resolver arrays are a memory leak."