### PR TITLE
feat: Add PHP 8+ attribute support for console command configuration

### DIFF
--- a/src/Illuminate/Console/Attributes/Alias.php
+++ b/src/Illuminate/Console/Attributes/Alias.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Alias
+{
+    /**
+     * Create a new Alias attribute instance.
+     *
+     * @param  string  $name  The alias name
+     */
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/src/Illuminate/Console/Attributes/Hidden.php
+++ b/src/Illuminate/Console/Attributes/Hidden.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Hidden
+{
+    /**
+     * Create a new Hidden attribute instance.
+     */
+    public function __construct() {}
+}

--- a/src/Illuminate/Console/Attributes/Isolated.php
+++ b/src/Illuminate/Console/Attributes/Isolated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+use Illuminate\Console\Command;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Isolated
+{
+    /**
+     * Create a new Isolated attribute instance.
+     *
+     * @param  int  $exitCode  The exit code when command is already running
+     */
+    public function __construct(
+        public int $exitCode = Command::SUCCESS,
+    ) {}
+}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -14,6 +14,7 @@ use Throwable;
 class Command extends SymfonyCommand
 {
     use Concerns\CallsCommands,
+        Concerns\ConfiguresFromAttributes,
         Concerns\ConfiguresPrompts,
         Concerns\HasParameters,
         Concerns\InteractsWithIO,
@@ -115,7 +116,9 @@ class Command extends SymfonyCommand
             $this->setAliases((array) $this->aliases);
         }
 
+        // Configure using PHP 8+ attributes if no signature is set
         if (! isset($this->signature)) {
+            $this->configureUsingAttributes();
             $this->specifyParameters();
         }
 

--- a/src/Illuminate/Console/Concerns/ConfiguresFromAttributes.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresFromAttributes.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Console\Attributes\Alias;
+use Illuminate\Console\Attributes\Hidden;
+use Illuminate\Console\Attributes\Isolated;
+use ReflectionClass;
+
+trait ConfiguresFromAttributes
+{
+    /**
+     * Configure the command using PHP attributes.
+     *
+     * @return bool Whether attributes were found and used
+     */
+    protected function configureUsingAttributes(): bool
+    {
+        $reflection = new ReflectionClass($this);
+
+        return $this->configureClassAttributes($reflection);
+    }
+
+    /**
+     * Configure class-level attributes (Hidden, Isolated, Alias).
+     *
+     * @param  ReflectionClass  $reflection
+     * @return bool
+     */
+    protected function configureClassAttributes(ReflectionClass $reflection): bool
+    {
+        $hasAttributes = false;
+
+        // Handle Hidden attribute
+        $hiddenAttrs = $reflection->getAttributes(Hidden::class);
+        if (! empty($hiddenAttrs)) {
+            $this->setHidden(true);
+            $hasAttributes = true;
+        }
+
+        // Handle Isolated attribute
+        $isolatedAttrs = $reflection->getAttributes(Isolated::class);
+        if (! empty($isolatedAttrs)) {
+            $isolated = $isolatedAttrs[0]->newInstance();
+            $this->isolated = true;
+            $this->isolatedExitCode = $isolated->exitCode;
+            $hasAttributes = true;
+        }
+
+        // Handle Alias attributes (repeatable)
+        $aliasAttrs = $reflection->getAttributes(Alias::class);
+        if (! empty($aliasAttrs)) {
+            $aliases = [];
+            foreach ($aliasAttrs as $attr) {
+                $alias = $attr->newInstance();
+                $aliases[] = $alias->name;
+            }
+            $this->setAliases($aliases);
+            $hasAttributes = true;
+        }
+
+        return $hasAttributes;
+    }
+}

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Attributes\Alias;
+use Illuminate\Console\Attributes\Hidden;
+use Illuminate\Console\Attributes\Isolated;
+use Illuminate\Console\Command;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+class CommandAttributesTest extends TestCase
+{
+    public function testHiddenAttribute()
+    {
+        $command = new CommandWithHiddenAttribute;
+
+        $this->assertTrue($command->isHidden());
+    }
+
+    public function testIsolatedAttribute()
+    {
+        $command = new CommandWithIsolatedAttribute;
+
+        $reflection = new \ReflectionClass($command);
+        
+        $isolatedProp = $reflection->getProperty('isolated');
+        $this->assertTrue($isolatedProp->getValue($command));
+        
+        $exitCodeProp = $reflection->getProperty('isolatedExitCode');
+        $this->assertSame(Command::FAILURE, $exitCodeProp->getValue($command));
+    }
+
+    public function testAliasAttribute()
+    {
+        $command = new CommandWithAliasAttribute;
+
+        $this->assertContains('cmd:alias1', $command->getAliases());
+        $this->assertContains('cmd:alias2', $command->getAliases());
+    }
+}
+
+// Test Command Classes
+
+#[AsCommand(name: 'test:hidden')]
+#[Hidden]
+class CommandWithHiddenAttribute extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'test:isolated')]
+#[Isolated(exitCode: Command::FAILURE)]
+class CommandWithIsolatedAttribute extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'test:alias')]
+#[Alias('cmd:alias1')]
+#[Alias('cmd:alias2')]
+class CommandWithAliasAttribute extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
# Add PHP 8+ attribute support for console command configuration

This PR introduces native PHP 8+ attributes for configuring Artisan commands, complementing Symfony's `#[AsCommand]` attribute with Laravel-specific functionality.

## New Attributes

| Attribute | Target | Description |
|-----------|--------|-------------|
| `#[Hidden]` | Class | Hide command from the command list |
| `#[Isolated]` | Class | Enable command isolation with optional custom exit code |
| `#[Alias]` | Class | Add command aliases (repeatable) |

## Usage Example

```php
use Illuminate\Console\Attributes\Alias;
use Illuminate\Console\Attributes\Hidden;
use Illuminate\Console\Attributes\Isolated;
use Illuminate\Console\Command;
use Symfony\Component\Console\Attribute\AsCommand;

#[AsCommand(name: 'cache:prime')]
#[Alias('cache:warm')]
#[Alias('cache:preload')]
#[Isolated(exitCode: self::FAILURE)]
class PrimeCacheCommand extends Command
{
    public function handle(): int
    {
        $this->info('Priming cache...');
        
        return self::SUCCESS;
    }
}
```

## Before (property-based)

```php
class PrimeCacheCommand extends Command
{
    protected $signature = 'cache:prime';
    protected $hidden = false;
    protected $isolated = true;
    protected $isolatedExitCode = self::FAILURE;
    protected $aliases = ['cache:warm', 'cache:preload'];
}
```

## After (attribute-based)

```php
#[AsCommand(name: 'cache:prime')]
#[Alias('cache:warm')]
#[Alias('cache:preload')]
#[Isolated(exitCode: self::FAILURE)]
class PrimeCacheCommand extends Command
{
}
```

## Benefits

- **Declarative**: Configuration is visible at the class level alongside `#[AsCommand]`
- **Type-safe**: IDE autocompletion and static analysis support
- **Repeatable**: `#[Alias]` can be used multiple times for clarity
- **Consistent**: Follows the same pattern as Symfony's `#[AsCommand]`
