### PR TITLE
[12.x] Fix missing InputArgument::IS_ARRAY in getArguments PHPDoc

### DIFF
--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -42,7 +42,7 @@ trait HasParameters
      *
      * @return (InputArgument|array{
      *    0: non-empty-string,
-     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL,
+     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL|InputArgument::IS_ARRAY,
      *    2?: string,
      *    3?: mixed,
      *    4?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -483,7 +483,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      *
      * @return (InputArgument|array{
      *    0: non-empty-string,
-     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL,
+     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL|InputArgument::IS_ARRAY,
      *    2?: string,
      *    3?: mixed,
      *    4?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>


### PR DESCRIPTION
This PR adds the missing `InputArgument::IS_ARRAY` constant to the `@return` PHPDoc of `getArguments()` in `HasParameters` and `GeneratorCommand`.

Caused by #58565 (0f197fe854).