### PR TITLE
[12.x] Update return type of merge for collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -897,8 +897,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Merge the collection with the given items.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * @template TMergeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TMergeValue>|iterable<TKey, TMergeValue>  $items
+     * @return static<TKey, TValue|TMergeValue>
      */
     public function merge($items)
     {

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -740,8 +740,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Merge the collection with the given items.
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static
+     * @template TMergeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TMergeValue>|iterable<TKey, TMergeValue>  $items
+     * @return static<TKey, TValue|TMergeValue>
      */
     public function merge($items);
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -646,6 +646,9 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->mapInto(User
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->merge([2]));
 assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->merge(['string']));
 
+assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->merge(['string']));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection->make(['string'])->merge([1]));
+
 assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->mergeRecursive([2 => 'string']));
 assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -539,6 +539,9 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->mapInto(
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->merge([2]));
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->merge(['string']));
 
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make([1])->merge(['string']));
+assertType('Illuminate\Support\LazyCollection<int, int|string>', $collection->make(['string'])->merge([1]));
+
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->mergeRecursive([2]));
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
 


### PR DESCRIPTION
I've updated the return type of the method `merge` in both `Collection` and `Enumerable`. Currently, the `merge` method expects the `$items` to be of the same type of the collection itself, which is not always the case.

Example:

```php
Collection::make([1, 2, 3])->merge(['a', 'b', 'c']);

// Parameter #1 $items of method Illuminate\Support\Collection<int,int>::merge() expects Illuminate\Contracts\Support\Arrayable<int, int>|iterable<int, int>, array{'a', 'b', 'c'} given.
```

The example above works as expected, but is causing a PHPStan issue. By adding the `TMergeValue` in the return type, the type will be unioned when necessary.

Please note that this has already been added for `mergeRecursive` in pull request #40504.

Thank you for your consideration!