### PR TITLE
[13.x] Adds Checksum utility

### DIFF
--- a/src/Illuminate/Hashing/Checksum.php
+++ b/src/Illuminate/Hashing/Checksum.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Illuminate\Hashing;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+use InvalidArgumentException;
+use JsonSerializable;
+use RuntimeException;
+use SplFileInfo as File;
+use Stringable;
+use function hash_final;
+
+class Checksum implements Stringable
+{
+    use Macroable, Conditionable, Tappable;
+
+    /**
+     * The algorithm that was used to calculate the checksum.
+     *
+     * @var string
+     */
+    protected $algorithm;
+
+    /**
+     * The options to pass to the algorithm.
+     *
+     * @var array|int|null
+     */
+    protected $options;
+
+    /**
+     * The calculated checksum.
+     *
+     * @var string
+     */
+    protected $checksum;
+
+    /**
+     * Adds a "seed" to the checksum calculation.
+     *
+     * @param  string|int  $seed
+     * @return $this
+     */
+    public function withSeed($seed)
+    {
+        $this->options['seed'] = $seed;
+
+        return $this;
+    }
+
+    /**
+     * Adds a "secret" to the checksum calculation.
+     *
+     * @param  string  $secret
+     * @return $this
+     */
+    public function withSecret($secret)
+    {
+        $this->options['secret'] = $secret;
+
+        return $this;
+    }
+
+    /**
+     * Calculate a checksum using CRC32.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return $this
+     */
+    public function crc32($data)
+    {
+        $this->algorithm = 'crc32b';
+        $this->checksum = $this->calculate($data);
+
+        return $this;
+    }
+
+    /**
+     * Calculate a checksum using MD5.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return $this
+     */
+    public function md5($data)
+    {
+        $this->algorithm = 'md5';
+        $this->checksum = $this->calculate($data);
+
+        return $this;
+    }
+
+    /**
+     * Calculate a checksum using MD5.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return $this
+     */
+    public function sha256($data)
+    {
+        $this->algorithm = 'sha256';
+        $this->checksum = $this->calculate($data);
+
+        return $this;
+    }
+
+    /**
+     * Calculate a checksum using XXH3.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return $this
+     */
+    public function xxh3($data)
+    {
+        $this->algorithm = 'xxh3';
+        $this->checksum = $this->calculate($data);
+
+        return $this;
+    }
+
+    /**
+     * Calculate a checksum using XXH3.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return $this
+     */
+    public function xxh128($data)
+    {
+        $this->algorithm = 'xxh128';
+        $this->checksum = $this->calculate($data);
+
+        return $this;
+    }
+
+    /**
+     * Calculate the checksum.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $data
+     * @return string
+     */
+    protected function calculate($data)
+    {
+        if (is_resource($data)) {
+            return $this->calculateResourceHash($data);
+        }
+
+        if ($data instanceof File) {
+            return $this->calculateFileHash($data);
+        }
+
+        $data = match (true) {
+            is_array($data),
+            $data instanceof JsonSerializable => json_encode($data),
+            $data instanceof Jsonable => $data->toJson(),
+            $data instanceof Arrayable => json_encode($data->toArray()),
+            default => (string) $data,
+        };
+
+        return hash($this->algorithm, $data, $this->options);
+    }
+
+    /**
+     * Calculate the hash of a resource using native functions.
+     *
+     * @param  resource  $data
+     * @return string
+     */
+    protected function calculateResourceHash($data)
+    {
+        $context = hash_init($this->algorithm, $this->options);
+
+        hash_update_stream($context, $data);
+
+        $final = hash_final($context);
+
+        rewind($data);
+        
+        return $final;
+    }
+
+    /**
+     * Calculate the hash of a file using native functions.
+     *
+     * @param  \SplFileInfo  $data
+     * @return string
+     */
+    protected function calculateFileHash($data)
+    {
+        $path = $data->getRealPath();
+
+        if (!$path) {
+            throw new RuntimeException('Unable to open the file real path.');
+        }
+
+        return hash_file($this->algorithm, $path, $this->options);
+    }
+
+    /**
+     * Determine if the calculated hash is equal to another hash.
+     *
+     * @param  string  $hash
+     * @return bool
+     */
+    public function is($hash)
+    {
+        return hash_equals($this->checksum, $hash);
+    }
+
+    /**
+     * Determine if the calculated hash is not equal to another hash.
+     *
+     * @param  string  $hash
+     * @return bool
+     */
+    public function isNot($hash)
+    {
+        return !$this->is($hash);
+    }
+
+    /**
+     * Determine if the calculated hash is equal to the given data.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $comparable
+     * @return bool
+     */
+    public function isSameHashOf($comparable)
+    {
+        return $this->is($this->calculate($comparable));
+    }
+
+    /**
+     * Determine if the calculated hash is not equal to the given data.
+     *
+     * @param  \Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string  $comparable
+     * @return bool
+     */
+    public function isNotSameHashOf($comparable)
+    {
+        return !$this->isSameHashOf($comparable);
+    }
+
+    /**
+     * Returns the checksum hash.
+     *
+     * @return string
+     */
+    public function hash()
+    {
+        return $this->checksum ?? throw new RuntimeException('No checksum was calculated.');
+    }
+
+    /**
+     * Returns the checksum as a string.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->hash();
+    }
+
+    /**
+     * Return the checksum as a string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->hash();
+    }
+
+    /**
+     * Returns the checksum as a binary string.
+     *
+     * @return string
+     */
+    public function toBinary()
+    {
+        return hex2bin($this->hash());
+    }
+}

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -21,6 +21,10 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('hash.driver', function ($app) {
             return $app['hash']->driver();
         });
