### PR TITLE
[12.x] Feat(`ValidatesAttributes`): add `validateUnsignedInt()`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1783,6 +1783,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is an unsigned integer.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateUnsignedInt($attribute, $value)
+    {
+        return $this->validateInteger($attribute, $value) && $this->validateMin($attribute, $value, [0]);
+    }
+
+    /**
      * Validate that an attribute has a minimum number of digits.
      *
      * @param  string  $attribute


### PR DESCRIPTION
Add `unsigned_int` validation rule

This PR introduces a new `unsigned_int` validation rule to simplify validation of non-negative integers.

## Motivation

Currently, validating unsigned integers requires combining multiple rules:
```php
'count' => ['required', 'integer', 'min:0'],
'quantity' => ['required', 'int', 'min:0'],
```

This is verbose and can be inconsistent across a codebase. A dedicated rule improves readability and developer experience.

## Benefits

- **Cleaner validation rules**: Replace `['integer', 'min:0']` with a single `'unsigned_int'` rule
- **Better semantics**: Explicitly communicates intent when validating quantities, counts, IDs, and other non-negative values
- **Consistency**: Provides a standard approach for unsigned integer validation across Laravel applications
- **Type safety**: Ensures both integer type and non-negative constraint in one step

## Usage
```php
// Before
'user_id' => ['required', 'integer', 'min:0'],
'quantity' => ['required', 'int', 'min:0'],

// After
'user_id' => ['required', 'unsigned_int'],
'quantity' => ['required', 'unsigned_int'],
```

The rule can still be combined with other constraints:
```php
'age' => ['required', 'unsigned_int', 'max:150'],
'stock' => ['required', 'unsigned_int', 'min:1'], // at least 1
```

## Implementation

The `validateUnsignedInt` method leverages existing `validateInteger` and `validateMin` methods, ensuring consistency with Laravel's validation behavior.