### PR TITLE
[12.x] Sort stan issue on PendingRequest

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,10 +2,10 @@ name: static analysis
 
 on:
   push:
-#    branches:
-#      - master
-#      - '*.x'
-#  pull_request:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
 
 jobs:
   types:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,10 +2,10 @@ name: static analysis
 
 on:
   push:
-    branches:
-      - master
-      - '*.x'
-  pull_request:
+#    branches:
+#      - master
+#      - '*.x'
+#  pull_request:
 
 jobs:
   types:

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1092,7 +1092,7 @@ class PendingRequest
                 throw $e;
             }
         }, $this->retryDelay ?? 100, function ($exception) use (&$shouldRetry) {
-            $result = $shouldRetry ?? ($this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request?->toPsrRequest()->getMethod()) : true);
+            $result = $shouldRetry !== null ? $shouldRetry : ($this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request?->toPsrRequest()->getMethod()) : true);
 
             $shouldRetry = null;
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1096,7 +1096,7 @@ class PendingRequest
 
             $shouldRetry = null;
 
-            return $result; 
+            return $result;
         });
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1096,7 +1096,7 @@ class PendingRequest
 
             $shouldRetry = null;
 
-            return $result;
+            return $result; 
         });
     }
 


### PR DESCRIPTION
Noticed stan said there was an issue re: 

https://github.com/laravel/framework/actions/runs/21909989680 
https://github.com/laravel/framework/actions/runs/21910476072
https://github.com/laravel/framework/actions/runs/21915430946/

Which is causing a few PR's CI to fail

$shouldRetry is defaulted to null which is why it's complaining- this stops CI from failing.

Minimal fix basically.. same outcome.