### PR TITLE
12.x fix: use multibyte-safe functions in Str::afterLast()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -109,13 +109,13 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string) $search);
+        $position = mb_strrpos($subject, $search);
 
         if ($position === false) {
             return $subject;
         }
 
-        return substr($subject, $position + strlen($search));
+        return static::substr($subject, $position + static::length($search));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -441,6 +441,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('te', Str::afterLast('yv0et0te', 0));
         $this->assertSame('te', Str::afterLast('yv2et2te', 2));
         $this->assertSame('foo', Str::afterLast('----foo', '---'));
+        // Test with multibyte characters in search string
+        $this->assertSame('', Str::afterLast('café au café', 'café'));
+        $this->assertSame('', Str::afterLast('こんにちは世界こんにちは', 'こんにちは'));
     }
 
     #[DataProvider('strContainsProvider')]


### PR DESCRIPTION
## Problem

The `Str::afterLast()` method used byte-based string functions which don't properly handle multibyte UTF-8 characters:

| Function Used | Issue |
|---------------|-------|
| `strrpos()` | Returns byte position, not character position |
| `substr()` | Operates on bytes, not characters |
| `strlen()` | Returns byte count, not character count |

## Solution

Replace with multibyte-safe equivalents already used elsewhere in the `Str` class:

```php
// Before
$position = strrpos($subject, (string) $search);
return substr($subject, $position + strlen($search));

// After
$position = mb_strrpos($subject, $search);
return static::substr($subject, $position + static::length($search));
```

## Files Changed

- `src/Illuminate/Support/Str.php` - Fix implementation
- `tests/Support/SupportStrTest.php` - Add multibyte test cases

## Test Coverage

```php
$this->assertSame('', Str::afterLast('café au café', 'café'));
$this->assertSame('', Str::afterLast('こんにちは世界こんにちは', 'こんにちは'));
```
