### PR TITLE
[12.x] Ensure throwIfStatus / throwUnlessStatus work for all status codes

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -396,11 +396,7 @@ class Response implements ArrayAccess, Stringable
             throw new RequestException($this);
         }
 
-        if ($this->status() === $statusCode) {
-            throw new RequestException($this);
-        }
-
-        return $this;
+        return $this->status() === $statusCode ?  throw new RequestException($this) : $this;
     }
 
     /**
@@ -413,16 +409,11 @@ class Response implements ArrayAccess, Stringable
      */
     public function throwUnlessStatus($statusCode)
     {
-        if (is_callable($statusCode) &&
-            ! $statusCode($this->status(), $this)) {
-            throw new RequestException($this);
+        if (is_callable($statusCode)) {
+            return $statusCode($this->status(), $this) ? $this : throw new RequestException($this);
         }
 
-        if (! is_callable($statusCode) && $this->status() !== $statusCode) {
-            throw new RequestException($this);
-        }
-
-        return $this;
+        return $this->status() === $statusCode ? $this : throw new RequestException($this);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -393,10 +393,10 @@ class Response implements ArrayAccess, Stringable
     {
         if (is_callable($statusCode) &&
             $statusCode($this->status(), $this)) {
-            throw new RequestException($this);
+            throw new RequestException($this, $this->truncateExceptionsAt);
         }
 
-        return $this->status() === $statusCode ? throw new RequestException($this) : $this;
+        return $this->status() === $statusCode ? throw new RequestException($this, $this->truncateExceptionsAt) : $this;
     }
 
     /**
@@ -410,10 +410,10 @@ class Response implements ArrayAccess, Stringable
     public function throwUnlessStatus($statusCode)
     {
         if (is_callable($statusCode)) {
-            return $statusCode($this->status(), $this) ? $this : throw new RequestException($this);
+            return $statusCode($this->status(), $this) ? $this : throw new RequestException($this, $this->truncateExceptionsAt);
         }
 
-        return $this->status() === $statusCode ? $this : throw new RequestException($this);
+        return $this->status() === $statusCode ? $this : throw new RequestException($this, $this->truncateExceptionsAt);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -396,7 +396,7 @@ class Response implements ArrayAccess, Stringable
             throw new RequestException($this);
         }
 
-        return $this->status() === $statusCode ?  throw new RequestException($this) : $this;
+        return $this->status() === $statusCode ? throw new RequestException($this) : $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -393,10 +393,14 @@ class Response implements ArrayAccess, Stringable
     {
         if (is_callable($statusCode) &&
             $statusCode($this->status(), $this)) {
-            return $this->throw();
+            throw new RequestException($this);
         }
 
-        return $this->status() === $statusCode ? $this->throw() : $this;
+        if ($this->status() === $statusCode) {
+            throw new RequestException($this);
+        }
+
+        return $this;
     }
 
     /**
@@ -409,11 +413,16 @@ class Response implements ArrayAccess, Stringable
      */
     public function throwUnlessStatus($statusCode)
     {
-        if (is_callable($statusCode)) {
-            return $statusCode($this->status(), $this) ? $this : $this->throw();
+        if (is_callable($statusCode) &&
+            ! $statusCode($this->status(), $this)) {
+            throw new RequestException($this);
         }
 
-        return $this->status() === $statusCode ? $this : $this->throw();
+        if (! is_callable($statusCode) && $this->status() !== $statusCode) {
+            throw new RequestException($this);
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3487,6 +3487,74 @@ class HttpClientTest extends TestCase
         $this->assertNull($exception);
     }
 
+    public function testThrowIfStatusWorksWithNonErrorStatusCodes()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 201),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwIfStatus(201);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwIfStatus(fn ($status) => $status === 201);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testThrowUnlessStatusWorksWithNonErrorStatusCodes()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 201),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwUnlessStatus(200);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwUnlessStatus(201);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNull($exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwUnlessStatus(fn ($status) => $status === 200);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
     public function testRequestExceptionIsThrownIfIsServerError()
     {
         $this->factory->fake([


### PR DESCRIPTION
`throwIfStatus` and `throwUnlessStatus` delegate to `$this->throw()` under the hood, which only throws when `failed()` is true ie status (4xx/5xx). This means both methods silently do nothing for 2xx and 3xx responses.

This means we can now do:
```php

// Ensure a resource was actually created...
Http::post('https://api.example.com/users', $data)
    ->throwUnlessStatus(201);

// Catch unexpected redirects...
Http::get('https://api.example.com/resource')
    ->throwIfStatus(302);
```

Before this fix, both of these silently passed without throwing. 

Neither passed the callback into throw..

I've added tests to ensure no regression - this should match what $this->throw was doing - can target 13.x but feels like this is expected behaviour.
