### PR TITLE
[12.x] widen PendingRequest@pool() return type

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -934,7 +934,7 @@ class PendingRequest
      *
      * @param  (callable(\Illuminate\Http\Client\Pool): mixed)  $callback
      * @param  non-negative-int|null  $concurrency
-     * @return array<array-key, \Illuminate\Http\Client\Response|\Illuminate\Http\Client\ConnectionException|\Illuminate\Http\Client\RequestException>
+     * @return array<array-key, \Illuminate\Http\Client\Response|\Throwable>
      */
     public function pool(callable $callback, ?int $concurrency = null)
     {


### PR DESCRIPTION
Now that we allow any Throwable inside of an async function, we should account for that in the `pool()` docblocks.