### PR TITLE
[12.x] Prevent dupe locale checks in `Lang::get()` when locale matches fallback

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -456,7 +456,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locales = array_filter([$locale ?: $this->locale, $this->fallback]);
 
-        return call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+        $determined = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+
+        return array_values(array_unique($determined));
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -456,7 +456,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locales = array_filter([$locale ?: $this->locale, $this->fallback]);
 
-        $determined = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+        $determined  = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+
+        dd($determined);
 
         return array_values(array_unique($determined));
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -456,9 +456,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $locales = array_filter([$locale ?: $this->locale, $this->fallback]);
 
-        $determined  = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
-
-        dd($determined);
+        $determined = call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
 
         return array_values(array_unique($determined));
     }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -113,6 +113,17 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
+    public function testGetDoesNotCallGetLineTwiceForMissingKeyWhenLocaleMatchesFallback()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['getLine'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->setFallback('en');
+        $t->getLoader()->shouldReceive('load')->with('en', '*', '*')->andReturn([]);
+
+        $t->expects($this->once())->method('getLine')->with('*', 'messages', 'en', 'test', [])->willReturn(null);
+
+        $t->get('messages.test', [], 'en');
+    }
+
     public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/58597

Essentially if you used the same locale in `Lang::get()`, as the fallback, it would cause the same locale to be checked twice.

```php
// Set the fallback... could be in our service provider
Lang::setFallback('en')


// Elsewhere we call...
Lang::get(key: 'header', locale: 'en') // same as our fallback  - IRL this could be $user->locale


// Internally.. localeArray returns
array:2 [
  0 => "en"
  1 => "en"
]
```

[Internally here](https://github.com/laravel/framework/blob/682289608091a45d455347a680de4387808dd657/src/Illuminate/Translation/Translator.php#L171), because the fallback matches the set locale, it causes the `localeArray` method to return `['en,'en'] - meaning the same locale gets checked 2* for the same key.

I've added array_values to re-index the array so there should be no B/C.

I've added a test - but you can remove it if its' a bit OTT, was just to prove it works.

TLDR is tiny efficiency boost / bug fix?

We must SHIP

Thanks!
