### PR TITLE
[12.x] Add decrementOrCreate to Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -763,7 +763,6 @@ class Builder implements BuilderContract
         });
     }
 
-
     /**
      * Create a record matching the attributes, or decrement the existing record.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -763,6 +763,26 @@ class Builder implements BuilderContract
         });
     }
 
+
+    /**
+     * Create a record matching the attributes, or decrement the existing record.
+     *
+     * @param  array  $attributes
+     * @param  string  $column
+     * @param  int|float  $default
+     * @param  int|float  $step
+     * @param  array  $extra
+     * @return TModel
+     */
+    public function decrementOrCreate(array $attributes, string $column = 'count', $default = 1, $step = 1, array $extra = [])
+    {
+        return tap($this->firstOrCreate($attributes, [$column => $default]), function ($instance) use ($column, $step, $extra) {
+            if (! $instance->wasRecentlyCreated) {
+                $instance->decrement($column, $step, $extra);
+            }
+        });
+    }
+
     /**
      * Execute the query and get the first result or throw an exception.
      *

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -490,7 +490,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $model->getConnection()
             ->expects('select')
-            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
             ->andReturn([[
                 'id' => 123,
                 'attr' => 'foo',
@@ -532,7 +532,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $model->getConnection()
             ->expects('select')
-            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
             ->andReturn([]);
 
         $model->getConnection()->expects('insert')->with(
@@ -560,7 +560,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $model->getConnection()
             ->expects('select')
-            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
             ->andReturn([[
                 'id' => 123,
                 'attr' => 'foo',
@@ -604,7 +604,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $model->getConnection()
             ->expects('select')
-            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true, [])
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], true)
             ->andReturn([]);
 
         $sql = 'insert into "table" ("attr", "count", "updated_at", "created_at") values (?, ?, ?, ?)';
@@ -617,7 +617,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
 
         $model->getConnection()
             ->expects('select')
-            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], false, [])
+            ->with('select * from "table" where ("attr" = ?) limit 1', ['foo'], false)
             ->andReturn([[
                 'id' => 123,
                 'attr' => 'foo',


### PR DESCRIPTION
This lets us do the below - and is the opposite of incrementOrCreate so felt like a worthy PR

Useful for rate limiting, quota management, inventory tracking etc..

```php
ApiUsage::query()->decrementOrCreate(
    ['user_id' => $user->id, 'date' => today()],
    'remaining',
    1000
);
```
Grouped it with incrementOrCreate