### PR TITLE
[12.x] Fix: add `|array` in doc block

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -105,6 +105,7 @@ class EncryptCookies
      * @param  string  $key
      * @param  string|array  $value
      * @return string|array|null
+     * @phpstan-return ($value is array ? array<string|null> : string|null)
      */
     protected function validateValue(string $key, $value)
     {

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -103,7 +103,7 @@ class EncryptCookies
      * Validate and remove the cookie value prefix from the value.
      *
      * @param  string  $key
-     * @param  string|array  $value
+     * @param  string|array<string, string>  $value
      * @return string|array|null
      * @phpstan-return ($value is array ? array<string|null> : string|null)
      */

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -103,8 +103,9 @@ class EncryptCookies
      * Validate and remove the cookie value prefix from the value.
      *
      * @param  string  $key
-     * @param  string|array<string, string>  $value
-     * @return string|array|null
+     * @param  array<string, string>|string  $value
+     * @return array|string|null
+     *
      * @phpstan-return ($value is array ? array<string|null> : string|null)
      */
     protected function validateValue(string $key, $value)

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -103,7 +103,7 @@ class EncryptCookies
      * Validate and remove the cookie value prefix from the value.
      *
      * @param  string  $key
-     * @param  string  $value
+     * @param  string|array  $value
      * @return string|array|null
      */
     protected function validateValue(string $key, $value)


### PR DESCRIPTION
Fix docblock type for `validateValue()` method

The `validateValue()` method checks if `$value` is an array using `is_array()` and handles array values via `validateArray()`, but the docblock only declared `string` as the parameter type. Updated the docblock to reflect that `$value` can be either `string|array` to match the actual implementation.