### PR TITLE
[12.x]  Add `$deleteWhenMissingModels` support for queued notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes for 12.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v12.55.1...12.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v12.56.0...12.x)
+
+## [v12.56.0](https://github.com/laravel/framework/compare/v12.55.1...v12.56.0) - 2026-03-26
+
+* [12.x] `schedule:list` display expression in the correct timezone by [@xiCO2k](https://github.com/xiCO2k) in https://github.com/laravel/framework/pull/59307
+* [12.x] Fix validation wildcard array message type error by [@sadique-cws](https://github.com/sadique-cws) in https://github.com/laravel/framework/pull/59339
+* Preserve class type of mocked classes by [@AJenbo](https://github.com/AJenbo) in https://github.com/laravel/framework/pull/59353
 
 ## [v12.55.1](https://github.com/laravel/framework/compare/v12.55.0...v12.55.1) - 2026-03-18
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -45,7 +45,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '12.55.1';
+    const VERSION = '12.56.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -80,9 +80,11 @@ trait InteractsWithContainer
     /**
      * Mock a partial instance of an object in the container.
      *
-     * @param  string  $abstract
+     * @template TInstance of object
+     *
+     * @param  class-string<TInstance>  $abstract
      * @param  \Closure|null  $mock
-     * @return \Mockery\MockInterface
+     * @return TInstance&\Mockery\MockInterface
      */
     protected function partialMock($abstract, ?Closure $mock = null)
     {
@@ -92,9 +94,11 @@ trait InteractsWithContainer
     /**
      * Spy an instance of an object in the container.
      *
-     * @param  string  $abstract
+     * @template TInstance of object
+     *
+     * @param  class-string<TInstance>  $abstract
      * @param  \Closure|null  $mock
-     * @return \Mockery\MockInterface
+     * @return TInstance&\Mockery\MockInterface
      */
     protected function spy($abstract, ?Closure $mock = null)
     {

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -66,6 +66,13 @@ class SendQueuedNotifications implements ShouldQueue
     public $shouldBeEncrypted = false;
 
     /**
+     * Indicates if the job should be deleted when models are missing.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
@@ -80,6 +87,7 @@ class SendQueuedNotifications implements ShouldQueue
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
         $this->maxExceptions = property_exists($notification, 'maxExceptions') ? $notification->maxExceptions : null;
+        $this->deleteWhenMissingModels = property_exists($notification, 'deleteWhenMissingModels') ? $notification->deleteWhenMissingModels : false;
 
         if ($notification instanceof ShouldQueueAfterCommit) {
             $this->afterCommit = true;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -87,6 +87,7 @@ class SendQueuedNotifications implements ShouldQueue
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
         $this->maxExceptions = property_exists($notification, 'maxExceptions') ? $notification->maxExceptions : null;
+
         $this->deleteWhenMissingModels = property_exists($notification, 'deleteWhenMissingModels')
             ? $notification->deleteWhenMissingModels
             : false;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -87,7 +87,9 @@ class SendQueuedNotifications implements ShouldQueue
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
         $this->maxExceptions = property_exists($notification, 'maxExceptions') ? $notification->maxExceptions : null;
-        $this->deleteWhenMissingModels = property_exists($notification, 'deleteWhenMissingModels') ? $notification->deleteWhenMissingModels : false;
+        $this->deleteWhenMissingModels = property_exists($notification, 'deleteWhenMissingModels')
+            ? $notification->deleteWhenMissingModels
+            : false;
 
         if ($notification instanceof ShouldQueueAfterCommit) {
             $this->afterCommit = true;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Log\Context\Repository as ContextRepository;
+use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use ReflectionClass;
@@ -249,10 +250,16 @@ class CallQueuedHandler
         $class = $job->resolveQueuedJobClass();
 
         try {
-            $reflectionClass = new ReflectionClass($class);
+            $shouldDelete = $this->shouldDeleteWhenMissingModels($class);
 
-            $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
-                ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+            if (! $shouldDelete && $class === SendQueuedNotifications::class) {
+                $payload = $job->payload();
+                $notificationClass = $payload['displayName'] ?? null;
+
+                if ($notificationClass && class_exists($notificationClass)) {
+                    $shouldDelete = $this->shouldDeleteWhenMissingModels($notificationClass);
+                }
+            }
         } catch (Exception) {
             $shouldDelete = false;
         }
@@ -266,6 +273,20 @@ class CallQueuedHandler
         }
 
         return $job->fail($e);
+    }
+
+    /**
+     * Determine if the job should be deleted when models are missing.
+     *
+     * @param  string  $class
+     * @return bool
+     */
+    protected function shouldDeleteWhenMissingModels(string $class)
+    {
+        $reflectionClass = new ReflectionClass($class);
+
+        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+            ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -249,16 +249,16 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
+        $payload = $job->payload();
+
+        if (array_key_exists('deleteWhenMissingModels', $payload)) {
+            return $payload['deleteWhenMissingModels'];
+        }
+
         $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
-        $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
             ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
-
-        try {
-            return $job->payload()['deleteWhenMissingModels'] ?? $shouldDelete;
-        } catch (Exception) {
-            return $shouldDelete;
-        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -226,13 +226,8 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        $class = $job->resolveQueuedJobClass();
-
         try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
-                || (($name = $job->resolveName()) !== $class
-                    && class_exists($name)
-                    && $this->shouldDeleteWhenMissingModels($name));
+            $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
         } catch (Exception) {
             $shouldDelete = false;
         }
@@ -249,15 +244,21 @@ class CallQueuedHandler
     /**
      * Determine if the job should be deleted when models are missing.
      *
-     * @param  string  $class
+     * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return bool
      */
-    protected function shouldDeleteWhenMissingModels(string $class)
+    protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $reflectionClass = new ReflectionClass($class);
+        $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
-        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+        $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
             ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+
+        try {
+            return $job->payload()['deleteWhenMissingModels'] ?? $shouldDelete;
+        } catch (Exception) {
+            return $shouldDelete;
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -245,7 +245,6 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $class = $job->resolveQueuedJobClass();
         $payload = $job->payload();
 
         if (array_key_exists('deleteWhenMissingModels', $payload)) {
@@ -253,7 +252,7 @@ class CallQueuedHandler
         }
 
         try {
-            $reflectionClass = new ReflectionClass($class);
+            $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
             return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
                 ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -245,14 +245,14 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
+        $class = $job->resolveQueuedJobClass();
+        $payload = $job->payload();
+
+        if (array_key_exists('deleteWhenMissingModels', $payload)) {
+            return $payload['deleteWhenMissingModels'];
+        }
+
         try {
-            $payload = $job->payload();
-
-            if (array_key_exists('deleteWhenMissingModels', $payload)) {
-                return $payload['deleteWhenMissingModels'];
-            }
-
-            $class = $job->resolveQueuedJobClass();
             $reflectionClass = new ReflectionClass($class);
 
             return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -17,7 +17,6 @@ use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Log\Context\Repository as ContextRepository;
-use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use ReflectionClass;
@@ -247,19 +246,13 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        $class = $job->resolveQueuedJobClass();
-
         try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($class);
+            $class = $job->resolveQueuedJobClass();
 
-            if (! $shouldDelete && $class === SendQueuedNotifications::class) {
-                $payload = $job->payload();
-                $notificationClass = $payload['displayName'] ?? null;
-
-                if ($notificationClass && class_exists($notificationClass)) {
-                    $shouldDelete = $this->shouldDeleteWhenMissingModels($notificationClass);
-                }
-            }
+            $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
+                || (($name = $job->resolveName()) !== $class
+                    && class_exists($name)
+                    && $this->shouldDeleteWhenMissingModels($name));
         } catch (Exception) {
             $shouldDelete = false;
         }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -267,7 +267,6 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $class = $job->resolveQueuedJobClass();
         $payload = $job->payload();
 
         if (array_key_exists('deleteWhenMissingModels', $payload)) {
@@ -275,7 +274,7 @@ class CallQueuedHandler
         }
 
         try {
-            $reflectionClass = new ReflectionClass($class);
+            $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
             return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
                 ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -246,9 +246,9 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        try {
-            $class = $job->resolveQueuedJobClass();
+        $class = $job->resolveQueuedJobClass();
 
+        try {
             $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
                 || (($name = $job->resolveName()) !== $class
                     && class_exists($name)

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -226,11 +226,7 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
-        } catch (Exception) {
-            $shouldDelete = false;
-        }
+        $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
 
         $this->ensureUniqueJobLockIsReleasedViaContext();
 
@@ -249,16 +245,21 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $payload = $job->payload();
+        try {
+            $payload = $job->payload();
 
-        if (array_key_exists('deleteWhenMissingModels', $payload)) {
-            return $payload['deleteWhenMissingModels'];
+            if (array_key_exists('deleteWhenMissingModels', $payload)) {
+                return $payload['deleteWhenMissingModels'];
+            }
+
+            $class = $job->resolveQueuedJobClass();
+            $reflectionClass = new ReflectionClass($class);
+
+            return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+                ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+        } catch (Exception) {
+            return false;
         }
-
-        $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
-
-        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
-            ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -271,16 +271,16 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
+        $payload = $job->payload();
+
+        if (array_key_exists('deleteWhenMissingModels', $payload)) {
+            return $payload['deleteWhenMissingModels'];
+        }
+
         $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
-        $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
             ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
-
-        try {
-            return $job->payload()['deleteWhenMissingModels'] ?? $shouldDelete;
-        } catch (Exception) {
-            return $shouldDelete;
-        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -246,11 +246,7 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
-        } catch (Exception) {
-            $shouldDelete = false;
-        }
+        $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
 
         $this->ensureUniqueJobLockIsReleasedViaContext();
 
@@ -271,16 +267,21 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $payload = $job->payload();
+        try {
+            $payload = $job->payload();
 
-        if (array_key_exists('deleteWhenMissingModels', $payload)) {
-            return $payload['deleteWhenMissingModels'];
+            if (array_key_exists('deleteWhenMissingModels', $payload)) {
+                return $payload['deleteWhenMissingModels'];
+            }
+
+            $class = $job->resolveQueuedJobClass();
+            $reflectionClass = new ReflectionClass($class);
+
+            return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+                ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+        } catch (Exception) {
+            return false;
         }
-
-        $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
-
-        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
-            ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -246,13 +246,8 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        $class = $job->resolveQueuedJobClass();
-
         try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
-                || (($name = $job->resolveName()) !== $class
-                    && class_exists($name)
-                    && $this->shouldDeleteWhenMissingModels($name));
+            $shouldDelete = $this->shouldDeleteWhenMissingModels($job);
         } catch (Exception) {
             $shouldDelete = false;
         }
@@ -271,15 +266,21 @@ class CallQueuedHandler
     /**
      * Determine if the job should be deleted when models are missing.
      *
-     * @param  string  $class
+     * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return bool
      */
-    protected function shouldDeleteWhenMissingModels(string $class)
+    protected function shouldDeleteWhenMissingModels(Job $job)
     {
-        $reflectionClass = new ReflectionClass($class);
+        $reflectionClass = new ReflectionClass($job->resolveQueuedJobClass());
 
-        return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
+        $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
             ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+
+        try {
+            return $job->payload()['deleteWhenMissingModels'] ?? $shouldDelete;
+        } catch (Exception) {
+            return $shouldDelete;
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -226,9 +226,9 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        try {
-            $class = $job->resolveQueuedJobClass();
+        $class = $job->resolveQueuedJobClass();
 
+        try {
             $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
                 || (($name = $job->resolveName()) !== $class
                     && class_exists($name)

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -15,7 +15,6 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Log\Context\Repository as ContextRepository;
-use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use ReflectionClass;
@@ -227,19 +226,13 @@ class CallQueuedHandler
      */
     protected function handleModelNotFound(Job $job, $e)
     {
-        $class = $job->resolveQueuedJobClass();
-
         try {
-            $shouldDelete = $this->shouldDeleteWhenMissingModels($class);
+            $class = $job->resolveQueuedJobClass();
 
-            if (! $shouldDelete && $class === SendQueuedNotifications::class) {
-                $payload = $job->payload();
-                $notificationClass = $payload['displayName'] ?? null;
-
-                if ($notificationClass && class_exists($notificationClass)) {
-                    $shouldDelete = $this->shouldDeleteWhenMissingModels($notificationClass);
-                }
-            }
+            $shouldDelete = $this->shouldDeleteWhenMissingModels($class)
+                || (($name = $job->resolveName()) !== $class
+                    && class_exists($name)
+                    && $this->shouldDeleteWhenMissingModels($name));
         } catch (Exception) {
             $shouldDelete = false;
         }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -267,14 +267,14 @@ class CallQueuedHandler
      */
     protected function shouldDeleteWhenMissingModels(Job $job)
     {
+        $class = $job->resolveQueuedJobClass();
+        $payload = $job->payload();
+
+        if (array_key_exists('deleteWhenMissingModels', $payload)) {
+            return $payload['deleteWhenMissingModels'];
+        }
+
         try {
-            $payload = $job->payload();
-
-            if (array_key_exists('deleteWhenMissingModels', $payload)) {
-                return $payload['deleteWhenMissingModels'];
-            }
-
-            $class = $job->resolveQueuedJobClass();
             $reflectionClass = new ReflectionClass($class);
 
             return $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -165,6 +165,7 @@ abstract class Queue
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
             'maxTries' => $this->getJobTries($job),
             'maxExceptions' => $job->maxExceptions ?? null,
+            'deleteWhenMissingModels' => property_exists($job, 'deleteWhenMissingModels') ? $job->deleteWhenMissingModels : null,
             'failOnTimeout' => $job->failOnTimeout ?? false,
             'backoff' => $this->getJobBackoff($job),
             'timeout' => $job->timeout ?? null,

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -93,6 +93,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(__CLASS__);
         $job->shouldReceive('fail')->once();
 
@@ -108,6 +109,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();
@@ -129,6 +131,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerAttributeExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -90,6 +90,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(__CLASS__);
         $job->shouldReceive('fail')->once();
 
@@ -105,6 +106,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();
@@ -126,6 +128,7 @@ class CallQueuedHandlerTest extends TestCase
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
         $job = m::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
         $job->shouldReceive('getConnectionName')->andReturn('connection');
         $job->shouldReceive('resolveQueuedJobClass')->andReturn(CallQueuedHandlerAttributeExceptionThrower::class);
         $job->shouldReceive('markAsFailed')->never();

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -130,7 +130,7 @@ class DeleteMissingModelNotification extends Notification implements ShouldQueue
 
     public function via($notifiable): array
     {
-        return ['database'];
+        return ['mail'];
     }
 
     public function toArray($notifiable): array

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -49,6 +49,7 @@ class DeleteModelWhenMissingTest extends QueueTestCase
 
     public function test_deleteModelWhenMissing_and_display_name(): void
     {
+        // Test with queued job
         $model = MyTestModel::query()->create(['name' => 'test']);
 
         DeleteMissingModelJob::dispatch($model);
@@ -59,16 +60,14 @@ class DeleteModelWhenMissingTest extends QueueTestCase
 
         $this->assertFalse(DeleteMissingModelJob::$handled);
         $this->assertNull(\DB::table('failed_jobs')->first());
-    }
 
-    public function test_deleteModelWhenMissing_works_with_queued_notifications(): void
-    {
-        $model = MyTestModel::query()->create(['name' => 'test']);
+        // Test with queued notification
+        $model = MyTestModel::query()->create(['name' => 'test2']);
 
         $notifiable = new TestNotifiableUser;
         $notifiable->notify(new DeleteMissingModelNotification($model));
 
-        MyTestModel::query()->where('name', 'test')->delete();
+        MyTestModel::query()->where('name', 'test2')->delete();
 
         $this->runQueueWorkerCommand(['--once' => '1']);
 

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -56,6 +56,25 @@ class DeleteModelWhenMissingTest extends QueueTestCase
         $this->assertFalse(DeleteMissingModelJob::$handled);
         $this->assertNull(\DB::table('failed_jobs')->first());
     }
+
+    public function test_deleteModelWhenMissing_without_deleteWhenMissingModels_payload_key(): void
+    {
+        $model = MyTestModel::query()->create(['name' => 'test']);
+
+        DeleteMissingModelJob::dispatch($model);
+
+        $payload = json_decode(\DB::table('jobs')->value('payload'), true);
+        unset($payload['deleteWhenMissingModels']);
+
+        \DB::table('jobs')->update(['payload' => json_encode($payload)]);
+
+        MyTestModel::query()->where('name', 'test')->delete();
+
+        $this->runQueueWorkerCommand(['--once' => '1']);
+
+        $this->assertFalse(DeleteMissingModelJob::$handled);
+        $this->assertNull(\DB::table('failed_jobs')->first());
+    }
 }
 
 class DeleteMissingModelJob implements ShouldQueue

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -22,23 +22,20 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
         $this->driver = 'database';
     }
 
-    protected function defineDatabaseMigrations()
+    protected function setUp(): void
     {
-        Schema::create('delete_notification_test_models', function (Blueprint $table) {
+        parent::setUp();
+
+        Schema::create('notification_test_models', function (Blueprint $table) {
             $table->id();
             $table->string('name');
         });
     }
 
-    protected function destroyDatabaseMigrations()
-    {
-        Schema::dropIfExists('delete_notification_test_models');
-    }
-
-    #[\Override]
     protected function tearDown(): void
     {
         DeleteMissingModelNotification::$handled = false;
+        Schema::dropIfExists('notification_test_models');
 
         parent::tearDown();
     }
@@ -61,7 +58,7 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
 
 class NotificationTestModel extends Model
 {
-    protected $table = 'delete_notification_test_models';
+    protected $table = 'notification_test_models';
 
     public $timestamps = false;
 

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class DeleteNotificationWhenMissingModelTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+        $app['config']->set('queue.default', 'database');
+        $this->driver = 'database';
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        Schema::create('delete_notification_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+
+        $this->beforeApplicationDestroyed(function () {
+            Schema::dropIfExists('delete_notification_test_models');
+        });
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DeleteMissingModelNotification::$handled = false;
+
+        parent::tearDown();
+    }
+
+    public function test_deleteWhenMissingModels_works_with_queued_notifications(): void
+    {
+        $model = NotificationTestModel::query()->create(['name' => 'test']);
+
+        $notifiable = new TestNotifiableUser;
+        $notifiable->notify(new DeleteMissingModelNotification($model));
+
+        NotificationTestModel::query()->where('name', 'test')->delete();
+
+        $this->runQueueWorkerCommand(['--once' => '1']);
+
+        $this->assertFalse(DeleteMissingModelNotification::$handled);
+        $this->assertNull(\DB::table('failed_jobs')->first());
+    }
+}
+
+class NotificationTestModel extends Model
+{
+    protected $table = 'delete_notification_test_models';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+class TestNotifiableUser
+{
+    use Notifiable;
+}
+
+class DeleteMissingModelNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public static bool $handled = false;
+
+    public $deleteWhenMissingModels = true;
+
+    public function __construct(public NotificationTestModel $model)
+    {
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toArray($notifiable): array
+    {
+        self::$handled = true;
+
+        return ['model_id' => $this->model->id];
+    }
+}

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -28,10 +28,11 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
             $table->id();
             $table->string('name');
         });
+    }
 
-        $this->beforeApplicationDestroyed(function () {
-            Schema::dropIfExists('delete_notification_test_models');
-        });
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('delete_notification_test_models');
     }
 
     #[\Override]

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -60,6 +60,19 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertEquals(23, $job->maxExceptions);
     }
+
+    public function testNotificationCanSetDeleteWhenMissingModels()
+    {
+        $notifiable = new NotifiableUser;
+        $notification = new class
+        {
+            public $deleteWhenMissingModels = true;
+        };
+
+        $job = new SendQueuedNotifications($notifiable, $notification);
+
+        $this->assertTrue($job->deleteWhenMissingModels);
+    }
 }
 
 class NotifiableUser extends Model

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Queue;
 
 use Carbon\Carbon;
-use Illuminate\Bus\Batchable;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
@@ -149,6 +148,20 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
+    public function testCreatePayloadIncludesDeleteWhenMissingModels()
+    {
+        $queue = m::mock(Queue::class)->makePartial();
+        $class = new ReflectionClass(Queue::class);
+
+        $createPayload = $class->getMethod('createPayload');
+        $payload = json_decode($createPayload->invokeArgs($queue, [
+            new DeleteWhenMissingModelsTestJob,
+            'queue-name',
+        ]), true);
+
+        $this->assertTrue($payload['deleteWhenMissingModels']);
+    }
+
     public function testBulkBatchPushesOntoDatabase()
     {
         $uuid = Str::uuid();
@@ -204,9 +217,4 @@ class MyTestJob
     {
         // ...
     }
-}
-
-class MyBatchableJob
-{
-    use Batchable;
 }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -122,6 +122,20 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
+    public function testCreatePayloadIncludesDeleteWhenMissingModels()
+    {
+        $queue = m::mock(Queue::class)->makePartial();
+        $class = new ReflectionClass(Queue::class);
+
+        $createPayload = $class->getMethod('createPayload');
+        $payload = json_decode($createPayload->invokeArgs($queue, [
+            new DeleteWhenMissingModelsTestJob,
+            'queue-name',
+        ]), true);
+
+        $this->assertTrue($payload['deleteWhenMissingModels']);
+    }
+
     public function testBulkBatchPushesOntoDatabase()
     {
         $uuid = Str::uuid();
@@ -173,6 +187,16 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
 class MyTestJob
 {
+    public function handle()
+    {
+        // ...
+    }
+}
+
+class DeleteWhenMissingModelsTestJob
+{
+    public $deleteWhenMissingModels = true;
+
     public function handle()
     {
         // ...

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -148,20 +148,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
-    public function testCreatePayloadIncludesDeleteWhenMissingModels()
-    {
-        $queue = m::mock(Queue::class)->makePartial();
-        $class = new ReflectionClass(Queue::class);
-
-        $createPayload = $class->getMethod('createPayload');
-        $payload = json_decode($createPayload->invokeArgs($queue, [
-            new DeleteWhenMissingModelsTestJob,
-            'queue-name',
-        ]), true);
-
-        $this->assertTrue($payload['deleteWhenMissingModels']);
-    }
-
     public function testBulkBatchPushesOntoDatabase()
     {
         $uuid = Str::uuid();

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -122,20 +122,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         ]);
     }
 
-    public function testCreatePayloadIncludesDeleteWhenMissingModels()
-    {
-        $queue = m::mock(Queue::class)->makePartial();
-        $class = new ReflectionClass(Queue::class);
-
-        $createPayload = $class->getMethod('createPayload');
-        $payload = json_decode($createPayload->invokeArgs($queue, [
-            new DeleteWhenMissingModelsTestJob,
-            'queue-name',
-        ]), true);
-
-        $this->assertTrue($payload['deleteWhenMissingModels']);
-    }
-
     public function testBulkBatchPushesOntoDatabase()
     {
         $uuid = Str::uuid();
@@ -187,16 +173,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
 
 class MyTestJob
 {
-    public function handle()
-    {
-        // ...
-    }
-}
-
-class DeleteWhenMissingModelsTestJob
-{
-    public $deleteWhenMissingModels = true;
-
     public function handle()
     {
         // ...


### PR DESCRIPTION
 This PR adds support for the `$deleteWhenMissingModels` property on queued notifications, allowing notifications to be silently discarded when their dependent models no longer exist.

If a notification is queued, it makes sense for it to play by the same rules as other queued work when a model disappears before it can be processed.  

This should give us the same level of control we already have with jobs, instead of forcing queued notifications into a different default for what is really the same kind of background work.

Also fixes #58025

