### PR TITLE
Add logs:rotate Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/LogRotateCommand.php
+++ b/src/Illuminate/Foundation/Console/LogRotateCommand.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'logs:rotate')]
+class LogRotateCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'logs:rotate
+                {--keep=50 : The number of rotated files to keep per log}
+                {--path= : The path to the log directory}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rotate the log files in the configured log directory';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new log rotate command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $logsPath = $this->resolveLogsPath();
+
+        if (! $this->files->isDirectory($logsPath)) {
+            $this->components->error("The log directory [{$logsPath}] does not exist.");
+
+            return self::FAILURE;
+        }
+
+        $keep = (int) $this->option('keep');
+
+        $maxSeq = $this->findMaxSequence($logsPath);
+
+        $this->bumpSequences($logsPath, $maxSeq);
+
+        $rotated = 0;
+
+        foreach ($this->files->glob("{$logsPath}/*.log") as $logFile) {
+            if ($this->files->size($logFile) === 0) {
+                continue;
+            }
+
+            $baseName = basename($logFile);
+            $datePart = date('Ymd-Hi', $this->files->lastModified($logFile));
+            $rotatedName = "{$baseName}-{$datePart}.1";
+
+            $this->files->move($logFile, "{$logsPath}/{$rotatedName}");
+
+            $this->components->info("Rotated [{$baseName}] to [{$rotatedName}].");
+            $rotated++;
+        }
+
+        $this->pruneOldRotations($logsPath, $keep);
+
+        $this->components->info("Rotated {$rotated} log file(s).");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve the path to the log directory.
+     *
+     * @return string
+     */
+    protected function resolveLogsPath(): string
+    {
+        if ($path = $this->option('path')) {
+            return $path;
+        }
+
+        $channels = $this->laravel['config']->get('logging.channels', []);
+
+        foreach ($channels as $channel) {
+            if (isset($channel['driver'], $channel['path']) &&
+                in_array($channel['driver'], ['single', 'daily'])) {
+                return dirname($channel['path']);
+            }
+        }
+
+        return $this->laravel->storagePath('logs');
+    }
+
+    /**
+     * Find the highest sequence number across all rotated log files.
+     *
+     * @param  string  $logsPath
+     * @return int
+     */
+    protected function findMaxSequence(string $logsPath): int
+    {
+        $maxSeq = 0;
+
+        foreach ($this->files->glob("{$logsPath}/*.log-*") as $file) {
+            $ext = pathinfo($file, PATHINFO_EXTENSION);
+
+            if (is_numeric($ext)) {
+                $maxSeq = max($maxSeq, (int) $ext);
+            }
+        }
+
+        return $maxSeq;
+    }
+
+    /**
+     * Bump all existing rotated files up by one sequence number.
+     *
+     * Works high-to-low to avoid collisions.
+     *
+     * @param  string  $logsPath
+     * @param  int  $maxSeq
+     * @return void
+     */
+    protected function bumpSequences(string $logsPath, int $maxSeq): void
+    {
+        for ($seq = $maxSeq; $seq >= 1; $seq--) {
+            foreach ($this->files->glob("{$logsPath}/*.log-*.{$seq}") as $file) {
+                $newFile = preg_replace('/\.\d+$/', '.'.($seq + 1), $file);
+
+                $this->files->move($file, $newFile);
+            }
+        }
+    }
+
+    /**
+     * Remove rotated logs with a sequence number beyond the keep limit.
+     *
+     * @param  string  $logsPath
+     * @param  int  $keep
+     * @return void
+     */
+    protected function pruneOldRotations(string $logsPath, int $keep): void
+    {
+        foreach ($this->files->glob("{$logsPath}/*.log-*") as $file) {
+            $ext = pathinfo($file, PATHINFO_EXTENSION);
+
+            if (is_numeric($ext) && (int) $ext > $keep) {
+                $this->files->delete($file);
+
+                $this->components->info('Pruned ['.basename($file).'].');
+            }
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -61,6 +61,7 @@ use Illuminate\Foundation\Console\JobMiddlewareMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
 use Illuminate\Foundation\Console\LangPublishCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
+use Illuminate\Foundation\Console\LogRotateCommand;
 use Illuminate\Foundation\Console\MailMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
@@ -143,6 +144,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventList' => EventListCommand::class,
         'InvokeSerializedClosure' => InvokeSerializedClosureCommand::class,
         'KeyGenerate' => KeyGenerateCommand::class,
+        'LogRotate' => LogRotateCommand::class,
         'Optimize' => OptimizeCommand::class,
         'OptimizeClear' => OptimizeClearCommand::class,
         'PackageDiscover' => PackageDiscoverCommand::class,
@@ -548,6 +550,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(ListenerMakeCommand::class, function ($app) {
             return new ListenerMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerLogRotateCommand()
+    {
+        $this->app->singleton(LogRotateCommand::class, function ($app) {
+            return new LogRotateCommand($app['files']);
         });
     }
 

--- a/tests/Foundation/Console/LogRotateCommandTest.php
+++ b/tests/Foundation/Console/LogRotateCommandTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Console\LogRotateCommand;
+use Orchestra\Testbench\TestCase;
+
+class LogRotateCommandTest extends TestCase
+{
+    private $logsPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logsPath = sys_get_temp_dir().'/laravel-log-rotate-test-'.uniqid();
+        (new Filesystem)->makeDirectory($this->logsPath);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem)->deleteDirectory($this->logsPath);
+
+        parent::tearDown();
+    }
+
+    public function testItRotatesALogFile()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", 'log content');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+    }
+
+    public function testItSkipsEmptyLogFiles()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", '');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/laravel.log");
+        $this->assertEmpty(glob("{$this->logsPath}/laravel.log-*"));
+    }
+
+    public function testItExitsCleanlyWithNoLogFiles()
+    {
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+    }
+
+    public function testItBumpsExistingRotatedFiles()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.1", 'old content');
+        file_put_contents("{$this->logsPath}/laravel.log", 'new content');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/laravel.log-20260101-0000.2");
+        $this->assertSame('old content', file_get_contents("{$this->logsPath}/laravel.log-20260101-0000.2"));
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+    }
+
+    public function testItBumpsMultipleSequencesHighToLow()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.1", 'seq 1');
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.2", 'seq 2');
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.3", 'seq 3');
+        file_put_contents("{$this->logsPath}/laravel.log", 'current');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertSame('seq 3', file_get_contents("{$this->logsPath}/laravel.log-20260101-0000.4"));
+        $this->assertSame('seq 2', file_get_contents("{$this->logsPath}/laravel.log-20260101-0000.3"));
+        $this->assertSame('seq 1', file_get_contents("{$this->logsPath}/laravel.log-20260101-0000.2"));
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+    }
+
+    public function testItPrunesOldRotationsBeyondKeepLimit()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.1", 'keep');
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.2", 'keep');
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.3", 'prune');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath, '--keep' => 3])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/laravel.log-20260101-0000.2");
+        $this->assertFileExists("{$this->logsPath}/laravel.log-20260101-0000.3");
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log-20260101-0000.4");
+    }
+
+    public function testItHandlesMultipleLogFiles()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", 'app logs');
+        file_put_contents("{$this->logsPath}/browser.log", 'browser logs');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+        $this->assertFileDoesNotExist("{$this->logsPath}/browser.log");
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+        $this->assertCount(1, glob("{$this->logsPath}/browser.log-*.1"));
+    }
+
+    public function testSequenceSkippingWhenFileDoesNotExistForSomeRotations()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log-20260101-0000.1", 'laravel batch 1');
+        file_put_contents("{$this->logsPath}/browser.log-20260101-0000.1", 'browser batch 1');
+        file_put_contents("{$this->logsPath}/laravel.log", 'laravel batch 2');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/laravel.log-20260101-0000.2");
+        $this->assertFileExists("{$this->logsPath}/browser.log-20260101-0000.2");
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+        $this->assertEmpty(glob("{$this->logsPath}/browser.log-*.1"));
+    }
+
+    public function testMultiRunCumulativeState()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", 'run 1 laravel');
+        file_put_contents("{$this->logsPath}/browser.log", 'run 1 browser');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        file_put_contents("{$this->logsPath}/laravel.log", 'run 2 laravel');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        file_put_contents("{$this->logsPath}/laravel.log", 'run 3 laravel');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $browserFiles = glob("{$this->logsPath}/browser.log-*");
+        $this->assertCount(1, $browserFiles);
+        $this->assertStringEndsWith('.3', $browserFiles[0]);
+        $this->assertSame('run 1 browser', file_get_contents($browserFiles[0]));
+
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.2"));
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.3"));
+    }
+
+    public function testItDoesNotCreateEmptyFileAfterRotation()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", 'content');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+    }
+
+    public function testItFailsWhenDirectoryDoesNotExist()
+    {
+        $this->artisan(LogRotateCommand::class, ['--path' => '/nonexistent/path'])
+            ->assertExitCode(1);
+    }
+
+    public function testItResolvesPathFromLoggingConfig()
+    {
+        $this->app['config']->set('logging.channels.single', [
+            'driver' => 'single',
+            'path' => "{$this->logsPath}/laravel.log",
+        ]);
+
+        file_put_contents("{$this->logsPath}/laravel.log", 'content');
+
+        $this->artisan(LogRotateCommand::class)
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+        $this->assertCount(1, glob("{$this->logsPath}/laravel.log-*.1"));
+    }
+
+    public function testItIncludesDateInRotatedFilename()
+    {
+        file_put_contents("{$this->logsPath}/laravel.log", 'content');
+        touch("{$this->logsPath}/laravel.log", mktime(14, 30, 0, 6, 15, 2026));
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/laravel.log-20260615-1430.1");
+    }
+
+    public function testItIgnoresNonLogFiles()
+    {
+        file_put_contents("{$this->logsPath}/notes.txt", 'not a log');
+        file_put_contents("{$this->logsPath}/laravel.log", 'a log');
+
+        $this->artisan(LogRotateCommand::class, ['--path' => $this->logsPath])
+            ->assertExitCode(0);
+
+        $this->assertFileExists("{$this->logsPath}/notes.txt");
+        $this->assertFileDoesNotExist("{$this->logsPath}/laravel.log");
+    }
+}


### PR DESCRIPTION
This adds a lightweight `logs:rotate` command that uses batch sequence numbering (like classic Unix logrotate) to rotate all `*.log` files in the configured log directory. It auto-discovers the log path from `logging.channels` config, supports `--keep` and `--path` options, and pairs well with the composer dev script.
Summary

  - Adds a first-party logs:rotate Artisan command that rotates *.log files using batch sequence
  numbering (like classic Unix logrotate)
  - Auto-discovers the log directory from logging.channels config (single/daily drivers), with --path
  override and storage/logs fallback
  - Supports --keep=50 (default) to prune old rotations beyond the limit

Motivation
  My usage of this was to add it to composer run dev script so that each dev session run you get fresh logs, this is helpful for humans but is really helpful in agentic coding sessions as it keeps the logs scoped to the current run and therefore saves significantly on context. A PR to laravel/laravel was also created https://github.com/laravel/laravel/pull/6752
  
Usage

  php artisan logs:rotate
  php artisan logs:rotate --keep=10
  php artisan logs:rotate --path=/var/log/myapp

Test plan

  - 14 tests covering all rotation behaviors
  - Pint passes clean
  - All tests pass