### PR TITLE
[12.x] chore: make PruneCommand::isPrunable() protected

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -187,7 +187,7 @@ class PruneCommand extends Command
      * @param  string  $model
      * @return bool
      */
-    private function isPrunable(string $model)
+    protected function isPrunable(string $model)
     {
         return class_exists($model)
             && is_a($model, Model::class, true)


### PR DESCRIPTION
Hello!

I extend this command in my application because I need to handle namespace mapping for models that are in Laravel modules, and I need to call this from inside the child class---all of the other methods are protected, there's no reason for this one to be private.

Thanks!