### PR TITLE
[13.x] Add enum types to repository contract / allow enums for tagged caches

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -9,18 +9,22 @@ use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connections\PredisClusterConnection;
 use Illuminate\Redis\Connections\PredisConnection;
 
+use function Illuminate\Support\enum_value;
+
 class RedisTaggedCache extends TaggedCache
 {
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
     public function add($key, $value, $ttl = null)
     {
+        $key = enum_value($key);
+
         $seconds = null;
 
         if ($ttl !== null) {
@@ -40,13 +44,15 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Store an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
     public function put($key, $value, $ttl = null)
     {
+        $key = enum_value($key);
+
         if (is_null($ttl)) {
             return $this->forever($key, $value);
         }
@@ -66,12 +72,14 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
     {
+        $key = enum_value($key);
+
         $this->tags->addEntry($this->itemKey($key), updateWhen: 'NX');
 
         return parent::increment($key, $value);
@@ -80,7 +88,7 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -94,12 +102,14 @@ class RedisTaggedCache extends TaggedCache
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value)
     {
+        $key = enum_value($key);
+
         $this->tags->addEntry($this->itemKey($key));
 
         return parent::forever($key, $value);

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -6,6 +6,8 @@ use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Cache\Events\CacheFlushing;
 use Illuminate\Contracts\Cache\Store;
 
+use function Illuminate\Support\enum_value;
+
 class TaggedCache extends Repository
 {
     use RetrievesMultipleKeys {
@@ -51,25 +53,25 @@ class TaggedCache extends Repository
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
     {
-        return $this->store->increment($this->itemKey($key), $value);
+        return $this->store->increment($this->itemKey(enum_value($key)), $value);
     }
 
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
-        return $this->store->decrement($this->itemKey($key), $value);
+        return $this->store->decrement($this->itemKey(enum_value($key)), $value);
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -12,7 +12,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  array|string  $key
+     * @param  \BackedEnum|\UnitEnum|array|string  $key
      * @param  TCacheValue|(\Closure(): TCacheValue)  $default
      * @return (TCacheValue is null ? mixed : TCacheValue)
      */
@@ -31,7 +31,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -41,7 +41,7 @@ interface Repository extends CacheInterface
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -50,7 +50,7 @@ interface Repository extends CacheInterface
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -59,7 +59,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
@@ -70,7 +70,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|\Closure|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
@@ -82,7 +82,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -93,7 +93,7 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -102,7 +102,7 @@ interface Repository extends CacheInterface
     /**
      * Set the expiration of a cached item; null TTL will retain the item forever.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
@@ -111,7 +111,7 @@ interface Repository extends CacheInterface
     /**
      * Remove an item from the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @return bool
      */
     public function forget($key);

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -21,7 +21,7 @@ interface Repository extends CacheInterface
     /**
      * Store an item in the cache.
      *
-     * @param  string  $key
+     * @param  \BackedEnum|\UnitEnum|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -548,6 +548,15 @@ class CacheRepositoryTest extends TestCase
         }
     }
 
+    public function testTaggedCacheWorksWithEnumKey()
+    {
+        $cache = (new Repository(new ArrayStore()))->tags('test-tag');
+
+        $cache->put(TestCacheKey::FOO, 5);
+        $this->assertSame(6, $cache->increment(TestCacheKey::FOO));
+        $this->assertSame(5, $cache->decrement(TestCacheKey::FOO));
+    }
+
     protected function getRepository()
     {
         $dispatcher = new Dispatcher(m::mock(Container::class));
@@ -562,4 +571,10 @@ class CacheRepositoryTest extends TestCase
     {
         return '2030-07-25 12:13:14 UTC';
     }
+
+}
+
+enum TestCacheKey: string
+{
+    case FOO = 'foo';
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -571,7 +571,6 @@ class CacheRepositoryTest extends TestCase
     {
         return '2030-07-25 12:13:14 UTC';
     }
-
 }
 
 enum TestCacheKey: string


### PR DESCRIPTION
12.x hasadded enum support for all the repository methods. For 13.x I thought it's good practice to keep the contract updated.

Then, I noticed there's tag caches, that probably should allow enums too.. as some methods don't fallback to the Repository (they override them).

So this PR:
- Adds enum types to the Repository contract
- Ensures TaggedCache / RedisTaggedCache also allow enums for any methods they override. 

This means: 
- The contract is up to date
- Tags work with enums too.

```php
// This now allows enums too...
Cache::tags(['people', 'authors'])->put(Test::FOO);
Cache::tags(['people', 'authors'])->get(Test::FOO);
```

I added tests for the TaggedCache, can't see anything for the Redis one.

Targeted 13.x as interface changes..