### PR TITLE
[12.x] Mark Request::get() as deprecated due to Symfony 7.4 deprecation

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -427,11 +427,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * This method belongs to Symfony HttpFoundation and is not usually needed when using Laravel.
      *
-     * Instead, you may use the "input" method.
-     *
      * @param  string  $key
      * @param  mixed  $default
      * @return mixed
+     *
+     * @deprecated since Symfony 7.4, you may use the "input" method instead.
      */
     #[\Override]
     public function get(string $key, mixed $default = null): mixed


### PR DESCRIPTION
### What does this PR do?

Marks `Illuminate\Http\Request::get()` as deprecated to reflect the upstream deprecation in Symfony HttpFoundation 7.4.

Symfony deprecated `Symfony\Component\HttpFoundation\Request::get()` in: https://github.com/symfony/http-foundation/commit/3d9e8f1198684f990fea34d0804940c078b3b4df

Since Laravel's `Illuminate\Http\Request::get()` directly proxies to the parent Symfony method, this change makes the deprecation explicit in Laravel's public API as well and guides developers towards the recommended alternatives.

---

### Why is this change needed?

After upgrading Symfony packages, I started receiving deprecation warnings in production related to `Request::get()`:

```
ErrorException: Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead. in /app/vendor/symfony/deprecation-contracts/function.php:25
```

The `Request::get()` method in Symfony is deprecated because it mixes multiple input sources (route parameters, query string, request body) with implicit precedence rules.  
Laravel already provides clearer and more explicit alternatives such as:

- `$request->input()`
- `$request->query()`
- `$request->post()`
- `$request->route()`

By marking `Request::get()` as deprecated in Laravel, developers are encouraged to migrate away from ambiguous access patterns and adopt Laravel's idiomatic request API.

---

### How does this benefit end users?

- Makes deprecation visible at the Laravel level instead of surfacing only through Symfony internals.
- Helps developers proactively migrate away from `Request::get()` before Symfony removes the method in a future major version.
- Improves code clarity by promoting explicit access to request data sources.
- Reduces future upgrade friction when Symfony 8 is adopted.

---

### Does this break existing functionality?

No.

This change only adds a `@deprecated` PHPDoc annotation.  
The runtime behavior of `Request::get()` remains unchanged.  
No backward compatibility is broken.

---

### Are tests required?

No runtime behavior is changed. This PR only adds documentation-level deprecation, so no additional tests are required.
