### PR TITLE
feat: add make:filter command to create Filter classes

### DIFF
--- a/src/Illuminate/Foundation/Console/FilterMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/FilterMakeCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'filter:make')]
+final class FilterMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'filter:make';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new filter class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Filter';
+
+    /**
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/filter.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Models')) ? $rootNamespace.'\\Models\\Scopes\\Filters' : $rootNamespace.'\Filters';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the scope already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/filter.stub
+++ b/src/Illuminate/Foundation/Console/stubs/filter.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+
+class {{ class }}
+{
+    /**
+     * Create a new filter instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Apply the filter to the given Eloquent query.
+     */
+    public function __invoke(Builder $query): void
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -55,6 +55,7 @@ use Illuminate\Foundation\Console\EventGenerateCommand;
 use Illuminate\Foundation\Console\EventListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
+use Illuminate\Foundation\Console\FilterMakeCommand;
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\JobMiddlewareMakeCommand;
@@ -206,6 +207,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventMake' => EventMakeCommand::class,
         'ExceptionMake' => ExceptionMakeCommand::class,
         'FactoryMake' => FactoryMakeCommand::class,
+        'FilterMake' => FilterMakeCommand::class,
         'InterfaceMake' => InterfaceMakeCommand::class,
         'JobMake' => JobMakeCommand::class,
         'JobMiddlewareMake' => JobMiddlewareMakeCommand::class,
@@ -488,6 +490,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(FactoryMakeCommand::class, function ($app) {
             return new FactoryMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerFilterMakeCommand()
+    {
+        $this->app->singleton(FilterMakeCommand::class, function ($app) {
+            return new FilterMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In this PR, I tried to add a make command for generating [Filter](https://laravel.com/docs/12.x/queries#reusable-query-components) classes. I tried to find any tests for artisan commands, especially makes commands, but I didn't find any. I would be really grateful if could say how I can test this small feature easily.
In my opinion it shouldn't break any existing features and at the same time this PR gives opportunity to make Filter classes for such a good feature as Reusable Query Components with ease. Just in case of acceptance this PR, I've prepared the [PR](https://github.com/laravel/docs/pull/11046) for updated docs as well.

All the best,
Ihor