### PR TITLE
[12.x] Refactor: use `enum_value()` helper for environment value extraction

### DIFF
--- a/src/Illuminate/Container/Attributes/Bind.php
+++ b/src/Illuminate/Container/Attributes/Bind.php
@@ -7,6 +7,8 @@ use BackedEnum;
 use InvalidArgumentException;
 use UnitEnum;
 
+use function Illuminate\Support\enum_value;
+
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Bind
 {
@@ -44,10 +46,9 @@ class Bind
 
         $this->concrete = $concrete;
 
-        $this->environments = array_map(fn ($environment) => match (true) {
-            $environment instanceof BackedEnum => $environment->value,
-            $environment instanceof UnitEnum => $environment->name,
-            default => $environment,
-        }, $environments);
+        $this->environments = array_map(
+            fn ($environment) => enum_value($environment),
+            $environments,
+        );
     }
 }


### PR DESCRIPTION
# Refactor: Use `enum_value()` helper for environment value extraction

Simplified the constructor by replacing the inline `match` expression with the `enum_value()` helper function for converting enum instances to their scalar values.

This improves code readability and maintains consistency with the framework's helper functions.