### PR TITLE
[12.x] Fix restoreLock for MemoizedStore

### DIFF
--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -190,7 +190,7 @@ class MemoizedStore implements LockProvider, Store
             throw new BadMethodCallException('This cache store does not support locks.');
         }
 
-        return $this->repository->restoreLock(...func_get_args());
+        return $this->repository->getStore()->restoreLock(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -186,11 +186,11 @@ class MemoizedStore implements LockProvider, Store
      */
     public function restoreLock($name, $owner)
     {
-        if (! $this->repository instanceof LockProvider) {
+        if (! $this->repository->getStore() instanceof LockProvider) {
             throw new BadMethodCallException('This cache store does not support locks.');
         }
 
-        return $this->repository->resoreLock(...func_get_args());
+        return $this->repository->restoreLock(...func_get_args());
     }
 
     /**

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -514,4 +514,13 @@ class MemoizedStoreTest extends TestCase
 
         $this->assertSame('value-2', $value);
     }
+
+    public function test_it_supports_restore_lock()
+    {
+        $owner = Cache::lock('foo', 10)->owner();
+
+        $restoredLock = Cache::memo()->restoreLock('foo', $owner);
+
+        $this->assertSame($owner, $restoredLock->owner());
+    }
 }


### PR DESCRIPTION
Noticed a typo which led me to the below:

- Should be `restoreLock` not `resoreLock`
- The restoreLock method should also be called on the store, rather than the repository  - keeping it consistent with the lock() method since LockProvider is a store interface
- Added a test


