### PR TITLE
[12.x] Add preserveKeys method to AnonymousResourceCollection

### DIFF
--- a/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/AnonymousResourceCollection.php
@@ -30,4 +30,14 @@ class AnonymousResourceCollection extends ResourceCollection
 
         parent::__construct($resource);
     }
+
+    /**
+     * Indicate that the collection keys should be preserved.
+     */
+    public function preserveKeys(bool $value = true): static
+    {
+        $this->preserveKeys = $value;
+
+        return $this;
+    }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1525,6 +1525,26 @@ class ResourceTest extends TestCase
         $response->assertJson(['data' => $data->toArray()]);
     }
 
+    public function testKeysArePreservedInAnAnonymousCollectionUsingPreserveKeysMethod()
+    {
+        $data = Collection::make([
+            ['id' => 1, 'title' => 'Test'],
+            ['id' => 2, 'title' => 'Test 2'],
+        ])->keyBy->id;
+
+        Route::get('/', function () use ($data) {
+            return JsonResource::collection($data)->preserveKeys();
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson(['data' => $data->toArray()]);
+    }
+
     public function testLeadingMergeKeyedValueIsMergedCorrectly()
     {
         $filter = new class


### PR DESCRIPTION
Hey!

This method allows chaining preserveKeys() directly when returning a resource collection, instead of having to store the collection in a variable and manually set the property.

Before:
```php
$collection = JsonResource::collection($posts);
$collection->preserveKeys = true;
return $collection;
```
After:
```php
return JsonResource::collection($posts)->preserveKeys();
```
Cheers!