### PR TITLE
[13.x] Remove override attribute on removed method

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -215,7 +215,6 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  \Symfony\Component\Console\Command\Command  $command
      * @return \Symfony\Component\Console\Command\Command|null
      */
-    #[\Override]
     public function add(SymfonyCommand $command): ?SymfonyCommand
     {
         return $this->addCommand($command);


### PR DESCRIPTION
`add()` method no longer available on Symfony 8 and is there only for Symfony 7.4 compatibility.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
