### PR TITLE
[12.x] Likely want to specify `SESSION_DOMAIN` on Laravel Cloud etc.

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -152,7 +152,7 @@ return [
     |
     | This value determines the domain and subdomains the session cookie is
     | available to. By default, the cookie will be available to the root
-    | domain and all subdomains. Typically, this shouldn't be changed.
+    | domain and all subdomains. Specify in a multi-environment setup.
     |
     */
 


### PR DESCRIPTION
While it's unlikely one environment would recognise the session cookie from another (i.e. associate in Redis or whatever), it's not good practise to allow it, and there's a mechanism to prevent doing do.

I suspect the existing comment pre-dates wider adoption of multi-environment setups, such as Laravel Cloud.

I've taken the time to respect comment line lengths, Big T! 😆
