### PR TITLE
`Illuminate\Console\Parser` typehint fix.

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -12,7 +12,7 @@ class Parser
      * Parse the given console command definition into an array.
      *
      * @param  string  $expression
-     * @return array{string, array{}, array{}}|array{string, \Symfony\Component\Console\Input\InputArgument, \Symfony\Component\Console\Input\InputOption}
+     * @return array{string, array{}, array{}}|array{string, \Symfony\Component\Console\Input\InputArgument[], \Symfony\Component\Console\Input\InputOption[]}
      *
      * @throws \InvalidArgumentException
      */
@@ -48,7 +48,7 @@ class Parser
      * Extract all parameters from the tokens.
      *
      * @param  string[]  $tokens
-     * @return array{\Symfony\Component\Console\Input\InputArgument, \Symfony\Component\Console\Input\InputOption}
+     * @return array{\Symfony\Component\Console\Input\InputArgument[], \Symfony\Component\Console\Input\InputOption[]}
      */
     protected static function parameters(array $tokens)
     {


### PR DESCRIPTION
The `Illuminate\Console\Parser::parameters()` actually returns `array{InputArgument[],InputOption[]}`

https://github.com/laravel/framework/blob/715f402610ffbd358b96e8d5f14b651b6dc084ac/src/Illuminate/Console/Parser.php#L53-L68

Related to #58565; @shaedrich 

