### PR TITLE
Fix Queue::fake() not releasing unique job locks between tests (#58533)

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -96,7 +96,7 @@ class Queue extends Facade
     public static function fake($jobsToFake = [])
     {
         $actualQueueManager = static::isFake()
-            ? static::getFacadeRoot()->queue
+            ? tap(static::getFacadeRoot(), fn ($fake) => $fake->cancelUniqueJobLocks())->queue
             : static::getFacadeRoot();
 
         return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), function ($fake) {

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -96,7 +96,7 @@ class Queue extends Facade
     public static function fake($jobsToFake = [])
     {
         $actualQueueManager = static::isFake()
-            ? tap(static::getFacadeRoot(), fn ($fake) => $fake->cancelUniqueJobLocks())->queue
+            ? tap(static::getFacadeRoot(), fn ($fake) => $fake->releaseUniqueJobLocks())->queue
             : static::getFacadeRoot();
 
         return tap(new QueueFake(static::getFacadeApplication(), $jobsToFake, $actualQueueManager), function ($fake) {

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -4,7 +4,10 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use BadMethodCallException;
 use Closure;
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\QueueManager;
@@ -54,6 +57,13 @@ class QueueFake extends QueueManager implements Fake, Queue
      * @var list<RawPushType>
      */
     protected $rawPushes = [];
+
+    /**
+     * All of the unique jobs that were pushed.
+     *
+     * @var array
+     */
+    private $uniqueJobs = [];
 
     /**
      * Indicates if items should be serialized and restored when pushed to the queue.
@@ -477,6 +487,10 @@ class QueueFake extends QueueManager implements Fake, Queue
                 'queue' => $queue,
                 'data' => $data,
             ];
+
+            if ($job instanceof ShouldBeUnique) {
+                $this->uniqueJobs[] = $job;
+            }
         } else {
             is_object($job) && isset($job->connection)
                 ? $this->queue->connection($job->connection)->push($job, $data, $queue)
@@ -637,6 +651,22 @@ class QueueFake extends QueueManager implements Fake, Queue
         $this->serializeAndRestore = $serializeAndRestore;
 
         return $this;
+    }
+
+    /**
+     * Release the locks for all unique jobs that were pushed.
+     *
+     * @return void
+     */
+    public function cancelUniqueJobLocks()
+    {
+        $lock = new UniqueLock($this->app->make(Cache::class));
+
+        foreach ($this->uniqueJobs as $job) {
+            $lock->release($job);
+        }
+
+        $this->uniqueJobs = [];
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -654,22 +654,6 @@ class QueueFake extends QueueManager implements Fake, Queue
     }
 
     /**
-     * Release the locks for all unique jobs that were pushed.
-     *
-     * @return void
-     */
-    public function cancelUniqueJobLocks()
-    {
-        $lock = new UniqueLock($this->app->make(Cache::class));
-
-        foreach ($this->uniqueJobs as $job) {
-            $lock->release($job);
-        }
-
-        $this->uniqueJobs = [];
-    }
-
-    /**
      * Serialize and unserialize the job to simulate the queueing process.
      *
      * @param  mixed  $job
@@ -678,6 +662,22 @@ class QueueFake extends QueueManager implements Fake, Queue
     protected function serializeAndRestoreJob($job)
     {
         return unserialize(serialize($job));
+    }
+
+    /**
+     * Release the locks for all unique jobs that were pushed.
+     *
+     * @return void
+     */
+    public function releaseUniqueJobLocks()
+    {
+        $lock = new UniqueLock($this->app->make(Cache::class));
+
+        foreach ($this->uniqueJobs as $job) {
+            $lock->release($job);
+        }
+
+        $this->uniqueJobs = [];
     }
 
     /**


### PR DESCRIPTION
Fixes #58533

The uniqueness lock created by `ShouldBeUnique` is never released since no real worker picked up the job. This PR keeps track of unique jobs in the `QueueFake` and releases their locks when `Queue::fake()` is called again. Within a test the uniqueness is preserved and from test to test it is cleared.