### PR TITLE
[12.x] Add missing @param documentation to SessionGuard constructor

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -141,7 +141,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Support\Timebox|null  $timebox
      * @param  bool  $rehashOnLogin
      * @param  int  $timeboxDuration
-     * @param string|null $hashKey
+     * @param  string|null  $hashKey
      */
     public function __construct(
         $name,

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -139,6 +139,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Support\Timebox|null  $timebox
      * @param  bool  $rehashOnLogin
      * @param  int  $timeboxDuration
+     * @param string|null $hashKey
      */
     public function __construct(
         $name,

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -112,6 +112,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
     /**
      * The key used to hash recaller cookie values.
+     *
+     * @var string|null
      */
     protected $hashKey;
 

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -60,9 +60,6 @@ class Dispatcher implements QueueingDispatcher
 
     /**
      * Create a new command dispatcher instance.
-     *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  \Closure|null  $queueResolver
      */
     public function __construct(Container $container, ?Closure $queueResolver = null)
     {

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -60,6 +60,9 @@ class Dispatcher implements QueueingDispatcher
 
     /**
      * Create a new command dispatcher instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Closure|null  $queueResolver
      */
     public function __construct(Container $container, ?Closure $queueResolver = null)
     {


### PR DESCRIPTION
I was gonna do a mega 13.x PR for property promotion, but threw it in the bin as didn't think it would land well.

I did however, see this on the way ...

The `$hashkey` param was missing  in the SessionGuard constructor / didn't have a `@var`


I've added it to be consistent with the other bits 🫡 