### PR TITLE
[12.x] add backoff to JobReleasedAfterException event

### DIFF
--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -9,7 +9,7 @@ class JobReleasedAfterException
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
-     * @param  int|null  $backoff  The backoff delay in seconds.
+     * @param  int|null  $backoff  The backoff delay.
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -9,10 +9,12 @@ class JobReleasedAfterException
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.
+     * @param  int|null  $backoff  The backoff delay in seconds.
      */
     public function __construct(
         public $connectionName,
         public $job,
+        public $backoff = null
     ) {
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -531,10 +531,12 @@ class Worker
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
-                $job->release($this->calculateBackoff($job, $options));
+                $backoff = $this->calculateBackoff($job, $options);
+
+                $job->release($backoff);
 
                 $this->events->dispatch(new JobReleasedAfterException(
-                    $connectionName, $job
+                    $connectionName, $job, $backoff
                 ));
             }
         }


### PR DESCRIPTION
Jobs and queues can have a specific backoff delay - including it in the event allows us to track the actual delay used without needing to track code / infra changes etc. ie just captures what actually happened at runtime. 

This is useful when its set via the worker options or via a job - (avoids tapping into the job to access the backoff / delay) for metrics / logging etc.

Included a test as didn't see one! (will probs pull the test out if this isnt accepted)

I've defaulted it to null incase anyone is overriding or extending it etc - to avoid any b/c but feel free to adjust.

Happy to target 13.x if you prefer