### PR TITLE
[13.x] Add `markEmailAsUnverified` to `MustVerifyEmail` interface

### DIFF
--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -19,6 +19,13 @@ interface MustVerifyEmail
     public function markEmailAsVerified();
 
     /**
+     * Mark the given user's email as unverified.
+     *
+     * @return bool
+     */
+    public function markEmailAsUnverified();
+
+    /**
      * Send the email verification notification.
      *
      * @return void


### PR DESCRIPTION
The `Illuminate\Auth\MustVerifyEmail` trait already provides a `markEmailAsUnverified()` method (#58255), but this behavior is not declared in the `Illuminate\Contracts\Auth\MustVerifyEmail` interface.