### PR TITLE
Refine doc-blocks and remove method return type hints in ConfigMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigMakeCommand.php
@@ -53,6 +53,7 @@ class ConfigMakeCommand extends GeneratorCommand
 
     /**
      * Get the stub file for the generator.
+     *
      * @return string
      */
     protected function getStub()
@@ -66,6 +67,7 @@ class ConfigMakeCommand extends GeneratorCommand
 
     /**
      * Get the console command arguments.
+     *
      * @return array
      */
     protected function getOptions()

--- a/src/Illuminate/Foundation/Console/ConfigMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigMakeCommand.php
@@ -44,16 +44,18 @@ class ConfigMakeCommand extends GeneratorCommand
      * Get the destination file path.
      *
      * @param  string  $name
+     * @return string
      */
-    protected function getPath($name): string
+    protected function getPath($name)
     {
         return config_path(Str::finish($this->argument('name'), '.php'));
     }
 
     /**
      * Get the stub file for the generator.
+     * @return string
      */
-    protected function getStub(): string
+    protected function getStub()
     {
         $relativePath = join_paths('stubs', 'config.stub');
 
@@ -64,8 +66,9 @@ class ConfigMakeCommand extends GeneratorCommand
 
     /**
      * Get the console command arguments.
+     * @return array
      */
-    protected function getOptions(): array
+    protected function getOptions()
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the configuration file even if it already exists'],


### PR DESCRIPTION
This PR improves ConfigMakeCommand by:

- Removing explicit method return type hints to match Laravel's existing style.
- Adding clearer docblocks with proper @return annotations.
- Enhancing readability of inline comments.

No functional changes are made—this is purely a code style and documentation improvement.
