### PR TITLE
Fix phpdoc type in promptForMissingArgumentsUsing

### DIFF
--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -75,7 +75,7 @@ trait PromptsForMissingInput
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array<string, string|array{string, string}|(\Closure(): array<int|string>|string|int|bool)>
+     * @return array<string, string|array{string, string}|\Closure(): (array<int|string>|string|int|bool)>
      */
     protected function promptForMissingArgumentsUsing()
     {

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -499,7 +499,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     /**
      * Prompt for missing input arguments using the returned questions.
      *
-     * @return array<string, string|array{string, string}|(\Closure(): array<int, string>|string|int|bool)>
+     * @return array<string, string|array{string, string}|\Closure(): (array<int, string>|string|int|bool)>
      */
     protected function promptForMissingArgumentsUsing()
     {


### PR DESCRIPTION
in #58565 another of the new types is for `PromptsForMissingInput::promptForMissingArgumentsUsing`. When using a callable to fully control the missing argument prompt such as using laravel/prompts, the union return type isn't quite correct. When specifying a callable return type, multiple return types should be wrapped in parentheses, not the entire `\Closure` block.

PHPStan docs ref - https://phpstan.org/writing-php-code/phpdoc-types#callables

PHPStan repros here: 
Error (current phpdoc) - https://phpstan.org/r/a1815f96-87f0-45eb-920a-3759e941e682
Fixed - https://phpstan.org/r/8d1bd604-6a48-4e7e-8d60-17a76f420ebf

Here's the actual code that is triggering the error:
```
protected function promptForMissingArgumentsUsing(): array
{
    return [
        'result' => fn (): string => textarea(
            'Enter the payload',
            required: true,
        ),
    ];
}
```

PHPStan error:
```
Method App\Console\CommandName::promptForMissingArgumentsUsing() should return array<string,
         array{string, string}|bool|(Closure(): array<int|string>)|int|string> but returns array{result: Closure(): string}.
```