### PR TITLE
[12.x] Ensure defer callbacks aren't discarded when using the sync queue

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -215,7 +215,12 @@ class FoundationServiceProvider extends AggregateServiceProvider
         });
 
         $this->app['events']->listen(function (JobAttempted $event) {
-            app(DeferredCallbackCollection::class)->invokeWhen(static fn ($callback) => ! in_array($event->connectionName, ['sync', 'deferred']) && ($event->successful() || $callback->always));
+
+            if (in_array($event->connectionName, ['sync', 'deferred'])) {
+                return;
+            }
+
+            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => $event->successful() || $callback->always);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -215,7 +215,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
         });
 
         $this->app['events']->listen(function (JobAttempted $event) {
-
             if (in_array($event->connectionName, ['sync', 'deferred'])) {
                 return;
             }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -219,7 +219,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
                 return;
             }
 
-            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => $event->successful() || $callback->always);
+            app(DeferredCallbackCollection::class)->invokeWhen(fn ($callback) => ($event->successful() || $callback->always));
         });
     }
 

--- a/tests/Integration/Support/DeferredCallbackTest.php
+++ b/tests/Integration/Support/DeferredCallbackTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Http\Middleware\InvokeDeferredCallbacks;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+
+class DeferredCallbackTest extends TestCase
+{
+    #[WithConfig('queue.default', 'sync')]
+    public function test_deferred_callback_is_not_discarded_by_sync_job()
+    {
+        $executed = false;
+
+        Route::get('/test', function () use (&$executed) {
+            defer(function () use (&$executed) {
+                $executed = true;
+            });
+
+            dispatch(new TestSyncJob);
+        })->middleware(InvokeDeferredCallbacks::class);
+
+        $this->get('/test');
+
+        $this->assertTrue($executed);
+    }
+}
+
+class TestSyncJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public function handle(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
Reported via https://github.com/laravel/framework/issues/58731

Currently, if you use the sync driver to dispatch a job as well as using defer during the request, the defer callbacks will be lost - which I don't think is expected behaviour.

A scenario this would be used is something like: 

```php
Route::post('/orders', function () {
    $order = Order::create($data);

    // Send confirmation email
    dispatch(new SendOrderConfirmation($order));

    // Defer something for after the response... - this is currently not executed
    defer(fn () => Metrics::reportOrder($order));

    return response()->json($order);
});
```

I've added a new test to cover it as couldnt find anything callback wise for tests.  You can drop the FoundationServiceProvider change and the test will fail.

TLDR is basically this happens when using the sync queue with defer 

You may see a better way so feel free to adjust etc as you see fit 🫡  I didn't want to go sledgehammer on it

Targeted 12.x as seems like a bug