### PR TITLE
[12.x] Allow $preserveKeys param for LazyCollection random

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1028,11 +1028,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
+     * @param  bool  $preserveKeys
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
-    public function random($number = null)
+    public function random($number = null, $preserveKeys = false)
     {
         $result = $this->collect()->random(...func_get_args());
 

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -512,4 +512,23 @@ class SupportLazyCollectionTest extends TestCase
 
         Carbon::setTestNow();
     }
+
+    public function testRandomPreservesKeys()
+    {
+        $collection = new LazyCollection([
+            'first' => 1,
+            'second' => 2,
+            'third' => 3,
+        ]);
+
+        $keysWithoutPreserve = array_keys($collection->random(2)->all());
+
+        $this->assertEquals([0, 1], $keysWithoutPreserve);
+
+        $keysWithPreserve = array_keys($collection->random(2, true)->all());
+
+        foreach ($keysWithPreserve as $key) {
+            $this->assertContains($key, ['first', 'second', 'third']);
+        }
+    }
 }


### PR DESCRIPTION
`Collection::random()` already allows the preserveKeys param

LazyCollection passes through to the collection.. this just allows us to specify the preserveKey param which defaults to false.

this just matches the Collection API version of random.. for consistency


```php
$entries = LazyCollection::make([
    'entry_9821' => ['name' => 'BigT', 'email' => 'bigt@laravel.com'],
    'entry_9393' => ['name' => 'Bob', 'email' => 'bob@example.com'],
    'entry_3108' => ['name' => 'Charlie', 'email' => 'charlie@example.com'],
]); 

$winners = $entries->random(2, true);
// Result: ['entry_9821' => [...], 'entry_3108' => [...]]
```
I couldn't see a test, so added one

Thanks
