### PR TITLE
[12.x] `new $class` instead of reflection for better performance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1169,7 +1169,7 @@ class Container implements ArrayAccess, ContainerContract
         array_pop($this->buildStack);
 
         $this->fireAfterResolvingAttributeCallbacks(
-            $reflector->getAttributes(), $instance = $reflector->newInstanceArgs($instances)
+            $reflector->getAttributes(), $instance = new $concrete(...$instances)
         );
 
         return $instance;


### PR DESCRIPTION
This PR replaces `ReflectionClass::newInstanceArgs($args)` with `new $className(...$args)`.
This will make the container faster.

### Quick benchmark of reflection vs constructor

<details><summary>constructor.php</summary>

```php
<?php

class Foo {
    public function __construct(
        public int $a,
        public string $b,
        public array $c,
    ) {
    }
}

$className = Foo::class;
$args = [1, 'example', [1, 2, 3]];

const LOOP = 1000000;

$start = hrtime(true);
for ($i = 0; $i < LOOP; $i++) {
    $instance = new $className(...$args);
}
$end = hrtime(true);
$duration = ($end - $start) / 1_000_000;
echo "Dynamic constructor invocation took {$duration} ms\n";
```

</details>

<details><summary>reflection.php</summary>

```php
<?php

class Foo {
    public function __construct(
        public int $a,
        public string $b,
        public array $c,
    ) {
    }
}

$className = Foo::class;
$reflectionClass = new ReflectionClass($className);
$args = [1, 'example', [1, 2, 3]];

const LOOP = 1000000;

$start = hrtime(true);
for ($i = 0; $i < LOOP; $i++) {
    $instance = $reflectionClass->newInstanceArgs($args);
}
$end = hrtime(true);
$duration = ($end - $start) / 1_000_000;
echo "ReflectionClass::newInstanceArgs: {$duration} ms\n";
```

</details>

`new $className(...$args)` is about 26% faster than `$reflectionClass->newInstanceArgs($args)`.

| | reflection | constructor |
| --- | --- | --- |
|1| 393.118259 ms | 272.36958 ms |
|2| 383.492222 ms | 291.622618 ms |
|3| 376.930884 ms | 286.945082 ms |
|Average| 384.51 ms | 283.65 ms |