### PR TITLE
[12.x] Add distinctBy, groupByMany, and joinBy to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -808,7 +808,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $value = $this->valueRetriever($value);
 
-        return $this->map(fn ($item, $key) => $value($item, $key))->join($glue, $finalGlue);
+        return $this->map($value(...))->join($glue, $finalGlue);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -571,7 +571,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  array<array-key, (callable(TValue, TKey): mixed)|string>  $groupBy
      * @param  bool  $preserveKeys
-     * @return static<array-key, static<($preserveKeys is true ? TKey : int), mixed>>
+     * @return ($groupBy is array{} ? never : static<array-key, static<($preserveKeys is true ? TKey : int), mixed>>)
      */
     public function groupByMany(array $groupBy, $preserveKeys = false)
     {

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -528,6 +528,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function groupBy($groupBy, $preserveKeys = false);
 
     /**
+     * Group an associative array by many fields or callbacks.
+     *
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|string>  $groupBy
+     * @param  bool  $preserveKeys
+     * @return static<array-key, static<($preserveKeys is true ? TKey : int), mixed>>
+     */
+    public function groupByMany(array $groupBy, $preserveKeys = false);
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @template TNewKey of array-key
@@ -640,6 +649,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return string
      */
     public function join($glue, $finalGlue = '');
+
+    /**
+     * Join all items from the collection using a string after extracting each value.
+     *
+     * @param  (callable(TValue, TKey): mixed)|string|null  $value
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return string
+     */
+    public function joinBy($value, $glue, $finalGlue = '');
 
     /**
      * Get the keys of the collection items.
@@ -1187,6 +1206,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return static
      */
     public function unique($key = null, $strict = false);
+
+    /**
+     * Return only distinct items from the collection using a key, callback, or key array.
+     *
+     * @param  (callable(TValue, TKey): mixed)|array<array-key, (callable(TValue, TKey): mixed)|string>|string|null  $key
+     * @param  bool  $strict
+     * @return static
+     */
+    public function distinctBy($key = null, $strict = false);
 
     /**
      * Return only unique items from the collection array using strict comparison.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -553,6 +553,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * {@inheritDoc}
+     */
+    #[\Override]
+    public function groupByMany(array $groupBy, $preserveKeys = false)
+    {
+        if ($groupBy === []) {
+            throw new InvalidArgumentException('The groupByMany method expects at least one grouping criterion.');
+        }
+
+        return $this->passthru(__FUNCTION__, func_get_args());
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @template TNewKey of array-key|\UnitEnum
@@ -718,6 +731,15 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public function join($glue, $finalGlue = '')
     {
         return $this->collect()->join(...func_get_args());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    #[\Override]
+    public function joinBy($value, $glue, $finalGlue = '')
+    {
+        return $this->collect()->joinBy(...func_get_args());
     }
 
     /**
@@ -1739,6 +1761,27 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 }
             }
         });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    #[\Override]
+    public function distinctBy($key = null, $strict = false)
+    {
+        if (! is_array($key)) {
+            return $this->unique($key, $strict);
+        }
+
+        if ($key === []) {
+            throw new InvalidArgumentException('The distinctBy method expects at least one key when an array is provided.');
+        }
+
+        $retrievers = array_map(fn ($key) => $this->valueRetriever($key), $key);
+
+        return $this->unique(function ($item, $itemKey) use ($retrievers) {
+            return array_map(fn ($retriever) => $retriever($item, $itemKey), $retrievers);
+        }, $strict);
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR introduces three new collection helpers to improve readability for common data-shaping operations:

- `distinctBy($key, $strict = false)`
- `groupByMany(array $groupBy, $preserveKeys = false)`
- `joinBy($value, $glue, $finalGlue = '')`

## Why
These APIs cover frequent real-world patterns:

- de-duplicating items by one or multiple attributes
- explicit multi-level grouping with clearer intent
- joining structured items by a selected field/callback without extra `map()` boilerplate

## Changes
- Added method contracts to `Illuminate\Support\Enumerable`.
- Implemented all methods in:
  - `Illuminate\Support\Collection`
  - `Illuminate\Support\LazyCollection`
- Added validation:
  - `distinctBy([])` throws `InvalidArgumentException`
  - `groupByMany([])` throws `InvalidArgumentException`
- Added tests in `tests/Support/SupportCollectionTest.php` for both `Collection` and `LazyCollection` (via existing provider).
