### PR TITLE
[12.x] Fix Filesystem::sharedGet partial reads (#58418)

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -90,7 +90,7 @@ class Filesystem
                 if (flock($handle, LOCK_SH)) {
                     clearstatcache(true, $path);
 
-                    $contents = fread($handle, $this->size($path) ?: 1);
+                    $contents = stream_get_contents($handle);
 
                     flock($handle, LOCK_UN);
                 }

--- a/tests/Integration/Filesystem/FilesystemTest.php
+++ b/tests/Integration/Filesystem/FilesystemTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Filesystem;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -81,5 +82,101 @@ class FilesystemTest extends TestCase
         File::deleteDirectory(storage_path('app/public/testdir'));
 
         $this->assertFalse(File::exists(storage_path('app/public/testdir')));
+    }
+
+    public function testSharedGetReadsEntireStreamEvenWhenReadIsPartial(): void
+    {
+        if (! in_array('partialread', stream_get_wrappers(), true)) {
+            stream_wrapper_register('partialread', PartialReadStreamWrapper::class);
+        }
+
+        $payload = str_repeat('a', 10 * 1024); // 10 KiB
+        PartialReadStreamWrapper::setData($payload);
+
+        $fs = new Filesystem();
+
+        $contents = $fs->sharedGet('partialread://test');
+
+        $this->assertSame(strlen($payload), strlen($contents));
+        $this->assertSame($payload, $contents);
+    }
+
+    protected function tearDown(): void
+    {
+        if (in_array('partialread', stream_get_wrappers(), true)) {
+            @stream_wrapper_unregister('partialread');
+        }
+
+        parent::tearDown();
+    }
+}
+
+class PartialReadStreamWrapper
+{
+    public $context;
+
+    private static string $data = '';
+    private int $pos = 0;
+
+    private static bool $locked = false;
+
+    public static function setData(string $data): void
+    {
+        self::$data = $data;
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path): bool
+    {
+        $this->pos = 0;
+
+        return true;
+    }
+
+    public function stream_read($count): string
+    {
+        // We emulate the behavior: one read returns a maximum of 8 KiB.
+        $count = min($count, 8192);
+
+        $chunk = substr(self::$data, $this->pos, $count);
+        $this->pos += strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->pos >= strlen(self::$data);
+    }
+
+    public function stream_stat(): array
+    {
+        return ['size' => strlen(self::$data)];
+    }
+
+    public function url_stat($path, $flags): array
+    {
+        return ['size' => strlen(self::$data)];
+    }
+
+    /**
+     * Required for flock() support on user-space streams.
+     *
+     * @param  int  $operation  One of LOCK_SH, LOCK_EX, LOCK_UN (+ optional LOCK_NB)
+     * @return bool
+     */
+    public function stream_lock($operation): bool
+    {
+        // For testing purposes, a “successful” implementation is sufficient.
+        // LOCK_UN — remove, otherwise assume that it is locked.
+        if (($operation & LOCK_UN) === LOCK_UN) {
+            self::$locked = false;
+
+            return true;
+        }
+
+        // Optionally, LOCK_NB can be taken into account, but it is not required here.
+        self::$locked = true;
+
+        return true;
     }
 }


### PR DESCRIPTION
Filesystem::sharedGet relied on a single fread() call to read the entire file.

Since fread() may return fewer bytes than requested, this could result in truncated reads (often 8 KiB) even when the underlying file or stream contains more data.

This change replaces the single fread() call with stream_get_contents() to ensure the entire stream is read, and adds a regression test using a custom stream wrapper that simulates partial reads.

Fixes #58418

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
