### PR TITLE
[12.x] Feat: add `isEmail()` to `Str`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -694,6 +694,17 @@ class Str
     }
 
     /**
+     * Determine if a given value is a valid email address.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function isEmail($value)
+    {
+        return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1982,4 +1982,28 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('UserGroups', Str::pluralPascal('UserGroup', $countable));
     }
+
+    public function testIsEmailValidates()
+    {
+        // Valid emails
+        $this->assertTrue(Str::isEmail('taylorotwell@example.com'));
+        $this->assertTrue(Str::isEmail('ali7.khosrojerdi@gmail.com'));
+        $this->assertTrue(Str::isEmail('user+tag@example.co.uk'));
+        $this->assertTrue(Str::isEmail('user_name@example-domain.com'));
+        $this->assertTrue(Str::isEmail('123@example.com'));
+        $this->assertTrue(Str::isEmail('user@subdomain.example.com'));
+
+        // Invalid emails
+        $this->assertFalse(Str::isEmail('invalid.email'));
+        $this->assertFalse(Str::isEmail('@example.com'));
+        $this->assertFalse(Str::isEmail('user@'));
+        $this->assertFalse(Str::isEmail('user @example.com'));
+        $this->assertFalse(Str::isEmail('user@example'));
+        $this->assertFalse(Str::isEmail(''));
+        $this->assertFalse(Str::isEmail(null));
+        $this->assertFalse(Str::isEmail('user@@example.com'));
+        $this->assertFalse(Str::isEmail('user@.com'));
+        $this->assertFalse(Str::isEmail(123));
+        $this->assertFalse(Str::isEmail([]));
+    }
 }


### PR DESCRIPTION
## Add `isEmail()` helper method to `Str` class

### Summary
Adds a convenient `isEmail()` method to the `Str` class for quick email validation.

### Motivation
Email validation is a common task in Laravel applications. While `filter_var()` works fine, having a dedicated method in the `Str` class provides:
- Better discoverability alongside other string helpers
- Consistent API with existing validation methods like `isUrl()`, `isUuid()`, `isJson()`
- Cleaner, more readable code

### Usage
```php
// Before
if (filter_var($email, FILTER_VALIDATE_EMAIL) !== false) {
    // ...
}

// After
if (Str::isEmail($email)) {
    // ...
}
```

### Changes
- Added `Str::isEmail()` method with proper type hints and PHPDoc
- Added comprehensive test coverage for valid and invalid email formats