### PR TITLE
[12.x] Adds `flat` to lower-case and flatten a string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -53,6 +53,13 @@ class Str
     protected static $studlyCache = [];
 
     /**
+     * The cache of flat-cased words.
+     *
+     * @var array<string, string>
+     */
+    protected static $flatCache = [];
+
+    /**
      * The callback that should be used to generate UUIDs.
      *
      * @var (callable(): \Ramsey\Uuid\UuidInterface)|null
@@ -472,6 +479,23 @@ class Str
         $quoted = preg_quote($cap, '/');
 
         return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+    }
+
+    /**
+     * Convert a string to flat case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function flat($value)
+    {
+        $key = $value;
+
+        if (isset(static::$flatCache[$key])) {
+            return static::$flatCache[$key];
+        }
+
+        return static::$flatCache[$key] = static::lower(static::replace(['-', '_', ' '], '', $value, false));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -360,6 +360,16 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Convert a string to flat case.
+     *
+     * @return static
+     */
+    public function flat()
+    {
+        return new static(Str::flat($this->value));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -558,6 +558,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
     }
 
+    public function testFlat()
+    {
+        $this->assertSame('foobarbaz', Str::flat('foo-bar-baz'));
+        $this->assertSame('foobarbaz', Str::flat('foo_bar_baz'));
+        $this->assertSame('foobarbaz', Str::flat('FooBarBaz'));
+        $this->assertSame('foo2bar1baz', Str::flat('Foo 2 Bar 1 Baz'));
+    }
+
     public function testWrap()
     {
         $this->assertEquals('"value"', Str::wrap('value', '"'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -924,6 +924,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
     }
 
+    public function testFlat()
+    {
+        $this->assertSame('foobarbaz', (string) $this->stringable('foo-bar-baz')->flat());
+        $this->assertSame('foobarbaz', (string) $this->stringable('foo_bar_baz')->flat());
+        $this->assertSame('foobarbaz', (string) $this->stringable('FooBarBaz')->flat());
+        $this->assertSame('foo2bar1baz', (string) $this->stringable('Foo 2  Bar 1 Baz')->flat());
+    }
+
     public function testIs()
     {
         $this->assertTrue($this->stringable('/')->is('/'));


### PR DESCRIPTION
Basically transforms removes all word-delimiters (`-`, `_` and ` `) and returns a lower-cased string.

```php
use Illuminate\Support\Str;

$phrase = 'This is great string done by user_67'.

echo Str::flat($phrase); // "thisisgreatstringdonebyuser67"
```

This does not apply other transformation to the string, which may be desirable for hash-functions over text or length calculation. For example, quotes or double-quotes will be respected. In that case, the user may use `slug` prior to the _flatification_:

```php
use Illuminate\Support\Str;

$phrase = 'Then he said «Great job!» to the user.'.

echo Str::flat(Str::slug($phrase)); // "thenhesaidgratjobtotheuser"
```