### PR TITLE
[12.x] Update callback type hints for Context's `Repository`

### DIFF
--- a/src/Illuminate/Log/Context/Repository.php
+++ b/src/Illuminate/Log/Context/Repository.php
@@ -580,7 +580,7 @@ class Repository
     /**
      * Execute the given callback when context is about to be dehydrated.
      *
-     * @param  callable  $callback
+     * @param  (callable(static): void)  $callback
      * @return $this
      */
     public function dehydrating($callback)
@@ -593,7 +593,7 @@ class Repository
     /**
      * Execute the given callback when context has been hydrated.
      *
-     * @param  callable  $callback
+     * @param  (callable(static): void)  $callback
      * @return $this
      */
     public function hydrated($callback)


### PR DESCRIPTION
I was in the kitchen cooking and I noticed some types would be nice on these methods.