### PR TITLE
[13.x] add dispatchAfterResponse to the Dispatcher Contract

### DIFF
--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -13,15 +13,6 @@ interface Dispatcher
     public function dispatch($command);
 
     /**
-     * Dispatch a command to its appropriate handler after the current process.
-     *
-     * @param  mixed  $command
-     * @param  mixed  $handler
-     * @return void
-     */
-    public function dispatchAfterResponse($command, $handler = null);
-
-    /**
      * Dispatch a command to its appropriate handler in the current process.
      *
      * Queueable jobs will be dispatched to the "sync" queue.
@@ -40,6 +31,15 @@ interface Dispatcher
      * @return mixed
      */
     public function dispatchNow($command, $handler = null);
+
+    /**
+     * Dispatch a command to its appropriate handler after the current process.
+     *
+     * @param  mixed  $command
+     * @param  mixed  $handler
+     * @return void
+     */
+    public function dispatchAfterResponse($command, $handler = null);
 
     /**
      * Determine if the given command has a handler.

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -13,6 +13,15 @@ interface Dispatcher
     public function dispatch($command);
 
     /**
+     * Dispatch a command to its appropriate handler after the current process.
+     *
+     * @param  mixed  $command
+     * @param  mixed  $handler
+     * @return void
+     */
+    public function dispatchAfterResponse($command, $handler = null);
+
+    /**
      * Dispatch a command to its appropriate handler in the current process.
      *
      * Queueable jobs will be dispatched to the "sync" queue.

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -13,7 +13,7 @@ interface Dispatcher
     public function dispatch($command);
 
     /**
-     * Dispatch a command to its appropriate handler after the current process.
+     * Dispatch a command to its appropriate handler after the current process
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -13,7 +13,7 @@ interface Dispatcher
     public function dispatch($command);
 
     /**
-     * Dispatch a command to its appropriate handler after the current process
+     * Dispatch a command to its appropriate handler after the current process.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -716,17 +716,18 @@ class BusFake implements Fake, QueueingDispatcher
     }
 
     /**
-     * Dispatch a command to its appropriate handler.
+     * Dispatch a command to its appropriate handler after the current process.
      *
      * @param  mixed  $command
-     * @return mixed
+     * @param  mixed  $handler
+     * @return void
      */
-    public function dispatchAfterResponse($command)
+    public function dispatchAfterResponse($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
             $this->commandsAfterResponse[get_class($command)][] = $this->getCommandRepresentation($command);
         } else {
-            return $this->dispatcher->dispatch($command);
+            return $this->dispatcher->dispatchAfterResponse($command, $handler);
         }
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -727,7 +727,7 @@ class BusFake implements Fake, QueueingDispatcher
         if ($this->shouldFakeJob($command)) {
             $this->commandsAfterResponse[get_class($command)][] = $this->getCommandRepresentation($command);
         } else {
-            return $this->dispatcher->dispatchAfterResponse($command, $handler);
+            $this->dispatcher->dispatchAfterResponse($command, $handler);
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -855,7 +855,7 @@ class SupportTestingBusFakeTest extends TestCase
         });
     }
 
-    public function testDispatchAfterResponsePassesThroughWithHandler()
+    public function testDispatchAfterResponseWithHandler()
     {
         $dispatcher = m::mock(QueueingDispatcher::class);
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -854,6 +854,22 @@ class SupportTestingBusFakeTest extends TestCase
             return $batchedCollection->jobs->count() === 1 && $batchedCollection->jobs->first()->value === 'hello';
         });
     }
+
+    public function testDispatchAfterResponsePassesThroughWithHandler()
+    {
+        $dispatcher = m::mock(QueueingDispatcher::class);
+
+        $job = new BusJobStub;
+        $handler = function ($job) {
+            return 'handled';
+        };
+
+        $dispatcher->shouldReceive('dispatchAfterResponse')->once()->with($job, $handler);
+
+        $fake = (new BusFake($dispatcher))->except(BusJobStub::class);
+
+        $fake->dispatchAfterResponse($job, $handler);
+    }
 }
 
 class BusJobStub

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -857,18 +857,14 @@ class SupportTestingBusFakeTest extends TestCase
 
     public function testDispatchAfterResponseWithHandler()
     {
-        $dispatcher = m::mock(QueueingDispatcher::class);
-
         $job = new BusJobStub;
-        $handler = function ($job) {
+        $handler = function () {
             return 'handled';
         };
 
-        $dispatcher->shouldReceive('dispatchAfterResponse')->once()->with($job, $handler);
+        $this->fake->dispatchAfterResponse($job, $handler);
 
-        $fake = (new BusFake($dispatcher))->except(BusJobStub::class);
-
-        $fake->dispatchAfterResponse($job, $handler);
+        $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
     }
 }
 


### PR DESCRIPTION
So, this method has been a thing for 7 years.

Feels nice to add to the contract after that long?

In adding to the contract, it highlighted the fake wasn't correct - so i've adjusted.

Have added a test to cover the fake, unlikely it'll ever be used - but follows consistency.

Could be reason it's not aligned, but dunno 

Targeted 13.x due to interface change.