### PR TITLE
[12.x] Bus::assertBatched() with array

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -499,7 +499,7 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Assert if a batch was dispatched based on a truth-test callback.
      *
-     * @param  callable(\Illuminate\Bus\PendingBatch): bool|array  $callback
+     * @param  array|callable(\Illuminate\Bus\PendingBatch): bool  $callback
      * @return void
      */
     public function assertBatched(callable|array $callback)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -499,11 +499,13 @@ class BusFake implements Fake, QueueingDispatcher
     /**
      * Assert if a batch was dispatched based on a truth-test callback.
      *
-     * @param  callable(\Illuminate\Bus\PendingBatch): bool  $callback
+     * @param  callable(\Illuminate\Bus\PendingBatch): bool|array  $callback
      * @return void
      */
-    public function assertBatched(callable $callback)
+    public function assertBatched(callable|array $callback)
     {
+        $callback = is_array($callback) ? fn (PendingBatchFake $batch) => $batch->hasJobs($callback) : $callback;
+
         PHPUnit::assertTrue(
             $this->batched($callback)->count() > 0,
             'The expected batch was not dispatched.'

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -865,6 +865,12 @@ class SupportTestingBusFakeTest extends TestCase
             ]);
         });
 
+        $this->fake->assertBatched([
+            new BusFakeJobWithSerialization('foo'),
+            new BusFakeJobWithSerialization('bar'),
+            new BusFakeJobWithSerialization('baz'),
+        ]);
+
         try {
             $this->fake->assertBatched(function (PendingBatchFake $batchedCollection) {
                 return $batchedCollection->hasJobs([


### PR DESCRIPTION
A follow-up to https://github.com/laravel/framework/pull/58606.

This PR makes it possible to provide an array to the `assertBatched` method (similar to the `assertChained` method). This will then trigger the use of the `hasJobs` method on the `PendingBatchFake` class that I introduced in https://github.com/laravel/framework/pull/58606.

```php
Bus::assertBatched([
    new FooJob(),
    new BarJob(),
    new BazJob(),
]);
```