### PR TITLE
[12.x] Use try/finally for buildStack cleanup in Container::build

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1160,13 +1160,9 @@ class Container implements ArrayAccess, ContainerContract
         // new instance of this class, injecting the created dependencies in.
         try {
             $instances = $this->resolveDependencies($dependencies);
-        } catch (BindingResolutionException $e) {
+        } finally {
             array_pop($this->buildStack);
-
-            throw $e;
         }
-
-        array_pop($this->buildStack);
 
         $this->fireAfterResolvingAttributeCallbacks(
             $reflector->getAttributes(), $instance = new $concrete(...$instances)


### PR DESCRIPTION
Hey!

I noticed the buildStack cleanup in Container::build() only happens for BindingResolutionException (added in [this commit](https://github.com/laravel/framework/commit/91d542fd19c149f3f30f271b5cec2dd2f55a884a)):

```php
try {
    $instances = $this->resolveDependencies($dependencies);
} catch (BindingResolutionException $e) {
    array_pop($this->buildStack);
    throw $e;
}

array_pop($this->buildStack);
```
This means if any other exception is thrown, the stack won't be cleaned up. I'm not sure if this is intentional or not.

If it's intentional, I think there should be a comment explaining why. Otherwise, using try/finally makes the code simpler and ensures the stack is always cleaned up:

```php
try {
    $instances = $this->resolveDependencies($dependencies);
} finally {
    array_pop($this->buildStack);
}
```
This PR assumes it wasn't intentional and uses finally. Let me know if I'm wrong!