### PR TITLE
[12.x] Refactor: improve tests

### DIFF
--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -32,7 +32,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testDenyHasNullStatus()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -53,7 +53,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testItCanDenyWithStatus()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -73,7 +73,7 @@ class AuthHandlesAuthorizationTest extends TestCase
             $this->assertSame(0, $e->getCode());
         }
 
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -96,7 +96,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testItCanDenyAsNotFound()
     {
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 
@@ -116,7 +116,7 @@ class AuthHandlesAuthorizationTest extends TestCase
             $this->assertSame(0, $e->getCode());
         }
 
-        $class = new class()
+        $class = new class
         {
             use HandlesAuthorization;
 

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -287,7 +287,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testFirstOrCreateMethodFallsBackToCreateOrFirst(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {
@@ -358,7 +358,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testUpdateOrCreateMethodCreatesNewRelated(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {
@@ -400,7 +400,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
     public function testUpdateOrCreateMethodUpdatesExistingRelated(): void
     {
-        $source = new class() extends BelongsToManyCreateOrFirstTestSourceModel
+        $source = new class extends BelongsToManyCreateOrFirstTestSourceModel
         {
             protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $relationName = null): BelongsToMany
             {

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -223,7 +223,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     public function testForceDeleteDoesntUpdateExistsPropertyIfFailed()
     {
-        $user = new class() extends SoftDeletesTestUser
+        $user = new class extends SoftDeletesTestUser
         {
             public $exists = true;
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2386,7 +2386,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having(
-            new class() implements ConditionExpression
+            new class implements ConditionExpression
             {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {
@@ -6525,7 +6525,7 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where(
-            new class() implements ConditionExpression
+            new class implements ConditionExpression
             {
                 public function getValue(\Illuminate\Database\Grammar $grammar)
                 {

--- a/tests/Filesystem/JoinPathsHelperTest.php
+++ b/tests/Filesystem/JoinPathsHelperTest.php
@@ -26,14 +26,14 @@ class JoinPathsHelperTest extends TestCase
         yield ['Empty/0/1/Segments/00/Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1/2/3', join_paths(1, 0, 2, 3)];
-        yield ['app/objecty', join_paths('app', new class()
+        yield ['app/objecty', join_paths('app', new class
         {
             public function __toString()
             {
                 return 'objecty';
             }
         })];
-        yield ['app/0', join_paths('app', new class()
+        yield ['app/0', join_paths('app', new class
         {
             public function __toString()
             {
@@ -58,14 +58,14 @@ class JoinPathsHelperTest extends TestCase
         yield ['Empty\0\1\Segments\00\Get_removed.php', join_paths('Empty', '', '0', null, 0, false, [], '1', 'Segments', '00', 'Get_removed.php')];
         yield ['', join_paths(null, null, '')];
         yield ['1\2\3', join_paths(1, 2, 3)];
-        yield ['app\\objecty', join_paths('app', new class()
+        yield ['app\\objecty', join_paths('app', new class
         {
             public function __toString()
             {
                 return 'objecty';
             }
         })];
-        yield ['app\\0', join_paths('app', new class()
+        yield ['app\\0', join_paths('app', new class
         {
             public function __toString()
             {

--- a/tests/Integration/Foundation/Exceptions/RendererTest.php
+++ b/tests/Integration/Foundation/Exceptions/RendererTest.php
@@ -47,7 +47,7 @@ class RendererTest extends TestCase
     public function testItCanRenderExceptionPageWithRendererWhenDebugEnabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer
+            return new class implements ExceptionRenderer
             {
                 public function render($throwable)
                 {
@@ -67,7 +67,7 @@ class RendererTest extends TestCase
     public function testItDoesNotRenderExceptionPageWithRendererWhenDebugDisabled()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer
+            return new class implements ExceptionRenderer
             {
                 public function render($throwable)
                 {
@@ -103,7 +103,7 @@ class RendererTest extends TestCase
     public function testItDoesNotRegisterListenersWhenRendererBound()
     {
         $this->app->singleton(ExceptionRenderer::class, function () {
-            return new class() implements ExceptionRenderer
+            return new class implements ExceptionRenderer
             {
                 public function render($throwable)
                 {

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -472,7 +472,7 @@ class LogManagerTest extends TestCase
             'driver' => 'single',
         ]);
 
-        $factory = new class()
+        $factory = new class
         {
             public function __invoke()
             {

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -78,7 +78,7 @@ class ComponentTest extends TestCase
         $this->viewFactory->shouldReceive('exists')->once()->andReturn(false);
         $this->viewFactory->shouldReceive('addNamespace')->once()->with('__components', '/tmp');
 
-        $component = new class() extends Component
+        $component = new class extends Component
         {
             protected $title;
 


### PR DESCRIPTION
Remove unnecessary parentheses from anonymous class instantiation

Removed empty parentheses when instantiating anonymous classes that don't require constructor arguments, as they are optional in PHP.
```php
// Before
$source = new class() extends ParentClass { }

// After
$source = new class extends ParentClass { }
```