### PR TITLE
[12.x] Add option to opt out of parallel safe cache prefix

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -21,7 +21,7 @@ trait TestCaches
     protected function bootTestCache()
     {
         ParallelTesting::setUpTestCase(function () {
-            if (ParallelTesting::option('without_cache_prefix')) {
+            if (ParallelTesting::option('without_cache')) {
                 return;
             }
 

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -21,6 +21,10 @@ trait TestCaches
     protected function bootTestCache()
     {
         ParallelTesting::setUpTestCase(function () {
+            if (property_exists($this, 'useParallelSafeCachePrefix') && $this->useParallelSafeCachePrefix === false) {
+                return;
+            }
+
             $this->switchToCachePrefix($this->parallelSafeCachePrefix());
         });
     }

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -20,11 +20,11 @@ trait TestCaches
      */
     protected function bootTestCache()
     {
-        if (ParallelTesting::option('without_cache')) {
-            return;
-        }
-
         ParallelTesting::setUpTestCase(function () {
+            if (ParallelTesting::option('without_cache')) {
+                return;
+            }
+
             $this->switchToCachePrefix($this->parallelSafeCachePrefix());
         });
     }

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -20,8 +20,8 @@ trait TestCaches
      */
     protected function bootTestCache()
     {
-        ParallelTesting::setUpTestCase(function () {
-            if (property_exists($this, 'useParallelSafeCachePrefix') && $this->useParallelSafeCachePrefix === false) {
+        ParallelTesting::setUpTestCase(function ($testCase) {
+            if (property_exists($testCase, 'useParallelSafeCachePrefix') && $testCase->useParallelSafeCachePrefix === false) {
                 return;
             }
 

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -20,11 +20,11 @@ trait TestCaches
      */
     protected function bootTestCache()
     {
-        ParallelTesting::setUpTestCase(function () {
-            if (ParallelTesting::option('without_cache')) {
-                return;
-            }
+        if (ParallelTesting::option('without_cache')) {
+            return;
+        }
 
+        ParallelTesting::setUpTestCase(function () {
             $this->switchToCachePrefix($this->parallelSafeCachePrefix());
         });
     }

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -20,8 +20,8 @@ trait TestCaches
      */
     protected function bootTestCache()
     {
-        ParallelTesting::setUpTestCase(function ($testCase) {
-            if (property_exists($testCase, 'useParallelSafeCachePrefix') && $testCase->useParallelSafeCachePrefix === false) {
+        ParallelTesting::setUpTestCase(function () {
+            if (ParallelTesting::option('without_cache_prefix')) {
                 return;
             }
 

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -115,23 +115,14 @@ class TestCachesTest extends TestCase
     {
         Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '7');
 
-        $instance = new class
-        {
-            use TestCaches;
-
-            public $app;
-            protected $useParallelSafeCachePrefix = false;
-
-            public function __construct()
-            {
-                $this->app = Container::getInstance();
-            }
-        };
+        $instance = $this->makeTestCachesInstance();
 
         (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
+        (new ReflectionMethod($instance, 'bootTestCache'))->invoke($instance);
 
-        $method = new ReflectionMethod($instance, 'bootTestCache');
-        $method->invoke($instance);
+        $testCase = new class { public $useParallelSafeCachePrefix = false; };
+
+        Container::getInstance()->make(ParallelTesting::class)->callSetUpTestCaseCallbacks($testCase);
 
         $this->assertSame('myapp_cache_', Container::getInstance()['config']->get('cache.prefix'));
     }

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -111,22 +111,6 @@ class TestCachesTest extends TestCase
         $this->assertCount(1, $setUpCallbacks);
     }
 
-    public function testBootTestCacheSkipsIsolationIfOptedOut()
-    {
-        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '7');
-
-        $instance = $this->makeTestCachesInstance();
-
-        (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
-        (new ReflectionMethod($instance, 'bootTestCache'))->invoke($instance);
-
-        $testCase = new class { public $useParallelSafeCachePrefix = false; };
-
-        Container::getInstance()->make(ParallelTesting::class)->callSetUpTestCaseCallbacks($testCase);
-
-        $this->assertSame('myapp_cache_', Container::getInstance()['config']->get('cache.prefix'));
-    }
-
     protected function getParallelSafeCachePrefix()
     {
         $instance = $this->makeTestCachesInstance();

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -110,6 +110,7 @@ class TestCachesTest extends TestCase
 
         $this->assertCount(1, $setUpCallbacks);
     }
+
     public function testBootTestCacheSkipsIsolationIfOptedOut()
     {
         Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '7');

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -110,6 +110,23 @@ class TestCachesTest extends TestCase
 
         $this->assertCount(1, $setUpCallbacks);
     }
+    public function testBootTestCacheSkipsIsolationIfOptedOut()
+    {
+        Container::getInstance()->make(ParallelTesting::class)->resolveTokenUsing(fn () => '7');
+
+        $instance = $this->makeTestCachesInstance();
+
+        (new ReflectionProperty($instance::class, 'originalCachePrefix'))->setValue(null, null);
+        (new ReflectionMethod($instance, 'bootTestCache'))->invoke($instance);
+
+        $_SERVER['LARAVEL_PARALLEL_TESTING_WITHOUT_CACHE'] = 1;
+
+        Container::getInstance()->make(ParallelTesting::class)->callSetUpTestCaseCallbacks(new class { });
+
+        $this->assertSame('myapp_cache_', Container::getInstance()['config']->get('cache.prefix'));
+
+        unset($_SERVER['LARAVEL_PARALLEL_TESTING_WITHOUT_CACHE']);
+    }
 
     protected function getParallelSafeCachePrefix()
     {


### PR DESCRIPTION
Applications that intentionally share cache state across parallel test processes cant opt out. This was recently added in the last release.

With this PR it means you can currently control this via `LARAVEL_PARALLEL_TESTING_WITHOUT_CACHE`.

Open to renaming , but this follows the same as without_databases . 

I've intentionally put the option check inside setUpTestCase so people can opt out within their testcases re feedback below..

I'll need to do a PR to collision to allow:
`php artisan test --parallel --without_cache`  - will do that if this is merged.. 


Thanks!


This closes https://github.com/laravel/framework/issues/58800