### PR TITLE
[12.x] Add `loadMissingCount` and `loadMissingAggregate` methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -207,32 +207,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function loadMissingCount(string|array $relations): self
     {
-        if ($this->isEmpty()) {
-            return $this;
-        }
-
-        if (is_string($relations)) {
-            $relations = func_get_args();
-        }
-
-        foreach ($relations as $key => $value) {
-            $name = is_numeric($key) ? $value : $key;
-
-            $segments = explode(' ', $name);
-
-            // If the relationship has been aliased, we will extract the alias as the attribute
-            // name. Otherwise, we will calculate the default name for the count column
-            // so we can determine if the relationship count is already loaded.
-            $attribute = count($segments) === 3 && Str::lower($segments[1]) === 'as'
-                ? $segments[2]
-                : Str::snake($name).'_count';
-
-            $this
-                ->filter(fn ($model) => $model instanceof Model && ! $model->hasAttribute($attribute))
-                ->loadCount([$key => $value]);
-        }
-
-        return $this;
+        return $this->loadMissingAggregate($relations, '*', 'count');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -866,6 +866,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Eager load relation counts on the model if they are not already eager loaded.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadMissingCount(string|array $relations): self
+    {
+        $relations = is_string($relations) ? func_get_args() : $relations;
+
+        $this->newCollection([$this])->loadMissingCount($relations);
+
+        return $this;
+    }
+
+    /**
      * Eager load relation max column values on the model.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -853,6 +853,21 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Eager load relation's column aggregations on the model if they are not already eager loaded.
+     *
+     * @param  array|string  $relations
+     * @param  string  $column
+     * @param  string|null  $function
+     * @return $this
+     */
+    public function loadMissingAggregate($relations, $column, $function = null)
+    {
+        $this->newCollection([$this])->loadMissingAggregate($relations, $column, $function);
+
+        return $this;
+    }
+
+    /**
      * Eager load relation counts on the model.
      *
      * @param  array|string  $relations

--- a/tests/Integration/Database/EloquentCollectionLoadMissingAggregateTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingAggregateTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Generator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversMethod(Collection::class, 'loadMissingAggregate')]
+class EloquentCollectionLoadMissingAggregateTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase(): void
+    {
+        Schema::create((new CollectionLoadMissingAggregateTestUser)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        Schema::create((new CollectionLoadMissingAggregateTestArticle)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('title');
+            $table->integer('views')->default(0);
+            $table->boolean('published')->default(false);
+        });
+    }
+
+    #[DataProvider('loadMissingAggregateProvider')]
+    public function test_load_missing_aggregate(
+        array $initialValues,
+        string|array $relations,
+        string $column,
+        string $function,
+        array $expectedValues,
+    ): void {
+        // Arrange
+
+        $user = CollectionLoadMissingAggregateTestUser::create(['email' => 'john@doe.com']);
+
+        $user->articles()->createMany([
+            ['title' => 'Article 1', 'views' => 10, 'published' => true],
+            ['title' => 'Article 2', 'views' => 20, 'published' => false],
+        ]);
+
+        $collection = new Collection([$user]);
+
+        foreach ($initialValues as $key => $value) {
+            $user->setAttribute($key, $value);
+        }
+
+        // Act
+
+        $collection->loadMissingAggregate($relations, $column, $function);
+
+        // Assert
+
+        foreach ($expectedValues as $key => $value) {
+            $this->assertEquals($value, $user->getAttribute($key));
+        }
+    }
+
+    public static function loadMissingAggregateProvider(): Generator
+    {
+        yield 'loads missing max' => [
+            'initialValues' => [],
+            'relations' => 'articles',
+            'column' => 'views',
+            'function' => 'max',
+            'expectedValues' => ['articles_max_views' => 20],
+        ];
+
+        yield 'does not reload existing aggregate' => [
+            'initialValues' => ['articles_max_views' => 100], // <- Already "loaded"
+            'relations' => 'articles',
+            'column' => 'views',
+            'function' => 'max',
+            'expectedValues' => ['articles_max_views' => 100],
+        ];
+
+        yield 'loads missing sum' => [
+            'initialValues' => [],
+            'relations' => 'articles',
+            'column' => 'views',
+            'function' => 'sum',
+            'expectedValues' => ['articles_sum_views' => 30],
+        ];
+
+        yield 'loads missing aggregate with alias' => [
+            'initialValues' => [],
+            'relations' => ['articles as total_views'],
+            'column' => 'views',
+            'function' => 'sum',
+            'expectedValues' => ['total_views' => 30],
+        ];
+
+        yield 'works with multiple relations' => [
+            'initialValues' => ['articles_max_views' => 100],
+            'relations' => ['articles', 'articles as max_views'],
+            'column' => 'views',
+            'function' => 'max',
+            'expectedValues' => [
+                'articles_max_views' => 100,
+                'max_views' => 20,
+            ],
+        ];
+
+        yield 'loads missing aggregate with closure and alias' => [
+            'initialValues' => [],
+            'relations' => ['articles as published_total_views' => fn ($query) => $query->wherePublished()],
+            'column' => 'views',
+            'function' => 'sum',
+            'expectedValues' => ['published_total_views' => 10],
+        ];
+    }
+
+    public function test_load_missing_aggregate_filters_models(): void
+    {
+        // Arrange
+
+        $user1 = CollectionLoadMissingAggregateTestUser::create(['email' => 'john@doe.com']);
+        $user2 = CollectionLoadMissingAggregateTestUser::create(['email' => 'foo@bar.com']);
+        $user1->articles()->create(['title' => 'Article 1', 'views' => 10]);
+        $user2->articles()->create(['title' => 'Article 2', 'views' => 20]);
+
+        $collection = new Collection([$user1, $user2]);
+
+        $user1->setAttribute('articles_sum_views', 100); // <- Already "loaded"
+
+        DB::enableQueryLog();
+
+        // Act
+
+        $collection->loadMissingAggregate('articles', 'views', 'sum');
+
+        // Assert
+
+        $this->assertEquals(100, $user1->articles_sum_views);
+        $this->assertEquals(20, $user2->articles_sum_views);
+
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(1, $queryLog);
+        $query = str_replace(['"', '`', '[', ']'], '', $queryLog[0]['query']);
+
+        $this->assertStringContainsString("where users.id in ($user2->id)", $query);
+    }
+}
+
+class CollectionLoadMissingAggregateTestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(CollectionLoadMissingAggregateTestArticle::class, 'user_id');
+    }
+}
+
+class CollectionLoadMissingAggregateTestArticle extends Model
+{
+    protected $table = 'articles';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function scopeWherePublished($query)
+    {
+        return $query->where('published', true);
+    }
+}

--- a/tests/Integration/Database/EloquentCollectionLoadMissingCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingCountTest.php
@@ -131,7 +131,9 @@ class EloquentCollectionLoadMissingCountTest extends DatabaseTestCase
         $queryLog = DB::getQueryLog();
 
         $this->assertCount(1, $queryLog);
-        $this->assertStringContainsString("where \"users\".\"id\" in ($user2->id)", $queryLog[0]['query']);
+        $query = str_replace(['"', '`', '[', ']'], '', $queryLog[0]['query']);
+
+        $this->assertStringContainsString("where users.id in ($user2->id)", $query);
     }
 }
 

--- a/tests/Integration/Database/EloquentCollectionLoadMissingCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingCountTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Generator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversMethod(Collection::class, 'loadMissingCount')]
+class EloquentCollectionLoadMissingCountTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase(): void
+    {
+        Schema::create((new CollectionLoadMissingCountTestUser)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        Schema::create((new CollectionLoadMissingCountTestArticle)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('title');
+            $table->boolean('published')->default(false);
+        });
+    }
+
+    #[DataProvider('loadMissingCountProvider')]
+    public function test_load_missing_count(
+        array $initialCounts,
+        string|array $relations,
+        array $expectedCounts,
+    ): void {
+        // Arrange
+
+        $user = CollectionLoadMissingCountTestUser::create(['email' => 'john@doe.com']);
+
+        $user->articles()->createMany([
+            ['title' => 'Article 1', 'published' => true],
+            ['title' => 'Article 2', 'published' => false],
+        ]);
+
+        $collection = new Collection([$user]);
+
+        foreach ($initialCounts as $key => $value) {
+            $user->setAttribute($key, $value);
+        }
+
+        // Act
+
+        $collection->loadMissingCount($relations);
+
+        // Assert
+
+        foreach ($expectedCounts as $key => $value) {
+            $this->assertEquals($value, $user->getAttribute($key));
+        }
+    }
+
+    public static function loadMissingCountProvider(): Generator
+    {
+        yield 'loads missing count' => [
+            'initialCounts' => [],
+            'relations' => 'articles',
+            'expectedCounts' => ['articles_count' => 2],
+        ];
+
+        yield 'does not reload existing count' => [
+            'initialCounts' => ['articles_count' => 5], // <- Wrong count but already loaded
+            'relations' => 'articles',
+            'expectedCounts' => ['articles_count' => 5],
+        ];
+
+        yield 'loads missing count with alias' => [
+            'initialCounts' => [],
+            'relations' => ['articles as posts_count'],
+            'expectedCounts' => ['posts_count' => 2], // <- This is the alias name.
+        ];
+
+        yield 'works with multiple relations' => [
+            'initialCounts' => ['articles_count' => 5],
+            'relations' => ['articles', 'articles as posts_count'],
+            'expectedCounts' => [
+                'articles_count' => 5,
+                'posts_count' => 2,
+            ],
+        ];
+
+        yield 'loads missing count with closure and alias' => [
+            'initialCounts' => [],
+            'relations' => ['articles as published_articles_count' => fn ($query) => $query->wherePublished()],
+            'expectedCounts' => ['published_articles_count' => 1],
+        ];
+
+        yield 'loads missing count with closure and no alias' => [
+            'initialCounts' => [],
+            'relations' => ['articles' => fn ($query) => $query->wherePublished()],
+            'expectedCounts' => ['articles_count' => 1],
+        ];
+    }
+
+    public function test_load_missing_count_filters_models(): void
+    {
+        // Arrange
+
+        $user1 = CollectionLoadMissingCountTestUser::create(['email' => 'john@doe.com']);
+        $user2 = CollectionLoadMissingCountTestUser::create(['email' => 'foo@bar.com']);
+        $user1->articles()->create(['title' => 'Article 1']);
+        $user2->articles()->create(['title' => 'Article 2']);
+
+        $collection = new Collection([$user1, $user2]);
+
+        $user1->setAttribute('articles_count', 5); // <- Already "loaded"
+
+        DB::enableQueryLog();
+
+        // Act
+
+        $collection->loadMissingCount('articles');
+
+        // Assert
+
+        $this->assertEquals(5, $user1->articles_count);
+        $this->assertEquals(1, $user2->articles_count);
+
+        $queryLog = DB::getQueryLog();
+
+        $this->assertCount(1, $queryLog);
+        $this->assertStringContainsString("where \"users\".\"id\" in ($user2->id)", $queryLog[0]['query']);
+    }
+}
+
+class CollectionLoadMissingCountTestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(CollectionLoadMissingCountTestArticle::class, 'user_id');
+    }
+}
+
+class CollectionLoadMissingCountTestArticle extends Model
+{
+    protected $table = 'articles';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function scopeWherePublished($query)
+    {
+        return $query->where('published', true);
+    }
+}

--- a/tests/Integration/Database/EloquentModelLoadMissingAggregateTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingAggregateTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+#[CoversMethod(Model::class, 'loadMissingAggregate')]
+class EloquentModelLoadMissingAggregateTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase(): void
+    {
+        Schema::create((new ModelLoadMissingAggregateTestUser)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        Schema::create((new ModelLoadMissingAggregateTestArticle)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('title');
+            $table->integer('views')->default(0);
+        });
+    }
+
+    public function test_load_missing_aggregate(): void
+    {
+        // Arrange
+
+        $user = ModelLoadMissingAggregateTestUser::create(['email' => 'john@doe.com']);
+
+        $user->articles()->createMany([
+            ['title' => 'Article 1', 'views' => 10],
+            ['title' => 'Article 2', 'views' => 20],
+        ]);
+
+        // Act
+
+        $user->loadMissingAggregate('articles', 'views', 'sum');
+
+        // Assert
+
+        $this->assertEquals(30, $user->articles_sum_views);
+    }
+
+    public function test_does_not_reload_existing_aggregate(): void
+    {
+        // Arrange
+
+        $user = ModelLoadMissingAggregateTestUser::create(['email' => 'john@doe.com']);
+
+        $user->articles()->createMany([
+            ['title' => 'Article 1', 'views' => 10],
+            ['title' => 'Article 2', 'views' => 20],
+        ]);
+
+        $user->setAttribute('articles_sum_views', 100);
+
+        // Act
+
+        $user->loadMissingAggregate('articles', 'views', 'sum');
+
+        // Assert
+
+        $this->assertEquals(100, $user->articles_sum_views);
+    }
+}
+
+class ModelLoadMissingAggregateTestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(ModelLoadMissingAggregateTestArticle::class, 'user_id');
+    }
+}
+
+class ModelLoadMissingAggregateTestArticle extends Model
+{
+    protected $table = 'articles';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/EloquentModelLoadMissingCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingCountTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+#[CoversMethod(Model::class, 'loadMissingCount')]
+class EloquentModelLoadMissingCountTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase(): void
+    {
+        Schema::create((new ModelLoadMissingCountTestUser)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        Schema::create((new ModelLoadMissingCountTestArticle)->getTable(), function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('title');
+            $table->boolean('published')->default(false);
+        });
+    }
+
+    public function test_model_load_missing_count(): void
+    {
+        // Arrange
+
+        $user = ModelLoadMissingCountTestUser::create(['email' => 'john@doe.com']);
+        $user->articles()->create(['title' => 'Article 1']);
+
+        DB::enableQueryLog();
+
+        // Act
+
+        $user->loadMissingCount('articles');
+
+        // Assert
+
+        $this->assertEquals(1, $user->articles_count);
+        $this->assertCount(1, DB::getQueryLog());
+
+        // Act (again)
+
+        $user->loadMissingCount('articles');
+
+        // Assert
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
+
+    public function test_model_load_missing_count_with_closure_and_alias(): void
+    {
+        // Arrange
+
+        $user = ModelLoadMissingCountTestUser::create(['email' => 'john@doe.com']);
+        $user->articles()->create(['title' => 'Article 1', 'published' => true]);
+        $user->articles()->create(['title' => 'Article 2', 'published' => false]);
+
+        DB::enableQueryLog();
+
+        // Act
+
+        $user->loadMissingCount(['articles as published_articles_count' => fn ($query) => $query->wherePublished()]);
+
+        // Assert
+
+        $this->assertEquals(1, $user->published_articles_count);
+        $this->assertCount(1, DB::getQueryLog());
+
+        // Act (again)
+
+        $user->loadMissingCount(['articles as published_articles_count' => fn ($query) => $query->wherePublished()]);
+
+        // Assert
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
+}
+
+class ModelLoadMissingCountTestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(ModelLoadMissingCountTestArticle::class, 'user_id');
+    }
+}
+
+class ModelLoadMissingCountTestArticle extends Model
+{
+    protected $table = 'articles';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function scopeWherePublished($query)
+    {
+        return $query->where('published', true);
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds`loadMissingCount` and `loadMissingAggregate` to Eloquent Model and Eloquent Collection for parity with the existing `loadMissing` method.

### Rationale
Currently, `loadCount` always executes a query even if the count is already available. `loadMissingCount` offers a way to eager load relationship counts only when the attribute is missing, avoiding redundant queries in partially loaded collections.

In complex applications, models often flow through various services or components. It is common to encounter a collection where some models already have counts loaded (via previous eager loading or manual assignment) while others do not. Using `loadCount` or `loadAggregate` in these scenarios results in redundant database queries for data that is already available.

This addition brings consistency to the Eloquent API by providing an aggregate equivalent to the relationship-based one.

### Usage
```php
$users->loadMissingCount('articles');
$users->loadMissingCount(['articles as post_count']);
$users->loadMissingCount(['articles as published_posts_count' => fn ($query) => $query->wherePublished()]);
$articles->loadMissingAggregate('ratings', 'value', 'avg');
```
