### PR TITLE
Scoped Method (allow temporal configuration overrides)

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -217,6 +217,35 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Execute a callback with temporarily modified configuration values.
+     *
+     * @template TReturn
+     *
+     * @param  array<string, mixed>  $values
+     * @param  (callable(): TReturn)  $callback
+     * @return TReturn
+     *
+     * @throws \Throwable
+     */
+    public function scoped(array $values, callable $callback)
+    {
+        $original = [];
+
+        foreach ($values as $key => $value) {
+            $original[$key] = $this->get($key);
+            $this->set($key, $value);
+        }
+
+        try {
+            return $callback();
+        } finally {
+            foreach ($original as $key => $value) {
+                $this->set($key, $value);
+            }
+        }
+    }
+
+    /**
      * Prepend a value onto an array configuration value.
      *
      * @param  string  $key


### PR DESCRIPTION
Add `scoped()` method to temporarily modify configuration values for the duration of a callback.

## Example

```php
use Illuminate\Support\Facades\Config;
use Laravel\Ai\Image;

$image = Config::scoped([
    'ai.gemini.key' => $team->encrypted_gemini_key,
], function () {
    return Image::of('A donut sitting on the kitchen counter')->generate();
});
```

## Implementation

- Temporarily sets config values within callback scope
- Automatically restores original values after (even on exception)
- Supports dot notation for nested keys
- Returns callback result with proper type inference
