### PR TITLE
[12.x] Normalize Throwable docblocks to fully-qualified name

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -114,7 +114,7 @@ class DatabaseLock extends Lock
      *
      * @return bool
      *
-     * @throws Throwable
+     * @throws \Throwable
      */
     public function release()
     {

--- a/src/Illuminate/Cache/Events/CacheFailedOver.php
+++ b/src/Illuminate/Cache/Events/CacheFailedOver.php
@@ -10,7 +10,7 @@ class CacheFailedOver
      * Create a new event instance.
      *
      * @param  string|null  $storeName  The name of the cache store that failed.
-     * @param  Throwable  $exception  The exception that was thrown.
+     * @param  \Throwable  $exception  The exception that was thrown.
      */
     public function __construct(
         public ?string $storeName,

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -37,7 +37,6 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Throwable;
 
 /**
  * @mixin \League\Flysystem\FilesystemOperator

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -1089,10 +1089,10 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Report the exception.
      *
-     * @param  Throwable  $exception
+     * @param  \Throwable  $exception
      * @return void
      *
-     * @throws Throwable
+     * @throws \Throwable
      */
     protected function report($exception)
     {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -209,7 +209,7 @@ class WorkCommand extends Command
      *
      * @param  Job  $job
      * @param  string  $status
-     * @param  Throwable|null  $exception
+     * @param  \Throwable|null  $exception
      * @return void
      */
     protected function writeOutput(Job $job, $status, ?Throwable $exception = null)
@@ -276,7 +276,7 @@ class WorkCommand extends Command
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  string  $status
-     * @param  Throwable|null  $exception
+     * @param  \Throwable|null  $exception
      * @return void
      */
     protected function writeOutputAsJson(Job $job, $status, ?Throwable $exception = null)

--- a/src/Illuminate/Queue/Events/QueueFailedOver.php
+++ b/src/Illuminate/Queue/Events/QueueFailedOver.php
@@ -11,7 +11,7 @@ class QueueFailedOver
      *
      * @param  string|null  $connectionName  The queue connection that failed.
      * @param  \Closure|string|object  $command  The job instance.
-     * @param  Throwable  $exception  The exception that was thrown.
+     * @param  \Throwable  $exception  The exception that was thrown.
      */
     public function __construct(
         public ?string $connectionName,

--- a/src/Illuminate/Queue/Middleware/FailOnException.php
+++ b/src/Illuminate/Queue/Middleware/FailOnException.php
@@ -54,7 +54,7 @@ class FailOnException
      * @param  callable  $next
      * @return mixed
      *
-     * @throws Throwable
+     * @throws \Throwable
      */
     public function handle($job, callable $next)
     {

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -185,7 +185,7 @@ class ThrottlesExceptions
     /**
      * Run the skip / delete callbacks to determine if the job should be deleted for the given exception.
      *
-     * @param  Throwable  $throwable
+     * @param  \Throwable  $throwable
      * @return bool
      */
     protected function shouldDelete(Throwable $throwable): bool
@@ -202,7 +202,7 @@ class ThrottlesExceptions
     /**
      * Run the skip / fail callbacks to determine if the job should be failed for the given exception.
      *
-     * @param  Throwable  $throwable
+     * @param  \Throwable  $throwable
      * @return bool
      */
     protected function shouldFail(Throwable $throwable): bool


### PR DESCRIPTION
Laravel core consistently references `\Throwable` in PHPDoc blocks using the fully-qualified class name.
This PR updates remaining occurrences of `Throwable` (without leading backslash) to `\Throwable` to maintain consistency across the framework.