### PR TITLE
Exception page: fix pop in for non main frames

### DIFF
--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/frame.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/frame.blade.php
@@ -50,6 +50,6 @@
     </div>
 
     @if($snippet = $frame->snippet())
-        <x-laravel-exceptions-renderer::frame-code :code="$snippet" :highlightedLine="$frame->line()" x-show="expanded" />
+        <x-laravel-exceptions-renderer::frame-code :code="$snippet" :highlightedLine="$frame->line()" x-show="expanded" :x-cloak="!$frame->isMain()" />
     @endif
 </div>


### PR DESCRIPTION
Fix for exception / error page that has some pop in that can be seen here:
https://github.com/user-attachments/assets/73110ec8-fc27-42bb-b451-bb12e95a7715

