### PR TITLE
[12.x] Add missing docblock to Uri::of() method 🇵🇾

### DIFF
--- a/src/Illuminate/Support/Uri.php
+++ b/src/Illuminate/Support/Uri.php
@@ -41,6 +41,9 @@ class Uri implements Htmlable, JsonSerializable, Responsable, Stringable
 
     /**
      * Create a new URI instance.
+     *
+     * @param  \League\Uri\Contracts\UriInterface|\Stringable|string  $uri
+     * @return static
      */
     public static function of(UriInterface|Stringable|string $uri = ''): static
     {


### PR DESCRIPTION
Add missing `@param` and `@return` docblock entries to the `Uri::of()` method for consistency with other static factory methods in the class

Committed from Asunción, Paraguay 🇵🇾

