### PR TITLE
[12.x] Add ArrayObject props to AsEncryptedArrayObject to match AsArrayObject

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -21,7 +21,7 @@ class AsEncryptedArrayObject implements Castable
             public function get($model, $key, $value, $attributes)
             {
                 if (isset($attributes[$key])) {
-                    return new ArrayObject(Json::decode(Crypt::decryptString($attributes[$key])));
+                    return new ArrayObject(Json::decode(Crypt::decryptString($attributes[$key])), ArrayObject::ARRAY_AS_PROPS);
                 }
 
                 return null;


### PR DESCRIPTION
## Why

The `AsArrayObject` cast allows for accessing the array keys as props, but `AsEncryptedArrayObject` does not. I unexpectedly ran into this issue when changing the cast from `AsArrayObject` to `AsEncryptedArrayObject`.

## What

I added `ArrayObject::ARRAY_AS_PROPS` when creating the `ArrayObject` in the `AsEncryptedArrayObject` cast.

```diff
- return new ArrayObject(Json::decode(Crypt::decryptString($attributes[$key])));
+ return new ArrayObject(Json::decode(Crypt::decryptString($attributes[$key])), ArrayObject::ARRAY_AS_PROPS);
```