### PR TITLE
[12.x] Add `hasSole()` method to collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -730,14 +730,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool
+     *
+     * @deprecated 12.49.0 Use the `hasSole()` method instead.
      */
     public function containsOneItem(?callable $callback = null): bool
     {
-        if ($callback) {
-            return $this->filter($callback)->count() === 1;
-        }
-
-        return $this->count() === 1;
+        return $this->hasSole($callback);
     }
 
     /**
@@ -1476,6 +1474,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         return $items->first();
+    }
+
+    /**
+     * Determine if the collection contains a single item, optionally matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasSole($key = null, $operator = null, $value = null): bool
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        return $this
+            ->unless($filter == null)
+            ->filter($filter)
+            ->count() === 1;
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -686,11 +686,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if the collection contains a single item.
      *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool
+     *
+     * @deprecated 12.49.0 Use the `hasSole()` method instead.
      */
-    public function containsOneItem()
+    public function containsOneItem(?callable $callback = null): bool
     {
-        return $this->take(2)->count() === 1;
+        return $this->hasSole($callback);
     }
 
     /**
@@ -1332,6 +1335,27 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             ->take(2)
             ->collect()
             ->sole();
+    }
+
+    /**
+     * Determine if the collection contains a single item or a single item matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasSole($key = null, $operator = null, $value = null): bool
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        return $this
+            ->unless($filter == null)
+            ->filter($filter)
+            ->take(2)
+            ->count() === 1;
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -81,6 +81,7 @@ trait EnumeratesValues
         'first',
         'flatMap',
         'groupBy',
+        'hasSole',
         'keyBy',
         'last',
         'map',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -147,6 +147,34 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testHasSole($collection)
+    {
+        $collection = new $collection([
+            ['age' => 2],
+            ['age' => 3],
+        ]);
+
+        $this->assertFalse($collection->hasSole());
+        $this->assertFalse($collection->where('age', 1)->hasSole());
+        $this->assertTrue($collection->where('age', 2)->hasSole());
+
+        $this->assertFalse($collection->hasSole(fn () => true));
+        $this->assertFalse($collection->hasSole(fn () => false));
+        $this->assertTrue($collection->hasSole(fn ($item) => $item['age'] === 2));
+
+        $this->assertFalse($collection->hasSole('age', '>', 1));
+        $this->assertFalse($collection->hasSole('age', '<', 1));
+        $this->assertTrue($collection->hasSole('age', 2));
+
+        $data = new $collection([
+            (object) ['active' => true, 'verified' => true],
+            (object) ['active' => false, 'verified' => true],
+        ]);
+
+        $this->assertFalse($data->hasSole->verified);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testFirstOrFailReturnsFirstItemInCollection($collection)
     {
         $collection = new $collection([

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -588,6 +588,23 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testHasSoleIsLazy()
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->hasSole();
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->hasSole(fn ($item) => $item <= 2);
+        });
+
+        $this->assertEnumeratesCollection(
+            LazyCollection::times(10, fn ($i) => ['age' => $i]),
+            2,
+            fn ($collection) => $collection->hasSole('age', '<=', 2),
+        );
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
This PR renames `containsOneItem()` to `hasSole()`, and adds callback and operator support.

## Background

Back in #36428, I added an `isSingle()` method to check if a collection contains exactly one item. Taylor later [renamed it](https://github.com/laravel/framework/commit/5b7ffc2b54dec803bd12541ab9c3d6bf3d4666ca) to `containsOneItem()` because—and I quote—"it's not a dating app" 😄

The problem is that `containsOneItem()` is actually *longer* than `count() === 1`, making the method rather pointless.

## New Method

Now that we have the [`sole()`](https://github.com/laravel/framework/pull/37034) nomenclature, we can add a `hasSole()` method that...

- Is shorter and more expressive than `containsOneItem()`
- Supports the same filter signatures as `sole()` (callback, key/value, and full operator syntax)

```php
$collection->hasSole();
$collection->hasSole(fn ($item) => $item->active);
$collection->hasSole('status', 'pending');
$collection->hasSole('age', '>=', 21);
```

## Deprecation

`containsOneItem()` is now deprecated and delegates to `hasSole()`.

## Laravel 13

After this is merged, and then merged into `master`, we'll add this method to the `Enumerable` interface, and remove the `containsOneItem()` method completely.
