### PR TITLE
[12.x] Retain associative keys on eager loaded relations

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -859,24 +859,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $dictionary = [];
 
-        $isAssociative = Arr::isAssoc($this->items);
-
         foreach ($this->items as $key => $item) {
             $pair = $callback($item, $key);
 
-            $pairKey = key($pair);
+            $key = key($pair);
 
             $value = reset($pair);
 
-            if (! isset($dictionary[$pairKey])) {
-                $dictionary[$pairKey] = [];
+            if (! isset($dictionary[$key])) {
+                $dictionary[$key] = [];
             }
 
-            if ($isAssociative) {
-                $dictionary[$pairKey][$key] = $value;
-            } else {
-                $dictionary[$pairKey][] = $value;
-            }
+            $dictionary[$key][] = $value;
         }
 
         return new static($dictionary);

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -859,18 +859,24 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $dictionary = [];
 
+        $isAssociative = Arr::isAssoc($this->items);
+
         foreach ($this->items as $key => $item) {
             $pair = $callback($item, $key);
 
-            $key = key($pair);
+            $pairKey = key($pair);
 
             $value = reset($pair);
 
-            if (! isset($dictionary[$key])) {
-                $dictionary[$key] = [];
+            if (! isset($dictionary[$pairKey])) {
+                $dictionary[$pairKey] = [];
             }
 
-            $dictionary[$key][] = $value;
+            if ($isAssociative) {
+                $dictionary[$pairKey][$key] = $value;
+            } else {
+                $dictionary[$pairKey][] = $value;
+            }
         }
 
         return new static($dictionary);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -13,8 +13,8 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -307,10 +308,15 @@ class BelongsToMany extends Relation
         // parents without having a possibly slow inner loop for every model.
         $dictionary = [];
 
-        foreach ($results as $result) {
+        $isAssociative = Arr::isAssoc($results->all());
+        foreach ($results as $key => $result) {
             $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
 
-            $dictionary[$value][] = $result;
+            if ($isAssociative) {
+                $dictionary[$value][$key] = $result;
+            } else {
+                $dictionary[$value][] = $result;
+            }
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -299,7 +299,7 @@ class BelongsToMany extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
-     * @return array<array<string, TRelatedModel>>
+     * @return array<array<array-key, TRelatedModel>>
      */
     protected function buildDictionary(EloquentCollection $results)
     {
@@ -309,6 +309,7 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         $isAssociative = Arr::isAssoc($results->all());
+
         foreach ($results as $key => $result) {
             $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -178,16 +178,17 @@ abstract class HasOneOrManyThrough extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param  \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>  $results
-     * @return array<array<TRelatedModel>>
+     * @return array<array<array-key, TRelatedModel>>
      */
     protected function buildDictionary(EloquentCollection $results)
     {
         $dictionary = [];
 
+        $isAssociative = Arr::isAssoc($results->all());
+
         // First we will create a dictionary of models keyed by the foreign key of the
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
-        $isAssociative = Arr::isAssoc($results->all());
         foreach ($results as $key => $result) {
             if ($isAssociative) {
                 $dictionary[$result->laravel_through_key][$key] = $result;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Arr;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -186,8 +187,13 @@ abstract class HasOneOrManyThrough extends Relation
         // First we will create a dictionary of models keyed by the foreign key of the
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
-        foreach ($results as $result) {
-            $dictionary[$result->laravel_through_key][] = $result;
+        $isAssociative = Arr::isAssoc($results->all());
+        foreach ($results as $key => $result) {
+            if ($isAssociative) {
+                $dictionary[$result->laravel_through_key][$key] = $result;
+            } else {
+                $dictionary[$result->laravel_through_key][] = $result;
+            }
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Support\Arr;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
@@ -106,12 +107,17 @@ class MorphTo extends BelongsTo
      */
     protected function buildDictionary(EloquentCollection $models)
     {
-        foreach ($models as $model) {
+        $isAssociative = Arr::isAssoc($models->all());
+        foreach ($models as $key => $model) {
             if ($model->{$this->morphType}) {
                 $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
                 $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
 
-                $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
+                if ($isAssociative) {
+                    $this->dictionary[$morphTypeKey][$foreignKeyKey][$key] = $model;
+                } else {
+                    $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
+                }
             }
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -108,6 +108,7 @@ class MorphTo extends BelongsTo
     protected function buildDictionary(EloquentCollection $models)
     {
         $isAssociative = Arr::isAssoc($models->all());
+
         foreach ($models as $key => $model) {
             if ($model->{$this->morphType}) {
                 $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});


### PR DESCRIPTION
Fixes #57754.

TL:DR; this specifically arose from a very niche use case in one of our projects, where you may try to use the (currently undocumented) `afterQuery` function as part of an eager loaded relation, in which that afterQuery causes your collection to get become an associative collection. For example:

```php
public function posts(): HasMany
{
    return $this
        ->hasMany(Post::class)
        ->afterQuery(fn($posts) => $posts->keyBy('id'));
}
```

If you use lazy loading, e.g., `User::first()->posts`, this already worked as I would have expected. However, when using eager loading, e.g., `User::with('posts')->first()->posts` the resulting array would become non-associative due to how the dictionary is being built. This PR changes that behaviour specifically for the case that the resulting array out of a relation is associative.

---

This (as far as I can tell) will not have any bad side effects as I've made sure this will only occur on non-associative arrays and only specifically in the dictionaries of relations. Non-associative arrays there won't normally occur unless you specifically want them to be there.

Of course I don't have the most in-depth knowledge about the inner workings of the core framework, so I could be wrong, however I wasn't able to find any counterexamples.