### PR TITLE
[12.x] Add fallback for callable dispatcher resolution in Route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
+use Illuminate\Routing\CallableDispatcher as ConcreteCallableDispatcher;
 use Illuminate\Routing\Contracts\CallableDispatcher;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Routing\Controllers\HasMiddleware;
@@ -240,7 +241,11 @@ class Route
             $callable = unserialize($this->action['uses'])->getClosure();
         }
 
-        return $this->container[CallableDispatcher::class]->dispatch($this, $callable);
+        $dispatcher = $this->container->bound(CallableDispatcher::class)
+            ? $this->container[CallableDispatcher::class]
+            : new ConcreteCallableDispatcher($this->container);
+
+        return $dispatcher->dispatch($this, $callable);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -180,6 +180,21 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testClosureRouteDispatchesWithoutCallableDispatcherBinding()
+    {
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
+        $router->get('foo', function () {
+            return 'hello';
+        });
+
+        $this->assertFalse($container->bound(CallableDispatcherContract::class));
+
+        $response = $router->dispatch(Request::create('/foo', 'GET'));
+
+        $this->assertSame('hello', $response->getContent());
+    }
+
     public function testNotModifiedResponseIsProperlyReturned()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
`Route::runCallable()` resolves the `CallableDispatcher` from the container without checking if its bound. In isolated tests & standalone router usage where `RoutingServiceProvider` has not been registered, this throws `BindingResolutionException` and prevents closure routes from running. This PR adds a fallback to `CallableDispatcher` when the contract is not bound.