### PR TITLE
Add support for `temporaryUploadUrl` to the `local` filesystem

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -92,6 +92,13 @@ class FilesystemAdapter implements CloudFilesystemContract
     protected $temporaryUrlCallback;
 
     /**
+     * The temporary upload URL builder callback.
+     *
+     * @var \Closure|null
+     */
+    protected $temporaryUploadUrlCallback;
+
+    /**
      * Create a new filesystem adapter instance.
      *
      * @param  \League\Flysystem\FilesystemOperator  $driver
@@ -794,6 +801,16 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Determine if temporary upload URLs can be generated.
+     *
+     * @return bool
+     */
+    public function providesTemporaryUploadUrls()
+    {
+        return method_exists($this->adapter, 'temporaryUploadUrl') || isset($this->temporaryUploadUrlCallback);
+    }
+
+    /**
      * Get a temporary URL for the file at the given path.
      *
      * @param  string  $path
@@ -832,6 +849,12 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         if (method_exists($this->adapter, 'temporaryUploadUrl')) {
             return $this->adapter->temporaryUploadUrl($path, $expiration, $options);
+        }
+
+        if ($this->temporaryUploadUrlCallback) {
+            return $this->temporaryUploadUrlCallback->bindTo($this, static::class)(
+                $path, $expiration, $options
+            );
         }
 
         throw new RuntimeException('This driver does not support creating temporary upload URLs.');
@@ -1040,6 +1063,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function buildTemporaryUrlsUsing(Closure $callback)
     {
         $this->temporaryUrlCallback = $callback;
+    }
+
+    /**
+     * Define a custom temporary upload URL builder callback.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function buildTemporaryUploadUrlsUsing(Closure $callback)
+    {
+        $this->temporaryUploadUrlCallback = $callback;
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -102,6 +102,14 @@ class FilesystemServiceProvider extends ServiceProvider
                         $isProduction
                     ))($request, $path);
                 })->where('path', '.*')->name('storage.'.$disk);
+
+                Route::put($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {
+                    return (new ReceiveFile(
+                        $disk,
+                        $config,
+                        $isProduction
+                    ))($request, $path);
+                })->where('path', '.*')->name('storage.'.$disk.'.upload');
             });
         }
     }

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -44,6 +44,18 @@ class LocalFilesystemAdapter extends FilesystemAdapter
     }
 
     /**
+     * Determine if temporary upload URLs can be generated.
+     *
+     * @return bool
+     */
+    public function providesTemporaryUploadUrls()
+    {
+        return $this->temporaryUploadUrlCallback || (
+            $this->shouldServeSignedUrls && $this->urlGeneratorResolver instanceof Closure
+        );
+    }
+
+    /**
      * Get a temporary URL for the file at the given path.
      *
      * @param  string  $path
@@ -71,6 +83,39 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             ['path' => $path],
             absolute: false
         ));
+    }
+
+    /**
+     * Get a temporary upload URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return array
+     */
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    {
+        if ($this->temporaryUploadUrlCallback) {
+            return $this->temporaryUploadUrlCallback->bindTo($this, static::class)(
+                $path, $expiration, $options
+            );
+        }
+
+        if (! $this->providesTemporaryUploadUrls()) {
+            throw new RuntimeException('This driver does not support creating temporary upload URLs.');
+        }
+
+        $url = call_user_func($this->urlGeneratorResolver);
+
+        return [
+            'url' => $url->to($url->temporarySignedRoute(
+                'storage.'.$this->disk.'.upload',
+                $expiration,
+                ['path' => $path],
+                absolute: false
+            )),
+            'headers' => [],
+        ];
     }
 
     /**

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -111,7 +111,7 @@ class LocalFilesystemAdapter extends FilesystemAdapter
             'url' => $url->to($url->temporarySignedRoute(
                 'storage.'.$this->disk.'.upload',
                 $expiration,
-                ['path' => $path],
+                ['path' => $path, 'upload' => true],
                 absolute: false
             )),
             'headers' => [],

--- a/src/Illuminate/Filesystem/ReceiveFile.php
+++ b/src/Illuminate/Filesystem/ReceiveFile.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\PathTraversalDetected;
+
+class ReceiveFile
+{
+    /**
+     * Create a new invokable controller to receive files.
+     */
+    public function __construct(
+        protected string $disk,
+        protected array $config,
+        protected bool $isProduction,
+    ) {
+        //
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request, string $path): Response
+    {
+        abort_unless(
+            $this->hasValidSignature($request),
+            $this->isProduction ? 404 : 403
+        );
+
+        try {
+            Storage::disk($this->disk)->put($path, $request->getContent());
+
+            return response()->noContent();
+        } catch (PathTraversalDetected $e) {
+            abort(404);
+        }
+    }
+
+    /**
+     * Determine if the request has a valid signature if applicable.
+     */
+    protected function hasValidSignature(Request $request): bool
+    {
+        return $request->hasValidRelativeSignature();
+    }
+}

--- a/src/Illuminate/Filesystem/ReceiveFile.php
+++ b/src/Illuminate/Filesystem/ReceiveFile.php
@@ -44,6 +44,6 @@ class ReceiveFile
      */
     protected function hasValidSignature(Request $request): bool
     {
-        return $request->hasValidRelativeSignature();
+        return $request->boolean('upload') && $request->hasValidRelativeSignature();
     }
 }

