### PR TITLE
[12.x] Fix Str::substrReplace for edge cases with negative offset or length

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1757,7 +1757,7 @@ class Str
 
         return mb_substr($string, 0, $offset)
             .$replace
-            .mb_substr($string, $offset + $length);
+            .mb_substr(mb_substr($string, $offset), $length);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1277,6 +1277,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));
         $this->assertSame('The Laravel Framework', Str::substrReplace('The Framework', 'Laravel ', 4, 0));
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
+        // test edge cases with negative offset or length
+        $this->assertSame('1567', Str::substrReplace('1234', '567', -3, 3));
+        $this->assertSame('125674', Str::substrReplace('1234', '567', 2, -1));
+        $this->assertSame('125674', Str::substrReplace('1234', '567', -2, -1));
     }
 
     public function testSubstrReplaceWithMultibyte()


### PR DESCRIPTION


New multibyte implementation doesn't return the right result string in all cases with negative offset or length.

For example in tinker:

    use Illuminate\Support\Str;
    Str::substrReplace('1234', '567', 2, -1)
    = "12567234"
    Str::substrReplace('1234', '567', -2, -1)
    = "12567234"
    Str::substrReplace('1234', '567', -3, 3)
    = "15671234"

should be (based on old implementation)

    substr_replace('1234', '567', 2, -1)
    = "125674"
    substr_replace('1234', '567', -2, -1)
    = "125674"
    substr_replace('1234', '567', -3, 3)
    = "1567"

This can be fixed to replace the last part of function substrReplace with a two step mb_substr, so positive and negatice offset or length combinations are handled as intended.
