### PR TITLE
[12.x] Fix memory leak in debug error page query listener (#56652)

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Listener.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Str;
 use Laravel\Octane\Events\RequestReceived;
 use Laravel\Octane\Events\RequestTerminated;
 use Laravel\Octane\Events\TaskReceived;
@@ -66,8 +67,10 @@ class Listener
         $this->queries[] = [
             'connectionName' => $event->connectionName,
             'time' => $event->time,
-            'sql' => $event->sql,
-            'bindings' => $event->connection->prepareBindings($event->bindings),
+            'sql' => Str::limit($event->sql, 2000),
+            'bindings' => $event->connection->prepareBindings(
+                array_slice($event->bindings, 0, 300)
+            ),
         ];
     }
 }

--- a/tests/Foundation/Exceptions/Renderer/ListenerTest.php
+++ b/tests/Foundation/Exceptions/Renderer/ListenerTest.php
@@ -39,4 +39,41 @@ class ListenerTest extends TestCase
         $this->assertEquals('select * from users where id = ?', $query['sql']);
         $this->assertEquals(['foo'], $query['bindings']);
     }
+
+    public function testSqlIsTruncatedWhenExceedingLimit()
+    {
+        $connection = m::mock();
+        $longSql = str_repeat('a', 10000);
+
+        $connection->shouldReceive('getName')->andReturn('testing');
+        $connection->shouldReceive('prepareBindings')->with([])->andReturn([]);
+
+        $event = new QueryExecuted($longSql, [], 1.0, $connection);
+
+        $listener = new Listener();
+        $listener->onQueryExecuted($event);
+
+        $query = $listener->queries()[0];
+
+        $this->assertLessThanOrEqual(2003, strlen($query['sql']));
+        $this->assertStringEndsWith('...', $query['sql']);
+    }
+
+    public function testBindingsAreLimitedWhenExceedingLimit()
+    {
+        $connection = m::mock();
+        $bindings = range(1, 10000);
+
+        $connection->shouldReceive('getName')->andReturn('testing');
+        $connection->shouldReceive('prepareBindings')->with(array_slice($bindings, 0, 300))->andReturn(array_slice($bindings, 0, 300));
+
+        $event = new QueryExecuted('select 1', $bindings, 1.0, $connection);
+
+        $listener = new Listener();
+        $listener->onQueryExecuted($event);
+
+        $query = $listener->queries()[0];
+
+        $this->assertLessThanOrEqual(300, count($query['bindings']));
+    }
 }


### PR DESCRIPTION
Fixes #56652

The exception listener is storing way too many queries and in turn with bulk inserts each storied query can contain a huge amount of SQL strings and bindings. This is what is leading to the large memory usage in Octane requests.

This PR truncates the stored SQL strings down to 2,000 characters and slices the bindings to 300 before prepping. This will keep the memory usage bounded and just impacts the rendered error page. DB::listen(), DB::enableQueryLog() for example are untouched by this change.

On the error page large queries will show truncated SQL with `...` and the first 300 bindings substituted. Any remaining `?` placeholders will appear as `?`.