### PR TITLE
[12.x] Isolate compiled views per process during parallel testing

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestViews.php
+++ b/src/Illuminate/Testing/Concerns/TestViews.php
@@ -22,44 +22,24 @@ trait TestViews
     protected function bootTestViews()
     {
         ParallelTesting::setUpProcess(function () {
-            $this->setUpParallelTestingViewDirectory();
+            if ($path = $this->parallelSafeCompiledViewPath()) {
+                File::ensureDirectoryExists($path);
+            }
         });
 
         ParallelTesting::setUpTestCase(function () {
-            $this->setUpParallelTestingViews();
+            if ($path = $this->parallelSafeCompiledViewPath()) {
+                $this->switchToCompiledViewPath($path);
+            }
         });
     }
 
     /**
-     * Create the parallel testing view directory.
-     *
-     * @return void
-     */
-    protected function setUpParallelTestingViewDirectory()
-    {
-        if ($path = $this->testCompiledViewPath()) {
-            File::ensureDirectoryExists($path);
-        }
-    }
-
-    /**
-     * Set up parallel testing views for the current test case.
-     *
-     * @return void
-     */
-    protected function setUpParallelTestingViews()
-    {
-        if ($path = $this->testCompiledViewPath()) {
-            $this->switchToCompiledViewPath($path);
-        }
-    }
-
-    /**
-     * Returns the test compiled view path.
+     * Get the test compiled view path.
      *
      * @return string|null
      */
-    protected function testCompiledViewPath()
+    protected function parallelSafeCompiledViewPath()
     {
         self::$originalCompiledViewPath ??= $this->app['config']->get('view.compiled', '');
 
@@ -67,9 +47,9 @@ trait TestViews
             return null;
         }
 
