### PR TITLE
[12.x] Add `makeMany` method to Factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -450,7 +450,7 @@ abstract class Factory
     /**
      * Create a collection of models.
      *
-     * @param  int|null|iterable<int, array<string, mixed>>  $records
+     * @param  iterable<int, array<string, mixed>>|int|null  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function makeMany(int|iterable|null $records = null)

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -448,6 +448,29 @@ abstract class Factory
     }
 
     /**
+     * Create a collection of models.
+     *
+     * @param  int|null|iterable<int, array<string, mixed>>  $records
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
+     */
+    public function makeMany(int|iterable|null $records = null)
+    {
+        $records ??= ($this->count ?? 1);
+
+        $this->count = null;
+
+        if (is_numeric($records)) {
+            $records = array_fill(0, $records, []);
+        }
+
+        return new EloquentCollection(
+            (new Collection($records))->map(function ($record) {
+                return $this->state($record)->make();
+            })
+        );
+    }
+
+    /**
      * Insert the model records in bulk. No model events are emitted.
      *
      * @param  array<string, mixed>  $attributes

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -453,7 +453,7 @@ abstract class Factory
      * @param  iterable<int, array<string, mixed>>|int|null  $records
      * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
-    public function makeMany(int|iterable|null $records = null)
+    public function makeMany(iterable|int|null $records = null)
     {
         $records ??= ($this->count ?? 1);
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -200,6 +200,31 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(0, FactoryTestUser::all());
     }
 
+    public function test_make_many_creates_unpersisted_model_instances()
+    {
+        $users = FactoryTestUserFactory::new()->makeMany([
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Jeffrey Way'],
+        ]);
+
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(2, $users);
+        $this->assertSame('Taylor Otwell', $users[0]->name);
+        $this->assertSame('Jeffrey Way', $users[1]->name);
+        $this->assertCount(0, FactoryTestUser::all());
+
+        $users = FactoryTestUserFactory::new()->makeMany(3);
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(3, $users);
+        $this->assertInstanceOf(FactoryTestUser::class, $users->first());
+        $this->assertCount(0, FactoryTestUser::all());
+
+        $users = FactoryTestUserFactory::new()->makeMany();
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(1, $users);
+        $this->assertCount(0, FactoryTestUser::all());
+    }
+
     public function test_basic_model_attributes_can_be_created()
     {
         $user = FactoryTestUserFactory::new()->raw();


### PR DESCRIPTION
We can `createMany`, but cant `makeMany`, 

This PR adds `makeMany` which is basically the same as `createMany` but calls `make` underneath. 

Seemed an easy enough change and easy to maintain.

This is generally useful for assertions where we don't need the database. 

```php
// This works fine - and goes to the db
$tags = Tag::factory()->createMany([
    ['name' => 'I'],
    ['name' => 'Am'],
    ['name' => 'Fake'],
]); 

// No DB, but currently we do... 
$tags = Tag::factory()->forEachSequence(
    ['name' => 'I'],
    ['name' => 'Am'],
    ['name' => 'Fake'],
)->make();

// With this PR we unlock... 
$tags = Tag::factory()->makeMany([
    ['name' => 'I'],
    ['name' => 'Am'],
    ['name' => 'Fake'],
]);
```