### PR TITLE
[12.x] Ensure Session now() and flash() accept enums

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-#    branches:
-#      - master
-#      - '*.x'
-#  pull_request:
-#  schedule:
-#    - cron: '0 0 * * *'
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-    branches:
-      - master
-      - '*.x'
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+#    branches:
+#      - master
+#      - '*.x'
+#  pull_request:
+#  schedule:
+#    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
@@ -16,6 +17,7 @@ use Illuminate\Support\ViewErrorBag;
 use RuntimeException;
 use SessionHandlerInterface;
 use stdClass;
+use UnitEnum;
 
 use function Illuminate\Support\enum_value;
 
@@ -462,12 +464,14 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */
-    public function flash(string $key, $value = true)
+    public function flash(BackedEnum|UnitEnum|string $key, $value = true)
     {
+        $key = enum_value($key);
+
         $this->put($key, $value);
 
         $this->push('_flash.new', $key);
@@ -478,12 +482,14 @@ class Store implements Session
     /**
      * Flash a key / value pair to the session for immediate use.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */
     public function now($key, $value)
     {
+        $key = enum_value($key);
+
         $this->put($key, $value);
 
         $this->push('_flash.old', $key);

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -717,6 +717,20 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->has('user'));
     }
 
+    public function testBackedEnumKeyFlash()
+    {
+        $session = $this->getSession();
+        $session->flash(SessionTestKey::User, 'Taylor');
+        $this->assertTrue($session->has(SessionTestKey::User));
+    }
+
+    public function testBackedEnumKeyNow()
+    {
+        $session = $this->getSession();
+        $session->now(SessionTestKey::User, 'Taylor');
+        $this->assertTrue($session->has(SessionTestKey::User));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $session = $this->getSession();


### PR DESCRIPTION
Hi Big T, 

Noticed these were outliers and didn't support enums.. so with this we can now sleep easy.

Imported the enums due to flash being typed

Tests added.