### PR TITLE
[12.x] Adjust freshTimestamp for SQL Server

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -111,7 +111,7 @@ trait HasTimestamps
      */
     public function freshTimestamp()
     {
-        return Date::now();
+        return Date::now()->startOfSecond();
     }
 
     /**


### PR DESCRIPTION
Contrary to other RDBMS, SQL Server stores microseconds in timestamps regardless of the timestamp precision and rounds the timestamp according to the microsecond value. This often leads to "off by one second" timestamps esp. in tests because timestamps stored as "2026-02-04 11:39:54.742" are rounded to "2026-02-04 11:39:55" while the original timestamp in Laravel is still "2026-02-04 11:39:54".

This fix ensures that all timestamps are stored with "000" as microseconds to ensure compatibility with all other RDBMS and to avoid the "off by one" problem in tests. The fix isn't breaking and if microseconds for timestamps are required, they can still be enabled in the booted() method of the model.