### PR TITLE
Fix `belongsToMany` pivot column and improve `tearDown in aggregate tests

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
@@ -101,8 +101,11 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $this->schema()->drop('orders');
-        $this->schema()->drop('products');
+        $this->schema()->dropIfExists('order_product');
+        $this->schema()->dropIfExists('allocations');
+        $this->schema()->dropIfExists('orders');
+        $this->schema()->dropIfExists('products');
+        $this->schema()->dropIfExists('transactions');
 
         parent::tearDown();
     }
@@ -193,6 +196,6 @@ class BelongsToManyAggregateTestTestTransaction extends Eloquent
     {
         return $this
             ->belongsToMany(BelongsToManyAggregateTestTestTransaction::class, 'allocations', 'from_id', 'to_id')
-            ->withPivot('quantity');
+            ->withPivot('amount');
     }
 }


### PR DESCRIPTION
This PR makes two improvements to the `DatabaseEloquentBelongsToManyAggregateTest`:

1. **Fixed pivot column**  
   - The `allocatedTo` relation in `BelongsToManyAggregateTestTestTransaction` 
     was incorrectly using `quantity` as the pivot.  
   - Updated to `amount` to match the database schema.

2. **Improved tearDown()**  
   - All related tables (`order_product`, `allocations`, `orders`, `products`, `transactions`) 
     are now dropped in dependency-safe order using `dropIfExists`.  
   - Ensures tests clean up properly and avoids foreign key constraint errors.
