### PR TITLE
[12.x] Use morphMap when serializing model identifiers

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -53,8 +53,8 @@ class ModelIdentifier
      */
     public function __construct($class, $id, array $relations, $connection)
     {
-        $this->id = $id;
         $this->class = Relation::getMorphAlias($class);
+        $this->id = $id;
         $this->relations = $relations;
         $this->connection = $connection;
     }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -102,12 +102,4 @@ class ModelIdentifier
     {
         static::$useMorphMap = $useMorphMap;
     }
-
-    /**
-     * Flush the ModelIdentifier's shared state.
-     */
-    public static function flushState(): void
-    {
-        self::$useMorphMap = false;
-    }
 }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class ModelIdentifier
 {
     /**
-     * Use the Relation morphMap for a model's name when serializing.
+     * Use the Relation morphMap for a Model's name when serializing.
      */
     protected static bool $useMorphMap = false;
 
@@ -82,6 +82,8 @@ class ModelIdentifier
     }
 
     /**
+     * Get the fully-qualified class name of the Model.
+     *
      * @return class-string<\Illuminate\Database\Eloquent\Model>|null
      */
     public function getClass(): ?string
@@ -90,9 +92,7 @@ class ModelIdentifier
             return null;
         }
 
-        return self::$useMorphMap
-            ? (Relation::getMorphedModel($this->class) ?? $this->class)
-            : $this->class;
+        return Relation::getMorphedModel($this->class) ?? $this->class;
     }
 
     /**

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Contracts\Database;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
+
 class ModelIdentifier
 {
     /**
      * The class name of the model.
      *
-     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     * @var class-string<\Illuminate\Database\Eloquent\Model>|string
      */
     public $class;
 
@@ -52,7 +54,7 @@ class ModelIdentifier
     public function __construct($class, $id, array $relations, $connection)
     {
         $this->id = $id;
-        $this->class = $class;
+        $this->class = Relation::getMorphAlias($class);
         $this->relations = $relations;
         $this->connection = $connection;
     }
@@ -68,5 +70,13 @@ class ModelIdentifier
         $this->collectionClass = $collectionClass;
 
         return $this;
+    }
+
+    /**
+     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    public function getClass(): string
+    {
+        return Relation::getMorphedModel($this->class) ?? $this->class;
     }
 }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -9,7 +9,7 @@ class ModelIdentifier
     /**
      * The class name of the model.
      *
-     * @var class-string<\Illuminate\Database\Eloquent\Model>|string
+     * @var class-string<\Illuminate\Database\Eloquent\Model>|string|null
      */
     public $class;
 
@@ -73,10 +73,14 @@ class ModelIdentifier
     }
 
     /**
-     * @return class-string<\Illuminate\Database\Eloquent\Model>
+     * @return class-string<\Illuminate\Database\Eloquent\Model>|null
      */
-    public function getClass(): string
+    public function getClass(): ?string
     {
+        if ($this->class === null) {
+            return null;
+        }
+
         return Relation::getMorphedModel($this->class) ?? $this->class;
     }
 }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -46,14 +46,14 @@ class ModelIdentifier
     /**
      * Create a new model identifier.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $class
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>|null  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
      */
     public function __construct($class, $id, array $relations, $connection)
     {
-        $this->class = Relation::getMorphAlias($class);
+        $this->class = $class === null ? null : Relation::getMorphAlias($class);
         $this->id = $id;
         $this->relations = $relations;
         $this->connection = $connection;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
-use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
@@ -187,7 +186,6 @@ trait InteractsWithTestCaseLifecycle
         JsonResource::flushState();
         Markdown::flushState();
         Migrator::withoutMigrations([]);
-        ModelIdentifier::flushState();
         Once::flush();
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
@@ -186,6 +187,7 @@ trait InteractsWithTestCaseLifecycle
         JsonResource::flushState();
         Markdown::flushState();
         Migrator::withoutMigrations([]);
+        ModelIdentifier::flushState();
         Once::flush();
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -106,7 +106,7 @@ trait SerializesAndRestoresModelIdentifiers
     public function restoreModel($value)
     {
         return $this->getQueryForModelRestoration(
-            (new $value->getClass())->setConnection($value->connection), $value->id
+            (new ($value->getClass()))->setConnection($value->connection), $value->id
         )->useWritePdo()->firstOrFail()->loadMissing($value->relations ?? []);
     }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -106,7 +106,7 @@ trait SerializesAndRestoresModelIdentifiers
     public function restoreModel($value)
     {
         return $this->getQueryForModelRestoration(
-            (new $value->class)->setConnection($value->connection), $value->id
+            (new $value->getClass())->setConnection($value->connection), $value->id
         )->useWritePdo()->firstOrFail()->loadMissing($value->relations ?? []);
     }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -75,7 +75,7 @@ class ModelSerializationTest extends TestCase
     protected function tearDown(): void
     {
         Relation::morphMap([], false);
-        ModelIdentifier::flushState();
+        ModelIdentifier::useMorphMap(false);
 
         parent::tearDown();
     }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -429,7 +429,10 @@ class ModelSerializationTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
-        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass($user, new DataValueObject('hello')));
+        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass(
+            $user,
+            new DataValueObject('hello')
+        ));
 
         $this->assertSame(
             'O:83:"Illuminate\Tests\Integration\Queue\ModelSerializationAttributeTargetsClassTestClass":2:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:4:"user";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}s:5:"value";O:50:"Illuminate\Tests\Integration\Queue\DataValueObject":1:{s:5:"value";s:5:"hello";}}',

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Queue\Attributes\WithoutRelations;
@@ -67,6 +68,13 @@ class ModelSerializationTest extends TestCase
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('role_id');
         });
