### PR TITLE
Feature/view render each iterable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -89,6 +89,13 @@ class BelongsToMany extends Relation
     protected $pivotWheres = [];
 
     /**
+     * Any pivot table restrictions for whereLike clauses.
+     *
+     * @var array
+     */
+    protected $pivotWhereLikes = [];
+
+    /**
      * Any pivot table restrictions for whereIn clauses.
      *
      * @var array
@@ -461,6 +468,63 @@ class BelongsToMany extends Relation
     public function orWherePivot($column, $operator = null, $value = null)
     {
         return $this->wherePivot($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function wherePivotLike($column, $value, $caseSensitive = false, $boolean = 'and', $not = false)
+    {
+        $this->pivotWhereLikes[] = func_get_args();
+
+        return $this->whereLike($this->qualifyPivotColumn($column), $value, $caseSensitive, $boolean, $not);
+    }
+
+    /**
+     * Add an "or where like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWherePivotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->wherePivotLike($column, $value, $caseSensitive, 'or');
+    }
+
+    /**
+     * Add a "where not like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function wherePivotNotLike($column, $value, $caseSensitive = false, $boolean = 'and')
+    {
+        return $this->wherePivotLike($column, $value, $caseSensitive, $boolean, true);
+    }
+
+    /**
+     * Add an "or where not like" clause for a pivot table column.
+     *
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $value
+     * @param  bool  $caseSensitive
+     * @return $this
+     */
+    public function orWherePivotNotLike($column, $value, $caseSensitive = false)
+    {
+        return $this->wherePivotNotLike($column, $value, $caseSensitive, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -582,6 +582,10 @@ trait InteractsWithPivotTable
             $query->where(...$arguments);
         }
 
+        foreach ($this->pivotWhereLikes as $arguments) {
+            $query->whereLike(...$arguments);
+        }
+
         foreach ($this->pivotWhereIns as $arguments) {
             $query->whereIn(...$arguments);
         }

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -8,7 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\View\View first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
  * @method static string renderWhen(bool $condition, string $view, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
  * @method static string renderUnless(bool $condition, string $view, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
- * @method static string renderEach(string $view, array $data, string $iterator, string $empty = 'raw|')
+ * @method static string renderEach(string $view, iterable $data, string $iterator, string $empty = 'raw|')
  * @method static bool exists(string $view)
  * @method static \Illuminate\Contracts\View\Engine getEngineFromPath(string $path)
  * @method static mixed share(array|string $key, mixed $value = null)

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -220,7 +220,7 @@ class Factory implements FactoryContract
      * Get the rendered contents of a partial from a loop.
      *
      * @param  string  $view
-     * @param  array  $data
+     * @param  iterable  $data
      * @param  string  $iterator
      * @param  string  $empty
      * @return string
@@ -228,22 +228,22 @@ class Factory implements FactoryContract
     public function renderEach($view, $data, $iterator, $empty = 'raw|')
     {
         $result = '';
+        $hasData = false;
 
-        // If is actually data in the array, we will loop through the data and append
-        // an instance of the partial view to the final result HTML passing in the
-        // iterated value of this data array, allowing the views to access them.
-        if (count($data) > 0) {
-            foreach ($data as $key => $value) {
-                $result .= $this->make(
-                    $view, ['key' => $key, $iterator => $value]
-                )->render();
-            }
+        // We will loop through the data and append an instance of the partial view
+        // to the final result HTML, allowing views to consume any iterable source.
+        foreach ($data as $key => $value) {
+            $hasData = true;
+
+            $result .= $this->make(
+                $view, ['key' => $key, $iterator => $value]
+            )->render();
         }
 
         // If there is no data in the array, we will render the contents of the empty
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.
-        else {
+        if (! $hasData) {
             $result = str_starts_with($empty, 'raw|')
                 ? substr($empty, 4)
                 : $this->make($empty)->render();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -87,6 +87,12 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $builder->shouldReceive('whereIn')->with($column, [$value], 'and', false)->once()->andReturnSelf();
         $relation->wherePivotIn($column, [$value]);
 
+        $builder->shouldReceive('whereLike')->with($column, $value, false, 'and', false)->once()->andReturnSelf();
+        $relation->wherePivotLike($column, $value);
+
+        $builder->shouldReceive('whereLike')->with($column, $value, false, 'and', true)->once()->andReturnSelf();
+        $relation->wherePivotNotLike($column, $value);
+
         $builder->shouldReceive('whereNull')->with($column, 'and', false)->once()->andReturnSelf();
         $relation->wherePivotNull($column);
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1130,6 +1130,94 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 
+    public function testWherePivotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'ba%')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag2->id, $tag3->id]);
+    }
+
+    public function testOrWherePivotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'fo%')->orWherePivotLike('flag', 'ba%')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag1->id, $tag2->id, $tag3->id]);
+    }
+
+    public function testWherePivotNotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTag = $post->tags()->wherePivotNotLike('flag', 'ba%')->first();
+
+        $this->assertEquals($tag1->id, $relationTag->id);
+    }
+
+    public function testOrWherePivotNotLikeMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'bar'],
+        ]);
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'baz'],
+        ]);
+
+        $relationTags = $post->tags()->wherePivotLike('flag', 'ba%')->orWherePivotNotLike('flag', '%z')->get();
+
+        $this->assertEquals($relationTags->pluck('id')->toArray(), [$tag1->id, $tag2->id, $tag3->id]);
+    }
+
     public function testWherePivotInMethod()
     {
         $tag = Tag::create(['name' => Str::random()])->fresh();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -117,6 +117,19 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('daylerees', $result);
     }
 
