### PR TITLE
[13.x] Add parameter and return type hints to Arr::accessible()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -24,7 +24,7 @@ class Arr
      * @param  mixed  $value
      * @return bool
      */
-    public static function accessible($value)
+    public static function accessible(mixed $value): bool
     {
         return is_array($value) || $value instanceof ArrayAccess;
     }


### PR DESCRIPTION
## Description
Adds explicit `mixed` parameter type hint and `bool` return type to the `Arr::accessible()` method.

## Changes
- Added `mixed` type hint to `$value` parameter
- Added `bool` return type declaration

## Rationale
- Follows the pattern established in recent type improvement PRs like #58356
- Improves type safety and IDE support
- The docblock already documented these types, now they're enforced at runtime
- No breaking changes - the method already accepted any type and returned bool

## Verification
- Method signature now matches its documented behavior
- Consistent with Laravel's ongoing type safety improvements