### PR TITLE
[12.x] Ensure Validator message defaults if using custom size messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "pda/pheanstalk": "^5.0.6|^7.0.0",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+        "phpunit/phpunit": "^10.5.62|^11.5.50|^12.5.8",
         "predis/predis": "^2.3|^3.0",
         "resend/resend-php": "^0.10.0|^1.0",
         "symfony/cache": "^7.2.0",

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "pda/pheanstalk": "^5.0.6|^7.0.0",
         "php-http/discovery": "^1.15",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.5.62|^11.5.50|^12.5.8",
+        "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
         "predis/predis": "^2.3|^3.0",
         "resend/resend-php": "^0.10.0|^1.0",
         "symfony/cache": "^7.2.0",

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -85,7 +85,7 @@ trait FormatsMessages
         $inlineEntry = $this->getFromLocalArray($attribute, Str::snake($rule));
 
         return is_array($inlineEntry) && in_array($rule, $this->sizeRules)
-            ? $inlineEntry[$this->getAttributeType($attribute)]
+            ? $inlineEntry[$this->getAttributeType($attribute)] ?? null
             : $inlineEntry;
     }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -85,7 +85,7 @@ trait FormatsMessages
         $inlineEntry = $this->getFromLocalArray($attribute, Str::snake($rule));
 
         return is_array($inlineEntry) && in_array($rule, $this->sizeRules)
-            ? $inlineEntry[$this->getAttributeType($attribute)] ?? null
+            ? ($inlineEntry[$this->getAttributeType($attribute)] ?? null)
             : $inlineEntry;
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10001,17 +10001,19 @@ class ValidationValidatorTest extends TestCase
 
         $data = [
             'array_data' => [0, 0, 0],
+            'some_more_array_data' => [0, 0, 0, 0],
             'numeric_data' => 5,
         ];
 
         $rules = [
             'array_data' => 'array|max:1',
+            'some_more_array_data' => 'array|max:3',
             'numeric_data' => 'integer|max:2',
         ];
 
         $messages = [
             'max' => [
-                'array' => 'array must be up to :max',
+                'array' => ':attribute must be up to :max',
             ],
         ];
 
@@ -10019,7 +10021,10 @@ class ValidationValidatorTest extends TestCase
 
         $this->assertSame([
             'array_data' => [
-                'array must be up to 1',
+                'array data must be up to 1',
+            ],
+            'some_more_array_data' => [
+                'some more array data must be up to 3',
             ],
             'numeric_data' => [
                 'validation.max.numeric',

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10006,23 +10006,23 @@ class ValidationValidatorTest extends TestCase
 
         $rules = [
             'array_data' => 'array|max:1',
-            'numeric_data' => 'integer|max:2'
+            'numeric_data' => 'integer|max:2',
         ];
 
         $messages = [
             'max' => [
                 'array' => 'array must be up to :max',
-            ]
+            ],
         ];
 
         $validator = new Validator($trans, $data, $rules, $messages, []);
 
         $this->assertSame([
             'array_data' => [
-                'array must be up to 1'
+                'array must be up to 1',
             ],
             'numeric_data' => [
-                'validation.max.numeric'
+                'validation.max.numeric',
             ]
         ], $validator->messages()->messages());
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10000,13 +10000,13 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
 
         $data = [
-            'arr_key' => [0, 0, 0],
-            'numeric_key' => 5,
+            'array_data' => [0, 0, 0],
+            'numeric_data' => 5,
         ];
 
         $rules = [
-            'arr_key' => 'array|max:1',
-            'numeric_key' => 'integer|max:2'
+            'array_data' => 'array|max:1',
+            'numeric_data' => 'integer|max:2'
         ];
 
         $messages = [
@@ -10019,10 +10019,10 @@ class ValidationValidatorTest extends TestCase
         $validator = new Validator($trans, $data, $rules, $messages, []);
 
         $this->assertSame([
-            'arr_key' => [
+            'array_data' => [
                 'array must be up to 1'
             ],
-            'numeric_key' => [
+            'numeric_data' => [
                 'validation.max.numeric'
             ]
         ], $validator->messages()->messages());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10015,7 +10015,6 @@ class ValidationValidatorTest extends TestCase
             ]
         ];
 
-
         $validator = new Validator($trans, $data, $rules, $messages, []);
 
         $this->assertSame([

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -9995,6 +9995,39 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($validator->passes());
     }
 
+    public function testMessagesDefaultWhenUsingSizeSpecificCustomMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'arr_key' => [0, 0, 0],
+            'numeric_key' => 5,
+        ];
+
+        $rules = [
+            'arr_key' => 'array|max:1',
+            'numeric_key' => 'integer|max:2'
+        ];
+
+        $messages = [
+            'max' => [
+                'array' => 'array must be up to :max',
+            ]
+        ];
+
+
+        $validator = new Validator($trans, $data, $rules, $messages, []);
+
+        $this->assertSame([
+            'arr_key' => [
+                'array must be up to 1'
+            ],
+            'numeric_key' => [
+                'validation.max.numeric'
+            ]
+        ], $validator->messages()->messages());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10023,7 +10023,7 @@ class ValidationValidatorTest extends TestCase
             ],
             'numeric_data' => [
                 'validation.max.numeric',
-            ]
+            ],
         ], $validator->messages()->messages());
     }
 


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/58543

When using the validator with different data types string, array etc, and size rules, we can currently add custom messages like this:

```php
'max' => [ // size rule
  'string' => 'The word length must be a max of :max', // type..
  // 'numeric' => // I won’t include this because I just want Laravels default...
]
```
Currently, if you ignore a custom message for a type (because you want the default), it throws an error.

I've traced this back and and as it's a size rule, it expects the message to be there.  Allowing it to return null which the method’s return type allows fixes it.

(Just revert the `?? null` I’ve added and run `testMessagesDefaultWhenUsingSizeSpecificCustomMessages` to see it.)

I don’t think this is a breaking change as it’s a pretty specific edge case and a simple fix, but happy to target 13.x if preferred 🫡