+    public function testRenderEachCreatesViewForEachItemInIterable()
+    {
+        $factory = m::mock(Factory::class.'[make]', $this->getFactoryArgs());
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'bar', 'value' => 'baz'])->andReturn($mockView1 = m::mock(stdClass::class));
+        $factory->shouldReceive('make')->once()->with('foo', ['key' => 'breeze', 'value' => 'boom'])->andReturn($mockView2 = m::mock(stdClass::class));
+        $mockView1->shouldReceive('render')->once()->andReturn('dayle');
+        $mockView2->shouldReceive('render')->once()->andReturn('rees');
+
+        $result = $factory->renderEach('foo', LazyCollection::make(['bar' => 'baz', 'breeze' => 'boom']), 'value');
+
+        $this->assertSame('daylerees', $result);
+    }
+
     public function testEmptyViewsCanBeReturnedFromRenderEach()
     {
         $factory = m::mock(Factory::class.'[make]', $this->getFactoryArgs());
@@ -129,6 +142,19 @@ class ViewFactoryTest extends TestCase
     public function testRawStringsMayBeReturnedFromRenderEach()
     {
         $this->assertSame('foo', $this->getFactory()->renderEach('foo', [], 'item', 'raw|foo'));
+    }
+
+    public function testEmptyViewsCanBeReturnedFromRenderEachIterable()
+    {
+        $factory = m::mock(Factory::class.'[make]', $this->getFactoryArgs());
+        $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock(stdClass::class));
+        $mockView->shouldReceive('render')->once()->andReturn('empty');
+
+        $this->assertSame('empty', $factory->renderEach('view', (function () {
+            if (false) {
+                yield;
+            }
+        })(), 'iterator', 'foo'));
     }
 
     public function testEnvironmentAddsExtensionWithCustomResolver()


### PR DESCRIPTION
This PR updates `View::renderEach()` to accept any `iterable` instead of only arrays.

`renderEach()` currently uses `count($data)`, which does not work for generators and other traversables.
Supporting `iterable` allows using lazy data sources (e.g. `LazyCollection`, generators) directly in view rendering.


## Example

Before:
```php
$users = User::query()->cursor(); // Traversable
echo view()->renderEach('users.row', $users, 'user'); // could fail due to count()
```

After: 
```php
$users = User::query()->cursor(); // Traversable / LazyCollection
echo view()->renderEach('users.row', $users, 'user'); // works
```

Also works with generators:
```php
$rows = (function () {
    yield ['name' => 'Taylor'];
    yield ['name' => 'Abigail'];
})();

echo view()->renderEach('users.row', $rows, 'user');
```
