### PR TITLE
[13.x] Add parameter and return type hints to Arr::toCssStyles()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1175,7 +1175,7 @@ class Arr
      * @param  array|string  $array
      * @return string
      */
-    public static function toCssStyles($array)
+    public static function toCssStyles(array|string $array): string
     {
         $styleList = static::wrap($array);
 


### PR DESCRIPTION
## Description
Adds explicit `array|string` parameter type hint and `string` return type to the `Arr::toCssStyles()` method.

## Changes
- Added `array|string` type hint to `$array` parameter
- Added `string` return type declaration

## Rationale
- Follows the pattern established in recent type improvement PRs like #58356
- Improves type safety and IDE support
- The docblock already documented these types, now they're enforced at runtime
- No breaking changes - the method already expected these types
- Companion to #58486 (toCssClasses)

## Verification
- Method signature now matches its documented behavior
- Consistent with Laravel's ongoing type safety improvements