### PR TITLE
[12.x] Drop foreach from preg_replace_callback helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,7 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-                return array_shift($replacements);
+            return array_shift($replacements);
         }, $subject);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -288,9 +288,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject): string
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $value) {
                 return array_shift($replacements);
-            }
         }, $subject);
     }
 }


### PR DESCRIPTION
Weekend poking - noticed this. 


Super simple PR, basically we don't need to foreach here. The loop immediately returns on the first iteration, so we can just call `array_shift()` directly. Seeing as it's a helper method it made sense to me.
