### PR TITLE
[12.x] Align file size validation with SI units (1000 vs 1024)

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -21,7 +21,7 @@ class FileFactory
         }
 
         return tap(new File($name, tmpfile()), function ($file) use ($kilobytes, $mimeType) {
-            $file->sizeToReport = $kilobytes * 1024;
+            $file->sizeToReport = $kilobytes * 1_000;
             $file->mimeTypeToReport = $mimeType;
         });
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2771,7 +2771,7 @@ trait ValidatesAttributes
         } elseif (is_array($value)) {
             return count($value);
         } elseif ($value instanceof File) {
-            return (string) ($value->getSize() / 1024);
+            return (string) ($value->getSize() / 1_000);
         }
 
         return mb_strlen($value ?? '');

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -231,17 +231,17 @@ class ValidationFileRuleTest extends TestCase
     public function testSize()
     {
         $this->fails(
-            File::default()->size(1024),
+            File::default()->size(1_500),
             [
-                UploadedFile::fake()->create('foo.txt', 1025),
-                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 1_501),
+                UploadedFile::fake()->create('foo.txt', 1_499),
             ],
             ['validation.size.file']
         );
 
         $this->passes(
-            File::default()->size(1024),
-            UploadedFile::fake()->create('foo.txt', 1024),
+            File::default()->size(1_000),
+            UploadedFile::fake()->create('foo.txt', 1_000),
         );
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3769,12 +3769,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(3072);
+        $file->expects($this->any())->method('getSize')->willReturn(3_000);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->expects($this->any())->method('getSize')->willReturn(4_000);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertFalse($v->passes());
     }
@@ -4094,10 +4094,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->expects($this->any())->method('getSize')->willReturn(4_000);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
+        $biggerFile->expects($this->any())->method('getSize')->willReturn(5_000);
         $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gt:bigger']);
         $this->assertFalse($v->passes());
@@ -4139,11 +4139,11 @@ class ValidationValidatorTest extends TestCase
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
+        $smallerFile->expects($this->any())->method('getSize')->willReturn(2_048);
         $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lt:smaller']);
         $this->assertFalse($v->passes());
-        $this->assertEquals(2, $v->messages()->first('photo'));
+        $this->assertEquals(2.048, $v->messages()->first('photo'));
 
         $v = new Validator($trans, ['items' => [1, 2, 3], 'less' => [0, 1]], ['items' => 'lt:less']);
         $this->assertFalse($v->passes());
@@ -4178,10 +4178,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->expects($this->any())->method('getSize')->willReturn(4_072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
+        $biggerFile->expects($this->any())->method('getSize')->willReturn(5_000);
         $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gte:bigger']);
         $this->assertFalse($v->passes());
@@ -4220,10 +4220,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(4072);
+        $file->expects($this->any())->method('getSize')->willReturn(4_072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
+        $smallerFile->expects($this->any())->method('getSize')->willReturn(2_000);
         $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lte:smaller']);
         $this->assertFalse($v->passes());
@@ -4563,10 +4563,10 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
+        $file->expects($this->any())->method('getSize')->willReturn(8_900);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(9216);
+        $otherFile->expects($this->any())->method('getSize')->willReturn(9_000);
         $otherFile->expects($this->any())->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
@@ -4603,10 +4603,10 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
+        $file->expects($this->any())->method('getSize')->willReturn(8_900);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(9216);
+        $otherFile->expects($this->any())->method('getSize')->willReturn(9_000);
         $otherFile->expects($this->any())->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [
@@ -4668,7 +4668,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals('The numeric field must be less than 5.', $v->messages()->first('numeric'));
         $this->assertEquals('The string field must be less than 3 characters.', $v->messages()->first('string'));
-        $this->assertEquals('The file field must be less than 8 kilobytes.', $v->messages()->first('file'));
+        $this->assertEquals('The file field must be less than 8.192 kilobytes.', $v->messages()->first('file'));
         $this->assertEquals('The array field must have less than 2 items.', $v->messages()->first('array'));
     }
 
@@ -4683,10 +4683,10 @@ class ValidationValidatorTest extends TestCase
         ], 'en');
 
         $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $file->expects($this->any())->method('getSize')->willReturn(8919);
+        $file->expects($this->any())->method('getSize')->willReturn(8_100);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $otherFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
-        $otherFile->expects($this->any())->method('getSize')->willReturn(8192);
+        $otherFile->expects($this->any())->method('getSize')->willReturn(8_000);
         $otherFile->expects($this->any())->method('isValid')->willReturn(true);
 
         $v = new Validator($trans, [


### PR DESCRIPTION
Change file size calculation from kibibytes (1024) to kilobytes (1000) to match Laravel's File validation rule behavior for size/min/max/between.

Reference: https://github.com/laravel/framework/blob/12.x/src/Illuminate/Validation/Rules/File.php#L237