### PR TITLE
[12.x] Add queue to JobPopping

### DIFF
--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -8,11 +8,11 @@ class JobPopping
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
-     * @param  string  $queueName  The queue name.
+     * @param  string|null  $queue  The queue name.
      */
     public function __construct(
         public $connectionName,
-        public $queueName
+        public $queue = null
     ) {
     }
 }

--- a/src/Illuminate/Queue/Events/JobPopping.php
+++ b/src/Illuminate/Queue/Events/JobPopping.php
@@ -8,9 +8,11 @@ class JobPopping
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
+     * @param  string  $queueName  The queue name.
      */
     public function __construct(
         public $connectionName,
+        public $queueName
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -684,10 +684,10 @@ class Worker
      * Raise an event indicating a job is being popped from the queue.
      *
      * @param  string  $connectionName
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return void
      */
-    protected function raiseBeforeJobPopEvent($connectionName, $queue)
+    protected function raiseBeforeJobPopEvent($connectionName, $queue = null)
     {
         $this->events->dispatch(new JobPopping($connectionName, $queue));
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -374,7 +374,7 @@ class Worker
             return $connection->pop($queue, $index);
         };
 
-        $this->raiseBeforeJobPopEvent($connection->getConnectionName());
+        $this->raiseBeforeJobPopEvent($connection->getConnectionName(), $queue);
 
         try {
             if (isset(static::$popCallbacks[$this->name ?? ''])) {
@@ -684,11 +684,12 @@ class Worker
      * Raise an event indicating a job is being popped from the queue.
      *
      * @param  string  $connectionName
+     * @param  string  $queue
      * @return void
      */
-    protected function raiseBeforeJobPopEvent($connectionName)
+    protected function raiseBeforeJobPopEvent($connectionName, $queue)
     {
-        $this->events->dispatch(new JobPopping($connectionName));
+        $this->events->dispatch(new JobPopping($connectionName, $queue));
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -59,6 +59,18 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->once();
     }
 
+    public function testJobPoppingEvent()
+    {
+        $worker = $this->getWorker('default', ['queue' => [$job = new WorkerFakeJob]]);
+        $worker->runNextJob('default', 'queue', new WorkerOptions);
+        $this->assertTrue($job->fired);
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
+            return $event instanceof JobPopping
+                && $event->connectionName === 'default'
+                && $event->queueName === 'queue';
+        }))->once();
+    }
     public function testWorkerCanWorkUntilQueueIsEmpty()
     {
         $workerOptions = new WorkerOptions;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -71,6 +71,7 @@ class QueueWorkerTest extends TestCase
                 && $event->queueName === 'queue';
         }))->once();
     }
+
     public function testWorkerCanWorkUntilQueueIsEmpty()
     {
         $workerOptions = new WorkerOptions;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -68,7 +68,7 @@ class QueueWorkerTest extends TestCase
         $this->events->shouldHaveReceived('dispatch')->with(m::on(function ($event) {
             return $event instanceof JobPopping
                 && $event->connectionName === 'default'
-                && $event->queueName === 'queue';
+                && $event->queue === 'queue';
         }))->once();
     }
 


### PR DESCRIPTION
The JobPopping event currently only includes the connection name, but not the queue. 

Adding the queue property helps when you're running various different queues (when tracking things like frequency etc with this event)  mainly helpful for loggers/metrics etc
 
JobPopped/JobProcessing etc allow us to access the queue via the job, ie via `getQueue()` but this event doesn't give us access to the queue so this aligns them closer.

I've defaulted it to null incase anyone is overriding or extending it etc - to avoid any b/c but feel free to adjust.