### PR TITLE
[12.x] Add missing void return type to test methods

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -16,7 +16,7 @@ include_once 'Enums.php';
 
 class AuthAccessGateTest extends TestCase
 {
-    public function testBasicClosuresCanBeDefined()
+    public function testBasicClosuresCanBeDefined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -31,7 +31,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
-    public function testBeforeCanTakeAnArrayCallbackAsObject()
+    public function testBeforeCanTakeAnArrayCallbackAsObject(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -42,7 +42,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
-    public function testBeforeCanTakeAnArrayCallbackAsObjectStatic()
+    public function testBeforeCanTakeAnArrayCallbackAsObjectStatic(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -53,7 +53,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
-    public function testBeforeCanTakeAnArrayCallbackWithStaticMethod()
+    public function testBeforeCanTakeAnArrayCallbackWithStaticMethod(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -64,7 +64,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
-    public function testBeforeCanAllowGuests()
+    public function testBeforeCanAllowGuests(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -77,7 +77,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
-    public function testAfterCanAllowGuests()
+    public function testAfterCanAllowGuests(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -90,7 +90,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('anything'));
     }
 
-    public function testClosuresCanAllowGuestUsers()
+    public function testClosuresCanAllowGuestUsers(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -108,7 +108,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('bar'));
     }
 
-    public function testPoliciesCanAllowGuests()
+    public function testPoliciesCanAllowGuests(): void
     {
         unset($_SERVER['__laravel.testBefore']);
 
@@ -132,7 +132,7 @@ class AuthAccessGateTest extends TestCase
         unset($_SERVER['__laravel.testBefore']);
     }
 
-    public function testPolicyBeforeNotCalledWithGuestsIfItDoesntAllowThem()
+    public function testPolicyBeforeNotCalledWithGuestsIfItDoesntAllowThem(): void
     {
         $_SERVER['__laravel.testBefore'] = false;
 
@@ -149,7 +149,7 @@ class AuthAccessGateTest extends TestCase
         unset($_SERVER['__laravel.testBefore']);
     }
 
-    public function testBeforeAndAfterCallbacksCanAllowGuests()
+    public function testBeforeAndAfterCallbacksCanAllowGuests(): void
     {
         $_SERVER['__laravel.gateBefore'] = false;
         $_SERVER['__laravel.gateBefore2'] = false;
@@ -195,7 +195,7 @@ class AuthAccessGateTest extends TestCase
         );
     }
 
-    public function testResourceGatesCanBeDefined()
+    public function testResourceGatesCanBeDefined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -209,7 +209,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('test.delete', $dummy));
     }
 
-    public function testCustomResourceGatesCanBeDefined()
+    public function testCustomResourceGatesCanBeDefined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -224,7 +224,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('test.ability2'));
     }
 
-    public function testBeforeCallbacksCanOverrideResultIfNecessary()
+    public function testBeforeCallbacksCanOverrideResultIfNecessary(): void
     {
         $gate = $this->getBasicGate();
 
@@ -240,7 +240,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('foo'));
     }
 
-    public function testBeforeCallbacksDontInterruptGateCheckIfNoValueIsReturned()
+    public function testBeforeCallbacksDontInterruptGateCheckIfNoValueIsReturned(): void
     {
         $gate = $this->getBasicGate();
 
@@ -254,7 +254,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testAfterCallbacksAreCalledWithResult()
+    public function testAfterCallbacksAreCalledWithResult(): void
     {
         $gate = $this->getBasicGate();
 
@@ -281,7 +281,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('missing'));
     }
 
-    public function testAfterCallbacksCanAllowIfNull()
+    public function testAfterCallbacksCanAllowIfNull(): void
     {
         $gate = $this->getBasicGate();
 
@@ -292,7 +292,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->allows('null'));
     }
 
-    public function testAfterCallbacksDoNotOverridePreviousResult()
+    public function testAfterCallbacksDoNotOverridePreviousResult(): void
     {
         $gate = $this->getBasicGate();
 
@@ -312,7 +312,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->denies('deny'));
     }
 
-    public function testAfterCallbacksDoNotOverrideEachOther()
+    public function testAfterCallbacksDoNotOverrideEachOther(): void
     {
         $gate = $this->getBasicGate();
 
@@ -328,7 +328,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->denies('deny'));
     }
 
-    public function testCanDefineGatesUsingBackedEnum()
+    public function testCanDefineGatesUsingBackedEnum(): void
     {
         $gate = $this->getBasicGate();
 
@@ -339,7 +339,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->allows('view-dashboard'));
     }
 
-    public function testBackedEnumInAllows()
+    public function testBackedEnumInAllows(): void
     {
         $gate = $this->getBasicGate();
 
@@ -350,7 +350,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->allows(AbilitiesEnum::VIEW_DASHBOARD));
     }
 
-    public function testBackedEnumInDenies()
+    public function testBackedEnumInDenies(): void
     {
         $gate = $this->getBasicGate();
 
@@ -361,7 +361,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->denies(AbilitiesEnum::VIEW_DASHBOARD));
     }
 
-    public function testArrayAbilitiesInAllows()
+    public function testArrayAbilitiesInAllows(): void
     {
         $gate = $this->getBasicGate();
 
@@ -384,7 +384,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->allows(['deny', 'allow_1', 'allow_2']));
     }
 
-    public function testArrayAbilitiesInDenies()
+    public function testArrayAbilitiesInDenies(): void
     {
         $gate = $this->getBasicGate();
 
@@ -408,7 +408,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->denies(['allow']));
     }
 
-    public function testCurrentUserThatIsOnGateAlwaysInjectedIntoClosureCallbacks()
+    public function testCurrentUserThatIsOnGateAlwaysInjectedIntoClosureCallbacks(): void
     {
         $gate = $this->getBasicGate();
 
@@ -421,7 +421,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testASingleArgumentCanBePassedWhenCheckingAbilities()
+    public function testASingleArgumentCanBePassedWhenCheckingAbilities(): void
     {
         $gate = $this->getBasicGate();
 
@@ -446,7 +446,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo', $dummy));
     }
 
-    public function testMultipleArgumentsCanBePassedWhenCheckingAbilities()
+    public function testMultipleArgumentsCanBePassedWhenCheckingAbilities(): void
     {
         $gate = $this->getBasicGate();
 
@@ -473,7 +473,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo', [$dummy1, $dummy2]));
     }
 
-    public function testClassesCanBeDefinedAsCallbacksUsingAtNotation()
+    public function testClassesCanBeDefinedAsCallbacksUsingAtNotation(): void
     {
         $gate = $this->getBasicGate();
 
@@ -482,7 +482,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testInvokableClassesCanBeDefined()
+    public function testInvokableClassesCanBeDefined(): void
     {
         $gate = $this->getBasicGate();
 
@@ -491,7 +491,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testGatesCanBeDefinedUsingAnArrayCallback()
+    public function testGatesCanBeDefinedUsingAnArrayCallback(): void
     {
         $gate = $this->getBasicGate();
 
@@ -500,7 +500,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testGatesCanBeDefinedUsingAnArrayCallbackWithStaticMethod()
+    public function testGatesCanBeDefinedUsingAnArrayCallbackWithStaticMethod(): void
     {
         $gate = $this->getBasicGate();
 
@@ -509,7 +509,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
-    public function testPolicyClassesCanBeDefinedToHandleChecksForGivenType()
+    public function testPolicyClassesCanBeDefinedToHandleChecksForGivenType(): void
     {
         $gate = $this->getBasicGate();
 
@@ -518,7 +518,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function testPolicyClassesHandleChecksForAllSubtypes()
+    public function testPolicyClassesHandleChecksForAllSubtypes(): void
     {
         $gate = $this->getBasicGate();
 
@@ -527,7 +527,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
     }
 
-    public function testPolicyClassesHandleChecksForInterfaces()
+    public function testPolicyClassesHandleChecksForInterfaces(): void
     {
         $gate = $this->getBasicGate();
 
@@ -536,7 +536,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestSubDummy));
     }
 
-    public function testPolicyConvertsDashToCamel()
+    public function testPolicyConvertsDashToCamel(): void
     {
         $gate = $this->getBasicGate();
 
@@ -545,7 +545,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
     }
 
-    public function testPolicyDefaultToFalseIfMethodDoesNotExistAndGateDoesNotExist()
+    public function testPolicyDefaultToFalseIfMethodDoesNotExistAndGateDoesNotExist(): void
     {
         $gate = $this->getBasicGate();
 
@@ -554,7 +554,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('nonexistent_method', new AccessGateTestDummy));
     }
 
-    public function testPolicyClassesCanBeDefinedToHandleChecksForGivenClassName()
+    public function testPolicyClassesCanBeDefinedToHandleChecksForGivenClassName(): void
     {
         $gate = $this->getBasicGate(true);
 
@@ -563,7 +563,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('create', [AccessGateTestDummy::class, true]));
     }
 
-    public function testPoliciesMayHaveBeforeMethodsToOverrideChecks()
+    public function testPoliciesMayHaveBeforeMethodsToOverrideChecks(): void
     {
         $gate = $this->getBasicGate();
 
@@ -572,7 +572,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function testPoliciesAlwaysOverrideClosuresWithSameName()
+    public function testPoliciesAlwaysOverrideClosuresWithSameName(): void
     {
         $gate = $this->getBasicGate();
 
@@ -585,7 +585,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
-    public function testPoliciesDeferToGatesIfMethodDoesNotExist()
+    public function testPoliciesDeferToGatesIfMethodDoesNotExist(): void
     {
         $gate = $this->getBasicGate();
 
@@ -598,7 +598,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('nonexistent_method', new AccessGateTestDummy));
     }
 
-    public function testForUserMethodAttachesANewUserToANewGateInstance()
+    public function testForUserMethodAttachesANewUserToANewGateInstance(): void
     {
         $gate = $this->getBasicGate();
 
@@ -612,7 +612,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->forUser((object) ['id' => 2])->check('foo'));
     }
 
-    public function testForUserMethodAttachesANewUserToANewGateInstanceWithGuessCallback()
+    public function testForUserMethodAttachesANewUserToANewGateInstanceWithGuessCallback(): void
     {
         $gate = $this->getBasicGate();
 
@@ -639,7 +639,7 @@ class AuthAccessGateTest extends TestCase
     }
 
     #[DataProvider('notCallableDataProvider')]
-    public function testDefineSecondParameterShouldBeStringOrCallable($callback)
+    public function testDefineSecondParameterShouldBeStringOrCallable($callback): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -661,7 +661,7 @@ class AuthAccessGateTest extends TestCase
         ];
     }
 
-    public function testAuthorizeThrowsUnauthorizedException()
+    public function testAuthorizeThrowsUnauthorizedException(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('You are not an admin.');
@@ -674,7 +674,7 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('create', new AccessGateTestDummy);
     }
 
-    public function testAuthorizeThrowsUnauthorizedExceptionWithCustomStatusCode()
+    public function testAuthorizeThrowsUnauthorizedExceptionWithCustomStatusCode(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('Not allowed to view as it is not published.');
@@ -687,7 +687,7 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('view', new AccessGateTestDummy);
     }
 
-    public function testAuthorizeWithPolicyThatReturnsDeniedResponseObjectThrowsException()
+    public function testAuthorizeWithPolicyThatReturnsDeniedResponseObjectThrowsException(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('Not allowed.');
@@ -700,7 +700,7 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('create', new AccessGateTestDummy);
     }
 
-    public function testPolicyThatThrowsAuthorizationExceptionIsCaughtInInspect()
+    public function testPolicyThatThrowsAuthorizationExceptionIsCaughtInInspect(): void
     {
         $gate = $this->getBasicGate();
 
@@ -714,7 +714,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('some_code', $response->code());
     }
 
-    public function testAuthorizeReturnsAllowedResponse()
+    public function testAuthorizeReturnsAllowedResponse(): void
     {
         $gate = $this->getBasicGate(true);
 
@@ -728,7 +728,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($check);
     }
 
-    public function testResponseReturnsResponseWhenAbilityGranted()
+    public function testResponseReturnsResponseWhenAbilityGranted(): void
     {
         $gate = $this->getBasicGate(true);
 
@@ -743,7 +743,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertNull($response->code());
     }
 
-    public function testResponseReturnsResponseWhenAbilityDenied()
+    public function testResponseReturnsResponseWhenAbilityDenied(): void
     {
         $gate = $this->getBasicGate();
 
@@ -758,7 +758,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('unpublished', $response->code());
     }
 
-    public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn()
+    public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn(): void
     {
         $gate = $this->getBasicGate();
 
@@ -770,28 +770,28 @@ class AuthAccessGateTest extends TestCase
         $this->assertNull($response->message());
     }
 
