### PR TITLE
[12.x] Allow Stringable::deduplicate() to accept array of characters

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -249,12 +249,12 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     /**
      * Replace consecutive instances of a given character with a single character.
      *
-     * @param  string  $character
+     * @param  array<string>|string  $characters
      * @return static
      */
-    public function deduplicate(string $character = ' ')
+    public function deduplicate(array|string $characters = ' ')
     {
-        return new static(Str::deduplicate($this->value, $character));
+        return new static(Str::deduplicate($this->value, $characters));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -248,6 +248,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('what', (string) $this->stringable('whaaat')->deduplicate('a'));
         $this->assertSame('/some/odd/path/', (string) $this->stringable('/some//odd//path/')->deduplicate('/'));
         $this->assertSame('ムだム', (string) $this->stringable('ムだだム')->deduplicate('だ'));
+        $this->assertSame(' laravel forever ', (string) $this->stringable(' laravell    foreverrr  ')->deduplicate([' ', 'l', 'r']));
     }
 
     public function testDirname()


### PR DESCRIPTION
This PR aligns `Stringable::deduplicate()` with `Str::deduplicate()` by allowing an array of characters to be passed.
before 

before
```php
<?php
// Str supports array - ✅
Str::deduplicate(' laravell    foreverrr  ', [' ', 'l', 'r']); // ' laravel forever '

// Stringable only supports string - ❌
str(' laravell    foreverrr  ')->deduplicate([' ', 'l', 'r']); // TypeError
```

after
```php
<?php
// Both now support array|string
str(' laravell    foreverrr  ')->deduplicate([' ', 'l', 'r']); // ' laravel forever '
```

### Changes
- Updated `Stringable::deduplicate()` signature from `string $character` to `array|string $characters`
- Added test case for array parameter

### Motivation
Currently, `Str::deduplicate()` accepts `array|string` as its second parameter, but the fluent `Stringable` wrapper only accepts a `string`. This inconsistency forces developers to break the fluent chain when they need to deduplicate multiple characters at once.