### PR TITLE
[12.x] Refactor: add `""` to standardize doc blocks

### DIFF
--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -194,7 +194,7 @@ class Envelope
     }
 
     /**
-     * Set the subject of the message.
+     * Set the "subject" of the message.
      *
      * @param  string  $subject
      * @return $this
@@ -233,7 +233,7 @@ class Envelope
     }
 
     /**
-     * Add metadata to the message.
+     * Add "metadata" to the message.
      *
      * @param  string  $key
      * @param  string|int  $value
@@ -260,7 +260,7 @@ class Envelope
     }
 
     /**
-     * Determine if the message is from the given address.
+     * Determine if the message "is from" the given address.
      *
      * @param  string  $address
      * @param  string|null  $name


### PR DESCRIPTION
## Standardize docblock formatting for consistency

Updated docblocks for `subject()`, `metadata()`, and `isFrom()` methods to wrap method names in quotes, maintaining consistency with the rest of the class where method names like "from", "to", "cc", "bcc", "reply to", and "tags" are already quoted in their docblock descriptions.

### Changes:
- `subject()`: "Set the subject" → "Set the "subject""
- `metadata()`: "Add metadata" → "Add "metadata""
- `isFrom()`: "Determine if the message is from" → "Determine if the message "is from""