### PR TITLE
[12.x] Add tests for hasAppended() method

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2475,6 +2475,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertContains('bar', $model->getAppends());
     }
 
+    public function testHasAppendedReturnsTrueWhenAttributeIsAppended()
+    {
+        $model = new EloquentModelAppendsStub;
+
+        $this->assertTrue($model->hasAppended('is_admin'));
+        $this->assertTrue($model->hasAppended('camelCased'));
+        $this->assertTrue($model->hasAppended('StudlyCased'));
+    }
+
+    public function testHasAppendedReturnsFalseWhenAttributeIsNotAppended()
+    {
+        $model = new EloquentModelAppendsStub;
+
+        $this->assertFalse($model->hasAppended('foo'));
+        $this->assertFalse($model->hasAppended('bar'));
+    }
+
     public function testWithoutAppendsRemovesAppends()
     {
         $model = new EloquentModelAppendsStub;


### PR DESCRIPTION
Description
---
This PR add tests for `hasAppended()` complementing the existing tests for `mergeAppends()` and `withoutAppends()` methods.

See
---
https://github.com/laravel/framework/blob/1f00ef9524d899a2dc17805e8bf4785b8e8eee7f/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L2415-L2424