### PR TITLE
[12.x] Fixed precision checks for column types in SQL Server grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -686,7 +686,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        return !is_null($column->precision) ? "float($column->precision)" : 'float';
+        return ! is_null($column->precision) ? "float($column->precision)" : 'float';
     }
 
     /**
@@ -804,7 +804,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return !is_null($column->precision) ? "time($column->precision)" : 'time';
+        return ! is_null($column->precision) ? "time($column->precision)" : 'time';
     }
 
     /**
@@ -830,7 +830,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return !is_null($column->precision) ? "datetime2($column->precision)" : 'datetime';
+        return ! is_null($column->precision) ? "datetime2($column->precision)" : 'datetime';
     }
 
     /**
@@ -847,7 +847,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return !is_null($column->precision) ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        return ! is_null($column->precision) ? "datetimeoffset($column->precision)" : 'datetimeoffset';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -686,11 +686,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        if ($column->precision) {
-            return "float({$column->precision})";
-        }
-
-        return 'float';
+        return !is_null($column->precision) ? "float($column->precision)" : 'float';
     }
 
     /**
@@ -808,7 +804,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return $column->precision ? "time($column->precision)" : 'time';
+        return !is_null($column->precision) ? "time($column->precision)" : 'time';
     }
 
     /**
@@ -834,7 +830,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return $column->precision ? "datetime2($column->precision)" : 'datetime';
+        return !is_null($column->precision) ? "datetime2($column->precision)" : 'datetime';
     }
 
     /**
@@ -851,7 +847,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        return !is_null($column->precision) ? "datetimeoffset($column->precision)" : 'datetimeoffset';
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -139,7 +139,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
-        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
+        $this->assertEquals(['alter table "users" add "created" datetime2(0) not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testDefaultCurrentTimestamp()
@@ -153,7 +153,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
-        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
+        $this->assertEquals(['alter table "users" add "created" datetime2(0) not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testDefaultCurrentYear()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -666,7 +666,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -684,7 +684,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -702,7 +702,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -720,7 +720,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -738,7 +738,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -756,7 +756,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -775,8 +775,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
-            'alter table "users" add "created_at" datetime null',
-            'alter table "users" add "updated_at" datetime null',
+            'alter table "users" add "created_at" datetime2(0) null',
+            'alter table "users" add "updated_at" datetime2(0) null',
         ], $statements);
     }
 
@@ -787,8 +787,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
-            'alter table "users" add "created_at" datetimeoffset null',
-            'alter table "users" add "updated_at" datetimeoffset null',
+            'alter table "users" add "created_at" datetimeoffset(0) null',
+            'alter table "users" add "updated_at" datetimeoffset(0) null',
         ], $statements);
     }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -243,13 +243,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertSame('exclude', $tag->pivot->flag);
 
-            if ($this->driver === 'sqlsrv') {
-                $this->assertSame('2017-10-10 10:10:10.000', $tag->pivot->getAttributes()['created_at']);
-                $this->assertSame('2017-10-10 10:10:20.000', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
-            } else {
-                $this->assertSame('2017-10-10 10:10:10', $tag->pivot->getAttributes()['created_at']);
-                $this->assertSame('2017-10-10 10:10:20', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
-            }
+            $this->assertSame('2017-10-10 10:10:10', $tag->pivot->getAttributes()['created_at']);
+            $this->assertSame('2017-10-10 10:10:20', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
     }
 

--- a/tests/Integration/Database/TimestampTypeTest.php
+++ b/tests/Integration/Database/TimestampTypeTest.php
@@ -23,6 +23,7 @@ class TimestampTypeTest extends DatabaseTestCase
         $this->assertSame(
             match ($this->driver) {
                 'mysql', 'mariadb', 'pgsql' => 'timestamp',
+                'sqlsrv' => 'datetime2',
                 default => 'datetime',
             },
             Schema::getColumnType('test', 'datetime_to_timestamp')
@@ -44,6 +45,7 @@ class TimestampTypeTest extends DatabaseTestCase
         $this->assertSame(
             match ($this->driver) {
                 'pgsql' => 'timestamp',
+                'sqlsrv' => 'datetime2',
                 default => 'datetime',
             },
             Schema::getColumnType('test', 'timestamp_to_datetime')


### PR DESCRIPTION
Migrations for SQL Server generate float, time and datetime columns with server dependent default precision in cases where 0 is passed as required precison because it's treated the same as NULL in the current grammar implementation. Thus, using a precision of 0 is not possible up to now for those column types.

The PR won't change existing installations but in new installations, timestamp columns will not contain microseconds any more. This will make the timestamp format compliant to the other supported RDBMS (Y-m-d H:i:s) as originally intended by the authors of the SQL Server Grammar implementation and won't break tests comparing timestamps any more. Float columns will still be generated in the same format as now besides that precision:0 is now possible too.