### PR TITLE
[13.x] Add parameter and return type hints to Arr::arrayable()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -35,7 +35,7 @@ class Arr
      * @param  mixed  $value
      * @return bool
      */
-    public static function arrayable($value)
+    public static function arrayable(mixed $value): bool
     {
         return is_array($value)
             || $value instanceof Arrayable


### PR DESCRIPTION
## Description
Adds explicit `mixed` parameter type hint and `bool` return type to the `Arr::arrayable()` method.

## Changes
- Added `mixed` type hint to `$value` parameter
- Added `bool` return type declaration

## Rationale
- Follows the pattern established in recent type improvement PRs like #58356
- Improves type safety and IDE support
- The docblock already documented these types, now they're enforced at runtime
- No breaking changes - the method already accepted any type and returned bool
- Companion to #58488 (accessible)

## Verification
- Method signature now matches its documented behavior
- Consistent with Laravel's ongoing type safety improvements