### PR TITLE
[12.x] fix: allow phpstan to understand default value for Request::enum

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -313,11 +313,12 @@ trait InteractsWithData
      * Retrieve data from the instance as an enum.
      *
      * @template TEnum of \BackedEnum
+     * @template TDefault of TEnum|null
      *
      * @param  string  $key
      * @param  class-string<TEnum>  $enumClass
-     * @param  TEnum|null  $default
-     * @return TEnum|null
+     * @param  TDefault  $default
+     * @return TEnum|TDefault
      */
     public function enum($key, $enumClass, $default = null)
     {

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -14,6 +14,7 @@ $request = Request::create('/', 'GET', [
 ]);
 
 assertType('TestEnum|null', $request->enum('key', TestEnum::class));
+assertType('TestEnum|TestEnum::Foo', $request->enum('key', TestEnum::class, TestEnum::Foo));
 
 assertType('Illuminate\Routing\Route', $request->route());
 assertType('object|string|null', $request->route('key'));


### PR DESCRIPTION
Hello!

This allows PHPStan to understand that the value cannot be null when a default is given.

Thanks!