### PR TITLE
[13.x] Fix Console Application parent method call

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -245,7 +245,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     protected function addToParent(SymfonyCommand|callable $command)
     {
-        return parent::addCommand($command);
+        return parent::add($command);
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes a PHPStan error where `Application::addToParent()` was calling `parent::addCommand()` which doesn't exist in Symfony's Console Application class.

## Changes
- Changed `parent::addCommand()` to `parent::add()` in line 248

## Verification
- PHPStan analysis now passes for this specific error
- Aligns with Symfony Console's actual API (Symfony 7.4/8.0)

## Related
- Fixes PHPStan error: `Call to an undefined static method Symfony\Component\Console\Application::addCommand()`