### PR TITLE
[12.x] Support dot notation for nested relations in relationLoaded method

### DIFF
--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -279,6 +279,48 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertTrue($model->isRelation('parent'));
         $this->assertFalse($model->isRelation('field'));
     }
+
+    public function testRelationLoadedWithNestedRelations()
+    {
+        $model = new EloquentRelationResetModelStub;
+        $related = new EloquentRelationResetModelStub;
+        $nested = new EloquentRelationResetModelStub;
+
+        $this->assertFalse($model->relationLoaded('related.nested'));
+
+        $model->setRelation('related', $related);
+        $this->assertFalse($model->relationLoaded('related.nested'));
+
+        $related->setRelation('nested', $nested);
+        $this->assertTrue($model->relationLoaded('related.nested'));
+    }
+
+    public function testRelationLoadedWithNullNestedRelation()
+    {
+        $model = new EloquentRelationResetModelStub;
+        $model->setRelation('related', null);
+
+        $this->assertTrue($model->relationLoaded('related.nested'));
+    }
+
+    public function testRelationLoadedWithCollectionRelation()
+    {
+        $model = new EloquentRelationResetModelStub;
+        $item1 = new EloquentRelationResetModelStub;
+        $item2 = new EloquentRelationResetModelStub;
+        $nested1 = new EloquentRelationResetModelStub;
+        $nested2 = new EloquentRelationResetModelStub;
+
+        $model->setRelation('items', new Collection([$item1, $item2]));
+
+        $this->assertFalse($model->relationLoaded('items.nested'));
+
+        $item1->setRelation('nested', $nested1);
+        $this->assertFalse($model->relationLoaded('items.nested'));
+
+        $item2->setRelation('nested', $nested2);
+        $this->assertTrue($model->relationLoaded('items.nested'));
+    }
 }
 
 class EloquentRelationResetModelStub extends Model


### PR DESCRIPTION
Hey!

This PR adds support for dot notation in the relationLoaded() method, allowing to check if nested relations are loaded.

Before: had to check each level manually
```php
if ($post->relationLoaded('author') 
    && $post->author?->relationLoaded('country')
    && $post->author->country?->relationLoaded('continent')) {
    $continent = $post->author->country->continent;
}
```
After: single call with dot notation
```php
if ($post->relationLoaded('author.country.continent')) {
    $continent = $post->author?->country?->continent;
}
```
This is particularly useful in API Resources where you often want to include relations only when they're loaded:

```php
public function toArray($request)
{
    return [
        'continent_name' => $this->when(
            $this->relationLoaded('author.country.continent'),
            fn () => $this->author?->country?->continent?->name
        ),
    ];
}
```
It also works with collection relations, returns true only if all items in the collection have the nested relation loaded. If a relation is null, it's considered as loaded (we can't go deeper anyway).

Let me know if you have any questions or if you'd like me to change anything!

---
It would be nice to also support dot notation in `whenLoaded()`, which currently doesn't work because it accesses the relationship value directly via `$this->resource->{$relationship}`. Should be a small change, happy to submit a follow-up PR if this one gets merged and you think it's a good idea.