### PR TITLE
[12.x] add BatchFinished event

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -4,6 +4,9 @@ namespace Illuminate\Bus;
 
 use Carbon\CarbonImmutable;
 use Closure;
+use Illuminate\Bus\Events\BatchFinished;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Queue\CallQueuedClosure;
@@ -247,6 +250,12 @@ class Batch implements Arrayable, JsonSerializable
 
         if ($counts->pendingJobs === 0) {
             $this->repository->markAsFinished($this->id);
+
+            $container = Container::getInstance();
+
+            if ($container->bound(Dispatcher::class)) {
+                $container->make(Dispatcher::class)->dispatch(new BatchFinished($this));
+            }
         }
 
         if ($counts->pendingJobs === 0 && $this->hasThenCallbacks()) {

--- a/src/Illuminate/Bus/Events/BatchFinished.php
+++ b/src/Illuminate/Bus/Events/BatchFinished.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Bus\Events;
+
+use Illuminate\Bus\Batch;
+
+class BatchFinished
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
+     */
+    public function __construct(
+        public Batch $batch,
+    ) {
+    }
+}

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -339,12 +339,14 @@ class ComponentTagCompiler
                     ? Str::after($component, $delimiter)
                     : $component;
 
-                if (! is_null($guess = match (true) {
+                $guess = match (true) {
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent) => $guess,
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.index') => $guess,
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.'.Str::afterLast($formattedComponent, '.')) => $guess,
                     default => null,
-                })) {
+                };
+
+                if (! is_null($guess)) {
                     return $guess;
                 }
             } catch (InvalidArgumentException) {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -339,14 +339,12 @@ class ComponentTagCompiler
                     ? Str::after($component, $delimiter)
                     : $component;
 
-                $guess = match (true) {
+                if (! is_null($guess = match (true) {
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent) => $guess,
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.index') => $guess,
                     $viewFactory->exists($guess = $path['prefixHash'].$delimiter.$formattedComponent.'.'.Str::afterLast($formattedComponent, '.')) => $guess,
                     default => null,
-                };
-
-                if (! is_null($guess)) {
+                })) {
                     return $guess;
                 }
             } catch (InvalidArgumentException) {

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -257,8 +257,7 @@ class BusBatchTest extends TestCase
 
     public function test_batch_finished_event_is_dispatched()
     {
-        $events = m::mock(EventDispatcher::class);
-        Container::getInstance()->instance(EventDispatcher::class, $events);
+        Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
 
         $queue = m::mock(Factory::class);
         $batch = $this->createTestBatch($queue);
@@ -276,9 +275,7 @@ class BusBatchTest extends TestCase
 
         $batch = $batch->add([$job]);
 
-        $events->shouldReceive('dispatch')
-            ->once()
-            ->with(m::on(function ($event) use ($batch) {
+        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
                 return $event instanceof BatchFinished && $event->batch === $batch;
             }));
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -389,7 +389,6 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->jobs->contains($secondJob));
     }
 
-
     public function test_failure_callbacks_execute_correctly(): void
     {
         $queue = m::mock(Factory::class);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -276,8 +276,8 @@ class BusBatchTest extends TestCase
         $batch = $batch->add([$job]);
 
         $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
-                return $event instanceof BatchFinished && $event->batch === $batch;
-            }));
+            return $event instanceof BatchFinished && $event->batch === $batch;
+        }));
 
         $batch->recordSuccessfulJob('test-id');
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -8,10 +8,12 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchFactory;
 use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Capsule\Manager as DB;
@@ -253,6 +255,36 @@ class BusBatchTest extends TestCase
         $this->assertEquals(1, $_SERVER['__then.count']);
     }
 
+    public function test_batch_finished_event_is_dispatched()
+    {
+        $events = m::mock(EventDispatcher::class);
+        Container::getInstance()->instance(EventDispatcher::class, $events);
+
+        $queue = m::mock(Factory::class);
+        $batch = $this->createTestBatch($queue);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+
+        $queue->shouldReceive('connection')->once()
+            ->with('test-connection')
+            ->andReturn($connection = m::mock(stdClass::class));
+
+        $connection->shouldReceive('bulk')->once();
+
+        $batch = $batch->add([$job]);
+
+        $events->shouldReceive('dispatch')
+            ->once()
+            ->with(m::on(function ($event) use ($batch) {
+                return $event instanceof BatchFinished && $event->batch === $batch;
+            }));
+
+        $batch->recordSuccessfulJob('test-id');
+    }
+
     public function test_failed_jobs_can_be_recorded_while_not_allowing_failures()
     {
         $queue = m::mock(Factory::class);
@@ -356,6 +388,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->jobs->contains($job));
         $this->assertTrue($batch->jobs->contains($secondJob));
     }
+
 
     public function test_failure_callbacks_execute_correctly(): void
     {


### PR DESCRIPTION
So, we have a [BatchDispatched ](https://github.com/laravel/framework/blob/93686c3b428bdc0d3a1ec7c2d7024869252b3e28/src/Illuminate/Bus/Events/BatchDispatched.php#L7) event, which we can hook into to find out when a batch was dispatched...

It would be nice to have a BatchFinished event too- that way we don't need to poll or even look at the DB to find out when its finished,  and we can make it available for metrics / logging etc.

### Why not just use the finally() callback?

Cause you have to remember to add it every time you create a batch, and if you're an infra man you just wanna see the metrics! 

With this event you can listen for it globally and handle all batch completions in one place useful for logging, metrics, notifications etc.

Not sure if it's a 100% great fit in the Batch class, but didn't want to go into the repositories - so this seems to fit in with some other places.

Happy to move to 13.x if you deem risky 🫡 