### PR TITLE
[12.x] Respect default value for class dependencies in BoundMethod::call

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -187,6 +187,8 @@ class BoundMethod
                 $pendingDependencies = array_merge($pendingDependencies, is_array($variadicDependencies)
                     ? $variadicDependencies
                     : [$variadicDependencies]);
+            } elseif ($parameter->isDefaultValueAvailable() && ! $container->bound($className)) {
+                $pendingDependencies[] = $parameter->getDefaultValue();
             } else {
                 $pendingDependencies[] = $container->make($className);
             }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -227,6 +227,29 @@ class ContainerCallTest extends TestCase
             return $foo;
         });
     }
+
+    public function testCallWithNullableClassParameterDefaultValue()
+    {
+        $container = new Container;
+
+        $result = $container->call(function (?ContainerCallConcreteStub $stub = null) {
+            return $stub;
+        });
+
+        $this->assertNull($result);
+    }
+
+    public function testCallWithNullableClassParameterDefaultValueWithBinding()
+    {
+        $container = new Container;
+        $container->bind(ContainerCallConcreteStub::class);
+
+        $result = $container->call(function (?ContainerCallConcreteStub $stub = null) {
+            return $stub;
+        });
+
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+    }
 }
 
 class ContainerTestCallStub


### PR DESCRIPTION
Hey!

This PR aligns the behavior of Container::call() with the constructor dependency resolution introduced in Laravel 12 (see [upgrade guide](https://laravel.com/docs/12.x/upgrade#container-class-dependency-resolution)).

Currently, when resolving class dependencies in a constructor, the container respects the default value if no binding exists:

```php
class Example
{
    public function __construct(public ?Carbon $date = null) {}
}

$example = resolve(Example::class);
$example->date === null; // ✓ default value is respected
```
However, when using Container::call() to invoke a method, this behavior wasn't applied:
```php
$container->call(function (?Carbon $date = null) {
    return $date;
}); // returned a Carbon instance instead of null
```
This PR fixes that inconsistency. Now both constructor injection and method injection respect the default value when no explicit binding exists.

I'm not sure if this should target 12.x as a fix or 13.x since it's technically a breaking change. Let me know what you think!