### PR TITLE
[12.x] Refactor: Clean up unused $config parameters in ConcurrencyManager 

### DIFF
--- a/src/Illuminate/Concurrency/ConcurrencyManager.php
+++ b/src/Illuminate/Concurrency/ConcurrencyManager.php
@@ -26,10 +26,9 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the process concurrency driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Concurrency\ProcessDriver
      */
-    public function createProcessDriver(array $config)
+    public function createProcessDriver()
     {
         return new ProcessDriver($this->app->make(ProcessFactory::class));
     }
@@ -37,12 +36,11 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the fork concurrency driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Concurrency\ForkDriver
      *
      * @throws \RuntimeException
      */
-    public function createForkDriver(array $config)
+    public function createForkDriver()
     {
         if (! $this->app->runningInConsole()) {
             throw new RuntimeException('Due to PHP limitations, the fork driver may not be used within web requests.');
@@ -58,10 +56,9 @@ class ConcurrencyManager extends MultipleInstanceManager
     /**
      * Create an instance of the sync concurrency driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Concurrency\SyncDriver
      */
-    public function createSyncDriver(array $config)
+    public function createSyncDriver()
     {
         return new SyncDriver;
     }


### PR DESCRIPTION
This PR removes the unused $config parameters from the createProcessDriver, createForkDriver, and createSyncDriver methods in the ConcurrencyManager class.

These parameters were never used in the method bodies.

Removing them makes the code cleaner and easier to read.

No functionality or backward compatibility is affected because these methods are internal to the ConcurrencyManager.

Before:

public function createProcessDriver(array $config) { ... }


After:

public function createProcessDriver() { ... }


Note:
If future configuration options are added for these drivers, parameters can be reintroduced at that time.