### PR TITLE
[12.x] Add Arr `prefix` and `suffix` helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -695,6 +695,34 @@ class Arr
     }
 
     /**
+     * Prefix the values of an array.
+     *
+     * @template TKey of array-key
+     *
+     * @param  array<TKey, scalar>  $array
+     * @param  string  $prefix
+     * @return array<TKey, string>
+     */
+    public static function prefix(array $array, string $prefix): array
+    {
+        return static::map($array, fn ($item) => $prefix.$item);
+    }
+
+    /**
+     * Suffix the values of an array.
+     *
+     * @template TKey of array-key
+     *
+     * @param  array<TKey, scalar>  $array
+     * @param  string  $suffix
+     * @return array<TKey, string>
+     */
+    public static function suffix(array $array, string $suffix): array
+    {
+        return static::map($array, fn ($item) => $item.$suffix);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1798,6 +1798,68 @@ class SupportArrTest extends TestCase
         ], Arr::prependKeysWith($array, 'test.'));
     }
 
+    public function testPrefix(): void
+    {
+        $this->assertEquals(
+            ['$9', '$54', '$77.489'],
+            Arr::prefix([9, 54, 77.489], '$'),
+        );
+
+        $this->assertEquals(
+            ['https://cdn.example.com/banners/winter.jpg', 'https://cdn.example.com/icons/check.svg'],
+            Arr::prefix(['banners/winter.jpg', 'icons/check.svg'], 'https://cdn.example.com/'),
+        );
+
+        $this->assertEquals(
+            ['#laravel', '#programming', '#php'],
+            Arr::prefix(['laravel', 'programming', 'php'], '#'),
+        );
+
+        $this->assertEquals(
+            ['%term', '%term_2'],
+            Arr::prefix(['term', 'term_2'], '%'),
+        );
+
+        $this->assertEquals(
+            ['mixed_1', 'mixed_one'],
+            Arr::prefix([1, 'one'], 'mixed_'),
+        );
+
+        $this->assertEquals(
+            ['key_1' => 'prefix_::value::', 'key_2' => 'prefix_::value_2::'],
+            Arr::prefix(['key_1' => '::value::', 'key_2' => '::value_2::'], 'prefix_'),
+        );
+    }
+
+    public function testSuffix(): void
+    {
+        $this->assertEquals(
+            ['9€', '54€', '77.489€'],
+            Arr::suffix([9, 54, 77.489], '€'),
+        );
+
+        $this->assertEquals(
+            ['invoice_1001.pdf', 'report_january.pdf'],
+            Arr::suffix(['invoice_1001', 'report_january'], '.pdf'),
+        );
+
+        $this->assertEquals(
+            ['term%', 'term_2%'],
+            Arr::suffix(['term', 'term_2'], '%'),
+        );
+
+        $this->assertEquals(
+            ['1_mixed', 'one_mixed'],
+            Arr::suffix([1, 'one'], '_mixed'),
+        );
+
+        $this->assertEquals(
+            ['key_1' => '::value::_suffix', 'key_2' => '::value_2::_suffix'],
+            Arr::suffix(['key_1' => '::value::', 'key_2' => '::value_2::'], '_suffix'),
+        );
+    }
+
+
     public function testTake(): void
     {
         $array = [1, 2, 3, 4, 5, 6];


### PR DESCRIPTION
## Summary

This PR adds two new helper methods to the `Illuminate\Support\Arr` class: `prefix` and `suffix`. These methods provide a declarative way to prepend or append strings to every value in an array.

## Rationale

Developers frequently need to transform array values by adding a prefix (e.g., a base URL, a currency symbol, an env identifier) or a suffix (e.g., a file extension or a measurement unit). 

Currently, this requires using array_map with a closure or wrapping the array in a Collection. These new methods provide a more semantic and expressive API that aligns with methods like `prependKeysWith`. So this aims to fill the logical gap next to the existing key-prefixing utility. While writing this, I realized that they can instead be named `prependValuesWith` and `appendValuesWith` instead.

**Before:**
```php
$urls = array_map(fn ($path) => 'https://cdn.com/'.$path, $paths); // or Arr::map
$prices = array_map(fn ($price) => $price . '€', $prices); // or Arr::map
```
**After:**
```php
$urls = Arr::prefix($paths, 'https://cdn.com/');
$prices = Arr::suffix($prices, '€');
```
---

## Example Use Cases
- CDN/Asset Paths.
- UI Formatting: Appending units (px, %, kg) or prepending symbols ($, @, #) to a list of values.
- Database Search Terms.
- Adding file extensions to a list of generated names.
- Scoping logs or messages by env or category.

### Code Examples

```php
// Generating absolute CDN URLs for a list of relative asset paths
Arr::prefix(['banners/winter.jpg', 'icons/check.svg'], 'https://cdn.example.com/')
# ['https://cdn.example.com/banners/winter.jpg', 'https://cdn.example.com/icons/check.svg']

// Formatting raw numbers into currency strings for a view component
Arr::prefix([29.99, 45.00, 10.50], '$')
# ['$29.99', '$45.00', '$10.50']

// Transforming plain identifiers into social media handles
Arr::prefix(['laravelphp', 'php'], '@')
# ['@laravelphp', '@php']

// Preparing a list of filenames for bulk export by adding the extension
Arr::suffix(['invoice_1001', 'report_january'], '.pdf') 
# ['invoice_1001.pdf', 'report_january.pdf']

// Scoping error or audit logs with a system-specific identifier
Arr::prefix(['Session expired', 'Invalid API key'], '[AUTH_SECURITY] ')
# ['[AUTH_SECURITY] Session expired', '[AUTH_SECURITY] Invalid API key']

// Constructing CLI flags from a list of option names for shell execution
Arr::prefix(['force', 'verbose', 'no-interaction'], '--')
# ['--force', '--verbose', '--no-interaction']

// Adding environment scopes to email subject lines for developers
Arr::prefix(['New User Registered', 'Database Warning'], '[STAGING] ') 
# ['[STAGING] New User Registered', '[STAGING] Database Warning']
```

---

_(Note: I didn't add the type tests inside of `types/Support/Arr.php` because the types are asserted by the type hinting already)_