### PR TITLE
[12.x] Ensure mailable HTML assertions properly escape quotes

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1412,7 +1412,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string, withQuote: isset($this->markdown)) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string, withQuote: $escape) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1434,7 +1434,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertDontSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string, withQuote: isset($this->markdown)) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string, withQuote: $escape) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1456,8 +1456,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInOrderInHtml($strings, $escape = true)
     {
-        $strings = $escape ? array_map(function ($string) {
-            return EncodedHtmlString::convert($string, withQuote: isset($this->markdown));
+        $strings = $escape ? array_map(function ($string) use ($escape) {
+            return EncodedHtmlString::convert($string, withQuote: $escape);
         }, $strings) : $strings;
 
         [$html] = $this->renderForAssertions();

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1412,7 +1412,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string, withQuote: true) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1434,7 +1434,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertDontSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string, withQuote: true) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1457,7 +1457,7 @@ class Mailable implements MailableContract, Renderable
     public function assertSeeInOrderInHtml($strings, $escape = true)
     {
         $strings = $escape ? array_map(function ($string) {
-            return EncodedHtmlString::convert($string);
+            return EncodedHtmlString::convert($string, withQuote: true);
         }, $strings) : $strings;
 
         [$html] = $this->renderForAssertions();

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1412,7 +1412,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string, withQuote: $escape) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1434,7 +1434,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertDontSeeInHtml($string, $escape = true)
     {
-        $string = $escape ? EncodedHtmlString::convert($string, withQuote: $escape) : $string;
+        $string = $escape ? EncodedHtmlString::convert($string) : $string;
 
         [$html] = $this->renderForAssertions();
 
@@ -1456,8 +1456,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertSeeInOrderInHtml($strings, $escape = true)
     {
-        $strings = $escape ? array_map(function ($string) use ($escape) {
-            return EncodedHtmlString::convert($string, withQuote: $escape);
+        $strings = $escape ? array_map(function ($string) {
+            return EncodedHtmlString::convert($string);
         }, $strings) : $strings;
 
         [$html] = $this->renderForAssertions();

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -194,6 +194,13 @@ class MailMailableAssertionsTest extends TestCase
         $mailable->assertDontSeeInHtml("<li>It's a wonderful day</li>", false);
     }
 
+    public function testMailableAssertSeeInHtmlWithBladeEscapedApostrophePassesWhenPresent(): void
+    {
+        $mailable = new MailableAssertionsBladeEscapedStub;
+
+        $mailable->assertSeeInHtml("It's a wonderful day");
+    }
+
     public function testMailableAssertSeeInOrderInHtmlWithApostrophePassesWhenPresentInOrder(): void
     {
         $mailable = new MailableAssertionsStub;
@@ -256,6 +263,25 @@ class MailableAssertionsStub extends Mailable
         <li>Sixth Item</li>
         <li>It's a wonderful day</li>
         </ul>
+        </body>
+        </html>
+        EOD;
+
+        return [$html, $text];
+    }
+}
+
+class MailableAssertionsBladeEscapedStub extends Mailable
+{
+    protected function renderForAssertions()
+    {
+        $text = "It's a wonderful day";
+
+        $html = <<<'EOD'
+        <!DOCTYPE html>
+        <html>
+        <body>
+        <div>It&#039;s a wonderful day</div>
         </body>
         </html>
         EOD;

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -286,6 +286,10 @@ class MailableAssertionsBladeEscapedStub extends Mailable
         </html>
         EOD;
 
+        /**
+         * Since stub override `renderForAssertions()` we should expect that `$html` is available from either `$this->view` or `$this->markdown`.
+         */
+
         return [$html, $text];
     }
 }


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/58586

When using `assertSeeInHtml()` escape is true by default but, apostrophes and quotes are not being properly escaped, causing assertions to fail  such as:

```php
// Blade template: {{ "It's a wonderful day" }}
// Renders as: It&#039;s a wonderful day in HTML

$mailable->assertSeeInHtml("It's a wonderful day"); // Would fail...
```

The fix ensures that quotes are properly escaped to match Blade's HTML escaping.. `withQuote` was being set based on if the markdown property was set, where as I think it should be left as true.. (its true by default) - to match the escape default.

I've targeted 12.x as everything passes and this only alters the assertion behaviour I can't think of a scenario where you'd  expect it to not escape quotes etc, can target 13.x if you prefer! but felt like an oversight perhaps.

Have added a test to prevent regression 🫡 
