### PR TITLE
[12.x] Adjust docblock for formatActionForCli

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -417,7 +417,7 @@ class RouteListCommand extends Command
      * Get the formatted action for display on the CLI.
      *
      * @param  array  $route
-     * @return string
+     * @return string|null
      */
     protected function formatActionForCli($route)
     {


### PR DESCRIPTION
This was causing static analysis issues:
 
https://github.com/laravel/framework/actions/runs/21527588688/job/62035125987

Which I retriggered here:
https://github.com/jackbayliss/framework/actions/runs/21529548767/job/62041765393


The `formatActionForCli` method can actually be null, which is why we have `?? ''`

https://github.com/laravel/framework/blob/a16a88ba95677add17faf3a6d2ec7ba9786a539f/src/Illuminate/Foundation/Console/RouteListCommand.php#L406