+    }
+
+    protected function tearDown(): void
+    {
+        Relation::morphMap([], false);
+
+        parent::tearDown();
     }
 
     public function testItSerializeUserOnDefaultConnection()
@@ -409,6 +417,29 @@ class ModelSerializationTest extends TestCase
         unserialize($serialized);
 
         $this->assertTrue(true);
+    }
+
+    public function test_it_users_morphmap_for_serialization()
+    {
+        Relation::morphMap([
+            'user' => User::class,
+        ]);
+
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $serialized = serialize(new ModelSerializationAttributeTargetsClassTestClass($user, new DataValueObject('hello')));
+
+        $this->assertSame(
+            'O:83:"Illuminate\Tests\Integration\Queue\ModelSerializationAttributeTargetsClassTestClass":2:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:4:"user";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}s:5:"value";O:50:"Illuminate\Tests\Integration\Queue\DataValueObject":1:{s:5:"value";s:5:"hello";}}',
+            $serialized
+        );
+
+        /** @var ModelSerializationAttributeTargetsClassTestClass $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertTrue($unserialized->user->is($user));
     }
 }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -419,6 +419,7 @@ class ModelSerializationTest extends TestCase
         $this->assertTrue(true);
     }
 
+    #[WithConfig('database.default', 'testing')]
     public function test_it_users_morphmap_for_serialization()
     {
         Relation::morphMap([

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Database\Eloquent\Attributes\Boot;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Collection;
@@ -70,9 +71,11 @@ class ModelSerializationTest extends TestCase
         });
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         Relation::morphMap([], false);
+        ModelIdentifier::flushState();
 
         parent::tearDown();
     }
@@ -425,6 +428,7 @@ class ModelSerializationTest extends TestCase
         Relation::morphMap([
             'user' => User::class,
         ]);
+        ModelIdentifier::useMorphMap();
 
         $user = User::create([
             'email' => 'taylor@laravel.com',


### PR DESCRIPTION
## What
This makes it so that when jobs are queued, they use the morph mapping for that class instead of the FQCN. We will fall back to using the FQCN if no morph mapping is set.

## Why
Let me tell you a story. It's a happy story!

Once upon a time, maybe six or seven years ago, there was a crazy idea for a startup. The developers chose our hero Laravel for its ease of deployment and rapid application development characteristics. They wrote the code using Laravel's suggested default coding style. It proved a viable project, and the company got traction and funding. There was much rejoicing! 🥳 

But there are no happily-ever-afters in life, because reality is not happily-ever-after.

The business continued to grow: new features, improved features, greater essential complexity as the business expanded its global reach, and more developers to ship Laravel code. Simple service classes grew to thousands of lines. Developers had merge conflicts as they all worked in the same files and shipping was delayed as devs required reviews from code area specialists.

The team was beginning to see they had outgrown the Laravel default structure. They looked for answers, and they settled upon a modular monolith 👍 and domain-driven design ☹️.

A decision is enforced only through action, so the team now had to break the monolith into modules and create CODEOWNER files. Even with the spells casted by wizards like Claude and Cursor, it took time. The story is still unfolding.

One of the dangers the team faces is moving Models into their respective modules. The team has come around to the concept of morphMaps, which means morphable columns in the database are no longer a concern. But it's very likely that **when they move a Model, it will end up breaking a job which relies on the Model as a property. This can cause catastrophic problems, as there are often thousands of jobs queued before a release is finished rolling out. When serialized, the Models referenced in the job are using its fully-qualified classname.  All of these jobs will now fail on the next release because the Model class can no longer be built as the class it references was moved.**

This is challenging to write tests for, and the best solution we have found is adding BugBot rules suggesting the developer needs to be careful about changes like this.

## TL;DR

Sometimes, you have to move models into different namespaces. Moving models can break jobs that have been dispatched prior to a new version roll-out. It requires diligence in code review to catch these sort of bugs. Using the relation morph-map instead of the FQCN will prevent this. Also, slightly smaller payload size when serializing to Redis.