### PR TITLE
[Console] Add --connection option to make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -245,7 +245,10 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $replace = $this->buildFactoryReplacements();
+        $replace = array_merge(
+            $this->buildFactoryReplacements(),
+            $this->buildConnectionReplacements()
+        );
 
         return str_replace(
             array_keys($replace), array_values($replace), parent::buildClass($name)
@@ -302,6 +305,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API resource controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
+            ['connection', null, InputOption::VALUE_REQUIRED, 'Set the database connection for the generated model'],
         ];
     }
 
@@ -327,4 +331,30 @@ class ModelMakeCommand extends GeneratorCommand
             'resource' => 'Resource Controller',
         ])))->each(fn ($option) => $input->setOption($option, true));
     }
+
+    /**
+     * Build the replacements for the connection property in the model stub.
+     *
+     * @return array
+     */
+    protected function buildConnectionReplacements()
+    {
+        // If no connection option is set, the model will not have a connection property.
+        if (! $connection = $this->option('connection')) {
+            return [
+                '{{ connection }}' => '',
+            ];
+        }
+
+        // Otherwise, generate the code for the protected $connection property.
+        return [
+            '{{ connection }}' =>
+                "\n".
+                "    /**\n".
+                "     * The database connection for the model.\n".
+                "     */\n".
+                "    protected \$connection = '{$connection}';\n",
+        ];
+    }
+
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -8,4 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class {{ class }} extends Model
 {
     {{ factory }}
+
+    {{ connection }}
 }

--- a/tests/Integration/Console/MakeModelConnectionOptionTest.php
+++ b/tests/Integration/Console/MakeModelConnectionOptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Orchestra\Testbench\TestCase;
+
+class MakeModelConnectionOptionTest extends TestCase
+{
+    public function test_model_is_generated_without_connection_property_when_option_is_not_provided()
+    {
+        $this->artisan('make:model', ['name' => 'Post'])
+            ->assertExitCode(0);
+
+        $path = app_path('Models/Post.php');
+
+        $this->assertFileExists($path);
+        $this->assertStringNotContainsString(
+            'protected $connection',
+            file_get_contents($path)
+        );
+    }
+
+    public function test_model_is_generated_with_connection_property_when_option_is_provided()
+    {
+        $this->artisan('make:model', [
+            'name' => 'Comment',
+            '--connection' => 'pgsql',
+        ])->assertExitCode(0);
+
+        $path = app_path('Models/Comment.php');
+
+        $this->assertFileExists($path);
+        $this->assertStringContainsString(
+            "protected \$connection = 'pgsql';",
+            file_get_contents($path)
+        );
+    }
+}


### PR DESCRIPTION
Hi everyone,

I’d like to propose a small developer experience improvement to the `make:model` command.

This PR introduces an optional `--connection` option that allows developers to set the `$connection` property directly when generating a model.

## Summary

This PR adds an optional `--connection` option to the `make:model` command.  
When provided, the generated model will include a `protected $connection = '...';` property.

## Example

```bash
php artisan make:model Post --connection=pgsql
```

Generated model will include:

```php
protected $connection = 'pgsql';
```

## Motivation

In multi-database or multi-tenant applications, models often need to target a specific database connection.  
Currently, this requires manually editing the generated model after scaffolding.

This option makes that workflow explicit, faster, and less error-prone.

## Design Considerations

- Scoped only to `make:model` (generator-level improvement)
- No global Artisan behavior changes
- No behavior change if the option is not used
- No short option is added to avoid conflicts with existing options (like `-c` for controller)

## Backward Compatibility

This change is fully backward compatible.  
If `--connection` is not provided, generated models remain exactly the same.

## Tests

This PR includes tests covering:

- Model generation without `--connection`
- Model generation with `--connection`

You can run the test file by executing this command

```bash
vendor/bin/phpunit tests/Integration/Console/MakeModelConnectionOptionTest.php
```

---

## Notes

I intentionally kept the scope limited to model generation only to avoid expanding generator behavior.  
If needed, similar support could be discussed separately for other generators.

---

## Personal Note

This is my first contribution to the Laravel framework.  
If I made any mistakes or missed something, I truly appreciate any feedback or guidance.

Thank you for your time and for maintaining such an amazing framework.