### PR TITLE
[12.x] Fix missing import

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Exceptions\Renderer\Mappers;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;


### PR DESCRIPTION
FIXED: BladeMapper Missing Application Import

File: src/Illuminate/Foundation/Exceptions/Renderer/Mappers/BladeMapper.php:154
Issue: Missing import statement for Application interface
Error: Class Illuminate\Foundation\Exceptions\Renderer\Mappers\Application not found
Fix Applied: Added use Illuminate\Contracts\Foundation\Application; to imports
