### PR TITLE
[12.x] do assignment instead of mutating to handle immutable carbon object.

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -357,7 +357,7 @@ class VendorPublishCommand extends Command
             $path = realpath($path);
 
             if ($from === $path && preg_match('/\d{4}_(\d{2})_(\d{2})_(\d{6})_/', $to)) {
-                $this->publishedAt->addSecond();
+                $this->publishedAt = $this->publishedAt->addSecond();
 
                 return preg_replace(
                     '/\d{4}_(\d{2})_(\d{2})_(\d{6})_/',


### PR DESCRIPTION
I checked this https://github.com/laravel/cashier-stripe/issues/1810 and some PRs related to it, and, like you, it was also working for me. But I was curious, so I did some deep digging into it, and I found that `publishedAt` property gets initialised with `now()`, which uses `Date::now()` behind the scenes and when someone uses `Date::use(CarbonImmutable::class)` at that moment it does not mutate. It creates a new object for each iteration. It creates all migrations with the same date and time that makes it resort in alphabetical order and that's why adding column migration runs before creating table migration.
