### PR TITLE
[12.x] Fix `schedule:work` subprocess working directory

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -58,7 +58,7 @@ class ScheduleWorkCommand extends Command
 
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
-                $executions[] = $execution = Process::fromShellCommandline($command);
+                $executions[] = $execution = $this->createScheduleRunProcess($command);
 
                 $execution->start();
 
@@ -76,5 +76,16 @@ class ScheduleWorkCommand extends Command
                 }
             }
         }
+    }
+
+    /**
+     * Create a new schedule:run process.
+     *
+     * @param  string  $command
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function createScheduleRunProcess($command)
+    {
+        return Process::fromShellCommandline($command, base_path());
     }
 }

--- a/tests/Console/Scheduling/ScheduleWorkCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleWorkCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\ScheduleWorkCommand;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class ScheduleWorkCommandTest extends TestCase
+{
+    public function testScheduleRunProcessUsesApplicationBasePathAsWorkingDirectory()
+    {
+        $originalContainer = Container::getInstance();
+
+        Container::setInstance(new class extends Container
+        {
+            public function basePath($path = '')
+            {
+                return '/test-base-path';
+            }
+        });
+
+        try {
+            $command = new class extends ScheduleWorkCommand
+            {
+                public function createProcess($command)
+                {
+                    return $this->createScheduleRunProcess($command);
+                }
+            };
+
+            $process = $command->createProcess('php artisan schedule:run');
+
+            $this->assertInstanceOf(Process::class, $process);
+            $this->assertSame('/test-base-path', $process->getWorkingDirectory());
+        } finally {
+            Container::setInstance($originalContainer);
+        }
+    }
+}


### PR DESCRIPTION

When running `schedule:work` using an absolute artisan path from outside the project directory, the child `schedule:run` process may fail with:

```
Could not open input file: artisan
```

Example:

```bash
php /home/laravel/artisan schedule:work
```

(from `/` or any non-project working directory)

### Root cause

`ScheduleWorkCommand` builds the command with `Application::formatCommandString('schedule:run')`, which uses `artisan` as a relative executable.
The subprocess was started without an explicit working directory, so `artisan` was resolved from the caller's current directory instead of the Laravel app base path.

### Fix

`ScheduleWorkCommand` now creates the `schedule:run` subprocess with `base_path()` as working directory.