### PR TITLE
MariaDB support for `->timeout()` method

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -9,6 +9,22 @@ use RuntimeException;
 class MariaDbGrammar extends MySqlGrammar
 {
     /**
+     * Apply the query timeout to the given SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $sql
+     * @return string
+     */
+    protected function applyTimeout(Builder $query, string $sql)
+    {
+        if ($query->timeout === null) {
+            return $sql;
+        }
+
+        return 'SET STATEMENT max_statement_time='.$query->timeout.' FOR '.$sql;
+    }
+
+    /**
      * Compile a "lateral join" clause.
      *
      * @param  \Illuminate\Database\Query\JoinLateralClause  $join

--- a/tests/Database/DatabaseMariaDbQueryGrammarTest.php
+++ b/tests/Database/DatabaseMariaDbQueryGrammarTest.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace Database;
+namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\MariaDbGrammar;
+use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +23,57 @@ class DatabaseMariaDbQueryGrammarTest extends TestCase
         );
 
         $this->assertSame('select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
+    }
+
+    public function testTimeout()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'like', '%test%')->timeout(60);
+        $this->assertSame(
+            'SET STATEMENT max_statement_time=60 FOR select * from `users` where `email` like ?',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutWithDistinct()
+    {
+        $builder = $this->getBuilder();
+        $builder->distinct()->select('*')->from('users')->timeout(30);
+        $this->assertSame(
+            'SET STATEMENT max_statement_time=30 FOR select distinct * from `users`',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutWithAggregate()
+    {
+        $builder = $this->getBuilder();
+        $builder->from('users')->timeout(10);
+        $builder->aggregate = ['function' => 'count', 'columns' => ['*']];
+        $this->assertSame(
+            'SET STATEMENT max_statement_time=10 FOR select count(*) as aggregate from `users`',
+            $builder->toSql()
+        );
+    }
+
+    public function testTimeoutWithExists()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'like', '%test%')->timeout(60);
+        $this->assertSame(
+            'SET STATEMENT max_statement_time=60 FOR select exists(select * from `users` where `email` like ?) as `exists`',
+            $builder->getGrammar()->compileExists($builder)
+        );
+    }
+
+    protected function getBuilder()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $grammar = new MariaDbGrammar($connection);
+        $processor = m::mock(Processor::class);
+
+        return new Builder($connection, $grammar, $processor);
     }
 }

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -57,6 +57,16 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
         );
     }
 
+    public function testTimeoutWithExists()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'like', '%test%')->timeout(60);
+        $this->assertSame(
+            'select /*+ MAX_EXECUTION_TIME(60000) */ exists(select * from `users` where `email` like ?) as `exists`',
+            $builder->getGrammar()->compileExists($builder)
+        );
+    }
+
     public function testTimeoutNullRemovesTimeout()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Follow up on #58644 

Since `MariaDbGrammar` extends `MySQLGrammar` it's somewhat important to implement the timeout possibility for MariaDB as well. 

[MariaDB per query timeout](https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/aborting-statements#per-query-max_statement_time). Docs for reference.

This basically addresses 2 concerns:
- MariaDB timeout support 
- Proper `exists()` layering. The timeout should be in the upper-most query to take affect. If it's defined in an inner query MySQL will basically will not honour the timeout request (the query will run as if without the timeout). 