-    public function testAllowIfAuthorizesTrue()
+    public function testAllowIfAuthorizesTrue(): void
     {
         $response = $this->getBasicGate()->allowIf(true);
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testAllowIfAuthorizesTruthy()
+    public function testAllowIfAuthorizesTruthy(): void
     {
         $response = $this->getBasicGate()->allowIf('truthy');
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testAllowIfAuthorizesIfGuest()
+    public function testAllowIfAuthorizesIfGuest(): void
     {
         $response = $this->getBasicGate()->forUser(null)->allowIf(true);
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testAllowIfAuthorizesCallbackTrue()
+    public function testAllowIfAuthorizesCallbackTrue(): void
     {
         $response = $this->getBasicGate()->allowIf(function ($user) {
             $this->assertSame(1, $user->id);
@@ -804,7 +804,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('bar', $response->code());
     }
 
-    public function testAllowIfAuthorizesResponseAllowed()
+    public function testAllowIfAuthorizesResponseAllowed(): void
     {
         $response = $this->getBasicGate()->allowIf(Response::allow('foo', 'bar'));
 
@@ -813,7 +813,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('bar', $response->code());
     }
 
-    public function testAllowIfAuthorizesCallbackResponseAllowed()
+    public function testAllowIfAuthorizesCallbackResponseAllowed(): void
     {
         $response = $this->getBasicGate()->allowIf(function () {
             return Response::allow('quz', 'qux');
@@ -824,7 +824,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('qux', $response->code());
     }
 
-    public function testAllowsIfCallbackAcceptsGuestsWhenAuthenticated()
+    public function testAllowsIfCallbackAcceptsGuestsWhenAuthenticated(): void
     {
         $response = $this->getBasicGate()->allowIf(function (?stdClass $user = null) {
             return $user !== null;
@@ -833,7 +833,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($response->allowed());
     }
 
-    public function testAllowIfCallbackAcceptsGuestsWhenUnauthenticated()
+    public function testAllowIfCallbackAcceptsGuestsWhenUnauthenticated(): void
     {
         $gate = $this->getBasicGate()->forUser(null);
 
@@ -844,14 +844,14 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($response->allowed());
     }
 
-    public function testAllowIfThrowsExceptionWhenFalse()
+    public function testAllowIfThrowsExceptionWhenFalse(): void
     {
         $this->expectException(AuthorizationException::class);
 
         $this->getBasicGate()->allowIf(false);
     }
 
-    public function testAllowIfThrowsExceptionWhenCallbackFalse()
+    public function testAllowIfThrowsExceptionWhenCallbackFalse(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -862,7 +862,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testAllowIfThrowsExceptionWhenResponseDenied()
+    public function testAllowIfThrowsExceptionWhenResponseDenied(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -871,7 +871,7 @@ class AuthAccessGateTest extends TestCase
         $this->getBasicGate()->allowIf(Response::deny('foo', 'bar'));
     }
 
-    public function testAllowIfThrowsExceptionWhenCallbackResponseDenied()
+    public function testAllowIfThrowsExceptionWhenCallbackResponseDenied(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('quz');
@@ -882,7 +882,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testAllowIfThrowsExceptionIfUnauthenticated()
+    public function testAllowIfThrowsExceptionIfUnauthenticated(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -895,7 +895,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testAllowIfThrowsExceptionIfAuthUserExpectedWhenGuest()
+    public function testAllowIfThrowsExceptionIfAuthUserExpectedWhenGuest(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -908,28 +908,28 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testDenyIfAuthorizesFalse()
+    public function testDenyIfAuthorizesFalse(): void
     {
         $response = $this->getBasicGate()->denyIf(false);
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testDenyIfAuthorizesFalsy()
+    public function testDenyIfAuthorizesFalsy(): void
     {
         $response = $this->getBasicGate()->denyIf(0);
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testDenyIfAuthorizesIfGuest()
+    public function testDenyIfAuthorizesIfGuest(): void
     {
         $response = $this->getBasicGate()->forUser(null)->denyIf(false);
 
         $this->assertTrue($response->allowed());
     }
 
-    public function testDenyIfAuthorizesCallbackFalse()
+    public function testDenyIfAuthorizesCallbackFalse(): void
     {
         $response = $this->getBasicGate()->denyIf(function ($user) {
             $this->assertSame(1, $user->id);
@@ -942,7 +942,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('bar', $response->code());
     }
 
-    public function testDenyIfAuthorizesResponseAllowed()
+    public function testDenyIfAuthorizesResponseAllowed(): void
     {
         $response = $this->getBasicGate()->denyIf(Response::allow('foo', 'bar'));
 
@@ -951,7 +951,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('bar', $response->code());
     }
 
-    public function testDenyIfAuthorizesCallbackResponseAllowed()
+    public function testDenyIfAuthorizesCallbackResponseAllowed(): void
     {
         $response = $this->getBasicGate()->denyIf(function () {
             return Response::allow('quz', 'qux');
@@ -962,7 +962,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('qux', $response->code());
     }
 
-    public function testDenyIfCallbackAcceptsGuestsWhenAuthenticated()
+    public function testDenyIfCallbackAcceptsGuestsWhenAuthenticated(): void
     {
         $response = $this->getBasicGate()->denyIf(function (?stdClass $user = null) {
             return $user === null;
@@ -971,7 +971,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($response->allowed());
     }
 
-    public function testDenyIfCallbackAcceptsGuestsWhenUnauthenticated()
+    public function testDenyIfCallbackAcceptsGuestsWhenUnauthenticated(): void
     {
         $gate = $this->getBasicGate()->forUser(null);
 
@@ -982,14 +982,14 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($response->allowed());
     }
 
-    public function testDenyIfThrowsExceptionWhenTrue()
+    public function testDenyIfThrowsExceptionWhenTrue(): void
     {
         $this->expectException(AuthorizationException::class);
 
         $this->getBasicGate()->denyIf(true);
     }
 
-    public function testDenyIfThrowsExceptionWhenCallbackTrue()
+    public function testDenyIfThrowsExceptionWhenCallbackTrue(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -1000,7 +1000,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testDenyIfThrowsExceptionWhenResponseDenied()
+    public function testDenyIfThrowsExceptionWhenResponseDenied(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -1009,7 +1009,7 @@ class AuthAccessGateTest extends TestCase
         $this->getBasicGate()->denyIf(Response::deny('foo', 'bar'));
     }
 
-    public function testDenyIfThrowsExceptionWhenCallbackResponseDenied()
+    public function testDenyIfThrowsExceptionWhenCallbackResponseDenied(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('quz');
@@ -1020,7 +1020,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testDenyIfThrowsExceptionIfUnauthenticated()
+    public function testDenyIfThrowsExceptionIfUnauthenticated(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -1033,7 +1033,7 @@ class AuthAccessGateTest extends TestCase
         }, 'foo', 'bar');
     }
 
-    public function testDenyIfThrowsExceptionIfAuthUserExpectedWhenGuest()
+    public function testDenyIfThrowsExceptionIfAuthUserExpectedWhenGuest(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('foo');
@@ -1053,7 +1053,7 @@ class AuthAccessGateTest extends TestCase
         });
     }
 
-    public function testAnyAbilityCheckPassesIfAllPass()
+    public function testAnyAbilityCheckPassesIfAllPass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1062,7 +1062,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testAnyAbilityCheckPassesIfAtLeastOnePasses()
+    public function testAnyAbilityCheckPassesIfAtLeastOnePasses(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1071,7 +1071,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testAnyAbilityCheckFailsIfNonePass()
+    public function testAnyAbilityCheckFailsIfNonePass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1080,7 +1080,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->any(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testNoneAbilityCheckPassesIfAllFail()
+    public function testNoneAbilityCheckPassesIfAllFail(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1089,7 +1089,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->none(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testEveryAbilityCheckPassesIfAllPass()
+    public function testEveryAbilityCheckPassesIfAllPass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1098,7 +1098,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testEveryAbilityCheckFailsIfAtLeastOneFails()
+    public function testEveryAbilityCheckFailsIfAtLeastOneFails(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1107,7 +1107,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testEveryAbilityCheckFailsIfNonePass()
+    public function testEveryAbilityCheckFailsIfNonePass(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1116,7 +1116,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
-    public function testAnyAbilitiesCheckUsingBackedEnum()
+    public function testAnyAbilitiesCheckUsingBackedEnum(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1125,7 +1125,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->any(['edit', AbilitiesEnum::UPDATE], new AccessGateTestDummy));
     }
 
-    public function testNoneAbilitiesCheckUsingBackedEnum()
+    public function testNoneAbilitiesCheckUsingBackedEnum(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1134,7 +1134,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->none(['edit', AbilitiesEnum::UPDATE], new AccessGateTestDummy));
     }
 
-    public function testAbilitiesCheckUsingBackedEnum()
+    public function testAbilitiesCheckUsingBackedEnum(): void
     {
         $gate = $this->getBasicGate();
 
@@ -1149,7 +1149,7 @@ class AuthAccessGateTest extends TestCase
      * @param  bool  $expectedHasValue
      */
     #[DataProvider('hasAbilitiesTestDataProvider')]
-    public function testHasAbilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue)
+    public function testHasAbilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue): void
     {
         $gate = $this->getBasicGate();
 
@@ -1179,7 +1179,7 @@ class AuthAccessGateTest extends TestCase
         ];
     }
 
-    public function testClassesCanBeDefinedAsCallbacksUsingAtNotationForGuests()
+    public function testClassesCanBeDefinedAsCallbacksUsingAtNotationForGuests(): void
     {
         $gate = new Gate(new Container, function () {
             //
@@ -1217,7 +1217,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check('absent_invokable'));
     }
 
-    public function testCanSetDenialResponseInConstructor()
+    public function testCanSetDenialResponseInConstructor(): void
     {
         $gate = new Gate(container: new Container, userResolver: function () {
             //
@@ -1238,7 +1238,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame(999, $response->status());
     }
 
-    public function testCanSetDenialResponse()
+    public function testCanSetDenialResponse(): void
     {
         $gate = new Gate(container: new Container, userResolver: function () {
             //

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthAccessResponseTest extends TestCase
 {
-    public function testAllowMethod()
+    public function testAllowMethod(): void
     {
         $response = Response::allow('some message', 'some_code');
 
@@ -18,7 +18,7 @@ class AuthAccessResponseTest extends TestCase
         $this->assertSame('some_code', $response->code());
     }
 
-    public function testDenyMethod()
+    public function testDenyMethod(): void
     {
         $response = Response::deny('some message', 'some_code');
 
@@ -28,14 +28,14 @@ class AuthAccessResponseTest extends TestCase
         $this->assertSame('some_code', $response->code());
     }
 
-    public function testDenyMethodWithNoMessageReturnsNull()
+    public function testDenyMethodWithNoMessageReturnsNull(): void
     {
         $response = Response::deny();
 
         $this->assertNull($response->message());
     }
 
-    public function testItSetsEmptyStatusOnExceptionWhenAuthorizing()
+    public function testItSetsEmptyStatusOnExceptionWhenAuthorizing(): void
     {
         try {
             Response::deny('foo', 3)->authorize();
@@ -49,7 +49,7 @@ class AuthAccessResponseTest extends TestCase
         }
     }
 
-    public function testItSetsStatusOnExceptionWhenAuthorizing()
+    public function testItSetsStatusOnExceptionWhenAuthorizing(): void
     {
         try {
             Response::deny('foo', 3)->withStatus(418)->authorize();
@@ -118,7 +118,7 @@ class AuthAccessResponseTest extends TestCase
         }
     }
 
-    public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied()
+    public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied(): void
     {
         $response = Response::deny('Some message.', 'some_code');
 
@@ -131,7 +131,7 @@ class AuthAccessResponseTest extends TestCase
         }
     }
 
-    public function testAuthorizeMethodThrowsAuthorizationExceptionWithDefaultMessage()
+    public function testAuthorizeMethodThrowsAuthorizationExceptionWithDefaultMessage(): void
     {
         $response = Response::deny();
 
@@ -142,14 +142,14 @@ class AuthAccessResponseTest extends TestCase
         }
     }
 
-    public function testThrowIfNeededDoesntThrowAuthorizationExceptionWhenResponseAllowed()
+    public function testThrowIfNeededDoesntThrowAuthorizationExceptionWhenResponseAllowed(): void
     {
         $response = Response::allow('Some message.', 'some_code');
 
         $this->assertEquals($response, $response->authorize());
     }
 
-    public function testCastingToStringReturnsMessage()
+    public function testCastingToStringReturnsMessage(): void
     {
         $response = new Response(true, 'some data');
         $this->assertSame('some data', (string) $response);
@@ -158,7 +158,7 @@ class AuthAccessResponseTest extends TestCase
         $this->assertSame('', (string) $response);
     }
 
-    public function testResponseToArrayMethod()
+    public function testResponseToArrayMethod(): void
     {
         $response = new Response(false, 'Not allowed.', 'some_code');
 

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -13,7 +13,7 @@ use stdClass;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
-    public function testCreateInsertsNewRecordIntoTable()
+    public function testCreateInsertsNewRecordIntoTable(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('make')->once()->andReturn('hashed-token');
@@ -30,7 +30,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertGreaterThan(1, strlen($results));
     }
 
-    public function testExistReturnsFalseIfNoRowFoundForUser()
+    public function testExistReturnsFalseIfNoRowFoundForUser(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
@@ -42,7 +42,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsFalseIfRecordIsExpired()
+    public function testExistReturnsFalseIfRecordIsExpired(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
@@ -55,7 +55,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsTrueIfValidRecordExists()
+    public function testExistReturnsTrueIfValidRecordExists(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
@@ -69,7 +69,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertTrue($repo->exists($user, 'token'));
     }
 
-    public function testExistReturnsFalseIfInvalidToken()
+    public function testExistReturnsFalseIfInvalidToken(): void
     {
         $repo = $this->getRepo();
         $repo->getHasher()->shouldReceive('check')->once()->with('wrong-token', 'hashed-token')->andReturn(false);
@@ -83,7 +83,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
 
-    public function testRecentlyCreatedReturnsFalseIfNoRowFoundForUser()
+    public function testRecentlyCreatedReturnsFalseIfNoRowFoundForUser(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
@@ -95,7 +95,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->recentlyCreatedToken($user));
     }
 
-    public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated()
+    public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -112,7 +112,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
+    public function testRecentlyCreatedReturnsFalseIfValidRecordExists(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -129,7 +129,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         Carbon::setTestNow();
     }
 
-    public function testDeleteMethodDeletesByToken()
+    public function testDeleteMethodDeletesByToken(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
@@ -141,7 +141,7 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $repo->delete($user);
     }
 
-    public function testDeleteExpiredMethodDeletesExpiredTokens()
+    public function testDeleteExpiredMethodDeletesExpiredTokens(): void
     {
         $repo = $this->getRepo();
         $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -14,7 +14,7 @@ use stdClass;
 
 class AuthDatabaseUserProviderTest extends TestCase
 {
-    public function testRetrieveByIDReturnsUserWhenUserIsFound()
+    public function testRetrieveByIDReturnsUserWhenUserIsFound(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -28,7 +28,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertSame('Dayle', $user->name);
     }
 
-    public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
+    public function testRetrieveByIDReturnsNullWhenUserIsNotFound(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -40,7 +40,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByTokenReturnsUser()
+    public function testRetrieveByTokenReturnsUser(): void
     {
         $mockUser = new stdClass;
         $mockUser->remember_token = 'a';
@@ -55,7 +55,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertEquals(new GenericUser((array) $mockUser), $user);
     }
 
-    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    public function testRetrieveTokenWithBadIdentifierReturnsNull(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -67,7 +67,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByBadTokenReturnsNull()
+    public function testRetrieveByBadTokenReturnsNull(): void
     {
         $mockUser = new stdClass;
         $mockUser->remember_token = null;
@@ -82,7 +82,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
+    public function testRetrieveByCredentialsReturnsUserWhenUserIsFound(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -98,7 +98,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertSame('taylor', $user->name);
     }
 
-    public function testRetrieveByCredentialsAcceptsCallback()
+    public function testRetrieveByCredentialsAcceptsCallback(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -118,7 +118,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertSame('taylor', $user->name);
     }
 
-    public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
+    public function testRetrieveByCredentialsReturnsNullWhenUserIsFound(): void
     {
         $conn = m::mock(Connection::class);
         $conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
@@ -131,7 +131,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull()
+    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull(): void
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
@@ -144,7 +144,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testCredentialValidation()
+    public function testCredentialValidation(): void
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
@@ -157,7 +157,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testCredentialValidationFails()
+    public function testCredentialValidationFails(): void
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
@@ -170,7 +170,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testCredentialValidationFailsGracefullyWithNullPassword()
+    public function testCredentialValidationFailsGracefullyWithNullPassword(): void
     {
         $conn = m::mock(Connection::class);
         $hasher = m::mock(Hasher::class);
@@ -183,7 +183,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testRehashPasswordIfRequired()
+    public function testRehashPasswordIfRequired(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(true);
@@ -205,7 +205,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $provider->rehashPasswordIfRequired($user, ['password' => 'plain']);
     }
 
-    public function testDontRehashPasswordIfNotRequired()
+    public function testDontRehashPasswordIfNotRequired(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(false);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -11,7 +11,7 @@ use stdClass;
 
 class AuthEloquentUserProviderTest extends TestCase
 {
-    public function testRetrieveByIDReturnsUser()
+    public function testRetrieveByIDReturnsUser(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
@@ -25,7 +25,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertSame('bar', $user);
     }
 
-    public function testRetrieveByTokenReturnsUser()
+    public function testRetrieveByTokenReturnsUser(): void
     {
         $mockUser = m::mock(stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn('a');
@@ -42,7 +42,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertEquals($mockUser, $user);
     }
 
-    public function testRetrieveTokenWithBadIdentifierReturnsNull()
+    public function testRetrieveTokenWithBadIdentifierReturnsNull(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
@@ -56,7 +56,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrievingWithOnlyPasswordCredentialReturnsNull()
+    public function testRetrievingWithOnlyPasswordCredentialReturnsNull(): void
     {
         $provider = $this->getProviderMock();
         $user = $provider->retrieveByCredentials(['api_password' => 'foo']);
@@ -64,7 +64,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByBadTokenReturnsNull()
+    public function testRetrieveByBadTokenReturnsNull(): void
     {
         $mockUser = m::mock(stdClass::class);
         $mockUser->shouldReceive('getRememberToken')->once()->andReturn(null);
@@ -81,7 +81,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testRetrieveByCredentialsReturnsUser()
+    public function testRetrieveByCredentialsReturnsUser(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
@@ -95,7 +95,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertSame('bar', $user);
     }
 
-    public function testRetrieveByCredentialsAcceptsCallback()
+    public function testRetrieveByCredentialsAcceptsCallback(): void
     {
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
@@ -112,7 +112,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertSame('bar', $user);
     }
 
-    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull()
+    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull(): void
     {
         $provider = $this->getProviderMock();
         $user = $provider->retrieveByCredentials([
@@ -123,7 +123,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testCredentialValidation()
+    public function testCredentialValidation(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
@@ -135,7 +135,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testCredentialValidationFailed()
+    public function testCredentialValidationFailed(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(false);
@@ -147,7 +147,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testCredentialValidationFailsGracefullyWithNullPassword()
+    public function testCredentialValidationFailsGracefullyWithNullPassword(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->never();
@@ -159,7 +159,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testRehashPasswordIfRequired()
+    public function testRehashPasswordIfRequired(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(true);
@@ -175,7 +175,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider->rehashPasswordIfRequired($user, ['password' => 'plain']);
     }
 
-    public function testDontRehashPasswordIfNotRequired()
+    public function testDontRehashPasswordIfNotRequired(): void
     {
         $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('needsRehash')->once()->with('hash')->andReturn(false);
@@ -191,7 +191,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider->rehashPasswordIfRequired($user, ['password' => 'plain']);
     }
 
-    public function testModelsCanBeCreated()
+    public function testModelsCanBeCreated(): void
     {
         $hasher = m::mock(Hasher::class);
         $provider = new EloquentUserProvider($hasher, EloquentProviderUserStub::class);
@@ -200,7 +200,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertInstanceOf(EloquentProviderUserStub::class, $model);
     }
 
-    public function testRegistersQueryHandler()
+    public function testRegistersQueryHandler(): void
     {
         $callback = function ($builder) {
             $builder->whereIn('group', ['one', 'two']);

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class AuthGuardTest extends TestCase
 {
-    public function testBasicReturnsNullOnValidAttempt()
+    public function testBasicReturnsNullOnValidAttempt(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
@@ -37,7 +37,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    public function testBasicReturnsNullWhenAlreadyLoggedIn()
+    public function testBasicReturnsNullWhenAlreadyLoggedIn(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class.'[check]', ['default', $provider, $session]);
@@ -49,7 +49,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    public function testBasicReturnsResponseOnFailure()
+    public function testBasicReturnsResponseOnFailure(): void
     {
         $this->expectException(UnauthorizedHttpException::class);
 
@@ -62,7 +62,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email');
     }
 
-    public function testBasicWithExtraConditions()
+    public function testBasicWithExtraConditions(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
@@ -74,7 +74,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email', ['active' => 1]);
     }
 
-    public function testBasicWithExtraArrayConditions()
+    public function testBasicWithExtraArrayConditions(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class.'[check,attempt]', ['default', $provider, $session]);
@@ -86,7 +86,7 @@ class AuthGuardTest extends TestCase
         $guard->basic('email', ['active' => 1, 'type' => [1, 2, 3]]);
     }
 
-    public function testAttemptCallsRetrieveByCredentials()
+    public function testAttemptCallsRetrieveByCredentials(): void
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
@@ -102,7 +102,7 @@ class AuthGuardTest extends TestCase
         $guard->attempt(['foo']);
     }
 
-    public function testAttemptReturnsUserInterface()
+    public function testAttemptReturnsUserInterface(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request, $timebox])->getMock();
@@ -120,7 +120,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->attempt(['foo']));
     }
 
-    public function testAttemptReturnsFalseIfUserNotGiven()
+    public function testAttemptReturnsFalseIfUserNotGiven(): void
     {
         $mock = $this->getGuard();
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
@@ -136,7 +136,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->attempt(['foo']));
     }
 
-    public function testAttemptAndWithCallbacks()
+    public function testAttemptAndWithCallbacks(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request, $timebox])->getMock();
@@ -182,7 +182,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($executed);
     }
 
-    public function testAttemptRehashesPasswordWhenRequired()
+    public function testAttemptRehashesPasswordWhenRequired(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request, $timebox])->getMock();
@@ -200,7 +200,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->attempt(['foo']));
     }
 
-    public function testAttemptDoesntRehashPasswordWhenDisabled()
+    public function testAttemptDoesntRehashPasswordWhenDisabled(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])
@@ -220,7 +220,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->attempt(['foo']));
     }
 
-    public function testLoginStoresIdentifierInSession()
+    public function testLoginStoresIdentifierInSession(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -232,7 +232,7 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
-    public function testSessionGuardIsMacroable()
+    public function testSessionGuardIsMacroable(): void
     {
         $guard = $this->getGuard();
 
@@ -245,7 +245,7 @@ class AuthGuardTest extends TestCase
         );
     }
 
-    public function testLoginFiresLoginAndAuthenticatedEvents()
+    public function testLoginFiresLoginAndAuthenticatedEvents(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -260,7 +260,7 @@ class AuthGuardTest extends TestCase
         $mock->login($user);
     }
 
-    public function testFailedAttemptFiresFailedEvent()
+    public function testFailedAttemptFiresFailedEvent(): void
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
@@ -276,7 +276,7 @@ class AuthGuardTest extends TestCase
         $guard->attempt(['foo']);
     }
 
-    public function testAuthenticateReturnsUserWhenUserIsNotNull()
+    public function testAuthenticateReturnsUserWhenUserIsNotNull(): void
     {
         $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard();
@@ -285,7 +285,7 @@ class AuthGuardTest extends TestCase
         $this->assertEquals($user, $guard->authenticate());
     }
 
-    public function testSetUserFiresAuthenticatedEvent()
+    public function testSetUserFiresAuthenticatedEvent(): void
     {
         $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard();
@@ -294,7 +294,7 @@ class AuthGuardTest extends TestCase
         $guard->setUser($user);
     }
 
-    public function testAuthenticateThrowsWhenUserIsNull()
+    public function testAuthenticateThrowsWhenUserIsNull(): void
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Unauthenticated.');
@@ -305,7 +305,7 @@ class AuthGuardTest extends TestCase
         $guard->authenticate();
     }
 
-    public function testHasUserReturnsTrueWhenUserIsNotNull()
+    public function testHasUserReturnsTrueWhenUserIsNotNull(): void
     {
         $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard();
@@ -314,7 +314,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->hasUser());
     }
 
-    public function testHasUserReturnsFalseWhenUserIsNull()
+    public function testHasUserReturnsFalseWhenUserIsNull(): void
     {
         $guard = $this->getGuard();
         $guard->getSession()->shouldNotReceive('get');
@@ -322,7 +322,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->hasUser());
     }
 
-    public function testIsAuthedReturnsTrueWhenUserIsNotNull()
+    public function testIsAuthedReturnsTrueWhenUserIsNotNull(): void
     {
         $user = m::mock(Authenticatable::class);
         $mock = $this->getGuard();
@@ -331,7 +331,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->guest());
     }
 
-    public function testIsAuthedReturnsFalseWhenUserIsNull()
+    public function testIsAuthedReturnsFalseWhenUserIsNull(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -340,7 +340,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($mock->guest());
     }
 
-    public function testUserMethodReturnsCachedUser()
+    public function testUserMethodReturnsCachedUser(): void
     {
         $user = m::mock(Authenticatable::class);
         $mock = $this->getGuard();
@@ -348,14 +348,14 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->user());
     }
 
-    public function testNullIsReturnedForUserIfNoUserFound()
+    public function testNullIsReturnedForUserIfNoUserFound(): void
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(null);
         $this->assertNull($mock->user());
     }
 
-    public function testUserIsSetToRetrievedUser()
+    public function testUserIsSetToRetrievedUser(): void
     {
         $mock = $this->getGuard();
         $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
@@ -365,7 +365,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->getUser());
     }
 
-    public function testLogoutRemovesSessionTokenAndRememberMeCookie()
+    public function testLogoutRemovesSessionTokenAndRememberMeCookie(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -388,7 +388,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
+    public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -407,7 +407,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutFiresLogoutEvent()
+    public function testLogoutFiresLogoutEvent(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -421,7 +421,7 @@ class AuthGuardTest extends TestCase
         $mock->logout();
     }
 
-    public function testLogoutDoesNotSetRememberTokenIfNotPreviouslySet()
+    public function testLogoutDoesNotSetRememberTokenIfNotPreviouslySet(): void
     {
         [$session, $provider, $request] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -435,7 +435,7 @@ class AuthGuardTest extends TestCase
         $mock->logout();
     }
 
-    public function testLogoutCurrentDeviceRemovesRememberMeCookie()
+    public function testLogoutCurrentDeviceRemovesRememberMeCookie(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -455,7 +455,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutCurrentDeviceDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
+    public function testLogoutCurrentDeviceDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -473,7 +473,7 @@ class AuthGuardTest extends TestCase
         $this->assertNull($mock->getUser());
     }
 
-    public function testLogoutCurrentDeviceFiresLogoutEvent()
+    public function testLogoutCurrentDeviceFiresLogoutEvent(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -487,7 +487,7 @@ class AuthGuardTest extends TestCase
         $mock->logoutCurrentDevice();
     }
 
-    public function testLoginMethodQueuesCookieWhenRemembering()
+    public function testLoginMethodQueuesCookieWhenRemembering(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = new SessionGuard('default', $provider, $session, $request);
@@ -507,7 +507,7 @@ class AuthGuardTest extends TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginMethodQueuesCookieWhenRememberingAndAllowsOverride()
+    public function testLoginMethodQueuesCookieWhenRememberingAndAllowsOverride(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = new SessionGuard('default', $provider, $session, $request);
@@ -528,7 +528,7 @@ class AuthGuardTest extends TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginMethodCreatesRememberTokenIfOneDoesntExist()
+    public function testLoginMethodCreatesRememberTokenIfOneDoesntExist(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = new SessionGuard('default', $provider, $session, $request);
@@ -547,7 +547,7 @@ class AuthGuardTest extends TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginUsingIdLogsInWithUser()
+    public function testLoginUsingIdLogsInWithUser(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
 
@@ -560,7 +560,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $guard->loginUsingId(10));
     }
 
-    public function testLoginUsingIdFailure()
+    public function testLoginUsingIdFailure(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
@@ -571,7 +571,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->loginUsingId(11));
     }
 
-    public function testOnceUsingIdSetsUser()
+    public function testOnceUsingIdSetsUser(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
@@ -583,7 +583,7 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $guard->onceUsingId(10));
     }
 
-    public function testOnceUsingIdFailure()
+    public function testOnceUsingIdFailure(): void
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
@@ -594,7 +594,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->onceUsingId(11));
     }
 
-    public function testUserUsesRememberCookieIfItExists()
+    public function testUserUsesRememberCookieIfItExists(): void
     {
         $guard = $this->getGuard();
         [$session, $provider, $request, $cookie] = $this->getMocks();
@@ -610,7 +610,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->viaRemember());
     }
 
-    public function testLoginOnceSetsUser()
+    public function testLoginOnceSetsUser(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session, $request, $timebox])->makePartial();
@@ -625,7 +625,7 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->once(['foo']));
     }
 
-    public function testLoginOnceFailure()
+    public function testLoginOnceFailure(): void
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
         $guard = m::mock(SessionGuard::class, ['default', $provider, $session, $request, $timebox])->makePartial();
@@ -639,7 +639,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->once(['foo']));
     }
 
-    public function testForgetUserSetsUserToNull()
+    public function testForgetUserSetsUserToNull(): void
     {
         $user = m::mock(Authenticatable::class);
         $guard = $this->getGuard();

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -10,7 +10,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 {
     use HandlesAuthorization;
 
-    public function testAllowMethod()
+    public function testAllowMethod(): void
     {
         $response = $this->allow('some message', 'some_code');
 
@@ -20,7 +20,7 @@ class AuthHandlesAuthorizationTest extends TestCase
         $this->assertSame('some_code', $response->code());
     }
 
-    public function testDenyMethod()
+    public function testDenyMethod(): void
     {
         $response = $this->deny('some message', 'some_code');
 
@@ -30,7 +30,7 @@ class AuthHandlesAuthorizationTest extends TestCase
         $this->assertSame('some_code', $response->code());
     }
 
-    public function testDenyHasNullStatus()
+    public function testDenyHasNullStatus(): void
     {
         $class = new class()
         {
@@ -51,7 +51,7 @@ class AuthHandlesAuthorizationTest extends TestCase
         }
     }
 
-    public function testItCanDenyWithStatus()
+    public function testItCanDenyWithStatus(): void
     {
         $class = new class()
         {
@@ -94,7 +94,7 @@ class AuthHandlesAuthorizationTest extends TestCase
         }
     }
 
-    public function testItCanDenyAsNotFound()
+    public function testItCanDenyAsNotFound(): void
     {
         $class = new class()
         {

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -14,7 +14,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     /**
      * @return void
      */
-    public function testWillExecuted()
+    public function testWillExecuted(): void
     {
         $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
         $user->method('hasVerifiedEmail')->willReturn(false);
@@ -28,7 +28,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     /**
      * @return void
      */
-    public function testUserIsNotInstanceOfMustVerifyEmail()
+    public function testUserIsNotInstanceOfMustVerifyEmail(): void
     {
         $user = m::mock(User::class);
         $user->shouldNotReceive('sendEmailVerificationNotification');
@@ -41,7 +41,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
     /**
      * @return void
      */
-    public function testHasVerifiedEmailAsTrue()
+    public function testHasVerifiedEmailAsTrue(): void
     {
         $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
         $user->method('hasVerifiedEmail')->willReturn(true);

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -14,7 +14,7 @@ use UnexpectedValueException;
 
 class AuthPasswordBrokerTest extends TestCase
 {
-    public function testIfUserIsNotFoundErrorRedirectIsReturned()
+    public function testIfUserIsNotFoundErrorRedirectIsReturned(): void
     {
         $mocks = $this->getMocks();
         $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();
@@ -23,7 +23,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertSame(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
     }
 
-    public function testIfTokenIsRecentlyCreated()
+    public function testIfTokenIsRecentlyCreated(): void
     {
         $mocks = $this->getMocks();
         $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();
@@ -34,7 +34,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertSame(PasswordBrokerContract::RESET_THROTTLED, $broker->sendResetLink(['foo']));
     }
 
-    public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
+    public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword(): void
     {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('User must implement CanResetPassword interface.');
@@ -45,7 +45,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker->getUser(['foo']);
     }
 
-    public function testUserIsRetrievedByCredentials()
+    public function testUserIsRetrievedByCredentials(): void
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
@@ -53,7 +53,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals($user, $broker->getUser(['foo']));
     }
 
-    public function testBrokerCreatesTokenAndRedirectsWithoutError()
+    public function testBrokerCreatesTokenAndRedirectsWithoutError(): void
     {
         $mocks = $this->getMocks();
         $broker = m::mock(PasswordBroker::class, array_values($mocks))->makePartial();
@@ -65,7 +65,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertSame(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
     }
 
-    public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()
+    public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid(): void
     {
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
@@ -75,7 +75,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
+    public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable(): void
     {
         $creds = ['token' => 'token'];
         $broker = $this->getBroker($mocks = $this->getMocks());
@@ -87,7 +87,7 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testResetRemovesRecordOnReminderTableAndCallsCallback()
+    public function testResetRemovesRecordOnReminderTableAndCallsCallback(): void
     {
         unset($_SERVER['__password.reset.test']);
         $mocks = $this->getMocks();
@@ -104,7 +104,7 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__password.reset.test']);
     }
 
-    public function testExecutesCallbackInsteadOfSendingNotification()
+    public function testExecutesCallbackInsteadOfSendingNotification(): void
     {
         $executed = false;
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthTokenGuardTest extends TestCase
 {
-    public function testUserCanBeRetrievedByQueryStringVariable()
+    public function testUserCanBeRetrievedByQueryStringVariable(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -28,7 +28,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $guard->id());
     }
 
-    public function testTokenCanBeHashed()
+    public function testTokenCanBeHashed(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -46,7 +46,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $guard->id());
     }
 
-    public function testUserCanBeRetrievedByAuthHeaders()
+    public function testUserCanBeRetrievedByAuthHeaders(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -59,7 +59,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
     }
 
-    public function testUserCanBeRetrievedByBearerToken()
+    public function testUserCanBeRetrievedByBearerToken(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -72,7 +72,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
     }
 
-    public function testValidateCanDetermineIfCredentialsAreValid()
+    public function testValidateCanDetermineIfCredentialsAreValid(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -85,7 +85,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
 
-    public function testValidateCanDetermineIfCredentialsAreInvalid()
+    public function testValidateCanDetermineIfCredentialsAreInvalid(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(null);
@@ -96,7 +96,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertFalse($guard->validate(['api_token' => 'foo']));
     }
 
-    public function testValidateIfApiTokenIsEmpty()
+    public function testValidateIfApiTokenIsEmpty(): void
     {
         $provider = m::mock(UserProvider::class);
         $request = Request::create('/', 'GET', ['api_token' => '']);
@@ -106,7 +106,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertFalse($guard->validate(['api_token' => '']));
     }
 
-    public function testItAllowsToPassCustomRequestInSetterAndUseItForValidation()
+    public function testItAllowsToPassCustomRequestInSetterAndUseItForValidation(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -122,7 +122,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
     }
 
-    public function testUserCanBeRetrievedByBearerTokenWithCustomKey()
+    public function testUserCanBeRetrievedByBearerTokenWithCustomKey(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -135,7 +135,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
     }
 
-    public function testUserCanBeRetrievedByQueryStringVariableWithCustomKey()
+    public function testUserCanBeRetrievedByQueryStringVariableWithCustomKey(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -153,7 +153,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $guard->id());
     }
 
-    public function testUserCanBeRetrievedByAuthHeadersWithCustomField()
+    public function testUserCanBeRetrievedByAuthHeadersWithCustomField(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn((object) ['id' => 1]);
@@ -166,7 +166,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
     }
 
-    public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey()
+    public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey(): void
     {
         $provider = m::mock(UserProvider::class);
         $user = new AuthTokenGuardTestUser;
@@ -179,7 +179,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertTrue($guard->validate(['custom_token_field' => 'foo']));
     }
 
-    public function testValidateCanDetermineIfCredentialsAreInvalidWithCustomKey()
+    public function testValidateCanDetermineIfCredentialsAreInvalidWithCustomKey(): void
     {
         $provider = m::mock(UserProvider::class);
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(null);
@@ -190,7 +190,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertFalse($guard->validate(['custom_token_field' => 'foo']));
     }
 
-    public function testValidateIfApiTokenIsEmptyWithCustomKey()
+    public function testValidateIfApiTokenIsEmptyWithCustomKey(): void
     {
         $provider = m::mock(UserProvider::class);
         $request = Request::create('/', 'GET', ['custom_token_field' => '']);

--- a/tests/Auth/AuthenticatableTest.php
+++ b/tests/Auth/AuthenticatableTest.php
@@ -7,21 +7,21 @@ use PHPUnit\Framework\TestCase;
 
 class AuthenticatableTest extends TestCase
 {
-    public function testItReturnsSameRememberTokenForString()
+    public function testItReturnsSameRememberTokenForString(): void
     {
         $user = new User;
         $user->setRememberToken('sample_token');
         $this->assertSame('sample_token', $user->getRememberToken());
     }
 
-    public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue()
+    public function testItReturnsStringAsRememberTokenWhenItWasSetToTrue(): void
     {
         $user = new User;
         $user->setRememberToken(true);
         $this->assertSame('1', $user->getRememberToken());
     }
 
-    public function testItReturnsNullWhenRememberTokenNameWasSetToEmpty()
+    public function testItReturnsNullWhenRememberTokenNameWasSetToEmpty(): void
     {
         $user = new class extends User
         {

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -37,7 +37,7 @@ class AuthenticateMiddlewareTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItCanGenerateDefinitionViaStaticMethod()
+    public function testItCanGenerateDefinitionViaStaticMethod(): void
     {
         $signature = Authenticate::using('foo');
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo', $signature);
@@ -49,7 +49,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame('Illuminate\Auth\Middleware\Authenticate:foo,bar,baz', $signature);
     }
 
-    public function testItCanGenerateDefinitionViaStaticMethodForBasic()
+    public function testItCanGenerateDefinitionViaStaticMethodForBasic(): void
     {
         $signature = AuthenticateWithBasicAuth::using('guard');
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:guard', $signature);
@@ -61,7 +61,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame('Illuminate\Auth\Middleware\AuthenticateWithBasicAuth:,field', $signature);
     }
 
-    public function testDefaultUnauthenticatedThrows()
+    public function testDefaultUnauthenticatedThrows(): void
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Unauthenticated.');
@@ -71,7 +71,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->authenticate();
     }
 
-    public function testDefaultUnauthenticatedThrowsWithGuards()
+    public function testDefaultUnauthenticatedThrowsWithGuards(): void
     {
         try {
             $this->registerAuthDriver('default', false);
@@ -86,7 +86,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->fail();
     }
 
-    public function testDefaultAuthenticatedKeepsDefaultDriver()
+    public function testDefaultAuthenticatedKeepsDefaultDriver(): void
     {
         $driver = $this->registerAuthDriver('default', true);
 
@@ -95,7 +95,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($driver, $this->auth->guard());
     }
 
-    public function testSecondaryAuthenticatedUpdatesDefaultDriver()
+    public function testSecondaryAuthenticatedUpdatesDefaultDriver(): void
     {
         $this->registerAuthDriver('default', false);
 
@@ -106,7 +106,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->assertSame($secondary, $this->auth->guard());
     }
 
-    public function testMultipleDriversUnauthenticatedThrows()
+    public function testMultipleDriversUnauthenticatedThrows(): void
     {
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Unauthenticated.');
@@ -118,7 +118,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->authenticate('default', 'secondary');
     }
 
-    public function testMultipleDriversUnauthenticatedThrowsWithGuards()
+    public function testMultipleDriversUnauthenticatedThrowsWithGuards(): void
     {
         $expectedGuards = ['default', 'secondary'];
 
@@ -137,7 +137,7 @@ class AuthenticateMiddlewareTest extends TestCase
         $this->fail();
     }
 
-    public function testMultipleDriversAuthenticatedUpdatesDefault()
+    public function testMultipleDriversAuthenticatedUpdatesDefault(): void
     {
         $this->registerAuthDriver('default', false);
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -55,7 +55,7 @@ class AuthorizeMiddlewareTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItCanGenerateDefinitionViaStaticMethod()
+    public function testItCanGenerateDefinitionViaStaticMethod(): void
     {
         $signature = Authorize::using('ability');
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability', $signature);
@@ -67,7 +67,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('Illuminate\Auth\Middleware\Authorize:ability,model,App\Models\Comment', $signature);
     }
 
-    public function testSimpleAbilityUnauthorized()
+    public function testSimpleAbilityUnauthorized(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('This action is unauthorized.');
@@ -88,7 +88,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('dashboard', 'GET'));
     }
 
-    public function testSimpleAbilityAuthorized()
+    public function testSimpleAbilityAuthorized(): void
     {
         $this->gate()->define('view-dashboard', function ($user) {
             return true;
@@ -106,7 +106,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testSimpleAbilityWithStringParameter()
+    public function testSimpleAbilityWithStringParameter(): void
     {
         $this->gate()->define('view-dashboard', function ($user, $param) {
             return $param === 'some string';
@@ -124,7 +124,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testSimpleAbilityWithBackedEnumParameter()
+    public function testSimpleAbilityWithBackedEnumParameter(): void
     {
         $this->gate()->define('view-dashboard', function ($user) {
             return true;
@@ -141,7 +141,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testSimpleAbilityWithNullParameter()
+    public function testSimpleAbilityWithNullParameter(): void
     {
         $this->gate()->define('view-dashboard', function ($user, $param = null) {
             $this->assertNull($param);
@@ -159,7 +159,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('dashboard', 'GET'));
     }
 
-    public function testSimpleAbilityWithOptionalParameter()
+    public function testSimpleAbilityWithOptionalParameter(): void
     {
         $post = new stdClass;
 
@@ -193,7 +193,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testSimpleAbilityWithStringParameterFromRouteParameter()
+    public function testSimpleAbilityWithStringParameterFromRouteParameter(): void
     {
         $this->gate()->define('view-dashboard', function ($user, $param) {
             return $param === 'true';
@@ -211,7 +211,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testSimpleAbilityWithStringParameter0FromRouteParameter()
+    public function testSimpleAbilityWithStringParameter0FromRouteParameter(): void
     {
         $this->gate()->define('view-dashboard', function ($user, $param) {
             return $param === '0';
@@ -229,7 +229,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testModelTypeUnauthorized()
+    public function testModelTypeUnauthorized(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('This action is unauthorized.');
@@ -250,7 +250,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('users/create', 'GET'));
     }
 
-    public function testModelTypeAuthorized()
+    public function testModelTypeAuthorized(): void
     {
         $this->gate()->define('create', function ($user, $model) {
             $this->assertSame('App\User', $model);
@@ -270,7 +270,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testModelUnauthorized()
+    public function testModelUnauthorized(): void
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('This action is unauthorized.');
@@ -297,7 +297,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->router->dispatch(Request::create('posts/1/edit', 'GET'));
     }
 
-    public function testModelAuthorized()
+    public function testModelAuthorized(): void
     {
         $post = new stdClass;
 
@@ -323,7 +323,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
-    public function testModelInstanceAsParameter()
+    public function testModelInstanceAsParameter(): void
     {
         $instance = m::mock(Model::class);
 

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthorizesResourcesTest extends TestCase
 {
-    public function testCreateMethod()
+    public function testCreateMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
@@ -23,7 +23,7 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User,App\Post');
     }
 
-    public function testStoreMethod()
+    public function testStoreMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
@@ -34,7 +34,7 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User,App\Post');
     }
 
-    public function testShowMethod()
+    public function testShowMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
@@ -45,7 +45,7 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'show', 'can:view,user,post');
     }
 
-    public function testEditMethod()
+    public function testEditMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
@@ -56,7 +56,7 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user,post');
     }
 
-    public function testUpdateMethod()
+    public function testUpdateMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 
@@ -67,7 +67,7 @@ class AuthorizesResourcesTest extends TestCase
         $this->assertHasMiddleware($controller, 'update', 'can:update,user,post');
     }
 
-    public function testDestroyMethod()
+    public function testDestroyMethod(): void
     {
         $controller = new AuthorizesResourcesController;
 

--- a/tests/Auth/EnsureEmailIsVerifiedTest.php
+++ b/tests/Auth/EnsureEmailIsVerifiedTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class EnsureEmailIsVerifiedTest extends TestCase
 {
-    public function testItCanGenerateDefinitionViaStaticMethod()
+    public function testItCanGenerateDefinitionViaStaticMethod(): void
     {
         $signature = EnsureEmailIsVerified::redirectTo('route.name');
         $this->assertSame('Illuminate\Auth\Middleware\EnsureEmailIsVerified:route.name', $signature);

--- a/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
+++ b/tests/Auth/RedirectIfAuthenticatedMiddlewareTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class RedirectIfAuthenticatedMiddlewareTest extends TestCase
 {
-    public function testItCanGenerateDefinitionViaStaticMethod()
+    public function testItCanGenerateDefinitionViaStaticMethod(): void
     {
         $signature = RedirectIfAuthenticated::using('foo');
         $this->assertSame('Illuminate\Auth\Middleware\RedirectIfAuthenticated:foo', $signature);

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -27,7 +27,7 @@ class AblyBroadcasterTest extends TestCase
         $this->broadcaster = m::mock(AblyBroadcaster::class, [$this->ably])->makePartial();
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue(): void
     {
         $this->broadcaster->channel('test', function () {
             return true;
@@ -41,7 +41,7 @@ class AblyBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -54,7 +54,7 @@ class AblyBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -67,7 +67,7 @@ class AblyBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray(): void
     {
         $returnData = [1, 2, 3, 4];
         $this->broadcaster->channel('test', function () use ($returnData) {
@@ -82,7 +82,7 @@ class AblyBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -95,7 +95,7 @@ class AblyBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class BroadcastEventTest extends TestCase
 {
-    public function testBasicEventBroadcastParameterFormatting()
+    public function testBasicEventBroadcastParameterFormatting(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 
@@ -30,7 +30,7 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
-    public function testManualParameterSpecification()
+    public function testManualParameterSpecification(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 
@@ -47,7 +47,7 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
-    public function testSpecificBroadcasterGiven()
+    public function testSpecificBroadcasterGiven(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 
@@ -62,7 +62,7 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
-    public function testSpecificChannelsPerConnection()
+    public function testSpecificChannelsPerConnection(): void
     {
         $broadcaster = m::mock(Broadcaster::class);
 
@@ -84,7 +84,7 @@ class BroadcastEventTest extends TestCase
         (new BroadcastEvent($event))->handle($manager);
     }
 
-    public function testMiddlewareProxiesMiddlewareFromUnderlyingEvent()
+    public function testMiddlewareProxiesMiddlewareFromUnderlyingEvent(): void
     {
         $event = new class
         {
@@ -99,7 +99,7 @@ class BroadcastEventTest extends TestCase
         $this->assertSame(['foo', 'bar'], $job->middleware());
     }
 
-    public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent()
+    public function testMiddlewareProxiesFailedHandlerFromUnderlyingEvent(): void
     {
         $event = new class
         {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -35,7 +35,7 @@ class BroadcasterTest extends TestCase
         parent::tearDown();
     }
 
-    public function testExtractingParametersWhileCheckingForUserAccess()
+    public function testExtractingParametersWhileCheckingForUserAccess(): void
     {
         $callback = function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {
             //
@@ -77,13 +77,13 @@ class BroadcasterTest extends TestCase
         Container::setInstance(new Container);
     }
 
-    public function testCanUseChannelClasses()
+    public function testCanUseChannelClasses(): void
     {
         $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', DummyBroadcastingChannel::class);
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
     }
 
-    public function testModelRouteBinding()
+    public function testModelRouteBinding(): void
     {
         $container = new Container;
         Container::setInstance($container);
@@ -100,14 +100,14 @@ class BroadcasterTest extends TestCase
         Container::setInstance(new Container);
     }
 
-    public function testUnknownChannelAuthHandlerTypeThrowsException()
+    public function testUnknownChannelAuthHandlerTypeThrowsException(): void
     {
         $this->expectException(Exception::class);
 
         $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
     }
 
-    public function testCanRegisterChannelsAsClasses()
+    public function testCanRegisterChannelsAsClasses(): void
     {
         $this->broadcaster->channel('something', function () {
             //
@@ -116,7 +116,7 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
     }
 
-    public function testNotFoundThrowsHttpException()
+    public function testNotFoundThrowsHttpException(): void
     {
         $this->expectException(HttpException::class);
 
@@ -126,14 +126,14 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
     }
 
-    public function testCanRegisterChannelsWithoutOptions()
+    public function testCanRegisterChannelsWithoutOptions(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
         });
     }
 
-    public function testCanRegisterChannelsWithOptions()
+    public function testCanRegisterChannelsWithOptions(): void
     {
         $options = ['a' => ['b', 'c']];
         $this->broadcaster->channel('somechannel', function () {
@@ -141,7 +141,7 @@ class BroadcasterTest extends TestCase
         }, $options);
     }
 
-    public function testCanRetrieveChannelsOptions()
+    public function testCanRetrieveChannelsOptions(): void
     {
         $options = ['a' => ['b', 'c']];
         $this->broadcaster->channel('somechannel', function () {
@@ -154,7 +154,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testCanRetrieveChannelsOptionsUsingAChannelNameContainingArgs()
+    public function testCanRetrieveChannelsOptionsUsingAChannelNameContainingArgs(): void
     {
         $options = ['a' => ['b', 'c']];
         $this->broadcaster->channel('somechannel.{id}.test.{text}', function () {
@@ -167,7 +167,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testCanRetrieveChannelsOptionsWhenMultipleChannelsAreRegistered()
+    public function testCanRetrieveChannelsOptionsWhenMultipleChannelsAreRegistered(): void
     {
         $options = ['a' => ['b', 'c']];
         $this->broadcaster->channel('somechannel', function () {
@@ -183,7 +183,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testDontRetrieveChannelsOptionsWhenChannelDoesntExists()
+    public function testDontRetrieveChannelsOptionsWhenChannelDoesntExists(): void
     {
         $options = ['a' => ['b', 'c']];
         $this->broadcaster->channel('somechannel', function () {
@@ -196,7 +196,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testRetrieveUserWithoutGuard()
+    public function testRetrieveUserWithoutGuard(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
@@ -214,7 +214,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testRetrieveUserWithOneGuardUsingAStringForSpecifyingGuard()
+    public function testRetrieveUserWithOneGuardUsingAStringForSpecifyingGuard(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
@@ -232,7 +232,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testRetrieveUserWithMultipleGuardsAndRespectGuardsOrder()
+    public function testRetrieveUserWithMultipleGuardsAndRespectGuardsOrder(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
@@ -263,7 +263,7 @@ class BroadcasterTest extends TestCase
         );
     }
 
-    public function testRetrieveUserDontUseDefaultGuardWhenOneGuardSpecified()
+    public function testRetrieveUserDontUseDefaultGuardWhenOneGuardSpecified(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
@@ -280,7 +280,7 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->retrieveUser($request, 'somechannel');
     }
 
-    public function testRetrieveUserDontUseDefaultGuardWhenMultipleGuardsSpecified()
+    public function testRetrieveUserDontUseDefaultGuardWhenMultipleGuardsSpecified(): void
     {
         $this->broadcaster->channel('somechannel', function () {
             //
@@ -301,7 +301,7 @@ class BroadcasterTest extends TestCase
         $this->broadcaster->retrieveUser($request, 'somechannel');
     }
 
-    public function testUserAuthenticationWithValidUser()
+    public function testUserAuthenticationWithValidUser(): void
     {
         $this->broadcaster->resolveAuthenticatedUserUsing(function ($request) {
             return ['id' => '12345', 'socket' => $request->socket_id];
@@ -315,7 +315,7 @@ class BroadcasterTest extends TestCase
         ], $user);
     }
 
-    public function testUserAuthenticationWithInvalidUser()
+    public function testUserAuthenticationWithInvalidUser(): void
     {
         $this->broadcaster->resolveAuthenticatedUserUsing(function ($request) {
             return null;
@@ -326,13 +326,13 @@ class BroadcasterTest extends TestCase
         $this->assertNull($user);
     }
 
-    public function testUserAuthenticationWithoutResolve()
+    public function testUserAuthenticationWithoutResolve(): void
     {
         $this->assertNull($this->broadcaster->resolveAuthenticatedUser(new Request(['socket_id' => '1234.1234'])));
     }
 
     #[DataProvider('channelNameMatchPatternProvider')]
-    public function testChannelNameMatchPattern($channel, $pattern, $shouldMatch)
+    public function testChannelNameMatchPattern($channel, $pattern, $shouldMatch): void
     {
         $this->assertEquals($shouldMatch, $this->broadcaster->channelNameMatchesPattern($channel, $pattern));
     }

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -25,7 +25,7 @@ class PusherBroadcasterTest extends TestCase
         $this->broadcaster = m::mock(PusherBroadcaster::class, [$this->pusher])->makePartial();
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue(): void
     {
         $this->broadcaster->channel('test', function () {
             return true;
@@ -39,7 +39,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -52,7 +52,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -65,7 +65,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray(): void
     {
         $returnData = [1, 2, 3, 4];
         $this->broadcaster->channel('test', function () use ($returnData) {
@@ -80,7 +80,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -93,7 +93,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -106,7 +106,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testValidAuthenticationResponseCallPusherSocketAuthMethodWithPrivateChannel()
+    public function testValidAuthenticationResponseCallPusherSocketAuthMethodWithPrivateChannel(): void
     {
         $request = $this->getMockRequestWithUserForChannel('private-test');
 
@@ -124,7 +124,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testValidAuthenticationResponseCallPusherPresenceAuthMethodWithPresenceChannel()
+    public function testValidAuthenticationResponseCallPusherPresenceAuthMethodWithPresenceChannel(): void
     {
         $request = $this->getMockRequestWithUserForChannel('presence-test');
 
@@ -146,7 +146,7 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
-    public function testUserAuthenticationForPusher()
+    public function testUserAuthenticationForPusher(): void
     {
         $this->pusher
             ->shouldReceive('getSettings')

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -29,7 +29,7 @@ class RedisBroadcasterTest extends TestCase
         });
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue(): void
     {
         $this->broadcaster->channel('test', function () {
             return true;
@@ -43,7 +43,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -56,7 +56,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -69,7 +69,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray(): void
     {
         $returnData = [1, 2, 3, 4];
         $this->broadcaster->channel('test', function () use ($returnData) {
@@ -84,7 +84,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -97,7 +97,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound(): void
     {
         $this->expectException(AccessDeniedHttpException::class);
 
@@ -110,7 +110,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testValidAuthenticationResponseWithPrivateChannel()
+    public function testValidAuthenticationResponseWithPrivateChannel(): void
     {
         $request = $this->getMockRequestWithUserForChannel('private-test');
 
@@ -120,7 +120,7 @@ class RedisBroadcasterTest extends TestCase
         );
     }
 
-    public function testValidAuthenticationResponseWithPresenceChannel()
+    public function testValidAuthenticationResponseWithPresenceChannel(): void
     {
         $request = $this->getMockRequestWithUserForChannel('presence-test');
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UsePusherChannelsNamesTest extends TestCase
 {
     #[DataProvider('channelsProvider')]
-    public function testChannelNameNormalization($requestChannelName, $normalizedName, $guarded)
+    public function testChannelNameNormalization($requestChannelName, $normalizedName, $guarded): void
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 
@@ -20,7 +20,7 @@ class UsePusherChannelsNamesTest extends TestCase
         );
     }
 
-    public function testChannelNameNormalizationSpecialCase()
+    public function testChannelNameNormalizationSpecialCase(): void
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 
@@ -30,7 +30,7 @@ class UsePusherChannelsNamesTest extends TestCase
         );
     }
 
-    public function testChannelNamePatternMatching()
+    public function testChannelNamePatternMatching(): void
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 
@@ -44,7 +44,7 @@ class UsePusherChannelsNamesTest extends TestCase
     }
 
     #[DataProvider('channelsProvider')]
-    public function testIsGuardedChannel($requestChannelName, $normalizedName, $guarded)
+    public function testIsGuardedChannel($requestChannelName, $normalizedName, $guarded): void
     {
         $broadcaster = new FakeBroadcasterUsingPusherChannelsNames;
 
@@ -117,7 +117,7 @@ class FakeBroadcasterUsingPusherChannelsNames extends Broadcaster
         //
     }
 
-    public function testChannelNameMatchesPattern($channel, $pattern)
+    public function testChannelNameMatchesPattern($channel, $pattern): void
     {
         return $this->channelNameMatchesPattern($channel, $pattern);
     }

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -117,7 +117,7 @@ class FakeBroadcasterUsingPusherChannelsNames extends Broadcaster
         //
     }
 
-    public function testChannelNameMatchesPattern($channel, $pattern): void
+    public function testChannelNameMatchesPattern($channel, $pattern)
     {
         return $this->channelNameMatchesPattern($channel, $pattern);
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -122,7 +122,7 @@ class BusBatchTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_jobs_can_be_added_to_the_batch()
+    public function test_jobs_can_be_added_to_the_batch(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -161,7 +161,7 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
-    public function test_jobs_can_be_added_to_pending_batch()
+    public function test_jobs_can_be_added_to_pending_batch(): void
     {
         $batch = new PendingBatch(new Container, collect());
         $this->assertCount(0, $batch->jobs);
@@ -183,7 +183,7 @@ class BusBatchTest extends TestCase
         $this->assertCount(2, $batch->jobs);
     }
 
-    public function test_jobs_can_be_added_to_the_pending_batch_from_iterable()
+    public function test_jobs_can_be_added_to_the_pending_batch_from_iterable(): void
     {
         $batch = new PendingBatch(new Container, collect());
         $this->assertCount(0, $batch->jobs);
@@ -202,7 +202,7 @@ class BusBatchTest extends TestCase
         $this->assertCount($count, $batch->jobs);
     }
 
-    public function test_processed_jobs_can_be_calculated()
+    public function test_processed_jobs_can_be_calculated(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -215,7 +215,7 @@ class BusBatchTest extends TestCase
         $this->assertEquals(60, $batch->progress());
     }
 
-    public function test_successful_jobs_can_be_recorded()
+    public function test_successful_jobs_can_be_recorded(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -255,7 +255,7 @@ class BusBatchTest extends TestCase
         $this->assertEquals(1, $_SERVER['__then.count']);
     }
 
-    public function test_batch_finished_event_is_dispatched()
+    public function test_batch_finished_event_is_dispatched(): void
     {
         Container::getInstance()->instance(EventDispatcher::class, $events = m::mock(EventDispatcher::class));
 
@@ -282,7 +282,7 @@ class BusBatchTest extends TestCase
         $batch->recordSuccessfulJob('test-id');
     }
 
-    public function test_failed_jobs_can_be_recorded_while_not_allowing_failures()
+    public function test_failed_jobs_can_be_recorded_while_not_allowing_failures(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -324,7 +324,7 @@ class BusBatchTest extends TestCase
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
-    public function test_failed_jobs_can_be_recorded_while_allowing_failures()
+    public function test_failed_jobs_can_be_recorded_while_allowing_failures(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -365,7 +365,7 @@ class BusBatchTest extends TestCase
         $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
-    public function test_pending_batch_filters_out_falsy_jobs()
+    public function test_pending_batch_filters_out_falsy_jobs(): void
     {
         $job = new class
         {
@@ -443,7 +443,7 @@ class BusBatchTest extends TestCase
         $this->assertEquals(2, $_SERVER['__failure3.param_count']);
     }
 
-    public function test_batch_can_be_cancelled()
+    public function test_batch_can_be_cancelled(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -456,7 +456,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->cancelled());
     }
 
-    public function test_batch_can_be_deleted()
+    public function test_batch_can_be_deleted(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -469,7 +469,7 @@ class BusBatchTest extends TestCase
         $this->assertNull($batch);
     }
 
-    public function test_batch_state_can_be_inspected()
+    public function test_batch_state_can_be_inspected(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -509,7 +509,7 @@ class BusBatchTest extends TestCase
         $this->assertIsString(json_encode($batch));
     }
 
-    public function test_chain_can_be_added_to_batch()
+    public function test_chain_can_be_added_to_batch(): void
     {
         $queue = m::mock(Factory::class);
 
@@ -545,7 +545,7 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
-    public function test_chained_closure_after_multiple_batches_is_properly_dispatched()
+    public function test_chained_closure_after_multiple_batches_is_properly_dispatched(): void
     {
         Queue::fake();
 
@@ -568,7 +568,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function test_options_serialization_on_postgres()
+    public function test_options_serialization_on_postgres(): void
     {
         $pendingBatch = (new PendingBatch(new Container, collect()))
             ->onQueue('test-queue');
@@ -595,7 +595,7 @@ class BusBatchTest extends TestCase
     }
 
     #[DataProvider('serializedOptions')]
-    public function test_options_unserialize_on_postgres($serialize, $options)
+    public function test_options_unserialize_on_postgres($serialize, $options): void
     {
         $factory = m::mock(BatchFactory::class);
 

--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class BusBatchableTest extends TestCase
 {
-    public function test_batch_may_be_retrieved()
+    public function test_batch_may_be_retrieved(): void
     {
         $class = new class
         {
@@ -32,7 +32,7 @@ class BusBatchableTest extends TestCase
         Container::setInstance(null);
     }
 
-    public function test_with_fake_batch_sets_and_returns_fake()
+    public function test_with_fake_batch_sets_and_returns_fake(): void
     {
         $job = new class
         {
@@ -49,7 +49,7 @@ class BusBatchableTest extends TestCase
         $this->assertSame(3, $job->batch()->totalJobs);
     }
 
-    public function test_batching_reflects_cancelled_state()
+    public function test_batching_reflects_cancelled_state(): void
     {
         $job = new class
         {

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 class BusDispatcherTest extends TestCase
 {
-    public function testCommandsThatShouldQueueIsQueued()
+    public function testCommandsThatShouldQueueIsQueued(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -28,7 +28,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(m::mock(ShouldQueue::class));
     }
 
-    public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
+    public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -41,7 +41,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherTestCustomQueueCommand);
     }
 
-    public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
+    public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay(): void
     {
         $container = new Container;
         $dispatcher = new Dispatcher($container, function () {
@@ -54,7 +54,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherTestSpecificQueueAndDelayCommand);
     }
 
-    public function testDispatchNowShouldNeverQueue()
+    public function testDispatchNowShouldNeverQueue(): void
     {
         $container = new Container;
         $mock = m::mock(Queue::class);
@@ -66,7 +66,7 @@ class BusDispatcherTest extends TestCase
         $dispatcher->dispatch(new BusDispatcherBasicCommand);
     }
 
-    public function testDispatcherCanDispatchStandAloneHandler()
+    public function testDispatcherCanDispatchStandAloneHandler(): void
     {
         $container = new Container;
         $mock = m::mock(Queue::class);
@@ -81,7 +81,7 @@ class BusDispatcherTest extends TestCase
         $this->assertInstanceOf(StandAloneCommand::class, $response);
     }
 
-    public function testOnConnectionOnJobWhenDispatching()
+    public function testOnConnectionOnJobWhenDispatching(): void
     {
         $container = new Container;
         $container->singleton('config', function () {

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -16,7 +16,7 @@ use stdClass;
 
 class BusPendingBatchTest extends TestCase
 {
-    public function test_pending_batch_may_be_configured_and_dispatched()
+    public function test_pending_batch_may_be_configured_and_dispatched(): void
     {
         $container = new Container;
 
@@ -60,7 +60,7 @@ class BusPendingBatchTest extends TestCase
         $pendingBatch->dispatch();
     }
 
-    public function test_batch_is_deleted_from_storage_if_exception_thrown_during_batching()
+    public function test_batch_is_deleted_from_storage_if_exception_thrown_during_batching(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -88,7 +88,7 @@ class BusPendingBatchTest extends TestCase
         $pendingBatch->dispatch();
     }
 
-    public function test_batch_is_dispatched_when_dispatchif_is_true()
+    public function test_batch_is_dispatched_when_dispatchif_is_true(): void
     {
         $container = new Container;
 
@@ -114,7 +114,7 @@ class BusPendingBatchTest extends TestCase
         $this->assertInstanceOf(Batch::class, $result);
     }
 
-    public function test_batch_is_not_dispatched_when_dispatchif_is_false()
+    public function test_batch_is_not_dispatched_when_dispatchif_is_false(): void
     {
         $container = new Container;
 
@@ -137,7 +137,7 @@ class BusPendingBatchTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function test_batch_is_dispatched_when_dispatchunless_is_false()
+    public function test_batch_is_dispatched_when_dispatchunless_is_false(): void
     {
         $container = new Container;
 
@@ -163,7 +163,7 @@ class BusPendingBatchTest extends TestCase
         $this->assertInstanceOf(Batch::class, $result);
     }
 
-    public function test_batch_is_not_dispatched_when_dispatchunless_is_true()
+    public function test_batch_is_not_dispatched_when_dispatchunless_is_true(): void
     {
         $container = new Container;
 
@@ -186,7 +186,7 @@ class BusPendingBatchTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function test_batch_before_event_is_called()
+    public function test_batch_before_event_is_called(): void
     {
         $container = new Container;
 

--- a/tests/Bus/BusPendingDispatchTest.php
+++ b/tests/Bus/BusPendingDispatchTest.php
@@ -33,62 +33,62 @@ class BusPendingDispatchTest extends TestCase
         parent::setUp();
     }
 
-    public function testOnConnection()
+    public function testOnConnection(): void
     {
         $this->job->shouldReceive('onConnection')->once()->with('test-connection');
         $this->pendingDispatch->onConnection('test-connection');
     }
 
-    public function testOnQueue()
+    public function testOnQueue(): void
     {
         $this->job->shouldReceive('onQueue')->once()->with('test-queue');
         $this->pendingDispatch->onQueue('test-queue');
     }
 
-    public function testAllOnConnection()
+    public function testAllOnConnection(): void
     {
         $this->job->shouldReceive('allOnConnection')->once()->with('test-connection');
         $this->pendingDispatch->allOnConnection('test-connection');
     }
 
-    public function testAllOnQueue()
+    public function testAllOnQueue(): void
     {
         $this->job->shouldReceive('allOnQueue')->once()->with('test-queue');
         $this->pendingDispatch->allOnQueue('test-queue');
     }
 
-    public function testDelay()
+    public function testDelay(): void
     {
         $this->job->shouldReceive('delay')->once()->with(60);
         $this->pendingDispatch->delay(60);
     }
 
-    public function testWithoutDelay()
+    public function testWithoutDelay(): void
     {
         $this->job->shouldReceive('withoutDelay')->once();
         $this->pendingDispatch->withoutDelay();
     }
 
-    public function testAfterCommit()
+    public function testAfterCommit(): void
     {
         $this->job->shouldReceive('afterCommit')->once();
         $this->pendingDispatch->afterCommit();
     }
 
-    public function testBeforeCommit()
+    public function testBeforeCommit(): void
     {
         $this->job->shouldReceive('beforeCommit')->once();
         $this->pendingDispatch->beforeCommit();
     }
 
-    public function testChain()
+    public function testChain(): void
     {
         $chain = [new stdClass];
         $this->job->shouldReceive('chain')->once()->with($chain);
         $this->pendingDispatch->chain($chain);
     }
 
-    public function testAfterResponse()
+    public function testAfterResponse(): void
     {
         $this->pendingDispatch->afterResponse();
         $this->assertTrue(
@@ -96,12 +96,12 @@ class BusPendingDispatchTest extends TestCase
         );
     }
 
-    public function testGetJob()
+    public function testGetJob(): void
     {
         $this->assertSame($this->job, $this->pendingDispatch->getJob());
     }
 
-    public function testDynamicallyProxyMethods()
+    public function testDynamicallyProxyMethods(): void
     {
         $newJob = m::mock(stdClass::class);
         $this->job->shouldReceive('appendToChain')->once()->with($newJob);

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheApcStoreTest extends TestCase
 {
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->willReturn(null);
@@ -17,7 +17,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertNull($store->get('bar'));
     }
 
-    public function testAPCValueIsReturned()
+    public function testAPCValueIsReturned(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->willReturn('bar');
@@ -25,7 +25,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testAPCFalseValueIsReturned()
+    public function testAPCFalseValueIsReturned(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->willReturn(false);
@@ -33,7 +33,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertFalse($store->get('foo'));
     }
 
-    public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
+    public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
@@ -49,7 +49,7 @@ class CacheApcStoreTest extends TestCase
         ], $store->many(['foo', 'bar', 'baz']));
     }
 
-    public function testSetMethodProperlyCallsAPC()
+    public function testSetMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
@@ -60,7 +60,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testSetMultipleMethodProperlyCallsAPC()
+    public function testSetMultipleMethodProperlyCallsAPC(): void
     {
         $apc = m::mock(ApcWrapper::class);
 
@@ -88,7 +88,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testIncrementMethodProperlyCallsAPC()
+    public function testIncrementMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
@@ -96,7 +96,7 @@ class CacheApcStoreTest extends TestCase
         $store->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsAPC()
+    public function testDecrementMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
@@ -104,7 +104,7 @@ class CacheApcStoreTest extends TestCase
         $store->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsAPC()
+    public function testStoreItemForeverProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
@@ -115,7 +115,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForgetMethodProperlyCallsAPC()
+    public function testForgetMethodProperlyCallsAPC(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'))->willReturn(true);
@@ -124,7 +124,7 @@ class CacheApcStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -16,7 +16,7 @@ class CacheArrayStoreTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItemsCanBeSetAndRetrieved()
+    public function testItemsCanBeSetAndRetrieved(): void
     {
         $store = new ArrayStore;
         $result = $store->put('foo', 'bar', 10);
@@ -38,7 +38,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($store->get('hello'));
     }
 
-    public function testMultipleItemsCanBeSetAndRetrieved()
+    public function testMultipleItemsCanBeSetAndRetrieved(): void
     {
         $store = new ArrayStore;
         $result = $store->put('foo', 'bar', 10);
@@ -56,7 +56,7 @@ class CacheArrayStoreTest extends TestCase
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
     }
 
-    public function testItemsCanExpire()
+    public function testItemsCanExpire(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -69,7 +69,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testStoreItemForeverProperlyStoresInArray()
+    public function testStoreItemForeverProperlyStoresInArray(): void
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();
         $mock->expects($this->once())
@@ -79,7 +79,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testValuesCanBeIncremented()
+    public function testValuesCanBeIncremented(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
@@ -92,7 +92,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(4, $store->get('foo'));
     }
 
-    public function testValuesGetCastedByIncrementOrDecrement()
+    public function testValuesGetCastedByIncrementOrDecrement(): void
     {
         $store = new ArrayStore;
         $store->put('foo', '1', 10);
@@ -106,7 +106,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(0, $store->get('bar'));
     }
 
-    public function testIncrementNonNumericValues()
+    public function testIncrementNonNumericValues(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'I am string', 10);
@@ -115,7 +115,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(1, $store->get('foo'));
     }
 
-    public function testNonExistingKeysCanBeIncremented()
+    public function testNonExistingKeysCanBeIncremented(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -129,7 +129,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(1, $store->get('foo'));
     }
 
-    public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
+    public function testExpiredKeysAreIncrementedLikeNonExistingKeys(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -142,7 +142,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testValuesCanBeDecremented()
+    public function testValuesCanBeDecremented(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 1, 10);
@@ -155,7 +155,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertEquals(-2, $store->get('foo'));
     }
 
-    public function testItemsCanBeRemoved()
+    public function testItemsCanBeRemoved(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
@@ -164,7 +164,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($store->forget('foo'));
     }
 
-    public function testItemsCanBeFlushed()
+    public function testItemsCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
@@ -175,13 +175,13 @@ class CacheArrayStoreTest extends TestCase
         $this->assertNull($store->get('baz'));
     }
 
-    public function testCacheKey()
+    public function testCacheKey(): void
     {
         $store = new ArrayStore;
         $this->assertEmpty($store->getPrefix());
     }
 
-    public function testCannotAcquireLockTwice()
+    public function testCannotAcquireLockTwice(): void
     {
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
@@ -190,7 +190,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($lock->acquire());
     }
 
-    public function testCanAcquireLockAgainAfterExpiry()
+    public function testCanAcquireLockAgainAfterExpiry(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -202,7 +202,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($lock->acquire());
     }
 
-    public function testLockExpirationLowerBoundary()
+    public function testLockExpirationLowerBoundary(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -214,7 +214,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($lock->acquire());
     }
 
-    public function testLockWithNoExpirationNeverExpires()
+    public function testLockWithNoExpirationNeverExpires(): void
     {
         $store = new ArrayStore;
         $lock = $store->lock('foo');
@@ -224,7 +224,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($lock->acquire());
     }
 
-    public function testCanAcquireLockAfterRelease()
+    public function testCanAcquireLockAfterRelease(): void
     {
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
@@ -234,7 +234,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($lock->acquire());
     }
 
-    public function testAnotherOwnerCannotReleaseLock()
+    public function testAnotherOwnerCannotReleaseLock(): void
     {
         $store = new ArrayStore;
         $owner = $store->lock('foo', 10);
@@ -244,7 +244,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($wannabeOwner->release());
     }
 
-    public function testAnotherOwnerCanForceReleaseALock()
+    public function testAnotherOwnerCanForceReleaseALock(): void
     {
         $store = new ArrayStore;
         $owner = $store->lock('foo', 10);
@@ -255,7 +255,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($wannabeOwner->acquire());
     }
 
-    public function testValuesAreNotStoredByReference()
+    public function testValuesAreNotStoredByReference(): void
     {
         $store = new ArrayStore($serialize = true);
         $object = new stdClass;
@@ -270,7 +270,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse(property_exists($retrievedObject, 'bar'));
     }
 
-    public function testValuesAreStoredByReferenceIfSerializationIsDisabled()
+    public function testValuesAreStoredByReferenceIfSerializationIsDisabled(): void
     {
         $store = new ArrayStore;
         $object = new stdClass;
@@ -285,7 +285,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($retrievedObject->bar);
     }
 
-    public function testReleasingLockAfterAlreadyForceReleasedByAnotherOwnerFails()
+    public function testReleasingLockAfterAlreadyForceReleasedByAnotherOwnerFails(): void
     {
         $store = new ArrayStore;
         $owner = $store->lock('foo', 10);
@@ -296,7 +296,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($wannabeOwner->release());
     }
 
-    public function testOwnerStatusCanBeCheckedAfterRestoringLock()
+    public function testOwnerStatusCanBeCheckedAfterRestoringLock(): void
     {
         $store = new ArrayStore;
         $firstLock = $store->lock('foo', 10);
@@ -308,7 +308,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertTrue($secondLock->isOwnedByCurrentProcess());
     }
 
-    public function testOtherOwnerDoesNotOwnLockAfterRestore()
+    public function testOtherOwnerDoesNotOwnLockAfterRestore(): void
     {
         $store = new ArrayStore;
         $firstLock = $store->lock('foo', 10);
@@ -320,7 +320,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($secondLock->isOwnedByCurrentProcess());
     }
 
-    public function testRestoringNonExistingLockDoesNotOwnAnything()
+    public function testRestoringNonExistingLockDoesNotOwnAnything(): void
     {
         $store = new ArrayStore;
         $firstLock = $store->restoreLock('foo', 'owner');
@@ -328,7 +328,7 @@ class CacheArrayStoreTest extends TestCase
         $this->assertFalse($firstLock->isOwnedByCurrentProcess());
     }
 
-    public function testCanGetAll()
+    public function testCanGetAll(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -340,7 +340,7 @@ class CacheArrayStoreTest extends TestCase
         ], $store->all());
     }
 
-    public function testCanGetAllWhenSerialized()
+    public function testCanGetAllWhenSerialized(): void
     {
         Carbon::setTestNow(Carbon::now());
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -13,7 +13,7 @@ use stdClass;
 
 class CacheDatabaseStoreTest extends TestCase
 {
-    public function testNullIsReturnedWhenItemNotFound()
+    public function testNullIsReturnedWhenItemNotFound(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
@@ -24,7 +24,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
-    public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
+    public function testNullIsReturnedAndItemDeletedWhenItemIsExpired(): void
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forgetIfExpired'])->setConstructorArgs($this->getMocks())->getMock();
 
@@ -42,7 +42,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
-    public function testDecryptedValueIsReturnedWhenItemIsValid()
+    public function testDecryptedValueIsReturnedWhenItemIsValid(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
@@ -53,7 +53,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testValueIsReturnedOnPostgres()
+    public function testValueIsReturnedOnPostgres(): void
     {
         $store = $this->getPostgresStore();
         $table = m::mock(stdClass::class);
@@ -64,7 +64,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testValueIsReturnedOnSqlite()
+    public function testValueIsReturnedOnSqlite(): void
     {
         $store = $this->getSqliteStore();
         $table = m::mock(stdClass::class);
@@ -75,7 +75,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertSame("\0bar\0", $store->get('foo'));
     }
 
-    public function testValueIsUpserted()
+    public function testValueIsUpserted(): void
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
@@ -87,7 +87,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testValueIsUpsertedOnPostgres()
+    public function testValueIsUpsertedOnPostgres(): void
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
         $table = m::mock(stdClass::class);
@@ -99,7 +99,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testValueIsUpsertedOnSqlite()
+    public function testValueIsUpsertedOnSqlite(): void
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getSqliteMocks())->getMock();
         $table = m::mock(stdClass::class);
@@ -111,7 +111,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForeverCallsStoreItemWithReallyLongTime()
+    public function testForeverCallsStoreItemWithReallyLongTime(): void
     {
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(315360000))->willReturn(true);
@@ -119,7 +119,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testItemsMayBeRemovedFromCache()
+    public function testItemsMayBeRemovedFromCache(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
@@ -130,7 +130,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store->forget('foo');
     }
 
-    public function testItemsMayBeFlushedFromCache()
+    public function testItemsMayBeFlushedFromCache(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
@@ -141,7 +141,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testIncrementReturnsCorrectValues()
+    public function testIncrementReturnsCorrectValues(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
@@ -180,7 +180,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertEquals(3, $store->increment('foo'));
     }
 
-    public function testDecrementReturnsCorrectValues()
+    public function testDecrementReturnsCorrectValues(): void
     {
         $store = $this->getStore();
         $table = m::mock(stdClass::class);

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheEventsTest extends TestCase
 {
-    public function testHasTriggersEvents()
+    public function testHasTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -46,7 +46,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->tags('taylor')->has('baz'));
     }
 
-    public function testGetTriggersEvents()
+    public function testGetTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -73,7 +73,7 @@ class CacheEventsTest extends TestCase
         $this->assertSame('qux', $repository->tags('taylor')->get('baz'));
     }
 
-    public function testPullTriggersEvents()
+    public function testPullTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -85,7 +85,7 @@ class CacheEventsTest extends TestCase
         $this->assertSame('qux', $repository->pull('baz'));
     }
 
-    public function testPullTriggersEventsUsingTags()
+    public function testPullTriggersEventsUsingTags(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -97,7 +97,7 @@ class CacheEventsTest extends TestCase
         $this->assertSame('qux', $repository->tags('taylor')->pull('baz'));
     }
 
-    public function testPutTriggersEvents()
+    public function testPutTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -116,7 +116,7 @@ class CacheEventsTest extends TestCase
         $repository->tags('taylor')->put('foo', 'bar', 99);
     }
 
-    public function testAddTriggersEvents()
+    public function testAddTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -134,7 +134,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->tags('taylor')->add('foo', 'bar', 99));
     }
 
-    public function testForeverTriggersEvents()
+    public function testForeverTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -148,7 +148,7 @@ class CacheEventsTest extends TestCase
         $repository->tags('taylor')->forever('foo', 'bar');
     }
 
-    public function testRememberTriggersEvents()
+    public function testRememberTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -170,7 +170,7 @@ class CacheEventsTest extends TestCase
         }));
     }
 
-    public function testRememberForeverTriggersEvents()
+    public function testRememberForeverTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -192,7 +192,7 @@ class CacheEventsTest extends TestCase
         }));
     }
 
-    public function testForgetTriggersEvents()
+    public function testForgetTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -206,7 +206,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->tags('taylor')->forget('baz'));
     }
 
-    public function testForgetDoesTriggerFailedEventOnFailure()
+    public function testForgetDoesTriggerFailedEventOnFailure(): void
     {
         $dispatcher = $this->getDispatcher();
         $store = m::mock(Store::class);
@@ -219,7 +219,7 @@ class CacheEventsTest extends TestCase
         $this->assertFalse($repository->forget('baz'));
     }
 
-    public function testFlushTriggersEvents()
+    public function testFlushTriggersEvents(): void
     {
         $dispatcher = $this->getDispatcher();
         $repository = $this->getRepository($dispatcher);
@@ -238,7 +238,7 @@ class CacheEventsTest extends TestCase
         $this->assertTrue($repository->clear());
     }
 
-    public function testFlushFailureDoesDispatchEvent()
+    public function testFlushFailureDoesDispatchEvent(): void
     {
         $dispatcher = $this->getDispatcher();
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -20,7 +20,7 @@ class CacheFileStoreTest extends TestCase
         parent::tearDown();
     }
 
-    public function testNullIsReturnedIfFileDoesntExist()
+    public function testNullIsReturnedIfFileDoesntExist(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('get')->will($this->throwException(new FileNotFoundException));
@@ -29,7 +29,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertNull($value);
     }
 
-    public function testPutCreatesMissingDirectories()
+    public function testPutCreatesMissingDirectories(): void
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foo');
@@ -42,7 +42,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testPutWillConsiderZeroAsEternalTime()
+    public function testPutWillConsiderZeroAsEternalTime(): void
     {
         $files = $this->mockFilesystem();
 
@@ -61,7 +61,7 @@ class CacheFileStoreTest extends TestCase
         (new FileStore($files, __DIR__))->put('O--L / key', 'gold', 0);
     }
 
-    public function testPutWillConsiderBigValuesAsEternalTime()
+    public function testPutWillConsiderBigValuesAsEternalTime(): void
     {
         $files = $this->mockFilesystem();
 
@@ -78,7 +78,7 @@ class CacheFileStoreTest extends TestCase
         (new FileStore($files, __DIR__))->put('O--L / key', 'gold', (int) $ten9s + 1);
     }
 
-    public function testExpiredItemsReturnNullAndGetDeleted()
+    public function testExpiredItemsReturnNullAndGetDeleted(): void
     {
         $files = $this->mockFilesystem();
         $contents = '0000000000';
@@ -89,7 +89,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertNull($value);
     }
 
-    public function testValidItemReturnsContents()
+    public function testValidItemReturnsContents(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -98,7 +98,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertSame('Hello World', $store->get('foo'));
     }
 
-    public function testStoreItemProperlyStoresValues()
+    public function testStoreItemProperlyStoresValues(): void
     {
         $files = $this->mockFilesystem();
         $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
@@ -111,7 +111,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testStoreItemProperlySetsPermissions()
+    public function testStoreItemProperlySetsPermissions(): void
     {
         $files = m::mock(Filesystem::class);
         $files->shouldIgnoreMissing();
@@ -131,7 +131,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testStoreItemDirectoryProperlySetsPermissions()
+    public function testStoreItemDirectoryProperlySetsPermissions(): void
     {
         $files = m::mock(Filesystem::class);
         $files->shouldIgnoreMissing();
@@ -155,7 +155,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForeversAreStoredWithHighTimestamp()
+    public function testForeversAreStoredWithHighTimestamp(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -167,7 +167,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForeversAreNotRemovedOnIncrement()
+    public function testForeversAreNotRemovedOnIncrement(): void
     {
         $files = $this->mockFilesystem();
         $contents = '9999999999'.serialize('Hello World');
@@ -178,7 +178,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertSame('Hello World', $store->get('foo'));
     }
 
-    public function testIncrementExpiredKeys()
+    public function testIncrementExpiredKeys(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -195,7 +195,7 @@ class CacheFileStoreTest extends TestCase
         $result = $store->increment('foo', 3);
     }
 
-    public function testIncrementCanAtomicallyJump()
+    public function testIncrementCanAtomicallyJump(): void
     {
         $filePath = $this->getCachePath('foo');
         $files = $this->mockFilesystem();
@@ -210,7 +210,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals(4, $result);
     }
 
-    public function testDecrementCanAtomicallyJump()
+    public function testDecrementCanAtomicallyJump(): void
     {
         $filePath = $this->getCachePath('foo');
 
@@ -226,7 +226,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals(0, $result);
     }
 
-    public function testIncrementNonNumericValues()
+    public function testIncrementNonNumericValues(): void
     {
         $filePath = $this->getCachePath('foo');
 
@@ -241,7 +241,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testIncrementNonExistentKeys()
+    public function testIncrementNonExistentKeys(): void
     {
         $filePath = $this->getCachePath('foo');
 
@@ -256,7 +256,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testIncrementDoesNotExtendCacheLife()
+    public function testIncrementDoesNotExtendCacheLife(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -272,7 +272,7 @@ class CacheFileStoreTest extends TestCase
         $store->increment('foo');
     }
 
-    public function testRemoveDeletesFileDoesntExist()
+    public function testRemoveDeletesFileDoesntExist(): void
     {
         $files = $this->mockFilesystem();
         $hash = sha1('foobull');
@@ -282,7 +282,7 @@ class CacheFileStoreTest extends TestCase
         $store->forget('foobull');
     }
 
-    public function testRemoveDeletesFile()
+    public function testRemoveDeletesFile(): void
     {
         $files = new Filesystem;
         $store = new FileStore($files, __DIR__);
@@ -295,7 +295,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertFileDoesNotExist($store->path('foobar'));
     }
 
-    public function testFlushCleansDirectory()
+    public function testFlushCleansDirectory(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->willReturn(true);
@@ -307,7 +307,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result, 'Flush failed');
     }
 
-    public function testFlushFailsDirectoryClean()
+    public function testFlushFailsDirectoryClean(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->willReturn(true);
@@ -319,7 +319,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertFalse($result, 'Flush should not have cleared directories');
     }
 
-    public function testFlushIgnoreNonExistingDirectory()
+    public function testFlushIgnoreNonExistingDirectory(): void
     {
         $files = $this->mockFilesystem();
         $files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__.'--wrong'))->willReturn(false);
@@ -329,7 +329,7 @@ class CacheFileStoreTest extends TestCase
         $this->assertFalse($result, 'Flush should not clean directory');
     }
 
-    public function testItHandlesForgettingNonFlexibleKeys()
+    public function testItHandlesForgettingNonFlexibleKeys(): void
     {
         $store = new FileStore(new Filesystem, __DIR__);
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheManagerTest extends TestCase
 {
-    public function testCustomDriverClosureBoundObjectIsCacheManager()
+    public function testCustomDriverClosureBoundObjectIsCacheManager(): void
     {
         $cacheManager = new CacheManager([
             'config' => [
@@ -31,7 +31,7 @@ class CacheManagerTest extends TestCase
         $this->assertEquals($cacheManager, $cacheManager->store(__CLASS__));
     }
 
-    public function testCustomDriverOverridesInternalDrivers()
+    public function testCustomDriverOverridesInternalDrivers(): void
     {
         $userConfig = [
             'cache' => [
@@ -54,7 +54,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame('mm(u_u)mm', $driver->flag);
     }
 
-    public function testItCanBuildRepositories()
+    public function testItCanBuildRepositories(): void
     {
         $app = $this->getApp([]);
         $cacheManager = new CacheManager($app);
@@ -66,7 +66,7 @@ class CacheManagerTest extends TestCase
         $this->assertInstanceOf(NullStore::class, $nullCache->getStore());
     }
 
-    public function testItMakesRepositoryWhenContainerHasNoDispatcher()
+    public function testItMakesRepositoryWhenContainerHasNoDispatcher(): void
     {
         $userConfig = [
             'cache' => [
@@ -99,7 +99,7 @@ class CacheManagerTest extends TestCase
         $this->assertNotNull($repo->getEventDispatcher());
     }
 
-    public function testItRefreshesDispatcherOnAllStores()
+    public function testItRefreshesDispatcherOnAllStores(): void
     {
         $userConfig = [
             'cache' => [
@@ -132,7 +132,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame($dispatcher, $repo2->getEventDispatcher());
     }
 
-    public function testItSetsDefaultDriverChangesGlobalConfig()
+    public function testItSetsDefaultDriverChangesGlobalConfig(): void
     {
         $userConfig = [
             'cache' => [
@@ -156,7 +156,7 @@ class CacheManagerTest extends TestCase
         $this->assertEquals('><((((@>', $app->get('config')->get('cache.default'));
     }
 
-    public function testItPurgesMemoizedStoreObjects()
+    public function testItPurgesMemoizedStoreObjects(): void
     {
         $userConfig = [
             'cache' => [
@@ -197,7 +197,7 @@ class CacheManagerTest extends TestCase
         $this->assertSame($repo3, $repo7);
     }
 
-    public function testForgetDriver()
+    public function testForgetDriver(): void
     {
         $cacheManager = m::mock(CacheManager::class)
             ->shouldAllowMockingProtectedMethods()
@@ -221,7 +221,7 @@ class CacheManagerTest extends TestCase
         }
     }
 
-    public function testForgetDriverForgets()
+    public function testForgetDriverForgets(): void
     {
         $cacheManager = new CacheManager([
             'config' => [
@@ -240,7 +240,7 @@ class CacheManagerTest extends TestCase
         $this->assertNull($cacheManager->store('forget')->get('foo'));
     }
 
-    public function testThrowExceptionWhenUnknownDriverIsUsed()
+    public function testThrowExceptionWhenUnknownDriverIsUsed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Driver [unknown_taxi_driver] is not supported.');
@@ -262,7 +262,7 @@ class CacheManagerTest extends TestCase
         $cacheManager->store('my_store');
     }
 
-    public function testThrowExceptionWhenUnknownStoreIsUsed()
+    public function testThrowExceptionWhenUnknownStoreIsUsed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache store [alien_store] is not defined.');
@@ -284,7 +284,7 @@ class CacheManagerTest extends TestCase
         $cacheManager->store('alien_store');
     }
 
-    public function testMakesRepositoryWithoutDispatcherWhenEventsDisabled()
+    public function testMakesRepositoryWithoutDispatcherWhenEventsDisabled(): void
     {
         $userConfig = [
             'cache' => [

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -11,7 +11,7 @@ use stdClass;
 
 class CacheMemcachedConnectorTest extends TestCase
 {
-    public function testServersAreAddedCorrectly()
+    public function testServersAreAddedCorrectly(): void
     {
         $memcached = $this->memcachedMockWithAddServer();
 
@@ -25,7 +25,7 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
-    public function testServersAreAddedCorrectlyWithPersistentConnection()
+    public function testServersAreAddedCorrectlyWithPersistentConnection(): void
     {
         $persistentConnectionId = 'persistent_connection_id';
 
@@ -43,7 +43,7 @@ class CacheMemcachedConnectorTest extends TestCase
     }
 
     #[RequiresPhpExtension('memcached')]
-    public function testServersAreAddedCorrectlyWithValidOptions()
+    public function testServersAreAddedCorrectlyWithValidOptions(): void
     {
         $validOptions = [
             Memcached::OPT_NO_BLOCK => true,
@@ -64,7 +64,7 @@ class CacheMemcachedConnectorTest extends TestCase
     }
 
     #[RequiresPhpExtension('memcached')]
-    public function testServersAreAddedCorrectlyWithSaslCredentials()
+    public function testServersAreAddedCorrectlyWithSaslCredentials(): void
     {
         $saslCredentials = ['foo', 'bar'];
 

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 #[RequiresPhpExtension('memcached')]
 class CacheMemcachedStoreTest extends TestCase
 {
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->willReturn(null);
@@ -21,7 +21,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertNull($store->get('bar'));
     }
 
-    public function testMemcacheValueIsReturned()
+    public function testMemcacheValueIsReturned(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->willReturn('bar');
@@ -30,7 +30,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys()
+    public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
@@ -49,7 +49,7 @@ class CacheMemcachedStoreTest extends TestCase
         ]));
     }
 
-    public function testSetMethodProperlyCallsMemcache()
+    public function testSetMethodProperlyCallsMemcache(): void
     {
         Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
@@ -60,7 +60,7 @@ class CacheMemcachedStoreTest extends TestCase
         Carbon::setTestNow(null);
     }
 
-    public function testIncrementMethodProperlyCallsMemcache()
+    public function testIncrementMethodProperlyCallsMemcache(): void
     {
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('increment')->with('foo', 5)->once()->andReturn(5);
@@ -69,7 +69,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsMemcache()
+    public function testDecrementMethodProperlyCallsMemcache(): void
     {
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('decrement')->with('foo', 5)->once()->andReturn(0);
@@ -78,7 +78,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsMemcached()
+    public function testStoreItemForeverProperlyCallsMemcached(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))->willReturn(true);
@@ -87,7 +87,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForgetMethodProperlyCallsMemcache()
+    public function testForgetMethodProperlyCallsMemcache(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['delete'])->getMock();
         $memcache->expects($this->once())->method('delete')->with($this->equalTo('foo'));
@@ -95,7 +95,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store->forget('foo');
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['flush'])->getMock();
         $memcache->expects($this->once())->method('flush')->willReturn(true);
@@ -104,7 +104,7 @@ class CacheMemcachedStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testGetAndSetPrefix()
+    public function testGetAndSetPrefix(): void
     {
         $store = new MemcachedStore(new Memcached, 'bar');
         $this->assertSame('bar', $store->getPrefix());

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -7,14 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class CacheNullStoreTest extends TestCase
 {
-    public function testItemsCanNotBeCached()
+    public function testItemsCanNotBeCached(): void
     {
         $store = new NullStore;
         $store->put('foo', 'bar', 10);
         $this->assertNull($store->get('foo'));
     }
 
-    public function testGetMultipleReturnsMultipleNulls()
+    public function testGetMultipleReturnsMultipleNulls(): void
     {
         $store = new NullStore;
 
@@ -27,7 +27,7 @@ class CacheNullStoreTest extends TestCase
         ]));
     }
 
-    public function testIncrementAndDecrementReturnFalse()
+    public function testIncrementAndDecrementReturnFalse(): void
     {
         $store = new NullStore;
         $this->assertFalse($store->increment('foo'));

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheRateLimiterTest extends TestCase
 {
-    public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut()
+    public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(1);
@@ -22,7 +22,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($rateLimiter->tooManyAttempts('key', 1));
     }
 
-    public function testHitProperlyIncrementsAttemptCount()
+    public function testHitProperlyIncrementsAttemptCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -34,7 +34,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->hit('key', 1);
     }
 
-    public function testIncrementProperlyIncrementsAttemptCount()
+    public function testIncrementProperlyIncrementsAttemptCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -46,7 +46,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->increment('key', 1, 5);
     }
 
-    public function testDecrementProperlyDecrementsAttemptCount()
+    public function testDecrementProperlyDecrementsAttemptCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -58,7 +58,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->decrement('key', 1, 5);
     }
 
-    public function testHitHasNoMemoryLeak()
+    public function testHitHasNoMemoryLeak(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1)->andReturn(true);
@@ -83,7 +83,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertSame(0, $rateLimiter->retriesLeft('key', 3));
     }
 
-    public function testRetriesLeftReturnsCorrectCount()
+    public function testRetriesLeftReturnsCorrectCount(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(3);
@@ -93,7 +93,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertEquals(2, $rateLimiter->retriesLeft('key', 5));
     }
 
-    public function testClearClearsTheCacheKeys()
+    public function testClearClearsTheCacheKeys(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('forget')->once()->with('key');
@@ -104,7 +104,7 @@ class CacheRateLimiterTest extends TestCase
         $rateLimiter->clear('key');
     }
 
-    public function testAvailableInReturnsPositiveValues()
+    public function testAvailableInReturnsPositiveValues(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->andReturn(now()->subSeconds(60)->getTimestamp(), null);
@@ -115,7 +115,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($rateLimiter->availableIn('key:timer') >= 0);
     }
 
-    public function testAttemptsCallbackReturnsTrue()
+    public function testAttemptsCallbackReturnsTrue(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(0);
@@ -134,7 +134,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($executed);
     }
 
-    public function testAttemptsCallbackReturnsCallbackReturn()
+    public function testAttemptsCallbackReturnsCallbackReturn(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->times(6)->with('key', 0)->andReturn(0);
@@ -170,7 +170,7 @@ class CacheRateLimiterTest extends TestCase
         }, 1));
     }
 
-    public function testAttemptsCallbackReturnsFalse()
+    public function testAttemptsCallbackReturnsFalse(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(2);
@@ -187,7 +187,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertFalse($executed);
     }
 
-    public function testKeysAreSanitizedFromUnicodeCharacters()
+    public function testKeysAreSanitizedFromUnicodeCharacters(): void
     {
         $cache = m::mock(Cache::class);
         $cache->shouldReceive('get')->once()->with('john', 0)->andReturn(1);
@@ -199,7 +199,7 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($rateLimiter->tooManyAttempts('jôhn', 1));
     }
 
-    public function testKeyIsSanitizedOnlyOnce()
+    public function testKeyIsSanitizedOnlyOnce(): void
     {
         $cache = m::mock(Cache::class);
         $rateLimiter = new RateLimiter($cache);

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheRedisStoreTest extends TestCase
 {
-    public function testGetReturnsNullWhenNotFound()
+    public function testGetReturnsNullWhenNotFound(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -17,7 +17,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertNull($redis->get('foo'));
     }
 
-    public function testRedisValueIsReturned()
+    public function testRedisValueIsReturned(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -25,7 +25,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertSame('foo', $redis->get('foo'));
     }
 
-    public function testRedisMultipleValuesAreReturned()
+    public function testRedisMultipleValuesAreReturned(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -45,7 +45,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertNull($results['null']);
     }
 
-    public function testRedisValueIsReturnedForNumerics()
+    public function testRedisValueIsReturnedForNumerics(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -53,7 +53,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertEquals(1, $redis->get('foo'));
     }
 
-    public function testSetMethodProperlyCallsRedis()
+    public function testSetMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -62,7 +62,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testSetMultipleMethodProperlyCallsRedis()
+    public function testSetMultipleMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         /** @var m\MockInterface $connection */
@@ -82,7 +82,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testSetMethodProperlyCallsRedisForNumerics()
+    public function testSetMethodProperlyCallsRedisForNumerics(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -91,7 +91,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testIncrementMethodProperlyCallsRedis()
+    public function testIncrementMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -99,7 +99,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->increment('foo', 5);
     }
 
-    public function testDecrementMethodProperlyCallsRedis()
+    public function testDecrementMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -107,7 +107,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->decrement('foo', 5);
     }
 
-    public function testStoreItemForeverProperlyCallsRedis()
+    public function testStoreItemForeverProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -116,7 +116,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testForgetMethodProperlyCallsRedis()
+    public function testForgetMethodProperlyCallsRedis(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -124,7 +124,7 @@ class CacheRedisStoreTest extends TestCase
         $redis->forget('foo');
     }
 
-    public function testFlushesCached()
+    public function testFlushesCached(): void
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
@@ -133,7 +133,7 @@ class CacheRedisStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testGetAndSetPrefix()
+    public function testGetAndSetPrefix(): void
     {
         $redis = $this->getRedis();
         $this->assertSame('prefix:', $redis->getPrefix());

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -42,35 +42,35 @@ class CacheRepositoryTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetReturnsValueFromCache()
+    public function testGetReturnsValueFromCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $this->assertSame('bar', $repo->get('foo'));
     }
 
-    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArray()
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArray(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with(['foo', 'bar'])->andReturn(['foo' => 'bar', 'bar' => 'baz']);
         $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $repo->get(['foo', 'bar']));
     }
 
-    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayWithDefaultValues()
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayWithDefaultValues(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with(['foo', 'bar'])->andReturn(['foo' => null, 'bar' => 'baz']);
         $this->assertEquals(['foo' => 'default', 'bar' => 'baz'], $repo->get(['foo' => 'default', 'bar']));
     }
 
-    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayOfOneTwoThree()
+    public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArrayOfOneTwoThree(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with([1, 2, 3])->andReturn([1 => null, 2 => null, 3 => null]);
         $this->assertEquals([1 => null, 2 => null, 3 => null], $repo->get([1, 2, 3]));
     }
 
-    public function testDefaultValueIsReturned()
+    public function testDefaultValueIsReturned(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
@@ -80,14 +80,14 @@ class CacheRepositoryTest extends TestCase
         }));
     }
 
-    public function testSettingDefaultCacheTime()
+    public function testSettingDefaultCacheTime(): void
     {
         $repo = $this->getRepository();
         $repo->setDefaultCacheTime(10);
         $this->assertEquals(10, $repo->getDefaultCacheTime());
     }
 
-    public function testHasMethod()
+    public function testHasMethod(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
@@ -99,7 +99,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->has('baz'));
     }
 
-    public function testMissingMethod()
+    public function testMissingMethod(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
@@ -109,7 +109,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->missing('bar'));
     }
 
-    public function testRememberMethodCallsPutAndReturnsDefault()
+    public function testRememberMethodCallsPutAndReturnsDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
@@ -144,7 +144,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testRememberForeverMethodCallsForeverAndReturnsDefault()
+    public function testRememberForeverMethodCallsForeverAndReturnsDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
@@ -155,14 +155,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testPuttingMultipleItemsInCache()
+    public function testPuttingMultipleItemsInCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
         $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1);
     }
 
-    public function testSettingMultipleItemsInCacheArray()
+    public function testSettingMultipleItemsInCacheArray(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1)->andReturn(true);
@@ -170,7 +170,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testSettingMultipleItemsInCacheIterator()
+    public function testSettingMultipleItemsInCacheIterator(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1)->andReturn(true);
@@ -178,14 +178,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testPutWithNullTTLRemembersItemForever()
+    public function testPutWithNullTTLRemembersItemForever(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'bar')->andReturn(true);
         $this->assertTrue($repo->put('foo', 'bar'));
     }
 
-    public function testPutWithDatetimeInPastOrZeroSecondsRemovesOldItem()
+    public function testPutWithDatetimeInPastOrZeroSecondsRemovesOldItem(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->never();
@@ -196,7 +196,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testPutManyWithNullTTLRemembersItemsForever()
+    public function testPutManyWithNullTTLRemembersItemsForever(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forever')->with('foo', 'bar')->andReturn(true);
@@ -204,7 +204,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->putMany(['foo' => 'bar', 'bar' => 'baz']));
     }
 
-    public function testAddWithStoreFailureReturnsFalse()
+    public function testAddWithStoreFailureReturnsFalse(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('add')->never();
@@ -213,7 +213,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->add('foo', 'bar', 60));
     }
 
-    public function testCacheAddCallsRedisStoreAdd()
+    public function testCacheAddCallsRedisStoreAdd(): void
     {
         $store = m::mock(RedisStore::class);
         $store->shouldReceive('add')->once()->with('k', 'v', 60)->andReturn(true);
@@ -221,7 +221,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repository->add('k', 'v', 60));
     }
 
-    public function testAddMethodCanAcceptDateIntervals()
+    public function testAddMethodCanAcceptDateIntervals(): void
     {
         $storeWithAdd = m::mock(RedisStore::class);
         $storeWithAdd->shouldReceive('add')->once()->with('k', 'v', 61)->andReturn(true);
@@ -236,7 +236,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repository->add('k', 'v', DateInterval::createFromDateString('60 seconds')));
     }
 
-    public function testAddMethodCanAcceptDateTimeInterface()
+    public function testAddMethodCanAcceptDateTimeInterface(): void
     {
         $withAddStore = m::mock(RedisStore::class);
         $withAddStore->shouldReceive('add')->once()->with('k', 'v', 61)->andReturn(true);
@@ -251,7 +251,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repository->add('k', 'v', Carbon::now()->addSeconds(62)));
     }
 
-    public function testAddWithNullTTLRemembersItemForever()
+    public function testAddWithNullTTLRemembersItemForever(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
@@ -259,7 +259,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->add('foo', 'bar'));
     }
 
-    public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately()
+    public function testAddWithDatetimeInPastOrZeroSecondsReturnsImmediately(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('add', 'get', 'put')->never();
@@ -286,14 +286,14 @@ class CacheRepositoryTest extends TestCase
      * @param  mixed  $duration
      */
     #[DataProvider('dataProviderTestGetSeconds')]
-    public function testGetSeconds($duration)
+    public function testGetSeconds($duration): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->once()->with($key = 'foo', $value = 'bar', 300);
         $repo->put($key, $value, $duration);
     }
 
-    public function testRegisterMacroWithNonStaticCall()
+    public function testRegisterMacroWithNonStaticCall(): void
     {
         $repo = $this->getRepository();
         $repo::macro(__CLASS__, function () {
@@ -302,14 +302,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('Taylor', $repo->{__CLASS__}());
     }
 
-    public function testForgettingCacheKey()
+    public function testForgettingCacheKey(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
         $repo->forget('a-key');
     }
 
-    public function testRemovingCacheKey()
+    public function testRemovingCacheKey(): void
     {
         // Alias of Forget
         $repo = $this->getRepository();
@@ -317,7 +317,7 @@ class CacheRepositoryTest extends TestCase
         $repo->delete('a-key');
     }
 
-    public function testSettingCache()
+    public function testSettingCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->with($key = 'foo', $value = 'bar', 1)->andReturn(true);
@@ -325,14 +325,14 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testClearingWholeCache()
+    public function testClearingWholeCache(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('flush')->andReturn(true);
         $repo->clear();
     }
 
-    public function testGettingMultipleValuesFromCache()
+    public function testGettingMultipleValuesFromCache(): void
     {
         $keys = ['key1', 'key2', 'key3'];
         $default = 5;
@@ -342,7 +342,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => 5], $repo->getMultiple($keys, $default));
     }
 
-    public function testRemovingMultipleKeys()
+    public function testRemovingMultipleKeys(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
@@ -351,7 +351,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repo->deleteMultiple(['a-key', 'a-second-key']));
     }
 
-    public function testRemovingMultipleKeysFailsIfOneFails()
+    public function testRemovingMultipleKeysFailsIfOneFails(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('forget')->once()->with('a-key')->andReturn(true);
@@ -360,7 +360,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($repo->deleteMultiple(['a-key', 'a-second-key']));
     }
 
-    public function testAllTagsArePassedToTaggableStore()
+    public function testAllTagsArePassedToTaggableStore(): void
     {
         $store = m::mock(ArrayStore::class);
         $repo = new Repository($store);
@@ -371,7 +371,7 @@ class CacheRepositoryTest extends TestCase
         $repo->tags('foo', 'bar', 'baz');
     }
 
-    public function testItThrowsExceptionWhenStoreDoesNotSupportTags()
+    public function testItThrowsExceptionWhenStoreDoesNotSupportTags(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -380,14 +380,14 @@ class CacheRepositoryTest extends TestCase
         (new Repository($store))->tags('foo');
     }
 
-    public function testTagMethodReturnsTaggedCache()
+    public function testTagMethodReturnsTaggedCache(): void
     {
         $store = (new Repository(new ArrayStore()))->tags('foo');
 
         $this->assertInstanceOf(TaggedCache::class, $store);
     }
 
-    public function testPossibleInputTypesToTags()
+    public function testPossibleInputTypesToTags(): void
     {
         $repo = new Repository(new ArrayStore());
 
@@ -401,7 +401,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertEquals(['r1', 'r2', 'r3'], $store->getTags()->getNames());
     }
 
-    public function testEventDispatcherIsPassedToStoreFromRepository()
+    public function testEventDispatcherIsPassedToStoreFromRepository(): void
     {
         $repo = new Repository(new ArrayStore());
         $repo->setEventDispatcher(new Dispatcher());
@@ -411,7 +411,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame($store->getEventDispatcher(), $repo->getEventDispatcher());
     }
 
-    public function testDefaultCacheLifeTimeIsSetOnTaggableStore()
+    public function testDefaultCacheLifeTimeIsSetOnTaggableStore(): void
     {
         $repo = new Repository(new ArrayStore());
         $repo->setDefaultCacheTime(random_int(1, 100));
@@ -421,7 +421,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame($store->getDefaultCacheTime(), $repo->getDefaultCacheTime());
     }
 
-    public function testTaggableRepositoriesSupportTags()
+    public function testTaggableRepositoriesSupportTags(): void
     {
         $taggable = m::mock(TaggableStore::class);
         $taggableRepo = new Repository($taggable);
@@ -429,7 +429,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($taggableRepo->supportsTags());
     }
 
-    public function testNonTaggableRepositoryDoesNotSupportTags()
+    public function testNonTaggableRepositoryDoesNotSupportTags(): void
     {
         $nonTaggable = m::mock(FileStore::class);
         $nonTaggableRepo = new Repository($nonTaggable);
@@ -437,7 +437,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($nonTaggableRepo->supportsTags());
     }
 
-    public function testAtomicExecutesCallbackAndReturnsResult()
+    public function testAtomicExecutesCallbackAndReturnsResult(): void
     {
         $repo = new Repository(new ArrayStore);
 
@@ -448,7 +448,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testAtomicPassesLockAndWaitSecondsToLock()
+    public function testAtomicPassesLockAndWaitSecondsToLock(): void
     {
         $store = m::mock(Store::class, LockProvider::class);
         $repo = new Repository($store);
@@ -466,7 +466,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testAtomicPassesOwnerToLock()
+    public function testAtomicPassesOwnerToLock(): void
     {
         $store = m::mock(Store::class, LockProvider::class);
         $repo = new Repository($store);
@@ -484,7 +484,7 @@ class CacheRepositoryTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    public function testAtomicThrowsOnLockTimeout()
+    public function testAtomicThrowsOnLockTimeout(): void
     {
         $repo = new Repository(new ArrayStore);
 
@@ -518,21 +518,21 @@ class CacheRepositoryTest extends TestCase
         return '2030-07-25 12:13:14 UTC';
     }
 
-    public function testItGetsAsString()
+    public function testItGetsAsString(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
         $this->assertSame('bar', $repo->string('foo'));
     }
 
-    public function testItGetsAsStringWithDefault()
+    public function testItGetsAsStringWithDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $this->assertSame('default', $repo->string('foo', 'default'));
     }
 
-    public function testItThrowsExceptionWhenGettingNonStringAsString()
+    public function testItThrowsExceptionWhenGettingNonStringAsString(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be a string, integer given.');
@@ -542,28 +542,28 @@ class CacheRepositoryTest extends TestCase
         $repo->string('foo');
     }
 
-    public function testItGetsAsInteger()
+    public function testItGetsAsInteger(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(123);
         $this->assertSame(123, $repo->integer('foo'));
     }
 
-    public function testItGetsAsIntegerWithDefault()
+    public function testItGetsAsIntegerWithDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $this->assertSame(456, $repo->integer('foo', 456));
     }
 
-    public function testItGetsAsIntegerFromNumericString()
+    public function testItGetsAsIntegerFromNumericString(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('123');
         $this->assertSame(123, $repo->integer('foo'));
     }
 
-    public function testItThrowsExceptionWhenGettingNonIntegerAsInteger()
+    public function testItThrowsExceptionWhenGettingNonIntegerAsInteger(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
@@ -573,7 +573,7 @@ class CacheRepositoryTest extends TestCase
         $repo->integer('foo');
     }
 
-    public function testItThrowsExceptionWhenGettingFloatStringAsInteger()
+    public function testItThrowsExceptionWhenGettingFloatStringAsInteger(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be an integer, string given.');
@@ -583,28 +583,28 @@ class CacheRepositoryTest extends TestCase
         $repo->integer('foo');
     }
 
-    public function testItGetsAsFloat()
+    public function testItGetsAsFloat(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(1.5);
         $this->assertSame(1.5, $repo->float('foo'));
     }
 
-    public function testItGetsAsFloatWithDefault()
+    public function testItGetsAsFloatWithDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $this->assertSame(2.5, $repo->float('foo', 2.5));
     }
 
-    public function testItGetsAsFloatFromNumericString()
+    public function testItGetsAsFloatFromNumericString(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('1.5');
         $this->assertSame(1.5, $repo->float('foo'));
     }
 
-    public function testItThrowsExceptionWhenGettingNonFloatAsFloat()
+    public function testItThrowsExceptionWhenGettingNonFloatAsFloat(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be a float, string given.');
@@ -614,21 +614,21 @@ class CacheRepositoryTest extends TestCase
         $repo->float('foo');
     }
 
-    public function testItGetsAsBoolean()
+    public function testItGetsAsBoolean(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(true);
         $this->assertTrue($repo->boolean('foo'));
     }
 
-    public function testItGetsAsBooleanWithDefault()
+    public function testItGetsAsBooleanWithDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $this->assertFalse($repo->boolean('foo', false));
     }
 
-    public function testItThrowsExceptionWhenGettingNonBooleanAsBoolean()
+    public function testItThrowsExceptionWhenGettingNonBooleanAsBoolean(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be a boolean, string given.');
@@ -638,21 +638,21 @@ class CacheRepositoryTest extends TestCase
         $repo->boolean('foo');
     }
 
-    public function testItGetsAsArray()
+    public function testItGetsAsArray(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(['bar', 'baz']);
         $this->assertSame(['bar', 'baz'], $repo->array('foo'));
     }
 
-    public function testItGetsAsArrayWithDefault()
+    public function testItGetsAsArrayWithDefault(): void
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
         $this->assertSame(['default'], $repo->array('foo', ['default']));
     }
 
-    public function testItThrowsExceptionWhenGettingNonArrayAsArray()
+    public function testItThrowsExceptionWhenGettingNonArrayAsArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cache value for key [foo] must be an array, string given.');

--- a/tests/Cache/CacheSessionStoreTest.php
+++ b/tests/Cache/CacheSessionStoreTest.php
@@ -18,7 +18,7 @@ class CacheSessionStoreTest extends TestCase
         parent::tearDown();
     }
 
-    public function testItemsCanBeSetAndRetrieved()
+    public function testItemsCanBeSetAndRetrieved(): void
     {
         $store = new SessionStore(self::getSession());
         $result = $store->put('foo', 'bar', 10);
@@ -40,7 +40,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertNull($store->get('hello'));
     }
 
-    public function testMultipleItemsCanBeSetAndRetrieved()
+    public function testMultipleItemsCanBeSetAndRetrieved(): void
     {
         $store = new SessionStore(self::getSession());
         $result = $store->put('foo', 'bar', 10);
@@ -58,7 +58,7 @@ class CacheSessionStoreTest extends TestCase
         ], $store->many(['foo', 'fizz', 'quz', 'norf']));
     }
 
-    public function testItemsCanExpire()
+    public function testItemsCanExpire(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -71,7 +71,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testStoreItemForeverProperlyStoresInArray()
+    public function testStoreItemForeverProperlyStoresInArray(): void
     {
         $mock = $this->getMockBuilder(SessionStore::class)
             ->setConstructorArgs([self::getSession()])
@@ -84,7 +84,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testValuesCanBeIncremented()
+    public function testValuesCanBeIncremented(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', 1, 10);
@@ -97,7 +97,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(4, $store->get('foo'));
     }
 
-    public function testValuesGetCastedByIncrementOrDecrement()
+    public function testValuesGetCastedByIncrementOrDecrement(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', '1', 10);
@@ -111,7 +111,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(0, $store->get('bar'));
     }
 
-    public function testIncrementNonNumericValues()
+    public function testIncrementNonNumericValues(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'I am string', 10);
@@ -120,7 +120,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(1, $store->get('foo'));
     }
 
-    public function testNonExistingKeysCanBeIncremented()
+    public function testNonExistingKeysCanBeIncremented(): void
     {
         $store = new SessionStore(self::getSession());
         $result = $store->increment('foo');
@@ -132,7 +132,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(1, $store->get('foo'));
     }
 
-    public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
+    public function testExpiredKeysAreIncrementedLikeNonExistingKeys(): void
     {
         Carbon::setTestNow(Carbon::now());
 
@@ -145,7 +145,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testValuesCanBeDecremented()
+    public function testValuesCanBeDecremented(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', 1, 10);
@@ -158,7 +158,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertEquals(-2, $store->get('foo'));
     }
 
-    public function testItemsCanBeRemoved()
+    public function testItemsCanBeRemoved(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'bar', 10);
@@ -167,7 +167,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertFalse($store->forget('foo'));
     }
 
-    public function testItemsCanBeFlushed()
+    public function testItemsCanBeFlushed(): void
     {
         $store = new SessionStore(self::getSession());
         $store->put('foo', 'bar', 10);
@@ -178,19 +178,19 @@ class CacheSessionStoreTest extends TestCase
         $this->assertNull($store->get('baz'));
     }
 
-    public function testCacheKey()
+    public function testCacheKey(): void
     {
         $store = new SessionStore(self::getSession());
         $this->assertEmpty($store->getPrefix());
     }
 
-    public function testItemKey()
+    public function testItemKey(): void
     {
         $store = new SessionStore(self::getSession(), 'custom_prefix');
         $this->assertEquals('custom_prefix.foo', $store->itemKey('foo'));
     }
 
-    public function testValuesAreStoredByReference()
+    public function testValuesAreStoredByReference(): void
     {
         $store = new SessionStore(self::getSession());
         $object = new stdClass;
@@ -205,7 +205,7 @@ class CacheSessionStoreTest extends TestCase
         $this->assertTrue($retrievedObject->bar);
     }
 
-    public function testCanGetAll()
+    public function testCanGetAll(): void
     {
         Carbon::setTestNow(Carbon::now());
 

--- a/tests/Cache/CacheSpyMemoTest.php
+++ b/tests/Cache/CacheSpyMemoTest.php
@@ -44,7 +44,7 @@ class CacheSpyMemoTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_cache_spy_works_with_memoized_cache()
+    public function test_cache_spy_works_with_memoized_cache(): void
     {
         $cache = Cache::spy();
 
@@ -53,7 +53,7 @@ class CacheSpyMemoTest extends TestCase
         $cache->shouldHaveReceived('memo')->once();
     }
 
-    public function test_cache_spy_tracks_remember_on_memoized_cache_as_described_in_issue()
+    public function test_cache_spy_tracks_remember_on_memoized_cache_as_described_in_issue(): void
     {
         $cache = Cache::spy();
 
@@ -65,7 +65,7 @@ class CacheSpyMemoTest extends TestCase
         $memoizedCache->shouldHaveReceived('remember')->once()->with('key', 60, m::type(Closure::class));
     }
 
-    public function test_cache_spy_tracks_remember_calls_on_memoized_cache()
+    public function test_cache_spy_tracks_remember_calls_on_memoized_cache(): void
     {
         $cache = Cache::spy();
 
@@ -75,7 +75,7 @@ class CacheSpyMemoTest extends TestCase
         $memoizedCache->shouldHaveReceived('remember')->once()->with('key', 60, m::type(Closure::class));
     }
 
-    public function test_cache_spy_memo_returns_spied_repository()
+    public function test_cache_spy_memo_returns_spied_repository(): void
     {
         $cache = Cache::spy();
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CacheTaggedCacheTest extends TestCase
 {
-    public function testCacheCanBeSavedWithMultipleTags()
+    public function testCacheCanBeSavedWithMultipleTags(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
@@ -17,7 +17,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
-    public function testCacheCanBeSetWithDatetimeArgument()
+    public function testCacheCanBeSetWithDatetimeArgument(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
@@ -27,7 +27,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
-    public function testCacheSavedWithMultipleTagsCanBeFlushed()
+    public function testCacheSavedWithMultipleTagsCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $tags1 = ['bop', 'zap'];
@@ -39,14 +39,14 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame('bar', $store->tags($tags2)->get('foo'));
     }
 
-    public function testTagsWithStringArgument()
+    public function testTagsWithStringArgument(): void
     {
         $store = new ArrayStore;
         $store->tags('bop')->put('foo', 'bar', 10);
         $this->assertSame('bar', $store->tags('bop')->get('foo'));
     }
 
-    public function testWithIncrement()
+    public function testWithIncrement(): void
     {
         $store = new ArrayStore;
         $taggableStore = $store->tags('bop');
@@ -72,7 +72,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame(10, $value);
     }
 
-    public function testWithDecrement()
+    public function testWithDecrement(): void
     {
         $store = new ArrayStore;
         $taggableStore = $store->tags('bop');
@@ -98,7 +98,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame(-10, $value);
     }
 
-    public function testMany()
+    public function testMany(): void
     {
         $store = $this->getTestCacheStoreWithTagValues();
 
@@ -112,7 +112,7 @@ class CacheTaggedCacheTest extends TestCase
         ], $values);
     }
 
-    public function testManyWithDefaultValues()
+    public function testManyWithDefaultValues(): void
     {
         $store = $this->getTestCacheStoreWithTagValues();
 
@@ -134,7 +134,7 @@ class CacheTaggedCacheTest extends TestCase
         ], $values);
     }
 
-    public function testGetMultiple()
+    public function testGetMultiple(): void
     {
         $store = $this->getTestCacheStoreWithTagValues();
 
@@ -157,7 +157,7 @@ class CacheTaggedCacheTest extends TestCase
         ], $values);
     }
 
-    public function testGetMultipleWithDefaultValue()
+    public function testGetMultipleWithDefaultValue(): void
     {
         $store = $this->getTestCacheStoreWithTagValues();
 
@@ -171,7 +171,7 @@ class CacheTaggedCacheTest extends TestCase
         ], $values);
     }
 
-    public function testTagsWithIncrementCanBeFlushed()
+    public function testTagsWithIncrementCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $store->tags('bop')->increment('foo', 5);
@@ -180,7 +180,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertNull($store->tags('bop')->get('foo'));
     }
 
-    public function testTagsWithDecrementCanBeFlushed()
+    public function testTagsWithDecrementCanBeFlushed(): void
     {
         $store = new ArrayStore;
         $store->tags('bop')->decrement('foo', 5);
@@ -189,7 +189,7 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertNull($store->tags('bop')->get('foo'));
     }
 
-    public function testTagsCacheForever()
+    public function testTagsCacheForever(): void
     {
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -52,7 +52,7 @@ class ClearCommandTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    public function testClearWithNoStoreArgument()
+    public function testClearWithNoStoreArgument(): void
     {
         $this->files->shouldReceive('exists')->andReturn(true);
         $this->files->shouldReceive('files')->andReturn([]);
@@ -63,7 +63,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command);
     }
 
-    public function testClearWithStoreArgument()
+    public function testClearWithStoreArgument(): void
     {
         $this->files->shouldReceive('exists')->andReturn(true);
         $this->files->shouldReceive('files')->andReturn([]);
@@ -74,7 +74,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command, ['store' => 'foo']);
     }
 
-    public function testClearWithInvalidStoreArgument()
+    public function testClearWithInvalidStoreArgument(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -86,7 +86,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command, ['store' => 'bar']);
     }
 
-    public function testClearWithTagsOption()
+    public function testClearWithTagsOption(): void
     {
         $this->files->shouldReceive('exists')->andReturn(true);
         $this->files->shouldReceive('files')->andReturn([]);
@@ -98,7 +98,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command, ['--tags' => 'foo,bar']);
     }
 
-    public function testClearWithStoreArgumentAndTagsOption()
+    public function testClearWithStoreArgumentAndTagsOption(): void
     {
         $this->files->shouldReceive('exists')->andReturn(true);
         $this->files->shouldReceive('files')->andReturn([]);
@@ -110,7 +110,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command, ['store' => 'redis', '--tags' => 'foo']);
     }
 
-    public function testClearWillClearRealTimeFacades()
+    public function testClearWillClearRealTimeFacades(): void
     {
         $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
         $this->cacheRepository->shouldReceive('flush')->once();
@@ -122,7 +122,7 @@ class ClearCommandTest extends TestCase
         $this->runCommand($this->command);
     }
 
-    public function testClearWillNotClearRealTimeFacadesIfCacheDirectoryDoesntExist()
+    public function testClearWillNotClearRealTimeFacadesIfCacheDirectoryDoesntExist(): void
     {
         $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
         $this->cacheRepository->shouldReceive('flush')->once();

--- a/tests/Cache/LimitTest.php
+++ b/tests/Cache/LimitTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class LimitTest extends TestCase
 {
-    public function testConstructors()
+    public function testConstructors(): void
     {
         $limit = new Limit('', 3, 1);
         $this->assertSame(1, $limit->decaySeconds);

--- a/tests/Cache/RateLimiterTest.php
+++ b/tests/Cache/RateLimiterTest.php
@@ -40,7 +40,7 @@ class RateLimiterTest extends TestCase
         $this->assertNotNull($limiterClosure);
     }
 
-    public function testShouldUseOriginKeyAsPrefixWhenMultipleLimiterWithSameKey()
+    public function testShouldUseOriginKeyAsPrefixWhenMultipleLimiterWithSameKey(): void
     {
         $rateLimiter = new RateLimiter(new Repository(new ArrayStore));
 


### PR DESCRIPTION
Description
---
This PR adds missing void return type to test methods for consistency and clarity.

Continuation of: #56860.