### PR TITLE
Update regex for trans_choice to allow negative ranges

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -58,7 +58,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        preg_match('/^[\{\[]([\d,\.*]*)[\}\]](.*)/s', $part, $matches);
+        preg_match('/^[\{\[]([-?\d|*,\.*]*)[\}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
             return null;
@@ -92,7 +92,7 @@ class MessageSelector
     private function stripConditions($segments)
     {
         return (new Collection($segments))
-            ->map(fn ($part) => preg_replace('/^[\{\[][\d,\.*]*[\}\]]/', '', $part))
+            ->map(fn ($part) => preg_replace('/^[\{\[][-?\d|*,\.*]*[\}\]]/', '', $part))
             ->all();
     }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -58,6 +58,13 @@ class TranslationMessageSelectorTest extends TestCase
             ['second', '{0}first|[1,3]second|[4,*]third', 1],
             ['third', '{0}first|[1,3]second|[4,*]third', 9],
 
+            ['first', '[*,-1]first|{0}second|[1,*]third', -4],
+            ['first', '[*,-1] first|{0} second|[1,*] third', -4],
+            ['second', '[*,-1]first|{0}second|[1,*]third', 0],
+            ['second', '[*,-1] first|{0} second|[1,*] third', 0],
+            ['third', '[*,-1]first|{0}second|[1,*]third', 9],
+            ['first', '[-5,-1]first|{0}second|[1,*]third', -4],
+
             ['first', 'first|second|third', 1],
             ['second', 'first|second|third', 9],
             ['second', 'first|second|third', 0],


### PR DESCRIPTION
Updating the stricter regex, that was introduced in #58367, to allow for negative ranges (`[-5,-1]`) and for "negative infinite" ranges (`[*,-1]`).

The current regex only allows positive numbers at the first position in the range.
This updates allow negative numbers and `*` as well.

Fixes: #58446
