### PR TITLE
docs: add missing description to FilesystemAdapter::report() docblock

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -1053,6 +1053,8 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Report the exception.
+     *
      * @param  Throwable  $exception
      * @return void
      *


### PR DESCRIPTION
Adds a missing method description to the `FilesystemAdapter::report()` protected method's docblock to align with Laravel's PHPDoc standards and improve code documentation.

**Before:**
```php
/**
 * @param  Throwable  $exception
 * @return void
 *
 * @throws Throwable
 */
protected function report($exception)
```

**After:**
```php
/**
 * Report the exception.
 *
 * @param  Throwable  $exception
 * @return void
 *
 * @throws Throwable
 */
protected function report($exception)
```

This is a documentation-only change with no impact on functionality.