### PR TITLE
[12.x] Added the ability to specify default values ​​for pipelines

### DIFF
--- a/src/Illuminate/Pipeline/DefaultValue.php
+++ b/src/Illuminate/Pipeline/DefaultValue.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Pipeline;
+
+final class DefaultValue
+{
+}

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -254,7 +254,7 @@ class Pipeline implements PipelineContract
         $reflection = new \ReflectionMethod($pipe, $method);
         $methodParameters = $reflection->getParameters();
 
-        for ($index = 2; $index < count($parameters); $index++) {
+        for ($index = 2; $index < count($parameters) && $index < count($methodParameters); $index++) {
             if ($parameters[$index] !== DefaultValue::class) {
                 continue;
             }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -268,6 +268,7 @@ class Pipeline implements PipelineContract
 
         return $parameters;
     }
+
     /**
      * Get the array of configured pipes.
      *

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -476,6 +476,23 @@ class PipelineTest extends TestCase
 
         unset($_SERVER['__test.pipe.parameters']);
     }
+
+    public function testPipelineUsageWithObjectDefaultParametersPlaceholderMoreThanMethodParameters()
+    {
+        $parameters = [DefaultValue::class, 'two', DefaultValue::class, DefaultValue::class];
+        $passedParameters = [null, 'two', 1];
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through(PipelineTestDefaultParameterPipeTwo::class.':'.implode(',', $parameters))
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertSame($passedParameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
 }
 
 class PipelineTestPipeOne


### PR DESCRIPTION

### Summary

This PR adds support for explicitly passing default values to pipeline stage methods by introducing a dedicated sentinel value (DefaultValue).

### Motivation

While working with the `AuthenticateWithBasicAuth` middleware, I ran into an issue with its method signature:

```php
public function handle($request, Closure $next, $guard = null, $field = null)
```
In order to specify a custom `$field`, the pipeline requires passing a value for `$guard`, since it comes earlier in the signature.

But you have no way to pass anything other than a string to the `$guard`.

### Proposed solution

This PR introduces an explicit sentinel value, DefaultValue, that can be used to indicate that a parameter should use its default value as defined in the method signature.

Example usage:
```php
->through([
    AuthenticateWithBasicAuth::class.':'.DefaultValue::class.',email',
]);

```