### PR TITLE
[12.x] Add conditional return type hint for Route::middleware() method.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1067,7 +1067,7 @@ class Route
      * Get or set the middlewares attached to the route.
      *
      * @param  array|string|null  $middleware
-     * @return $this|array
+     * @return ($middleware is null ? array : $this)
      */
     public function middleware($middleware = null)
     {

--- a/types/Routing/Route.php
+++ b/types/Routing/Route.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+use function PHPStan\Testing\assertType;
+
+assertType('array', RouteFacade::get('/')->middleware());
+assertType(Route::class, RouteFacade::get('/')->middleware('auth'));
+assertType(Route::class, RouteFacade::get('/')->middleware(['auth']));


### PR DESCRIPTION
This pull request adds a conditional return type to the `Route::middleware()` method based on the `$middleware` parameter, so PHPStan knows that the method returns the `Route` instance when `$middleware` is not null.

This is necessary for PHPStan level 7+ to be able to call `Route::get('/')->middleware('auth')->name('home');`, because otherwise PHPStan does not know if the `Route` or an `array` gets returned from the `middleware` method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
