### PR TITLE
[12.x] Fix incorrect @return type in VendorPublishCommand::publishTag

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -190,7 +190,7 @@ class VendorPublishCommand extends Command
      * Publishes the assets for a tag.
      *
      * @param  string  $tag
-     * @return mixed
+     * @return void
      */
     protected function publishTag($tag)
     {


### PR DESCRIPTION
The `publishTag` method does not return any value, however its docblock specifies `@return mixed`.

This PR updates the return type to `void` to accurately reflect the method's actual behavior.
