### PR TITLE
[12.x] Fix PHP 8.5+ deprecation warnings for PDO MySQL SSL CA constant

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -15,8 +15,7 @@ if (! function_exists('get_mysql_ssl_ca_constant')) {
             return \Pdo\Mysql::ATTR_SSL_CA;
         }
 
-        // @phpstan-ignore-next-line
-        return @constant('PDO::MYSQL_ATTR_SSL_CA');
+        return \PDO::MYSQL_ATTR_SSL_CA;
     }
 }
 

--- a/config/database.php
+++ b/config/database.php
@@ -2,6 +2,24 @@
 
 use Illuminate\Support\Str;
 
+/**
+ * Get the MySQL SSL CA constant for the current PHP version.
+ *
+ * @return int
+ */
+if (! function_exists('get_mysql_ssl_ca_constant')) {
+    function get_mysql_ssl_ca_constant()
+    {
+        if (PHP_VERSION_ID >= 80500) {
+            /** @phpstan-ignore class.notFound */
+            return \Pdo\Mysql::ATTR_SSL_CA;
+        }
+
+        // @phpstan-ignore-next-line
+        return @constant('PDO::MYSQL_ATTR_SSL_CA');
+    }
+}
+
 return [
 
     /*
@@ -61,7 +79,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                (PHP_VERSION_ID >= 80500 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                get_mysql_ssl_ca_constant() => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -81,7 +99,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                (PHP_VERSION_ID >= 80500 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                get_mysql_ssl_ca_constant() => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -21,7 +21,6 @@ class MySqlSchemaState extends SchemaState
             return \Pdo\Mysql::ATTR_SSL_CA;
         }
 
-        // @phpstan-ignore-next-line
         return @constant('PDO::MYSQL_ATTR_SSL_CA');
     }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -21,7 +21,7 @@ class MySqlSchemaState extends SchemaState
             return \Pdo\Mysql::ATTR_SSL_CA;
         }
 
-        return @constant('PDO::MYSQL_ATTR_SSL_CA');
+        return \PDO::MYSQL_ATTR_SSL_CA;
     }
 
     /**

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -9,6 +9,22 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+/**
+ * Get the MySQL SSL CA constant for the current PHP version.
+ *
+ * @return int
+ */
+function get_mysql_ssl_ca_constant_for_test()
+{
+    if (PHP_VERSION_ID >= 80500) {
+        /** @phpstan-ignore class.notFound */
+        return \Pdo\Mysql::ATTR_SSL_CA;
+    }
+
+    // @phpstan-ignore-next-line
+    return @constant('PDO::MYSQL_ATTR_SSL_CA');
+}
+
 class DatabaseMariaDbSchemaStateTest extends TestCase
 {
     #[DataProvider('provider')]
@@ -63,7 +79,7 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    get_mysql_ssl_ca_constant_for_test() => 'ssl.ca',
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -21,8 +21,7 @@ function get_mysql_ssl_ca_constant_for_test()
         return \Pdo\Mysql::ATTR_SSL_CA;
     }
 
-    // @phpstan-ignore-next-line
-    return @constant('PDO::MYSQL_ATTR_SSL_CA');
+    return \PDO::MYSQL_ATTR_SSL_CA;
 }
 
 class DatabaseMariaDbSchemaStateTest extends TestCase

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -11,6 +11,22 @@ use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Symfony\Component\Process\Process;
 
+/**
+ * Get the MySQL SSL CA constant for the current PHP version.
+ *
+ * @return int
+ */
+function get_mysql_ssl_ca_constant_for_test()
+{
+    if (PHP_VERSION_ID >= 80500) {
+        /** @phpstan-ignore class.notFound */
+        return \Pdo\Mysql::ATTR_SSL_CA;
+    }
+
+    // @phpstan-ignore-next-line
+    return @constant('PDO::MYSQL_ATTR_SSL_CA');
+}
+
 class DatabaseMySqlSchemaStateTest extends TestCase
 {
     #[DataProvider('provider')]
@@ -65,7 +81,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
-                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    get_mysql_ssl_ca_constant_for_test() => 'ssl.ca',
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -23,8 +23,7 @@ function get_mysql_ssl_ca_constant_for_test()
         return \Pdo\Mysql::ATTR_SSL_CA;
     }
 
-    // @phpstan-ignore-next-line
-    return @constant('PDO::MYSQL_ATTR_SSL_CA');
+    return \PDO::MYSQL_ATTR_SSL_CA;
 }
 
 class DatabaseMySqlSchemaStateTest extends TestCase


### PR DESCRIPTION
This fixes deprecation warnings that occur in PHP 8.5+ when using PDO::MYSQL_ATTR_SSL_CA. In PHP 8.5+, this constant has been moved to the Pdo\Mysql class.

Changes:
- Added helper function to resolve the correct SSL CA constant based on PHP version
- Updated config/database.php to use the helper function for mysql and mariadb connections
- Updated MySqlSchemaState to use a protected static method for constant resolution
- Updated test files to use helper functions to avoid deprecation warnings

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
