### PR TITLE
[12.x] Update import for PreventRequestsDuringMaintenance

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
-use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Console\Command;


### PR DESCRIPTION
I noticed my excluded webhooks routes were not working during maintenance on Laravel 12. I had them defined in app.php with:

```php
        $middleware->preventRequestsDuringMaintenance(except: [
            'api/webhooks/*',
        ]);
```

But it seems the DownCommand still imports the old `App\Http\Middleware\PreventRequestsDuringMaintenance` middleware that is no longer present in Laravel by default (428a190). I removed this file when upgrading to Laravel 11.

https://github.com/laravel/framework/blob/c50f17af167b539bd7930ef6ebce893b35b68b35/src/Illuminate/Foundation/Console/DownCommand.php#L5

Updated to use the framework default class. But this might prevent users from overriding it. So it might be wise to handle that for backwards compatibility but will leave that to the Laravel team to decide.

```php
protected function excludedPaths()
{
    try {
        $class = class_exists(\App\Http\Middleware\PreventRequestsDuringMaintenance::class)
            ? \App\Http\Middleware\PreventRequestsDuringMaintenance::class
            : PreventRequestsDuringMaintenance::class;

        return $this->laravel->make($class)->getExcludedPaths();
    } catch (Throwable) {
        return [];
    }
}
```

Might also need backporting to Laravel 11.