### PR TITLE
[12.x] Add `--skip` Option to Laravel Migration Command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -36,7 +36,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 {--seed : Indicates if the seed task should be re-run}
                 {--seeder= : The class name of the root seeder}
                 {--step : Force the migrations to be run so they can be rolled back individually}
-                {--graceful : Return a successful exit code even if an error occurs}';
+                {--graceful : Return a successful exit code even if an error occurs}
+                {--skip=* : Migration file(s) to skip}';
 
     /**
      * The console command description.
@@ -116,6 +117,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 ->run($this->getMigrationPaths(), [
                     'pretend' => $this->option('pretend'),
                     'step' => $this->option('step'),
+                    'skip' => $this->option('skip'),
                 ]);
 
             // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -128,7 +128,7 @@ class Migrator
         // run each of the outstanding migrations against a database connection.
         $files = $this->getMigrationFiles($paths);
 
-        self::withoutMigrations($options['skip'] ?? []);
+        self::withoutMigrations(array_merge(self::$withoutMigrations, $options['skip'] ?? []));
 
         $this->requireFiles($migrations = $this->pendingMigrations(
             $files, $this->repository->getRan()

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -128,6 +128,8 @@ class Migrator
         // run each of the outstanding migrations against a database connection.
         $files = $this->getMigrationFiles($paths);
 
+        self::withoutMigrations($options['skip']);
+
         $this->requireFiles($migrations = $this->pendingMigrations(
             $files, $this->repository->getRan()
         ));

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -128,7 +128,7 @@ class Migrator
         // run each of the outstanding migrations against a database connection.
         $files = $this->getMigrationFiles($paths);
 
-        self::withoutMigrations($options['skip']);
+        self::withoutMigrations($options['skip'] ?? []);
 
         $this->requireFiles($migrations = $this->pendingMigrations(
             $files, $this->repository->getRan()


### PR DESCRIPTION
## Description

This PR adds a new `--skip` option to the `php artisan migrate` command, allowing developers to selectively skip specific migration files during execution.

## Motivation

Previously, developers had to add `shouldRun()` method, which required code changes. This was particularly problematic during deployments when migrations needed to be skipped due to environment-specific issues, timing concerns, or emergency situations.
This option enables flexible, deployment-time decisions about which migrations to run without pre-planning or code modifications.

## Usage

```bash
# Skip a single migration
php artisan migrate --skip=2026_01_01_000000_create_users_table

# Skip multiple migrations
php artisan migrate --skip=2026_01_01_000000_create_users_table --skip=2026_01_02_000000_create_posts_table

# Works with .php extension too
php artisan migrate --skip=2026_01_01_000000_create_users_table.php
```