### PR TITLE
Fix race condition in Filesystem::ensureDirectoryExists

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -640,7 +640,7 @@ class Filesystem
     public function ensureDirectoryExists($path, $mode = 0755, $recursive = true)
     {
         if (! $this->isDirectory($path)) {
-            $this->makeDirectory($path, $mode, $recursive);
+            $this->makeDirectory($path, $mode, $recursive, true);
         }
     }
 


### PR DESCRIPTION
This PR fixes a TOCTOU (Time-of-Check-Time-of-Use) race condition in `Filesystem::ensureDirectoryExists()`.

## Problem

When multiple processes concurrently call `ensureDirectoryExists()`, the following race can occur:

1. Process A checks `isDirectory($path)` - returns `false`
2. Process B checks `isDirectory($path)` - returns `false`
3. Process B calls `mkdir()` - succeeds
4. Process A calls `mkdir()` - throws `ErrorException: mkdir(): File exists`

This commonly happens during concurrent HTTP requests when views are being compiled, especially after running `view:clear` or `optimize:clear`.

## Solution

Pass `$force = true` to `makeDirectory()`, which suppresses the error when the directory already exists. The existence check still provides an optimization for the common case, but the force flag ensures concurrent processes don't fail.

## Impact

This change is backwards compatible. The method still creates the directory if it doesn't exist, but no longer throws an exception if another process created it between the check and the mkdir call.