### PR TITLE
fix(number): respect precision when maxPrecision is provided

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -37,12 +37,28 @@ class Number
     {
         static::ensureIntlExtensionIsInstalled();
 
-        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
+        $formatter = new NumberFormatter(
+            $locale ?? static::$locale,
+            NumberFormatter::DECIMAL
+        );
+
+        if (! is_null($precision)) {
+            $formatter->setAttribute(
+                NumberFormatter::MIN_FRACTION_DIGITS,
+                $precision
+            );
+        }
 
         if (! is_null($maxPrecision)) {
-            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
+            $formatter->setAttribute(
+                NumberFormatter::MAX_FRACTION_DIGITS,
+                $maxPrecision
+            );
         } elseif (! is_null($precision)) {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+            $formatter->setAttribute(
+                NumberFormatter::FRACTION_DIGITS,
+                $precision
+            );
         }
 
         return $formatter->format($number);
@@ -162,12 +178,28 @@ class Number
     {
         static::ensureIntlExtensionIsInstalled();
 
-        $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::PERCENT);
+        $formatter = new NumberFormatter(
+            $locale ?? static::$locale,
+            NumberFormatter::PERCENT
+        );
+
+        if (! is_null($precision)) {
+            $formatter->setAttribute(
+                NumberFormatter::MIN_FRACTION_DIGITS,
+                $precision
+            );
+        }
 
         if (! is_null($maxPrecision)) {
-            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $maxPrecision);
+            $formatter->setAttribute(
+                NumberFormatter::MAX_FRACTION_DIGITS,
+                $maxPrecision
+            );
         } else {
-            $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $precision);
+            $formatter->setAttribute(
+                NumberFormatter::FRACTION_DIGITS,
+                $precision
+            );
         }
 
         return $formatter->format($number / 100);

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -48,6 +48,11 @@ class SupportNumberTest extends TestCase
 
         $this->assertSame('∞', Number::format(INF));
         $this->assertSame('NaN', Number::format(NAN));
+
+        $this->assertSame(
+            '5.10',
+            Number::format(5.1, precision: 2, maxPrecision: 4, locale: 'en')
+        );
     }
 
     #[RequiresPhpExtension('intl')]
@@ -135,6 +140,11 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0.00%', Number::percentage(0, precision: 2));
         $this->assertSame('0.12%', Number::percentage(0.12345, precision: 2));
         $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
+
+        $this->assertSame(
+            '1.50%',
+            Number::percentage(1.5, precision: 2, maxPrecision: 4, locale: 'en')
+        );
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
# Fix precision handling when maxPrecision is provided

### Description

This PR fixes an issue where `Number::format()` ignores the `$precision` argument whenever `$maxPrecision` is provided.

Currently, passing both parameters causes the minimum fraction digits to be dropped entirely, which leads to unexpected output and makes it impossible to express a “minimum + maximum precision” range.

---

### Problem

When both `$precision` and `$maxPrecision` are set:

```php
Number::format(5.1, precision: 2, maxPrecision: 4);
// Before: "5.1"
```

The `$precision` argument is effectively ignored, even though it appears earlier in the method signature and is expected to control the minimum number of fraction digits.

---

### Solution

This change ensures that:

- `$precision` is always applied as **minimum fraction digits**
- `$maxPrecision` is applied as **maximum fraction digits**
- When only `$precision` is provided, the existing behavior (exact precision) is preserved

This aligns the implementation with `NumberFormatter`’s intended usage and makes both parameters work together logically.

---

### Result

```php
Number::format(5.1, precision: 2, maxPrecision: 4);
// After: "5.10"
```

The same logic is applied consistently to `Number::percentage()`.

---

### Backward Compatibility

- No existing behavior changes when only `$precision` or only `$maxPrecision` is used
- This only affects cases where both parameters are explicitly provided
- Covered by new tests to prevent regressions

---

### Tests

- Added test cases to assert that `$precision` is respected when `$maxPrecision` is set
- Existing test suite passes unchanged

---

Fixes #58517
