### PR TITLE
[12.x] Fix: division by zero

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,9 +47,15 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      * @param  int  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options  (path, query, fragment, pageName)
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
+        if ($perPage < 1) {
+            throw new \InvalidArgumentException('perPage value must be at least 1.');
+        }
+
         $this->options = $options;
 
         foreach ($options as $key => $value) {

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -52,7 +52,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
-        if ($perPage < 1) {
+        if ($perPage  < 1) {
             throw new \InvalidArgumentException('perPage value must be at least 1.');
         }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -44,7 +44,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  Collection<TKey, TValue>|Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
      * @param  int  $total
-     * @param  int  $perPage
+     * @param  positive-int  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options  (path, query, fragment, pageName)
      *

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -52,7 +52,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
-        if ($perPage  < 1) {
+        if ($perPage < 1) {
             throw new \InvalidArgumentException('perPage value must be at least 1.');
         }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -52,9 +52,9 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
-        if ($perPage < 1) {
-            throw new \InvalidArgumentException('perPage value must be at least 1.');
-        }
+//        if ($perPage < 1) {
+//            throw new \InvalidArgumentException('perPage value must be at least 1.');
+//        }
 
         $this->options = $options;
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -52,9 +52,9 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function __construct($items, $total, $perPage, $currentPage = null, array $options = [])
     {
-//        if ($perPage < 1) {
-//            throw new \InvalidArgumentException('perPage value must be at least 1.');
-//        }
+        if ($perPage < 1) {
+            throw new \InvalidArgumentException('perPage value must be at least 1.');
+        }
 
         $this->options = $options;
 


### PR DESCRIPTION
## Fix division by zero error in Paginator constructor

### Problem
The paginator constructor divides `$total` by `$perPage` without validating that `$perPage` is greater than zero, which causes a division by zero error when an invalid value is passed.

### Solution
Added validation at the beginning of the constructor to throw an `InvalidArgumentException` if `$perPage` is less than 1, preventing the division by zero error and providing a clear error message.

### Changes
- Added `$perPage` validation before any calculations
- Throws `InvalidArgumentException` with descriptive message when `$perPage < 1`
- Updated PHPDoc to document the new exception