### PR TITLE
[12.x] Refactor: use `Dumpable`

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -4,13 +4,14 @@ namespace Illuminate\Support;
 
 use ArrayIterator;
 use Illuminate\Contracts\Support\ValidatedData;
+use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 class ValidatedInput implements ValidatedData
 {
-    use InteractsWithData;
+    use Dumpable, InteractsWithData;
 
     /**
      * The underlying input.
@@ -98,29 +99,14 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Dump the validated inputs items and end the script.
-     *
-     * @param  mixed  ...$keys
-     * @return never
-     */
-    public function dd(...$keys)
-    {
-        $this->dump(...$keys);
-
-        exit(1);
-    }
-
-    /**
      * Dump the items.
      *
-     * @param  mixed  $keys
+     * @param  mixed  ...$keys
      * @return $this
      */
-    public function dump($keys = [])
+    public function dump(...$keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        VarDumper::dump(count($keys) > 0 ? $this->only($keys) : $this->all());
+        dump(count($keys) > 0 ? $this->only($keys) : $this->all());
 
         return $this;
     }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -6,7 +6,6 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\ValidatedData;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\InteractsWithData;
-use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 class ValidatedInput implements ValidatedData


### PR DESCRIPTION
# [12.x] Use `Dumpable` trait in `ValidatedInput`

This PR applies the `Dumpable` trait to the `ValidatedInput` class, following the pattern established in #47122.

The `dump()` method is overridden to maintain the existing behavior of filtering keys, while `dd()` is inherited from the trait.

## Changes:
- Add `Dumpable` trait to `ValidatedInput`
- Update `dump()` signature to use variadic parameters (`...$keys`)
- Remove custom `dd()` implementation (inherited from trait)
- Maintain backward compatibility with existing filtering behavior