### PR TITLE
[12.x] Account for `Throwable` inside of PendingRequest

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -31,6 +31,7 @@ use OutOfBoundsException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\VarDumper\VarDumper;
+use Throwable;
 
 /**
  * @template TAsync of bool = false
@@ -1180,7 +1181,7 @@ class PendingRequest
 
                 return $this->runAfterResponseCallbacks($response);
             })
-            ->otherwise(function (OutOfBoundsException|TransferException|StrayRequestException $e) {
+            ->otherwise(function (Throwable $e) {
                 if ($e instanceof StrayRequestException) {
                     throw $e;
                 }
@@ -1198,7 +1199,7 @@ class PendingRequest
 
                 return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse($this->newResponse($e->getResponse())) : $e;
             })
-            ->then(function (Response|ConnectionException|TransferException $response) use ($method, $url, $options, $attempt) {
+            ->then(function (Response|Throwable $response) use ($method, $url, $options, $attempt) {
                 return $this->handlePromiseResponse($response, $method, $url, $options, $attempt);
             });
     }
@@ -1206,14 +1207,14 @@ class PendingRequest
     /**
      * Handle the response of an asynchronous request.
      *
-     * @param  \Illuminate\Http\Client\Response  $response
+     * @param  \Illuminate\Http\Client\Response|\Throwable  $response
      * @param  string  $method
      * @param  string  $url
      * @param  array  $options
      * @param  int  $attempt
      * @return mixed
      */
-    protected function handlePromiseResponse(Response|ConnectionException|TransferException $response, $method, $url, $options, $attempt)
+    protected function handlePromiseResponse(Response|Throwable $response, $method, $url, $options, $attempt)
     {
         if ($response instanceof Response && $response->successful()) {
             return $response;


### PR DESCRIPTION
Builds on https://github.com/laravel/framework/pull/58335

Any exception can be thrown inside of an async request. The `otherwise()` method, and the methods that it calls, are all too limited to account for something like this:

```php
Http::fake(
    ['*' => Http::response(['luke' => 'kuzmish'])]
);

$v = Http::async()
    ->afterResponse(
        fn (Response $response) => $response->json('luke') === 'kuzmish' 
            ? throw new \RuntimeException('No Lukes allowed')
            : null
    )->get('https://cosmastech.com')
    ->wait();
```

This will fail with a TypeError because the Exception thrown (RuntimeException) doesn't match the types specified in the Closure passed to otherwise. But we can't just change it there, we also have to change it in the methods that use the result of the promise.

That said, after these fixes, `$v` is the `RuntimeException`, which is a little bit unusual.

I have a suspicion that the general way that Promises were added to Laravel was probably not how Guzzle Promises are intended to be used. Haven't been able to wrap my brain around all of this yet, but just my gut telling me that failures should be a rejected promise, not a fulfilled one.