### PR TITLE
[12.x] Clean up compiled views after parallel testing

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestViews.php
+++ b/src/Illuminate/Testing/Concerns/TestViews.php
@@ -32,6 +32,12 @@ trait TestViews
                 $this->switchToCompiledViewPath($path);
             }
         });
+
+        ParallelTesting::tearDownProcess(function () {
+            if ($path = $this->parallelSafeCompiledViewPath()) {
+                File::deleteDirectory($path);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Amendment to #58390 after a point was raised by @andreasnij 

This PR adds cleanup of the test-specific compiled view directories (`test_1/`, `test_2/`, etc.) when parallel test processes finish, following the same pattern used by `TestDatabases` for dropping test databases.