### PR TITLE
[12.x] Add whereDayIn, whereMonthIn, and whereYearIn to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1737,10 +1737,10 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $column
-     * @param $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  $column
+     * @param  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return mixed
      */
     public function whereDayIn($column, $values, $boolean = 'and', bool $not = false): mixed
@@ -1749,9 +1749,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $column
-     * @param $values
-     * @param string $boolean
+     * @param  $column
+     * @param  $values
+     * @param  string  $boolean
      * @return mixed
      */
     public function whereDayNotIn($column, $values, $boolean = 'and'): mixed
@@ -1760,8 +1760,8 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param string $column
-     * @param $values
+     * @param  string  $column
+     * @param  $values
      * @return mixed
      */
     public function orWhereDayIn($column, $values): mixed
@@ -1922,10 +1922,10 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $column
-     * @param $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  $column
+     * @param  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return mixed
      */
     public function whereMonthIn($column, $values, $boolean = 'and', bool $not = false): mixed
@@ -1934,9 +1934,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $column
-     * @param $values
-     * @param string $boolean
+     * @param  $column
+     * @param  $values
+     * @param  string  $boolean
      * @return mixed
      */
     public function whereMonthNotIn($column, $values, $boolean = 'and'): mixed
@@ -1945,8 +1945,8 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $column
-     * @param $values
+     * @param  $column
+     * @param  $values
      * @return mixed
      */
     public function orWhereMonthIn($column, $values): mixed
@@ -2002,10 +2002,10 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param string $column
-     * @param $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  string  $column
+     * @param  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return mixed
      */
     public function whereYearIn($column, $values, $boolean = 'and', bool $not = false): mixed
@@ -2014,9 +2014,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param string $column
-     * @param $values
-     * @param string $boolean
+     * @param  string  $column
+     * @param  $values
+     * @param  string  $boolean
      * @return mixed
      */
     public function whereYearNotIn($column, $values, $boolean = 'and'): mixed
