### PR TITLE
[12.x] Allow retrieving all view data via viewData() in TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1341,14 +1341,20 @@ class TestResponse implements ArrayAccess
     /**
      * Get a piece of data from the original view.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @return mixed
      */
-    public function viewData($key)
+    public function viewData($key = null)
     {
         $this->ensureResponseHasView();
 
-        return $this->original->gatherData()[$key];
+        $data = $this->original->gatherData();
+
+        if (is_null($key)) {
+            return $data;
+        }
+
+        return $data[$key];
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -239,6 +239,18 @@ class TestResponseTest extends TestCase
         $response->assertViewMissing('foo.baz');
     }
 
+    public function testViewData(): void
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar', 'baz' => 'qux'],
+        ]);
+
+        $this->assertEquals('bar', $response->viewData('foo'));
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'qux'], $response->viewData());
+    }
+
     public function testAssertContent(): void
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Description

Currently, the `viewData($key)` method in `Illuminate\Testing\TestResponse` requires a `$key` argument to retrieve a specific piece of data. If a developer wants to inspect **all** view data (e.g., for debugging or asserting multiple values), they currently have to access the underlying property directly:

```php
// Current way to get all data
$allData = $response->original->gatherData();
```

This PR makes the `$key` argument optional. If `null` is passed (or no argument is provided), the method will return the entire array of view data. This aligns with the behavior of many other Laravel helpers and methods (e.g., `session()`, `input()`, `json()`) where omitting the key returns the full payload.

example:
```php
// Can now retrieve all data
$allData = $response->viewData();
```