### PR TITLE
[12.x] Add `withoutCookie` and `withoutCookies` methods to `MakesHttpRequests` trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -283,6 +283,34 @@ trait MakesHttpRequests
     }
 
     /**
+     * Remove cookies from the request.
+     *
+     * @param  array  $cookies
+     * @return $this
+     */
+    public function withoutCookies(array $cookies)
+    {
+        foreach ($cookies as $name) {
+            $this->withoutCookie($name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a cookie from the request.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function withoutCookie(string $name)
+    {
+        unset($this->defaultCookies[$name], $this->unencryptedCookies[$name]);
+
+        return $this;
+    }
+
+    /**
      * Automatically follow any redirects returned from the response.
      *
      * @return $this

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -174,6 +174,43 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('new-value', $this->unencryptedCookies['new-cookie']);
     }
 
+    public function testWithoutCookieRemovesCookie()
+    {
+        $this->withCookie('foo', 'bar');
+
+        $this->assertArrayHasKey('foo', $this->defaultCookies);
+
+        $this->withoutCookie('foo');
+
+        $this->assertArrayNotHasKey('foo', $this->defaultCookies);
+    }
+
+    public function testWithoutCookieRemovesUnencryptedCookie()
+    {
+        $this->withUnencryptedCookie('foo', 'bar');
+
+        $this->assertArrayHasKey('foo', $this->unencryptedCookies);
+
+        $this->withoutCookie('foo');
+
+        $this->assertArrayNotHasKey('foo', $this->unencryptedCookies);
+    }
+
+    public function testWithoutCookiesRemovesCookies()
+    {
+        $this->withCookies([
+            'foo' => 'bar',
+            'new-cookie' => 'new-value',
+        ]);
+
+        $this->assertCount(2, $this->defaultCookies);
+
+        $this->withoutCookies(['foo', 'new-cookie']);
+
+        $this->assertArrayNotHasKey('foo', $this->defaultCookies);
+        $this->assertArrayNotHasKey('new-cookie', $this->defaultCookies);
+    }
+
     public function testWithoutAndWithCredentials()
     {
         $this->encryptCookies = false;


### PR DESCRIPTION
This PR adds `withoutCookie` and `withoutCookies` methods to the `MakesHttpRequests` trait.

Currently, the trait provides:

- `withCookie`
- `withCookies`
- `withUnencryptedCookie`
- `withUnencryptedCookies`

However, there is no way to remove previously set cookies in a fluent and expressive way, unlike headers which already support:

- `withoutHeader`
- `withoutHeaders`

This change introduces symmetry to the API and improves test ergonomics by allowing cookies to be removed cleanly without directly mutating internal properties.