### PR TITLE
[12.x] Fix typo in type definition

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -7,10 +7,10 @@ use Illuminate\Support\Fluent;
 /**
  * @method ForeignKeyDefinition deferrable(bool $value = true) Set the foreign key as deferrable (PostgreSQL)
  * @method ForeignKeyDefinition initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
- * @method ForeignKeyDefinition lock('none'|'shared'|'default'|'exclusive' $value) Specify the DDL lock mode for the foreign key operation (MySQL)
+ * @method ForeignKeyDefinition lock(('none'|'shared'|'default'|'exclusive') $value) Specify the DDL lock mode for the foreign key operation (MySQL)
  * @method ForeignKeyDefinition on(string $table) Specify the referenced table
- * @method ForeignKeyDefinition onDelete('cascade'|'restrict|'set null'|'no action' $action) Add an ON DELETE action
- * @method ForeignKeyDefinition onUpdate('cascade'|'restrict|'set null'|'no action' $action) Add an ON UPDATE action
+ * @method ForeignKeyDefinition onDelete(('cascade'|'restrict'|'set null'|'no action') $action) Add an ON DELETE action
+ * @method ForeignKeyDefinition onUpdate(('cascade'|'restrict'|'set null'|'no action') $action) Add an ON UPDATE action
  * @method ForeignKeyDefinition references(string|string[] $columns) Specify the referenced column(s)
  */
 class ForeignKeyDefinition extends Fluent

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Fluent;
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
- * @method $this lock('none'|'shared'|'default'|'exclusive' $value) Specify the DDL lock mode for the index operation (MySQL)
+ * @method $this lock(('none'|'shared'|'default'|'exclusive') $value) Specify the DDL lock mode for the index operation (MySQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
  */

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Fluent;
  * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
  * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
- * @method $this lock(('none'|'shared'|'default'|'exclusive' $value) Specify the DDL lock mode for the index operation (MySQL)
+ * @method $this lock('none'|'shared'|'default'|'exclusive' $value) Specify the DDL lock mode for the index operation (MySQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
  */


### PR DESCRIPTION
Turns out, `@method` type annotations are a little more fragile than others.

Fixes #58561 (https://github.com/laravel/framework/pull/58561#issuecomment-3849508155)

Thanks to @rforced for reporting this 👍🏻 