### PR TITLE
Refactor: cache string and array lengths before iteration

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1555,7 +1555,9 @@ class Grammar extends BaseGrammar
 
         $isStringLiteral = false;
 
-        for ($i = 0; $i < strlen($sql); $i++) {
+        $sqlLength = strlen($sql);
+
+        for ($i = 0; $i < $sqlLength; $i++) {
             $char = $sql[$i];
             $nextChar = $sql[$i + 1] ?? null;
 

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -268,8 +268,10 @@ class RouteUrlGenerator
             }
         }
 
+        $lengthParameter = count($namedParameters);
+
         // Starting from the offset, match any passed parameters from left to right...
-        for ($i = $offset; $i < count($namedParameters); $i++) {
+        for ($i = $offset; $i < $lengthParameter; $i++) {
             $key = array_keys($namedParameters)[$i];
 
             if ($namedParameters[$key] !== '') {


### PR DESCRIPTION
**What changed**

This PR replaces repeated strlen() and count() calls inside loop conditions with cached local variables.

Specifically:

- Cache SQL string length before iterating during raw SQL binding substitution 
- Cache named parameter count before iterating during parameter matching

Why

Calling strlen() / count() inside loop conditions recalculates the same value on every iteration.
While the performance impact is small, caching these values:

- Improves readability and intent
- Avoids unnecessary repeated function calls
- Matches common Laravel and PHP core optimization patterns

Behavior impact

- No behavioral changes
- No API changes
- No backward compatibility impact

Logic and output remain identical.

Risk assessment

- Low risk
- Limited to internal iteration mechanics
- Covered by existing query binding behavior