### PR TITLE
feat(query): add whereNullOrEmpty helpers

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1499,6 +1499,56 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where null or empty string" clause to the query.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNullOrEmpty($column, $boolean = 'and')
+    {
+        return $this->whereNested(function ($query) use ($column) {
+            $query->whereNull($column)->orWhere($column, '');
+        }, $boolean);
+    }
+
+    /**
+     * Add an "or where null or empty string" clause to the query.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function orWhereNullOrEmpty($column)
+    {
+        return $this->whereNullOrEmpty($column, 'or');
+    }
+
+    /**
+     * Add a "where not null and not empty string" clause to the query.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotNullOrEmpty($column, $boolean = 'and')
+    {
+        return $this->whereNested(function ($query) use ($column) {
+            $query->whereNotNull($column)->where($column, '!=', '');
+        }, $boolean);
+    }
+
+    /**
+     * Add an "or where not null and not empty string" clause to the query.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function orWhereNotNullOrEmpty($column)
+    {
+        return $this->whereNotNullOrEmpty($column, 'or');
+    }
+
+    /**
      * Add a "where between" statement to the query.
      *
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<*>|\Illuminate\Contracts\Database\Query\Expression|string  $column

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -573,6 +573,27 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(2, $results);
     }
 
+    public function testWhereNullOrEmpty()
+    {
+        Schema::create('nullable_values', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+        });
+
+        try {
+            DB::table('nullable_values')->insert([
+                ['name' => null],
+                ['name' => ''],
+                ['name' => 'filled'],
+            ]);
+
+            $this->assertSame(2, DB::table('nullable_values')->whereNullOrEmpty('name')->count());
+            $this->assertSame(1, DB::table('nullable_values')->whereNotNullOrEmpty('name')->count());
+        } finally {
+            Schema::drop('nullable_values');
+        }
+    }
+
     public function testPaginateWithSpecificColumns()
     {
         $result = DB::table('posts')->paginate(5, ['title', 'content']);


### PR DESCRIPTION
Add query builder helpers for nullable/empty string checks:
- whereNullOrEmpty / orWhereNullOrEmpty
- whereNotNullOrEmpty / orWhereNotNullOrEmpty

## Files Changed
- src/Illuminate/Database/Query/Builder.php
- tests/Integration/Database/QueryBuilderTest.php

## Description
Adds query builder helpers that group `NULL` and empty-string checks into a
single, reusable condition.

## How to Use

```php
// Find rows where "name" is NULL or an empty string
DB::table('users')->whereNullOrEmpty('name')->get();

// Exclude NULL/empty "name"
DB::table('users')->whereNotNullOrEmpty('name')->get();

// Combine with other conditions
DB::table('users')
    ->where('active', 1)
    ->orWhereNullOrEmpty('name')
    ->get();
```