+
+        $this->app->singleton('checksum', function () {
+            return new Checksum();
+        });
     }
 
     /**
@@ -30,6 +34,6 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function provides()
     {
-        return ['hash', 'hash.driver'];
+        return ['hash', 'hash.driver', 'checksum'];
     }
 }

--- a/src/Illuminate/Support/Facades/Checksum.php
+++ b/src/Illuminate/Support/Facades/Checksum.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+use Mockery;
+
+/**
+ * @method static \Illuminate\Hashing\Checksum withSeed(string|int $seed)
+ * @method static \Illuminate\Hashing\Checksum withSecret(string $secret)
+ * @method static \Illuminate\Hashing\Checksum crc32(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $data)
+ * @method static \Illuminate\Hashing\Checksum md5(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $data)
+ * @method static \Illuminate\Hashing\Checksum sha256(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $data)
+ * @method static \Illuminate\Hashing\Checksum xxh3(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $data)
+ * @method static \Illuminate\Hashing\Checksum xxh128(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $data)
+ * @method static bool isEqualTo(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $comparable)
+ * @method static bool isNotEqualTo(\Illuminate\Contracts\Support\Jsonable|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable|\SplFileInfo|resource|string $comparable)
+ * @method static string hash()
+ * @method static string toString()
+ * @method static string toBinary()
+ *
+ * @see \Illuminate\Hashing\Checksum
+ */
+class Checksum extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'checksum';
+    }
+}

