### PR TITLE
[12.x] Refactor: use `InteractsWithTime` `currentTime()` function

### DIFF
--- a/src/Illuminate/Cache/RedisTagSet.php
+++ b/src/Illuminate/Cache/RedisTagSet.php
@@ -4,10 +4,13 @@ namespace Illuminate\Cache;
 
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\LazyCollection;
 
 class RedisTagSet extends TagSet
 {
+    use InteractsWithTime;
+
     /**
      * Add a reference entry to the tag set's underlying sorted set.
      *
@@ -87,7 +90,7 @@ class RedisTagSet extends TagSet
     {
         $flushStaleEntries = function ($pipe) {
             foreach ($this->tagIds() as $tagKey) {
-                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, Carbon::now()->getTimestamp());
+                $pipe->zremrangebyscore($this->store->getPrefix().$tagKey, 0, $this->currentTime());
             }
         };
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -629,11 +629,11 @@ class Repository implements ArrayAccess, CacheContract
         if (in_array(null, [$value, $created], true)) {
             return tap(value($callback), fn ($value) => $this->putMany([
                 $key => $value,
-                "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
+                "illuminate:cache:flexible:created:{$key}" => $this->currentTime(),
             ], $ttl[1]));
         }
 
-        if (($created + $this->getSeconds($ttl[0])) > Carbon::now()->getTimestamp()) {
+        if (($created + $this->getSeconds($ttl[0])) > $this->currentTime()) {
             return $value;
         }
 
@@ -649,7 +649,7 @@ class Repository implements ArrayAccess, CacheContract
 
                 $this->putMany([
                     $key => value($callback),
-                    "illuminate:cache:flexible:created:{$key}" => Carbon::now()->getTimestamp(),
+                    "illuminate:cache:flexible:created:{$key}" => $this->currentTime(),
                 ], $ttl[1]);
             });
         };

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -174,7 +174,7 @@ abstract class Queue
                 'command' => $job,
                 'batchId' => $job->batchId ?? null,
             ],
-            'createdAt' => Carbon::now()->getTimestamp(),
+            'createdAt' => $this->currentTime(),
         ]);
 
         try {
@@ -304,7 +304,7 @@ abstract class Queue
             'backoff' => null,
             'timeout' => null,
             'data' => $data,
-            'createdAt' => Carbon::now()->getTimestamp(),
+            'createdAt' => $this->currentTime(),
         ]);
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -19,11 +19,12 @@ use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\InteractsWithTime;
 use Throwable;
 
 class Worker
 {
-    use DetectsLostConnections;
+    use DetectsLostConnections, InteractsWithTime;
 
     const EXIT_SUCCESS = 0;
     const EXIT_ERROR = 1;
@@ -562,7 +563,7 @@ class Worker
 
         $retryUntil = $job->retryUntil();
 
-        if ($retryUntil && Carbon::now()->getTimestamp() <= $retryUntil) {
+        if ($retryUntil && $this->currentTime() <= $retryUntil) {
             return;
         }
 
@@ -588,7 +589,7 @@ class Worker
     {
         $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
 
-        if ($job->retryUntil() && $job->retryUntil() <= Carbon::now()->getTimestamp()) {
+        if ($job->retryUntil() && $job->retryUntil() <= $this->currentTime()) {
             $this->failJob($job, $e);
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -497,7 +497,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $expires = $request->query('expires');
 
-        return ! ($expires && Carbon::now()->getTimestamp() > $expires);
+        return ! ($expires && $this->currentTime() > $expires);
     }
 
     /**


### PR DESCRIPTION
remove `Carbon::now()->getTimestamp()` and use `currentTime()`