### PR TITLE
Fix types for ConfirmableTrait::confirmToProceed

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -11,7 +11,7 @@ trait ConfirmableTrait
      *
      * This method only asks for confirmation in production.
      *
-     * @template TReturn of bool
+     * @template TReturn of bool = bool
      *
      * @param  string  $warning
      * @param  (\Closure(): TReturn)|TReturn|null  $callback


### PR DESCRIPTION
This PR adds a default value to the `TReturn` template type for `ConfirmableTrait::confirmToProceed`. Without this, the following code gives a PHPStan error (on level 6 and higher).

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Console\ConfirmableTrait;

class MyCommand extends Command
{
    use ConfirmableTrait;

    protected $signature = 'my-command';

    public function handle(): void
    {
        if ($this->confirmToProceed()) {
            // Do something destructive
        }
    }
}
```

Without any parameters PHPStan cannot determine the value of `TReturn`. In that case `bool` seems like a reasonable default. This is a problem since Laravel 12.50.0 because of the changes in #58565 