### PR TITLE
[13.x] Fix RoundRobinTransport and FailoverTransport constructor parameters

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -430,7 +430,7 @@ class MailManager implements FactoryContract
                 : $this->createSymfonyTransport($config);
         }
 
-        return new $class($transports, $config['retry_after'] ?? 60, $this->app->make(LoggerInterface::class));
+        return new $class($transports, $config['retry_after'] ?? 60);
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes a PHPStan error where `MailManager` was passing 3 parameters to `RoundRobinTransport` and `FailoverTransport` constructors, but Symfony's implementation only accepts 2.

## Changes
- Removed the third parameter (`LoggerInterface`) from the constructor call in `createRoundrobinTransportOfClass()` method

## Verification
- PHPStan analysis now passes for this specific error
- Aligns with Symfony Mailer's documented API (Symfony 7.4/8.0)

## Related
- Fixes PHPStan error: `Class Symfony\Component\Mailer\Transport\RoundRobinTransport constructor invoked with 3 parameters, 1-2 required`