### PR TITLE
[12.x] Make QueueFake assertPushedTimes public

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -121,7 +121,7 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @param  int  $times
      * @return void
      */
-    protected function assertPushedTimes($job, $times = 1)
+    public function assertPushedTimes($job, $times = 1)
     {
         $count = $this->pushed($job)->count();
 


### PR DESCRIPTION
I would like this to be public.. ie  currently we have: 

<img width="484" height="32" alt="image" src="https://github.com/user-attachments/assets/9c50b6b7-a2a2-45a2-9f34-db830d63ed28" />

But, this is confusing when you see it's asking for a callback..

Would be nice to just do.. 
<img width="594" height="43" alt="image" src="https://github.com/user-attachments/assets/1c59efa0-f7ea-40e0-973f-42734c10a209" />

assertSentTimes is also public on the Mail / Notification Facade, so follows consistency.

Bit of DX 🫡 
