### PR TITLE
[12.x] Refactor: simplify conditional logic

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -901,7 +901,7 @@ class Validator implements ValidatorContract
      */
     protected function hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute)
     {
-        return ! in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
+        return !in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -901,7 +901,7 @@ class Validator implements ValidatorContract
      */
     protected function hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute)
     {
-        return in_array($rule, ['Unique', 'Exists']) ? ! $this->messages->has($attribute) : true;
+        return ! in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -901,7 +901,7 @@ class Validator implements ValidatorContract
      */
     protected function hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute)
     {
-        return !in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
+        return ! in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
     }
 
     /**


### PR DESCRIPTION
Simplify conditional logic using De Morgan's law

Replace ternary operator with cleaner boolean expression:
- Before: `condition ? ! x : true`
- After: `! condition || ! x`

Both expressions are logically equivalent but the new version is more concise and readable.