### PR TITLE
[12.x] Ensure File fail doesn't double translate in fail()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-#    branches:
-#      - master
-#      - '*.x'
-#  pull_request:
-#  schedule:
-#    - cron: '0 0 * * *'
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: tests
 
 on:
   push:
-    branches:
-      - master
-      - '*.x'
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+#    branches:
+#      - master
+#      - '*.x'
+#  pull_request:
+#  schedule:
+#    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -357,11 +357,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = Collection::wrap($messages)
-            ->map(fn ($message) => $this->validator->getTranslator()->get($message))
-            ->all();
-
-        $this->messages = array_merge($this->messages, $messages);
+        $this->messages = array_merge($this->messages, Arr::wrap($messages));
 
         return false;
     }

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Translation;
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -108,8 +110,8 @@ class TranslatorTest extends TestCase
         });
 
         $validator = $this->app['validator']->make(
-            ['file' => \Illuminate\Http\UploadedFile::fake()->create('file.pdf')],
-            ['file' => [\Illuminate\Validation\Rules\File::types(['txt'])]]
+            ['file' => UploadedFile::fake()->create('file.pdf')],
+            ['file' => [File::types(['txt'])]]
         );
 
         $validator->fails();

--- a/tests/Integration/Translation/TranslatorTest.php
+++ b/tests/Integration/Translation/TranslatorTest.php
@@ -99,6 +99,26 @@ class TranslatorTest extends TestCase
         $this->app['translator']->handleMissingKeysUsing(null);
     }
 
+    public function testFileValidationDoesNotAttemptToTranslateAlreadyTranslatedMessages()
+    {
+        $keysLookedUp = [];
+
+        $this->app['translator']->handleMissingKeysUsing(function ($key) use (&$keysLookedUp) {
+            $keysLookedUp[] = $key;
+        });
+
+        $validator = $this->app['validator']->make(
+            ['file' => \Illuminate\Http\UploadedFile::fake()->create('file.pdf')],
+            ['file' => [\Illuminate\Validation\Rules\File::types(['txt'])]]
+        );
+
+        $validator->fails();
+
+        $this->assertNotContains('The file field must be a file of type: txt.', $keysLookedUp);
+
+        $this->app['translator']->handleMissingKeysUsing(null);
+    }
+
     #[DataProvider('greetingChoiceDataProvider')]
     public function testItCanHandleChoice(int $count, string $expected, ?string $locale = null)
     {

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Validation\Rules;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Validation\Rules;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -76,5 +77,131 @@ class FileValidationTest extends TestCase
             'File one is too large',
             'File two is not a file',
         ], $validator->messages()->all());
+    }
+    public function test_file_mimes_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['document' => UploadedFile::fake()->create('file.pdf')],
+            ['document' => [File::types(['jpg', 'png'])]],
+            ['document.mimes' => 'Wrong file type']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Wrong file type'], $validator->messages()->all());
+    }
+
+    public function test_file_min_size_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['upload' => UploadedFile::fake()->create('small.pdf', 50)],
+            ['upload' => [File::types(['pdf'])->min(100)]],
+            ['upload.min' => 'File too small']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['File too small'], $validator->messages()->all());
+    }
+
+    public function test_file_max_size_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['upload' => UploadedFile::fake()->create('large.pdf', 2000)],
+            ['upload' => [File::types(['pdf'])->max(1024)]],
+            ['upload.max' => 'File exceeds limit']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['File exceeds limit'], $validator->messages()->all());
+    }
+
+    public function test_file_dimension_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['image' => UploadedFile::fake()->image('foo.jpg', 100, 100)],
+            ['image' => [File::image()->dimensions(new Dimensions(['min_width' => 50, 'min_height' => 50]))]],
+            ['image.dimensions' => 'Invalid dimensions']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Invalid dimensions'], $validator->messages()->all());
+    }
+
+    public function test_file_between_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['file' => UploadedFile::fake()->create('foo.pdf', 10)],
+            ['file' => [File::types(['pdf'])->between(100, 1000)]],
+            ['file.between' => 'Size out of range']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Size out of range'], $validator->messages()->all());
+    }
+
+    public function test_image_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['avatar' => UploadedFile::fake()->create('foo.txt')],
+            ['avatar' => [File::image()]],
+            ['avatar.image' => 'Not an image']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Not an image'], $validator->messages()->all());
+    }
+
+    public function test_file_multiple_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['photo' => UploadedFile::fake()->create('foo.pdf', 5000)],
+            ['photo' => [File::types(['jpg', 'png'])->max(1024)]],
+            [
+                'photo.mimes' => 'Invalid type',
+                'photo.max' => 'Too large',
+            ]
+        );
+
+        $this->assertTrue($validator->fails());
+
+        $messages = $validator->messages()->all();
+
+        $this->assertContains('Invalid type', $messages);
+        $this->assertContains('Too large', $messages);
+    }
+
+    public function test_file_size_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['file' => UploadedFile::fake()->create('doc.pdf', 500)],
+            ['file' => [File::types(['pdf'])->size(100)]],
+            ['file.size' => 'File must be exactly 100KB']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['File must be exactly 100KB'], $validator->messages()->all());
+    }
+
+    public function test_file_extensions_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['file' => UploadedFile::fake()->create('foo.pdf')],
+            ['file' => [File::default()->extensions(['txt', 'doc'])]],
+            ['file.extensions' => 'Invalid file extension']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Invalid file extension'], $validator->messages()->all());
+    }
+
+    public function test_file_encoding_custom_validation_messages()
+    {
+        $validator = Validator::make(
+            ['file' => UploadedFile::fake()->createWithContent('foo.txt', "\xf0\x28\x8c\x28")],
+            ['file' => [File::types(['txt'])->encoding('UTF-8')]],
+            ['file.encoding' => 'Invalid file encoding']
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['Invalid file encoding'], $validator->messages()->all());
     }
 }

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -78,6 +78,7 @@ class FileValidationTest extends TestCase
             'File two is not a file',
         ], $validator->messages()->all());
     }
+
     public function test_file_mimes_custom_validation_messages()
     {
         $validator = Validator::make(

--- a/tests/Integration/Validation/Rules/FileValidationTest.php
+++ b/tests/Integration/Validation/Rules/FileValidationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Validation\Rules;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\File;
 use Orchestra\Testbench\TestCase;
@@ -119,7 +120,7 @@ class FileValidationTest extends TestCase
     {
         $validator = Validator::make(
             ['image' => UploadedFile::fake()->image('foo.jpg', 100, 100)],
-            ['image' => [File::image()->dimensions(new Dimensions(['min_width' => 50, 'min_height' => 50]))]],
+            ['image' => [File::image()->dimensions(Rule::dimensions()->width(50)->height(50))]],
             ['image.dimensions' => 'Invalid dimensions']
         );
 


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/58596

The File validation `fail()` method attempts to translate messages that have already been translated by the validator, causing false positives when using `Lang::handleMissingKeysUsing()` to track missing translations.

The translation is already done via the validator addFailure method afaik. Thought this would be useful to remove as makes it a tiny bit more efficient either way.

Have added a test to cover this use case.. and added tests to cover custom messages for all file rules just to be sure there's no regression / we can be certain its not gonna break anything.

Can target 13.x if you prefer