### PR TITLE
[12.x] Refactor: remove unnecessary cast to `(bool)`

### DIFF
--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -57,7 +57,7 @@ class ValidationData
         $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute, '/'));
 
         foreach ($data as $key => $value) {
-            if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {
+            if (preg_match('/^'.$pattern.'/', $key, $matches)) {
                 $keys[] = $matches[0];
             }
         }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -162,7 +162,7 @@ class ValidationRuleParser
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
         foreach ($data as $key => $value) {
-            if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
+            if (Str::startsWith($key, $attribute) || preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $rule) {
                     if ($rule instanceof CompilableRules) {
                         $context = Arr::get($this->data, Str::beforeLast($key, '.'));

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -314,7 +314,7 @@ class ComponentTest extends TestCase
     {
         $slot = new ComponentSlot();
 
-        $this->assertTrue((bool) $slot->isEmpty());
+        $this->assertTrue($slot->isEmpty());
     }
 
     public function testComponentSlotSanitizedEmpty()
@@ -329,9 +329,9 @@ class ComponentTest extends TestCase
         <img border="0" src="" alt="">
         -->');
 
-        $this->assertFalse((bool) $slot->hasActualContent());
-        $this->assertFalse((bool) $linebreakingSlot->hasActualContent('trim'));
-        $this->assertFalse((bool) $moreComplexSlot->hasActualContent());
+        $this->assertFalse($slot->hasActualContent());
+        $this->assertFalse($linebreakingSlot->hasActualContent('trim'));
+        $this->assertFalse($moreComplexSlot->hasActualContent());
     }
 
     public function testComponentSlotSanitizedNotEmpty()
@@ -346,9 +346,9 @@ class ComponentTest extends TestCase
         <img border="0" src="" alt="">
         -->after');
 
-        $this->assertTrue((bool) $slot->hasActualContent());
-        $this->assertTrue((bool) $linebreakingSlot->hasActualContent('trim'));
-        $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
+        $this->assertTrue($slot->hasActualContent());
+        $this->assertTrue($linebreakingSlot->hasActualContent('trim'));
+        $this->assertTrue($moreComplexSlot->hasActualContent());
     }
 
     public function testComponentSlotIsNotEmpty()
@@ -362,9 +362,9 @@ class ComponentTest extends TestCase
         <img border="0" src="pic_trulli.jpg" alt="Trulli">
         -->est');
 
-        $this->assertTrue((bool) $slot->hasActualContent());
-        $this->assertTrue((bool) $anotherSlot->hasActualContent());
-        $this->assertTrue((bool) $moreComplexSlot->hasActualContent());
+        $this->assertTrue($slot->hasActualContent());
+        $this->assertTrue($anotherSlot->hasActualContent());
+        $this->assertTrue($moreComplexSlot->hasActualContent());
     }
 }
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -187,14 +187,14 @@ class ViewComponentAttributeBagTest extends TestCase
     {
         $bag = new ComponentAttributeBag([]);
 
-        $this->assertTrue((bool) $bag->isEmpty());
+        $this->assertTrue($bag->isEmpty());
     }
 
     public function testAttributeIsNotEmpty()
     {
         $bag = new ComponentAttributeBag(['name' => 'test']);
 
-        $this->assertTrue((bool) $bag->isNotEmpty());
+        $this->assertTrue($bag->isNotEmpty());
     }
 
     public function testAttributeIsArray()


### PR DESCRIPTION
remove unnecessary cast to `(bool)`
in `if` and some tests