### PR TITLE
[12.x] Feature: add `chunk()` to `Arr`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1309,4 +1309,20 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Split an array into chunks.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  int  $size
+     * @param  bool  $preserveKeys
+     * @return array<int, array<TKey, TValue>>
+     */
+    public static function chunk($array, $size, $preserveKeys = false)
+    {
+        return array_chunk($array, $size, $preserveKeys);
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1900,4 +1900,43 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([[0 => 'John', 1 => 'Jane'], [2 => 'Greg']], $result);
     }
+
+    public function testChunk()
+    {
+        // Basic chunking
+        $this->assertEquals(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            Arr::chunk([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)
+        );
+
+        // Uneven chunks
+        $this->assertEquals(
+            [[1, 2, 3], [4, 5]],
+            Arr::chunk([1, 2, 3, 4, 5], 3)
+        );
+
+        // Preserve keys
+        $this->assertEquals(
+            [['a' => 1, 'b' => 2], ['c' => 3, 'd' => 4]],
+            Arr::chunk(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], 2, true)
+        );
+
+        // Without preserve keys on associative array
+        $this->assertEquals(
+            [[1, 2], [3, 4]],
+            Arr::chunk(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], 2, false)
+        );
+
+        // Empty array
+        $this->assertEquals(
+            [],
+            Arr::chunk([], 3)
+        );
+
+        // Size larger than array
+        $this->assertEquals(
+            [[1, 2, 3]],
+            Arr::chunk([1, 2, 3], 10)
+        );
+    }
 }


### PR DESCRIPTION
## Add `Arr::chunk()` method

### Summary
This PR adds a new `chunk()` method to the `Arr` helper class for splitting arrays into smaller chunks of a specified size.

### Why is this useful?
- **Batch Processing**: Easily divide large datasets into manageable batches for processing, API calls, or database operations
- **Pagination**: Simplify pagination logic when displaying data in groups
- **Memory Efficiency**: Process large arrays in smaller chunks to reduce memory usage
- **Consistency**: Provides a fluent API consistent with Laravel's existing `Arr` methods and the `Collection::chunk()` method
- **Convenience**: Wraps `array_chunk()` with Laravel's familiar syntax and documentation style

### Usage Examples
```php
// Basic chunking
Arr::chunk([1, 2, 3, 4, 5, 6], 2);
// [[1, 2], [3, 4], [5, 6]]

// Batch process users
foreach (Arr::chunk($users, 100) as $batch) {
    $this->sendEmailToBatch($batch);
}

// Preserve associative keys
Arr::chunk(['a' => 1, 'b' => 2, 'c' => 3], 2, true);
// [['a' => 1, 'b' => 2], ['c' => 3]]
```

### Changes
- Added `Arr::chunk()` method with full PHPDoc type hints
- Added comprehensive test coverage for various use cases
- Maintains backward compatibility (no breaking changes)

### Related
This method complements the existing `Collection::chunk()` method, providing the same functionality for arrays without needing to instantiate a Collection.