### PR TITLE
[12.x] keep single NotificationSender instance

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -29,6 +29,13 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     protected $locale;
 
     /**
+     * The locale used when sending notifications.
+     *
+     * @var \Illuminate\Notifications\NotificationSender|null
+     */
+    protected $notificationSender;
+
+    /**
      * Send the given notification to the given notifiable entities.
      *
      * @param  \Illuminate\Support\Collection|mixed  $notifiables
@@ -37,9 +44,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function send($notifiables, $notification)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->send($notifiables, $notification);
+        $this->resolveNotificationSender()->send($notifiables, $notification);
     }
 
     /**
@@ -52,9 +57,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     public function sendNow($notifiables, $notification, ?array $channels = null)
     {
-        (new NotificationSender(
-            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
-        )->sendNow($notifiables, $notification, $channels);
+        $this->resolveNotificationSender()->sendNow($notifiables, $notification, $channels);
     }
 
     /**
@@ -117,6 +120,18 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
 
             throw $e;
         }
+    }
+
+    /**
+     * Resolve the NotificationSender instance.
+     *
+     * @return \Illuminate\Notifications\NotificationSender
+     */
+    protected function resolveNotificationSender()
+    {
+        return $this->notificationSender ??= new NotificationSender(
+            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale
+        );
     }
 
     /**

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -15,6 +15,13 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     use Macroable;
 
     /**
+     * The resolved notification sender instance.
+     *
+     * @var \Illuminate\Notifications\NotificationSender|null
+     */
+    protected $notificationSender;
+
+    /**
      * The default channel used to deliver messages.
      *
      * @var string
@@ -27,13 +34,6 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @var string|null
      */
     protected $locale;
-
-    /**
-     * The locale used when sending notifications.
-     *
-     * @var \Illuminate\Notifications\NotificationSender|null
-     */
-    protected $notificationSender;
 
     /**
      * Send the given notification to the given notifiable entities.

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -149,6 +149,49 @@ class NotificationChannelManagerTest extends TestCase
         $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
     }
 
+    public function testNotificationFailedDispatchedOnlyOnceWhenMultipleFailed()
+    {
+        $this->expectException(Exception::class);
+
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Dispatcher::class, $events = m::mock(Dispatcher::class));
+        Container::setInstance($container);
+        $manager = $container->make(ChannelManager::class, ['container' => $container]);
+        $manager->extend('test', function () use ($events) {
+            return new class($events) {
+                private $count = 0;
+
+                public function __construct(private $events) {}
+
+                public function send($notifiable, Notification $notification)
+                {
+                    if ($this->count > 1) {
+                        throw new \Exception();
+                    }
+
+                    $this->count++;
+                }
+            };
+        });
+        $listeners = new Collection();
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $events->shouldReceive('listen')->once()->andReturnUsing(function ($event, $callback) use ($listeners) {
+            $listeners->push($callback);
+        });
+        $events->shouldReceive('dispatch')->once()->with(m::type(NotificationFailed::class))->andReturnUsing(function ($event) use ($listeners) {
+            foreach ($listeners as $listener) {
+                $listener($event);
+            }
+        });
+        $events->shouldReceive('dispatch')->twice()->with(m::type(NotificationSent::class));
+
+        $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
+        $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
+        $manager->send(new NotificationChannelManagerTestNotifiable, new NotificationChannelManagerTestNotification);
+    }
+
     public function testNotificationCanBeQueued()
     {
         $container = new Container;


### PR DESCRIPTION
PR #55507, authored by me, added logic to ensure the `Illuminate\Notifications\Events\NotificationFailed` is dispatched whenever a notification failed and also guard against double sending the same event in case a 3rd-party channel was already manually dispatching that event.

As noted by discussion #58434, the `Illuminate\Notifications\ChannelManager` always `new` up a new instance of the `Illuminate\Notifications\NotificationSender` class, and as such, a new listener for the `Illuminate\Notifications\Events\NotificationFailed` is registered times for each instance.

In a case where multiple notifications are sent, but then down the road one fails, those multiple listeners were invoked. 

The current approach also prevents garbage collection of the `Illuminate\Notifications\NotificationSender` instances, as the registered listener would prevent those instances from being collected/destructed.

In a scenario where an artisan command is scheduled to send multiple notifications for several users, that could lead to a memory overflow.


**This PR**

- Keeps a single instance of `Illuminate\Notifications\NotificationSender` on the `Illuminate\Notifications\ChannelManager`.
- Adds a test case to ensure the listener registered by the `Illuminate\Notifications\NotificationSender` instance is just called once even after multiple notifications were sent.


Notes:

- As `Illuminate\Notifications\ChannelManager` is already registered as a singleton, that will only instantiate a single `Illuminate\Notifications\NotificationSender` instance per life cycle.
- With a single `Illuminate\Notifications\NotificationSender` instance, only one listener is reg

---

Thanks @macropay-solutions for the heads-up.

