### PR TITLE
[12.x] Fix JSON translation fallback locale support

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -155,9 +155,17 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key. These are
         // only one level deep so we do not need to do any fancy searching through it.
-        $this->load('*', '*', $locale);
+        $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = null;
+
+        foreach ($locales as $localeForJson) {
+            $this->load('*', '*', $localeForJson);
+
+            if (! is_null($line = $this->loaded['*']['*'][$localeForJson][$key] ?? null)) {
+                break;
+            }
+        }
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -107,6 +107,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->setFallback('lv');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lv', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
         $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
@@ -365,6 +366,7 @@ class TranslationTranslatorTest extends TestCase
             return ['en', 'lz'];
         });
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lz', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
         $this->assertSame('foo', $t->get('foo'));

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -113,6 +113,16 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testGetMethodProperlyLoadsAndRetrievesJsonItemForFallback()
+    {
+        $t = new Translator($this->getLoader(), 'fr');
+        $t->setFallback('en');
+        $t->getLoader()->shouldReceive('load')->once()->with('fr', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['Hello' => 'Hello', 'Welcome :name' => 'Welcome :name']);
+        $this->assertSame('Hello', $t->get('Hello'));
+        $this->assertSame('Welcome Taylor', $t->get('Welcome :name', ['name' => 'Taylor']));
+    }
+
     public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
### Problem                                                                                                                                                                         
                                                                                                                                                                                      
  When a JSON translation key is missing in the current locale, it does not fall back to the fallback locale. Array-style translations correctly iterate through the fallback chain,  
  but JSON translations only check the current locale.                                                                                                                                
                                                                                                                                                                                      
  ### Solution                                                                                                                                                                        
                                                                                                                                                                                      
  Modified `Translator::get()` to iterate through `$this->localeArray($locale)` for JSON translations when `$fallback=true`.                                                          
                                                                                                                                                                                      
  ### Benefit to End Users                                                                                                                                                            
                                                                                                                                                                                      
  Users with multi-locale applications can now rely on JSON translation fallbacks. Previously, missing keys in a locale would return the key itself instead of the fallback           
  translation.                                                                                                                                                                        
                                                                                                                                                                                      
  ```php                                                                                                                                                                              
  // lang/en.json: {"welcome": "Welcome Everyone !"}                                                                                                                                             
  // lang/fr.json: {}                                                                                                                                                                 
                                                                                                                                                                                      
  $translator->setLocale('fr');                                                                                                                                                       
  $translator->setFallback('en');                                                                                                                                                     
                                                                                                                                                                                      
  // Before: "welcome" (key returned as-is)                                                                                                                                           
  // After:  "Welcome Everyone !" (from en.json)                                                                                                                                                 
  $translator->get('Welcome');          

  ```                                                                                                                                                  
                                                                                                                                                                                      
  Why This Doesn't Break Existing Features                                                                                                                                            
                                                                                                                                                                                      
  - Mirrors existing array-style fallback logic already in Translator::get()                                                                                                          
  - Only affects JSON translations when key is missing in current locale                                                                                                              
  - Respects $fallback parameter (disabled when false)                                                                                                                                
                                                                                                                                                                                      
  Tests                                                                                                                                                                               
                                                                                                                                                                                      
  Added `testGetMethodProperlyLoadsAndRetrievesJsonItemForFallback` to verify JSON fallback behavior.                                                                                   
                                     