### PR TITLE
[13.x] Ensure PendingBatch isn't dispatched if theres no jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-#    branches:
-#      - master
-#      - '*.x'
-#  pull_request:
-#  schedule:
-#    - cron: '0 0 * * *'
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-    branches:
-      - master
-      - '*.x'
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+#    branches:
+#      - master
+#      - '*.x'
+#  pull_request:
+#  schedule:
+#    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -360,12 +360,16 @@ class PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Bus\Batch|null
      *
      * @throws \Throwable
      */
     public function dispatch()
     {
+        if ($this->jobs->isEmpty()) {
+            return null;
+        }
+
         $repository = $this->container->make(BatchRepository::class);
 
         try {
@@ -390,10 +394,14 @@ class PendingBatch
     /**
      * Dispatch the batch after the response is sent to the browser.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Bus\Batch|null
      */
     public function dispatchAfterResponse()
     {
+        if ($this->jobs->isEmpty()) {
+            return null;
+        }
+
         $repository = $this->container->make(BatchRepository::class);
 
         $batch = $this->store($repository);

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -775,7 +775,9 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function dispatchFakeBatch($name = '')
     {
-        return $this->batch([])->name($name)->dispatch();
+        return $this->recordPendingBatch(
+            $this->batch([])->name($name)
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -29,10 +29,14 @@ class PendingBatchFake extends PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Bus\Batch|null
      */
     public function dispatch()
     {
+        if ($this->jobs->isEmpty()) {
+            return null;
+        }
+
         return $this->bus->recordPendingBatch($this);
     }
 
@@ -43,6 +47,10 @@ class PendingBatchFake extends PendingBatch
      */
     public function dispatchAfterResponse()
     {
+        if ($this->jobs->isEmpty()) {
+            return null;
+        }
+
         return $this->bus->recordPendingBatch($this);
     }
 }

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -392,6 +392,44 @@ class BusPendingBatchTest extends TestCase
 
         $this->assertCount(2, $anotherBatch->failureCallbacks());
     }
+
+    public function test_batch_is_not_dispatched_when_empty()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $pendingBatch = new PendingBatch($container, new Collection([]));
+
+        $repository = m::mock(BatchRepository::class);
+        $repository->shouldNotReceive('store');
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatch();
+
+        $this->assertNull($result);
+    }
+
+    public function test_batch_is_not_dispatched_after_response_when_empty()
+    {
+        $container = new Container;
+
+        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+        $container->instance(Dispatcher::class, $eventDispatcher);
+
+        $pendingBatch = new PendingBatch($container, new Collection([]));
+
+        $repository = m::mock(BatchRepository::class);
+        $repository->shouldNotReceive('store');
+        $container->instance(BatchRepository::class, $repository);
+
+        $result = $pendingBatch->dispatchAfterResponse();
+
+        $this->assertNull($result);
+    }
 }
 
 class BatchableJob

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -860,6 +860,22 @@ class SupportTestingBusFakeTest extends TestCase
 
         $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
     }
+
+    public function testDoesNotDispatchEmptyBatch()
+    {
+        $batch = $this->fake->batch([])->dispatch();
+
+        $this->assertNull($batch);
+        $this->fake->assertNothingBatched();
+    }
+
+    public function testDoesNotDispatchEmptyBatchAfterResponse()
+    {
+        $batch = $this->fake->batch([])->dispatchAfterResponse();
+
+        $this->assertNull($batch);
+        $this->fake->assertNothingBatched();
+    }
 }
 
 class BusJobStub

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -34,7 +34,7 @@ class SupportTestingBusFakeTest extends TestCase
 
         $this->assertNull($fake->findBatch('non-existent-batch'));
 
-        $batch = $fake->batch([])->dispatch();
+        $batch = $fake->batch([new BusJobStub])->dispatch();
 
         $this->assertSame($batch, $fake->findBatch($batch->id));
         $this->assertSame($batch, $busRepository->find($batch->id));
@@ -733,14 +733,14 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->assertNull($this->fake->findBatch('non-existent-batch'));
 
-        $batch = $this->fake->batch([])->dispatch();
+        $batch = $this->fake->batch([new BusJobStub])->dispatch();
 
         $this->assertSame($batch, $this->fake->findBatch($batch->id));
     }
 
     public function testBatchesCanBeCancelled()
     {
-        $batch = $this->fake->batch([])->dispatch();
+        $batch = $this->fake->batch([new BusJobStub])->dispatch();
 
         $this->assertFalse($batch->cancelled());
 


### PR DESCRIPTION
Currently, a batch is dispatched and saved even when they contain no jobs. The batch method currently allows falsy items.

So, imagine the following:

```php
foreach ($users as $user) {
    $jobs = $user->transactions->map(function ($transaction) {
        return $transaction->needsProcessing() 
            ? new ProcessTransaction($transaction) 
            : null;
    });
    
    // One user may have no transactions that need processing...
    // $jobs = [null, null, null];
    
    Bus::batch($jobs)
        ->name("Process transactions for {$user->username}")
        ->dispatch(); // Still creates an empty batch in the DB and will be picked up / worked on.
}
```

This PR prevents unnecessary dispatches.

`dispatch()` and `dispatchAfterResponse()` now return null if there's no jobs. Like other dispatch methods (such as the event dispatcher) 
 
Updated / added tests which hopefully cover it.

I've targeted 13.x as could be a B/C / probably need docs to be updated for 13.x (to say it can return null)- but can port to 12.x if you deem sensible.

Feels like this should be the expected behaviour as I guess people wouldn't realise this is happening, but open to your feedback ofc.

If merged, I guess next steps are to add an event for when there's no jobs, just incase people need some specific behavior. 

Thanks!

