### PR TITLE
[12.x] Support `afterSending` method on notification

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -177,6 +177,10 @@ class NotificationSender
             throw $exception;
         }
 
+        if (method_exists($notification, 'afterSending')) {
+            $notification->afterSending($notifiable, $channel, $response);
+        }
+
         $this->events->dispatch(
             new NotificationSent($notifiable, $notification, $channel, $response)
         );


### PR DESCRIPTION
When a notification is sent, I sometimes want to do something small, for example, update a single property on the eloquent model used by the notification. Currently, you have to create a dedicated listener that listens for the NotificationSent event.

```php
class BookingNotification extends Notification
{
    public function __construct(
		public Booking $booking;
	) {
	}

	public function via()
	{
		return ['mail'];
	}

	public function toMail()
	{
		// ...
	}
}

class BookingNotificationListener
{
	public function handle(NotificationSent $event)
	{
		if ($event->notification instanceof BookingNotification) {
			$event->notification->booking->update(['notified_at' => now()]);
		}
	}
}
```

That is a lot of code to do something very simple.
This PR improves that by allowing you to implement an `afterSending` method in your notification class. Now you don't need a dedicated listener class anymore. When you look at the notification class, you also now immediately see what happens to the model after sending the notification instead of having to look for a separate class that contains some logic linked to that specific notification.

```php
class BookingNotification extends Notification
{
    public function __construct(
		public Booking $booking;
	) {
	}

	public function via()
	{
		return ['mail'];
	}

	public function toMail()
	{
		// ...
	}

	public function afterSending($notifiable, $channel, $response)
	{
		$this->booking->update(['notified_at' => now()]);
	}
}
```