### PR TITLE
[13.x] Write console component output to stderr (#56602)

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -172,7 +173,11 @@ class Command extends SymfonyCommand
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 
-        $this->components = $this->laravel->make(Factory::class, ['output' => $this->output]);
+        $componentOutput = $output instanceof ConsoleOutputInterface
+            ? $this->laravel->make(OutputStyle::class, ['input' => $input, 'output' => $output->getErrorOutput()])
+            : $this->output;
+
+        $this->components = $this->laravel->make(Factory::class, ['output' => $componentOutput]);
 
         $this->configurePrompts($input);
 


### PR DESCRIPTION
Fixes #56602

Right now the console components (`->info()`, `->task()`, etc) write to stdout. This PR creates a new OutputStyle instance that will write to `stderr` instead of `stdout`. 

I verified the fix by creating this command:

```php
Artisan::command('test:stderr', function () {
    $this->components->info('Component info (should be stderr)');
    $this->components->warn('Component warn (should be stderr)');
    $this->line('Direct line output (should be stdout)');
    $this->info('Direct info output (should be stdout)');
});
```

Then run php artisan test:stderr > /tmp/stdout.txt 2> /tmp/stderr.txt — stdout shows the regular output and stderr gets the component banners. I'm targeting  `master` on this since it's a breaking change but would be nice to have.
