### PR TITLE
[MorphTo] Preserve string "0" keys when gathering eager load IDs

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -185,7 +185,9 @@ class MorphTo extends BelongsTo
             ? array_keys($this->dictionary[$type])
             : array_map(function ($modelId) {
                 return (string) $modelId;
-            }, array_filter(array_keys($this->dictionary[$type])));
+            }, array_filter(array_keys($this->dictionary[$type]), static function ($modelId) {
+                return $modelId !== '';
+            }));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class DatabaseEloquentMorphToTest extends TestCase
 {
@@ -66,6 +67,21 @@ class DatabaseEloquentMorphToTest extends TestCase
                 ],
             ],
         ], $dictionary);
+    }
+
+    public function testGatherKeysByTypeKeepsStringZeroForStringKeyTypes()
+    {
+        $relation = $this->getRelation();
+
+        $relation->addEagerConstraints([
+            (object) ['morph_type' => 'morph_type_1', 'foreign_key' => '0'],
+            (object) ['morph_type' => 'morph_type_1', 'foreign_key' => ''],
+        ]);
+
+        $method = new ReflectionMethod(MorphTo::class, 'gatherKeysByType');
+        $method->setAccessible(true);
+
+        $this->assertSame(['0'], $method->invoke($relation, 'morph_type_1', 'string'));
     }
 
     public function testMorphToWithDefault()


### PR DESCRIPTION
`MorphTo::gatherKeysByType()` used `array_filter()` without a callback, which removed falsey values including the valid string key "0" for string key types.

This patch keeps "0" and only filters out empty-string keys, then adds a regression test to cover this behavior.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
