### PR TITLE
Add Failover for Redis Connections

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -180,6 +180,60 @@ return [
             'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
         ],
 
+        /*
+        |--------------------------------------------------------------------------
+        | Redis Failover Connection
+        |--------------------------------------------------------------------------
+        |
+        | You may define a Redis connection that tries multiple connections in
+        | order. This is useful when migrating between Redis providers or for
+        | high availability setups. Set REDIS_CACHE_CONNECTION or
+        | REDIS_QUEUE_CONNECTION to "failover" to use it.
+        |
+        | Each connection in the list can specify 'read_only' => true in its
+        | own config to indicate it only accepts read commands. Write commands
+        | will skip read-only connections in the failover chain.
+        |
+        | Example with inline read_only override:
+        |
+        | 'connections' => [
+        |     'cache',                                    // inherits read_only from config
+        |     ['name' => 'fallback', 'read_only' => true], // override read_only
+        | ],
+        |
+        */
+        'failover' => [
+            'connections' => [
+                env('REDIS_FAILOVER_PRIMARY', 'cache'),
+                env('REDIS_FAILOVER_FALLBACK', 'fallback'),
+            ],
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Redis Fallback Connection (Read-Only Example)
+        |--------------------------------------------------------------------------
+        |
+        | This is an example of a read-only fallback connection. When used in
+        | a failover connection, read commands (get, exists, etc.) will try
+        | this connection if the primary fails, but write commands (set, del,
+        | etc.) will skip it entirely.
+        |
+        */
+        'fallback' => [
+            'url' => env('REDIS_FALLBACK_URL'),
+            'host' => env('REDIS_FALLBACK_HOST', '127.0.0.1'),
+            'username' => env('REDIS_FALLBACK_USERNAME'),
+            'password' => env('REDIS_FALLBACK_PASSWORD'),
+            'port' => env('REDIS_FALLBACK_PORT', '6379'),
+            'database' => env('REDIS_FALLBACK_DB', '0'),
+            'read_only' => env('REDIS_FALLBACK_READ_ONLY', true),
+            'max_retries' => env('REDIS_MAX_RETRIES', 3),
+            'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
+            'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+            'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+        ],
+
     ],
 
 ];

