### PR TITLE
[12.x] Enum support for Cache::get() with array keys

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -149,7 +149,7 @@ class Repository implements ArrayAccess, CacheContract
         $this->event(new RetrievingManyKeys($this->getName(), $keys));
 
         $values = $this->store->many((new Collection($keys))
-            ->map(fn ($value, $key) => is_string($key) ? $key : $value)
+            ->map(fn ($value, $key) => is_string($key) ? $key : enum_value($value))
             ->values()
             ->all()
         );
@@ -169,7 +169,7 @@ class Repository implements ArrayAccess, CacheContract
         $defaults = [];
 
         foreach ($keys as $key) {
-            $defaults[$key] = $default;
+            $defaults[enum_value($key)] = $default;
         }
 
         return $this->many($defaults);

--- a/tests/Integration/Cache/RepositoryTest.php
+++ b/tests/Integration/Cache/RepositoryTest.php
@@ -287,6 +287,7 @@ class RepositoryTest extends TestCase
         // put / get / has / missing
         $cache->put(TestCacheKey::FOO, 'value');
         $this->assertSame('value', $cache->get(TestCacheKey::FOO));
+        $this->assertSame(['foo' => 'value', 'bar' => null], $cache->get([TestCacheKey::FOO, TestCacheKey::BAR]));
         $this->assertTrue($cache->has(TestCacheKey::FOO));
         $this->assertFalse($cache->missing(TestCacheKey::FOO));
 
@@ -321,6 +322,11 @@ class RepositoryTest extends TestCase
         // flexible / withoutOverlapping
         $this->assertSame('flexible', $cache->flexible(TestCacheKey::FOO, [5, 10], fn () => 'flexible'));
         $this->assertSame('overlapping', $cache->withoutOverlapping(TestCacheKey::FOO, fn () => 'overlapping'));
+
+        // many / getMultiple
+        $cache->clear();
+        $this->assertSame(['foo' => null, 'bar' => null, 'baz' => null], $cache->many([TestCacheKey::FOO, TestCacheKey::BAR, TestCacheKey::BAZ]));
+        $this->assertSame(['foo' => 'default', 'qux' => 'default'], $cache->getMultiple([TestCacheKey::FOO, TestCacheKey::QUX], 'default'));
     }
 }
 


### PR DESCRIPTION
This works:
```php
Cache::get(CacheKey::Users)
```
This doesn't:
```php
Cache::get([CacheKey::Users, CacheKey::Posts]) 
Cache::getMultiple([CacheKey::Users, CacheKey::Posts])
```

Someone on my team  (@MizouziE) tried this and it didn't work, so thought I'd  try a PR.. not sure on your opinion (I know you're sick of these), but felt like it keeps the API consistent, but probably will open a can of worms on array usages...  


If you want me to go through all of the array ones, let me know.. (ie `put` etc also support arrays) but thought i'd try just these for now to get the ball rolling - but totally understand if you don't fancy it!