### PR TITLE
[12.x] Add `whenFails` and `whenPasses` methods on `Validator`

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\ValidatedInput;
 use InvalidArgumentException;
 use RuntimeException;
@@ -514,6 +515,46 @@ class Validator implements ValidatorContract
     public function fails()
     {
         return ! $this->passes();
+    }
+
+    /**
+     * Execute the callback if the data passes the validation rules.
+     *
+     * @template TWhenReturnType
+     *
+     * @param  (callable($this): TWhenReturnType)  $callback
+     * @param  (callable($this): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenPasses(callable $callback, ?callable $default = null)
+    {
+        if ($this->passes()) {
+            return $callback($this) ?? $this;
+        } elseif ($default) {
+            return $default($this) ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the callback if the data fails the validation rules.
+     *
+     * @template TWhenReturnType
+     *
+     * @param  (callable($this): TWhenReturnType)  $callback
+     * @param  (callable($this): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
+     */
+    public function whenFails(callable $callback, ?callable $default = null)
+    {
+        if ($this->fails()) {
+            return $callback($this) ?? $this;
+        } elseif ($default) {
+            return $default($this) ?? $this;
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
-use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\ValidatedInput;
 use InvalidArgumentException;
 use RuntimeException;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10032,6 +10032,66 @@ class ValidationValidatorTest extends TestCase
         ], $validator->messages()->messages());
     }
 
+    public function testWhenFails()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['text' => 'abcdef'], ['text' => 'string|max:5']);
+
+        $result = $v->whenFails(function () {
+            return 'whenFails';
+        });
+
+        $this->assertSame('whenFails', $result);
+
+        $v = new Validator($trans, ['text' => 'abc'], ['text' => 'string|max:5']);
+
+        $result = $v->whenFails(function () {
+            return 'whenFails';
+        });
+
+        $this->assertSame($v, $result);
+
+        $v = new Validator($trans, ['text' => 'abc'], ['text' => 'string|max:5']);
+
+        $result = $v->whenFails(function () {
+            return 'whenFails';
+        }, function () {
+            return 'whenNotFails';
+        });
+
+        $this->assertSame('whenNotFails', $result);
+    }
+
+    public function testWhenPasses()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['text' => 'abc'], ['text' => 'string|max:5']);
+
+        $result = $v->whenPasses(function () {
+            return 'whenPasses';
+        });
+
+        $this->assertSame('whenPasses', $result);
+
+        $v = new Validator($trans, ['text' => 'abcdef'], ['text' => 'string|max:5']);
+
+        $result = $v->whenPasses(function () {
+            return 'whenPasses';
+        });
+
+        $this->assertSame($v, $result);
+
+        $v = new Validator($trans, ['text' => 'abcdef'], ['text' => 'string|max:5']);
+
+        $result = $v->whenPasses(function () {
+            return 'whenPasses';
+        }, function () {
+            return 'whenNotPasses';
+        });
+
+        $this->assertSame('whenNotPasses', $result);
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
This PR introduces `whenFails` and `whenPasses` methods on the `Validator` class so you can fluently react to the validation passing or failing.

This would be useful when you use the validator to validate data outside the request cycle, for example, data that is provided to a constructor or a method on a class.
```php
// Before

public function someMethod($file)
{
	$validator = Validator::make(
		['file' => $file],
		['file' => 'required|image|dimensions:min_width=100,min_height=200']
	);
	
	if ($validator->fails()) {
		throw new InvalidArgumentException('Provided file is invalid');
	}
}
```
```php
// After

public function someMethod($file)
{
	Validator::make(
		['file' => $file],
		['file' => 'required|image|dimensions:min_width=100,min_height=200']
	)->whenFails(function () {
		throw new InvalidArgumentException('Provided file is invalid');
	});
}
```