### PR TITLE
12.x] Add `orderByPivotDesc()` test and type coverage

### DIFF
--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -92,6 +92,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
         $builder->shouldReceive('orderBy')->with($column, 'asc')->once()->andReturnSelf();
         $relation->orderByPivot($column);
+
+        $builder->shouldReceive('orderBy')->with($column, 'desc')->once()->andReturnSelf();
+        $relation->orderByPivotDesc($column);
     }
 
     public function getRelation(): MorphToMany

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1363,6 +1363,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $relationTag2 = $post->tagsWithCustomExtraPivot()->orderByPivot('flag', 'desc')->first();
         $this->assertEquals($relationTag2->getAttributes(), $tag3->getAttributes());
+
+        $relationTag3 = $post->tagsWithCustomExtraPivot()->orderByPivotDesc('flag')->first();
+        $this->assertEquals($relationTag3->getAttributes(), $tag3->getAttributes());
     }
 
     public function testFirstOrMethod()

--- a/types/Database/Eloquent/Relations.php
+++ b/types/Database/Eloquent/Relations.php
@@ -78,6 +78,8 @@ function test(User $user, Post $post, Comment $comment, ChildUser $child): void
     assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Relations\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->lazy());
     assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Relations\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->lazyById());
     assertType('Illuminate\Support\LazyCollection<int, Illuminate\Types\Relations\Role&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot}>', $user->roles()->cursor());
+    assertType("Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Types\Relations\Role, Illuminate\Types\Relations\User, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>", $user->roles()->orderByPivot('foo', 'asc'));
+    assertType("Illuminate\Database\Eloquent\Relations\BelongsToMany<Illuminate\Types\Relations\Role, Illuminate\Types\Relations\User, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>", $user->roles()->orderByPivotDesc('foo'));
 
     assertType('Illuminate\Database\Eloquent\Relations\HasOneThrough<Illuminate\Types\Relations\Car, Illuminate\Types\Relations\Mechanic, Illuminate\Types\Relations\User>', $user->car());
     assertType('Illuminate\Types\Relations\Car|null', $user->car()->getResults());


### PR DESCRIPTION

This PR adds missing coverage for `BelongsToMany::orderByPivotDesc()`.

- Adds an integration assertion that `orderByPivotDesc('flag')` returns the same first record as `orderByPivot('flag', 'desc')`.
- Extends `MorphToMany` unit tests to verify `orderByPivotDesc()` delegates to `orderBy(..., 'desc')`.
- Adds PHPStan type assertions for `orderByPivot()` and `orderByPivotDesc()` fluent return types.

### Why

`orderByPivotDesc()` exists on `BelongsToMany`, but there was no direct test coverage for it and no explicit type assertion in `types/Database/Eloquent/Relations.php`.  
This PR closes that gap and helps prevent regressions.