### PR TITLE
[12.x] Add Support for Batch Closures

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -4,6 +4,7 @@ namespace Illuminate\Bus;
 
 use Closure;
 use Illuminate\Bus\Events\BatchDispatched;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Arr;
@@ -360,12 +361,20 @@ class PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Bus\Batch|null
      *
      * @throws \Throwable
      */
     public function dispatch()
     {
+        $dispatcher = $this->container->make(BusDispatcher::class);
+
+        if ($dispatcher instanceof Dispatcher && $dispatcher->isCapturingBatch()) {
+            $dispatcher->addToCapturedBatch($this);
+
+            return null;
+        }
+
         $repository = $this->container->make(BatchRepository::class);
 
         try {

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -70,8 +70,7 @@ class BusPendingBatchTest extends TestCase
 
         $container = new Container;
 
-        $job = new class
-        {
+        $job = new class {
         };
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
@@ -235,8 +234,7 @@ class BusPendingBatchTest extends TestCase
 
     public function test_it_throws_exception_if_batched_job_is_not_batchable(): void
     {
-        $nonBatchableJob = new class
-        {
+        $nonBatchableJob = new class {
         };
 
         $this->expectException(RuntimeException::class);
@@ -252,8 +250,7 @@ class BusPendingBatchTest extends TestCase
         new PendingBatch(
             $container,
             new Collection(
-                [new PendingBatch($container, new Collection([new BatchableJob, new class
-                {
+                [new PendingBatch($container, new Collection([new BatchableJob, new class {
                 }]))]
             )
         );

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -7,7 +7,8 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -20,10 +21,13 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $busDispatcher = m::mock(BusDispatcher::class);
+        $container->instance(BusDispatcher::class, $busDispatcher);
+
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldReceive('dispatch')->once();
 
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -66,7 +70,8 @@ class BusPendingBatchTest extends TestCase
 
         $container = new Container;
 
-        $job = new class {
+        $job = new class
+        {
         };
 
         $pendingBatch = new PendingBatch($container, new Collection([$job]));
@@ -92,9 +97,12 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $busDispatcher = m::mock(BusDispatcher::class);
+        $container->instance(BusDispatcher::class, $busDispatcher);
+
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldReceive('dispatch')->once();
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -118,9 +126,9 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldNotReceive('dispatch');
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -141,9 +149,12 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $busDispatcher = m::mock(BusDispatcher::class);
+        $container->instance(BusDispatcher::class, $busDispatcher);
+
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldReceive('dispatch')->once();
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -167,9 +178,9 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldNotReceive('dispatch');
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -190,10 +201,13 @@ class BusPendingBatchTest extends TestCase
     {
         $container = new Container;
 
-        $eventDispatcher = m::mock(Dispatcher::class);
+        $busDispatcher = m::mock(BusDispatcher::class);
+        $container->instance(BusDispatcher::class, $busDispatcher);
+
+        $eventDispatcher = m::mock(EventDispatcher::class);
         $eventDispatcher->shouldReceive('dispatch')->once();
 
-        $container->instance(Dispatcher::class, $eventDispatcher);
+        $container->instance(EventDispatcher::class, $eventDispatcher);
 
         $job = new class
         {
@@ -221,7 +235,8 @@ class BusPendingBatchTest extends TestCase
 
     public function test_it_throws_exception_if_batched_job_is_not_batchable(): void
     {
-        $nonBatchableJob = new class {
+        $nonBatchableJob = new class
+        {
         };
 
         $this->expectException(RuntimeException::class);
@@ -237,7 +252,8 @@ class BusPendingBatchTest extends TestCase
         new PendingBatch(
             $container,
             new Collection(
-                [new PendingBatch($container, new Collection([new BatchableJob, new class {
+                [new PendingBatch($container, new Collection([new BatchableJob, new class
+                {
                 }]))]
             )
         );

--- a/tests/Integration/Queue/BatchClosureTest.php
+++ b/tests/Integration/Queue/BatchClosureTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class BatchClosureTest extends QueueTestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        $this->afterApplicationCreated(function () {
+            BatchClosureJobRecorder::reset();
+        });
+
+        parent::setUp();
+    }
+
+    public function testBatchWithClosureAndThenCallback()
+    {
+        Bus::batch(function () {
+            Bus::dispatch(new BatchClosureTestJob('job1'));
+            Bus::dispatch(new BatchClosureTestJob('job2'));
+        })->then(function () {
+            BatchClosureJobRecorder::record('then');
+        })->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertEquals(['job1', 'job2', 'then'], BatchClosureJobRecorder::$results);
+    }
+
+    public function testNestedBatchWithClosureAndThenCallbacks()
+    {
+        Bus::batch(function () {
+            Bus::dispatch(new BatchClosureTestJob('outer'));
+
+            Bus::batch(function () {
+                Bus::dispatch(new BatchClosureTestJob('inner'));
+            })->then(function () {
+                BatchClosureJobRecorder::record('inner-then');
+            })->dispatch();
+        })->then(function () {
+            BatchClosureJobRecorder::record('outer-then');
+        })->dispatch();
+
+        $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
+
+        $this->assertEquals(['outer', 'inner', 'inner-then', 'outer-then'], BatchClosureJobRecorder::$results);
+    }
+}
+
+class BatchClosureTestJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(public string $value)
+    {
+    }
+
+    public function handle()
+    {
+        BatchClosureJobRecorder::record($this->value);
+    }
+}
+
+class BatchClosureJobRecorder
+{
+    public static $results = [];
+
+    public static function record(string $id)
+    {
+        self::$results[] = $id;
+    }
+
+    public static function reset()
+    {
+        self::$results = [];
+    }
+}

--- a/tests/Integration/Queue/BatchClosureTest.php
+++ b/tests/Integration/Queue/BatchClosureTest.php
@@ -68,18 +68,13 @@ class BatchClosureTest extends QueueTestCase
             BatchClosureJobRecorder::record('then');
         })->dispatch();
 
-        // The non-queueable job should have already executed synchronously
-        $this->assertContains('sync', BatchClosureJobRecorder::$results);
-
         $this->runQueueWorkerCommand(['--stop-when-empty' => true]);
 
-        // Final order: sync runs immediately, then queued job, then the then callback
         $this->assertEquals(['sync', 'queued', 'then'], BatchClosureJobRecorder::$results);
     }
 
     public function testExceptionInClosureRestoresCapturingState()
     {
-        /** @var \Illuminate\Bus\Dispatcher $dispatcher */
         $dispatcher = $this->app->make(\Illuminate\Bus\Dispatcher::class);
 
         $this->assertFalse($dispatcher->isCapturingBatch());
@@ -88,13 +83,10 @@ class BatchClosureTest extends QueueTestCase
             Bus::batch(function () {
                 throw new \RuntimeException('Test exception');
             })->dispatch();
-
-            $this->fail('Expected exception was not thrown');
-        } catch (\RuntimeException $e) {
-            $this->assertEquals('Test exception', $e->getMessage());
+        } catch (\RuntimeException) {
+            //
         }
 
-        // State should be restored after exception
         $this->assertFalse($dispatcher->isCapturingBatch());
     }
 }


### PR DESCRIPTION
Adds support for defining batch jobs using a closure syntax, so any dispatches or even nested batches are wrapped:

```php
Bus::batch(function () {
    dispatch(new ProcessPodcast($podcast));
    dispatch(new ProcessPodcast($podcast));

    Bus::batch(function () {
        dispatch(new ProcessPodcast($podcast));
        dispatch(new ProcessPodcast($podcast));
    })->then(() => 'nice')->dispatch();
})->then(() => 'nice')->dispatch();
```

Non-queueable jobs dispatched within the closure execute immediately and are not added to the batch.

This can be useful to group job dispatches per job, command or per request across the app... Opens a lot of fun possibilities.

PS: If this ones gets accepted i can create another PR for the Docs later on.