### PR TITLE
Fix MySQL connection string to use --ssl-mode=DISABLED for modern clients

### DIFF
--- a/src/Illuminate/Database/Schema/MariaDbSchemaState.php
+++ b/src/Illuminate/Database/Schema/MariaDbSchemaState.php
@@ -12,7 +12,9 @@ class MariaDbSchemaState extends MySqlSchemaState
      */
     public function load($path)
     {
-        $command = 'mariadb '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $versionInfo = $this->detectClientVersion();
+
+        $command = 'mariadb '.$this->connectionString($versionInfo).' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $process = $this->makeProcess($command)->setTimeout(null);
 
@@ -28,7 +30,9 @@ class MariaDbSchemaState extends MySqlSchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mariadb-dump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+        $versionInfo = $this->detectClientVersion();
+
+        $command = 'mariadb-dump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class MySqlSchemaState extends SchemaState
@@ -64,6 +65,29 @@ class MySqlSchemaState extends SchemaState
     }
 
     /**
+     * @return array{version: string, isMariaDb: bool}
+     */
+    protected function detectClientVersion(): array
+    {
+        $version = '8.0.0';
+        $isMariaDb = false;
+
+        try {
+            $versionOutput = $this->makeProcess('mysql --version')->mustRun()->getOutput();
+            if (preg_match('/(\d+\.\d+\.\d+)/', $versionOutput, $matches)) {
+                $version = $matches[1];
+            }
+            $isMariaDb = stripos($versionOutput, 'mariadb') !== false;
+        } catch (ProcessFailedException) {
+        }
+
+        return [
+            'version' => $version,
+            'isMariaDb' => $isMariaDb,
+        ];
+    }
+
+    /**
      * Load the given schema file into the database.
      *
      * @param  string  $path
@@ -71,7 +95,9 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $versionInfo = $this->detectClientVersion();
+
+        $command = 'mysql '.$this->connectionString($versionInfo).' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $process = $this->makeProcess($command)->setTimeout(null);
 
@@ -87,7 +113,9 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
+        $versionInfo = $this->detectClientVersion();
+
+        $command = 'mysqldump '.$this->connectionString($versionInfo).' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         if (! $this->connection->isMaria()) {
             $command .= ' --set-gtid-purged=OFF';
@@ -99,9 +127,10 @@ class MySqlSchemaState extends SchemaState
     /**
      * Generate a basic connection string (--socket, --host, --port, --user, --password) for the database.
      *
+     * @param  array{version: string, isMariaDb: bool}  $versionInfo
      * @return string
      */
-    protected function connectionString()
+    protected function connectionString(array $versionInfo)
     {
         $value = ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}"';
 
@@ -126,10 +155,16 @@ class MySqlSchemaState extends SchemaState
             $value .= ' --ssl-key="${:LARAVEL_LOAD_SSL_KEY}"';
         }
 
-        // if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT]) &&
-        //     $config['options'][\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] === false) {
-        //     $value .= ' --ssl=off';
-        // }
+        /** @phpstan-ignore class.notFound */
+        $verifyCertOption = PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+
+        if (isset($config['options'][$verifyCertOption]) && $config['options'][$verifyCertOption] === false) {
+            if (version_compare($versionInfo['version'], '5.7.11', '>=') && ! $versionInfo['isMariaDb']) {
+                $value .= ' --ssl-mode=DISABLED';
+            } else {
+                $value .= ' --ssl=off';
+            }
+        }
 
         return $value;
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -65,29 +65,6 @@ class MySqlSchemaState extends SchemaState
     }
 
     /**
-     * @return array{version: string, isMariaDb: bool}
-     */
-    protected function detectClientVersion(): array
-    {
-        $version = '8.0.0';
-        $isMariaDb = false;
-
-        try {
-            $versionOutput = $this->makeProcess('mysql --version')->mustRun()->getOutput();
-            if (preg_match('/(\d+\.\d+\.\d+)/', $versionOutput, $matches)) {
-                $version = $matches[1];
-            }
-            $isMariaDb = stripos($versionOutput, 'mariadb') !== false;
-        } catch (ProcessFailedException) {
-        }
-
-        return [
-            'version' => $version,
-            'isMariaDb' => $isMariaDb,
-        ];
-    }
-
-    /**
      * Load the given schema file into the database.
      *
      * @param  string  $path
@@ -226,5 +203,31 @@ class MySqlSchemaState extends SchemaState
         }
 
         return $process;
+    }
+
+    /**
+     * Detect the MySQL client version.
+     *
+     * @return array{version: string, isMariaDb: bool}
+     */
+    protected function detectClientVersion(): array
+    {
+        [$version, $isMariaDb] = ['8.0.0', false];
+
+        try {
+            $versionOutput = $this->makeProcess('mysql --version')->mustRun()->getOutput();
+
+            if (preg_match('/(\d+\.\d+\.\d+)/', $versionOutput, $matches)) {
+                $version = $matches[1];
+            }
+
+            $isMariaDb = stripos($versionOutput, 'mariadb') !== false;
+        } catch (ProcessFailedException) {
+        }
+
+        return [
+            'version' => $version,
+            'isMariaDb' => $isMariaDb,
+        ];
     }
 }

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -19,9 +19,11 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
 
         $schemaState = new MariaDbSchemaState($connection);
 
