### PR TITLE
[12.x] Refactor: add `\BackedEnum` to doc blocks

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -94,7 +94,7 @@ trait Queueable
     /**
      * Set the desired connection for the job.
      *
-     * @param  \UnitEnum|string|null  $connection
+     * @param  \BackedEnum|\UnitEnum|string|null  $connection
      * @return $this
      */
     public function onConnection($connection)
@@ -107,7 +107,7 @@ trait Queueable
     /**
      * Set the desired queue for the job.
      *
-     * @param  \UnitEnum|string|null  $queue
+     * @param  \BackedEnum|\UnitEnum|string|null  $queue
      * @return $this
      */
     public function onQueue($queue)
@@ -122,7 +122,7 @@ trait Queueable
      *
      * This feature is only supported by some queues, such as Amazon SQS.
      *
-     * @param  \UnitEnum|string  $group
+     * @param  \BackedEnum|\UnitEnum|string  $group
      * @return $this
      */
     public function onGroup($group)
@@ -152,7 +152,7 @@ trait Queueable
     /**
      * Set the desired connection for the chain.
      *
-     * @param  \UnitEnum|string|null  $connection
+     * @param  \BackedEnum|\UnitEnum|string|null  $connection
      * @return $this
      */
     public function allOnConnection($connection)


### PR DESCRIPTION
## Add `\BackedEnum` to docblocks for enum-compatible methods

Updated docblocks for `onConnection()`, `onQueue()`, `onGroup()`, and `allOnConnection()` methods to include `\BackedEnum` alongside `\UnitEnum`.

Since these methods use `enum_value()` which accepts both `\UnitEnum` and `\BackedEnum`, the docblocks should reflect both types for better IDE support and more accurate documentation.