### PR TITLE
[12.x] Refactor: rename unused `foreach` variable for better readability

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1040,7 +1040,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $collectionCount = $this->count();
 
-        foreach (range(1, min($count, $collectionCount)) as $item) {
+        foreach (range(1, min($count, $collectionCount)) as $ignored) {
             $results[] = array_pop($this->items);
         }
 
@@ -1285,7 +1285,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $collectionCount = $this->count();
 
-        foreach (range(1, min($count, $collectionCount)) as $item) {
+        foreach (range(1, min($count, $collectionCount)) as $ignored) {
             $results[] = array_shift($this->items);
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $ignored) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements); 
         }, $subject);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,7 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
+            foreach ($replacements as $ignored) {
                 return array_shift($replacements);
             }
         }, $subject);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,7 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            return array_shift($replacements); 
+            return array_shift($replacements);
         }, $subject);
     }
 }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -317,7 +317,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
 
         $this->assertEnumeratesOnce(function ($collection) {
-            foreach ($collection as $key => $value) {
+            foreach ($collection as $ignored) {
                 // Silence is golden!
             }
         });


### PR DESCRIPTION
In this loop, the iteration variable was not used.
Renamed `$item` to `$ignored` to better reflect its purpose and improve code readability.