@@ -2058,11 +2058,11 @@ class Builder implements BuilderContract
     }
 
     /**
-     * @param $type
-     * @param $column
-     * @param $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  $type
+     * @param  $column
+     * @param  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this|Builder
      */
     protected function addDateBasedWhereIn($type, $column, $values, string $boolean = 'and', bool $not = false): Builder|static

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1737,6 +1737,39 @@ class Builder implements BuilderContract
     }
 
     /**
+     * @param $column
+     * @param $values
+     * @param string $boolean
+     * @param bool $not
+     * @return mixed
+     */
+    public function whereDayIn($column, $values, $boolean = 'and', bool $not = false): mixed
+    {
+        return $this->addDateBasedWhereIn('DayIn', $column, $values, $boolean, $not);
+    }
+
+    /**
+     * @param $column
+     * @param $values
+     * @param string $boolean
+     * @return mixed
+     */
+    public function whereDayNotIn($column, $values, $boolean = 'and'): mixed
+    {
+        return $this->addDateBasedWhereIn('DayIn', $column, $values, $boolean, true);
+    }
+
+    /**
+     * @param string $column
+     * @param $values
+     * @return mixed
+     */
+    public function orWhereDayIn($column, $values): mixed
+    {
+        return $this->whereDayIn($column, $values, 'or');
+    }
+
+    /**
      * Add a "where time" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1889,6 +1922,38 @@ class Builder implements BuilderContract
     }
 
     /**
+     * @param $column
+     * @param $values
+     * @param string $boolean
+     * @param bool $not
+     * @return mixed
+     */
+    public function whereMonthIn($column, $values, $boolean = 'and', bool $not = false): mixed
+    {
+        return $this->addDateBasedWhereIn('MonthIn', $column, $values, $boolean, $not);
+    }
+
+    /**
+     * @param $column
+     * @param $values
+     * @param string $boolean
+     * @return mixed
+     */
+    public function whereMonthNotIn($column, $values, $boolean = 'and'): mixed
+    {
+        return $this->addDateBasedWhereIn('MonthIn', $column, $values, $boolean, true);
+    }
+
+    /**
+     * @param $column
+     * @param $values
+     * @return mixed
+     */
+    public function orWhereMonthIn($column, $values): mixed
+    {
+        return $this->whereMonthIn($column, $values, 'or');
+    }
+    /**
      * Add a "where year" statement to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
@@ -1937,6 +2002,41 @@ class Builder implements BuilderContract
     }
 
     /**
+     * @param string $column
+     * @param $values
+     * @param string $boolean
+     * @param bool $not
+     * @return mixed
+     */
+    public function whereYearIn($column, $values, $boolean = 'and', bool $not = false): mixed
+    {
+        return $this->addDateBasedWhereIn('YearIn', $column, $values, $boolean, $not);
+    }
+
+    /**
+     * @param string $column
+     * @param $values
+     * @param string $boolean
+     * @return mixed
+     */
+    public function whereYearNotIn($column, $values, $boolean = 'and'): mixed
+    {
+        return $this->addDateBasedWhereIn('YearIn', $column, $values, $boolean, true);
+    }
+
+    /**
+     * Add an "or where year" statement to the query.
+     *
+     * @param  string  $column
+     * @param  $values
+     * @return $this
+     */
+    public function orWhereYearIn($column, $values): static
+    {
+        return $this->whereYearIn($column, $values, 'or');
+    }
+
+    /**
      * Add a date based (year, month, day, time) statement to the query.
      *
      * @param  string  $type
@@ -1953,6 +2053,39 @@ class Builder implements BuilderContract
         if (! $value instanceof ExpressionContract) {
             $this->addBinding($value, 'where');
         }
+
+        return $this;
+    }
+
+    /**
+     * @param $type
+     * @param $column
+     * @param $values
+     * @param string $boolean
+     * @param bool $not
+     * @return $this|Builder
+     */
+    protected function addDateBasedWhereIn($type, $column, $values, string $boolean = 'and', bool $not = false): Builder|static
+    {
+        if ($this->isQueryable($values)) {
+            [$query, $bindings] = $this->createSub($values);
+
+            $values = [new Expression($query)];
+
+            $this->addBinding($bindings, 'where');
+        }
+
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
+
+        if (count($values) !== count(Arr::flatten($values, 1))) {
+            throw new InvalidArgumentException("Nested arrays may not be passed to the {$type} method.");
+        }
+
+        $this->addBinding($this->cleanBindings($values), 'where');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1953,6 +1953,7 @@ class Builder implements BuilderContract
     {
         return $this->whereMonthIn($column, $values, 'or');
     }
+
     /**
      * Add a "where year" statement to the query.
      *

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -510,6 +510,16 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * @param Builder $query
+     * @param $where
+     * @return string
+     */
+    protected function whereDayIn(Builder $query, $where): string
+    {
+        return $this->dateBasedWhereIn('day', $query, $where);
+    }
+
+    /**
      * Compile a "where month" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -522,6 +532,16 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * @param Builder $query
+     * @param $where
+     * @return string
+     */
+    protected function whereMonthIn(Builder $query, $where): string
+    {
+        return $this->dateBasedWhereIn('month', $query, $where);
+    }
+
+    /**
      * Compile a "where year" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -531,6 +551,16 @@ class Grammar extends BaseGrammar
     protected function whereYear(Builder $query, $where)
     {
         return $this->dateBasedWhere('year', $query, $where);
+    }
+
+    /**
+     * @param Builder $query
+     * @param $where
+     * @return string
+     */
+    protected function whereYearIn(Builder $query, $where): string
+    {
+        return $this->dateBasedWhereIn('year', $query, $where);
     }
 
     /**
@@ -547,6 +577,30 @@ class Grammar extends BaseGrammar
 
         return $type.'('.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
     }
+
+    /**
+     * Compile a "where date in" clause.
+     *
+     * @param string $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param array $where
+     * @return string
+     */
+    protected function dateBasedWhereIn(string $type, Builder $query, array $where): string
+    {
+        $column = $this->wrap($where['column']);
+        $values = $this->parameterize($where['values']);
+        $not = $where['not'] ? ' not' : '';
+
+        return sprintf(
+            '%s(%s)%s in (%s)',
+            $type,
+            $column,
+            $not,
+            $values
+        );
+    }
+
 
     /**
      * Compile a where clause comparing two columns.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -510,8 +510,8 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * @param Builder $query
-     * @param $where
+     * @param  Builder  $query
+     * @param  $where
      * @return string
      */
     protected function whereDayIn(Builder $query, $where): string
@@ -532,8 +532,8 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * @param Builder $query
-     * @param $where
+     * @param  Builder  $query
+     * @param  $where
      * @return string
      */
     protected function whereMonthIn(Builder $query, $where): string
@@ -554,8 +554,8 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * @param Builder $query
-     * @param $where
+     * @param  Builder  $query
+     * @param  $where
      * @return string
      */
     protected function whereYearIn(Builder $query, $where): string
@@ -581,9 +581,9 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "where date in" clause.
      *
-     * @param string $type
+     * @param  string $type
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param array $where
+     * @param  array  $where
      * @return string
      */
     protected function dateBasedWhereIn(string $type, Builder $query, array $where): string

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -601,7 +601,6 @@ class Grammar extends BaseGrammar
         );
     }
 
