### PR TITLE
[12.x] Backport withMiddleware changes from 13.x

### DIFF
--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -303,6 +303,12 @@ class ApplicationBuilder
             }
         });
 
+        $this->app->afterResolving(ConsoleKernel::class, function () use ($callback) {
+            if (! is_null($callback)) {
+                $callback(new Middleware);
+            }
+        });
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Foundation\Console;
 
-use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use App\Http\Middleware\PreventRequestsDuringMaintenance as AppPreventRequestsDuringMaintenance;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -102,9 +103,13 @@ class DownCommand extends Command
     protected function excludedPaths()
     {
         try {
-            return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExcludedPaths();
+            return $this->laravel->make(AppPreventRequestsDuringMaintenance::class)->getExcludedPaths();
         } catch (Throwable) {
-            return [];
+            try {
+                return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExcludedPaths();
+            } catch (Throwable) {
+                return [];
+            }
         }
     }
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -256,4 +256,20 @@ class MaintenanceModeTest extends TestCase
         $expectedDate = Carbon::createFromTimestamp($futureTimestamp)->format(DateTimeInterface::RFC7231);
         $this->assertSame($expectedDate, $data['retry']);
     }
+
+    public function testMaintenanceModeRespectsBootstrapConfiguredExcludedPaths()
+    {
+        PreventRequestsDuringMaintenance::except([
+            '/api/*',
+            '/webhooks/*',
+        ]);
+        $this->artisan(DownCommand::class);
+
+        $data = json_decode(file_get_contents(storage_path('framework/down')), true);
+
+        $this->assertSame([
+            '/api/*',
+            '/webhooks/*',
+        ], $data['except']);
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/laravel/framework/pull/58796#issuecomment-3897451353

This is just a cherry pick of the commit.

The afterResolving bit is to make sure the properties are set on PreventRequestsDuringMaintenance from what I remember.