### PR TITLE
[12.x] Add `assertJobs` method on `PendingBatchFake`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -45,4 +45,23 @@ class PendingBatchFake extends PendingBatch
     {
         return $this->bus->recordPendingBatch($this);
     }
+
+    public function assertJobs(array $expectedJobs)
+    {
+        if (count($this->jobs) !== count($expectedJobs)) {
+            return false;
+        }
+
+        foreach ($expectedJobs as $index => $expectedJob) {
+            if (is_string($expectedJob)) {
+                if ($expectedJob != get_class($this->jobs[$index])) {
+                    return false;
+                }
+            } elseif (serialize($expectedJob) != serialize($this->jobs[$index])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
-use RuntimeException;
 
 class PendingBatchFake extends PendingBatch
 {

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -46,6 +46,12 @@ class PendingBatchFake extends PendingBatch
         return $this->bus->recordPendingBatch($this);
     }
 
+    /**
+     * Assert the jobs in the batch match the given jobs.
+     *
+     * @param  array  $expectedJobs
+     * @return bool
+     */
     public function assertJobs(array $expectedJobs)
     {
         if (count($this->jobs) !== count($expectedJobs)) {

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -865,12 +865,6 @@ class SupportTestingBusFakeTest extends TestCase
             ]);
         });
 
-        $this->fake->assertBatched([
-            new BusFakeJobWithSerialization('foo'),
-            new BusFakeJobWithSerialization('bar'),
-            new BusFakeJobWithSerialization('baz'),
-        ]);
-
         try {
             $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
                 return $batchedCollection->assertJobs([

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Support;
 
-use AssertionError;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -882,7 +882,7 @@ class SupportTestingBusFakeTest extends TestCase
             });
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The expected batch was not dispatched.", $e->getMessage());
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
         }
 
         try {
@@ -895,7 +895,7 @@ class SupportTestingBusFakeTest extends TestCase
             });
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The expected batch was not dispatched.", $e->getMessage());
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
         }
 
         try {
@@ -907,7 +907,7 @@ class SupportTestingBusFakeTest extends TestCase
             });
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The expected batch was not dispatched.", $e->getMessage());
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
         }
 
         try {
@@ -921,7 +921,7 @@ class SupportTestingBusFakeTest extends TestCase
             });
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The expected batch was not dispatched.", $e->getMessage());
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
Currently, when you want to assert the jobs of a batch in a test, you have to manually check them all by accessing the jobs-property on the `PendingBatchFake` class.
```php
Bus::assertBatched(function (PendingBatchFake $batch) {
    return $batch->jobs->count() === 3
        && $batch->jobs[0] instanceof FooJob & $batch->jobs[0]->someProperty === 'someValue'
        && $batch->jobs[1] instanceof BarJob & $batch->jobs[1]->someProperty === 'someOtherValue'
        && $batch->jobs[2] instanceof BazJob & $batch->jobs[2]->someProperty === 'againAnotherValue';
});
```
This PR fixes that by adding a `assertJobs` method to the `PendingBatchFake` class.
```php
Bus::assertBatched(function (PendingBatchFake $batch) {
    return $batch->assertJobs([
        new FooJob(someProperty: 'someValue'),
        new BarJob(someProperty: 'someOtherValue'),
        new BazJob(someProperty: 'againAnotherValue'),
    ]);
});
```