### PR TITLE
[12.x] Use searchable prompt for db:table command

### DIFF
--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -43,6 +43,7 @@ class TableCommand extends DatabaseInspectionCommand
             ->keyBy('schema_qualified_name')->all();
 
         $tableNames = (new Collection($tables))->keys();
+
         $tableName = $this->argument('table') ?: search(
             'Which table would you like to inspect?',
             fn (string $query) => $tableNames

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Number;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-use function Laravel\Prompts\select;
+use function Laravel\Prompts\search;
 
 #[AsCommand(name: 'db:table')]
 class TableCommand extends DatabaseInspectionCommand
@@ -42,9 +42,13 @@ class TableCommand extends DatabaseInspectionCommand
         $tables = (new Collection($connection->getSchemaBuilder()->getTables()))
             ->keyBy('schema_qualified_name')->all();
 
-        $tableName = $this->argument('table') ?: select(
+        $tableName = $this->argument('table') ?: search(
             'Which table would you like to inspect?',
-            array_keys($tables)
+            fn (string $query) => (new Collection($tables))
+                ->keys()
+                ->filter(fn ($table) => str_contains(strtolower($table), strtolower($query)))
+                ->values()
+                ->all()
         );
 
         $table = $tables[$tableName] ?? (new Collection($tables))->when(

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -42,10 +42,10 @@ class TableCommand extends DatabaseInspectionCommand
         $tables = (new Collection($connection->getSchemaBuilder()->getTables()))
             ->keyBy('schema_qualified_name')->all();
 
+        $tableNames = (new Collection($tables))->keys();
         $tableName = $this->argument('table') ?: search(
             'Which table would you like to inspect?',
-            fn (string $query) => (new Collection($tables))
-                ->keys()
+            fn (string $query) => $tableNames
                 ->filter(fn ($table) => str_contains(strtolower($table), strtolower($query)))
                 ->values()
                 ->all()


### PR DESCRIPTION
## Description
This PR updates the `php artisan db:table` command to use the `search` prompt instead of `select`.

## Why
Currently, the db:table command uses a standard list selection. In applications with large database schemas (50+ tables), finding a specific table requires scrolling through the entire list. The current select component does not support filtering by typing.

## Demo

| Before (Standard Scrolling) | After (Searchable) |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/402c2c45-7f71-4392-9894-061e483d6111) | ![After](https://github.com/user-attachments/assets/4a11fadf-0953-41ad-b772-7dfb03ff3c1b) |

## Implementation Details
- I have optimized the logic by generating the collection of table names once, outside the search closure.
- Ensures ->values() is called on the collection to prevent array key issues within the prompt component.