### PR TITLE
[12.x] cast `Batch::progress()` return value to `int`

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -214,7 +214,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Get the percentage of jobs that have been processed (between 0-100).
      *
-     * @return int
+     * @return int<0, 100>
      */
     public function progress()
     {

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -218,7 +218,7 @@ class Batch implements Arrayable, JsonSerializable
      */
     public function progress()
     {
-        return $this->totalJobs > 0 ? round(($this->processedJobs() / $this->totalJobs) * 100) : 0;
+        return $this->totalJobs > 0 ? (int) round(($this->processedJobs() / $this->totalJobs) * 100) : 0;
     }
 
     /**


### PR DESCRIPTION
The documented return type for the `Batch::progress()` method is integer but the `round` function returns float even though it doesn't contain any decimals.

This will cause a `TypeError` when the value is float and is consumed by a function expecting an integer in strict mode `declare(strict_type=1);`

To resolve this issue, the rounded value should be cast to an integer.

Edit:
- return value update to `int<0, 100>` - suggested by @shaedrich 