### PR TITLE
Add SSL cert/key support to MySQL schema dump and load (#57821)

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,6 +116,16 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
         }
 
+        /** @phpstan-ignore class.notFound */
+        if (isset($config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT])) {
+            $value .= ' --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}"';
+        }
+
+        /** @phpstan-ignore class.notFound */
+        if (isset($config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY])) {
+            $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
+        }
+
         // if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
         //     $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
         //     $value .= ' --ssl=off';
@@ -142,6 +152,8 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
             'LARAVEL_LOAD_SSL_CA' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA] ?? '', // @phpstan-ignore class.notFound
+            'LARAVEL_LOAD_SSL_CERT' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT] ?? '', // @phpstan-ignore class.notFound
+            'LARAVEL_LOAD_SSL_KEY' => $config['options'][PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY] ?? '', // @phpstan-ignore class.notFound
         ];
     }
 

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -43,6 +43,8 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -59,11 +61,35 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                ],
+            ],
+        ];
+
+        yield 'ssl_cert_and_key' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}" --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}" --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+                'LARAVEL_LOAD_SSL_CERT' => '/path/to/client-cert.pem',
+                'LARAVEL_LOAD_SSL_KEY' => '/path/to/client-key.pem',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT => '/path/to/client-cert.pem',
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY => '/path/to/client-key.pem',
                 ],
             ],
         ];
@@ -77,6 +103,8 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -45,6 +45,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'host' => '127.0.0.1',
@@ -61,11 +63,35 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',
                 'options' => [
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                ],
+            ],
+        ];
+
+        yield 'ssl_cert_and_key' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}" --ssl-cert="${:LARAVEL_LOAD_SSL_CERT}" --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+                'LARAVEL_LOAD_SSL_CERT' => '/path/to/client-cert.pem',
+                'LARAVEL_LOAD_SSL_KEY' => '/path/to/client-key.pem',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT => '/path/to/client-cert.pem',
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY => '/path/to/client-key.pem',
                 ],
             ],
         ];
@@ -79,6 +105,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         //         'LARAVEL_LOAD_PASSWORD' => '',
         //         'LARAVEL_LOAD_DATABASE' => 'forge',
         //         'LARAVEL_LOAD_SSL_CA' => '',
+        //         'LARAVEL_LOAD_SSL_CERT' => '',
+        //         'LARAVEL_LOAD_SSL_KEY' => '',
         //     ], [
         //         'username' => 'root',
         //         'database' => 'forge',
@@ -97,6 +125,8 @@ class DatabaseMySqlSchemaStateTest extends TestCase
                 'LARAVEL_LOAD_PASSWORD' => '',
                 'LARAVEL_LOAD_DATABASE' => 'forge',
                 'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
             ], [
                 'username' => 'root',
                 'database' => 'forge',


### PR DESCRIPTION
Fixes #57821

When using PDO SSL client certificate options MYSQL_ATTR_SSL_CERT and MYSQL_ATTR_SSL_KEY, the mysqldump and mysql commands were not getting the corresponding --ssl-cert and --ssl-key flags. This causes auth failures for users with client certs.

I added `--ssl-cert` and `--ssl-key` CLI flag support to `MySqlSchemaState::connectionString()` when `PDO::MYSQL_ATTR_SSL_CERT` and `PDO::MYSQL_ATTR_SSL_KEY` options are configured. MariaDbinherits the fix automatically.

I tested this on MySQL 9.3.0 by generating self signed certs and required X509 for a new user (`CREATE USER 'laravel_ssl'@'localhost' IDENTIFIED BY 'secret' REQUIRE X509`). I configured the `config/database.php` and added the `MYSQL_ATTR_SSL_CA`, `MYSQL_ATTR_SSL_CERT`, `MYSQL_ATTR_SSL_KEY` options. I then ran `php artisan schema:dump` and `php artisan migrate` which succeeded over TLS.