### PR TITLE
[12.x] Refactor: remove `Arr::wrap()` and add `Collection::wrap()`

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
+++ b/src/Illuminate/Http/Resources/JsonApi/JsonApiRequest.php
@@ -60,7 +60,7 @@ class JsonApiRequest extends Request
         }
 
         return transform($this->cachedSparseIncluded[$key] ?? null, function ($value) {
-            return (new Collection(Arr::wrap($value)))
+            return Collection::wrap($value)
                 ->transform(function ($item) {
                     $item = implode('.', Arr::take(explode('.', $item), JsonApiResource::$maxRelationshipDepth - 1));
 


### PR DESCRIPTION
# [12.x] Use `Collection::wrap` in `sparseIncluded()` method

This PR updates the `sparseIncluded()` method to use `Collection::wrap()` instead of `new Collection()`, following the improvements introduced in #53891.

## Changes

- Replaced `new Collection(...)` with `Collection::wrap()` for cleaner, more consistent code
- Maintains the same functionality while improving code clarity
- In cases where the value is already `Enumerable`, this approach is more efficient

## Before
```php
        return transform($this->cachedSparseIncluded[$key] ?? null, function ($value) {
            return (new Collection(Arr::wrap($value)))
                ->transform(function ($item) {
                    $item = implode('.', Arr::take(explode('.', $item), JsonApiResource::$maxRelationshipDepth - 1));

                    return ! empty($item) ? $item : null;
                })->filter()->all();
        }) ?? [];
```

## After
```php
        return transform($this->cachedSparseIncluded[$key] ?? null, function ($value) {
            return Collection::wrap($value)
                ->transform(function ($item) {
                    $item = implode('.', Arr::take(explode('.', $item), JsonApiResource::$maxRelationshipDepth - 1));

                    return ! empty($item) ? $item : null;
                })->filter()->all();
        }) ?? [];
```

This change aligns with the framework's preference for using `Collection::wrap()` when creating collections, as established in #53891.