### PR TITLE
[12.x] Fix return type docblock for Number::abbreviate method

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -222,7 +222,7 @@ class Number
      * @param  int|float  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
-     * @return bool|string
+     * @return string|false
      */
     public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null)
     {


### PR DESCRIPTION
The `abbreviate` method's docblock incorrectly states `@return bool|string`, but the method actually returns `string|false` (via `forHumans` which returns `string|false`).

This PR fixes the docblock to use `@return string|false`, which:
- Accurately reflects the actual return type
- Maintains consistency with `forHumans` and `summarize` methods in the same class
- Improves IDE autocompletion and static analysis accuracy