### PR TITLE
[13.x] Add Rule::aiModerated() for AI-powered content moderation

### DIFF
--- a/src/Illuminate/Contracts/Validation/AiModerationResult.php
+++ b/src/Illuminate/Contracts/Validation/AiModerationResult.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface AiModerationResult
+{
+    /**
+     * Determine if the content was flagged by moderation.
+     *
+     * @return bool
+     */
+    public function flagged(): bool;
+
+    /**
+     * Get the categories that were flagged.
+     *
+     * @return array<string>
+     */
+    public function flaggedCategories(): array;
+
+    /**
+     * Get the scores for each category.
+     *
+     * @return array<string, float>
+     */
+    public function scores(): array;
+}

--- a/src/Illuminate/Contracts/Validation/AiModerationVerifier.php
+++ b/src/Illuminate/Contracts/Validation/AiModerationVerifier.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface AiModerationVerifier
+{
+    /**
+     * Verify that the given content passes AI moderation.
+     *
+     * @param  array{value: string, categories: array<string>, threshold: float, provider: string|null}  $data
+     * @return \Illuminate\Contracts\Validation\AiModerationResult
+     */
+    public function verify(array $data): AiModerationResult;
+}

--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -16,6 +16,10 @@ return [
     'accepted' => 'The :attribute field must be accepted.',
     'accepted_if' => 'The :attribute field must be accepted when :other is :value.',
     'active_url' => 'The :attribute field must be a valid URL.',
+    'ai_moderated' => [
+        'flagged' => 'The :attribute field contains content that violates our content policy.',
+        'categories' => 'The :attribute field contains inappropriate content in the following categories: :categories.',
+    ],
     'after' => 'The :attribute field must be a date after :date.',
     'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
     'alpha' => 'The :attribute field must only contain letters.',

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\AiModerated;
 use Illuminate\Validation\Rules\AnyOf;
 use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Can;
@@ -26,6 +27,16 @@ use Illuminate\Validation\Rules\Unique;
 class Rule
 {
     use Macroable;
+
+    /**
+     * Get an AI moderation rule builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\AiModerated
+     */
+    public static function aiModerated()
+    {
+        return new AiModerated;
+    }
 
     /**
      * Get a can constraint builder instance.
@@ -182,6 +193,14 @@ class Rule
     public static function date()
     {
         return new Date;
+    }
+
+    /**
+     * Get a datetime rule builder instance.
+     */
+    public static function dateTime(): Date
+    {
+        return (new Date)->format('Y-m-d H:i:s');
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -196,14 +196,6 @@ class Rule
     }
 
     /**
-     * Get a datetime rule builder instance.
-     */
-    public static function dateTime(): Date
-    {
-        return (new Date)->format('Y-m-d H:i:s');
-    }
-
-    /**
      * Get an email rule builder instance.
      *
      * @return \Illuminate\Validation\Rules\Email

--- a/src/Illuminate/Validation/Rules/AiModerated.php
+++ b/src/Illuminate/Validation/Rules/AiModerated.php
@@ -1,0 +1,450 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Validation\AiModerationVerifier;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
+
+class AiModerated implements DataAwareRule, ValidationRule, ValidatorAwareRule
+{
+    use Conditionable;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The categories to check for moderation.
+     *
+     * @var array<string>
+     */
+    protected array $categories = [];
+
+    /**
+     * The threshold for flagging content (0.0 to 1.0).
+     *
+     * @var float
+     */
+    protected float $threshold = 0.5;
+
+    /**
+     * The AI provider to use for moderation.
+     *
+     * @var string|null
+     */
+    protected ?string $provider = null;
+
+    /**
+     * The number of seconds to cache moderation results.
+     *
+     * @var int|null
+     */
+    protected ?int $cacheFor = null;
+
+    /**
+     * Custom verifier callback.
+     *
+     * @var callable|null
+     */
+    protected $customVerifier = null;
+
+    /**
+     * The callback that will generate the "default" version of the rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Set the default callback to be used for determining the default configuration.
+     *
+     * If no arguments are passed, the default configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|void
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $rule = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $rule instanceof static ? $rule : new static;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Specify the categories to check during moderation.
+     *
+     * @param  array<string>|string  $categories
+     * @return $this
+     */
+    public function categories(array|string $categories)
+    {
+        $this->categories = is_array($categories) ? $categories : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Check for hate speech content.
+     *
+     * @return $this
+     */
+    public function noHate()
+    {
+        $this->categories[] = 'hate';
+
+        return $this;
+    }
+
+    /**
+     * Check for threatening hate content.
+     *
+     * @return $this
+     */
+    public function noHateThreatening()
+    {
+        $this->categories[] = 'hate/threatening';
+
+        return $this;
+    }
+
+    /**
+     * Check for harassment content.
+     *
+     * @return $this
+     */
+    public function noHarassment()
+    {
+        $this->categories[] = 'harassment';
+
+        return $this;
+    }
+
+    /**
+     * Check for threatening harassment content.
+     *
+     * @return $this
+     */
+    public function noHarassmentThreatening()
+    {
+        $this->categories[] = 'harassment/threatening';
+
+        return $this;
+    }
+
+    /**
+     * Check for self-harm content.
+     *
+     * @return $this
+     */
+    public function noSelfHarm()
+    {
+        $this->categories[] = 'self-harm';
+
+        return $this;
+    }
+
+    /**
+     * Check for self-harm intent content.
+     *
+     * @return $this
+     */
+    public function noSelfHarmIntent()
+    {
+        $this->categories[] = 'self-harm/intent';
+
+        return $this;
+    }
+
+    /**
+     * Check for self-harm instructions content.
+     *
+     * @return $this
+     */
+    public function noSelfHarmInstructions()
+    {
+        $this->categories[] = 'self-harm/instructions';
+
+        return $this;
+    }
+
+    /**
+     * Check for sexual content.
+     *
+     * @return $this
+     */
+    public function noSexual()
+    {
+        $this->categories[] = 'sexual';
+
+        return $this;
+    }
+
+    /**
+     * Check for sexual content involving minors.
+     *
+     * @return $this
+     */
+    public function noSexualMinors()
+    {
+        $this->categories[] = 'sexual/minors';
+
+        return $this;
+    }
+
+    /**
+     * Check for violent content.
+     *
+     * @return $this
+     */
+    public function noViolence()
+    {
+        $this->categories[] = 'violence';
+
+        return $this;
+    }
+
+    /**
+     * Check for graphic violence content.
+     *
+     * @return $this
+     */
+    public function noViolenceGraphic()
+    {
+        $this->categories[] = 'violence/graphic';
+
+        return $this;
+    }
+
+    /**
+     * Apply strict moderation by checking all known categories.
+     *
+     * @return $this
+     */
+    public function strict()
+    {
+        $this->categories = [
+            'hate',
+            'hate/threatening',
+            'harassment',
+            'harassment/threatening',
+            'self-harm',
+            'self-harm/intent',
+            'self-harm/instructions',
+            'sexual',
+            'sexual/minors',
+            'violence',
+            'violence/graphic',
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Set the threshold for flagging content.
+     *
+     * @param  float  $threshold
+     * @return $this
+     */
+    public function threshold(float $threshold)
+    {
+        $this->threshold = max(0.0, min(1.0, $threshold));
+
+        return $this;
+    }
+
+    /**
+     * Set a low threshold for stricter moderation.
+     *
+     * @return $this
+     */
+    public function strictThreshold()
+    {
+        $this->threshold = 0.2;
+
+        return $this;
+    }
+
+    /**
+     * Set a high threshold for lenient moderation.
+     *
+     * @return $this
+     */
+    public function lenientThreshold()
+    {
+        $this->threshold = 0.8;
+
+        return $this;
+    }
+
+    /**
+     * Specify the AI provider to use for moderation.
+     *
+     * @param  string  $provider
+     * @return $this
+     */
+    public function using(string $provider)
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    /**
+     * Cache the moderation results for the given number of seconds.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function remember(int $seconds)
+    {
+        $this->cacheFor = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Use a custom verifier callback for moderation.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function verifyUsing(callable $callback)
+    {
+        $this->customVerifier = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $result = $this->moderate($value);
+
+        if ($result->flagged()) {
+            $flaggedCategories = $result->flaggedCategories();
+
+            if (empty($flaggedCategories)) {
+                $fail('validation.ai_moderated.flagged')->translate();
+            } else {
+                $fail('validation.ai_moderated.categories')->translate([
+                    'categories' => implode(', ', $flaggedCategories),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Perform the AI moderation check.
+     *
+     * @param  string  $value
+     * @return \Illuminate\Contracts\Validation\AiModerationResult
+     */
+    protected function moderate(string $value)
+    {
+        if ($this->customVerifier !== null) {
+            return call_user_func($this->customVerifier, [
+                'value' => $value,
+                'categories' => $this->categories,
+                'threshold' => $this->threshold,
+                'provider' => $this->provider,
+                'cacheFor' => $this->cacheFor,
+            ]);
+        }
+
+        return Container::getInstance()->make(AiModerationVerifier::class)->verify([
+            'value' => $value,
+            'categories' => $this->categories,
+            'threshold' => $this->threshold,
+            'provider' => $this->provider,
+            'cacheFor' => $this->cacheFor,
+        ]);
+    }
+
+    /**
+     * Get information about the current state of the moderation rules.
+     *
+     * @return array
+     */
+    public function appliedRules()
+    {
+        return [
+            'categories' => $this->categories,
+            'threshold' => $this->threshold,
+            'provider' => $this->provider,
+            'cacheFor' => $this->cacheFor,
+        ];
+    }
+}

--- a/tests/Validation/ValidationAiModeratedRuleTest.php
+++ b/tests/Validation/ValidationAiModeratedRuleTest.php
@@ -400,7 +400,7 @@ class ValidationAiModeratedRuleTest extends TestCase
     {
         $container = Container::getInstance();
 
-        $mockResult = new class($flagged, $categories) implements AiModerationResult 
+        $mockResult = new class($flagged, $categories) implements AiModerationResult
         {
             public function __construct(
                 private bool $flagged,
@@ -424,7 +424,7 @@ class ValidationAiModeratedRuleTest extends TestCase
             }
         };
 
-        $mockVerifier = new class($mockResult, $captureData) implements AiModerationVerifier 
+        $mockVerifier = new class($mockResult, $captureData) implements AiModerationVerifier
         {
             public function __construct(
                 private AiModerationResult $result,

--- a/tests/Validation/ValidationAiModeratedRuleTest.php
+++ b/tests/Validation/ValidationAiModeratedRuleTest.php
@@ -202,7 +202,8 @@ class ValidationAiModeratedRuleTest extends TestCase
 
     public function testCustomVerifier()
     {
-        $customResult = new class implements AiModerationResult {
+        $customResult = new class implements AiModerationResult 
+        {
             public function flagged(): bool
             {
                 return true;
@@ -422,7 +423,8 @@ class ValidationAiModeratedRuleTest extends TestCase
             }
         };
 
-        $mockVerifier = new class($mockResult, $captureData) implements AiModerationVerifier {
+        $mockVerifier = new class($mockResult, $captureData) implements AiModerationVerifier 
+        {
             public function __construct(
                 private AiModerationResult $result,
                 private ?Closure $captureData

--- a/tests/Validation/ValidationAiModeratedRuleTest.php
+++ b/tests/Validation/ValidationAiModeratedRuleTest.php
@@ -202,7 +202,7 @@ class ValidationAiModeratedRuleTest extends TestCase
 
     public function testCustomVerifier()
     {
-        $customResult = new class implements AiModerationResult 
+        $customResult = new class implements AiModerationResult
         {
             public function flagged(): bool
             {

--- a/tests/Validation/ValidationAiModeratedRuleTest.php
+++ b/tests/Validation/ValidationAiModeratedRuleTest.php
@@ -400,7 +400,8 @@ class ValidationAiModeratedRuleTest extends TestCase
     {
         $container = Container::getInstance();
 
-        $mockResult = new class($flagged, $categories) implements AiModerationResult {
+        $mockResult = new class($flagged, $categories) implements AiModerationResult 
+        {
             public function __construct(
                 private bool $flagged,
                 private array $categories

--- a/tests/Validation/ValidationAiModeratedRuleTest.php
+++ b/tests/Validation/ValidationAiModeratedRuleTest.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Validation\AiModerationResult;
+use Illuminate\Contracts\Validation\AiModerationVerifier;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\AiModerated;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationAiModeratedRuleTest extends TestCase
+{
+    public function testItPassesWhenContentIsSafe()
+    {
+        $this->registerMockVerifier(flagged: false);
+
+        $this->passes(Rule::aiModerated(), ['Hello world', 'This is safe content']);
+    }
+
+    public function testItFailsWhenContentIsFlagged()
+    {
+        $this->registerMockVerifier(flagged: true, categories: ['hate']);
+
+        $this->fails(Rule::aiModerated(), ['harmful content'], [
+            'validation.ai_moderated.categories',
+        ]);
+    }
+
+    public function testItFailsWithGenericMessageWhenNoCategories()
+    {
+        $this->registerMockVerifier(flagged: true, categories: []);
+
+        $this->fails(Rule::aiModerated(), ['harmful content'], [
+            'validation.ai_moderated.flagged',
+        ]);
+    }
+
+    public function testItPassesForEmptyValues()
+    {
+        $this->registerMockVerifier(flagged: true);
+
+        $this->passes(Rule::aiModerated(), ['', null]);
+    }
+
+    public function testItPassesForNonStringValues()
+    {
+        $this->registerMockVerifier(flagged: true);
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 123],
+            ['content' => Rule::aiModerated()]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testCategoriesConfiguration()
+    {
+        $capturedData = null;
+        $this->registerMockVerifier(flagged: false, captureData: function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        $rule = Rule::aiModerated()->categories(['hate', 'violence']);
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test'],
+            ['content' => $rule]
+        );
+
+        $v->passes();
+
+        $this->assertEquals(['hate', 'violence'], $capturedData['categories']);
+    }
+
+    public function testFluentCategoryMethods()
+    {
+        $rule = Rule::aiModerated()
+            ->noHate()
+            ->noViolence()
+            ->noSexual()
+            ->noHarassment();
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertContains('violence', $appliedRules['categories']);
+        $this->assertContains('sexual', $appliedRules['categories']);
+        $this->assertContains('harassment', $appliedRules['categories']);
+    }
+
+    public function testStrictModeration()
+    {
+        $rule = Rule::aiModerated()->strict();
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertContains('hate/threatening', $appliedRules['categories']);
+        $this->assertContains('harassment', $appliedRules['categories']);
+        $this->assertContains('harassment/threatening', $appliedRules['categories']);
+        $this->assertContains('self-harm', $appliedRules['categories']);
+        $this->assertContains('self-harm/intent', $appliedRules['categories']);
+        $this->assertContains('self-harm/instructions', $appliedRules['categories']);
+        $this->assertContains('sexual', $appliedRules['categories']);
+        $this->assertContains('sexual/minors', $appliedRules['categories']);
+        $this->assertContains('violence', $appliedRules['categories']);
+        $this->assertContains('violence/graphic', $appliedRules['categories']);
+    }
+
+    public function testThresholdConfiguration()
+    {
+        $capturedData = null;
+        $this->registerMockVerifier(flagged: false, captureData: function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        $rule = Rule::aiModerated()->threshold(0.8);
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test'],
+            ['content' => $rule]
+        );
+
+        $v->passes();
+
+        $this->assertEquals(0.8, $capturedData['threshold']);
+    }
+
+    public function testThresholdIsClamped()
+    {
+        $rule = Rule::aiModerated()->threshold(1.5);
+        $this->assertEquals(1.0, $rule->appliedRules()['threshold']);
+
+        $rule = Rule::aiModerated()->threshold(-0.5);
+        $this->assertEquals(0.0, $rule->appliedRules()['threshold']);
+    }
+
+    public function testStrictThreshold()
+    {
+        $rule = Rule::aiModerated()->strictThreshold();
+
+        $this->assertEquals(0.2, $rule->appliedRules()['threshold']);
+    }
+
+    public function testLenientThreshold()
+    {
+        $rule = Rule::aiModerated()->lenientThreshold();
+
+        $this->assertEquals(0.8, $rule->appliedRules()['threshold']);
+    }
+
+    public function testProviderConfiguration()
+    {
+        $capturedData = null;
+        $this->registerMockVerifier(flagged: false, captureData: function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        $rule = Rule::aiModerated()->using('openai');
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test'],
+            ['content' => $rule]
+        );
+
+        $v->passes();
+
+        $this->assertEquals('openai', $capturedData['provider']);
+    }
+
+    public function testCacheConfiguration()
+    {
+        $capturedData = null;
+        $this->registerMockVerifier(flagged: false, captureData: function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        $rule = Rule::aiModerated()->remember(3600);
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test'],
+            ['content' => $rule]
+        );
+
+        $v->passes();
+
+        $this->assertEquals(3600, $capturedData['cacheFor']);
+    }
+
+    public function testCustomVerifier()
+    {
+        $customResult = new class implements AiModerationResult {
+            public function flagged(): bool
+            {
+                return true;
+            }
+
+            public function flaggedCategories(): array
+            {
+                return ['custom-category'];
+            }
+
+            public function scores(): array
+            {
+                return ['custom-category' => 0.9];
+            }
+        };
+
+        $rule = Rule::aiModerated()->verifyUsing(function ($data) use ($customResult) {
+            return $customResult;
+        });
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test'],
+            ['content' => $rule]
+        );
+
+        $this->assertTrue($v->fails());
+    }
+
+    public function testDefaultCallback()
+    {
+        AiModerated::defaults(function () {
+            return (new AiModerated)->strict()->threshold(0.3);
+        });
+
+        $rule = AiModerated::default();
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertEquals(0.3, $appliedRules['threshold']);
+    }
+
+    public function testConditionalConfiguration()
+    {
+        $isStrict = true;
+
+        $rule = Rule::aiModerated()
+            ->when($isStrict, function ($rule) {
+                $rule->strict()->strictThreshold();
+            });
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertEquals(0.2, $appliedRules['threshold']);
+
+        $isStrict = false;
+
+        $rule = Rule::aiModerated()
+            ->when($isStrict, function ($rule) {
+                $rule->strict();
+            });
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertEmpty($appliedRules['categories']);
+    }
+
+    public function testDataAwareRule()
+    {
+        $this->registerMockVerifier(flagged: false);
+
+        $rule = Rule::aiModerated();
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'test', 'other_field' => 'value'],
+            ['content' => $rule]
+        );
+
+        $v->passes();
+
+        // The rule should have access to all data
+        $this->assertIsArray($rule->appliedRules());
+    }
+
+    public function testMultipleFlaggedCategories()
+    {
+        $this->registerMockVerifier(flagged: true, categories: ['hate', 'violence', 'harassment']);
+
+        $v = new Validator(
+            resolve('translator'),
+            ['content' => 'harmful content'],
+            ['content' => Rule::aiModerated()]
+        );
+
+        $this->assertTrue($v->fails());
+
+        // The message key should include 'categories' indicating multiple categories were flagged
+        $message = $v->messages()->first('content');
+        $this->assertStringContainsString('ai_moderated.categories', $message);
+    }
+
+    public function testAllFluentCategoryMethods()
+    {
+        $rule = Rule::aiModerated()
+            ->noHate()
+            ->noHateThreatening()
+            ->noHarassment()
+            ->noHarassmentThreatening()
+            ->noSelfHarm()
+            ->noSelfHarmIntent()
+            ->noSelfHarmInstructions()
+            ->noSexual()
+            ->noSexualMinors()
+            ->noViolence()
+            ->noViolenceGraphic();
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertCount(11, $appliedRules['categories']);
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertContains('hate/threatening', $appliedRules['categories']);
+        $this->assertContains('harassment', $appliedRules['categories']);
+        $this->assertContains('harassment/threatening', $appliedRules['categories']);
+        $this->assertContains('self-harm', $appliedRules['categories']);
+        $this->assertContains('self-harm/intent', $appliedRules['categories']);
+        $this->assertContains('self-harm/instructions', $appliedRules['categories']);
+        $this->assertContains('sexual', $appliedRules['categories']);
+        $this->assertContains('sexual/minors', $appliedRules['categories']);
+        $this->assertContains('violence', $appliedRules['categories']);
+        $this->assertContains('violence/graphic', $appliedRules['categories']);
+    }
+
+    public function testCategoriesCanBePassedAsVariadicArguments()
+    {
+        $rule = Rule::aiModerated()->categories('hate', 'violence', 'sexual');
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertCount(3, $appliedRules['categories']);
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertContains('violence', $appliedRules['categories']);
+        $this->assertContains('sexual', $appliedRules['categories']);
+    }
+
+    public function testRuleCanBeChainedFluentlyInAnyOrder()
+    {
+        $rule = Rule::aiModerated()
+            ->using('anthropic')
+            ->threshold(0.7)
+            ->remember(1800)
+            ->noHate()
+            ->noViolence();
+
+        $appliedRules = $rule->appliedRules();
+
+        $this->assertEquals('anthropic', $appliedRules['provider']);
+        $this->assertEquals(0.7, $appliedRules['threshold']);
+        $this->assertEquals(1800, $appliedRules['cacheFor']);
+        $this->assertContains('hate', $appliedRules['categories']);
+        $this->assertContains('violence', $appliedRules['categories']);
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true, []);
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->assertValidationRules($rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($rule, $values, $result, $messages)
+    {
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['content' => $value],
+                ['content' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['content' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function registerMockVerifier(bool $flagged, array $categories = [], ?Closure $captureData = null)
+    {
+        $container = Container::getInstance();
+
+        $mockResult = new class($flagged, $categories) implements AiModerationResult {
+            public function __construct(
+                private bool $flagged,
+                private array $categories
+            ) {
+            }
+
+            public function flagged(): bool
+            {
+                return $this->flagged;
+            }
+
+            public function flaggedCategories(): array
+            {
+                return $this->categories;
+            }
+
+            public function scores(): array
+            {
+                return array_fill_keys($this->categories, 0.9);
+            }
+        };
+
+        $mockVerifier = new class($mockResult, $captureData) implements AiModerationVerifier {
+            public function __construct(
+                private AiModerationResult $result,
+                private ?Closure $captureData
+            ) {
+            }
+
+            public function verify(array $data): AiModerationResult
+            {
+                if ($this->captureData) {
+                    ($this->captureData)($data);
+                }
+
+                return $this->result;
+            }
+        };
+
+        $container->instance(AiModerationVerifier::class, $mockVerifier);
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        AiModerated::$defaultCallback = null;
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This PR introduces a new fluent validation rule `Rule::aiModerated()` for AI-powered content moderation. The implementation follows a contract-based design, requiring devs to implement `AiModerationVerifier` themselves! **No AI provider code** is included in the framework core.

## Discussion
This feature was discussed in: [here](https://github.com/laravel/framework/discussions/58406#discussioncomment-15526898)!

## Benefits to End Users

### 1. Standardized Content Moderation
User-generated content (comments, posts, messages, reviews) often requires moderation. This rule provides a familiar, Laravel-native way to validate content safety without custom implementations:

```php
'comment' => Rule::aiModerated()
    ->noHate()
    ->noViolence()
    ->threshold(0.5)
```
    
I Followed Established Patterns
- Same fluent API as Rule::password() and Rule::unique()
- Implements standard interfaces: ValidationRule, DataAwareRule, ValidatorAwareRule
- Uses Conditionable trait for conditional application
- Contract pattern similar to NotPwnedVerifier

```php
<?php
// Basic usage
Rule::aiModerated()
    ->noHate()
    ->noViolence()
    ->noSexual()
    ->noHarassment()

// Advanced configuration
Rule::aiModerated()
    ->strict()                    // All harmful categories
    ->threshold(0.3)              // Custom strictness
    ->strictThreshold()           // Preset: 0.2
    ->lenientThreshold()          // Preset: 0.8
    ->using('openai')             // Provider hint
    ->remember(3600)              // Cache for 1 hour
    ->verifyUsing($callback)      // Custom verifier