### PR TITLE
[12.x] - Add the ability to register a custom response for the `health` route

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -9,15 +9,12 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
-use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as AppEventServiceProvider;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as AppRouteServiceProvider;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\View;
 use Laravel\Folio\Folio;
 
 class ApplicationBuilder
@@ -216,25 +213,7 @@ class ApplicationBuilder
             }
 
             if (is_string($health)) {
-                Route::get($health, function () {
-                    $exception = null;
-
-                    try {
-                        Event::dispatch(new DiagnosingHealth);
-                    } catch (\Throwable $e) {
-                        if (app()->hasDebugModeEnabled()) {
-                            throw $e;
-                        }
-
-                        report($e);
-
-                        $exception = $e->getMessage();
-                    }
-
-                    return response(View::file(__DIR__.'/../resources/health-up.blade.php', [
-                        'exception' => $exception,
-                    ]), status: $exception ? 500 : 200);
-                });
+                HealthRouteManager::register($health);
             }
 
             if (is_string($web) || is_array($web)) {

--- a/src/Illuminate/Foundation/Configuration/HealthRouteManager.php
+++ b/src/Illuminate/Foundation/Configuration/HealthRouteManager.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Foundation\Configuration;
+
+use Closure;
+use Illuminate\Foundation\Events\DiagnosingHealth;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
+
+class HealthRouteManager
+{
+    /** @var  Closure(?string $exception): void|null */
+    protected static ?Closure $responseCallback = null;
+
+    public static function register(string $route): void
+    {
+        Route::get($route, function () {
+            $exception = null;
+
+            try {
+                Event::dispatch(new DiagnosingHealth);
+            } catch (\Throwable $e) {
+                if (app()->hasDebugModeEnabled()) {
+                    throw $e;
+                }
+
+                report($e);
+
+                $exception = $e->getMessage();
+            }
+
+            if (static::$responseCallback) {
+                return call_user_func(static::$responseCallback, $exception);
+            }
+
+            return response(View::file(__DIR__.'/../resources/health-up.blade.php', [
+                'exception' => $exception,
+            ]), status: $exception ? 500 : 200);
+        });
+    }
+
+    /**
+     * @param  Closure(?string $exception): mixed  $callback
+     */
+    public static function respondUsing(Closure $callback): void
+    {
+        static::$responseCallback = $callback;
+    }
+}

--- a/src/Illuminate/Foundation/Configuration/HealthRouteManager.php
+++ b/src/Illuminate/Foundation/Configuration/HealthRouteManager.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\View;
 
 class HealthRouteManager
 {
-    /** @var  Closure(?string $exception): void|null */
+    /** @var Closure(?string): void|null */
     protected static ?Closure $responseCallback = null;
 
     public static function register(string $route): void

--- a/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
+++ b/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Configuration;
+
+use Exception;
+use Illuminate\Foundation\Configuration\HealthRouteManager;
+use Illuminate\Foundation\Events\DiagnosingHealth;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class HealthRouteManagerTest extends TestCase
+{
+    public function testHealthRouteIsRegistered()
+    {
+        $this->assertNotContains('health', $this->getRegisteredRoutes());
+
+        HealthRouteManager::register('health');
+
+        $this->assertContains('health', $this->getRegisteredRoutes());
+    }
+
+    public function testReturnsTheDefaultHealthViewByDefault()
+    {
+        HealthRouteManager::register('health');
+
+        $view = str_replace('/tests/Integration/', '/src/Illuminate/', __DIR__ . '/../resources/health-up.blade.php');
+
+        $this->get('health')
+            ->assertViewIs($view)
+            ->assertViewHas('exception');
+    }
+
+    public function testCanHaveACustomResponseRegistered()
+    {
+        HealthRouteManager::register('health');
+        HealthRouteManager::respondUsing(fn() => ['ok' => true]);
+
+        $this->get('health')->assertJson(['ok' => true]);
+    }
+
+    public function testCanAccessTheExceptionMessageInTheRespondUsingCallback()
+    {
+        HealthRouteManager::register('health');
+        HealthRouteManager::respondUsing(fn($exception) => [
+            'ok' => false,
+            'exception' => $exception,
+        ]);
+
+        Event::listen(DiagnosingHealth::class, function () {
+            throw new Exception('Uh oh, something went wrong');
+        });
+
+        $this->get('health')->assertJson([
+            'ok' => false,
+            'exception' => 'Uh oh, something went wrong',
+        ]);
+    }
+
+    public function testTheDefaultResponseHasTheExceptionMessageAndReturns500IfItIsSet()
+    {
+        HealthRouteManager::register('health');
+
+        Event::listen(DiagnosingHealth::class, function () {
+            throw new Exception('Uh oh, something went wrong');
+        });
+
+        $this->get('health')
+            ->assertServerError()
+            ->assertViewHas('exception', 'Uh oh, something went wrong');
+    }
+
+    protected function getRegisteredRoutes(): Collection
+    {
+        return collect(Route::getRoutes()->getRoutes())->map(fn(\Illuminate\Routing\Route $route) => $route->uri());
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset the state of the health route manager
+        $reflection = new \ReflectionClass(HealthRouteManager::class);
+
+        $prop = $reflection->getProperty('responseCallback');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+
+        parent::tearDown();
+    }
+}
+

--- a/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
+++ b/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\View;
 use Orchestra\Testbench\TestCase;
 
 class HealthRouteManagerTest extends TestCase
@@ -25,11 +26,12 @@ class HealthRouteManagerTest extends TestCase
     {
         HealthRouteManager::register('health');
 
-        $view = str_replace('/tests/Integration/', '/src/Illuminate/', __DIR__.'/../resources/health-up.blade.php');
+        $response = $this->get('health');
 
-        $this->get('health')
-            ->assertViewIs($view)
-            ->assertViewHas('exception');
+        $this->assertInstanceOf(View::class, $response->original);
+        $this->assertStringEndsWith('health-up.blade.php', $response->original->name());
+
+        $response->assertViewHas('exception');
     }
 
     public function testCanHaveACustomResponseRegistered()

--- a/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
+++ b/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Illuminate\Foundation\Configuration\HealthRouteManager;
 use Illuminate\Foundation\Events\DiagnosingHealth;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
@@ -26,7 +25,7 @@ class HealthRouteManagerTest extends TestCase
     {
         HealthRouteManager::register('health');
 
-        $view = str_replace('/tests/Integration/', '/src/Illuminate/', __DIR__ . '/../resources/health-up.blade.php');
+        $view = str_replace('/tests/Integration/', '/src/Illuminate/', __DIR__.'/../resources/health-up.blade.php');
 
         $this->get('health')
             ->assertViewIs($view)
@@ -36,7 +35,7 @@ class HealthRouteManagerTest extends TestCase
     public function testCanHaveACustomResponseRegistered()
     {
         HealthRouteManager::register('health');
-        HealthRouteManager::respondUsing(fn() => ['ok' => true]);
+        HealthRouteManager::respondUsing(fn () => ['ok' => true]);
 
         $this->get('health')->assertJson(['ok' => true]);
     }
@@ -44,7 +43,7 @@ class HealthRouteManagerTest extends TestCase
     public function testCanAccessTheExceptionMessageInTheRespondUsingCallback()
     {
         HealthRouteManager::register('health');
-        HealthRouteManager::respondUsing(fn($exception) => [
+        HealthRouteManager::respondUsing(fn ($exception) => [
             'ok' => false,
             'exception' => $exception,
         ]);
@@ -74,7 +73,7 @@ class HealthRouteManagerTest extends TestCase
 
     protected function getRegisteredRoutes(): Collection
     {
-        return collect(Route::getRoutes()->getRoutes())->map(fn(\Illuminate\Routing\Route $route) => $route->uri());
+        return collect(Route::getRoutes()->getRoutes())->map(fn (\Illuminate\Routing\Route $route) => $route->uri());
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
+++ b/tests/Integration/Foundation/Configuration/HealthRouteManagerTest.php
@@ -88,4 +88,3 @@ class HealthRouteManagerTest extends TestCase
         parent::tearDown();
     }
 }
-


### PR DESCRIPTION
I was recently working on a project for my employer, Jump24 (a Laravel Diamond Partner), where we had a requirement to return JSON from a standard up (health) route. This endpoint was being checked by an ALB and other tools to determine application health, dependency status, and basic metrics.

Laravel’s built-in health route at /up is very useful, but it always returns a Blade view and cannot currently be customised. Because of this limitation, we had to register a separate health route rather than using the built in one.

This PR adds the ability to register a custom response for the health route by allowing a callback to be registered from the application’s service provider:

```
public function boot(): void
    {
        HealthRouteManager::respondUsing(function() {
            return [
                'ok' => true,
            ];
        });
    }
```

To support this, the existing health route registration logic has been extracted from the `ApplicationBuilder` into a new `HealthRouteManager`. This keeps the builder declarative while giving the health route a single, well defined owner.

If a response callback is registered, it will be invoked and its return value used as the response (for example, an array or a full response object). If no callback is registered, the existing behaviour is preserved and the standard health Blade view is returned.

The callback is also passed a nullable string `$exception`, which contains the message from any exception thrown during health diagnostics. This mirrors the current behaviour of the Blade view and allows the callback to determine application state or response status where needed.