--- a/tests/Hashing/ChecksumTest.php
+++ b/tests/Hashing/ChecksumTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Hashing;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Hashing\Checksum;
+use JsonSerializable;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use SplFileInfo;
+use Stringable;
+
+class ChecksumTest extends TestCase
+{
+    protected Checksum $checksum;
+
+    protected function setUp(): void
+    {
+        $this->checksum = new Checksum();
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public static function providesDataWithChecksums(): array
+    {
+        $string = '["test-string"]';
+
+        $hashes = [
+            'crc32' => hash('crc32b', $string),
+            'md5' => hash('md5', $string),
+            'sha256' => hash('sha256', $string),
+            'xxh3' => hash('xxh3', $string),
+            'xxh128' => hash('xxh128', $string),
+        ];
+
+        return [
+            [
+                function () {
+                    $resource = fopen('php://memory', 'r+');
+                    fwrite($resource, '["test-string"]');
+                    rewind($resource);
+                    return $resource;
+                },
+                $hashes,
+            ],
+            [
+                function () {
+                    $file = m::mock(SplFileInfo::class);
+                    $file->expects('getRealPath')->andReturn(
+                        'data://text/plain;base64,'.base64_encode('["test-string"]'),
+                    )->atLeast()->once();
+                    return $file;
+                },
+                $hashes,
+            ],
+            [
+                ['test-string'],
+                $hashes,
+            ],
+            [
+                function () {
+                    $file = m::mock(JsonSerializable::class);
+                    $file->expects('jsonSerialize')->andReturn(['test-string'])->atLeast()->once();
+                    return $file;
+                },
+                $hashes,
+            ],
+            [
+                function () {
+                    $arrayable = m::mock(Arrayable::class);
+                    $arrayable->expects('toArray')->andReturn(['test-string'])->atLeast()->once();
+                    return $arrayable;
+                },
+                $hashes,
+            ],
+            [
+                function () {
+                    $jsonable = m::mock(Jsonable::class);
+                    $jsonable->expects('toJson')->andReturn('["test-string"]')->atLeast()->once();
+                    return $jsonable;
+                },
+                $hashes,
+            ],
+            [
+                new class implements Stringable
+                {
+                    public function __toString()
+                    {
+                        return '["test-string"]';
+                    }
+                },
+                $hashes,
+            ],
+            [
+                $string,
+                $hashes,
+            ],
+        ];
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testCrc32($data, $checksums)
+    {
+        if ($data instanceof Closure) {
+            $data = $data();
+        }
+
+        try {
+            $this->assertEquals($checksums['crc32'], $this->checksum->crc32($data)->hash());
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testMd5($data, $checksums)
+    {
+        if ($data instanceof Closure) {
+            $data = $data();
+        }
+
+        try {
+            $this->assertEquals($checksums['md5'], $this->checksum->md5($data)->hash());
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testSha256($data, $checksums)
+    {
+        if ($data instanceof Closure) {
+            $data = $data();
+        }
+
+        try {
+            $this->assertEquals($checksums['sha256'], $this->checksum->sha256($data)->hash());
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testXxh3($data, $checksums)
+    {
+        if ($data instanceof Closure) {
+            $data = $data();
+        }
+
+        try {
+            $this->assertEquals($checksums['xxh3'], $this->checksum->xxh3($data)->hash());
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testXxh128($data, $checksums)
+    {
+        if ($data instanceof Closure) {
+            $data = $data();
+        }
+
+        try {
+            $this->assertEquals($checksums['xxh128'], $this->checksum->xxh128($data)->hash());
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testIs($data)
+    {
+        $comparable = $data;
+
+        if ($data instanceof Closure) {
+            $data = $data();
+            $comparable = $comparable();
+        }
+
+        try {
+            $this->assertTrue($this->checksum->crc32($data)->is((new Checksum())->crc32($comparable)->hash()));
+            $this->assertFalse($this->checksum->crc32($data)->isNot((new Checksum())->crc32($comparable)->hash()));
+
+            $this->assertTrue($this->checksum->crc32($data)->isNot('invalid-hash'));
+            $this->assertFalse($this->checksum->crc32($data)->is('invalid-hash'));
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+                fclose($comparable);
+            }
+        }
+    }
+
+    #[DataProvider('providesDataWithChecksums')]
+    public function testIsSameHashOf($data)
+    {
+        $comparable = $data;
+
+        if ($data instanceof Closure) {
+            $data = $data();
+            $comparable = $comparable();
+        }
+
+        try {
+            $this->assertTrue($this->checksum->crc32($data)->isSameHashOf($comparable));
+            $this->assertFalse($this->checksum->crc32($data)->isNotSameHashOf($comparable));
+
+            $this->assertTrue($this->checksum->crc32($data)->isNotSameHashOf('invalid-hash'));
+            $this->assertFalse($this->checksum->crc32($data)->isSameHashOf('invalid-hash'));
+        } finally {
+            if (is_resource($data)) {
+                fclose($data);
+                fclose($comparable);
+            }
+        }
+    }
+
+    public function testThrowsIfNoDataWasChecksum()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No checksum was calculated.');
+
+        $this->checksum->hash();
+    }
+}


### PR DESCRIPTION
# What?

A convenience object to calculate checksums from string or files. The main idea is to _replace_ direct calls to hash functions and instead use the object which, contrary to these functions, can be mocked for testing.

I expect developers will either do checksums against strings or files (local or on the cloud) to avoid deduplication (uploading the same video... again), or just checking public data when signatures are _overkill_ or can be safely be crosschecked.

It works by simply calling the algorithm as method with the data to checksum.

```php
use Illuminate\Support\Facades\Checksum;

$checksum = Checksum::sha256('This is a giant document')->hash();
```

The data can be a string, an Array or Arrayable (for JSON purposes), but also resources, `SplFile` (Uploaded files and local files), and Jsonable/JsonSerializable instances.

For example, imagine trying to get the hash of giant cloud file, like a Linux ISO, without killing the app in the process, instead of downloading it.

```php
use Illuminate\Support\Facades\Checksum;use Illuminate\Support\Facades\Storage;

$stream = Storage::readStream('/isos/bluefin-dx/stable/20260101.iso')

$checksum = Checksum::sha256($stream)->hash();
```

It also has convenience checks that use `hash_equals()` behind the scenes to avoid timing attacks, for both plain hashes or data-to-be-checksum'ed (like to compare two files or strings). For example, the scenario where a user wants to upload a file with a known hash.

```php
use Illuminate\Http\Request;
use Illuminate\Support\Facades\Checksum;
use Illuminate\Support\Facades\File;
use Illuminate\Support\Facades\Route;

Route::post('/check-document', function (Request $request) {
    $file = $request->file('document');
    
    $expectedHash = File::get('document.md5');
    
    // Before
    if (! hash_equals(md5_file($file->getRealPath()), $expectedHash) {
        return '...';
    }
    
    // After
    if (Checksum::md5($file)->isNot($expectedHash) {
        return 'This is not the same file, no update will be done.'
    }
})
```

The main idea is to also allow _sane_ testing when checking for data integrity. Here we can save preparing the uploaded file contents to just fake it.

```php
use Illuminate\Http\UploadedFile;
use Illuminate\Support\Facades\Checksum;

public function test_shows_alert_when_hash_different()
{
    Checksum::expects('md5->is')->andReturnFalse();
    
    $this->get('check-document', ['document' => UploadedFile::fake()])
        ->assertViewIs('errors.file-hash-mismatch');
}
```
