### PR TITLE
[12.x] Fix: `@return` in doc blocks

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -190,7 +190,7 @@ class VendorPublishCommand extends Command
      * Publishes the assets for a tag.
      *
      * @param  string  $tag
-     * @return mixed
+     * @return void
      */
     protected function publishTag($tag)
     {

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -29,7 +29,7 @@ class ViewCacheCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return void
      */
     public function handle()
     {


### PR DESCRIPTION
The current return type of `publishTag()` and `handle()` is `void`