### PR TITLE
[12.x] try-catch all composer package uninstalls

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -8,6 +8,7 @@ use Illuminate\Concurrency\ProcessDriver;
 use Illuminate\Encryption\EncryptionServiceProvider;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Throwable;
 
 class ComposerScripts
 {
@@ -81,6 +82,8 @@ class ComposerScripts
             $laravel->make(ProcessDriver::class)->run(
                 static fn () => app()['events']->dispatch("composer_package.{$name}:pre_uninstall")
             );
+        } catch (Throwable $e) {
+            // We ignore this exception to prevent uninstall from failing
         }
     }
 

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -86,9 +86,9 @@ class ComposerScripts
                 static fn () => app()['events']->dispatch($eventName)
             );
         } catch (Throwable $e) {
-            // Ignore any errors to allow the composer uninstall to complete...
+            // Ignore any errors to allow the package removal to complete...
             $event->getIO()->write('There was an error dispatching or handling the ['.($eventName ?? 'unknown').'] event. Continuing with package removal...');
-            $event->getIO()->writeError('Exception message: '.$e->getMessage(), verbosity: IOInterface::VERBOSE);
+            $event->getIO()->writeError('Exception message: '.$e->getMessage(), verbosity: IOInterface::VERBOSE); // @phpstan-ignore class.notFound (Composer exists if this is running)
         }
     }
 

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -63,23 +63,25 @@ class ComposerScripts
             return;
         }
 
-        require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
-
-        $laravel = new Application(getcwd());
-
-        $laravel->bootstrapWith([
-            LoadEnvironmentVariables::class,
-            LoadConfiguration::class,
-        ]);
-
-        // Ensure we can encrypt our serializable closure...
-        (new EncryptionServiceProvider($laravel))->register();
-
-        $name = $event->getOperation()->getPackage()->getName();
-
-        $laravel->make(ProcessDriver::class)->run(
-            static fn () => app()['events']->dispatch("composer_package.{$name}:pre_uninstall")
-        );
+        try {
+            require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
+    
+            $laravel = new Application(getcwd());
+    
+            $laravel->bootstrapWith([
+                LoadEnvironmentVariables::class,
+                LoadConfiguration::class,
+            ]);
+    
+            // Ensure we can encrypt our serializable closure...
+            (new EncryptionServiceProvider($laravel))->register();
+    
+            $name = $event->getOperation()->getPackage()->getName();
+    
+            $laravel->make(ProcessDriver::class)->run(
+                static fn () => app()['events']->dispatch("composer_package.{$name}:pre_uninstall")
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -83,7 +83,7 @@ class ComposerScripts
                 static fn () => app()['events']->dispatch("composer_package.{$name}:pre_uninstall")
             );
         } catch (Throwable $e) {
-            // We ignore this exception to prevent uninstall from failing
+            // Ignore any errors to allow the composer uninstall to complete...
         }
     }
 


### PR DESCRIPTION
If the uninstall fails, I think we can just proceed forward. This was intended as a convenience thing for cleanup, and it's been a lot of PRs. I am sorry.

To resolve https://github.com/laravel/framework/issues/58599

Following the reproduction steps, the console looks like this (when using the `-v` flag):

<img width="2172" height="1376" alt="image" src="https://github.com/user-attachments/assets/eb945fa7-9fd3-44ba-8447-583f8b4950b9" />

Without the `-v` flag, the exception message isn't written.