### PR TITLE
[12.x] Update forever cookie factory docblock to reflect 400-day duration

### DIFF
--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -21,7 +21,7 @@ interface Factory
     public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null);
 
     /**
-     * Create a cookie that lasts "forever" (five years).
+     * Create a cookie that lasts "forever" (400 days).
      *
      * @param  string  $name
      * @param  string  $value


### PR DESCRIPTION
Was poking some cookie bits and noticed this.

The concrete implementation uses a 400 day duration (to align with Chromes 400 day max-age I believe) but the interface docblock still references "five years."   This PR just keeps the contract aligned 🤷🏻 

https://github.com/laravel/framework/blob/8469f5ef8dcd79c5835750f39a0c3eca9c8d6cc9/src/Illuminate/Cookie/CookieJar.php#L73-L86

Targeted 12 as it's boring docbloc bits..