### PR TITLE
[13.x] Add starting to Monitor Contract

### DIFF
--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -5,6 +5,14 @@ namespace Illuminate\Contracts\Queue;
 interface Monitor
 {
     /**
+     * Register a callback to be executed when a daemon queue is starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback);
+
+    /**
      * Register a callback to be executed on every iteration through the queue loop.
      *
      * @param  mixed  $callback
@@ -19,14 +27,6 @@ interface Monitor
      * @return void
      */
     public function failing($callback);
-
-    /**
-     * Register a callback to be executed when a daemon queue is starting.
-     *
-     * @param  mixed  $callback
-     * @return void
-     */
-    public function starting($callback);
 
     /**
      * Register a callback to be executed when a daemon queue is stopping.

--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -21,6 +21,14 @@ interface Monitor
     public function failing($callback);
 
     /**
+     * Register a callback to be executed when a daemon queue is starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback);
+
+    /**
      * Register a callback to be executed when a daemon queue is stopping.
      *
      * @param  mixed  $callback


### PR DESCRIPTION
The starting method was was added to the queue manager  7 months ago, via https://github.com/laravel/framework/pull/55941

But, the contract never got updated.  I thought it would be useful to add / just keeps consistency. 

Targets 13.x :) 