### PR TITLE
[12.x] Restore original dispatcher bindings after precognitive request

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -70,6 +70,21 @@ class HandlePrecognitiveRequests
     }
 
     /**
+     * Append the appropriate "Vary" header to the given response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Response  $response
+     * @return \Illuminate\Http\Response
+     */
+    protected function appendVaryHeader($request, $response)
+    {
+        return tap($response, fn () => $response->headers->set('Vary', implode(', ', array_filter([
+            $response->headers->get('Vary'),
+            'Precognition',
+        ]))));
+    }
+
+    /**
      * Restore the original route dispatcher bindings.
      *
      * @param  array|null  $callableBinding
@@ -85,20 +100,5 @@ class HandlePrecognitiveRequests
         if ($controllerBinding) {
             $this->container->bind(ControllerDispatcherContract::class, $controllerBinding['concrete'], $controllerBinding['shared']);
         }
-    }
-
-    /**
-     * Append the appropriate "Vary" header to the given response.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response  $response
-     * @return \Illuminate\Http\Response
-     */
-    protected function appendVaryHeader($request, $response)
-    {
-        return tap($response, fn () => $response->headers->set('Vary', implode(', ', array_filter([
-            $response->headers->get('Vary'),
-            'Precognition',
-        ]))));
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -40,12 +40,18 @@ class HandlePrecognitiveRequests
             return $this->appendVaryHeader($request, $next($request));
         }
 
+        $bindings = $this->container->getBindings();
+        $callableBinding = $bindings[CallableDispatcherContract::class] ?? null;
+        $controllerBinding = $bindings[ControllerDispatcherContract::class] ?? null;
+
         $this->prepareForPrecognition($request);
 
-        return tap($next($request), function ($response) use ($request) {
+        return tap($next($request), function ($response) use ($request, $callableBinding, $controllerBinding) {
             $response->headers->set('Precognition', 'true');
 
             $this->appendVaryHeader($request, $response);
+
+            $this->restoreDispatchers($callableBinding, $controllerBinding);
         });
     }
 
@@ -61,6 +67,24 @@ class HandlePrecognitiveRequests
 
         $this->container->bind(CallableDispatcherContract::class, fn ($app) => new PrecognitionCallableDispatcher($app));
         $this->container->bind(ControllerDispatcherContract::class, fn ($app) => new PrecognitionControllerDispatcher($app));
+    }
+
+    /**
+     * Restore the original route dispatcher bindings.
+     *
+     * @param  array|null  $callableBinding
+     * @param  array|null  $controllerBinding
+     * @return void
+     */
+    protected function restoreDispatchers($callableBinding, $controllerBinding)
+    {
+        if ($callableBinding) {
+            $this->container->bind(CallableDispatcherContract::class, $callableBinding['concrete'], $callableBinding['shared']);
+        }
+
+        if ($controllerBinding) {
+            $this->container->bind(ControllerDispatcherContract::class, $controllerBinding['concrete'], $controllerBinding['shared']);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

In long-lived processes such as Laravel Octane or Pest Browser's Amp-based HTTP server, a precognitive request permanently pollutes the container. Subsequent non-precognitive requests resolve `PrecognitionCallableDispatcher` instead of the original `CallableDispatcher`, causing the controller to be skipped and a 204 response to be returned.

## Cause

`HandlePrecognitiveRequests::prepareForPrecognition()` overrides the `CallableDispatcherContract` and `ControllerDispatcherContract` bindings with precognition variants using `bind()`, but never restores the original `singleton()` bindings.

In PHP-FPM this is harmless because the process dies after each request, but in long-lived processes the polluted bindings persist across requests.

## Solution

Capture the original bindings before overriding them in `prepareForPrecognition()`, then restore them in the tap callback after the precognitive response is prepared.

Fixes https://github.com/pestphp/pest/issues/1579
