### PR TITLE
[13.x] Use unescaped unicode in `Js` support class by default

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -23,7 +23,12 @@ class Js implements Htmlable, Stringable
      *
      * @var int
      */
-    protected const REQUIRED_FLAGS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_THROW_ON_ERROR;
+    protected const REQUIRED_FLAGS = 0
+        | JSON_HEX_TAG
+        | JSON_HEX_APOS
+        | JSON_HEX_AMP
+        | JSON_HEX_QUOT
+        | JSON_THROW_ON_ERROR;
 
     /**
      * Create a new class instance.

--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -28,6 +28,7 @@ class Js implements Htmlable, Stringable
         | JSON_HEX_APOS
         | JSON_HEX_AMP
         | JSON_HEX_QUOT
+        | JSON_UNESCAPED_UNICODE
         | JSON_THROW_ON_ERROR;
 
     /**

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -23,6 +23,7 @@ class SupportJsTest extends TestCase
         $this->assertSame('[]', (string) Js::from(collect()));
         $this->assertSame('null', (string) Js::from(null));
         $this->assertSame("'Hello world'", (string) Js::from('Hello world'));
+        $this->assertSame("'Hèlló world'", (string) Js::from('Hèlló world'));
         $this->assertEquals(
             "'\\u003Cdiv class=\\u0022foo\\u0022\\u003E\\u0027quoted html\\u0027\\u003C\\/div\\u003E'",
             (string) Js::from('<div class="foo">\'quoted html\'</div>')


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `Js::from` helper can be used to serialize variables into valid JS/JSON; see also https://laravel.com/docs/12.x/blade#rendering-json. The current implementation escapes unicode (`json_encode` PHP default behavior), which is not necessary on modern browsers when employing `utf-8` charsets. This makes the output unnecessarily lengthy and moreover harder to use for a variety of purposes (e.g. finding strings in the produced output with manual search or even in the scope of running tests). Therefore this PR proposes to change the default encoding behavior.

Out of an abundance of caution, this PR targets `master` as it is technically a behavioral change, although I cannot currently think of a real-world scenario where this will actually break anything.