### PR TITLE
[12.x] Clear parallel test view cache directories

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -63,7 +63,11 @@ class ViewClearCommand extends Command
             ->forgetCompiledOrNotExpired();
 
         foreach ($this->files->glob("{$path}/*") as $view) {
-            $this->files->delete($view);
+            if ($this->files->isDirectory($view)) {
+                $this->files->deleteDirectory($view);
+            } else {
+                $this->files->delete($view);
+            }
         }
 
         $this->components->info('Compiled views cleared successfully.');

--- a/tests/View/ClearCommandTest.php
+++ b/tests/View/ClearCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\View;
+
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Console\ViewClearCommand;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class ClearCommandTest extends TestCase
+{
+    private $files;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = m::mock(Filesystem::class);
+        Container::setInstance($this->app);
+        $this->app->instance('files', $this->files);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        m::close();
+        parent::tearDown();
+    }
+
+    public function test_clear_view_command_should_remove_parallel_test_directories()
+    {
+        $globResult = [
+            '/views/cache/path/filehash123.php',
+            '/views/cache/path/test_33',
+        ];
+        $this->files->shouldReceive('glob')->once()->andReturn($globResult);
+
+        $this->files->shouldReceive('isDirectory')->once()->with($globResult[0])->andreturn(false);
+        $this->files->shouldReceive('isDirectory')->once()->with($globResult[1])->andreturn(true);
+        $this->files->shouldReceive('delete')->once()->with($globResult[0]);
+        $this->files->shouldReceive('deleteDirectory')->once()->with($globResult[1]);
+
+        $this->artisan(ViewClearCommand::class);
+    }
+}


### PR DESCRIPTION
## Description

Fixes #58521

Added a directory check and deletion on `view:clear`

previously, parallel test directories would be left untouched
```php
foreach ($this->files->glob("{$path}/*") as $view) {
    $this->files->delete($view);
}
```

added directory verification and directory deletion

```php
foreach ($this->files->glob("{$path}/*") as $view) {
    if ($this->files->isDirectory($view)) {
        $this->files->deleteDirectory($view);
    } else {
        $this->files->delete($view);
    }
}
```

## Test

not sure if I should test against real fixture view files then I just mocked the filesystem to go through a sample list and ensured it was calling for `deleteDirectory` when `isDirectory` returns true

```bash
./vendor/bin/phpunit --filter test_clear_view_command_should_remove_parallel_test_directories
```


Let me know if it needs any change

