### PR TITLE
[12.x] `Mailable::later()` does not set delay on `SendQueuedMailable` instance

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -250,8 +250,12 @@ class Mailable implements MailableContract, Renderable
 
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
+        $job = $this->newQueuedJob();
+
+        $job->delay($delay);
+
         return $queue->connection($connection)->laterOn(
-            $queueName ?: null, $delay, $this->newQueuedJob()
+            $queueName ?: null, $delay, $job
         );
     }
 


### PR DESCRIPTION
## Description

When queuing mail using:

```php
Mail::to($user)->later($delay, new ExampleMail());
```

the delay is correctly applied at the queue driver level and the job is executed at the expected time.

However, the delay value is not set on the `SendQueuedMailable` job instance itself.

Because of this:
- The delay is respected by the queue system.
- But the delay is not present in the serialized job payload.
- Queue observers (e.g., Horizon) cannot detect that the job is delayed.
- The job appears as a normal pending job instead of a delayed one.

This creates an inconsistency with:

```php
dispatch(new ExampleJob())->delay($delay);
```

where the delay is stored on the job instance and included in the payload metadata.

## Root Cause

`Mailable::later()` currently forwards the delay directly to the queue driver via:

```php
$queue->connection($connection)->laterOn(
    $queueName ?: null, $delay, $this->newQueuedJob()
);
```

The delay is applied at the driver level but never set on the `SendQueuedMailable` instance, which uses the `Queueable` trait.

## Proposed Fix

Set the delay on the queued job instance, aligning behavior with `dispatch()->delay()`.