-        $token = ParallelTesting::token();
-
-        return rtrim(self::$originalCompiledViewPath, '\/').'/test_'.$token;
+        return rtrim(self::$originalCompiledViewPath, '\/')
+            .'/test_'
+            .ParallelTesting::token();
     }
 
     /**

--- a/src/Illuminate/Testing/Concerns/TestViews.php
+++ b/src/Illuminate/Testing/Concerns/TestViews.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Testing\Concerns;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\ParallelTesting;
+
+trait TestViews
+{
+    /**
+     * The original compiled view path prior to appending the token.
+     *
+     * @var string|null
+     */
+    protected static $originalCompiledViewPath = null;
+
+    /**
+     * Boot test views for parallel testing.
+     *
+     * @return void
+     */
+    protected function bootTestViews()
+    {
+        ParallelTesting::setUpProcess(function () {
+            $this->setUpParallelTestingViewDirectory();
+        });
+
+        ParallelTesting::setUpTestCase(function () {
+            $this->setUpParallelTestingViews();
+        });
+    }
+
+    /**
+     * Create the parallel testing view directory.
+     *
+     * @return void
+     */
+    protected function setUpParallelTestingViewDirectory()
+    {
+        $path = $this->testCompiledViewPath();
+
+        if ($path) {
+            File::ensureDirectoryExists($path);
+        }
+    }
+
+    /**
+     * Set up parallel testing views for the current test case.
+     *
+     * @return void
+     */
+    protected function setUpParallelTestingViews()
+    {
+        $path = $this->testCompiledViewPath();
+
+        if ($path) {
+            $this->switchToCompiledViewPath($path);
+        }
+    }
+
+    /**
+     * Returns the test compiled view path.
+     *
+     * @return string|null
+     */
+    protected function testCompiledViewPath()
+    {
+        if (! isset(self::$originalCompiledViewPath)) {
+            self::$originalCompiledViewPath = $this->app['config']->get('view.compiled', '');
+        }
+
+        $path = self::$originalCompiledViewPath;
+
+        if (! $path) {
+            return null;
+        }
+
+        $token = ParallelTesting::token();
+
+        return rtrim($path, '\/').'/'.'test_'.$token;
+    }
+
+    /**
+     * Switch to the given compiled view path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function switchToCompiledViewPath($path)
+    {
+        $this->app['config']->set('view.compiled', $path);
+
+        if ($this->app->resolved('blade.compiler')) {
+            $compiler = $this->app['blade.compiler'];
+
+            (function () use ($path) {
+                $this->cachePath = $path;
+            })->bindTo($compiler, $compiler)();
+        }
+    }
+}

--- a/src/Illuminate/Testing/Concerns/TestViews.php
+++ b/src/Illuminate/Testing/Concerns/TestViews.php
@@ -37,9 +37,7 @@ trait TestViews
      */
     protected function setUpParallelTestingViewDirectory()
     {
-        $path = $this->testCompiledViewPath();
-
-        if ($path) {
+        if ($path = $this->testCompiledViewPath()) {
             File::ensureDirectoryExists($path);
         }
     }
@@ -51,9 +49,7 @@ trait TestViews
      */
     protected function setUpParallelTestingViews()
     {
-        $path = $this->testCompiledViewPath();
-
-        if ($path) {
+        if ($path = $this->testCompiledViewPath()) {
             $this->switchToCompiledViewPath($path);
         }
     }
@@ -65,19 +61,15 @@ trait TestViews
      */
     protected function testCompiledViewPath()
     {
-        if (! isset(self::$originalCompiledViewPath)) {
-            self::$originalCompiledViewPath = $this->app['config']->get('view.compiled', '');
-        }
+        self::$originalCompiledViewPath ??= $this->app['config']->get('view.compiled', '');
 
-        $path = self::$originalCompiledViewPath;
-
-        if (! $path) {
+        if (! self::$originalCompiledViewPath) {
             return null;
         }
 
         $token = ParallelTesting::token();
 
-        return rtrim($path, '\/').'/'.'test_'.$token;
+        return rtrim(self::$originalCompiledViewPath, '\/').'/test_'.$token;
     }
 
     /**

--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -5,10 +5,11 @@ namespace Illuminate\Testing;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\Concerns\TestDatabases;
+use Illuminate\Testing\Concerns\TestViews;
 
 class ParallelTestingServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    use TestDatabases;
+    use TestDatabases, TestViews;
 
     /**
      * Boot the application's service providers.
@@ -19,6 +20,7 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
     {
         if ($this->app->runningInConsole()) {
             $this->bootTestDatabase();
+            $this->bootTestViews();
         }
     }
 

--- a/tests/Testing/Concerns/TestViewsTest.php
+++ b/tests/Testing/Concerns/TestViewsTest.php
@@ -117,7 +117,7 @@ class TestViewsTest extends TestCase
 
         (new ReflectionProperty($instance::class, 'originalCompiledViewPath'))->setValue(null, null);
 
-        $method = new ReflectionMethod($instance, 'testCompiledViewPath');
+        $method = new ReflectionMethod($instance, 'parallelSafeCompiledViewPath');
 
         return $method->invoke($instance);
     }

--- a/tests/Testing/Concerns/TestViewsTest.php
+++ b/tests/Testing/Concerns/TestViewsTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Concerns;
+
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\ParallelTesting as ParallelTestingFacade;
+use Illuminate\Testing\Concerns\TestViews;
+use Illuminate\Testing\ParallelTesting;
+use Illuminate\View\Compilers\BladeCompiler;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class TestViewsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::setInstance($container = new Container);
+
+        Facade::setFacadeApplication($container);
+
+        $container->singleton('config', fn () => new Config([
+            'view' => [
+                'compiled' => '/path/to/compiled/views',
+            ],
+        ]));
+
+        $container->singleton(ParallelTesting::class, fn ($app) => new ParallelTesting($app));
+
+        $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        ParallelTestingFacade::clearResolvedInstance();
+        Facade::setFacadeApplication(null);
+
+        unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
+
+        m::close();
+
+        parent::tearDown();
+    }
+
+    public function testCompiledViewPathAppendsToken()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '5');
+
+        $this->assertSame('/path/to/compiled/views/test_5', $this->testCompiledViewPath());
+    }
+
+    public function testCompiledViewPathTrimsTrailingSlash()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '3');
+
+        Container::getInstance()['config']->set('view.compiled', '/path/to/compiled/views/');
+
+        $this->assertSame('/path/to/compiled/views/test_3', $this->testCompiledViewPath());
+    }
+
+    public function testCompiledViewPathWithDifferentToken()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '42');
+
+        Container::getInstance()['config']->set('view.compiled', '/var/www/storage/views');
+
+        $this->assertSame('/var/www/storage/views/test_42', $this->testCompiledViewPath());
+    }
+
+    public function testCompiledViewPathReturnsNullWhenEmpty()
+    {
+        Container::getInstance()['config']->set('view.compiled', '');
+
+        $this->assertNull($this->testCompiledViewPath());
+    }
+
+    public function testSwitchToCompiledViewPathUpdatesConfig()
+    {
+        $this->switchToCompiledViewPath('/new/compiled/path');
+
+        $this->assertSame('/new/compiled/path', Container::getInstance()['config']->get('view.compiled'));
+    }
+
+    public function testSwitchToCompiledViewPathUpdatesCompilerCachePath()
+    {
+        $container = Container::getInstance();
+        $compiler = new BladeCompiler(m::mock(Filesystem::class), '/original/path');
+
+        $container->instance('blade.compiler', $compiler);
+
+        $this->switchToCompiledViewPath('/new/compiled/path');
+
+        $this->assertSame('/new/compiled/path', $container['config']->get('view.compiled'));
+        $this->assertSame('/new/compiled/path', (new ReflectionProperty($compiler, 'cachePath'))->getValue($compiler));
+    }
+
+    public function testCompiledViewPath()
+    {
+        $instance = new class
+        {
+            use TestViews;
+
+            public $app;
+
+            public function __construct()
+            {
+                $this->app = Container::getInstance();
+            }
+        };
+
+        (new ReflectionProperty($instance::class, 'originalCompiledViewPath'))->setValue(null, null);
+
+        $method = new ReflectionMethod($instance, 'testCompiledViewPath');
+
+        return $method->invoke($instance);
+    }
+
+    public function switchToCompiledViewPath($path)
+    {
+        $instance = new class
+        {
+            use TestViews;
+
+            public $app;
+
+            public function __construct()
+            {
+                $this->app = Container::getInstance();
+            }
+        };
+
+        $method = new ReflectionMethod($instance, 'switchToCompiledViewPath');
+        $method->invoke($instance, $path);
+    }
+}


### PR DESCRIPTION
Fixes #58378

## Overview

Addressing race conditions that can occur when running tests in parallel. I originally approached this issue with updates to the `CompilerEngine` and `BladeCompiler` in #58381, but I closed that since it was starting to involve too many changes.

## Problem

When running parallel tests, multiple processes compile and read Blade views from the same directory simultaneously. This causes several types of failures:

- `FileNotFoundException` when a compiled view is deleted by another process before it can be read
- `ParseError` by reading a partially-written compiled view file (`file_put_contents()` is not atomic)
- Livewire's `RootTagMissingFromViewException` when inline component templates are truncated

None of these are deterministic and can be difficult to reproduce, but become increasingly common as the number of parallel processes increases.

## Solution

Following a similar pattern that's used for database isolation (`TestDatabases`), this PR introduces a `TestViews` trait that isolates compiled views per test process. Each parallel process now uses its own subdirectory.

This completely eliminates race conditions since processes no longer share compiled view files.

[^1]: https://laracasts.com/discuss/channels/testing/laravel-parallel-testing-with-separate-storage-for-views-per-process