### PR TITLE
[13.x] Add parameter and return type hints to Arr::toCssClasses()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1152,7 +1152,7 @@ class Arr
      * @param  array|string  $array
      * @return string
      */
-    public static function toCssClasses($array)
+    public static function toCssClasses(array|string $array): string
     {
         $classList = static::wrap($array);
 


### PR DESCRIPTION
## Description
Adds explicit `array|string` parameter type hint and `string` return type to the `Arr::toCssClasses()` method.

## Changes
- Added `array|string` type hint to `$array` parameter
- Added `string` return type declaration

## Rationale
- Follows the pattern established in recent type improvement PRs like #58356
- Improves type safety and IDE support
- The docblock already documented these types, now they're enforced at runtime
- No breaking changes - the method already expected these types

## Verification
- Method signature now matches its documented behavior
- Consistent with Laravel's ongoing type safety improvements