### PR TITLE
[12.x] Standardize regex delimiter in ObserverMakeCommand::parseModel

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -88,7 +88,7 @@ class ObserverMakeCommand extends GeneratorCommand
      */
     protected function parseModel($model)
     {
-        if (preg_match('([^A-Za-z0-9_/\\\\])', $model)) {
+        if (preg_match('/[^A-Za-z0-9_\/\\\\]/', $model)) {
             throw new InvalidArgumentException('Model name contains invalid characters.');
         }
 


### PR DESCRIPTION
The `parseModel` method currently uses a preg_match without standard delimiters:

    preg_match('([^A-Za-z0-9_/\\\\])', $model)

This works, but it is not consistent with typical PHP and Laravel coding standards.

This PR updates the regex to use proper delimiters:

    preg_match('/[^A-Za-z0-9_\/\\\\]/', $model)

No behavior is changed. This is purely a readability and consistency improvement.