+        $versionInfo = ['version' => '11.8.3', 'isMariaDb' => true];
+
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
-        $connString = $method->invoke($schemaState);
+        $connString = $method->invoke($schemaState, $versionInfo);
 
         self::assertEquals($expectedConnectionString, $connString);
 
@@ -90,6 +92,26 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT => '/path/to/client-cert.pem',
                     PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY => '/path/to/client-key.pem',
+                ],
+            ],
+        ];
+
+        yield 'no_ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl=off', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ],
             ],
         ];

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -21,9 +21,11 @@ class DatabaseMySqlSchemaStateTest extends TestCase
 
         $schemaState = new MySqlSchemaState($connection);
 
+        $versionInfo = ['version' => '8.0.0', 'isMariaDb' => false];
+
         // test connectionString
         $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
-        $connString = $method->invoke($schemaState);
+        $connString = $method->invoke($schemaState, $versionInfo);
 
         self::assertEquals($expectedConnectionString, $connString);
 
@@ -96,25 +98,25 @@ class DatabaseMySqlSchemaStateTest extends TestCase
             ],
         ];
 
-        // yield 'no_ssl' => [
-        //     ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl=off', [
-        //         'LARAVEL_LOAD_SOCKET' => '',
-        //         'LARAVEL_LOAD_HOST' => '',
-        //         'LARAVEL_LOAD_PORT' => '',
-        //         'LARAVEL_LOAD_USER' => 'root',
-        //         'LARAVEL_LOAD_PASSWORD' => '',
-        //         'LARAVEL_LOAD_DATABASE' => 'forge',
-        //         'LARAVEL_LOAD_SSL_CA' => '',
-        //         'LARAVEL_LOAD_SSL_CERT' => '',
-        //         'LARAVEL_LOAD_SSL_KEY' => '',
-        //     ], [
-        //         'username' => 'root',
-        //         'database' => 'forge',
-        //         'options' => [
-        //             \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
-        //         ],
-        //     ],
-        // ];
+        yield 'no_ssl' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-mode=DISABLED', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+                'LARAVEL_LOAD_SSL_CERT' => '',
+                'LARAVEL_LOAD_SSL_KEY' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                ],
+            ],
+        ];
 
         yield 'unix socket' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [


### PR DESCRIPTION
This PR updates `MySqlSchemaState` to detect the MySQL/MariaDB client version and adjust SSL flags when loading or dumping schemas.

 `connectionString()` now to accept version info and use `--ssl-mode=DISABLED` for MySQL ≥ 5.7.11 when `MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` is false, falling back to `--ssl=off` for older clients.

**Motivation:**

* Starting with MySQL 5.7.11, the `--ssl` option was **deprecated** in favor of `--ssl-mode` ([[MySQL 5.7.11 release notes](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-11.html)](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-11.html)).
* In MySQL 8.0.0, the `--ssl` option was **removed entirely**.
* Using `--ssl-mode=DISABLED` ensures compatibility with modern MySQL clients while still supporting older MySQL versions and MariaDB.

**Related PRs/Commits:**

* [[#55683](https://github.com/laravel/framework/pull/55683)](https://github.com/laravel/framework/pull/55683)
* [[#55758](https://github.com/laravel/framework/pull/55758)](https://github.com/laravel/framework/pull/55758)
* [[1bfad30](https://github.com/laravel/framework/commit/1bfad3020ec5d542ac7352c6fd0d388cbe29c46c)](https://github.com/laravel/framework/commit/1bfad3020ec5d542ac7352c6fd0d388cbe29c46c)

**Note:**

We are testing for MariaDB in the base implementation since it's possible to use MariaDB client's with a MySQL server.