### PR TITLE
[12.x] Fix return empty Collection for non-model JSON:API resources

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -324,7 +324,7 @@ trait ResolvesJsonApiElements
     public function resolveIncludedResourceObjects(JsonApiRequest $request): Collection
     {
         if (! $this->resource instanceof Model) {
-            return [];
+            return new Collection;
         }
 
         $this->compileResourceRelationships($request);

--- a/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
+++ b/tests/Integration/Http/Resources/JsonApi/JsonApiResourceTest.php
@@ -645,6 +645,22 @@ class JsonApiResourceTest extends TestCase
             ->assertJsonCount(1, 'included');
     }
 
+    public function testTopLevelArrayBackedCustomResourceCanGenerateJsonApiResponse()
+    {
+        $this->getJson('/things/99')
+            ->assertHeader('Content-type', 'application/vnd.api+json')
+            ->assertExactJson([
+                'data' => [
+                    'id' => '99',
+                    'type' => 'things',
+                    'attributes' => [
+                        'name' => 'test',
+                    ],
+                ],
+            ])
+            ->assertJsonMissing(['jsonapi', 'included']);
+    }
+
     public function testSameModelWithTheSameResourceTypeIsDeduplicated()
     {
         $user = User::factory()->create();

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -51,6 +51,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             return Post::find($postId)->toResource();
         });
 
+        $router->get('things/{id}', function ($id) {
+            return new ArrayBackedJsonApiResource(['id' => (int) $id, 'name' => 'test']);
+        });
+
         $router->get('users/{userId}/with-array-relationship', function ($userId) {
             $resource = new UserWithArrayRelationshipResource(User::find($userId));
             $resource->loadedRelationshipsMap = [


### PR DESCRIPTION
Fixed JSON:API included resource resolution for top-level, array-based custom resources.

`resolveIncludedResourceObjects()` was returning an array `[]` for non-model resources, despite the method contract being `Collection`.

This change now returns an empty `Collection` instead.