### PR TITLE
[12.x] Add `hasMany()` method to collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -739,30 +739,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Determine if the collection contains multiple items. If a callback is provided, determine if multiple items match the condition.
+     * Determine if the collection contains multiple items.
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return bool
+     *
+     * @deprecated 12.50.0 Use the `hasMany()` method instead.
      */
     public function containsManyItems(?callable $callback = null): bool
     {
-        if (! $callback) {
-            return $this->count() > 1;
-        }
-
-        $count = 0;
-
-        foreach ($this as $key => $item) {
-            if ($callback($item, $key)) {
-                $count++;
-            }
-
-            if ($count > 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->hasMany($callback);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -700,10 +700,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Determine if the collection contains multiple items.
      *
      * @return bool
+     *
+     * @deprecated 12.50.0 Use the `hasMany()` method instead.
      */
     public function containsManyItems(): bool
     {
-        return $this->take(2)->count() > 1;
+        return $this->hasMany();
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -33,6 +33,8 @@ use function Illuminate\Support\enum_value;
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $first
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $flatMap
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $groupBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasMany
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasSole
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $keyBy
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $last
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $map
@@ -81,6 +83,7 @@ trait EnumeratesValues
         'first',
         'flatMap',
         'groupBy',
+        'hasMany',
         'hasSole',
         'keyBy',
         'last',
@@ -1014,6 +1017,27 @@ trait EnumeratesValues
         return $this->escapeWhenCastingToString
             ? e($this->toJson())
             : $this->toJson();
+    }
+
+    /**
+     * Determine if the collection contains multiple items, optionally matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasMany($key = null, $operator = null, $value = null): bool
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        return $this
+            ->unless($filter == null)
+            ->filter($filter)
+            ->take(2)
+            ->count() === 2;
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -334,6 +334,27 @@ trait EnumeratesValues
     }
 
     /**
+     * Determine if the collection contains multiple items, optionally matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasMany($key = null, $operator = null, $value = null): bool
+    {
+        $filter = func_num_args() > 1
+            ? $this->operatorForWhere(...func_get_args())
+            : $key;
+
+        return $this
+            ->unless($filter == null)
+            ->filter($filter)
+            ->take(2)
+            ->count() === 2;
+    }
+
+    /**
      * Get a single key's value from the first matching item in the collection.
      *
      * @template TValueDefault
@@ -1017,27 +1038,6 @@ trait EnumeratesValues
         return $this->escapeWhenCastingToString
             ? e($this->toJson())
             : $this->toJson();
-    }
-
-    /**
-     * Determine if the collection contains multiple items, optionally matching the given criteria.
-     *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function hasMany($key = null, $operator = null, $value = null): bool
-    {
-        $filter = func_num_args() > 1
-            ? $this->operatorForWhere(...func_get_args())
-            : $key;
-
-        return $this
-            ->unless($filter == null)
-            ->filter($filter)
-            ->take(2)
-            ->count() === 2;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -175,6 +175,34 @@ class SupportCollectionTest extends TestCase
     }
 
     #[DataProvider('collectionClassProvider')]
+    public function testHasMany($collection)
+    {
+        $collection = new $collection([
+            ['age' => 2],
+            ['age' => 3],
+        ]);
+
+        $this->assertTrue($collection->hasMany());
+        $this->assertFalse($collection->where('age', 1)->hasMany());
+        $this->assertFalse($collection->where('age', 2)->hasMany());
+
+        $this->assertTrue($collection->hasMany(fn () => true));
+        $this->assertFalse($collection->hasMany(fn () => false));
+        $this->assertFalse($collection->hasMany(fn ($item) => $item['age'] === 2));
+
+        $this->assertTrue($collection->hasMany('age', '>', 1));
+        $this->assertFalse($collection->hasMany('age', '<', 1));
+        $this->assertFalse($collection->hasMany('age', 2));
+
+        $data = new $collection([
+            (object) ['active' => true, 'verified' => true],
+            (object) ['active' => false, 'verified' => true],
+        ]);
+
+        $this->assertTrue($data->hasMany->verified);
+    }
+
+    #[DataProvider('collectionClassProvider')]
     public function testFirstOrFailReturnsFirstItemInCollection($collection)
     {
         $collection = new $collection([

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -605,6 +605,23 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         );
     }
 
+    public function testHasManyIsLazy()
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->hasMany();
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->hasMany(fn ($item) => $item <= 2);
+        });
+
+        $this->assertEnumeratesCollection(
+            LazyCollection::times(10, fn ($i) => ['age' => $i]),
+            2,
+            fn ($collection) => $collection->hasMany('age', '<=', 2),
+        );
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
This PR renames `containsManyItems()` to `hasMany()`, and adds callback and operator support.

## Background

In #58312, `containsManyItems()` was added as a companion to `containsOneItem()`. Now that we have `hasSole()` (#58463), we should add a matching `hasMany()` method.

This is now more coherent:

```php
$collection->isEmpty();
$collection->hasSole();
$collection->hasMany();
```

## New Method

`hasMany()` checks if a collection contains more than one item, with the same filter signatures as `hasSole()`:

```php
$collection->hasMany();
$collection->hasMany(fn ($item) => $item->active);
$collection->hasMany('status', 'pending');
$collection->hasMany('age', '>=', 21);
$collection->hasMany->active;
```

## Improvements

`containsManyItems()` had several issues:

- **Overly complex implementation**: The method in `Collection` used a manual complex loop, instead of simply using `take(2)->count()`.
- **Inconsistent signatures**: `Collection` accepted a callback, `LazyCollection` did not.
- **No higher-order proxy support**: Not included in the `$proxies` array.
- **Missing lazy tests**: `LazyCollection::containsManyItems()` had no laziness tests.

`hasMany()` addresses all of these with a single, shared implementation in the `EnumeratesValues` trait.

## Deprecation

`containsManyItems()` is now deprecated and delegates to `hasMany()`.

## Laravel 13

After this is merged, and then merged into `master`, we'll add this method to the `Enumerable` interface, and remove the `containsManyItems()` method completely.
