### PR TITLE
[12.x] Fix: add `|null` for `$name` in `storeAs()`

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -77,7 +77,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk.
      *
      * @param  string  $path
-     * @param  string|array  $name
+     * @param  string|array|null  $name
      * @param  array|string  $options
      * @return string|false
      */

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -77,7 +77,7 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk.
      *
      * @param  string  $path
-     * @param  string|array|null  $name
+     * @param  array|string|null  $name
      * @param  array|string  $options
      * @return string|false
      */


### PR DESCRIPTION
Updated PHPDoc for `storeAs()` to include null in the `$name` parameter type, aligning the documentation with the actual method behavior when `$name` is omitted.