### PR TITLE
[13.x] Restore eager-loaded relations when deserializing collections

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -90,11 +90,11 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collectionClass = get_class($collection);
 
-        return new $collectionClass(
+        return (new $collectionClass(
             (new Collection($value->id))
                 ->map(fn ($id) => $collection[$id] ?? null)
                 ->filter()
-        );
+        ))->loadMissing($value->relations ?? []);
     }
 
     /**


### PR DESCRIPTION
Restores eager-loaded relations when deserializing Eloquent collections, matching the existing behavior for single models.

## Background

This feature was intentionally deferred in the original implementation (#21191 / #21229). The author stated:

> I did not restore Collection relationships in this PR. I want to make sure this works and is accepted first, and then go 
  back to add.

Two subsequent attempts were made to complete this work:
- #35720 - closed, recommended targeting `master`
- #36712 - closed, same concern about mid-cycle behavior changes

## Use Cases

- **Queued Jobs:** When collections with eager-loaded relations are serialized, the relations are lost on deserialization. This forces developers to manually reload relations or suffer N+1 problems
- **Livewire:** Caleb expected this behavior, and collections losing their relations causes N+1 problems when Blade templates iterate through relations. I haven't checked, but I would assume this issue has been addressed separately in Livewire by now.
- **Broadcasting:** The original feature was motivated by broadcasting models. Frontend code couldn't access nested relationship data because serialized collections lost their relations.

## `Model::preventsLazyLoading()` Compatibility

As is stands, accessing relations on deserialized collections throw exceptions when this is enabled since relations aren't restored and lazy loading is blocked. This is a bit of an inconsistency since single models work but collections fail.

Addresses #58468