### PR TITLE
[12.x] Fix: `@return` for `resolveResourceRelationshipIdentifiers()`

### DIFF
--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -167,7 +167,7 @@ trait ResolvesJsonApiElements
     protected function resolveResourceRelationshipIdentifiers(JsonApiRequest $request): array
     {
         if (! $this->resource instanceof Model) {
-            return [];
+             return [];
         }
 
         $this->compileResourceRelationships($request);

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -160,7 +160,7 @@ trait ResolvesJsonApiElements
     /**
      * Resolves `relationships` for the resource's data object.
      *
-     * @return string|int
+     * @return array
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
+++ b/src/Illuminate/Http/Resources/JsonApi/Concerns/ResolvesJsonApiElements.php
@@ -167,7 +167,7 @@ trait ResolvesJsonApiElements
     protected function resolveResourceRelationshipIdentifiers(JsonApiRequest $request): array
     {
         if (! $this->resource instanceof Model) {
-             return [];
+            return [];
         }
 
         $this->compileResourceRelationships($request);


### PR DESCRIPTION
The `resolveResourceRelationshipIdentifiers()` method returns an `array`, but the docblock incorrectly specifies the return type as `string|int`. This PR fixes the docblock to correctly reflect the `array` return type.