### PR TITLE
[12.x] allow string-based expressions for selectExpression()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -328,14 +328,14 @@ class Builder implements BuilderContract
     /**
      * Add a select expression to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression  $expression
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
      * @param  string  $as
      * @return $this
      */
     public function selectExpression($expression, $as)
     {
         return $this->selectRaw(
-            '('.$expression->getValue($this->grammar).') as '.$this->grammar->wrap($as)
+            '('.$this->grammar->getValue($expression).') as '.$this->grammar->wrap($as)
         );
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5433,9 +5433,11 @@ SQL;
     public function testSelectExpression()
     {
         $builder = $this->getBuilder();
-        $builder->from('one')->selectExpression(new Raw('1 + 1'), 'expr');
+        $builder->from('one')
+            ->selectExpression(new Raw('1 + 1'), 'expr')
+            ->selectExpression('2 + 2', 'expr2');
 
-        $this->assertSame('select (1 + 1) as "expr" from "one"', $builder->toSql());
+        $this->assertSame('select (1 + 1) as "expr", (2 + 2) as "expr2" from "one"', $builder->toSql());
     }
 
     public function testSelect()


### PR DESCRIPTION
So in 12.48.0 I contributed a way to make using SQL functions easier (after some stuff had to be reverted):

```php
// before 12.48.0
$query->select(new Expression("jsonb_agg(DISTINCT col) AS values"))

// with 12.48.0
$query->selectExpressions(new Expression("jsonb_agg(DISTINCT col)", 'values')
``` 

but this is still a lot of boilerplate as you must create a new expression object. And that object is really not needed as the method already defines that you pass expressions. So with this PR, any query builder code can be simplified to this:

```php
$query->selectExpression("jsonb_agg(DISTINCT col)", 'values')
``` 

That's much simpler code. And in a real example, it looks also more cleanly:

```php
Visits::query()
  ->select('domain')
  ->selectExpression('count(distinct user)', 'users_unique')
  ->selectExpression('count(user)', 'users_total')
  ->groupBy('domain');
```

No more expressions needed :)

---

This PR is fully backwards compatible.
