### PR TITLE
[12.x] Improve typing in console/command namespace

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -55,7 +55,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * A map of command names to classes.
      *
-     * @var array
+     * @var array<string, \Illuminate\Console\Command|string>
      */
     protected $commandMap = [];
 
@@ -172,7 +172,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @param  array  $parameters
-     * @return array
+     * @return array<string, \Symfony\Component\Console\Input\ArrayInput>
      */
     protected function parseCommand($command, $parameters)
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -73,14 +73,14 @@ class Command extends SymfonyCommand
     /**
      * The default exit code for isolated commands.
      *
-     * @var int
+     * @var self::SUCCESS|self::FAILURE|self::INVALID
      */
     protected $isolatedExitCode = self::SUCCESS;
 
     /**
      * The console command name aliases.
      *
-     * @var array
+     * @var string[]
      */
     protected $aliases;
 

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -92,7 +92,7 @@ trait CallsCommands
     /**
      * Get all of the context passed to the command.
      *
-     * @return array
+     * @return array{'--ansi'?: bool, '--no-ansi'?: bool, '--no-interaction'?: bool, '--quiet'?: bool, '--verbose'?: bool}
      */
     protected function context()
     {

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -120,7 +120,7 @@ trait ConfiguresPrompts
      * @param  \Closure(): PResult  $prompt
      * @param  bool|string  $required
      * @param  (\Closure(PResult): mixed)|null  $validate
-     * @return mixed
+     * @return PResult
      */
     protected function promptUntilValid($prompt, $required, $validate)
     {

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -115,9 +115,11 @@ trait ConfiguresPrompts
     /**
      * Prompt the user until the given validation callback passes.
      *
-     * @param  \Closure  $prompt
+     * @template PResult
+     *
+     * @param  \Closure(): PResult  $prompt
      * @param  bool|string  $required
-     * @param  \Closure|null  $validate
+     * @param  (\Closure(PResult): mixed)|null  $validate
      * @return mixed
      */
     protected function promptUntilValid($prompt, $required, $validate)
@@ -204,7 +206,7 @@ trait ConfiguresPrompts
     /**
      * Get the validation messages that should be used during prompt validation.
      *
-     * @return array
+     * @return array<string, string>
      */
     protected function validationMessages()
     {
@@ -214,7 +216,7 @@ trait ConfiguresPrompts
     /**
      * Get the validation attributes that should be used during prompt validation.
      *
-     * @return array
+     * @return array<string, string>
      */
     protected function validationAttributes()
     {
@@ -235,7 +237,7 @@ trait ConfiguresPrompts
      * Select fallback.
      *
      * @param  string  $label
-     * @param  array  $options
+     * @param  array<array-key, string>  $options
      * @param  string|int|null  $default
      * @return string|int
      */

--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Console\Concerns;
 
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -37,12 +40,12 @@ trait HasParameters
     /**
      * Get the console command arguments.
      *
-     * @return (\Symfony\Component\Console\Input\InputArgument|array{
+     * @return (InputArgument|array{
      *    0: non-empty-string,
-     *    1?: \Symfony\Component\Console\Input\InputArgument::REQUIRED|\Symfony\Component\Console\Input\InputArgument::OPTIONAL,
+     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL,
      *    2?: string,
      *    3?: mixed,
-     *    4?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     *    4?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>
      * })[]
      */
     protected function getArguments()
@@ -53,13 +56,13 @@ trait HasParameters
     /**
      * Get the console command options.
      *
-     * @return (\Symfony\Component\Console\Input\InputOption|array{
+     * @return (InputOption|array{
      *    0: non-empty-string,
      *    1?: string|non-empty-array<string>,
-     *    2?: \Symfony\Component\Console\Input\InputOption::VALUE_*,
+     *    2?: InputOption::VALUE_*,
      *    3?: string,
      *    4?: mixed,
-     *    5?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     *    5?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>
      * })[]
      */
     protected function getOptions()

--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -37,7 +37,13 @@ trait HasParameters
     /**
      * Get the console command arguments.
      *
-     * @return array
+     * @return (\Symfony\Component\Console\Input\InputArgument|array{
+     *    0: non-empty-string,
+     *    1?: \Symfony\Component\Console\Input\InputArgument::REQUIRED|\Symfony\Component\Console\Input\InputArgument::OPTIONAL,
+     *    2?: string,
+     *    3?: mixed,
+     *    4?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     * })[]
      */
     protected function getArguments()
     {
@@ -47,7 +53,14 @@ trait HasParameters
     /**
      * Get the console command options.
      *
-     * @return array
+     * @return (\Symfony\Component\Console\Input\InputOption|array{
+     *    0: non-empty-string,
+     *    1?: string|non-empty-array<string>,
+     *    2?: \Symfony\Component\Console\Input\InputOption::VALUE_*,
+     *    3?: string,
+     *    4?: mixed,
+     *    5?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     * })[]
      */
     protected function getOptions()
     {

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -71,7 +71,7 @@ trait InteractsWithIO
      * Get the value of a command argument.
      *
      * @param  string|null  $key
-     * @return ($key is null ? array<string|bool|int|float|array|null> : string|bool|int|float|array|null)
+     * @return ($key is null ? array<array|string|float|int|bool|null> : array|string|float|int|bool|null)
      */
     public function argument($key = null)
     {
@@ -85,7 +85,7 @@ trait InteractsWithIO
     /**
      * Get all of the arguments passed to the command.
      *
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|string|float|int|bool|null>
      */
     public function arguments()
     {
@@ -107,7 +107,7 @@ trait InteractsWithIO
      * Get the value of a command option.
      *
      * @param  string|null  $key
-     * @return ($key is null ? array<string|bool|int|float|array|null> : string|bool|int|float|array|null)
+     * @return ($key is null ? array<array|string|float|int|bool|null> : array|string|float|int|bool|null)
      */
     public function option($key = null)
     {
@@ -121,7 +121,7 @@ trait InteractsWithIO
     /**
      * Get all of the options passed to the command.
      *
-     * @return array<string|bool|int|float|array|null>
+     * @return array<array|string|float|int|bool|null>
      */
     public function options()
     {
@@ -204,7 +204,7 @@ trait InteractsWithIO
      * Give the user a single choice from an array of answers.
      *
      * @param  string  $question
-     * @param  array<string|bool|int|float|\Stringable>  $choices
+     * @param  array<\Stringable|string|float|int|bool>  $choices
      * @param  string|int|null  $default
      * @param  ?positive-int  $attempts
      * @param  bool  $multiple

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -39,14 +39,14 @@ trait InteractsWithIO
     /**
      * The default verbosity of output commands.
      *
-     * @var int
+     * @var \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*
      */
     protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * The mapping between human-readable verbosity levels and Symfony's OutputInterface.
      *
-     * @var array
+     * @var array<string, \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*>
      */
     protected $verbosityMap = [
         'v' => OutputInterface::VERBOSITY_VERBOSE,
@@ -71,7 +71,7 @@ trait InteractsWithIO
      * Get the value of a command argument.
      *
      * @param  string|null  $key
-     * @return array|string|bool|null
+     * @return ($key is null ? array<string|bool|int|float|array|null> : string|bool|int|float|array|null)
      */
     public function argument($key = null)
     {
@@ -85,7 +85,7 @@ trait InteractsWithIO
     /**
      * Get all of the arguments passed to the command.
      *
-     * @return array
+     * @return array<string|bool|int|float|array|null>
      */
     public function arguments()
     {
@@ -107,7 +107,7 @@ trait InteractsWithIO
      * Get the value of a command option.
      *
      * @param  string|null  $key
-     * @return string|array|bool|null
+     * @return ($key is null ? array<string|bool|int|float|array|null> : string|bool|int|float|array|null)
      */
     public function option($key = null)
     {
@@ -121,7 +121,7 @@ trait InteractsWithIO
     /**
      * Get all of the options passed to the command.
      *
-     * @return array
+     * @return array<string|bool|int|float|array|null>
      */
     public function options()
     {
@@ -169,7 +169,7 @@ trait InteractsWithIO
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array|callable  $choices
+     * @param  iterable|(callable(string): string[])  $choices
      * @param  string|null  $default
      * @return mixed
      */
@@ -204,9 +204,9 @@ trait InteractsWithIO
      * Give the user a single choice from an array of answers.
      *
      * @param  string  $question
-     * @param  array  $choices
+     * @param  array<string|bool|int|float|\Stringable>  $choices
      * @param  string|int|null  $default
-     * @param  mixed  $attempts
+     * @param  ?positive-int  $attempts
      * @param  bool  $multiple
      * @return string|array
      */
@@ -225,7 +225,7 @@ trait InteractsWithIO
      * @param  array  $headers
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  \Symfony\Component\Console\Helper\TableStyle|string  $tableStyle
-     * @param  array  $columnStyles
+     * @param  array<int, \Symfony\Component\Console\Helper\TableStyle|string>  $columnStyles
      * @return void
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
@@ -248,8 +248,11 @@ trait InteractsWithIO
     /**
      * Execute a given callback while advancing a progress bar.
      *
-     * @param  iterable|int  $totalSteps
-     * @param  \Closure  $callback
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  iterable<TKey, TValue>|int  $totalSteps
+     * @param  \Closure(\Symfony\Component\Console\Helper\ProgressBar|TValue, \Symfony\Component\Console\Helper\ProgressBar|null, TKey|null): void  $callback
      * @return mixed|void
      */
     public function withProgressBar($totalSteps, Closure $callback)
@@ -281,7 +284,7 @@ trait InteractsWithIO
      * Write a string as information output.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function info($string, $verbosity = null)
@@ -293,8 +296,8 @@ trait InteractsWithIO
      * Write a string as standard output.
      *
      * @param  string  $string
-     * @param  string|null  $style
-     * @param  int|string|null  $verbosity
+     * @param  'info'|'comment'|'question'|'error'|'warn'|'alert'|null  $style
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function line($string, $style = null, $verbosity = null)
@@ -308,7 +311,7 @@ trait InteractsWithIO
      * Write a string as comment output.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function comment($string, $verbosity = null)
@@ -320,7 +323,7 @@ trait InteractsWithIO
      * Write a string as question output.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function question($string, $verbosity = null)
@@ -332,7 +335,7 @@ trait InteractsWithIO
      * Write a string as error output.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function error($string, $verbosity = null)
@@ -344,7 +347,7 @@ trait InteractsWithIO
      * Write a string as warning output.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function warn($string, $verbosity = null)
@@ -362,7 +365,7 @@ trait InteractsWithIO
      * Write a string in an alert box.
      *
      * @param  string  $string
-     * @param  int|string|null  $verbosity
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $verbosity
      * @return void
      */
     public function alert($string, $verbosity = null)
@@ -414,7 +417,7 @@ trait InteractsWithIO
     /**
      * Set the verbosity level.
      *
-     * @param  string|int  $level
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*  $level
      * @return void
      */
     protected function setVerbosity($level)
@@ -425,7 +428,7 @@ trait InteractsWithIO
     /**
      * Get the verbosity level in terms of Symfony's OutputInterface level.
      *
-     * @param  string|int|null  $level
+     * @param  'v'|'vv'|'vvv'|'quiet'|'normal'|\Symfony\Component\Console\Output\OutputInterface::VERBOSITY_*|null  $level
      * @return int
      */
     protected function parseVerbosity($level = null)

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -75,7 +75,7 @@ trait PromptsForMissingInput
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array
+     * @return array<string, string|array{string, string}|(\Closure(): int|string|bool|array<int|string>)>
      */
     protected function promptForMissingArgumentsUsing()
     {

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -75,7 +75,7 @@ trait PromptsForMissingInput
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array<string, string|array{string, string}|(\Closure(): int|string|bool|array<int|string>)>
+     * @return array<string, string|array{string, string}|(\Closure(): array<int|string>|string|int|bool)>
      */
     protected function promptForMissingArgumentsUsing()
     {

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -11,9 +11,11 @@ trait ConfirmableTrait
      *
      * This method only asks for confirmation in production.
      *
+     * @template TReturn of bool
+     *
      * @param  string  $warning
-     * @param  \Closure|bool|null  $callback
-     * @return bool
+     * @param  (\Closure(): TReturn)|TReturn|null  $callback
+     * @return (TReturn is false ? true : bool)
      */
     public function confirmToProceed($warning = 'Application In Production', $callback = null)
     {
@@ -43,7 +45,7 @@ trait ConfirmableTrait
     /**
      * Get the default confirmation callback.
      *
-     * @return \Closure
+     * @return \Closure(): bool
      */
     protected function getDefaultConfirmCallback()
     {

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -19,7 +19,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
     /**
      * A map of command names to classes.
      *
-     * @var array
+     * @var array<string, \Illuminate\Console\Command|string>
      */
     protected $commandMap;
 
@@ -27,7 +27,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
      * Create a new command loader instance.
      *
      * @param  \Psr\Container\ContainerInterface  $container
-     * @param  array  $commandMap
+     * @param  array<string, \Illuminate\Console\Command|string>  $commandMap
      */
     public function __construct(ContainerInterface $container, array $commandMap)
     {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -8,6 +8,9 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Finder\Finder;
 
@@ -122,8 +125,6 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
 
     /**
      * Create a new generator command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
      */
     public function __construct(Filesystem $files)
     {
@@ -222,7 +223,6 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Qualify the given model class base name.
      *
-     * @param  string  $model
      * @return class-string
      */
     protected function qualifyModel(string $model)
@@ -481,12 +481,12 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Get the console command arguments.
      *
-     * @return (\Symfony\Component\Console\Input\InputArgument|array{
+     * @return (InputArgument|array{
      *    0: non-empty-string,
-     *    1?: \Symfony\Component\Console\Input\InputArgument::REQUIRED|\Symfony\Component\Console\Input\InputArgument::OPTIONAL,
+     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL,
      *    2?: string,
      *    3?: mixed,
-     *    4?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     *    4?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>
      * })[]
      */
     protected function getArguments()
@@ -499,7 +499,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array<string, string|array{string, string}|(\Closure(): int|string|bool|array<int|string>)>
+     * @return array<string, string|array{string, string}|(\Closure(): array<int, string>|string|int|bool)>
      */
     protected function promptForMissingArgumentsUsing()
     {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -223,7 +223,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      * Qualify the given model class base name.
      *
      * @param  string  $model
-     * @return string
+     * @return class-string
      */
     protected function qualifyModel(string $model)
     {
@@ -481,7 +481,13 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Get the console command arguments.
      *
-     * @return array
+     * @return (\Symfony\Component\Console\Input\InputArgument|array{
+     *    0: non-empty-string,
+     *    1?: \Symfony\Component\Console\Input\InputArgument::REQUIRED|\Symfony\Component\Console\Input\InputArgument::OPTIONAL,
+     *    2?: string,
+     *    3?: mixed,
+     *    4?: list<string|\Symfony\Component\Console\Completion\Suggestion>|\Closure(\Symfony\Component\Console\Completion\CompletionInput, \Symfony\Component\Console\Completion\CompletionSuggestions): list<string|\Symfony\Component\Console\Completion\Suggestion>
+     * })[]
      */
     protected function getArguments()
     {
@@ -493,7 +499,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array
+     * @return array<string, string|array{string, string}|(\Closure(): int|string|bool|array<int|string>)>
      */
     protected function promptForMissingArgumentsUsing()
     {

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -128,7 +128,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /*
      * Count the number of trailing new lines in a string.
      *
-     * @param  string|iterable  $messages
+     * @param  string|iterabley<string>  $messages
      * @return int
      */
     protected function trailingNewLineCount($messages)

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -128,7 +128,7 @@ class OutputStyle extends SymfonyStyle implements NewLineAware
     /*
      * Count the number of trailing new lines in a string.
      *
-     * @param  string|iterabley<string>  $messages
+     * @param  string|iterable<string>  $messages
      * @return int
      */
     protected function trailingNewLineCount($messages)

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -12,7 +12,7 @@ class Parser
      * Parse the given console command definition into an array.
      *
      * @param  string  $expression
-     * @return array
+     * @return array{string, array{}, array{}}|array{string, \Symfony\Component\Console\Input\InputArgument, \Symfony\Component\Console\Input\InputOption}
      *
      * @throws \InvalidArgumentException
      */
@@ -47,8 +47,8 @@ class Parser
     /**
      * Extract all parameters from the tokens.
      *
-     * @param  array  $tokens
-     * @return array
+     * @param  string[]  $tokens
+     * @return array{\Symfony\Component\Console\Input\InputArgument, \Symfony\Component\Console\Input\InputOption}
      */
     protected static function parameters(array $tokens)
     {
@@ -119,7 +119,7 @@ class Parser
      * Parse the token into its token and description segments.
      *
      * @param  string  $token
-     * @return array
+     * @return array{string, string}
      */
     protected static function extractDescription(string $token)
     {

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -17,7 +17,7 @@ class Signals
     /**
      * The signal registry's previous list of handlers.
      *
-     * @var array<int, array<int, callable>>|null
+     * @var array<int, array<int, callable(int $signal): void>>|null
      */
     protected $previousHandlers;
 

--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -17,7 +17,7 @@ class Signals
     /**
      * The signal registry's previous list of handlers.
      *
-     * @var array<int, array<int, callable(int $signal): void>>|null
+     * @var array<int, array<int, callable(int): void>>|null
      */
     protected $previousHandlers;
 


### PR DESCRIPTION
# Benefits
✅ Improved static analysis
✅ Improved type inference
✅ Increased type coverage

# Highlights
* Typing of arrays
* Typing of closures
* Using constants, union string literals, and `class-string` instead of wider primitive types where possible
* Using generics to determine return types

# Approach
* Many types are inferred from usage
* Some types are taken from the Symfony code base when classes extended or wrapped Symfony