### PR TITLE
[12.x] Add BatchCancelled Event

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -4,6 +4,8 @@ namespace Illuminate\Bus;
 
 use Carbon\CarbonImmutable;
 use Closure;
+use Illuminate\Bus\Events\BatchCancelled;
+use Illuminate\Bus\Events\BatchDeleted;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -421,6 +423,12 @@ class Batch implements Arrayable, JsonSerializable
     public function cancel()
     {
         $this->repository->cancel($this->id);
+
+        $container = Container::getInstance();
+
+        if ($container->bound(Dispatcher::class)) {
+            $container->make(Dispatcher::class)->dispatch(new BatchCancelled($this));
+        }
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -5,7 +5,6 @@ namespace Illuminate\Bus;
 use Carbon\CarbonImmutable;
 use Closure;
 use Illuminate\Bus\Events\BatchCancelled;
-use Illuminate\Bus\Events\BatchDeleted;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -4,7 +4,7 @@ namespace Illuminate\Bus;
 
 use Carbon\CarbonImmutable;
 use Closure;
-use Illuminate\Bus\Events\BatchCancelled;
+use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -104,19 +104,6 @@ class Batch implements Arrayable, JsonSerializable
 
     /**
      * Create a new batch instance.
-     *
-     * @param  \Illuminate\Contracts\Queue\Factory  $queue
-     * @param  \Illuminate\Bus\BatchRepository  $repository
-     * @param  string  $id
-     * @param  string  $name
-     * @param  int  $totalJobs
-     * @param  int  $pendingJobs
-     * @param  int  $failedJobs
-     * @param  array  $failedJobIds
-     * @param  array  $options
-     * @param  \Carbon\CarbonImmutable  $createdAt
-     * @param  \Carbon\CarbonImmutable|null  $cancelledAt
-     * @param  \Carbon\CarbonImmutable|null  $finishedAt
      */
     public function __construct(
         QueueFactory $queue,
@@ -203,7 +190,6 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Prepare a chain that exists within the jobs being added.
      *
-     * @param  array  $chain
      * @return \Illuminate\Support\Collection
      */
     protected function prepareBatchedChain(array $chain)
@@ -238,7 +224,6 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Record that a job within the batch finished successfully, executing any callbacks if necessary.
      *
-     * @param  string  $jobId
      * @return void
      */
     public function recordSuccessfulJob(string $jobId)
@@ -271,7 +256,6 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Decrement the pending jobs for the batch.
      *
-     * @param  string  $jobId
      * @return \Illuminate\Bus\UpdatedBatchJobCounts
      */
     public function decrementPendingJobs(string $jobId)
@@ -344,7 +328,6 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Record that a job within the batch failed to finish successfully, executing any callbacks if necessary.
      *
-     * @param  string  $jobId
      * @param  \Throwable  $e
      * @return void
      */
@@ -378,7 +361,6 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Increment the failed jobs for the batch.
      *
-     * @param  string  $jobId
      * @return \Illuminate\Bus\UpdatedBatchJobCounts
      */
     public function incrementFailedJobs(string $jobId)
@@ -426,7 +408,7 @@ class Batch implements Arrayable, JsonSerializable
         $container = Container::getInstance();
 
         if ($container->bound(Dispatcher::class)) {
-            $container->make(Dispatcher::class)->dispatch(new BatchCancelled($this));
+            $container->make(Dispatcher::class)->dispatch(new BatchCanceled($this));
         }
     }
 
@@ -464,8 +446,6 @@ class Batch implements Arrayable, JsonSerializable
      * Invoke a batch callback handler.
      *
      * @param  callable  $handler
-     * @param  \Illuminate\Bus\Batch  $batch
-     * @param  \Throwable|null  $e
      * @return void
      */
     protected function invokeHandlerCallback($handler, Batch $batch, ?Throwable $e = null)
@@ -503,8 +483,6 @@ class Batch implements Arrayable, JsonSerializable
 
     /**
      * Get the JSON serializable representation of the object.
-     *
-     * @return array
      */
     public function jsonSerialize(): array
     {

--- a/src/Illuminate/Bus/Events/BatchCanceled.php
+++ b/src/Illuminate/Bus/Events/BatchCanceled.php
@@ -4,7 +4,7 @@ namespace Illuminate\Bus\Events;
 
 use Illuminate\Bus\Batch;
 
-class BatchCancelled
+class BatchCanceled
 {
     /**
      * Create a new event instance.

--- a/src/Illuminate/Bus/Events/BatchCancelled.php
+++ b/src/Illuminate/Bus/Events/BatchCancelled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Bus\Events;
+
+use Illuminate\Bus\Batch;
+
+class BatchCancelled
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Bus\Batch  $batch  The batch instance.
+     */
+    public function __construct(
+        public Batch $batch,
+    ) {
+    }
+}

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -8,7 +8,7 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchFactory;
 use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\Dispatcher;
-use Illuminate\Bus\Events\BatchCancelled;
+use Illuminate\Bus\Events\BatchCanceled;
 use Illuminate\Bus\Events\BatchFinished;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
@@ -107,8 +107,6 @@ class BusBatchTest extends TestCase
 
     /**
      * Tear down the database schema.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -141,8 +139,7 @@ class BusBatchTest extends TestCase
             use Batchable;
         };
 
-        $thirdJob = function () {
-        };
+        $thirdJob = function () {};
 
         $queue->shouldReceive('connection')->once()
             ->with('test-connection')
@@ -467,7 +464,7 @@ class BusBatchTest extends TestCase
         $batch = $this->createTestBatch($queue);
 
         $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) use ($batch) {
-            return $event instanceof BatchCancelled && $event->batch->id === $batch->id;
+            return $event instanceof BatchCanceled && $event->batch->id === $batch->id;
         }));
 
         $batch->cancel();
@@ -570,16 +567,13 @@ class BusBatchTest extends TestCase
         {
             use Batchable;
 
-            public function handle()
-            {
-            }
+            public function handle() {}
         };
 
         Bus::chain([
             Bus::batch([$TestBatchJob])->name('Batch 1'),
             Bus::batch([$TestBatchJob])->name('Batch 2'),
-            function () {
-            },
+            function () {},
         ])->dispatch();
 
         $this->assertTrue(true);
@@ -705,15 +699,15 @@ class BusBatchTest extends TestCase
 
 class ChainHeadJob implements ShouldQueue
 {
-    use Dispatchable, Queueable, Batchable;
+    use Batchable, Dispatchable, Queueable;
 }
 
 class SecondTestJob implements ShouldQueue
 {
-    use Dispatchable, Queueable, Batchable;
+    use Batchable, Dispatchable, Queueable;
 }
 
 class ThirdTestJob implements ShouldQueue
 {
-    use Dispatchable, Queueable, Batchable;
+    use Batchable, Dispatchable, Queueable;
 }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -469,6 +469,8 @@ class BusBatchTest extends TestCase
         }));
 
         $batch->cancel();
+
+        Container::setInstance(null);
     }
 
     public function test_batch_can_be_deleted()

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -116,6 +116,8 @@ class BusBatchTest extends TestCase
             Facade::setFacadeApplication(null);
         }
 
+        Container::setInstance(null);
+
         unset($_SERVER['__finally.batch'], $_SERVER['__progress.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');
@@ -469,8 +471,6 @@ class BusBatchTest extends TestCase
         }));
 
         $batch->cancel();
-
-        Container::setInstance(null);
     }
 
     public function test_batch_can_be_deleted()


### PR DESCRIPTION
Currently there's no way to globally monitor batch cancellations - you'd need to add a catch callback to every batch individually. 

This is particularly important because batches are automatically cancelled when a job fails (unless allowFailures is enabled) - this will also trigger when calling `cancel()` manually. 

I haven't done a Delete event as that's mainly on cleanup, though I did toy with the idea..


🫡