### PR TITLE
[12.x] Feat: add optional key prefix support to `Collection` flattening

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1808,11 +1808,12 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
+     * @param  string  $prepend
      * @return static
      */
-    public function dot()
+    public function dot($prepend = '')
     {
-        return new static(Arr::dot($this->all()));
+        return new static(Arr::dot($this->all(), $prepend));
     }
 
     /**


### PR DESCRIPTION
This PR extends the dot method on `collections` by adding support for an optional `$prepend` parameter.

The new parameter allows callers to prefix generated keys when flattening nested arrays, making it easier to compose or merge dotted keys in more complex scenarios.

The existing behavior remains unchanged when no prefix is provided, ensuring full backward compatibility.