-
     /**
      * Compile a where clause comparing two columns.
      *

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -581,7 +581,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "where date in" clause.
      *
-     * @param  string $type
+     * @param  string  $type
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where
      * @return string

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -153,6 +153,29 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhereIn(string $type, Builder $query, array $where): string
+    {
+        $column = $this->wrap($where['column']);
+        $values = $this->parameterize($where['values']);
+        $not = $where['not'] ? ' not' : '';
+
+        return sprintf(
+            'cast(extract(%s from %s) as integer)%s in (%s)',
+            $type,
+            $column,
+            $not,
+            $values
+        );
+    }
+
+    /**
      * Compile a "where fulltext" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -172,6 +172,33 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * @param string $type
+     * @param Builder $query
+     * @param array $where
+     * @return string
+     */
+    protected function dateBasedWhereIn(string $type, Builder $query, array $where): string
+    {
+        $column = $this->wrap($where['column']);
+        $values = $this->parameterize($where['values']);
+        $not = $where['not'] ? ' not' : '';
+
+        $format = [
+            'year' => '%Y',
+            'month' => '%m',
+            'day' => '%d',
+        ][$type];
+
+        return sprintf(
+            'cast(strftime("%s", %s) as integer)%s in (%s)',
+            $format,
+            $column,
+            $not,
+            $values
+        );
+    }
+
+    /**
      * Compile the index hints for the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -172,9 +172,9 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * @param string $type
-     * @param Builder $query
-     * @param array $where
+     * @param  string  $type
+     * @param  Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function dateBasedWhereIn(string $type, Builder $query, array $where): string

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -146,9 +146,9 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * @param string $type
-     * @param Builder $query
-     * @param array $where
+     * @param  string  $type
+     * @param  Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function dateBasedWhereIn(string $type, Builder $query, array $where): string

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -146,6 +146,27 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * @param string $type
+     * @param Builder $query
+     * @param array $where
+     * @return string
+     */
+    protected function dateBasedWhereIn(string $type, Builder $query, array $where): string
+    {
+        $column = $this->wrap($where['column']);
+        $values = $this->parameterize($where['values']);
+        $not = $where['not'] ? ' not' : '';
+
+        return sprintf(
+            'datepart(%s, %s)%s in (%s)',
+            $type,
+            $column,
+            $not,
+            $values
+        );
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -66,5 +67,193 @@ class DatabasePostgresQueryGrammarTest extends TestCase
         $this->assertEquals([
             'truncate "users" restart identity cascade' => [],
         ], $postgres->compileTruncate($builder));
+    }
+
+    protected function getBuilder(): Builder
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        $grammar = new PostgresGrammar($connection);
+        $processor = m::mock(PostgresProcessor::class);
+
+        return new Builder($connection, $grammar, $processor);
+    }
+
+    public function testWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayIn('created_at', [1, 15, 30]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(day from "created_at") as integer) in (?, ?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 15, 30], $builder->getBindings());
+    }
+
+    public function testOrWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->where('id', 1)
+            ->orWhereDayIn('created_at', [1, 12]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(extract(day from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereDayNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayNotIn('created_at', [2, 4]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(day from "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2, 4], $builder->getBindings());
+    }
+
+    public function testWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthIn('created_at', [1, 6, 12]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(month from "created_at") as integer) in (?, ?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 6, 12], $builder->getBindings());
+    }
+
+    public function testOrWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->where('id', 1)
+            ->orWhereMonthIn('created_at', [1, 12]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(extract(month from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereMonthNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthNotIn('created_at', [1, 2]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(month from "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 2], $builder->getBindings());
+    }
+
+    public function testWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearIn('created_at', [2023, 2024]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(year from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2023, 2024], $builder->getBindings());
+    }
+    public function testOrWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')
+            ->where('id', 1)
+            ->orWhereYearIn('created_at', [2023, 2024]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(extract(year from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 2023, 2024], $builder->getBindings());
+    }
+
+    public function testWhereYearNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearNotIn('created_at', [2023, 2024]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(extract(year from "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2023, 2024], $builder->getBindings());
+    }
+
+    public function testMultipleDateBasedWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2024])
+            ->whereMonthIn('created_at', [1, 2])
+            ->whereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from "users" where cast(extract(year from "created_at") as integer) in (?) and cast(extract(month from "created_at") as integer) in (?, ?) and cast(extract(day from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals([2024, 1, 2, 10, 20], $builder->getBindings());
+    }
+
+    public function testMultipleDateBasedOrWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2023])
+            ->orWhereMonthIn('created_at', [5, 6])
+            ->orWhereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from "users" where cast(extract(year from "created_at") as integer) in (?) or cast(extract(month from "created_at") as integer) in (?, ?) or cast(extract(day from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals(
+            [2023, 5, 6, 10, 20],
+            $builder->getBindings()
+        );
+    }
+
+    public function testWhereDayInCollection()
+    {
+        $builder = $this->getBuilder();
+
+        // Testing that passing a Collection works just like an array
+        $builder->select('*')->from('users')->whereDayIn('created_at', collect([5, 10]));
+
+        $this->assertSame(
+            'select * from "users" where cast(extract(day from "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([5, 10], $builder->getBindings());
+    }
+
+    public function testWhereDayInSubquery()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')->whereDayIn('created_at', function ($query) {
+            $query->select('day')->from('holidays');
+        });
+
+        $this->assertSame(
+            'select * from "users" where cast(extract(day from "created_at") as integer) in (select "day" from "holidays")',
+            $builder->toSql()
+        );
     }
 }

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -166,6 +166,7 @@ class DatabasePostgresQueryGrammarTest extends TestCase
         );
         $this->assertEquals([2023, 2024], $builder->getBindings());
     }
