### PR TITLE
[12.x] Add missing @param docblock to ValidatedInput::__isset()

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -161,6 +161,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if an input item is set.
      *
+     * @param  string  $name
      * @return bool
      */
     public function __isset($name)


### PR DESCRIPTION
This PR adds the missing `@param string $name` docblock annotation to the `__isset()` magic method in `ValidatedInput`.

**Consistency:** The other magic methods in this class (`__get`, `__set`, `__unset`) all have their `@param` annotations properly documented, but `__isset()` was missing it.

**Before:**
```php
/**
 * Determine if an input item is set.
 *
 * @return bool
 */
public function __isset($name)
```

**After:**
```php
/**
 * Determine if an input item is set.
 *
 * @param  string  $name
 * @return bool
 */
public function __isset($name)
```