--- a/src/Illuminate/Redis/Connections/FailoverConnection.php
+++ b/src/Illuminate/Redis/Connections/FailoverConnection.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Illuminate\Redis\Connections;
+
+use Closure;
+use Illuminate\Contracts\Redis\Connection as ConnectionContract;
+use Illuminate\Redis\RedisManager;
+use RuntimeException;
+use Throwable;
+
+class FailoverConnection extends Connection implements ConnectionContract
+{
+    /**
+     * The Redis manager instance.
+     *
+     * @var \Illuminate\Redis\RedisManager
+     */
+    protected RedisManager $manager;
+
+    /**
+     * The normalized connection configurations.
+     *
+     * @var array<int, array{name: string, read_only: bool}>
+     */
+    protected array $connectionConfigs = [];
+
+    /**
+     * Resolved connections (lazy).
+     *
+     * @var array<string, \Illuminate\Redis\Connections\Connection>
+     */
+    protected array $connections = [];
+
+    /**
+     * Redis commands that are read-only and may use read-only connections.
+     *
+     * @var array<string, true>
+     */
+    protected static array $readOnlyCommands = [
+        'get' => true,
+        'mget' => true,
+        'exists' => true,
+        'type' => true,
+        'ttl' => true,
+        'pttl' => true,
+        'llen' => true,
+        'lindex' => true,
+        'lrange' => true,
+        'zcard' => true,
+        'zrange' => true,
+        'zrangebyscore' => true,
+        'zrank' => true,
+        'zrevrank' => true,
+        'zcount' => true,
+        'zscore' => true,
+        'hget' => true,
+        'hgetall' => true,
+        'hlen' => true,
+        'hmget' => true,
+        'hexists' => true,
+        'hkeys' => true,
+        'hvals' => true,
+        'scan' => true,
+        'sscan' => true,
+        'hscan' => true,
+        'zscan' => true,
+        'keys' => true,
+        'dump' => true,
+        'getrange' => true,
+        'strlen' => true,
+        'smembers' => true,
+        'sismember' => true,
+        'scard' => true,
+        'srandmember' => true,
+        'sdiff' => true,
+        'sinter' => true,
+        'sunion' => true,
+        'ping' => true,
+        'time' => true,
+        'info' => true,
+        'dbsize' => true,
+        'object' => true,
+        'randomkey' => true,
+        'bitcount' => true,
+        'bitpos' => true,
+        'getbit' => true,
+        'pfcount' => true,
+        'geohash' => true,
+        'geopos' => true,
+        'geodist' => true,
+        'georadius_ro' => true,
+        'georadiusbymember_ro' => true,
+        'lpos' => true,
+        'xlen' => true,
+        'xrange' => true,
+        'xrevrange' => true,
+        'xread' => true,
+        'xinfo' => true,
+        'xpending' => true,
+    ];
+
+    /**
+     * Create a new failover connection instance.
+     *
+     * @param  \Illuminate\Redis\RedisManager  $manager
+     * @param  array  $connections  Array of connection names or ['name' => string, 'read_only' => bool] arrays
+     */
+    public function __construct(RedisManager $manager, array $connections)
+    {
+        $this->manager = $manager;
+        $this->connectionConfigs = $this->normalizeConnections($connections);
+
+        if (empty($this->connectionConfigs)) {
+            throw new RuntimeException('At least one connection must be specified for failover.');
+        }
+    }
+
+    /**
+     * Normalize connections to array of ['name' => string, 'read_only' => bool].
+     *
+     * @param  array  $connections
+     * @return array<int, array{name: string, read_only: bool}>
+     */
+    protected function normalizeConnections(array $connections): array
+    {
+        $normalized = [];
+
+        foreach ($connections as $connection) {
+            if (is_string($connection)) {
+                $normalized[] = [
+                    'name' => $connection,
+                    'read_only' => $this->manager->getConnectionConfig($connection)['read_only'] ?? false,
+                ];
+            } elseif (is_array($connection) && isset($connection['name'])) {
+                $name = $connection['name'];
+                $normalized[] = [
+                    'name' => $name,
+                    'read_only' => $connection['read_only']
+                        ?? $this->manager->getConnectionConfig($name)['read_only']
+                        ?? false,
+                ];
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Run a command against the Redis database.
+     *
+     * Read commands try all connections in order.
+     * Write commands only try connections where read_only is false.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public function command($method, array $parameters = [])
+    {
+        $method = strtolower($method);
+        $isReadCommand = isset(static::$readOnlyCommands[$method]);
+
+        if ($isReadCommand) {
+            return $this->attemptOnConnections($method, $parameters, $this->connectionConfigs);
+        }
+
+        $writableConnections = array_values(array_filter(
+            $this->connectionConfigs,
+            fn ($config) => ! $config['read_only']
+        ));
+
+        if (empty($writableConnections)) {
+            throw new RuntimeException('No writable Redis connections available in failover.');
+        }
+
+        return $this->attemptOnConnections($method, $parameters, $writableConnections);
+    }
+
+    /**
+     * Attempt the command on each connection in order.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @param  array<int, array{name: string, read_only: bool}>  $configs
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    protected function attemptOnConnections(string $method, array $parameters, array $configs)
+    {
+        $lastException = null;
+
+        foreach ($configs as $config) {
+            try {
+                return $this->resolveConnection($config['name'])->command($method, $parameters);
+            } catch (Throwable $e) {
+                $lastException = $e;
+            }
+        }
+
+        throw $lastException ?? new RuntimeException('All failover Redis connections failed.');
+    }
+
+    /**
+     * Resolve a connection by name (lazy).
+     *
+     * @param  string  $name
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    protected function resolveConnection(string $name): Connection
+    {
+        if (! isset($this->connections[$name])) {
+            $this->connections[$name] = $this->manager->connection($name);
+        }
+
+        return $this->connections[$name];
+    }
+
+    /**
+     * Get the writable connection names.
+     *
+     * @return array<int, string>
+     */
+    public function getWritableConnections(): array
+    {
+        return array_map(
+            fn ($config) => $config['name'],
+            array_filter($this->connectionConfigs, fn ($config) => ! $config['read_only'])
+        );
+    }
+
+    /**
+     * Get all connection names.
+     *
+     * @return array<int, string>
+     */
+    public function getConnections(): array
+    {
+        return array_map(fn ($config) => $config['name'], $this->connectionConfigs);
+    }
+
+    /**
+     * Subscribe to a set of given channels for messages.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $method
+     * @return void
+     */
+    public function createSubscription($channels, Closure $callback, $method = 'subscribe')
+    {
+        // Use first connection for subscriptions
+        $this->resolveConnection($this->connectionConfigs[0]['name'])
+            ->createSubscription($channels, $callback, $method);
+    }
+
+    /**
+     * Get the underlying Redis client (first connection).
+     *
+     * @return mixed
+     */
+    public function client()
+    {
+        return $this->resolveConnection($this->connectionConfigs[0]['name'])->client();
+    }
+}

--- a/tests/Redis/FailoverConnectionTest.php
+++ b/tests/Redis/FailoverConnectionTest.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connections\FailoverConnection;
+use Illuminate\Redis\RedisManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class FailoverConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    public function testReadCommandTriesAllConnectionsInOrder()
+    {
+        $primary = m::mock(Connection::class);
+        $fallback = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+        $manager->shouldReceive('connection')
+            ->with('fallback')->andReturn($fallback);
+
+        $primary->shouldReceive('command')
+            ->once()->with('get', ['foo'])->andThrow(new RuntimeException('Connection refused'));
+        $fallback->shouldReceive('command')
+            ->once()->with('get', ['foo'])->andReturn('fallback-value');
+
+        $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+        $this->assertSame('fallback-value', $connection->command('get', ['foo']));
+    }
+
+    public function testReadCommandUsesPrimaryWhenPrimarySucceeds()
+    {
+        $primary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+
+        $primary->shouldReceive('command')
+            ->once()->with('get', ['foo'])->andReturn('primary-value');
+
+        $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+        $this->assertSame('primary-value', $connection->command('get', ['foo']));
+    }
+
+    public function testWriteCommandSkipsReadOnlyConnections()
+    {
+        $primary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+        // fallback should never be resolved for write commands
+
+        $primary->shouldReceive('command')
+            ->once()->with('set', ['foo', 'bar'])->andThrow(new RuntimeException('Connection refused'));
+
+        $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Connection refused');
+
+        $connection->command('set', ['foo', 'bar']);
+    }
+
+    public function testWriteCommandTriesAllWritableConnections()
+    {
+        $primary = m::mock(Connection::class);
+        $secondary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('secondary')->andReturn(['read_only' => false]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+        $manager->shouldReceive('connection')
+            ->with('secondary')->andReturn($secondary);
+
+        $primary->shouldReceive('command')
+            ->once()->with('set', ['foo', 'bar'])->andThrow(new RuntimeException('Connection refused'));
+        $secondary->shouldReceive('command')
+            ->once()->with('set', ['foo', 'bar'])->andReturn(true);
+
+        $connection = new FailoverConnection($manager, ['primary', 'secondary']);
+
+        $this->assertTrue($connection->command('set', ['foo', 'bar']));
+    }
+
+    public function testThrowsExceptionWhenNoWritableConnections()
+    {
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('readonly1')->andReturn(['read_only' => true]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('readonly2')->andReturn(['read_only' => true]);
+
+        $connection = new FailoverConnection($manager, ['readonly1', 'readonly2']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No writable Redis connections available in failover.');
+
+        $connection->command('set', ['foo', 'bar']);
+    }
+
+    public function testThrowsExceptionWhenNoConnectionsConfigured()
+    {
+        $manager = m::mock(RedisManager::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('At least one connection must be specified for failover.');
+
+        new FailoverConnection($manager, []);
+    }
+
+    public function testInlineReadOnlyOverridesConnectionConfig()
+    {
+        $primary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        // secondary has read_only => false in config, but we override to true inline
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('secondary')->andReturn(['read_only' => false]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+
+        $primary->shouldReceive('command')
+            ->once()->with('set', ['foo', 'bar'])->andThrow(new RuntimeException('Connection refused'));
+
+        // Override secondary to be read_only via inline config
+        $connection = new FailoverConnection($manager, [
+            'primary',
+            ['name' => 'secondary', 'read_only' => true],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Connection refused');
+
+        $connection->command('set', ['foo', 'bar']);
+    }
+
+    public function testGetWritableConnectionsReturnsOnlyWritable()
+    {
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('secondary')->andReturn(['read_only' => false]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        $connection = new FailoverConnection($manager, ['primary', 'secondary', 'fallback']);
+
+        $this->assertEquals(['primary', 'secondary'], $connection->getWritableConnections());
+    }
+
+    public function testGetConnectionsReturnsAllConnections()
+    {
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+        $this->assertEquals(['primary', 'fallback'], $connection->getConnections());
+    }
+
+    public function testClientReturnsFirstConnectionClient()
+    {
+        $primary = m::mock(Connection::class);
+        $client = new \stdClass;
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+
+        $manager->shouldReceive('connection')
+            ->with('primary')->andReturn($primary);
+
+        $primary->shouldReceive('client')->andReturn($client);
+
+        $connection = new FailoverConnection($manager, ['primary']);
+
+        $this->assertSame($client, $connection->client());
+    }
+
+    public function testConnectionsAreResolvedLazily()
+    {
+        $primary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('fallback')->andReturn(['read_only' => true]);
+
+        // Only primary should be resolved since it succeeds
+        $manager->shouldReceive('connection')
+            ->once()->with('primary')->andReturn($primary);
+        $manager->shouldNotReceive('connection')->with('fallback');
+
+        $primary->shouldReceive('command')
+            ->once()->with('get', ['foo'])->andReturn('value');
+
+        $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+        $this->assertSame('value', $connection->command('get', ['foo']));
+    }
+
+    public function testConnectionsAreCached()
+    {
+        $primary = m::mock(Connection::class);
+        $manager = m::mock(RedisManager::class);
+
+        $manager->shouldReceive('getConnectionConfig')
+            ->with('primary')->andReturn([]);
+
+        // Should only resolve once even with multiple commands
+        $manager->shouldReceive('connection')
+            ->once()->with('primary')->andReturn($primary);
+
+        $primary->shouldReceive('command')
+            ->twice()->andReturn('value');
+
+        $connection = new FailoverConnection($manager, ['primary']);
+
+        $connection->command('get', ['foo']);
+        $connection->command('get', ['bar']);
+    }
+
+    public function testVariousReadOnlyCommandsUseFailover()
+    {
+        $readOnlyCommands = ['get', 'mget', 'exists', 'ttl', 'llen', 'hget', 'zcard', 'smembers', 'scan'];
+
+        foreach ($readOnlyCommands as $cmd) {
+            $primary = m::mock(Connection::class);
+            $fallback = m::mock(Connection::class);
+            $manager = m::mock(RedisManager::class);
+
+            $manager->shouldReceive('getConnectionConfig')
+                ->with('primary')->andReturn([]);
+            $manager->shouldReceive('getConnectionConfig')
+                ->with('fallback')->andReturn(['read_only' => true]);
+
+            $manager->shouldReceive('connection')
+                ->with('primary')->andReturn($primary);
+            $manager->shouldReceive('connection')
+                ->with('fallback')->andReturn($fallback);
+
+            $primary->shouldReceive('command')
+                ->once()->andThrow(new RuntimeException('fail'));
+            $fallback->shouldReceive('command')
+                ->once()->andReturn('fallback-result');
+
+            $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+            $this->assertSame('fallback-result', $connection->command($cmd, []), "Command {$cmd} should use failover");
+
+            m::close();
+        }
+    }
+
+    public function testVariousWriteCommandsSkipReadOnlyConnections()
+    {
+        $writeCommands = ['set', 'setex', 'del', 'lpush', 'rpush', 'zadd', 'hset', 'incr', 'decr', 'expire'];
+
+        foreach ($writeCommands as $cmd) {
+            $primary = m::mock(Connection::class);
+            $manager = m::mock(RedisManager::class);
+
+            $manager->shouldReceive('getConnectionConfig')
+                ->with('primary')->andReturn([]);
+            $manager->shouldReceive('getConnectionConfig')
+                ->with('fallback')->andReturn(['read_only' => true]);
+
+            $manager->shouldReceive('connection')
+                ->with('primary')->andReturn($primary);
+
+            $primary->shouldReceive('command')
+                ->once()->andThrow(new RuntimeException('fail'));
+
+            $connection = new FailoverConnection($manager, ['primary', 'fallback']);
+
+            try {
+                $connection->command($cmd, []);
+                $this->fail("Command {$cmd} should have thrown exception");
+            } catch (RuntimeException $e) {
+                $this->assertSame('fail', $e->getMessage());
+            }
+
+            m::close();
+        }
+    }
+}

--- a/tests/Redis/RedisManagerFailoverTest.php
+++ b/tests/Redis/RedisManagerFailoverTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connections\FailoverConnection;
+use Illuminate\Redis\RedisManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RedisManagerFailoverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    public function testConnectionReturnsFailoverConnectionWhenConnectionsConfigured()
+    {
+        $app = new Application;
+        $cacheConnection = m::mock(Connection::class);
+        $cacheConnection->shouldReceive('setName')->with('failover')->andReturnSelf();
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->andReturn($cacheConnection);
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+            ],
+            'fallback' => [
+                'host' => '127.0.0.1',
+                'port' => 6380,
+                'database' => 0,
+                'read_only' => true,
+            ],
+            'failover' => [
+                'connections' => ['cache', 'fallback'],
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $connection = $manager->connection('failover');
+
+        $this->assertInstanceOf(FailoverConnection::class, $connection);
+    }
+
+    public function testFailoverConnectionReadsReadOnlyFromConnectionConfig()
+    {
+        $app = new Application;
+        $cacheConnection = m::mock(Connection::class);
+        $cacheConnection->shouldReceive('setName')->andReturnSelf();
+        $cacheConnection->shouldReceive('command')->andThrow(new \RuntimeException('fail'));
+
+        $fallbackConnection = m::mock(Connection::class);
+        $fallbackConnection->shouldReceive('setName')->andReturnSelf();
+        $fallbackConnection->shouldReceive('command')->andReturn('fallback-value');
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->andReturnUsing(function ($config) use ($cacheConnection, $fallbackConnection) {
+            return ($config['database'] ?? null) === 0 ? $fallbackConnection : $cacheConnection;
+        });
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+            ],
+            'fallback' => [
+                'host' => '127.0.0.1',
+                'port' => 6380,
+                'database' => 0,
+                'read_only' => true,
+            ],
+            'failover' => [
+                'connections' => ['cache', 'fallback'],
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $connection = $manager->connection('failover');
+
+        // Read command should try both connections
+        $this->assertSame('fallback-value', $connection->command('get', ['foo']));
+    }
+
+    public function testFailoverConnectionSkipsReadOnlyForWriteCommands()
+    {
+        $app = new Application;
+        $cacheConnection = m::mock(Connection::class);
+        $cacheConnection->shouldReceive('setName')->andReturnSelf();
+        $cacheConnection->shouldReceive('command')->once()->with('set', ['foo', 'bar'])->andThrow(new \RuntimeException('Connection refused'));
+
+        $fallbackConnection = m::mock(Connection::class);
+        // fallback should never receive the write command since it's read_only
+        $fallbackConnection->shouldNotReceive('command');
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->andReturnUsing(function ($config) use ($cacheConnection, $fallbackConnection) {
+            return ($config['database'] ?? null) === 0 ? $fallbackConnection : $cacheConnection;
+        });
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+            ],
+            'fallback' => [
+                'host' => '127.0.0.1',
+                'port' => 6380,
+                'database' => 0,
+                'read_only' => true,
+            ],
+            'failover' => [
+                'connections' => ['cache', 'fallback'],
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $connection = $manager->connection('failover');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Connection refused');
+
+        $connection->command('set', ['foo', 'bar']);
+    }
+
+    public function testParseConnectionConfigurationStripsReadOnlyAndConnections()
+    {
+        $app = new Application;
+        $configPassedToConnector = null;
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->once()->andReturnUsing(function ($config) use (&$configPassedToConnector) {
+            $configPassedToConnector = $config;
+            $connection = m::mock(Connection::class);
+            $connection->shouldReceive('setName')->andReturnSelf();
+            return $connection;
+        });
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+                'read_only' => false,
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $manager->connection('cache');
+
+        $this->assertArrayNotHasKey('read_only', $configPassedToConnector);
+    }
+
+    public function testGetConnectionConfigReturnsConnectionConfiguration()
+    {
+        $app = new Application;
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+                'read_only' => false,
+            ],
+            'fallback' => [
+                'host' => '127.0.0.1',
+                'port' => 6380,
+                'database' => 0,
+                'read_only' => true,
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+
+        $cacheConfig = $manager->getConnectionConfig('cache');
+        $this->assertSame('127.0.0.1', $cacheConfig['host']);
+        $this->assertFalse($cacheConfig['read_only']);
+
+        $fallbackConfig = $manager->getConnectionConfig('fallback');
+        $this->assertTrue($fallbackConfig['read_only']);
+
+        $nonExistentConfig = $manager->getConnectionConfig('nonexistent');
+        $this->assertSame([], $nonExistentConfig);
+    }
+
+    public function testConnectionReturnsRegularConnectionWhenNoConnectionsConfigured()
+    {
+        $app = new Application;
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('setName')->with('cache')->andReturnSelf();
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->once()->andReturn($connection);
+
+        $config = [
+            'options' => [],
+            'cache' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $result = $manager->connection('cache');
+
+        $this->assertSame($connection, $result);
+    }
+
+    public function testFailoverWithMultipleWritableConnections()
+    {
+        $app = new Application;
+        $primaryConnection = m::mock(Connection::class);
+        $primaryConnection->shouldReceive('setName')->andReturnSelf();
+        $primaryConnection->shouldReceive('command')->once()->with('set', ['foo', 'bar'])->andThrow(new \RuntimeException('fail'));
+
+        $secondaryConnection = m::mock(Connection::class);
+        $secondaryConnection->shouldReceive('setName')->andReturnSelf();
+        $secondaryConnection->shouldReceive('command')->once()->with('set', ['foo', 'bar'])->andReturn(true);
+
+        $connector = m::mock(\Illuminate\Contracts\Redis\Connector::class);
+        $connector->shouldReceive('connect')->andReturnUsing(function ($config) use ($primaryConnection, $secondaryConnection) {
+            return ($config['database'] ?? null) === 2 ? $secondaryConnection : $primaryConnection;
+        });
+
+        $config = [
+            'options' => [],
+            'primary' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 1,
+                'read_only' => false,
+            ],
+            'secondary' => [
+                'host' => '127.0.0.1',
+                'port' => 6380,
+                'database' => 2,
+                'read_only' => false,
+            ],
+            'failover' => [
+                'connections' => ['primary', 'secondary'],
+            ],
+        ];
+
+        $manager = new RedisManager($app, 'phpredis', $config);
+        $manager->extend('phpredis', function () use ($connector) {
+            return $connector;
+        });
+
+        $connection = $manager->connection('failover');
+
+        // Write command should try both writable connections
+        $this->assertTrue($connection->command('set', ['foo', 'bar']));
+    }
+}

--- a/tests/Redis/RedisManagerFailoverTest.php
+++ b/tests/Redis/RedisManagerFailoverTest.php
@@ -156,6 +156,7 @@ class RedisManagerFailoverTest extends TestCase
             $configPassedToConnector = $config;
             $connection = m::mock(Connection::class);
             $connection->shouldReceive('setName')->andReturnSelf();
+
             return $connection;
         });
 


### PR DESCRIPTION
This allows for a user to specify a failover connection for their redis cache.
I think the main benefit to an end user would be for High Availability of applications that have a secondary read replica of the cache for connections when the primary fails.