+
     public function testOrWhereYearIn()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -145,6 +145,7 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
         );
         $this->assertEquals([2024, 2025], $builder->getBindings());
     }
+
     public function testMultipleDateBasedWhereIns()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
+use Illuminate\Database\Query\Processors\SQLiteProcessor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +23,191 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
         );
 
         $this->assertSame('select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
+    }
+
+    protected function getBuilder(): Builder
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        $grammar = new SQLiteGrammar($connection);
+        $processor = m::mock(SQLiteProcessor::class);
+
+        return new Builder($connection, $grammar, $processor);
+    }
+
+    public function testWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayIn('created_at', [1, 15, 30]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%d", "created_at") as integer) in (?, ?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 15, 30], $builder->getBindings());
+    }
+
+    public function testOrWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereDayIn('created_at', [1, 15]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(strftime("%d", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 1, 15], $builder->getBindings());
+    }
+
+    public function testWhereDayNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayNotIn('created_at', [2, 3]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%d", "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2, 3], $builder->getBindings());
+    }
+
+    public function testWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthIn('created_at', [1, 12, 6]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%m", "created_at") as integer) in (?, ?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 12, 6], $builder->getBindings());
+    }
+
+    public function testOrWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereMonthIn('created_at', [1, 12]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(strftime("%m", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([1, 1, 12], $builder->getBindings());
+    }
+
+    public function testWhereMonthNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthNotIn('created_at', [2, 3]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%m", "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2, 3], $builder->getBindings());
+    }
+
+    public function testWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearIn('created_at', [2012, 2015, 2030]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%Y", "created_at") as integer) in (?, ?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2012, 2015, 2030], $builder->getBindings());
+    }
+
+    public function testOrWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereYearIn('created_at', [2024, 2025]);
+
+        $this->assertEquals(
+            'select * from "users" where "id" = ? or cast(strftime("%Y", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals([1, 2024, 2025], $builder->getBindings());
+    }
+
+    public function testWhereYearNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearNotIn('created_at', [2024, 2025]);
+
+        $this->assertEquals(
+            'select * from "users" where cast(strftime("%Y", "created_at") as integer) not in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([2024, 2025], $builder->getBindings());
+    }
+    public function testMultipleDateBasedWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2024])
+            ->whereMonthIn('created_at', [1, 2])
+            ->whereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from "users" where cast(strftime("%Y", "created_at") as integer) in (?) and cast(strftime("%m", "created_at") as integer) in (?, ?) and cast(strftime("%d", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals([2024, 1, 2, 10, 20], $builder->getBindings());
+    }
+
+    public function testMultipleDateBasedOrWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2023])
+            ->orWhereMonthIn('created_at', [5, 6])
+            ->orWhereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from "users" where cast(strftime("%Y", "created_at") as integer) in (?) or cast(strftime("%m", "created_at") as integer) in (?, ?) or cast(strftime("%d", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals(
+            [2023, 5, 6, 10, 20],
+            $builder->getBindings()
+        );
+    }
+
+    public function testWhereDayInCollection()
+    {
+        $builder = $this->getBuilder();
+
+        // Testing Collection support for SQLite
+        $builder->select('*')->from('users')->whereDayIn('created_at', collect([5, 10]));
+
+        $this->assertSame(
+            'select * from "users" where cast(strftime("%d", "created_at") as integer) in (?, ?)',
+            $builder->toSql()
+        );
+        $this->assertEquals([5, 10], $builder->getBindings());
+    }
+
+    public function testWhereDayInSubquery()
+    {
+        $builder = $this->getBuilder();
+
+        // Testing Subquery support for SQLite
+        $builder->select('*')->from('users')->whereDayIn('created_at', function ($query) {
+            $query->select('day')->from('holidays');
+        });
+
+        $this->assertSame(
+            'select * from "users" where cast(strftime("%d", "created_at") as integer) in (select "day" from "holidays")',
+            $builder->toSql()
+        );
     }
 }

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -135,6 +135,7 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
             $builder->toSql()
         );
     }
