### PR TITLE
[12.x] Improved type hints for when() helper function.

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -271,10 +271,13 @@ if (! function_exists('when')) {
     /**
      * Return a value if the given condition is true.
      *
+     * @template TValue
+     * @template TDefault
+     *
      * @param  mixed  $condition
-     * @param  \Closure|mixed  $value
-     * @param  \Closure|mixed  $default
-     * @return mixed
+     * @param  TValue|\Closure(): TValue  $value
+     * @param  TDefault|\Closure(): TDefault  $default
+     * @return ($condition is true ? TValue : ($condition is positive-int ? TValue : ($condition is non-falsy-string ? TValue : ($condition is non-empty-array ? TValue : ($condition is callable ? TValue|TDefault : TDefault)))))
      */
     function when($condition, $value, $default = null)
     {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -277,7 +277,7 @@ if (! function_exists('when')) {
      * @param  mixed  $condition
      * @param  TValue|\Closure(): TValue  $value
      * @param  TDefault|\Closure(): TDefault  $default
-     * @return ($condition is true ? TValue : ($condition is positive-int ? TValue : ($condition is non-falsy-string ? TValue : ($condition is non-empty-array ? TValue : ($condition is callable ? TValue|TDefault : TDefault)))))
+     * @return ($condition is true|positive-int|non-falsy-string|non-empty-array ? TValue : ($condition is callable ? TValue|TDefault : TDefault))
      */
     function when($condition, $value, $default = null)
     {

--- a/types/Collections/helpers.php
+++ b/types/Collections/helpers.php
@@ -9,3 +9,24 @@ assertType('42', value(function ($foo) {
 
     return 42;
 }, true));
+
+assertType("'foo'", when(true, 'foo'));
+assertType("'foo'", when(true, 'foo', 42));
+assertType('null', when(false, 'foo'));
+assertType('42', when(false, 'foo', 42));
+assertType("'foo'", when(true, fn () => 'foo'));
+assertType("'foo'", when(true, fn () => 'foo', fn () => 42));
+assertType('null', when(false, fn () => 'foo'));
+assertType('42', when(false, fn () => 'foo', fn () => 42));
+assertType("'foo'", when(1, 'foo', 42));
+assertType("'foo'", when(42, 'foo'));
+assertType('null', when(0, 'foo'));
+assertType('null', when(-42, 'foo'));
+assertType('null', when(null, 'foo'));
+assertType('42', when(['foo'], 42));
+assertType('null', when([], 42));
+assertType('42|null', when(random_int(0, 1), 42));
+assertType('42|1337', when(random_int(0, 1), 42, 1337));
+assertType("array{'bar'}|array{'foo'}", when(random_int(0, 1), ['foo'], ['bar']));
+assertType('42|null', when(fn () => random_int(0, 1), 42));
+assertType('42|1337', when(fn () => random_int(0, 1), 42, 1337));


### PR DESCRIPTION
This pull request adds more detailed type hints to the `when()` helper function, allowing PHPStan to better analyze the output. Allowing the usage of `when()` in higher PHPStan levels (9+) where the output of `when()` gets provided to another method that requires a specific parameter type.

### Examples

```php
// Before
when(random_int(0, 1), 42); // <- mixed

// After
when(random_int(0, 1), 42); // <- 42|null
```

```php
// Before
when(true, 42); // <- mixed

// After
when(true, 42); // <- 42
```

```php
// Before
when(random_int(0, 1), 42, 1337); // <- mixed

// After
when(random_int(0, 1), 42, 1337); // <- 42|1337
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
