### PR TITLE
[12.x] Add `InteractsWithData::clamp()`

### DIFF
--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Number;
 use Illuminate\Support\Str;
 use stdClass;
 
@@ -283,6 +284,21 @@ trait InteractsWithData
     {
         return (float) $this->data($key, $default);
     }
+
+    /**
+     * Retrieve data clamped between min and max values.
+     *
+     * @param  string  $key
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @param  int|float  $default
+     * @return float|int
+     */
+    public function clamp($key, $min, $max, $default = 0)
+    {
+        return Number::clamp($this->data($key, $default), $min, $max);
+    }
+
 
     /**
      * Retrieve data from the instance as a Carbon instance.

--- a/src/Illuminate/Support/Traits/InteractsWithData.php
+++ b/src/Illuminate/Support/Traits/InteractsWithData.php
@@ -299,7 +299,6 @@ trait InteractsWithData
         return Number::clamp($this->data($key, $default), $min, $max);
     }
 
-
     /**
      * Retrieve data from the instance as a Carbon instance.
      *

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1801,4 +1801,13 @@ class HttpRequestTest extends TestCase
 
         $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
     }
+
+    public function testItClampsValues()
+    {
+        $request = Request::create('/', 'GET', ['per_page' => 100]);
+        $this->assertEquals(100, $request->clamp('per_page', 100, 101));
+        $this->assertEquals(10, $request->clamp('per_page', -10, 10));
+        $this->assertEquals(25, $request->clamp('per_page_2', 25, 100, 1));
+        $this->assertEquals(100, $request->clamp('per_page', 1, 250, 99));
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1804,10 +1804,12 @@ class HttpRequestTest extends TestCase
 
     public function testItClampsValues()
     {
-        $request = Request::create('/', 'GET', ['per_page' => 100]);
-        $this->assertEquals(100, $request->clamp('per_page', 100, 101));
-        $this->assertEquals(10, $request->clamp('per_page', -10, 10));
-        $this->assertEquals(25, $request->clamp('per_page_2', 25, 100, 1));
-        $this->assertEquals(100, $request->clamp('per_page', 1, 250, 99));
+        $request = Request::create('/', 'GET', ['per_page' => 100, 'float' => 9.24]);
+        $this->assertSame(100, $request->clamp('per_page', 100, 101));
+        $this->assertSame(10, $request->clamp('per_page', -10, 10));
+        $this->assertSame(25, $request->clamp('per_page_2', 25, 100, 1));
+        $this->assertSame(100, $request->clamp('per_page', 1, 250, 99));
+        $this->assertSame(22.4, $request->clamp('per_page', 1.11, 22.4, 2));
+        $this->assertSame(9.24, $request->clamp('float', 1, 10));
     }
 }


### PR DESCRIPTION
I see it happen pretty routinely that an endpoint has a `per_page` parameter that someone will retrieve like this:

```php
/** @var int<PHP_INT_MIN, PHP_INT_MAX> $perPage */
$perPage = request()->integer('per_page', 50);
```

If the request doesn't have validation in front of it (which happens pretty frequently), an attack surface is opened up to perform painfully large DB queries. If we can gently nudge developers to instead use:

```php
/** @var int<1, 100> $perPage */
$perPage = request()->clamp('per_page', 1, 100, 50);
```

then databases everywhere will be overjoyed! OWASP experts will have to find new work! Gitlab and GitHub will receive fewer comments by yours truly!