### PR TITLE
[12.x] Feat: add `allowedAbilities()` and `deniedAbilities()`

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -53,4 +53,38 @@ trait Authorizable
     {
         return $this->cant($abilities, $arguments);
     }
+
+    /**
+     * Get abilities that the user has from the given list.
+     *
+     * @param  iterable|\UnitEnum|string  $abilities
+     * @param  mixed  $arguments
+     * @return array
+     */
+    public function allowedAbilities($abilities, $arguments = [])
+    {
+        $abilities = is_array($abilities) ? $abilities : [$abilities];
+        $gate = app(Gate::class)->forUser($this);
+
+        return collect($abilities)->filter(function ($ability) use ($gate, $arguments) {
+            return $gate->check($ability, $arguments);
+        })->values()->all();
+    }
+
+    /**
+     * Get abilities that the user does not have from the given list.
+     *
+     * @param  iterable|\UnitEnum|string  $abilities
+     * @param  mixed  $arguments
+     * @return array
+     */
+    public function deniedAbilities($abilities, $arguments = [])
+    {
+        $abilities = is_array($abilities) ? $abilities : [$abilities];
+        $gate = app(Gate::class)->forUser($this);
+
+        return collect($abilities)->filter(function ($ability) use ($gate, $arguments) {
+            return ! $gate->check($ability, $arguments);
+        })->values()->all();
+    }
 }


### PR DESCRIPTION
## Add `allowedAbilities()` and `deniedAbilities()` methods to Authorizable trait

### Problem
Currently, when building dynamic UIs (menus, action buttons, feature lists), developers need to manually loop through abilities and check each one individually:
```php
$abilities = ['edit-post', 'delete-post', 'publish-post'];
$allowed = [];
foreach ($abilities as $ability) {
    if ($user->can($ability, $post)) {
        $allowed[] = $ability;
    }
}
```

This is verbose and repetitive across codebases.

### Solution
Add two helper methods to filter abilities based on authorization:

- `allowedAbilities()` - Returns abilities the user **has**
- `deniedAbilities()` - Returns abilities the user **lacks**

### Benefits

**1. Cleaner Code**
```php
// Before
$allowed = array_filter($abilities, fn($ability) => $user->can($ability, $post));

// After
$allowed = $user->allowedAbilities($abilities, $post);
```

**2. Common Use Cases**
- **Dynamic Menus**: Show only permitted menu items
- **Bulk Actions**: Display available bulk operations
- **Feature Flags**: Filter enabled features per user
- **API Responses**: Return allowed actions in JSON

**3. Consistency**
Follows existing naming conventions (`can`, `canAny`, `cannot`) and leverages the same Gate infrastructure.

### Example Usage
```php
// Show only allowed actions in a dropdown
$actions = $user->allowedAbilities(['edit', 'delete', 'share'], $document);

// Log denied permissions for audit
$denied = $user->deniedAbilities(['admin', 'superuser']);
```

This small addition significantly improves DX for authorization-heavy applications.