--- a/src/Illuminate/Filesystem/ServeFile.php
+++ b/src/Illuminate/Filesystem/ServeFile.php
@@ -54,7 +54,9 @@ class ServeFile
      */
     protected function hasValidSignature(Request $request): bool
     {
-        return ($this->config['visibility'] ?? 'private') === 'public' ||
-               $request->hasValidRelativeSignature();
+        return ! $request->boolean('upload') && (
+            ($this->config['visibility'] ?? 'private') === 'public' ||
+            $request->hasValidRelativeSignature()
+        );
     }
 }

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -63,6 +63,7 @@ use function Illuminate\Support\enum_value;
  * @method static string|false mimeType(string $path)
  * @method static string url(string $path)
  * @method static bool providesTemporaryUrls()
+ * @method static bool providesTemporaryUploadUrls()
  * @method static string temporaryUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static array temporaryUploadUrl(string $path, \DateTimeInterface $expiration, array $options = [])
  * @method static \League\Flysystem\FilesystemOperator getDriver()
@@ -70,6 +71,7 @@ use function Illuminate\Support\enum_value;
  * @method static array getConfig()
  * @method static void serveUsing(\Closure $callback)
  * @method static void buildTemporaryUrlsUsing(\Closure $callback)
+ * @method static void buildTemporaryUploadUrlsUsing(\Closure $callback)
  * @method static \Illuminate\Filesystem\FilesystemAdapter|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Illuminate\Filesystem\FilesystemAdapter|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static void macro(string $name, object|callable $macro)
@@ -110,8 +112,14 @@ class Storage extends Facade
             self::buildDiskConfiguration($disk, $config, root: $root)
         ));
 
-        return tap($fake)->buildTemporaryUrlsUsing(function ($path, $expiration) {
-            return URL::to($path.'?expiration='.$expiration->getTimestamp());
+        return tap($fake, function ($fake) {
+            $fake->buildTemporaryUrlsUsing(function ($path, $expiration) {
+                return URL::to($path.'?expiration='.$expiration->getTimestamp());
+            });
+
+            $fake->buildTemporaryUploadUrlsUsing(function ($path, $expiration) {
+                return ['url' => URL::to($path.'?expiration='.$expiration->getTimestamp()), 'headers' => []];
+            });
         });
     }
 

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Filesystem;
+
+use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+
+#[WithConfig('filesystems.disks.local.serve', true)]
+class ReceiveFileTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->beforeApplicationDestroyed(function () {
+            Storage::delete('receive-file-test.txt');
+        });
+
+        parent::setUp();
+    }
+
+    public function testItCanReceiveAFile()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
+
+        $response->assertNoContent();
+        Storage::assertExists('receive-file-test.txt', 'Hello World');
+    }
+
+    public function testItWill403OnWrongSignature()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+
+        $url = $result['url'].'c';
+
+        $response = $this->call('PUT', $url, [], [], [], [], 'Hello World');
+
+        $response->assertForbidden();
+        Storage::assertMissing('receive-file-test.txt');
+    }
+
+    public function testItWill403OnExpiredUrl()
+    {
+        $result = Storage::temporaryUploadUrl('receive-file-test.txt', now()->subMinutes(1));
+
+        $response = $this->call('PUT', $result['url'], [], [], [], [], 'Hello World');
+
+        $response->assertForbidden();
+        Storage::assertMissing('receive-file-test.txt');
+    }
+}

--- a/tests/Integration/Filesystem/ReceiveFileTest.php
+++ b/tests/Integration/Filesystem/ReceiveFileTest.php
@@ -49,4 +49,27 @@ class ReceiveFileTest extends TestCase
         $response->assertForbidden();
         Storage::assertMissing('receive-file-test.txt');
     }
+
+    public function testDownloadUrlCannotBeUsedForUpload()
+    {
+        Storage::put('receive-file-test.txt', 'Original Content');
+
+        $downloadUrl = Storage::temporaryUrl('receive-file-test.txt', now()->addMinutes(1));
+
+        $response = $this->call('PUT', $downloadUrl, [], [], [], [], 'Malicious Content');
+
+        $response->assertForbidden();
+        $this->assertSame('Original Content', Storage::get('receive-file-test.txt'));
+    }
+
+    public function testUploadUrlCannotBeUsedForDownload()
+    {
+        Storage::put('receive-file-test.txt', 'Secret Content');
+
+        $uploadUrl = Storage::temporaryUploadUrl('receive-file-test.txt', now()->addMinutes(1));
+
+        $response = $this->get($uploadUrl['url']);
+
+        $response->assertForbidden();
+    }
 }


### PR DESCRIPTION
This is heavily inspired from the `temporaryUrl` feature, but applied for uploads.

I also added support for `buildTemporaryUploadUrlsUsing()`, that way temporary upload and download URLs have exactly the same features (for the `local` filesystem).

Background: https://github.com/mnapoli/laravel-local-temporary-upload-url and https://x.com/taylorotwell/status/2014899205295243592