### PR TITLE
[12.x] Refactor: improve doc block

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -77,7 +77,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  int  $from
      * @param  int  $to
      * @param  int  $step
-     * @return static<int, int>
+     * @return ($step is zero ? never : static<int, int>)
+     *
+     * @throws \InvalidArgumentException
      */
     public static function range($from, $to, $step = 1)
     {


### PR DESCRIPTION
add `@throws` and modify `@return`
for this line:
```php
        if ($step == 0) {
            throw new InvalidArgumentException('Step value cannot be zero.');
        }
```