### PR TITLE
[12.x] Add missing docblock in QueuedHandler method

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -220,6 +220,9 @@ class CallQueuedHandler
 
     /**
      * Determine if the given command should be unique.
+     *
+     * @param  mixed  $command
+     * @return bool
      */
     protected function commandShouldBeUnique(mixed $command): bool
     {
@@ -229,6 +232,9 @@ class CallQueuedHandler
 
     /**
      * Determine if the given command should be unique until processing begins.
+     *
+     * @param  mixed  $command
+     * @return bool
      */
     protected function commandShouldBeUniqueUntilProcessing(mixed $command): bool
     {


### PR DESCRIPTION
in `CallQueuedHandler` method commandShouldBeUnique Added missing docblock `@param mixed $command and @return bool` and `commandShouldBeUniqueUntilProcessing `- Added missing docblock `@param mixed $command and @return bool`