### PR TITLE
[12.x] Add withoutHeader() method to Response

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -101,7 +101,7 @@ trait ResponseTrait
     /**
      * Remove a header or headers from the response.
      *
-     * @param  string|array  $key
+     * @param  array|string  $key
      * @return $this
      */
     public function withoutHeader($key)

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -99,6 +99,21 @@ trait ResponseTrait
     }
 
     /**
+     * Remove a header or headers from the response.
+     *
+     * @param  string|array  $key
+     * @return $this
+     */
+    public function withoutHeader($key)
+    {
+        foreach ((array) $key as $header) {
+            $this->headers->remove($header);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a cookie to the response.
      *
      * @param  \Symfony\Component\HttpFoundation\Cookie|mixed  $cookie

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -208,6 +208,26 @@ class HttpResponseTest extends TestCase
         $this->assertSame('TATA', $response->headers->get('titi'));
     }
 
+    public function testWithoutHeader()
+    {
+        $response = new Response(null, 200, ['foo' => 'bar', 'baz' => 'qux', 'zal' => 'ter']);
+        $this->assertSame('bar', $response->headers->get('foo'));
+        $this->assertSame('qux', $response->headers->get('baz'));
+        $this->assertSame('ter', $response->headers->get('zal'));
+
+        // Test removing single header
+        $result = $response->withoutHeader('foo');
+        $this->assertSame($response, $result);
+        $this->assertNull($response->headers->get('foo'));
+        $this->assertSame('qux', $response->headers->get('baz'));
+        $this->assertSame('ter', $response->headers->get('zal'));
+
+        // Test removing multiple headers at once
+        $response->withoutHeader(['baz', 'zal']);
+        $this->assertNull($response->headers->get('baz'));
+        $this->assertNull($response->headers->get('zal'));
+    }
+
     public function testMagicCall()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
## Description

This PR adds a `withoutHeader()` method to `ResponseTrait`, allowing removal of headers from HTTP responses.

Laravel provides `withHeaders()` to add multiple headers and `header()` to set individual headers, but there's no fluent method to remove headers. Similarly, cookies have both `withCookie()` and `withoutCookie()` for symmetry. This addition completes the header manipulation API.

## Use Cases

- Removing sensitive headers (e.g., `X-Debug-Token`) before production responses
- Stripping headers set by middleware for specific routes
- Removing default server headers (`X-Powered-By`, `Server`)
- Testing scenarios where header absence needs verification

## Usage

```php
// Remove a single header
return response($content)->withoutHeader('X-Debug');

// Remove multiple headers
return response($content)->withoutHeader(['X-Debug', 'X-Powered-By', 'Server']);
