### PR TITLE
[12.x] brick/math `of` float deprecation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1502,7 +1502,7 @@ trait HasAttributes
     protected function asDecimal($value, $decimals)
     {
         try {
-            return (string) BigDecimal::of($value)->toScale($decimals, RoundingMode::HALF_UP);
+            return (string) BigDecimal::of((string) $value)->toScale($decimals, RoundingMode::HALF_UP);
         } catch (BrickMathException $e) {
             throw new MathException('Unable to cast value to a decimal.', previous: $e);
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2756,7 +2756,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return int|float|string
+     * @return int|string
      */
     protected function getSize($attribute, $value)
     {
@@ -2767,11 +2767,11 @@ trait ValidatesAttributes
         // is the size. If it is a file, we take kilobytes, and for a string the
         // entire length of the string will be considered the attribute size.
         if (is_numeric($value) && $hasNumeric) {
-            return $this->ensureExponentWithinAllowedRange($attribute, $this->trim($value));
+            return (string) $this->ensureExponentWithinAllowedRange($attribute, $this->trim($value));
         } elseif (is_array($value)) {
             return count($value);
         } elseif ($value instanceof File) {
-            return $value->getSize() / 1024;
+            return (string) ($value->getSize() / 1024);
         }
 
         return mb_strlen($value ?? '');
@@ -2882,7 +2882,7 @@ trait ValidatesAttributes
      */
     protected function trim($value)
     {
-        return is_string($value) ? trim($value) : $value;
+        return (string) (is_string($value) ? trim($value) : $value);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2878,7 +2878,7 @@ trait ValidatesAttributes
      * Trim the value if it is a string.
      *
      * @param  mixed  $value
-     * @return mixed
+     * @return string
      */
     protected function trim($value)
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2882,7 +2882,7 @@ trait ValidatesAttributes
      */
     protected function trim($value)
     {
-        return (string) (is_string($value) ? trim($value) : $value);
+        return is_string($value) ? trim($value) : (string) $value;
     }
 
     /**

--- a/tests/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Database/EloquentModelCustomCastingTest.php
@@ -444,14 +444,14 @@ class EuroCaster implements CastsAttributes
 
     public function increment($model, $key, $value, $attributes)
     {
-        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->plus($value->value)->toScale(2));
+        $model->$key = new Euro((string) BigNumber::of((string) $model->$key->value)->plus($value->value)->toScale(2));
 
         return $model->$key;
     }
 
     public function decrement($model, $key, $value, $attributes)
     {
-        $model->$key = new Euro((string) BigNumber::of($model->$key->value)->subtract($value->value)->toScale(2));
+        $model->$key = new Euro((string) BigNumber::of((string) $model->$key->value)->subtract($value->value)->toScale(2));
 
         return $model->$key;
     }


### PR DESCRIPTION
[Seeing this in CI](https://github.com/laravel/framework/actions/runs/21527588692/job/62035125939), which is killing tests:  
```
Passing floats to BigNumber::of() and arithmetic methods is deprecated and will be removed in 0.15. Cast the float to string explicitly to preserve the previous behaviour.
```

Passing float values to of() or arithmetic methods is deprecated in brick/math [0.14.2](https://github.com/brick/math/releases/tag/0.14.2)

This basically handles the float types and casts it to a string as suggested. All of the changes are basically within the ValidatesAttributes trait.

I don't think it's a B/C as it's just ensuring the current output / internal methods and all tests seem to pass. 

Feel free to close / adjust as you see fit-  figured I'd throw up a PR up as it was annoying me.