+
     public function testMultipleDateBasedWhereIns()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar;
+use Illuminate\Database\Query\Processors\SqlServerProcessor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +23,152 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
         );
 
         $this->assertSame("select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = 'foo'", $query);
+    }
+
+    protected function getBuilder(): Builder
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        $grammar = new SqlServerGrammar($connection);
+        $processor = m::mock(SqlServerProcessor::class);
+
+        return new Builder($connection, $grammar, $processor);
+    }
+
+    public function testWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayIn('created_at', [1, 15, 30]);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(day, [created_at]) in (?, ?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testOrWhereDayIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereDayIn('created_at', [3, 5]);
+
+        $this->assertEquals(
+            'select * from [users] where [id] = ? or datepart(day, [created_at]) in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereDayNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDayNotIn('created_at', [2024, 2025], 'and', true);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(day, [created_at]) not in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthIn('created_at', [1, 3, 4]);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(month, [created_at]) in (?, ?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testOrWhereMonthIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereMonthIn('created_at', [1, 12]);
+
+        $this->assertEquals(
+            'select * from [users] where [id] = ? or datepart(month, [created_at]) in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereMonthNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonthNotIn('created_at', [2, 9], 'and', true);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(month, [created_at]) not in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearIn('created_at', [2015, 2029, 2030]);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(year, [created_at]) in (?, ?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testOrWhereYearIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1)->orWhereYearIn('created_at', [2005, 2012]);
+
+        $this->assertEquals(
+            'select * from [users] where [id] = ? or datepart(year, [created_at]) in (?, ?)',
+            $builder->toSql()
+        );
+    }
+
+    public function testWhereYearNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYearIn('created_at', [2024, 2025], 'and', true);
+
+        $this->assertEquals(
+            'select * from [users] where datepart(year, [created_at]) not in (?, ?)',
+            $builder->toSql()
+        );
+    }
+    public function testMultipleDateBasedWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2024])
+            ->whereMonthIn('created_at', [1, 2])
+            ->whereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from [users] where datepart(year, [created_at]) in (?) and datepart(month, [created_at]) in (?, ?) and datepart(day, [created_at]) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals([2024, 1, 2, 10, 20], $builder->getBindings());
+    }
+
+    public function testMultipleDateBasedOrWhereIns()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->select('*')->from('users')
+            ->whereYearIn('created_at', [2023])
+            ->orWhereMonthIn('created_at', [5, 6])
+            ->orWhereDayIn('created_at', [10, 20]);
+
+        $this->assertSame(
+            'select * from [users] where datepart(year, [created_at]) in (?) or datepart(month, [created_at]) in (?, ?) or datepart(day, [created_at]) in (?, ?)',
+            $builder->toSql()
+        );
+
+        $this->assertEquals(
+            [2023, 5, 6, 10, 20],
+            $builder->getBindings()
+        );
     }
 }


### PR DESCRIPTION
This PR introduces whereDayIn, whereMonthIn, whereYearIn, and their corresponding or and not variants to the Query Builder.

Currently, to filter a date column by multiple specific days, months, or years, developers must either chain multiple orWhereDay calls or resort to a whereRaw expression. This addition brings consistency to the API, matching the behavior of the standard whereIn method while leveraging native database date functions.

Supported Dialects
The implementation includes grammar support for:

- MySQL / MariaDB: Uses native day(), month(), year().
- PostgreSQL: Uses extract() with an integer cast.
- SQLite: Uses strftime() with an integer cast.
- SQL Server: Uses datepart().

Feature Highlights

- Supports Arrays of integers.
- Supports Collections or any Arrayable object.
- Supports Subqueries / Closures.
- Includes validation to prevent nested arrays (matching whereIn behavior).

Example Usage

```
// Simple array
DB::table('users')->whereYearIn('created_at', [2023, 2024, 2025])->get();

// Using a Collection
$months = collect([1, 6, 12]);
DB::table('reports')->whereMonthIn('published_at', $months)->get();

// Using a Subquery
DB::table('users')->whereDayIn('created_at', function ($query) {
    $query->select('day')->from('promotional_days');
})->get();
```