### PR TITLE
[12.x] Allow enum keys in Cache::flexible() and withoutOverlapping()

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -491,7 +491,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  array{ 0: \DateTimeInterface|\DateInterval|int, 1: \DateTimeInterface|\DateInterval|int }  $ttl
      * @param  (callable(): TCacheValue)  $callback
      * @param  array{ seconds?: int, owner?: string }|null  $lock
@@ -500,6 +500,8 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function flexible($key, $ttl, $callback, $lock = null, $alwaysDefer = false)
     {
+        $key = enum_value($key);
+
         [
             $key => $value,
             "illuminate:cache:flexible:created:{$key}" => $created,
@@ -543,7 +545,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TReturn
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  callable(): TReturn  $callback
      * @param  int  $lockFor
      * @param  int  $waitFor
@@ -554,7 +556,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function withoutOverlapping($key, callable $callback, $lockFor = 0, $waitFor = 10, $owner = null)
     {
-        return $this->store->lock($key, $lockFor, $owner)->block($waitFor, $callback);
+        return $this->store->lock(enum_value($key), $lockFor, $owner)->block($waitFor, $callback);
     }
 
     /**
@@ -794,7 +796,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  string  $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -805,7 +807,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache for the default time.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  string  $key
      * @param  mixed  $value
      * @return void
      */

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -785,7 +785,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if a cached value exists.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -796,7 +796,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -807,7 +807,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache for the default time.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */
@@ -819,7 +819,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return void
      */
     public function offsetUnset($key): void

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -321,8 +321,6 @@ class RepositoryTest extends TestCase
         // flexible / withoutOverlapping
         $this->assertSame('flexible', $cache->flexible(TestCacheKey::FOO, [5, 10], fn () => 'flexible'));
         $this->assertSame('overlapping', $cache->withoutOverlapping(TestCacheKey::FOO, fn () => 'overlapping'));
-        $this->assertTrue($cache->offsetExists(TestCacheKey::BAR));
-        $cache->offsetUnset(TestCacheKey::BAR);
     }
 }
 

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -319,18 +319,10 @@ class RepositoryTest extends TestCase
         $this->assertNull($cache->get(TestCacheKey::FOO));
 
         // flexible / withoutOverlapping
-        $value = $cache->flexible(
-            TestCacheKey::FOO,
-            [5, 10],
-            fn () => 'flexible'
-        );
-        $this->assertSame('flexible', $value);
-
-        $result = $cache->withoutOverlapping(
-            TestCacheKey::FOO,
-            fn () => 'overlapping'
-        );
-        $this->assertSame('overlapping', $result);
+        $this->assertSame('flexible', $cache->flexible(TestCacheKey::FOO, [5, 10], fn () => 'flexible'));
+        $this->assertSame('overlapping', $cache->withoutOverlapping(TestCacheKey::FOO, fn () => 'overlapping'));
+        $this->assertTrue($cache->offsetExists(TestCacheKey::BAR));
+        $cache->offsetUnset(TestCacheKey::BAR);
     }
 }
 

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -317,6 +317,20 @@ class RepositoryTest extends TestCase
         $cache->put(TestCacheKey::FOO, 'x');
         $this->assertTrue($cache->forget(TestCacheKey::FOO));
         $this->assertNull($cache->get(TestCacheKey::FOO));
+
+        // flexible / withoutOverlapping
+        $value = $cache->flexible(
+            TestCacheKey::FOO,
+            [5, 10],
+            fn () => 'flexible'
+        );
+        $this->assertSame('flexible', $value);
+
+        $result = $cache->withoutOverlapping(
+            TestCacheKey::FOO,
+            fn () => 'overlapping'
+        );
+        $this->assertSame('overlapping', $result);
     }
 }
 


### PR DESCRIPTION
Me again

`Cache::flexible()` and `withoutOverlapping()` didn't support support enums, so adjusted / added tests for consistency with everything else.

Also noticed two of the offset method docs were missing enum types, so added.
 (Valuable if anyone is calling it directly I guess unlikely, but possible such as `Cache::driver('x')->offsetUnset(...)`)

I think this now covers everything here enum wise.

Thanks