### PR TITLE
[12.x] Add HashManager::checkAndRehash() convenience method

### DIFF
--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -125,4 +125,28 @@ class HashManager extends Manager implements Hasher
 
         return true;
     }
+
+    /**
+     * Check the given plain value against a hash and return a new hash when the
+     * hash should be rehashed.
+     *
+     * Returns null when the value does not match the given hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return string|null
+     */
+    public function checkAndRehash(#[\SensitiveParameter] $value, $hashedValue, array $options = [])
+    {
+        if (! $this->check($value, $hashedValue, $options)) {
+            return null;
+        }
+
+        if (! $this->needsRehash($hashedValue, $options)) {
+            return $hashedValue;
+        }
+
+        return $this->make($value, $options);
+    }
 }


### PR DESCRIPTION
Adds `HashManager::checkAndRehash()` to verify a plain value against an existing hash and automatically return a rehashed value when needed.

### Behavior:

returns null when verification fails
returns the original hash when verification succeeds and rehash is not needed
returns a new hash when verification succeeds and rehash is needed

Adds tests in `tests/Hashing/HasherTest.php` to cover all branches (fail, success/no rehash, success/rehash).