### PR TITLE
Add missing chain method to interface

### DIFF
--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -4,7 +4,7 @@ namespace Illuminate\Contracts\Bus;
 
 interface Dispatcher
 {
-     /**
+    /**
      * Create a new chain of queueable jobs.
      *
      * @param  \Illuminate\Support\Collection|array|null  $jobs

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -4,6 +4,14 @@ namespace Illuminate\Contracts\Bus;
 
 interface Dispatcher
 {
+     /**
+     * Create a new chain of queueable jobs.
+     *
+     * @param  \Illuminate\Support\Collection|array|null  $jobs
+     * @return mixed
+     */
+    public function chain($jobs = null);
+
     /**
      * Dispatch a command to its appropriate handler.
      *


### PR DESCRIPTION
Maybe there is a reason, but I was missing the chain method in the Dispatcher interface.