### PR TITLE
[12.x] Refactor: remove unnecessary `\BackedEnum`

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -41,7 +41,7 @@ class RateLimiter
     /**
      * Register a named limiter configuration.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @param  \Closure  $callback
      * @return $this
      */
@@ -57,7 +57,7 @@ class RateLimiter
     /**
      * Get the given named rate limiter.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return \Closure|null
      */
     public function limiter($name)
@@ -312,7 +312,7 @@ class RateLimiter
     /**
      * Resolve the rate limiter name.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $name
+     * @param  \UnitEnum|string  $name
      * @return string
      */
     private function resolveLimiterName($name): string

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -84,7 +84,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item exists in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @return bool
      */
     public function has($key): bool
@@ -95,7 +95,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item doesn't exist in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @return bool
      */
     public function missing($key)
@@ -106,7 +106,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -205,7 +205,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache and delete it.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  mixed  $default
      * @return mixed
      */
@@ -219,7 +219,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve a string item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  (\Closure():(string|null))|string|null  $default
      * @return string
      *
@@ -241,7 +241,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an integer item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  (\Closure():(int|null))|int|null  $default
      * @return int
      *
@@ -267,7 +267,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve a float item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  (\Closure():(float|null))|float|null  $default
      * @return float
      *
@@ -293,7 +293,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve a boolean item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  (\Closure():(bool|null))|bool|null  $default
      * @return bool
      *
@@ -315,7 +315,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an array item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
      * @return array<array-key, mixed>
      *
@@ -337,7 +337,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -376,7 +376,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -452,7 +452,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache if the key does not exist.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @param  mixed  $value
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
@@ -493,7 +493,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Increment the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -505,7 +505,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Decrement the value of an item in the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return int|bool
      */
@@ -517,7 +517,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache indefinitely.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return bool
      */
@@ -543,7 +543,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
@@ -571,7 +571,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -585,7 +585,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  \Closure(): TCacheValue  $callback
      * @return TCacheValue
      */
@@ -610,7 +610,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  array{ 0: \DateTimeInterface|\DateInterval|int, 1: \DateTimeInterface|\DateInterval|int }  $ttl
      * @param  (callable(): TCacheValue)  $callback
      * @param  array{ seconds?: int, owner?: string }|null  $lock
@@ -664,7 +664,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TReturn
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  callable(): TReturn  $callback
      * @param  int  $lockFor
      * @param  int  $waitFor
@@ -681,7 +681,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Remove an item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @return bool
      */
     public function forget($key)
@@ -702,7 +702,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Remove an item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|array|string  $key
+     * @param  \UnitEnum|array|string  $key
      * @return bool
      */
     public function delete($key): bool
@@ -904,7 +904,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if a cached value exists.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -915,7 +915,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -926,7 +926,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Store an item in the cache for the default time.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */
@@ -938,7 +938,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Remove an item from the cache.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @return void
      */
     public function offsetUnset($key): void

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -274,7 +274,7 @@ class Store implements Session
     /**
      * Checks if a key exists.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array  $key
+     * @param  \UnitEnum|string|array  $key
      * @return bool
      */
     public function exists($key)
@@ -289,7 +289,7 @@ class Store implements Session
     /**
      * Determine if the given key is missing from the session data.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array  $key
+     * @param  \UnitEnum|string|array  $key
      * @return bool
      */
     public function missing($key)
@@ -300,7 +300,7 @@ class Store implements Session
     /**
      * Determine if a key is present and not null.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array  $key
+     * @param  \UnitEnum|string|array  $key
      * @return bool
      */
     public function has($key)
@@ -313,7 +313,7 @@ class Store implements Session
     /**
      * Determine if any of the given keys are present and not null.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array  $key
+     * @param  \UnitEnum|string|array  $key
      * @return bool
      */
     public function hasAny($key)
@@ -422,7 +422,7 @@ class Store implements Session
     /**
      * Push a value onto a session array.
      *
-     * @param  \BackedEnum|\UnitEnum|string  $key
+     * @param  \UnitEnum|string  $key
      * @param  mixed  $value
      * @return void
      */


### PR DESCRIPTION
refactor: simplify enum type hints to use parent interface

Since `BackedEnum` extends `UnitEnum`, union types like `BackedEnum|UnitEnum` are redundant. Updated type hints to use only `UnitEnum` for better clarity and consistency.