### PR TITLE
Add cache prefix isolation for parallel testing (#57584)

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Testing\Concerns;
+
+use Illuminate\Support\Facades\ParallelTesting;
+
+trait TestCaches
+{
+    /**
+     * The original cache prefix prior to appending the token.
+     *
+     * @var string|null
+     */
+    protected static $originalCachePrefix = null;
+
+    /**
+     * Boot test cache for parallel testing.
+     *
+     * @return void
+     */
+    protected function bootTestCache()
+    {
+        ParallelTesting::setUpTestCase(function () {
+            $this->switchToCachePrefix($this->parallelSafeCachePrefix());
+        });
+    }
+
+    /**
+     * Get the test cache prefix.
+     *
+     * @return string
+     */
+    protected function parallelSafeCachePrefix()
+    {
+        self::$originalCachePrefix ??= $this->app['config']->get('cache.prefix', '');
+
+        return self::$originalCachePrefix.'test_'.ParallelTesting::token().'_';
+    }
+
+    /**
+     * Switch to the given cache prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    protected function switchToCachePrefix($prefix)
+    {
+        $this->app['config']->set('cache.prefix', $prefix);
+
+        if ($this->app->resolved('cache')) {
+            $this->app['cache']->forgetDriver();
+        }
+    }
+}

--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -4,12 +4,13 @@ namespace Illuminate\Testing;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\Concerns\TestCaches;
 use Illuminate\Testing\Concerns\TestDatabases;
 use Illuminate\Testing\Concerns\TestViews;
 
 class ParallelTestingServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    use TestDatabases, TestViews;
+    use TestCaches, TestDatabases, TestViews;
 
     /**
      * Boot the application's service providers.
@@ -19,6 +20,7 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
     public function boot()
     {
         if ($this->app->runningInConsole()) {
+            $this->bootTestCache();
             $this->bootTestDatabase();
             $this->bootTestViews();
         }

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Concerns;
+
+use Generator;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\ParallelTesting as ParallelTestingFacade;
+use Illuminate\Testing\Concerns\TestCaches;
+use Illuminate\Testing\ParallelTesting;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class TestCachesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::setInstance($container = new Container);
+
+        Facade::setFacadeApplication($container);
+
+        $container->singleton('config', fn () => new Config([
+            'cache' => [
+                'prefix' => 'myapp_cache_',
+            ],
+        ]));
+
+        $container->singleton(ParallelTesting::class, fn ($app) => new ParallelTesting($app));
+
+        $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        ParallelTestingFacade::clearResolvedInstance();
+        Facade::setFacadeApplication(null);
+
+        unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
+
+        // Reset static property between tests
+        $instance = new class
+        {
+            use TestCaches;
+
+            public $app;
+
+            public function __construct()
+            {
+                $this->app = Container::getInstance() ?? new Container;
+            }
+        };
+
+        (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('cachePrefixes')]
+    public function testCachePrefixAppendsToken(string $prefix, string $token, string $expected)
+    {
+        Container::getInstance()['config']->set('cache.prefix', $prefix);
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => $token);
+
+        $this->assertSame($expected, $this->getParallelSafeCachePrefix());
+    }
+
+    public static function cachePrefixes(): Generator
+    {
+        yield 'with prefix' => ['myapp_cache_', '5', 'myapp_cache_test_5_'];
+        yield 'empty prefix' => ['', '3', 'test_3_'];
+    }
+
+    public function testCachePrefixPreservesOriginalPrefix()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '1');
+
+        $this->getParallelSafeCachePrefix();
+
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '2');
+
+        $this->assertSame('myapp_cache_test_2_', $this->getParallelSafeCachePrefix());
+    }
+
+    public function testSwitchToCachePrefixUpdatesConfig()
+    {
+        $this->switchToCachePrefix('new_prefix_');
+
+        $this->assertSame('new_prefix_', Container::getInstance()['config']->get('cache.prefix'));
+    }
+
+    public function testBootTestCacheRegistersSetUpTestCaseCallback()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '7');
+
+        $instance = $this->makeTestCachesInstance();
+
+        (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
+
+        $method = new ReflectionMethod($instance, 'bootTestCache');
+        $method->invoke($instance);
+
+        $parallelTesting = Container::getInstance()->make(ParallelTesting::class);
+        $setUpCallbacks = (new ReflectionProperty($parallelTesting, 'setUpTestCaseCallbacks'))->getValue($parallelTesting);
+
+        $this->assertCount(1, $setUpCallbacks);
+    }
+
+    protected function getParallelSafeCachePrefix()
+    {
+        $instance = $this->makeTestCachesInstance();
+
+        (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
+
+        $method = new ReflectionMethod($instance, 'parallelSafeCachePrefix');
+
+        return $method->invoke($instance);
+    }
+
+    protected function switchToCachePrefix($prefix)
+    {
+        $instance = $this->makeTestCachesInstance();
+
+        $method = new ReflectionMethod($instance, 'switchToCachePrefix');
+        $method->invoke($instance, $prefix);
+    }
+
+    protected function makeTestCachesInstance()
+    {
+        return new class
+        {
+            use TestCaches;
+
+            public $app;
+
+            public function __construct()
+            {
+                $this->app = Container::getInstance();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #57584

When running parallel tests all processes share the same cache prefix. This can cause key collisions and test flakiness.

Databases and compiled views already have per-process isolation (`TestDatabases`, `TestViews`), but cache had no equivalent.

I created a `TestCaches` trait that follows this existing pattern. The parallel process get their own cache prefix by appending the token: `laravel-cache-test_1_`, `laravel-cache-test_2_`, and so on.