### PR TITLE
[12.x] Add attribute to unserialize models without eager loads in jobs

### DIFF
--- a/src/Illuminate/Queue/Attributes/WithoutEagerLoads.php
+++ b/src/Illuminate/Queue/Attributes/WithoutEagerLoads.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+class WithoutEagerLoads
+{
+    //
+}


### PR DESCRIPTION
Additional attribute `WithoutEagerLoads` for jobs to accompany the optional existing attribute `WihoutRelations`.

When a model makes use of `$with = [...]` for its relation loading, jobs unserialize will obviously load these. There should be a clear way to prevent it, and `WithoutRelations` is not it. Doing it with a standardized way also keeps `DeleteWhenMissingModels` intact without confusion if it does or not.

```
#[WithoutEagerLoads, WithoutRelations]
class MyJob implements ShouldQueue
```

My use case is keeping my legacy frontend intact with `->with` and making my jobs lean and mean.

I would also like to add a `#withTrashed` after this.
