### PR TITLE
[12.x] Add `MaintenanceMode` facade to docblock generator

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -69,6 +69,7 @@ jobs:
             Illuminate\\Support\\Facades\\Lang \
             Illuminate\\Support\\Facades\\Log \
             Illuminate\\Support\\Facades\\Mail \
+            Illuminate\\Support\\Facades\\MaintenanceMode \
             Illuminate\\Support\\Facades\\Notification \
             Illuminate\\Support\\Facades\\ParallelTesting \
             Illuminate\\Support\\Facades\\Password \

--- a/src/Illuminate/Support/Facades/MaintenanceMode.php
+++ b/src/Illuminate/Support/Facades/MaintenanceMode.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support\Facades;
 
 use Illuminate\Foundation\MaintenanceModeManager;
 
+/**
+ * @see \Illuminate\Foundation\MaintenanceModeManager
+ */
 class MaintenanceMode extends Facade
 {
     /**


### PR DESCRIPTION
Noticed this facade doesn't ship with method annotations, this PR fixes that