### PR TITLE
[12.x] Update `reload` tasks to include `schedule:interruption`

### DIFF
--- a/src/Illuminate/Foundation/Console/ReloadCommand.php
+++ b/src/Illuminate/Foundation/Console/ReloadCommand.php
@@ -52,7 +52,7 @@ class ReloadCommand extends Command
     }
 
     /**
-     * Get the commands that should be run to clear the "optimization" files.
+     * Get the commands that should be reloaded.
      *
      * @return array
      */
@@ -60,6 +60,7 @@ class ReloadCommand extends Command
     {
         return [
             'queue' => 'queue:restart',
+            'schedule' => 'schedule:interrupt',
             ...ServiceProvider::$reloadCommands,
         ];
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add `schedule:interrupt` to the default tasks of the `reload` artisan command implemented in #57923.

In the comments of that PR [it was suggested](https://github.com/laravel/framework/pull/57923#issuecomment-3606481252) to include this as well.

Also updated the comment, which seems to have been copied from the `optimize:clear` command.