### PR TITLE
[12.x] Exclude decorative ASCII art SVG from exception page in non-browser contexts

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -97,7 +97,6 @@ class Renderer
         return $this->viewFactory->make('laravel-exceptions-renderer::show', [
             'exception' => $exception,
             'exceptionAsMarkdown' => $exceptionAsMarkdown,
-            'includeDecorations' => $this->shouldIncludeDecorations(),
         ])->render();
     }
 
@@ -129,15 +128,5 @@ class Renderer
         return '<script>'
             .file_get_contents(static::DIST.'scripts.js')
             .'</script>'.$viteJsAutoRefresh;
-    }
-
-    /**
-     * Determine if decorative elements should be included in the rendered output.
-     *
-     * @return bool
-     */
-    protected function shouldIncludeDecorations()
-    {
-        return ! app()->runningUnitTests() && ! app()->runningInConsole();
     }
 }

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Renderer.php
@@ -97,6 +97,7 @@ class Renderer
         return $this->viewFactory->make('laravel-exceptions-renderer::show', [
             'exception' => $exception,
             'exceptionAsMarkdown' => $exceptionAsMarkdown,
+            'includeDecorations' => $this->shouldIncludeDecorations(),
         ])->render();
     }
 
@@ -128,5 +129,15 @@ class Renderer
         return '<script>'
             .file_get_contents(static::DIST.'scripts.js')
             .'</script>'.$viteJsAutoRefresh;
+    }
+
+    /**
+     * Determine if decorative elements should be included in the rendered output.
+     *
+     * @return bool
+     */
+    protected function shouldIncludeDecorations()
+    {
+        return ! app()->runningUnitTests() && ! app()->runningInConsole();
     }
 }

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
@@ -31,7 +31,9 @@
 
     <x-laravel-exceptions-renderer::separator />
 
-    <x-laravel-exceptions-renderer::section-container class="pb-0 sm:pb-0">
-        <x-laravel-exceptions-renderer::laravel-ascii-spotlight />
-    </x-laravel-exceptions-renderer::section-container>
+    @if ($includeDecorations)
+        <x-laravel-exceptions-renderer::section-container class="pb-0 sm:pb-0">
+            <x-laravel-exceptions-renderer::laravel-ascii-spotlight />
+        </x-laravel-exceptions-renderer::section-container>
+    @endif
 </x-laravel-exceptions-renderer::layout>

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/show.blade.php
@@ -31,7 +31,7 @@
 
     <x-laravel-exceptions-renderer::separator />
 
-    @if ($includeDecorations)
+    @if (! app()->runningUnitTests() && ! app()->runningInConsole())
         <x-laravel-exceptions-renderer::section-container class="pb-0 sm:pb-0">
             <x-laravel-exceptions-renderer::laravel-ascii-spotlight />
         </x-laravel-exceptions-renderer::section-container>

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -139,4 +139,14 @@ class RendererTest extends TestCase
         $provider = $this->app->getProvider(FoundationServiceProvider::class);
         $provider->boot();
     }
+
+    #[WithConfig('app.debug', true)]
+    public function testItExcludesDecorativeAsciiArtInNonBrowserContexts()
+    {
+        $this->get('/failed')
+            ->assertInternalServerError()
+            ->assertSee('RuntimeException')
+            ->assertSee('Bad route!')
+            ->assertDontSee('viewBox="0 0 1268 308"', false);
+    }
 }


### PR DESCRIPTION
The exception renderer includes a ~474KB inline SVG as a decorative ASCII art element at the bottom of the error page. The `laravel-ascii-spotlight` component renders this SVG twice (~970KB total) for the spotlight mouse-follow effect.

When running tests with constrained memory (`memory_limit=128M`), rendering this SVG during error page generation can cause memory exhaustion - masking the original exception with a confusing "Allowed memory size exhausted" error.

This change adds a `shouldIncludeDecorations()` method to the `Renderer` class that skips the decorative SVG in test and console contexts where it serves no purpose, while preserving the full visual error page for browser rendering.

Fixes #58560