### PR TITLE
[12.x] fix(session): fix redis session handler to reuse connections without mutating cache store

### DIFF
--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Session\CacheBasedSessionHandler;
+use Illuminate\Session\SessionManager;
+use PHPUnit\Framework\TestCase;
+
+class SessionManagerTest extends TestCase
+{
+    public function test_cache_based_session_handler_uses_cached_repository_instance()
+    {
+        $app = new Container;
+        $app->singleton('config', function () {
+            return new Repository([
+                'session' => [
+                    'driver' => 'array',
+                    'lifetime' => 120,
+                    'store' => 'array',
+                ],
+                'cache' => [
+                    'default' => 'array',
+                    'stores' => [
+                        'array' => [
+                            'driver' => 'array',
+                        ],
+                    ],
+                ],
+            ]);
+        });
+        $app->singleton('cache', fn ($app) => new CacheManager($app));
+
+        $manager = new class($app) extends SessionManager
+        {
+            public function createCacheHandlerPublic($driver)
+            {
+                return $this->createCacheHandler($driver);
+            }
+        };
+
+        $cacheRepository = $app->make('cache')->store('array');
+
+        $handler = $manager->createCacheHandlerPublic('array');
+
+        $this->assertSame($cacheRepository, $handler->getCache());
+    }
+
+    public function test_redis_session_connection_does_not_mutate_cache_store_connection()
+    {
+        $app = new Container;
+        $app->singleton('config', function () {
+            return new Repository([
+                'session' => [
+                    'driver' => 'redis',
+                    'lifetime' => 120,
+                    'store' => null,
+                    'connection' => 'session',
+                ],
+                'cache' => [
+                    'default' => 'redis',
+                    'stores' => [
+                        'redis' => [
+                            'driver' => 'redis',
+                            'connection' => 'cache',
+                        ],
+                    ],
+                ],
+            ]);
+        });
+
+        $cacheManager = new CacheManager($app);
+        $cacheManager->extend('redis', function ($app, $config) {
+            return new CacheRepository(new FakeRedisStore($config['connection'] ?? 'default'));
+        });
+        $app->instance('cache', $cacheManager);
+
+        $manager = new SessionManager($app);
+
+        $cacheRepository = $cacheManager->store('redis');
+        $this->assertSame('cache', $cacheRepository->getStore()->getConnection());
+
+        $sessionStore = $manager->driver('redis');
+        $handler = $sessionStore->getHandler();
+
+        $this->assertInstanceOf(CacheBasedSessionHandler::class, $handler);
+        $this->assertSame('session', $handler->getCache()->getStore()->getConnection());
+        $this->assertSame('cache', $cacheRepository->getStore()->getConnection());
+        $this->assertNotSame($cacheRepository, $handler->getCache());
+    }
+
+    public function test_redis_session_reuses_connection_for_same_label()
+    {
+        $app = new Container;
+        $app->singleton('config', function () {
+            return new Repository([
+                'session' => [
+                    'driver' => 'redis',
+                    'lifetime' => 120,
+                    'store' => null,
+                    'connection' => 'cache',
+                ],
+                'cache' => [
+                    'default' => 'redis',
+                    'stores' => [
+                        'redis' => [
+                            'driver' => 'redis',
+                            'connection' => 'cache',
+                        ],
+                    ],
+                ],
+            ]);
+        });
+
+        $fakeRedis = new FakeRedisFactory;
+        $app->instance('redis', $fakeRedis);
+        $app->singleton('cache', fn ($app) => new CacheManager($app));
+
+        $manager = new SessionManager($app);
+
+        $cacheRepository = $app->make('cache')->store('redis');
+        $cacheConnection = $cacheRepository->getStore()->connection();
+
+        $sessionStore = $manager->driver('redis');
+        $handler = $sessionStore->getHandler();
+        $sessionConnection = $handler->getCache()->getStore()->connection();
+
+        $this->assertSame($cacheConnection, $sessionConnection);
+        $this->assertSame(1, $fakeRedis->connectionCount('cache'));
+    }
+}
+
+class FakeRedisStore extends ArrayStore
+{
+    protected $connection;
+
+    public function __construct($connection)
+    {
+        parent::__construct();
+
+        $this->connection = $connection;
+    }
+
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+}
+
+class FakeRedisFactory implements \Illuminate\Contracts\Redis\Factory
+{
+    protected $connections = [];
+    protected $connectionCounts = [];
+
+    public function connection($name = null)
+    {
+        $name = $name ?: 'default';
+
+        if (! isset($this->connections[$name])) {
+            $this->connections[$name] = new FakeRedisConnection($name);
+            $this->connectionCounts[$name] = ($this->connectionCounts[$name] ?? 0) + 1;
+        }
+
+        return $this->connections[$name];
+    }
+
+    public function connectionCount($name)
+    {
+        return $this->connectionCounts[$name] ?? 0;
+    }
+}
+
+class FakeRedisConnection extends Connection
+{
+    public function __construct($name)
+    {
+        $this->setName($name);
+    }
+
+    public function createSubscription($channels, \Closure $callback, $method = 'subscribe')
+    {
+        // No-op for test.
+    }
+}


### PR DESCRIPTION
Related #58377.

## Problem

cache-based sessions previously cloned the cache repository, which can instantiate a second Redis connection for the same label (e.g., with phpredis pconnect and strict connection count limits). Removing the clone alone causes the Redis session driver to mutate the shared cache store connection, potentially redirecting cache traffic (if cache connection label != session connection label).

## Solution

build a dedicated Redis cache repository for the session driver using `session.connection`, while keeping other cache-based handlers using the shared cached store instance. This preserves one connection per label, avoids side effects on the cache store, and prevents connection-limit race conditions.

## Result

consistent behavior across cache stores, no duplicate Redis connections for the same label, and no session/cache connection cross-talk.