### PR TITLE
[12.x] chore: add deprecation to Request::get()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -432,6 +432,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  string  $key
      * @param  mixed  $default
      * @return mixed
+     * @deprecated use ->input(), ->request->get(), or ->query->get() instead
      */
     #[\Override]
     public function get(string $key, mixed $default = null): mixed

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -432,7 +432,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  string  $key
      * @param  mixed  $default
      * @return mixed
-     * @deprecated use ->input(), ->request->get(), or ->query->get() instead
+     *
+     * @deprecated use ->input() instead
      */
     #[\Override]
     public function get(string $key, mixed $default = null): mixed


### PR DESCRIPTION
The parent method is deprecated, but it doesn't show up in the IDE because the child method is not marked as deprecated.

Thanks!