### PR TITLE
[12.x] Refactor: remove extra space

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -34,7 +34,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public $with = [];
 
     /**
-     * The additional meta data that should be added to the resource response.
+     * The additional metadata that should be added to the resource response.
      *
      * Added during response construction by the developer.
      *
@@ -211,7 +211,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Add additional meta data to the resource response.
+     * Add additional metadata to the resource response.
      *
      * @param  array  $data
      * @return $this

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -81,7 +81,7 @@ class PaginatedResourceResponse extends ResourceResponse
     }
 
     /**
-     * Gather the meta data for the response.
+     * Gather the metadata for the response.
      *
      * @param  array  $paginated
      * @return array

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -61,7 +61,7 @@ class Envelope
     public $tags = [];
 
     /**
-     * The message's meta data.
+     * The message's metadata.
      *
      * @var array
      */


### PR DESCRIPTION
Standardize "meta data" to "metadata" to align with Laravel's conventions used throughout the framework.