### PR TITLE
[12.x] Add `Relation::flushState()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -523,6 +523,17 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Flush the state of Relation.
+     */
+    public static function flushState(): void
+    {
+        self::$morphMap = [];
+        self::$requireMorphMap = false;
+        self::$selfJoinCount = 0;
+        self::$constraints = true;
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -7,7 +7,6 @@ use Illuminate\Console\Application as Artisan;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
@@ -191,7 +190,6 @@ trait InteractsWithTestCaseLifecycle
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
-        Relation::flushState();
         Response::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Application as Artisan;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
@@ -190,6 +191,7 @@ trait InteractsWithTestCaseLifecycle
         PreventRequestsDuringMaintenance::flushState();
         Queue::createPayloadUsing(null);
         RegisterProviders::flushState();
+        Relation::flushState();
         Response::flushState();
         Sleep::fake(false);
         TrimStrings::flushState();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2194,7 +2194,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "eloquent_builder_test_model_parent_stubs"."morph_type" = ?', $builder->toSql());
         $this->assertEquals(['alias'], $builder->getBindings());
 
-        Relation::morphMap([], false);
+        Relation::flushState();
     }
 
     public function testWhereKeyMethodWithInt()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -202,7 +202,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $this->schema($connection)->drop('photos');
         }
 
-        Relation::morphMap([], false);
+        Relation::flushState();
         Eloquent::unsetConnectionResolver();
 
         Carbon::setTestNow(null);

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -75,7 +75,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
             $this->schema($connection)->drop('photos');
         }
 
-        Relation::morphMap([], false);
+        Relation::flushState();
 
         parent::tearDown();
     }

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -67,7 +67,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
             $this->schema($connection)->drop('taggables');
         }
 
-        Relation::morphMap([], false);
+        Relation::flushState();
 
         parent::tearDown();
     }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -15,6 +15,13 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Relation::flushState();
+        parent::tearDown();
+    }
+
     public function testSetRelationFail()
     {
         $parent = new EloquentRelationResetModelStub;
@@ -215,8 +222,6 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertEquals([
             'reset' => EloquentRelationResetModelStub::class,
         ], Relation::morphMap());
-
-        Relation::morphMap([], false);
     }
 
     public function testSettingMorphMapWithNumericKeys()
@@ -226,8 +231,6 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertEquals([
             1 => 'App\User',
         ], Relation::morphMap());
-
-        Relation::morphMap([], false);
     }
 
     public function testGetMorphAlias()

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -70,8 +70,7 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
     protected function tearDown(): void
     {
-        Relation::morphMap([], false);
-        Relation::requireMorphMap(false);
+        Relation::flushState();
 
         parent::tearDown();
     }

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -53,6 +53,13 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         }
     }
 
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Relation::flushState();
+        parent::tearDown();
+    }
+
     public function testWhereHasMorph()
     {
         $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
@@ -68,15 +75,11 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
         Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
 
-        try {
-            $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
-                $query->where('title', 'foo');
-            })->orderBy('id')->get();
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+            $query->where('title', 'foo');
+        })->orderBy('id')->get();
 
-            $this->assertEquals([1, 4], $comments->pluck('id')->all());
-        } finally {
-            Relation::morphMap([], false);
-        }
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
 
     public function testWhereHasMorphWithWildcard()
@@ -98,15 +101,11 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
         Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
 
-        try {
-            $comments = Comment::whereHasMorph('commentable', '*', function (Builder $query) {
-                $query->where('title', 'foo');
-            })->orderBy('id')->get();
+        $comments = Comment::whereHasMorph('commentable', '*', function (Builder $query) {
+            $query->where('title', 'foo');
+        })->orderBy('id')->get();
 
-            $this->assertEquals([1, 4], $comments->pluck('id')->all());
-        } finally {
-            Relation::morphMap([], false);
-        }
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
 
     public function testWhereHasMorphWithWildcardAndOnlyNullMorphTypes()


### PR DESCRIPTION
Adds a helper method to reset the global state of `Relation`.