### PR TITLE
Add rounding mode support to Number formatting

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -25,6 +25,13 @@ class Number
     protected static $currency = 'USD';
 
     /**
+     * The current default rounding mode.
+     *
+     * @var int|null
+     */
+    protected static $roundingMode = null;
+
+    /**
      * Format the given number according to the current locale.
      *
      * @param  int|float  $number
@@ -33,7 +40,7 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
+    public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null, ?int $roundingMode = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -43,6 +50,11 @@ class Number
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
         } elseif (! is_null($precision)) {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        }
+        $rounding = $roundingMode ?? static::$roundingMode;
+
+        if (! is_null($rounding)) {
+            $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, $rounding);
         }
 
         return $formatter->format($number);
@@ -158,7 +170,7 @@ class Number
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function percentage(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
+    public static function percentage(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null, ?int $roundingMode = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -168,6 +180,12 @@ class Number
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
         } else {
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+        }
+
+        $rounding = $roundingMode ?? static::$roundingMode;
+
+        if (! is_null($rounding)) {
+            $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, $rounding);
         }
 
         return $formatter->format($number / 100);
@@ -182,7 +200,7 @@ class Number
      * @param  int|null  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null)
+    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null, ?int $roundingMode = null)
     {
         static::ensureIntlExtensionIsInstalled();
 
@@ -192,7 +210,34 @@ class Number
             $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
         }
 
+        $rounding = $roundingMode ?? static::$roundingMode;
+
+        if (! is_null($rounding)) {
+            $formatter->setAttribute(NumberFormatter::ROUNDING_MODE, $rounding);
+        }
+
         return $formatter->formatCurrency($number, ! empty($in) ? $in : static::$currency);
+    }
+
+    /**
+     * Set the default rounding mode.
+     *
+     * @param  int|null  $roundingMode
+     * @return void
+     */
+    public static function useRoundingMode(?int $roundingMode)
+    {
+        static::$roundingMode = $roundingMode;
+    }
+
+    /**
+     * Get the default rounding mode.
+     *
+     * @return int|null
+     */
+    public static function defaultRoundingMode()
+    {
+        return static::$roundingMode;
     }
 
     /**

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -94,7 +94,6 @@ class SupportNumberTest extends TestCase
         Number::useRoundingMode(null);
     }
 
-
     public function testSpellout()
     {
         $this->assertSame('ten', Number::spell(10));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Number;
+use NumberFormatter;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
@@ -72,6 +73,28 @@ class SupportNumberTest extends TestCase
         Number::useLocale('en');
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testFormatWithRoundingModeParameter()
+    {
+        $this->assertSame('13', Number::format(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFUP));
+        $this->assertSame('12', Number::format(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFEVEN));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testGlobalRoundingMode()
+    {
+        Number::useRoundingMode(NumberFormatter::ROUND_HALFUP);
+
+        $this->assertSame('13', Number::format(12.5, precision: 0));
+
+        Number::useRoundingMode(NumberFormatter::ROUND_HALFEVEN);
+
+        $this->assertSame('12', Number::format(12.5, precision: 0));
+
+        Number::useRoundingMode(null);
+    }
+
+
     public function testSpellout()
     {
         $this->assertSame('ten', Number::spell(10));
@@ -138,6 +161,29 @@ class SupportNumberTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
+    public function testPercentageWithRoundingModeParameter()
+    {
+        $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4, roundingMode: NumberFormatter::ROUND_HALFUP));
+        $this->assertSame('0.13%', Number::percentage(0.125, precision: 2, roundingMode: NumberFormatter::ROUND_HALFUP));
+        $this->assertSame('0.12%', Number::percentage(0.125, precision: 2, roundingMode: NumberFormatter::ROUND_HALFEVEN));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testGlobalRoundingModeAffectsPercentage()
+    {
+        Number::useRoundingMode(NumberFormatter::ROUND_HALFUP);
+
+        $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
+        $this->assertSame('0.13%', Number::percentage(0.125, precision: 2));
+
+        Number::useRoundingMode(NumberFormatter::ROUND_HALFEVEN);
+
+        $this->assertSame('0.12%', Number::percentage(0.125, precision: 2));
+
+        Number::useRoundingMode(null);
+    }
+
+    #[RequiresPhpExtension('intl')]
     public function testToCurrency()
     {
         $this->assertSame('$0.00', Number::currency(0));
@@ -167,6 +213,13 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123.456.789,12 $', Number::currency(123456789.12345, 'USD', 'de'));
         $this->assertSame('123.456.789,12 €', Number::currency(123456789.12345, 'EUR', 'de'));
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testToCurrencyWithRoundingMode()
+    {
+        $this->assertSame('$13', Number::currency(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFUP));
+        $this->assertSame('$12', Number::currency(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFEVEN));
     }
 
     public function testBytesToHuman()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adds an optional roundingMode parameter to Number::format(), Number::currency(), and Number::percentage(), and Number::useRoundingMode() / Number::defaultRoundingMode() functions. This gives developers explicit control over NumberFormatter rounding (avoids surprising banker’s rounding) while keeping existing behavior unchanged when no rounding mode is provided. It makes formatting predictable for accounting/finance and UI use cases.
```php
<?php
use NumberFormatter;
use Illuminate\Support\Number;

// Per-call rounding:
Number::format(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFUP); // "13"

// Currency with per-call rounding:
Number::currency(12.5, precision: 0, roundingMode: NumberFormatter::ROUND_HALFUP); // "$13"

// Set global default rounding:
Number::useRoundingMode(NumberFormatter::ROUND_HALFUP);
Number::format(12.5, precision: 0); // "13"
Number::useRoundingMode(null); // revert to default
```

Discussion related https://github.com/laravel/framework/discussions/58001