### PR TITLE
[13.x] `Bus::assertBatched()` with array

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -499,11 +499,13 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Assert if a batch was dispatched based on a truth-test callback.
      *
-     * @param  callable(\Illuminate\Bus\PendingBatch): bool  $callback
+     * @param  callable(\Illuminate\Bus\PendingBatch): bool|array  $callback
      * @return void
      */
-    public function assertBatched(callable $callback)
+    public function assertBatched(callable|array $callback)
     {
+        $callback = is_array($callback) ? fn (PendingBatchFake $batch) => $batch->hasJobs($callback) : $callback;
+
         PHPUnit::assertTrue(
             $this->batched($callback)->count() > 0,
             'The expected batch was not dispatched.'

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -860,6 +860,132 @@ class SupportTestingBusFakeTest extends TestCase
 
         $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
     }
+
+    public function testCanAssertJobsOnPendingBatchFake()
+    {
+        $this->fake->batch([
+            new BusFakeJobWithSerialization('foo'),
+            new BusFakeJobWithSerialization('bar'),
+            new BusFakeJobWithSerialization('baz'),
+        ])->dispatch();
+
+        $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+            return $batchedCollection->hasJobs([
+                new BusFakeJobWithSerialization('foo'),
+                new BusFakeJobWithSerialization('bar'),
+                new BusFakeJobWithSerialization('baz'),
+            ]);
+        });
+
+        $this->fake->assertBatched([
+            new BusFakeJobWithSerialization('foo'),
+            new BusFakeJobWithSerialization('bar'),
+            new BusFakeJobWithSerialization('baz'),
+        ]);
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    new BusFakeJobWithSerialization('baz'),
+                    new BusFakeJobWithSerialization('foo'),
+                    new BusFakeJobWithSerialization('bar'),
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    new BusFakeJobWithSerialization('foo'),
+                    new BusFakeJobWithSerialization('baaar'),
+                    new BusFakeJobWithSerialization('baz'),
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    new BusFakeJobWithSerialization('foo'),
+                    new BusFakeJobWithSerialization('baz'),
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    new BusFakeJobWithSerialization('foo'),
+                    new BusFakeJobWithSerialization('bar'),
+                    new BusFakeJobWithSerialization('baz'),
+                    new BusFakeJobWithSerialization('qux'),
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+    }
+
+    public function testCanAssertJobsOnPendingBatchFakeWithClosures()
+    {
+        $this->fake->batch([
+            new BusFakeJobWithSerialization('foo'),
+            new BusFakeJobWithSerialization('bar'),
+            new BusFakeJobWithSerialization('baz'),
+        ])->dispatch();
+
+        $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+            return $batchedCollection->hasJobs([
+                fn (BusFakeJobWithSerialization $job) => $job->value === 'foo',
+                fn (BusFakeJobWithSerialization $job) => $job->value === 'bar',
+                fn (BusFakeJobWithSerialization $job) => $job->value === 'baz',
+            ]);
+        });
+
+        $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+            return $batchedCollection->hasJobs([
+                fn (BusFakeJobWithSerialization $job) => $job->value === 'foo',
+                BusFakeJobWithSerialization::class,
+                new BusFakeJobWithSerialization('baz'),
+            ]);
+        });
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    fn (BusFakeJobWithSerialization $job) => $job->value === 'foo',
+                    fn (BusFakeJobWithSerialization $job) => $job->value === 'wrong',
+                    fn (BusFakeJobWithSerialization $job) => $job->value === 'baz',
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+
+        try {
+            $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
+                return $batchedCollection->hasJobs([
+                    fn (BusFakeJobWithSerialization $job) => $job->value === 'foo',
+                    fn (BusJobStub $job) => true,
+                    fn (BusFakeJobWithSerialization $job) => $job->value === 'baz',
+                ]);
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('The expected batch was not dispatched.', $e->getMessage());
+        }
+    }
 }
 
 class BusJobStub


### PR DESCRIPTION
A follow-up to https://github.com/laravel/framework/pull/58606 (I re-added the changes of that branch as the master branch does not have those yet)

This PR makes it possible to provide an array to the `assertBatched` method (similar to the `assertChained` method). This will then trigger the use of the `hasJobs` method on the `PendingBatchFake` class that I introduced in https://github.com/laravel/framework/pull/58606.
```php
Bus::assertBatched([
    new FooJob(),
    new BarJob(),
    new BazJob(),
]);
```

I targeted the master branch as I changed a method signature.