### PR TITLE
[12.x] Skip message serialization when log level is not handled

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -180,6 +180,10 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context): void
     {
+        if (method_exists($this->logger, 'isHandling') && ! $this->logger->isHandling($level)) {
+            return;
+        }
+
         $this->logger->{$level}(
             $message = $this->formatMessage($message),
             $context = array_merge($this->context, $context)

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Log;
 
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Log\Logger;
@@ -13,7 +12,6 @@ use Monolog\Handler\TestHandler;
 use Monolog\Level;
 use Monolog\Logger as Monolog;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class LogLoggerTest extends TestCase

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -3,12 +3,17 @@
 namespace Illuminate\Tests\Log;
 
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Log\Logger;
 use Mockery as m;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
 use Monolog\Logger as Monolog;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class LogLoggerTest extends TestCase
@@ -16,6 +21,7 @@ class LogLoggerTest extends TestCase
     public function testMethodsPassErrorAdditionsToMonolog()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class));
+        $monolog->shouldReceive('isHandling')->with('error')->andReturn(true);
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
         $writer->error('foo');
@@ -26,6 +32,7 @@ class LogLoggerTest extends TestCase
         $writer = new Logger($monolog = m::mock(Monolog::class));
         $writer->withContext(['bar' => 'baz']);
 
+        $monolog->shouldReceive('isHandling')->with('error')->andReturn(true);
         $monolog->shouldReceive('error')->once()->with('foo', ['bar' => 'baz']);
 
         $writer->error('foo');
@@ -37,6 +44,7 @@ class LogLoggerTest extends TestCase
         $writer->withContext(['bar' => 'baz']);
         $writer->withoutContext();
 
+        $monolog->shouldReceive('isHandling')->with('error')->andReturn(true);
         $monolog->expects('error')->with('foo', []);
 
         $writer->error('foo');
@@ -48,6 +56,7 @@ class LogLoggerTest extends TestCase
         $writer->withContext(['bar' => 'baz', 'forget' => 'me']);
         $writer->withoutContext(['forget']);
 
+        $monolog->shouldReceive('isHandling')->with('error')->andReturn(true);
         $monolog->shouldReceive('error')->once()->with('foo', ['bar' => 'baz']);
 
         $writer->error('foo');
@@ -56,6 +65,7 @@ class LogLoggerTest extends TestCase
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);
+        $monolog->shouldReceive('isHandling')->with('error')->andReturn(true);
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
         $events->listen(MessageLogged::class, function ($event) {
@@ -107,6 +117,7 @@ class LogLoggerTest extends TestCase
         $writer->withContext(['ip' => '127.0.0.1', 'timestamp' => '1986-10-29']);
         $writer->withoutContext(['timestamp']);
 
+        $monolog->shouldReceive('isHandling')->with('info')->andReturn(true);
         $monolog->shouldReceive('info')->once()->with('User action', [
             'user_id' => 123,
             'action' => 'login',
@@ -114,5 +125,55 @@ class LogLoggerTest extends TestCase
         ]);
 
         $writer->info('User action');
+    }
+
+    public function testSkipsSerializationWhenLogLevelNotHandled()
+    {
+        $monolog = new Monolog('test');
+        $monolog->pushHandler(new TestHandler(Level::Error));
+
+        $writer = new Logger($monolog);
+
+        $arrayable = new class implements Arrayable
+        {
+            public bool $wasCalled = false;
+
+            public function toArray(): array
+            {
+                $this->wasCalled = true;
+
+                return ['serialized' => 'data'];
+            }
+        };
+
+        $writer->debug($arrayable);
+
+        $this->assertFalse($arrayable->wasCalled);
+    }
+
+    public function testSerializesWhenLogLevelIsHandled()
+    {
+        $monolog = new Monolog('test');
+        $handler = new TestHandler(Level::Debug);
+        $monolog->pushHandler($handler);
+
+        $writer = new Logger($monolog);
+
+        $arrayable = new class implements Arrayable
+        {
+            public bool $wasCalled = false;
+
+            public function toArray(): array
+            {
+                $this->wasCalled = true;
+
+                return ['serialized' => 'data'];
+            }
+        };
+
+        $writer->debug($arrayable);
+
+        $this->assertTrue($arrayable->wasCalled);
+        $this->assertTrue($handler->hasDebugRecords());
     }
 }


### PR DESCRIPTION
Fixes #58472

Adds a check in `Logger::writeLog()` to skip potentially expensive `formatMessage()` serialization (e.g., `var_export()`, `toJson()`, `toArray()`) when the log level won't be handled by any handler.

This uses Monolog's `isHandling()` method when available, and falls back to the existing behavior for other PSR-3 implementations.