### PR TITLE
[12.x] Allow customizing the "undeleted" value for Soft Deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -41,6 +41,12 @@ trait SoftDeletes
         if (! isset($this->casts[$this->getDeletedAtColumn()])) {
             $this->casts[$this->getDeletedAtColumn()] = 'datetime';
         }
+
+        $undeleted = $this->getUndeletedValue();
+
+        if (! is_null($undeleted) && ! isset($this->attributes[$this->getDeletedAtColumn()])) {
+            $this->attributes[$this->getDeletedAtColumn()] = $undeleted;
+        }
     }
 
     /**
@@ -171,7 +177,7 @@ trait SoftDeletes
             return false;
         }
 
-        $this->{$this->getDeletedAtColumn()} = null;
+        $this->{$this->getDeletedAtColumn()} = $this->getUndeletedValue();
 
         // Once we have saved the model, we will fire the "restored" event so this
         // developer will do anything they need to after a restore operation is
@@ -202,7 +208,7 @@ trait SoftDeletes
      */
     public function trashed()
     {
-        return ! is_null($this->{$this->getDeletedAtColumn()});
+        return $this->{$this->getDeletedAtColumn()} != $this->getUndeletedValue();
     }
 
     /**
@@ -278,6 +284,18 @@ trait SoftDeletes
     public function getDeletedAtColumn()
     {
         return defined(static::class.'::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
+    }
+
+    /**
+     * Get the value that indicates the model is not soft deleted.
+     *
+     * @return mixed
+     */
+    public function getUndeletedValue()
+    {
+        return property_exists($this, 'undeletedValue')
+            ? $this->undeletedValue
+            : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -71,8 +71,8 @@ class SoftDeletingScope implements Scope
     {
         $builder->macro('restore', function (Builder $builder) {
             $builder->withTrashed();
-
-            return $builder->update([$builder->getModel()->getDeletedAtColumn() => $builder->getModel()->getUndeletedValue()]);
+            $model = $builder->getModel();
+            return $builder->update([$model->getDeletedAtColumn() => $model->getUndeletedValue()]);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -72,6 +72,7 @@ class SoftDeletingScope implements Scope
         $builder->macro('restore', function (Builder $builder) {
             $builder->withTrashed();
             $model = $builder->getModel();
+
             return $builder->update([$model->getDeletedAtColumn() => $model->getUndeletedValue()]);
         });
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -22,7 +22,7 @@ class SoftDeletingScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereNull($model->getQualifiedDeletedAtColumn());
+        $builder->where($model->getQualifiedDeletedAtColumn(), $model->getUndeletedValue());
     }
 
     /**
@@ -72,7 +72,7 @@ class SoftDeletingScope implements Scope
         $builder->macro('restore', function (Builder $builder) {
             $builder->withTrashed();
 
-            return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);
+            return $builder->update([$builder->getModel()->getDeletedAtColumn() => $builder->getModel()->getUndeletedValue()]);
         });
     }
 
@@ -138,8 +138,9 @@ class SoftDeletingScope implements Scope
         $builder->macro('withoutTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
-            $builder->withoutGlobalScope($this)->whereNull(
-                $model->getQualifiedDeletedAtColumn()
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(),
+                $model->getUndeletedValue()
             );
 
             return $builder;
@@ -157,8 +158,10 @@ class SoftDeletingScope implements Scope
         $builder->macro('onlyTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
-            $builder->withoutGlobalScope($this)->whereNotNull(
-                $model->getQualifiedDeletedAtColumn()
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(),
+                '!=',
+                $model->getUndeletedValue()
             );
 
             return $builder;

--- a/tests/Database/DatabaseEloquentSoftDeletesCustomValueTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesCustomValueTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentSoftDeletesCustomValueTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Create the database schema.
+     */
+    public function createSchema(): void
+    {
+        $this->schema()->create('custom_soft_delete_users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+            $table->timestamps();
+            // deleted_at uses a custom default value instead of null
+            $table->dateTime('deleted_at')->default('9999-12-31 23:59:59');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     */
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow(null);
+
+        $this->schema()->drop('custom_soft_delete_users');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Get a schema builder instance.
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Create users for testing.
+     */
+    protected function createUsers(): array
+    {
+        $taylor = CustomSoftDeleteUser::create(['email' => 'taylorotwell@gmail.com']);
+        $taylor->delete(); // Soft delete
+
+        $abigail = CustomSoftDeleteUser::create(['email' => 'abigailotwell@gmail.com']);
+
+        return [$taylor, $abigail];
+    }
+
+    public function testModelUsingCustomUndeletedValue()
+    {
+        $user = CustomSoftDeleteUser::create(['email' => 'test@example.com']);
+
+        // Check if the custom undeleted value is set when not deleted
+        $this->assertEquals('9999-12-31 23:59:59', $user->deleted_at);
+        $this->assertFalse($user->trashed());
+    }
+
+    public function testTrashedMethodWithCustomUndeletedValue()
+    {
+        $user = CustomSoftDeleteUser::create(['email' => 'test@example.com']);
+        $this->assertFalse($user->trashed());
+
+        $user->delete();
+
+        $this->assertTrue($user->trashed());
+        $this->assertNotEquals('9999-12-31 23:59:59', $user->deleted_at);
+    }
+
+    public function testRestoreWithCustomUndeletedValue()
+    {
+        $user = CustomSoftDeleteUser::create(['email' => 'test@example.com']);
+        $user->delete();
+
+        $this->assertTrue($user->trashed());
+
+        $user->restore();
+
+        $this->assertFalse($user->trashed());
+        $this->assertEquals('9999-12-31 23:59:59', $user->deleted_at);
+    }
+
+    public function testQueryScopesWithCustomUndeletedValue()
+    {
+        $this->createUsers();
+
+        // Get only non-deleted records by default
+        $users = CustomSoftDeleteUser::all();
+        $this->assertCount(1, $users);
+        $this->assertEquals('abigailotwell@gmail.com', $users->first()->email);
+
+        // Get all records including trashed ones with withTrashed()
+        $allUsers = CustomSoftDeleteUser::withTrashed()->get();
+        $this->assertCount(2, $allUsers);
+
+        // Get only trashed records with onlyTrashed()
+        $trashedUsers = CustomSoftDeleteUser::onlyTrashed()->get();
+        $this->assertCount(1, $trashedUsers);
+        $this->assertEquals('taylorotwell@gmail.com', $trashedUsers->first()->email);
+    }
+
+    public function testBuilderRestoreMacro()
+    {
+        [$taylor, $abigail] = $this->createUsers();
+
+        // Restore via builder
+        CustomSoftDeleteUser::withTrashed()->where('email', 'taylorotwell@gmail.com')->restore();
+
+        $taylor = CustomSoftDeleteUser::find($taylor->id);
+        $this->assertNotNull($taylor);
+        $this->assertFalse($taylor->trashed());
+        $this->assertEquals('9999-12-31 23:59:59', $taylor->deleted_at);
+    }
+}
+
+class CustomSoftDeleteUser extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $table = 'custom_soft_delete_users';
+    protected $guarded = [];
+
+    /**
+     * Set the value indicating the model is not soft deleted.
+     */
+    protected $undeletedValue = '9999-12-31 23:59:59';
+}

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -21,7 +21,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $builder = m::mock(EloquentBuilder::class);
         $model = m::mock(Model::class);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
-        $builder->shouldReceive('whereNull')->once()->with('table.deleted_at');
+        $model->shouldReceive('getUndeletedValue')->once()->andReturn(null);
+        $builder->shouldReceive('where')->once()->with('table.deleted_at', null);
 
         $scope->apply($builder, $model);
     }
@@ -40,6 +41,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder->shouldReceive('withTrashed')->once();
         $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(stdClass::class));
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
+        $model->shouldReceive('getUndeletedValue')->once()->andReturn(null);
         $givenBuilder->shouldReceive('update')->once()->with(['deleted_at' => null]);
 
         $callback($givenBuilder);
@@ -124,7 +126,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
-        $givenBuilder->shouldReceive('whereNotNull')->once()->with('table.deleted_at');
+        $model->shouldReceive('getUndeletedValue')->andReturn(null);
+        $givenBuilder->shouldReceive('where')->once()->with('table.deleted_at', '!=', null);
         $result = $callback($givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);
@@ -147,7 +150,8 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
-        $givenBuilder->shouldReceive('whereNull')->once()->with('table.deleted_at');
+        $model->shouldReceive('getUndeletedValue')->andReturn(null);
+        $givenBuilder->shouldReceive('where')->once()->with('table.deleted_at', null);
         $result = $callback($givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);


### PR DESCRIPTION
This PR adds support for customizing the "undeleted" value in Soft Deletes.
Currently, Laravel's Soft Deletes assumes that `NULL` indicates an active (undeleted) record. However, this assumption conflicts with database partitioning requirements in MySQL.
In MySQL, all columns used in the partitioning expression must be part of every unique key on the table, including the primary key. Since primary key columns cannot be nullable, it is impossible to use a nullable `deleted_at` column as a partition key.
With this change, developers can define a non-null "undeleted" value (e.g., `'9999-12-31 23:59:59'`). This allows `deleted_at` to be defined as `NOT NULL`, making it eligible for use in partitioning keys while retaining Soft Deletes functionality.
#### Usage
```php
class Post extends Model
{
    use SoftDeletes;
    /**
     * The value that indicates the model is not soft deleted.
     *
     * @var string
     */
    protected $undeletedValue = '9999-12-31 23:59:59';
}
```