### PR TITLE
[12.x] Support "where subquery between columns"

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1544,6 +1544,13 @@ class Builder implements BuilderContract
     {
         $type = 'betweenColumns';
 
+        if ($this->isQueryable($column)) {
+            [$sub, $bindings] = $this->createSub($column);
+
+            return $this->addBinding($bindings, 'where')
+                ->whereBetweenColumns(new Expression('('.$sub.')'), $values, $boolean, $not);
+        }
+
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 
         return $this;


### PR DESCRIPTION
A follow-up to https://github.com/laravel/framework/pull/58290. In that PR I made it possible to add "where subquery between values" clauses to the query builder:
```php
$query->whereBetween($subquery, [$minValue, $maxValue])
```
In this PR, I add support for adding "where subquery between columns" clauses to a the query builder:
```php
$query->whereBetweenColumns($subquery, ['min_value_column', 'max_value_column']);
```