### PR TITLE
Fix whereBetween to accept DatePeriod and handle missing end dates (#58092)

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1538,7 +1538,7 @@ class Builder implements BuilderContract
      * Resolve the start and end dates from a DatePeriod.
      *
      * @param  \DatePeriod  $period
-     * @return array
+     * @return array{\DateTimeInterface, \DateTimeInterface}
      */
     protected function resolveDatePeriodBounds(\DatePeriod $period)
     {
@@ -1548,7 +1548,8 @@ class Builder implements BuilderContract
         if ($end === null) {
             $end = clone $start;
 
-            for ($i = 0; $i < $period->getRecurrences(); $i++) {
+            $recurrences = $period->getRecurrences();
+            for ($i = 0; $i < $recurrences; $i++) {
                 $end = $end->add($period->getDateInterval());
             }
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1058,6 +1058,20 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
         $this->assertEquals([now()->startOfDay(), now()->addMonth()->startOfDay()], $builder->getBindings());
 
+        // DatePeriod with end date
+        $builder = $this->getBuilder();
+        $period = new \DatePeriod(now()->startOfDay(), new \DateInterval('P1D'), now()->addDays(5)->startOfDay());
+        $builder->select('*')->from('users')->whereBetween('created_at', $period);
+        $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay(), now()->addDays(5)->startOfDay()], $builder->getBindings());
+
+        // DatePeriod with recurrence count (no end date)
+        $builder = $this->getBuilder();
+        $period = new \DatePeriod(now()->startOfDay(), new \DateInterval('P1D'), 5);
+        $builder->select('*')->from('users')->whereBetween('created_at', $period);
+        $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
+        $this->assertEquals([now()->startOfDay(), now()->addDays(5)->startOfDay()], $builder->getBindings());
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
         $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());


### PR DESCRIPTION
Fixes #58092

`whereBetween` and `havingBetween` used `CarbonPeriod` instead of `DatePeriod`.

This PR changes `instanceof CarbonPeriod` to `instanceof \DatePeriod` which is backward compatible and calculates the end date from when `getEndDate()` is null

Respecting `EXCLUDE_START_DATE` / `INCLUDE_END_DATE` flags is a behavioral change and needs to be in a separate issue to target master.