### PR TITLE
[12.x] Annotate tuple return type of Number::pairs()

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -312,7 +312,7 @@ class Number
      * @param  int|float  $by
      * @param  int|float  $start
      * @param  int|float  $offset
-     * @return array
+     * @return list<array{int|float, int|float}>
      */
     public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {


### PR DESCRIPTION
This PR improves the return type annotation for `Number::pairs()` from generic `array` to `list<array{int|float, int|float}>`.

The method returns a list of two-element arrays where each array contains the lower and upper bounds of a range. The new type annotation accurately describes this structure.

**Benefits:**
- ✅ Improved static analysis accuracy
- ✅ Better IDE type inference  
- ✅ Enhanced developer experience with precise autocompletion

Similar to #58354 which annotated tuple return types for `TableGuesser::guess()`.