### PR TITLE
[12.x] Use default mail config name when Address is created without 

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1739,7 +1739,9 @@ class Mailable implements MailableContract, Renderable
         $envelope = $this->envelope();
 
         if (isset($envelope->from)) {
-            $this->from($envelope->from->address, $envelope->from->name);
+            $name = $envelope->from->name ?? Container::getInstance()->get(ConfigRepository::class)->get('mail.from.name', null);
+
+            $this->from($envelope->from->address, $name);
         }
 
         foreach (['to', 'cc', 'bcc', 'replyTo'] as $type) {

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -18,7 +18,6 @@ class SendingMarkdownMailTest extends TestCase
         $app['config']->set('mail.driver', 'array');
         $app['config']->set('mail.from.name', 'Default Name');
 
-
         $app['view']->addNamespace('mail', __DIR__.'/Fixtures')
             ->addLocation(__DIR__.'/Fixtures');
     }

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -181,17 +181,6 @@ class SendingMarkdownMailTest extends TestCase
         $this->assertEquals('Default Name', $from[0]->getName());
     }
 
-    public function testNullEnvelopeFromNameDefaultsToGlobal()
-    {
-        Mail::to('test@mail.com')->send(new MailableWithNullName());
-
-        $from = app('mailer')->getSymfonyTransport()->messages()[0]->getOriginalMessage()->getFrom();
-
-        $this->assertCount(1, $from);
-        $this->assertEquals('taylor@laravel.com', $from[0]->getAddress());
-        $this->assertEquals('Default Name', $from[0]->getName());
-    }
-
     /**
      * Extract Content IDs from email for embedded image validation.
      *
@@ -354,25 +343,6 @@ class MailableWithNullAddressName extends Mailable
         );
     }
 }
-
-class MailableWithNullName extends Mailable
-{
-    public function envelope()
-    {
-        return new Envelope(
-            from: 'taylor@laravel.com',
-        );
-    }
-
-
-    public function content()
-    {
-        return new Content(
-            markdown: 'basic',
-        );
-    }
-}
-
 
 class MessageAsPublicPropertyMailable extends Mailable
 {

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -192,6 +192,7 @@ class SendingMarkdownMailTest extends TestCase
         $this->assertEquals('taylor@laravel.com', $from[0]->getAddress());
         $this->assertEquals('Default Name', $from[0]->getName());
     }
+
     /**
      * Extract Content IDs from email for embedded image validation.
      *

--- a/tests/Integration/Mail/SendingMarkdownMailTest.php
+++ b/tests/Integration/Mail/SendingMarkdownMailTest.php
@@ -170,7 +170,7 @@ class SendingMarkdownMailTest extends TestCase
         $this->assertEquals($expectedContentId, $htmlCid, 'Multiple clones should preserve original CID');
     }
 
-    public function testNullAddressFromNameDefaultsToGlobal()
+    public function testNullAddressFromNameDefaultsToDefault()
     {
         Mail::to('test@mail.com')->send(new MailableWithNullAddressName());
 


### PR DESCRIPTION
I had this in one of my applications, and was a bit confused. Had someone report they could no longer see the mail name in their email after I removed the name param

Imagine the following:

Mail from default is set as `Team X`

```php
// Imagine there's 20 other similar mailable classes.
class PaymentSuccessful extends Mailable
{
    public function envelope()
    {
        return new Address(
            from: 'payments@i-am-so-fake.com',
            // name is defaulted to null for Address.
        );
    }
}
```

When the above mailable is sent, the name defaults to `''` meaning the name for the recipient shows the `from` that was set, and doesn't fallback to the default from name from the config  which is what I'd expect. 

I've used the ConfigRepository, as it's already used similarly in the class already.  

If you revert the mailable change I've made, the test I've added will fail. 

Trying 12.x as would be nice.  But otherwise I'll target 13.x :)


