### PR TITLE
Add key prefix to ThrottleRequestsWithRedis

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -85,7 +85,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->getRedisConnection(), $key, $maxAttempts, $decaySeconds
+            $this->getRedisConnection(), $this->keyPrefix().$key, $maxAttempts, $decaySeconds
         );
 
         return tap(! $limiter->acquire(), function () use ($key, $limiter) {
@@ -117,6 +117,16 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function getTimeUntilNextRetry($key)
     {
         return $this->decaysAt[$key] - $this->currentTime();
+    }
+
+    /**
+     * Get the prefix for rate limiter keys.
+     *
+     * @return string
+     */
+    protected function keyPrefix()
+    {
+        return 'throttle:';
     }
 
     /**


### PR DESCRIPTION
Fixes #58279

`ThrottleRequestsWithRedis` passes keys directly to `DurationLimiter` without a namespace. Other Redis-backed features add their own such as `RedisQueue` hard coding 'queues:' in `getQueue()`.

This PR adds a protected `keyPrefix()` method to `ThrottleRequestsWithRedis` that returns 'throttle:' by default, applied to the key before passing it to `DurationLimiter`. Keys become `{redis_prefix}throttle:{hash}`, enabling ACL patterns like *throttle:*. The method can be overriden to create your own prefixes.

Developers using with Redis ACL-based key restrictions can use `ThrottleRequestsWithRedis` without workarounds. This matches exsiting patterns for namespaces: `queues:*` for queues, `laravel_cache:*` for cache, and now `throttle:*` for rate limiting.

This changes the key from `{redis_prefix}{hash`} to `{redis_prefix}throttle:{hash}`. Existing throttle keys won't be recognized after upgrade, but since they're short-lived the impact is a reset of active rate limiters.