### PR TITLE
[12.x] Add `authority`method to Support/Uri

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -116,6 +116,14 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
     }
 
     /**
+     * Get the URI's authority.
+     */
+    public function authority(): ?string
+    {
+        return $this->uri->getAuthority();
+    }
+
+    /**
      * Get the URI's scheme.
      */
     public function scheme(): ?string

--- a/tests/Support/SupportUriTest.php
+++ b/tests/Support/SupportUriTest.php
@@ -42,6 +42,7 @@ class SupportUriTest extends TestCase
         $this->assertEquals('hello', $uri->fragment());
         $this->assertEquals(['version' => 1], $uri->query()->all());
         $this->assertEquals(1, $uri->query()->integer('version'));
+        $this->assertEquals('taylor:password@laravel.com', $uri->authority());
     }
 
     public function test_complicated_query_string_parsing()


### PR DESCRIPTION
Good day Big T, 

I currently handle CSP logic by passing in the endpoint from the file system, so something like:

```php 
// Locally, `filesystems.disks.s3.endpoint` could be https://filesystem:9600 (a docker image) 

// In real, this could be https://fake-fake.r2.eu.cloudstorage.com

// Currently, I have to do this..
$url = Uri::of(config('filesystems.disks.s3.endpoint'))

$url->port() ? implode(':', $url->host(), $url->port()) : $url->host();


// With the change, I can sleep easy and just do...
Uri::of(config('filesystems.disks.s3.endpoint'))->authority();

// Some tinker dumps..
> Uri::of('https://filesystem:9600')->authority();
= "filesystem:9600"


> Uri::of('https://laravel.com')->authority();
= "laravel.com"
```


As this is just a wrapper for League/Uri, I thought it would be a nice addition.

authority is part of URI re - https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Authority

Test also added 🫡 