### PR TITLE
[12.x] Refactor: improve tests

### DIFF
--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -39,25 +39,25 @@ class AuthenticateMiddlewareTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Authenticate::using('foo');
+        $signature = Authenticate::using('foo');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo', $signature);
 
-        $signature = (string) Authenticate::using('foo', 'bar');
+        $signature = Authenticate::using('foo', 'bar');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar', $signature);
 
-        $signature = (string) Authenticate::using('foo', 'bar', 'baz');
+        $signature = Authenticate::using('foo', 'bar', 'baz');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar,baz', $signature);
     }
 
     public function testItCanGenerateDefinitionViaStaticMethodForBasic()
     {
-        $signature = (string) AuthenticateWithBasicAuth::using('guard');
+        $signature = AuthenticateWithBasicAuth::using('guard');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard', $signature);
 
-        $signature = (string) AuthenticateWithBasicAuth::using('guard', 'field');
+        $signature = AuthenticateWithBasicAuth::using('guard', 'field');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard,field', $signature);
 
-        $signature = (string) AuthenticateWithBasicAuth::using(field: 'field');
+        $signature = AuthenticateWithBasicAuth::using(field: 'field');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:,field', $signature);
     }
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -57,13 +57,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) Authorize::using('ability');
+        $signature = Authorize::using('ability');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability', $signature);
 
-        $signature = (string) Authorize::using('ability', 'model');
+        $signature = Authorize::using('ability', 'model');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model', $signature);
 
-        $signature = (string) Authorize::using('ability', 'model', \App\Models\Comment::class);
+        $signature = Authorize::using('ability', 'model', \App\Models\Comment::class);
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
     }
 

--- a/tests/Auth/EnsureEmailIsVerifiedTest.php
+++ b/tests/Auth/EnsureEmailIsVerifiedTest.php
@@ -9,7 +9,7 @@ class EnsureEmailIsVerifiedTest extends TestCase
 {
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) EnsureEmailIsVerified::redirectTo('route.name');
+        $signature = EnsureEmailIsVerified::redirectTo('route.name');
         $this->assertSame('Illuminate\Auth\Middleware\EnsureEmailIsVerified:route.name', $signature);
     }
 }

--- a/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
+++ b/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
@@ -9,13 +9,13 @@ class RedirectIfAuthenticatedMiddlewareTest extends TestCase
 {
     public function testItCanGenerateDefinitionViaStaticMethod()
     {
-        $signature = (string) RedirectIfAuthenticated::using('foo');
+        $signature = RedirectIfAuthenticated::using('foo');
         $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo', $signature);
 
-        $signature = (string) RedirectIfAuthenticated::using('foo', 'bar');
+        $signature = RedirectIfAuthenticated::using('foo', 'bar');
         $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo,bar', $signature);
 
-        $signature = (string) RedirectIfAuthenticated::using('foo', 'bar', 'baz');
+        $signature = RedirectIfAuthenticated::using('foo', 'bar', 'baz');
         $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo,bar,baz', $signature);
     }
 }


### PR DESCRIPTION
remove unnecessary cast to `(string)`
`using()` and `redirectTo()` is already return `string`