### PR TITLE
[12.x] Ignore deadlock on DatabaseLock release

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -129,7 +129,6 @@ class DatabaseLock extends Lock
 
             } catch (Throwable $e) {
                 if ($this->causedByConcurrencyError($e)) {
-                    // Ignore concurrency errors - the lock will expire naturally...
                     return true;
                 }
 

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -113,16 +113,28 @@ class DatabaseLock extends Lock
      * Release the lock.
      *
      * @return bool
+     *
+     * @throws Throwable
      */
     public function release()
     {
         if ($this->isOwnedByCurrentProcess()) {
-            $this->connection->table($this->table)
-                ->where('key', $this->name)
-                ->where('owner', $this->owner)
-                ->delete();
+            try {
+                $this->connection->table($this->table)
+                    ->where('key', $this->name)
+                    ->where('owner', $this->owner)
+                    ->delete();
 
-            return true;
+                return true;
+
+            } catch (Throwable $e) {
+                if ($this->causedByConcurrencyError($e)) {
+                    // Ignore concurrency errors - the lock will expire naturally...
+                    return true;
+                }
+
+                throw $e;
+            }
         }
 
         return false;

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -126,7 +126,6 @@ class DatabaseLock extends Lock
                     ->delete();
 
                 return true;
-
             } catch (Throwable $e) {
                 if ($this->causedByConcurrencyError($e)) {
                     return true;

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -119,7 +119,7 @@ class DatabaseLockTest extends DatabaseTestCase
         $owner = 'owner-123';
 
         $selectBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
-        $selectBuilder->shouldReceive('first')->once()->andReturn((object)['owner' => $owner]);
+        $selectBuilder->shouldReceive('first')->once()->andReturn((object) ['owner' => $owner]);
 
         $deleteBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
         $deleteBuilder->shouldReceive('where')->with('owner', $owner)->once()->andReturnSelf();

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -107,4 +107,41 @@ class DatabaseLockTest extends DatabaseTestCase
             $this->assertFalse($lock->acquire());
         }
     }
+
+    #[TestWith(['Serialization failure: 1213 Deadlock', 40001, true])]
+    #[TestWith(['Table does not exist', 1146, false])]
+    public function testReleaseIgnoresConcurrencyException(string $message, int $code, bool $hasConcurrencyError)
+    {
+        $connection = m::mock(Connection::class);
+        $selectBuilder = m::mock(Builder::class);
+        $deleteBuilder = m::mock(Builder::class);
+
+        $owner = 'owner-123';
+
+        $selectBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $selectBuilder->shouldReceive('first')->once()->andReturn((object)['owner' => $owner]);
+
+        $deleteBuilder->shouldReceive('where')->with('key', 'foo')->once()->andReturnSelf();
+        $deleteBuilder->shouldReceive('where')->with('owner', $owner)->once()->andReturnSelf();
+        $deleteBuilder->shouldReceive('delete')->once()->andThrow(
+            new QueryException(
+                'mysql',
+                'delete from cache_locks where key = ? and owner = ?',
+                ['foo', $owner],
+                new PDOException($message, $code)
+            )
+        );
+
+        $connection->shouldReceive('table')->with('cache_locks')->andReturn($selectBuilder, $deleteBuilder);
+
+        $lock = new DatabaseLock($connection, 'cache_locks', 'foo', 10, $owner); // same owner...
+
+        if ($hasConcurrencyError) {
+            $this->assertTrue($lock->release());
+        } else {
+            $this->expectException(QueryException::class);
+            $this->expectExceptionMessage($message);
+            $lock->release();
+        }
+    }
 }


### PR DESCRIPTION
When using shared database locks (ie WithoutOverlapping with shared()), when running multiple workers,  multiple jobs can have the same lock owner and race when releasing simultaneously, causing deadlocks on the cache_locks table.

This is happening for me in production environments: 
```
Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction (Connection: mysql, Host: my-database, Port: 3306, Database: my database-, SQL: delete from `cache_locks` where `....
```

This PR uses the existing `DetectsConcurrencyErrors` trait to catch and ignore deadlock errors  - ie exactly the same as we have in `pruneExpiredLocks` 

Added test coverage. Feedback welcome 🫡