### PR TITLE
Remove type hint in favor of return type

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -617,7 +617,6 @@ if (! function_exists('now')) {
      * Create a new Carbon instance for the current time.
      *
      * @param  \DateTimeZone|\UnitEnum|string|null  $tz
-     * @return \Illuminate\Support\Carbon
      */
     function now($tz = null): CarbonInterface
     {


### PR DESCRIPTION
This removes the type hint in `@return` in favor of the typed return to avoid issues with the type hinting in IDEs and code editors