### PR TITLE
[12.x] Avoid duplicate notifiable normalization in NotificationSender

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -82,8 +82,6 @@ class NotificationSender
      */
     public function send($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }


### PR DESCRIPTION
### Summary

This pull request removes a redundant call to `formatNotifiables()` in
`NotificationSender::send()`.

Both execution paths (`queueNotification()` and `sendNow()`) already
normalize notifiables internally, so performing normalization earlier
does not affect behavior.

---

### Why this change is needed

Currently, `NotificationSender::send()` normalizes notifiables before
delegating to either `queueNotification()` or `sendNow()`. However, both
of these methods already perform the same normalization step.

This results in duplicate normalization that does not contribute to
correctness and makes the notification flow harder to reason about when
reading or extending the code.

---

### Why this is not a breaking change

- `formatNotifiables()` is still executed in all code paths
- Public APIs remain unchanged
- Notification behavior and outputs are identical
- The change only affects internal control flow

---

### Benefit to end users

While this is an internal refactor, it improves clarity of the
notification pipeline, making it easier for framework contributors and
package authors to understand where normalization occurs and reason
about notification delivery behavior.

---

### Tests

Existing notification integration tests continue to pass, confirming
that notification delivery behavior is unchanged.

