### PR TITLE
[13.x] Add `passes()` to Validator contract

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -25,6 +25,13 @@ interface Validator extends MessageProvider
     public function validated();
 
     /**
+     * Determine if the data passes the validation rules.
+     *
+     * @return bool
+     */
+    public function passes();
+
+    /**
      * Determine if the data fails the validation rules.
      *
      * @return bool


### PR DESCRIPTION
Feels like this should be here to me, It's been on the Validator for 13 years?!  ( I would have been 16!?)

Targeted 13.x as contract change. 