### PR TITLE
[Relations] Add pivot LIKE helpers to BelongsToMany relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -89,6 +89,13 @@ class BelongsToMany extends Relation
     protected $pivotWheres = [];
 
     /**
+     * Any pivot table restrictions for whereLike clauses.
+     *
+     * @var array
+     */
+    protected $pivotWhereLikes = [];
+
+    /**
      * Any pivot table restrictions for whereIn clauses.
      *
      * @var array
@@ -461,6 +468,63 @@ class BelongsToMany extends Relation
     public function orWherePivot($column, $operator = null, $value = null)
     {
         return $this->wherePivot($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function wherePivotLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        $this->pivotWhereLikes[] = func_get_args();
+
+        return $this->whereLike($this->qualifyPivotColumn($column), $value, $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add an "or where like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWherePivotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->wherePivotLike($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function wherePivotNotLike($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->wherePivotLike($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWherePivotNotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->wherePivotNotLike($column, $value, $caseSensitive, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -582,6 +582,10 @@ trait InteractsWithPivotTable
             $query->where(...$arguments);
         }
 
+        foreach ($this->pivotWhereLikes as $arguments) {
+            $query->whereLike(...$arguments);
+        }
+
         foreach ($this->pivotWhereIns as $arguments) {
             $query->whereIn(...$arguments);
         }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -87,6 +87,12 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $builder->shouldReceive('whereIn')->with($column, [$value], 'and', false)->once()->andReturnSelf();
         $relation->wherePivotIn($column, [$value]);
 
+        $builder->shouldReceive('whereLike')->with($column, $value, false, 'and', false)->once()->andReturnSelf();
+        $relation->wherePivotLike($column, $value);
+
+        $builder->shouldReceive('whereLike')->with($column, $value, false, 'and', true)->once()->andReturnSelf();
+        $relation->wherePivotNotLike($column, $value);
+
         $builder->shouldReceive('whereNull')->with($column, 'and', false)->once()->andReturnSelf();
         $relation->wherePivotNull($column);
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1130,6 +1130,94 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 
+    public function testWherePivotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'ba%')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag2->id, $tag3->id]);
+    }
+
+    public function testOrWherePivotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'fo%')->orWherePivotLike('flag', 'ba%')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag1->id, $tag2->id, $tag3->id]);
+    }
+
+    public function testWherePivotNotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTag = $post->tags()->wherePivotNotLike('flag', 'ba%')->first();
+
+        $this->assertEquals($tag1->id, $relationTag->id);
+    }
+
+    public function testOrWherePivotNotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'ba%')->orWherePivotNotLike('flag', '%z')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag1->id, $tag2->id, $tag3->id]);
+    }
+
     public function testWherePivotInMethod()
     {
         $tag = Tag::create(['name' => Str::random()])->fresh();


### PR DESCRIPTION
This PR adds `LIKE`-based pivot query helpers to `BelongsToMany` / `MorphToMany` relations:

- `wherePivotLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)`
- `orWherePivotLike($column, $value, $caseSensitive = false)`
- `wherePivotNotLike($column, $value, $caseSensitive = false, $boolean = 'and')`
- `orWherePivotNotLike($column, $value, $caseSensitive = false)`

Pivot filtering currently supports `wherePivot`, `wherePivotIn`, `wherePivotNull`, etc., but not `LIKE` matching.
This fills that API gap and aligns relation pivot filtering with query builder capabilities.

- Added a dedicated `$pivotWhereLikes` constraint store in `BelongsToMany`.
- Added the four public pivot-like helpers in `BelongsToMany`.
- Updated `InteractsWithPivotTable::newPivotQuery()` to replay stored `whereLike` pivot constraints on pivot queries, consistent with existing pivot where/in/null behavior.