### PR TITLE
[12.x] Resolve the correct queue factory when using laravel octane

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Bus;
 use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Bus\QueueingDispatcher as QueueingDispatcherContract;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\Arr;
@@ -20,8 +21,8 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
     public function register()
     {
         $this->app->singleton(Dispatcher::class, function ($app) {
-            return new Dispatcher($app, function ($connection = null) use ($app) {
-                return $app[QueueFactoryContract::class]->connection($connection);
+            return new Dispatcher($app, function ($connection = null) {
+                return Container::getInstance()->make(QueueFactoryContract::class)->connection($connection);
             });
         });
 

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Bus;
 
 use Aws\DynamoDb\DynamoDbClient;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Bus\QueueingDispatcher as QueueingDispatcherContract;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\Arr;


### PR DESCRIPTION
[This](https://github.com/laravel/framework/pull/58452) change breaks sending queued notifications when used with Laravel Octane. The first request proceeds as usual, however the on the second request I get `Target [Illuminate\Contracts\Queue\Factory] is not instantiable.`.  This PR should resolve that issue