### PR TITLE
Added timeout method to query builder for MySQL

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -220,6 +220,13 @@ class Builder implements BuilderContract
     public $lock;
 
     /**
+     * The query execution timeout in seconds.
+     *
+     * @var int|null
+     */
+    public $timeout;
+
+    /**
      * The callbacks that should be invoked before the query is executed.
      *
      * @var array
@@ -3205,6 +3212,25 @@ class Builder implements BuilderContract
     public function sharedLock()
     {
         return $this->lock(false);
+    }
+
+    /**
+     * Set a query execution timeout in seconds.
+     *
+     * @param  int|null  $seconds
+     * @return $this
+     *
+     * @throws InvalidArgumentException
+     */
+    public function timeout(?int $seconds): static
+    {
+        if ($seconds !== null && $seconds <= 0) {
+            throw new InvalidArgumentException('Timeout must be greater than zero.');
+        }
+
+        $this->timeout = $seconds;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -18,6 +18,32 @@ class MySqlGrammar extends Grammar
     protected $operators = ['sounds like'];
 
     /**
+     * Compile a select query into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileSelect(Builder $query)
+    {
+        $sql = parent::compileSelect($query);
+
+        if ($query->timeout === null) {
+            return $sql;
+        }
+
+        $milliseconds = $query->timeout * 1000;
+
+        $sql = preg_replace(
+            '/^select\b/i',
+            'select /*+ MAX_EXECUTION_TIME('.$milliseconds.') */',
+            $sql,
+            1
+        );
+
+        return $sql;
+    }
+
+    /**
      * Compile a "where like" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -547,31 +573,5 @@ class MySqlGrammar extends Grammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_extract('.$field.$path.')';
-    }
-
-    /**
-     * Compile a select query into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    public function compileSelect(Builder $query)
-    {
-        $sql = parent::compileSelect($query);
-
-        if ($query->timeout === null) {
-            return $sql;
-        }
-
-        $milliseconds = $query->timeout * 1000;
-
-        $sql = preg_replace(
-            '/^select\b/i',
-            'select /*+ MAX_EXECUTION_TIME('.$milliseconds.') */',
-            $sql,
-            1
-        );
-
-        return $sql;
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -548,4 +548,30 @@ class MySqlGrammar extends Grammar
 
         return 'json_extract('.$field.$path.')';
     }
+
+    /**
+     * Compile a select query into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileSelect(Builder $query)
+    {
+        $sql = parent::compileSelect($query);
+
+        if ($query->timeout === null) {
+            return $sql;
+        }
+
+        $milliseconds = $query->timeout * 1000;
+
+        $sql = preg_replace(
+            '/^select\b/i',
+            'select /*+ MAX_EXECUTION_TIME('.$milliseconds.') */',
+            $sql,
+            1
+        );
+
+        return $sql;
+    }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -3,7 +3,10 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Processors\Processor;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +24,62 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
         );
 
         $this->assertSame('select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
+    }
+
+    public function testTimeout()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'like', '%test%')->timeout(60);
+        $this->assertSame(
+            'select /*+ MAX_EXECUTION_TIME(60000) */ * from `users` where `email` like ?',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutWithDistinct()
+    {
+        $builder = $this->getBuilder();
+        $builder->distinct()->select('*')->from('users')->timeout(30);
+        $this->assertSame(
+            'select /*+ MAX_EXECUTION_TIME(30000) */ distinct * from `users`',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutWithAggregate()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->timeout(10);
+        $builder->aggregate = ['function' => 'count', 'columns' => ['*']];
+        $this->assertSame(
+            'select /*+ MAX_EXECUTION_TIME(10000) */ count(*) as aggregate from `users`',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutNullRemovesTimeout()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->timeout(60)->timeout(null);
+        $this->assertSame('select * from `users`', $builder->toSql());
+    }
+
+    public function testTimeoutThrowsExceptionForNegativeValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->timeout(-1);
+    }
+
+    protected function getBuilder()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $grammar = new MySqlGrammar($connection);
+        $processor = m::mock(Processor::class);
+
+        return new Builder($connection, $grammar, $processor);
     }
 }


### PR DESCRIPTION
## Summary

Add a `timeout(int $seconds)` method to the query builder that sets a per-query execution timeout for MySQL via the `MAX_EXECUTION_TIME` optimiser hint.

## Problem

When a long-running **select query** exceeds an external timeout (e.g., nginx, a load balancer, or PHP's `max_execution_time`), the HTTP connection is terminated and the end user receives a timeout error. However, the query itself continues executing on the MySQL server. Since no client is waiting for the result, this needlessly consumes database resources — CPU, memory, and potentially locks.

## Solution

A new `timeout()` method on the query builder allows setting a per-query execution timeout in seconds. 

**Usage:**
```php
Student::query()->where('email', 'like', '%text%')->timeout(60)->get();
```

```sql
select /*+ MAX_EXECUTION_TIME(60000) */ * from `users` where `email` like ?
```

We could probably go as far as setting this as default model behaviour for non-console queries.
I don't see a reason as to why allow **select queries** to run longer than an external timeout.

```php 
class TimeoutScope implements Scope
{
    public function apply(Builder $builder, Model $model)
    {
        $builder->timeout(60); // Or whatever the external timeout is
    }
}

class User extends Model
{
    protected static function booted(): void
    {
        if (! app()->runningInConsole()) {
            static::addGlobalScope(new TimeoutScope);
        }
    }
}
```

## Additional thoughts

It's debatable on current approach to just inject the `MAX_EXECUTION_TIME` after the base query builder already compiled the select, but my arguments are:
- A single point of change
- Adding additional select building layers in the base query would create a somewhat big maintenance burden for very little gain
- If we would want this feature for other databases some of them handle timeouts differently. For example - `PostgreSQL` doesn't modifying the select query at all but rather sets a variable `SET statement_timeout = 1000;` and then selecting thus making the implementation yet again different thus in turn make the previously mentioned potential approach even less appealing (from my perspective)
  - As for `PostgreSQL` implementation altogether I think it could work but it feels like it would be a bit more complex than the MySQL approach. I think it would need some teardown statements to reset the timeout and also feels like it would be hard to ensure that the statement timeout doesn't accidentally bleed into other queries, but possible nevertheless. Would probably leave dabbling into that for another day. 
  
 `MariaDB` should also support this.
