### PR TITLE
[12.x] Preserve notification state mutations from via() in sendNow()

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -106,11 +106,11 @@ class NotificationSender
         $original = clone $notification;
 
         foreach ($notifiables as $notifiable) {
-            if (empty($viaChannels = $channels ?: $notification->via($notifiable))) {
+            if (empty($viaChannels = $channels ?: $original->via($notifiable))) {
                 continue;
             }
 
-            $this->withLocale($this->preferredLocale($notifiable, $notification), function () use ($viaChannels, $notifiable, $original) {
+            $this->withLocale($this->preferredLocale($notifiable, $original), function () use ($viaChannels, $notifiable, $original) {
                 $notificationId = (string) Str::uuid();
 
                 foreach ((array) $viaChannels as $channel) {


### PR DESCRIPTION
## Summary

Fixes bug where locale set dynamically in `via()` is lost when sending notifications via `sendNow()`.

## Problem

### Inconsistency between `queueNotification()` and `sendNow()`

Both methods clone notification to `$original` for sending, but call `via()` on different objects:

**`queueNotification()` ✅ Correct**
```php
protected function queueNotification($notifiables, $notification)
{ 
    $notifiables = $this->formatNotifiables($notifiables);
    $original = clone $notification;

    foreach ($notifiables as $notifiable) {
        foreach ($original->via($notifiable) as $channel) {
        //       ^^^^^^^^^ uses $original
```

**`sendNow()` ❌ Bug**
```php
public function sendNow($notifiables, $notification, array $channels = null)
{
    $original = clone $notification;

    foreach ($notifiables as $notifiable) {
        if (empty($viaChannels = $channels ?: $notification->via($notifiable))) {
        //                                    ^^^^^^^^^^^^^ uses $notification (pre-clone)

        $this->withLocale($this->preferredLocale($notifiable, $notification), ...);
        //                                                    ^^^^^^^^^^^^^ also wrong
```

When `via()` mutates state (e.g., sets `$this->locale`), those changes happen on `$notification` but `$original` is sent — losing the mutations.

### Real-world use case

Setting notification locale dynamically based on notifiable:

```php
public function via($notifiable)
{
    $this->locale = $notifiable->preferred_language;

    return ['mail', 'database'];
}
```

Works for queued notifications, fails silently for synchronous ones.

## Solution

Align `sendNow()` with `queueNotification()`:

```diff
- if (empty($viaChannels = $channels ?: $notification->via($notifiable))) {
+ if (empty($viaChannels = $channels ?: $original->via($notifiable))) {

- $this->withLocale($this->preferredLocale($notifiable, $notification), ...);
+ $this->withLocale($this->preferredLocale($notifiable, $original), ...);
```

## Test Plan

- Added `testItPreservesLocaleSetInViaMethod` to verify locale set in `via()` is preserved
- All existing notification tests pass
