### PR TITLE
[12.x] Add DDL algorithm support for index operations

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -427,10 +427,11 @@ class MySqlGrammar extends Grammar
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('alter table %s add primary key %s(%s)%s',
+        return sprintf('alter table %s add primary key %s(%s)%s%s',
             $this->wrapTable($blueprint),
             $command->algorithm ? 'using '.$command->algorithm : '',
             $this->columnize($command->columns),
+            $command->useAlgorithm ? ', algorithm='.$command->useAlgorithm : '',
             $command->lock ? ', lock='.$command->lock : ''
         );
     }
@@ -493,12 +494,13 @@ class MySqlGrammar extends Grammar
      */
     protected function compileKey(Blueprint $blueprint, Fluent $command, $type)
     {
-        return sprintf('alter table %s add %s %s%s(%s)%s',
+        return sprintf('alter table %s add %s %s%s(%s)%s%s',
             $this->wrapTable($blueprint),
             $type,
             $this->wrap($command->index),
             $command->algorithm ? ' using '.$command->algorithm : '',
             $this->columnize($command->columns),
+            $command->useAlgorithm ? ', algorithm='.$command->useAlgorithm : '',
             $command->lock ? ', lock='.$command->lock : ''
         );
     }

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Fluent;
  * @method $this lock(('none'|'shared'|'default'|'exclusive') $value) Specify the DDL lock mode for the index operation (MySQL)
  * @method $this nullsNotDistinct(bool $value = true) Specify that the null values should not be treated as distinct (PostgreSQL)
  * @method $this online(bool $value = true) Specify that index creation should not lock the table (PostgreSQL/SqlServer)
+ * @method $this useAlgorithm(('inplace'|'copy'|'instant'|'default') $value) Specify the DDL algorithm for the index operation (MySQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1739,6 +1739,86 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add index `custom_idx` using btree(`name`), lock=none', $statements[0]);
     }
 
+    public function testAddingFullTextIndexWithUseAlgorithm()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fullText(['title', 'description'])->useAlgorithm('copy');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add fulltext `users_title_description_fulltext`(`title`, `description`), algorithm=copy', $statements[0]);
+    }
+
+    public function testAddingFullTextIndexWithUseAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fullText('body')->useAlgorithm('copy')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add fulltext `users_body_fulltext`(`body`), algorithm=copy, lock=none', $statements[0]);
+    }
+
+    public function testAddingIndexWithUseAlgorithm()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('name')->useAlgorithm('inplace');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `users_name_index`(`name`), algorithm=inplace', $statements[0]);
+    }
+
+    public function testAddingIndexWithAlgorithmAndUseAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->index('email', 'idx', 'hash')->useAlgorithm('inplace')->lock('none');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `idx` using hash(`email`), algorithm=inplace, lock=none', $statements[0]);
+    }
+
+    public function testAddingUniqueIndexWithUseAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->unique('email')->useAlgorithm('inplace')->lock('shared');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add unique `users_email_unique`(`email`), algorithm=inplace, lock=shared', $statements[0]);
+    }
+
+    public function testAddingPrimaryKeyWithUseAlgorithm()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->primary('id')->useAlgorithm('inplace');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add primary key (`id`), algorithm=inplace', $statements[0]);
+    }
+
+    public function testAddingPrimaryKeyWithAlgorithmAndUseAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->primary('id', 'pk', 'hash')->useAlgorithm('copy')->lock('exclusive');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add primary key using hash(`id`), algorithm=copy, lock=exclusive', $statements[0]);
+    }
+
+    public function testAddingSpatialIndexWithUseAlgorithmAndLock()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->spatialIndex('location')->useAlgorithm('copy')->lock('shared');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add spatial index `users_location_spatialindex`(`location`), algorithm=copy, lock=shared', $statements[0]);
+    }
+
     public function getGrammar(?Connection $connection = null)
     {
         return new MySqlGrammar($connection ?? $this->getConnection());


### PR DESCRIPTION
### Problem

PR #58293 added `lock()` support for specifying the DDL lock mode on index operations. This PR adds the complementary `useAlgorithm()` method for specifying the [DDL algorithm](https://dev.mysql.com/doc/refman/8.4/en/innodb-online-ddl-operations.html) (`INPLACE`, `COPY`, `INSTANT`, `DEFAULT`) on the same operations.

 While MySQL chooses an appropriate algorithm by default, there are cases where explicitly controlling the DDL algorithm is necessary — for example enforcing `ALGORITHM=COPY` for a table rebuild, or `ALGORITHM=INSTANT` to guarantee a metadata-only operation.

  ### Usage

  ```php
$table->fullText(['title', 'description'])->useAlgorithm('copy');
$table->index('email')->useAlgorithm('inplace')->lock('none');
$table->primary('id')->useAlgorithm('instant');
```

Generates:
```mysql
ALTER TABLE `t` ADD FULLTEXT `idx`(`title`, `description`), ALGORITHM=COPY
ALTER TABLE `t` ADD INDEX `idx`(`email`), ALGORITHM=INPLACE, LOCK=NONE
ALTER TABLE `t` ADD PRIMARY KEY (`id`), ALGORITHM=INSTANT
```

### Naming

The name `useAlgorithm()` was chosen because `algorithm()` is already taken — it was introduced in #12776 (2016) for the `USING BTREE`/`USING HASH` clause, which specifies the index storage type rather than the DDL execution strategy. Renaming `algorithm()` would be a breaking change.

I'm happy to rename `useAlgorithm()` if there's a better suggestion.

### Changes

- Added useAlgorithm() support to compileKey() and compilePrimary() in MySqlGrammar
- Added PHPDoc for useAlgorithm on IndexDefinition
- Added 8 tests covering all index types with the new option