### PR TITLE
[12.x] Add missing @throws annotations to validation rules and JsonResponse

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -69,6 +69,8 @@ class JsonResponse extends BaseJsonResponse
      * {@inheritdoc}
      *
      * @return static
+     *
+     * @throws \InvalidArgumentException
      */
     #[\Override]
     public function setData($data = []): static

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -64,6 +64,8 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @param  static|callable|null  $callback
      * @return static|void
+     *
+     * @throws \InvalidArgumentException
      */
     public static function defaults($callback = null)
     {

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -64,6 +64,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @param  static|callable|null  $callback
      * @return static|void
+     *
      * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -64,6 +64,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @param  static|callable|null  $callback
      * @return static|void
+     * @phpstan-return ($callback is null ? static : ($callback is callable ? void : ($callback is static ? void : never)))
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -93,6 +93,8 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @param  static|callable|null  $callback
      * @return static|void
+     *
+     * @throws \InvalidArgumentException
      */
     public static function defaults($callback = null)
     {
@@ -229,6 +231,8 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * @param  string|int  $size
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     protected function toKilobytes($size)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -142,6 +142,8 @@ class Password implements DataAwareRule, ImplicitRule, IteratorAggregate, Rule, 
      *
      * @param  static|callable|null  $callback
      * @return static|void
+     *
+     * @throws \InvalidArgumentException
      */
     public static function defaults($callback = null)
     {

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,6 +19,8 @@ class RequiredIf implements Stringable
      * Create a new required validation rule based on a condition.
      *
      * @param  (\Closure(): bool)|bool|null  $condition
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($condition)
     {


### PR DESCRIPTION
This PR adds missing `@throws \InvalidArgumentException` annotations to methods that throw but don't document it:

- **`Email::defaults()`** — throws when callback is not callable or instance of static
- **`Password::defaults()`** — same pattern
- **`File::defaults()`** — same pattern
- **`File::toKilobytes()`** — throws on invalid file size suffix
- **`RequiredIf::__construct()`** — throws when condition is not callable or boolean
- **`JsonResponse::setData()`** — throws on JSON encoding error

These annotations improve IDE support and static analysis by making the exception contracts explicit.