### PR TITLE
[12.x] Add onSuccess / onFailure to ProcessResult

### DIFF
--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -136,6 +136,36 @@ class FakeProcessResult implements ProcessResultContract
     }
 
     /**
+     * Execute the given callback if the process was successful.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onSuccess(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the process failed.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onFailure(callable $callback)
+    {
+        if ($this->failed()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the output contains the given string.
      *
      * @param  string  $output
@@ -203,36 +233,6 @@ class FakeProcessResult implements ProcessResultContract
     {
         if ($condition) {
             return $this->throw($callback);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Execute the given callback if the process was successful.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function onSuccess(callable $callback)
-    {
-        if ($this->successful()) {
-            $callback($this);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Execute the given callback if the process failed.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function onFailure(callable $callback)
-    {
-        if ($this->failed()) {
-            $callback($this);
         }
 
         return $this;

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -214,7 +214,7 @@ class FakeProcessResult implements ProcessResultContract
      * @param  callable  $callback
      * @return $this
      */
-    public function whenSuccessful(callable $callback)
+    public function onSuccess(callable $callback)
     {
         if ($this->successful()) {
             $callback($this);
@@ -229,7 +229,7 @@ class FakeProcessResult implements ProcessResultContract
      * @param  callable  $callback
      * @return $this
      */
-    public function whenFailed(callable $callback)
+    public function onFailure(callable $callback)
     {
         if ($this->failed()) {
             $callback($this);

--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -207,4 +207,34 @@ class FakeProcessResult implements ProcessResultContract
 
         return $this;
     }
+
+    /**
+     * Execute the given callback if the process was successful.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function whenSuccessful(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the process failed.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function whenFailed(callable $callback)
+    {
+        if ($this->failed()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -154,7 +154,7 @@ class ProcessResult implements ProcessResultContract
      * @param  callable  $callback
      * @return $this
      */
-    public function whenSuccessful(callable $callback)
+    public function onSuccess(callable $callback)
     {
         if ($this->successful()) {
             $callback($this);
@@ -169,7 +169,7 @@ class ProcessResult implements ProcessResultContract
      * @param  callable  $callback
      * @return $this
      */
-    public function whenFailed(callable $callback)
+    public function onFailure(callable $callback)
     {
         if ($this->failed()) {
             $callback($this);

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -147,4 +147,34 @@ class ProcessResult implements ProcessResultContract
 
         return $this;
     }
+
+    /**
+     * Execute the given callback if the process was successful.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function whenSuccessful(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the process failed.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function whenFailed(callable $callback)
+    {
+        if ($this->failed()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Process/ProcessResult.php
+++ b/src/Illuminate/Process/ProcessResult.php
@@ -76,6 +76,36 @@ class ProcessResult implements ProcessResultContract
     }
 
     /**
+     * Execute the given callback if the process was successful.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onSuccess(callable $callback)
+    {
+        if ($this->successful()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the process failed.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function onFailure(callable $callback)
+    {
+        if ($this->failed()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the output contains the given string.
      *
      * @param  string  $output
@@ -143,36 +173,6 @@ class ProcessResult implements ProcessResultContract
     {
         if ($condition) {
             return $this->throw($callback);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Execute the given callback if the process was successful.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function onSuccess(callable $callback)
-    {
-        if ($this->successful()) {
-            $callback($this);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Execute the given callback if the process failed.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function onFailure(callable $callback)
-    {
-        if ($this->failed()) {
-            $callback($this);
         }
 
         return $this;

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1084,11 +1084,10 @@ class ProcessTest extends TestCase
     public function testWhenSuccessful()
     {
         $factory = new Factory;
-        $factory->fake();
 
         $executed = false;
 
-        $factory->run('ls -la')->whenSuccessful(function () use (&$executed) {
+        $factory->path(__DIR__)->run($this->ls())->whenSuccessful(function () use (&$executed) {
             $executed = true;
         });
 
@@ -1098,11 +1097,10 @@ class ProcessTest extends TestCase
     public function testWhenFailed()
     {
         $factory = new Factory;
-        $factory->fake(fn () => $factory->result(exitCode: 1));
 
         $executed = false;
 
-        $factory->run('ls -la')->whenFailed(function () use (&$executed) {
+        $factory->run('exit 1')->whenFailed(function () use (&$executed) {
             $executed = true;
         });
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1081,27 +1081,27 @@ class ProcessTest extends TestCase
         }, 2);
     }
 
-    public function testWhenSuccessful()
+    public function testOnSuccess()
     {
         $factory = new Factory;
 
         $executed = false;
 
-        $factory->path(__DIR__)->run($this->ls())->whenSuccessful(function () use (&$executed) {
+        $factory->path(__DIR__)->run($this->ls())->onSuccess(function () use (&$executed) {
             $executed = true;
         });
 
         $this->assertTrue($executed);
     }
 
-    public function testWhenFailed()
+    public function testOnFailure()
     {
         $factory = new Factory;
         $factory->fake(fn () => $factory->result(exitCode: 1));
 
         $executed = false;
 
-        $factory->run('ls -la')->whenFailed(function () use (&$executed) {
+        $factory->run('ls -la')->onFailure(function () use (&$executed) {
             $executed = true;
         });
 

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1081,6 +1081,34 @@ class ProcessTest extends TestCase
         }, 2);
     }
 
+    public function testWhenSuccessful()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $executed = false;
+
+        $factory->run('ls -la')->whenSuccessful(function () use (&$executed) {
+            $executed = true;
+        });
+
+        $this->assertTrue($executed);
+    }
+
+    public function testWhenFailed()
+    {
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(exitCode: 1));
+
+        $executed = false;
+
+        $factory->run('ls -la')->whenFailed(function () use (&$executed) {
+            $executed = true;
+        });
+
+        $this->assertTrue($executed);
+    }
+
     protected function ls()
     {
         return windows_os() ? 'dir' : 'ls';

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -1097,10 +1097,11 @@ class ProcessTest extends TestCase
     public function testWhenFailed()
     {
         $factory = new Factory;
+        $factory->fake(fn () => $factory->result(exitCode: 1));
 
         $executed = false;
 
-        $factory->run('exit 1')->whenFailed(function () use (&$executed) {
+        $factory->run('ls -la')->whenFailed(function () use (&$executed) {
             $executed = true;
         });
 


### PR DESCRIPTION
This adds a fluent way of handling fail / success for the ProcessResult class  thought I'd try the below as a bit of DX:

Imagine currently... we could have multiple of these in a row...

```php
$result = Process::run('npm run build');

if ($result->successful()) {
    Cache::put('last-build', now());
} else {
    Log::error($result->errorOutput());
}
```

Becomes...:

```php
Process::run('npm run build')
    ->onSuccess(fn($result) => Cache::put('last-build', now()))
    ->onFailure(fn($result) => Log::error($result->errorOutput()));
```

 Open to renaming 🫡  -   this follows the same as the Event class
 Thanks!