### PR TITLE
Add resolve_if() and resolve_unless() helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -819,7 +819,7 @@ if (! function_exists('resolve')) {
      * @param  string|class-string<TClass>  $name
      * @return ($name is class-string<TClass> ? TClass : mixed)
      */
-    function resolve(string $name, array $parameters = []): mixed
+    function resolve($name, array $parameters = [])
     {
         return app($name, $parameters);
     }
@@ -831,14 +831,17 @@ if (! function_exists('resolve_if')) {
      *
      * @template TClass of object
      *
+     * @param  bool  $boolean
      * @param  string|class-string<TClass>  $name
      * @return ($boolean is true ? ($name is class-string<TClass> ? TClass : mixed) : null)
      */
-    function resolve_if(bool $boolean, string $name, array $parameters = []): mixed
+    function resolve_if($boolean, $name, array $parameters = [])
     {
         if ($boolean) {
             return resolve($name, $parameters);
         }
+
+        return null;
     }
 }
 
@@ -846,15 +849,19 @@ if (! function_exists('resolve_unless')) {
     /**
      * Resolve a service from the container unless the given condition is true.
      *
+     * @template TClass of object
+     *
      * @param  bool  $boolean
-     * @param  string  $name
-     * @return mixed
+     * @param  string|class-string<TClass>  $name
+     * @return ($boolean is true ? null : ($name is class-string<TClass> ? TClass : mixed))
      */
     function resolve_unless($boolean, $name, array $parameters = [])
     {
         if (! $boolean) {
             return resolve($name, $parameters);
         }
+
+        return null;
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -825,6 +825,42 @@ if (! function_exists('resolve')) {
     }
 }
 
+if (! function_exists('resolve_if')) {
+    /**
+     * Resolve a service from the container if the given condition is true.
+     *
+     * @template TClass of object
+     *
+     * @param  bool  $boolean
+     * @param  string|class-string<TClass>  $name
+     * @return ($name is class-string<TClass> ? TClass : mixed)|null
+     */
+    function resolve_if($boolean, $name, array $parameters = [])
+    {
+        if ($boolean) {
+            return resolve($name, $parameters);
+        }
+    }
+}
+
+if (! function_exists('resolve_unless')) {
+    /**
+     * Resolve a service from the container unless the given condition is true.
+     *
+     * @template TClass of object
+     *
+     * @param  bool  $boolean
+     * @param  string|class-string<TClass>  $name
+     * @return ($name is class-string<TClass> ? TClass : mixed)|null
+     */
+    function resolve_unless($boolean, $name, array $parameters = [])
+    {
+        if (! $boolean) {
+            return resolve($name, $parameters);
+        }
+    }
+}
+
 if (! function_exists('resource_path')) {
     /**
      * Get the path to the resources folder.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -840,8 +840,6 @@ if (! function_exists('resolve_if')) {
         if ($boolean) {
             return resolve($name, $parameters);
         }
-
-        return null;
     }
 }
 
@@ -860,8 +858,6 @@ if (! function_exists('resolve_unless')) {
         if (! $boolean) {
             return resolve($name, $parameters);
         }
-
-        return null;
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -829,11 +829,9 @@ if (! function_exists('resolve_if')) {
     /**
      * Resolve a service from the container if the given condition is true.
      *
-     * @template TClass of object
-     *
      * @param  bool  $boolean
-     * @param  string|class-string<TClass>  $name
-     * @return ($name is class-string<TClass> ? TClass : mixed)|null
+     * @param  string  $name
+     * @return mixed
      */
     function resolve_if($boolean, $name, array $parameters = [])
     {
@@ -847,11 +845,9 @@ if (! function_exists('resolve_unless')) {
     /**
      * Resolve a service from the container unless the given condition is true.
      *
-     * @template TClass of object
-     *
      * @param  bool  $boolean
-     * @param  string|class-string<TClass>  $name
-     * @return ($name is class-string<TClass> ? TClass : mixed)|null
+     * @param  string  $name
+     * @return mixed
      */
     function resolve_unless($boolean, $name, array $parameters = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -819,7 +819,7 @@ if (! function_exists('resolve')) {
      * @param  string|class-string<TClass>  $name
      * @return ($name is class-string<TClass> ? TClass : mixed)
      */
-    function resolve($name, array $parameters = [])
+    function resolve(string $name, array $parameters = []): mixed
     {
         return app($name, $parameters);
     }
@@ -829,11 +829,12 @@ if (! function_exists('resolve_if')) {
     /**
      * Resolve a service from the container if the given condition is true.
      *
-     * @param  bool  $boolean
-     * @param  string  $name
-     * @return mixed
+     * @template TClass of object
+     *
+     * @param  string|class-string<TClass>  $name
+     * @return ($boolean is true ? ($name is class-string<TClass> ? TClass : mixed) : null)
      */
-    function resolve_if($boolean, $name, array $parameters = [])
+    function resolve_if(bool $boolean, string $name, array $parameters = []): mixed
     {
         if ($boolean) {
             return resolve($name, $parameters);

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -306,4 +306,36 @@ class FoundationHelpersTest extends TestCase
     {
         $this->assertInstanceOf(FakePendingBroadcast::class, broadcast_if(false, 'foo'));
     }
+
+    public function testResolveIfResolvesWhenConditionIsTrue()
+    {
+        $app = new Application;
+        $app->bind('foo', fn () => 'bar');
+
+        $this->assertSame('bar', resolve_if(true, 'foo'));
+    }
+
+    public function testResolveIfReturnsNullWhenConditionIsFalse()
+    {
+        $app = new Application;
+        $app->bind('foo', fn () => 'bar');
+
+        $this->assertNull(resolve_if(false, 'foo'));
+    }
+
+    public function testResolveUnlessResolvesWhenConditionIsFalse()
+    {
+        $app = new Application;
+        $app->bind('foo', fn () => 'bar');
+
+        $this->assertSame('bar', resolve_unless(false, 'foo'));
+    }
+
+    public function testResolveUnlessReturnsNullWhenConditionIsTrue()
+    {
+        $app = new Application;
+        $app->bind('foo', fn () => 'bar');
+
+        $this->assertNull(resolve_unless(true, 'foo'));
+    }
 }

--- a/types/Foundation/Helpers.php
+++ b/types/Foundation/Helpers.php
@@ -45,6 +45,16 @@ assertType('Illuminate\Http\RedirectResponse', redirect('foo'));
 assertType('mixed', resolve('foo'));
 assertType('Illuminate\Config\Repository', resolve(Repository::class));
 
+assertType('mixed', resolve_if(true, 'foo'));
+assertType('null', resolve_if(false, 'foo'));
+assertType('object', resolve_if(true, Repository::class));
+assertType('null', resolve_if(false, Repository::class));
+
+assertType('null', resolve_unless(true, 'foo'));
+assertType('mixed', resolve_unless(false, 'foo'));
+assertType('null', resolve_unless(true, Repository::class));
+assertType('object', resolve_unless(false, Repository::class));
+
 assertType('Illuminate\Http\Request', request());
 assertType('mixed', request('foo'));
 assertType('array<string, mixed>', request(['foo', 'bar']));


### PR DESCRIPTION
● Here's the PR description:                                                                                                                                                                                            
                                                                                                                                                                                                                        
  ---                                                                                                                                                                                                                   
  Title: [12.x] Add resolve_if() and resolve_unless() helpers
                                                                                                                                                                                                                        
  Body:                                  

### Summary
  - Add `resolve_if()` helper that conditionally resolves a service from the container when the given condition is true, returning `null` otherwise
  - Add `resolve_unless()` helper that conditionally resolves a service from the container when the given condition is false, returning `null` otherwise
  - Add tests for both helpers

  These follow the same convention used by existing conditional helpers such as `report_if()`/`report_unless()` and `abort_if()`/`abort_unless()`.

  ### Usage

  ```php
  // Resolves 'App\Service' only when $condition is true
  $service = resolve_if($condition, App\Service::class);

  // Resolves 'App\Service' only when $condition is false
  $service = resolve_unless($condition, App\Service::class);