### PR TITLE
[12.x] Add callback to customize fresh timestamp creation for all models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -21,6 +21,13 @@ trait HasTimestamps
     protected static $ignoreTimestampsOn = [];
 
     /**
+     * The callback that should be used to create fresh timestamps.
+     *
+     * @var (\Closure(): \Illuminate\Support\Carbon)|null
+     */
+    public static $freshTimestampsCallback;
+
+    /**
      * Update the model's update timestamp.
      *
      * @param  string|null  $attribute
@@ -105,12 +112,37 @@ trait HasTimestamps
     }
 
     /**
+     * Set a callback that should be used to create fresh timestamps.
+     *
+     * @param  \Closure(): \Illuminate\Support\Carbon  $callback
+     * @return void
+     */
+    public static function freshTimestampsUsing($callback)
+    {
+        static::$freshTimestampsCallback = $callback;
+    }
+
+    /**
+     * Create fresh timestamps without microseconds.
+     *
+     * @return void
+     */
+    public static function freshTimestampsWithoutMicroseconds()
+    {
+        static::$freshTimestampsCallback = fn () => Date::now()->startOfSecond();
+    }
+
+    /**
      * Get a fresh timestamp for the model.
      *
      * @return \Illuminate\Support\Carbon
      */
     public function freshTimestamp()
     {
+        if (static::$freshTimestampsCallback) {
+            return call_user_func(static::$freshTimestampsCallback);
+        }
+
         return Date::now();
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This is an alternative to PR #58614.

## Why

Like @aimeos pointed out in the PR, sometimes the implementation for creating fresh timestamps needs to be changed. While this can be accomplished by overriding the `freshTimestamp` method for a specific model, you might need to change the behavior for all models, in the case with storing timestamp values into a SQL Server database.

This PR adds a `Model::freshTimestampsUsing($callback);` method to accomplish this. It also adds a `Model::freshTimestampsWithoutMicroseconds();` method to simply change the fresh timestamp logic to `Date::now()->startOfSecond()`, like @aimeos originally had in their PR. 

## What

Added the following to `HasTimestamps` trait to allow for a custom fresh timestamps callback:
```php
/**
 * The callback that should be used to create fresh timestamps.
 *
 * @var (\Closure(): \Illuminate\Support\Carbon)|null
 */
public static $freshTimestampsCallback;


/**
 * Set a callback that should be used to create fresh timestamps.
 *
 * @param  \Closure(): \Illuminate\Support\Carbon  $callback
 * @return void
 */
public static function freshTimestampsUsing($callback)
{
    static::$freshTimestampsCallback = $callback;
}

/**
 * Create fresh timestamps without microseconds.
 *
 * @return void
 */
public static function freshTimestampsWithoutMicroseconds()
{
    static::$freshTimestampsCallback = fn () => Date::now()->startOfSecond();
}
```
And updated `freshTimestamp` to use the callback:
```php
/**
 * Get a fresh timestamp for the model.
 *
 * @return \Illuminate\Support\Carbon
 */
public function freshTimestamp()
{
    if (static::$freshTimestampsCallback) {
        return call_user_func(static::$freshTimestampsCallback);
    }

    return Date::now();
}
```

## Tests
Still working on tests, would appreciate tips as I don't write tests often.