### PR TITLE
[12.x] Handle binary data in Js::encode() debug renderer

### DIFF
--- a/src/Illuminate/Support/Js.php
+++ b/src/Illuminate/Support/Js.php
@@ -93,6 +93,8 @@ class Js implements Htmlable, Stringable
     /**
      * Encode the given data as JSON.
      *
+     * Invalid UTF-8 sequences are replaced with � instead of throwing.
+     *
      * @param  mixed  $data
      * @param  int  $flags
      * @param  int  $depth
@@ -110,7 +112,7 @@ class Js implements Htmlable, Stringable
             $data = $data->toArray();
         }
 
-        return json_encode($data, $flags | static::REQUIRED_FLAGS, $depth);
+        return json_encode($data, $flags | static::REQUIRED_FLAGS | JSON_INVALID_UTF8_SUBSTITUTE, $depth);
     }
 
     /**


### PR DESCRIPTION
Add JSON_INVALID_UTF8_SUBSTITUTE flag to prevent JsonException when encoding binary data (e.g., gzipped strings) in debug mode.

Before: Js::encode(gzencode('test')) throws "Malformed UTF-8"
After:  Js::encode(gzencode('test')) encodes with � placeholders

This prevents the debug renderer from masking actual exceptions when query logs or context contain binary data.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
