### PR TITLE
[12.x] Implement Stringable in Enum rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -7,9 +7,12 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
+use Stringable;
 use TypeError;
 
-class Enum implements Rule, ValidatorAwareRule
+use function Illuminate\Support\enum_value;
+
+class Enum implements Rule, ValidatorAwareRule, Stringable
 {
     use Conditionable;
 
@@ -143,5 +146,25 @@ class Enum implements Rule, ValidatorAwareRule
         $this->validator = $validator;
 
         return $this;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $cases = ! empty($this->only)
+            ? $this->only
+            : array_filter($this->type::cases(), fn ($case) => ! in_array($case, $this->except, true));
+
+        $values = array_map(function ($case) {
+            $value = enum_value($case);
+
+            return '"'.str_replace('"', '""', (string) $value).'"';
+        }, $cases);
+
+        return 'in:'.implode(',', $values);
     }
 }

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -303,6 +303,27 @@ class ValidationEnumRuleTest extends TestCase
         ], $v->messages()->all());
     }
 
+    public function testEnumRuleIsStringable()
+    {
+        $rule = new Enum(StringStatus::class);
+
+        $this->assertSame('in:"pending","done"', (string) $rule);
+    }
+
+    public function testEnumRuleStringableWithOnly()
+    {
+        $rule = (new Enum(StringStatus::class))->only([StringStatus::pending]);
+
+        $this->assertSame('in:"pending"', (string) $rule);
+    }
+
+    public function testEnumRuleStringableWithExcept()
+    {
+        $rule = (new Enum(StringStatus::class))->except([StringStatus::pending]);
+
+        $this->assertSame('in:"done"', (string) $rule);
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();


### PR DESCRIPTION
This allows the Enum rule class to be stringable, serializing to the "in:" rule.