### PR TITLE
[12.x] Pin symfony/string to ^7.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "symfony/polyfill-php85": "^1.33",
         "symfony/process": "^7.2.0",
         "symfony/routing": "^7.2.0",
+        "symfony/string": "^7.2.0",
         "symfony/uid": "^7.2.0",
         "symfony/var-dumper": "^7.2.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.5",


### PR DESCRIPTION
Upgrading `psy/psysh` to v0.12.19 ([CVE-2026-25129](https://advisories.gitlab.com/pkg/composer/psy/psysh/CVE-2026-25129/)) (often from Dependabot) directly fails as Composer resolves `symfony/string` to v8.0, breaking bootstrap (`Call to a member function make() on null`).

`symfony/console` v7.4 widened its `symfony/string` constraint to `^7.2|^8.0`, and since the framework doesn't directly require it, there's nothing stopping the drift. This forces developers to manually pin `symfony/string` in their own `composer.json` before they can apply the security fix.

Consistent with the 14 other Symfony packages already pinned to `^7.2.0`. Symfony 8 is supported in Laravel 13 per #58629.
