### PR TITLE
Remove redundant notifiable normalization in send method

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -82,8 +82,6 @@ class NotificationSender
      */
     public function send($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }


### PR DESCRIPTION
Both `queueNotification` and `sendNow` already normalize notifiables
internally via `formatNotifiables()`.

Normalizing them again in `NotificationSender::send()` is redundant and
can be safely removed without changing behavior.
