### PR TITLE
[12.x] feat: query builder aliases for expressions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -292,6 +292,8 @@ class Builder implements BuilderContract
         foreach ($columns as $as => $column) {
             if (is_string($as) && $this->isQueryable($column)) {
                 $this->selectSub($column, $as);
+            } elseif (is_string($as) && $this->grammar->isExpression($column)) {
+                $this->selectExpression($column, $as);
             } else {
                 $this->columns[] = $column;
             }
@@ -315,6 +317,20 @@ class Builder implements BuilderContract
 
         return $this->selectRaw(
             '('.$query.') as '.$this->grammar->wrap($as), $bindings
+        );
+    }
+
+    /**
+     * Add a select expression to the query.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression  $expression
+     * @param  string  $as
+     * @return $this
+     */
+    public function selectExpression($expression, $as)
+    {
+        return $this->selectRaw(
+            '('.$expression->getValue($this->grammar).') as '.$this->grammar->wrap($as)
         );
     }
 
@@ -447,6 +463,8 @@ class Builder implements BuilderContract
                 }
 
                 $this->selectSub($column, $as);
+            } elseif (is_string($as) && $this->grammar->isExpression($column)) {
+                $this->selectExpression($column, $as);
             } else {
                 if (is_array($this->columns) && in_array($column, $this->columns, true)) {
                     continue;


### PR DESCRIPTION
Currently, you can add subqueries to a query builder with an alias.

```php
// select (select "allowed_to_x" from "configuration") as "sub" from "users"
User::select([
    'sub' => Configuration::select('allowed_to_x'),
]);
```

But the same is not yet possible for expressions There's just no way to define an alias. This PR fixes this
```php
// current: select available_a - used_a from "users"
// with pr: select (available_a - used_a) as "remaining_a" from "users"
User::select([
    'remaining_a' => new Expression('available_a - used_a'),
]);
```

---

So this PR changes:
* adds `selectExpression` (like `selectSub`)
* adds expression alias support to `select`
* adds expression alias support to `addSelect`
* adds units to test the behaviour of array keys for `select` and `addSelect` which was not covered yet