### PR TITLE
Fix ThrottleRequests over-throttling with multiple distinct rate limit keys (#54386)

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -157,7 +157,9 @@ class ThrottleRequests
             if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
+        }
 
+        foreach ($limits as $limit) {
             if (! $limit->afterCallback) {
                 $this->limiter->hit($limit->key, $limit->decaySeconds);
             }


### PR DESCRIPTION
Fixes #54386

When using two or more rate limits with different keys the rate limiter over throttles requests due to limits being incremented when they should not be. This PR splits the loop to check the limits first and then increment them.