### PR TITLE
[13.x] `Enumerable`: Remove `containsOneItem`/`containsManyItems` and add `hasSole`/`hasMany`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -711,32 +711,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Determine if the collection contains exactly one item. If a callback is provided, determine if exactly one item matches the condition.
-     *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @return bool
-     *
-     * @deprecated 12.49.0 Use the `hasSole()` method instead.
-     */
-    public function containsOneItem(?callable $callback = null): bool
-    {
-        return $this->hasSole($callback);
-    }
-
-    /**
-     * Determine if the collection contains multiple items.
-     *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @return bool
-     *
-     * @deprecated 12.50.0 Use the `hasMany()` method instead.
-     */
-    public function containsManyItems(?callable $callback = null): bool
-    {
-        return $this->hasMany($callback);
-    }
-
-    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -624,6 +624,26 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function isNotEmpty();
 
     /**
+     * Determine if the collection contains a single item, optionally matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasSole($key = null, $operator = null, $value = null);
+
+    /**
+     * Determine if the collection contains multiple items, optionally matching the given criteria.
+     *
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function hasMany($key = null, $operator = null, $value = null);
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -624,20 +624,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function isNotEmpty();
 
     /**
-     * Determine if the collection contains a single item.
-     *
-     * @return bool
-     */
-    public function containsOneItem();
-
-    /**
-     * Determine if the collection contains multiple items.
-     *
-     * @return bool
-     */
-    public function containsManyItems();
-
-    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -668,31 +668,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Determine if the collection contains a single item.
-     *
-     * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @return bool
-     *
-     * @deprecated 12.49.0 Use the `hasSole()` method instead.
-     */
-    public function containsOneItem(?callable $callback = null): bool
-    {
-        return $this->hasSole($callback);
-    }
-
-    /**
-     * Determine if the collection contains multiple items.
-     *
-     * @return bool
-     *
-     * @deprecated 12.50.0 Use the `hasMany()` method instead.
-     */
-    public function containsManyItems(): bool
-    {
-        return $this->hasMany();
-    }
-
-    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -944,32 +944,6 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, '', null, false, [], 'name'], $c->add('name')->values()->all());
     }
 
-    #[DataProvider('collectionClassProvider')]
-    public function testContainsOneItem($collection)
-    {
-        $this->assertFalse((new $collection([]))->containsOneItem());
-        $this->assertTrue((new $collection([1]))->containsOneItem());
-        $this->assertFalse((new $collection([1, 2]))->containsOneItem());
-
-        $this->assertFalse(collect([1, 2, 2])->containsOneItem(fn ($number) => $number === 2));
-        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) === 4));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsOneItem(fn ($word) => strlen($word) > 4));
-    }
-
-    #[DataProvider('collectionClassProvider')]
-    public function testContainsManyItems($collection)
-    {
-        $this->assertFalse((new $collection([]))->containsManyItems());
-        $this->assertFalse((new $collection([1]))->containsManyItems());
-        $this->assertTrue((new $collection([1, 2]))->containsManyItems());
-        $this->assertTrue((new $collection([1, 2, 3]))->containsManyItems());
-
-        $this->assertTrue(collect([1, 2, 2])->containsManyItems(fn ($number) => $number === 2));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 4));
-        $this->assertFalse(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) > 4));
-        $this->assertTrue(collect(['ant', 'bear', 'cat'])->containsManyItems(fn ($word) => strlen($word) === 3));
-    }
-
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -581,13 +581,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testContainsOneItemIsLazy()
-    {
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->containsOneItem();
-        });
-    }
-
     public function testHasSoleIsLazy()
     {
         $this->assertEnumerates(2, function ($collection) {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -378,33 +378,6 @@ class SupportLazyCollectionTest extends TestCase
         $this->assertEquals(['a' => 1, 'b' => 2], $collapsed->all());
     }
 
-    public function testContainsOneItem()
-    {
-        $collection = new LazyCollection([5]);
-        $this->assertTrue($collection->containsOneItem());
-
-        $emptyCollection = new LazyCollection([]);
-        $this->assertFalse($emptyCollection->containsOneItem());
-
-        $multipleCollection = new LazyCollection([1, 2, 3]);
-        $this->assertFalse($multipleCollection->containsOneItem());
-    }
-
-    public function testContainsManyItems()
-    {
-        $emptyCollection = new LazyCollection([]);
-        $this->assertFalse($emptyCollection->containsManyItems());
-
-        $singleCollection = new LazyCollection([1]);
-        $this->assertFalse($singleCollection->containsManyItems());
-
-        $multipleCollection = new LazyCollection([1, 2]);
-        $this->assertTrue($multipleCollection->containsManyItems());
-
-        $manyCollection = new LazyCollection([1, 2, 3]);
-        $this->assertTrue($manyCollection->containsManyItems());
-    }
-
     public function testDoesntContain()
     {
         $collection = new LazyCollection([1, 2, 3, 4, 5]);


### PR DESCRIPTION
Final cleanup from #58463 and #58550 for Laravel 13:

1. Remove the deprecated `containsOneItem()` and `containsManyItems()` methods from `Collection`, `LazyCollection`, and `Enumerable`.
  
2. Add `hasSole()` and `hasMany()` to the `Enumerable` interface.