### PR TITLE
[12.x] Fix rate limiter's `remaining` function double escaping the key

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -228,8 +228,6 @@ class RateLimiter
      */
     public function remaining($key, $maxAttempts)
     {
-        $key = $this->cleanRateLimiterKey($key);
-
         $attempts = $this->attempts($key);
 
         return max(0, $maxAttempts - $attempts);


### PR DESCRIPTION
`attempts` function already call the `cleanRateLimiterKey` so the `remaining` function should pass the original value instead of pre-escaping it (which results in being escaped twice).