### PR TITLE
[12.x] Add withoutAppends to HasAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2400,16 +2400,6 @@ trait HasAttributes
     }
 
     /**
-     * Remove appended properties from the collection.
-     *
-     * @return $this
-     */
-    public function withoutAppends()
-    {
-        return $this->setAppends([]);
-    }
-
-    /**
      * Merge new appended attributes with existing appended attributes on the model.
      *
      * @param  array<string>  $appends
@@ -2431,6 +2421,16 @@ trait HasAttributes
     public function hasAppended($attribute)
     {
         return in_array($attribute, $this->appends);
+    }
+
+    /**
+     * Remove all appended properties from the model.
+     *
+     * @return $this
+     */
+    public function withoutAppends()
+    {
+        return $this->setAppends([]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2400,6 +2400,16 @@ trait HasAttributes
     }
 
     /**
+     * Remove appended properties from the collection.
+     *
+     * @return $this
+     */
+    public function withoutAppends()
+    {
+        return $this->setAppends([]);
+    }
+
+    /**
      * Merge new appended attributes with existing appended attributes on the model.
      *
      * @param  array<string>  $appends


### PR DESCRIPTION
Description
---
After #57561 I noticed that we could do:

```php
$user->setAppends(['is_admin'])->toArray();
```

But we cannot do:

```php
$user->withoutAppends()->toArray();
```

See
---
https://laravel.com/docs/12.x/eloquent-serialization#appending-at-run-time