### PR TITLE
[12.x] Support custom environment variable name in `key:generate`

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -124,10 +124,11 @@ class KeyGenerateCommand extends Command
      * @param  string  $name
      * @return string
      */
-    protected function keyReplacementPattern($name)
+    protected function keyReplacementPattern(string $name)
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escapedName = preg_quote($name, '/');
+        $escapedAssignment = preg_quote('='.$this->laravel['config']['app.key'], '/');
 
-        return "/^{$name}{$escaped}/m";
+        return "/^{$escapedName}{$escapedAssignment}/m";
     }
 }

--- a/tests/Foundation/Console/KeyGenerateCommandTest.php
+++ b/tests/Foundation/Console/KeyGenerateCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Foundation\Console;
+
+use Generator;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class KeyGenerateCommandTest extends TestCase
+{
+    private string $testEnvFileName = '';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (file_exists($this->testEnvFileName)) {
+            unlink($this->testEnvFileName);
+        }
+    }
+
+    #[DataProvider('keyNamesDataProvider')]
+    public function test_it_can_generate_keys_with_provided_name(
+        ?string $optionValue,
+        string $expectedEnvVariable,
+    ): void {
+        // Arrange
+
+        // Use a unique filename to avoid flakiness with other tests in parallel mode.
+        $this->testEnvFileName = uniqid().'.env';
+
+        $envPath = base_path($this->testEnvFileName);
+
+        file_put_contents($envPath, sprintf('%s=', $optionValue ?? 'APP_KEY'));
+
+        $this->app['config']->set('app.key', '');
+
+        $this->app->useEnvironmentPath(base_path());
+        $this->app->loadEnvironmentFrom($this->testEnvFileName);
+
+        // Act
+
+        $this->artisan(KeyGenerateCommand::class, $optionValue ? ['--name' => $optionValue] : [])
+            ->expectsOutputToContain('Application key set successfully.')
+            ->assertExitCode(0);
+
+        // Assert
+
+        $content = file_get_contents($envPath);
+
+        $this->assertStringContainsString("{$optionValue}=base64:", $content);
+    }
+
+    public static function keyNamesDataProvider(): Generator
+    {
+        yield 'implicit default key' => [
+            'optionValue' => null,
+            'expectedEnvVariable' => 'APP_KEY',
+        ];
+
+        yield 'explicit default key' => [
+            'optionValue' => 'APP_KEY',
+            'expectedEnvVariable' => 'APP_KEY',
+        ];
+
+        yield 'custom key' => [
+            'optionValue' => 'MY_SPECIAL_APP_KEY',
+            'expectedEnvVariable' => 'MY_SPECIAL_APP_KEY',
+        ];
+    }
+}

--- a/tests/Foundation/Console/KeyGenerateCommandTest.php
+++ b/tests/Foundation/Console/KeyGenerateCommandTest.php
@@ -32,7 +32,12 @@ class KeyGenerateCommandTest extends TestCase
 
         $envPath = base_path($this->testEnvFileName);
 
-        file_put_contents($envPath, sprintf('%s=', $optionValue ?? 'APP_KEY'));
+        $envFileContent = 'NAMESPACE.APP_ENV=local'.PHP_EOL
+            .'APP_DEBUG=false'.PHP_EOL;
+
+        $appKeyLine = sprintf('%s=', $optionValue ?? 'APP_KEY');
+
+        file_put_contents($envPath, $envFileContent.$appKeyLine);
 
         $this->app['config']->set('app.key', '');
 
@@ -49,7 +54,9 @@ class KeyGenerateCommandTest extends TestCase
 
         $content = file_get_contents($envPath);
 
-        $this->assertStringContainsString("{$optionValue}=base64:", $content);
+        $expectedSubString = $envFileContent."{$expectedEnvVariable}=base64:";
+
+        $this->assertStringContainsString($expectedEnvVariable, $content);
     }
 
     public static function keyNamesDataProvider(): Generator
@@ -67,6 +74,16 @@ class KeyGenerateCommandTest extends TestCase
         yield 'custom key' => [
             'optionValue' => 'MY_SPECIAL_APP_KEY',
             'expectedEnvVariable' => 'MY_SPECIAL_APP_KEY',
+        ];
+
+        yield 'custom key with regex char' => [
+            'optionValue' => 'NAMESPACE.APP_KEY',
+            'expectedEnvVariable' => 'NAMESPACE.APP_KEY',
+        ];
+
+        yield 'custom key with regex char 2' => [
+            'optionValue' => 'NAMESPACE$APP_KEY',
+            'expectedEnvVariable' => 'NAMESPACE$APP_KEY',
         ];
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `--name` option to the php artisan `key:generate` command. This option allows developers to specify which environment variable should be updated with the generated encryption key. By default, the command continues to use `APP_KEY`.

## Rationale

It is increasingly common to orchestrate multiple services within a single environment (e.g., using tools like devenv process compose). In these scenarios, environment variables often need to be namespaced (e.g., `PAYMENTS_SERVICE_APP_KEY`, `AUTH_SERVICE_APP_KEY`) to avoid collisions between different service instances sharing the same environment.

Currently, the `key:generate` command is hardcoded to look for and update `APP_KEY`. This forces developers in multi-service environments to have workarounds to update their app key variable value.