### PR TITLE
[12.x] Allow enum keys in RateLimiter methods

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -96,7 +96,7 @@ class RateLimiter
     /**
      * Attempts to execute a callback if it's not limited.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $maxAttempts
      * @param  \Closure  $callback
      * @param  \DateTimeInterface|\DateInterval|int  $decaySeconds
@@ -120,14 +120,14 @@ class RateLimiter
     /**
      * Determine if the given key has been "accessed" too many times.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $maxAttempts
      * @return bool
      */
     public function tooManyAttempts($key, $maxAttempts)
     {
         if ($this->attempts($key) >= $maxAttempts) {
-            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
+            if ($this->cache->has($this->cleanRateLimiterKey(enum_value($key)).':timer')) {
                 return true;
             }
 
@@ -140,7 +140,7 @@ class RateLimiter
     /**
      * Increment (by 1) the counter for a given key for a given decay time.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int  $decaySeconds
      * @return int
      */
@@ -152,14 +152,14 @@ class RateLimiter
     /**
      * Increment the counter for a given key for a given decay time by a given amount.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int  $decaySeconds
      * @param  int  $amount
      * @return int
      */
     public function increment($key, $decaySeconds = 60, $amount = 1)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         $this->cache->add(
             $key.':timer', $this->availableAt($decaySeconds), $decaySeconds
@@ -183,7 +183,7 @@ class RateLimiter
     /**
      * Decrement the counter for a given key for a given decay time by a given amount.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int  $decaySeconds
      * @param  int  $amount
      * @return int
@@ -196,12 +196,12 @@ class RateLimiter
     /**
      * Get the number of attempts for the given key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return mixed
      */
     public function attempts($key)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         return $this->withoutSerializationOrCompression(fn () => $this->cache->get($key, 0));
     }
@@ -209,12 +209,12 @@ class RateLimiter
     /**
      * Reset the number of attempts for the given key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function resetAttempts($key)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         return $this->cache->forget($key);
     }
@@ -222,13 +222,13 @@ class RateLimiter
     /**
      * Get the number of retries left for the given key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $maxAttempts
      * @return int
      */
     public function remaining($key, $maxAttempts)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         $attempts = $this->attempts($key);
 
@@ -238,7 +238,7 @@ class RateLimiter
     /**
      * Get the number of retries left for the given key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  int  $maxAttempts
      * @return int
      */
@@ -250,12 +250,12 @@ class RateLimiter
     /**
      * Clear the hits and lockout timer for the given key.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return void
      */
     public function clear($key)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         $this->resetAttempts($key);
 
@@ -265,12 +265,12 @@ class RateLimiter
     /**
      * Get the number of seconds until the "key" is accessible again.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return int
      */
     public function availableIn($key)
     {
-        $key = $this->cleanRateLimiterKey($key);
+        $key = $this->cleanRateLimiterKey(enum_value($key));
 
         return max(0, $this->cache->get($key.':timer') - $this->currentTime());
     }


### PR DESCRIPTION
Added enum support to `Cache::flexible()` and `Cache::withoutOverlapping()`, this PR adds enum support to all `RateLimiter` methods that accept key parameters.

The `RateLimiter` class is used for rate limiting operations and all its key-accepting methods now support `BackedEnum` and `UnitEnum` in addition to strings.

**Methods updated:**
- `attempt()`
- `tooManyAttempts()`
- `hit()`
- `increment()`
- `decrement()`
- `attempts()`
- `resetAttempts()`
- `remaining()`
- `retriesLeft()`
- `clear()`
- `availableIn()`

**Changes made:**
1. Updated PHPDoc to include `\BackedEnum|\UnitEnum|string` for all `$key` parameters
2. Added `enum_value($key)` calls before `cleanRateLimiterKey()` to convert enum keys to their string values

This provides consistency with the rest of the Cache system and allows developers to use enums for rate limiter keys, improving type safety and code clarity.

**Example usage:**
```php
enum RateLimitKey: string
{
    case API_LOGIN = 'api.login';
    case API_REGISTER = 'api.register';
}

RateLimiter::attempt(RateLimitKey::API_LOGIN, 5, function() {
    // ...
});
```