### PR TITLE
[12.x] Refactor: improve doc block

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -920,7 +920,7 @@ trait HasRelationships
      *
      * @param  string  $related
      * @param  \Illuminate\Database\Eloquent\Model|null  $instance
-     * @return string
+     * @return lowercase-string
      */
     public function joiningTable($related, $instance = null)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -11,7 +11,7 @@ trait HasUlids
     /**
      * Generate a new unique key for the model.
      *
-     * @return string
+     * @return lowercase-string
      */
     public function newUniqueId()
     {


### PR DESCRIPTION
Updated the PHPDoc return type from `string` to `lowercase-string` to better reflect the actual behavior of the method, since the returned table name is always normalized to lowercase. This improves static analysis accuracy and documentation clarity without changing runtime behavior.