### PR TITLE
Resolve validation exception summary suffix from validation.php

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -21,6 +21,7 @@ return [
     'alpha' => 'The :attribute field must only contain letters.',
     'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
     'alpha_num' => 'The :attribute field must only contain letters and numbers.',
+    'and_more' => '(and :count more error)|(and :count more errors)',
     'any_of' => 'The :attribute field is invalid.',
     'array' => 'The :attribute field must be an array.',
     'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -93,9 +93,7 @@ class ValidationException extends Exception
         $message = array_shift($messages);
 
         if ($count = count($messages)) {
-            $pluralized = $count === 1 ? 'error' : 'errors';
-
-            $message .= ' '.$validator->getTranslator()->choice("(and :count more $pluralized)", $count, compact('count'));
+            $message .= ' '.$validator->getTranslator()->choice('validation.and_more', $count, compact('count'));
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -46,10 +46,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -67,10 +66,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -89,10 +87,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -180,9 +177,18 @@ class ValidationExceptionTest extends TestCase
 
     protected function getTranslator($locale = 'en', $loaded = [])
     {
-        $translator ??= new Translator(new ArrayLoader, $locale);
+        $default = [
+            '*' => [
+                'validation' => [
+                    'en' => [
+                        'and_more' => '(and :count more error)|(and :count more errors)',
+                    ],
+                ],
+            ],
+        ];
 
-        $translator->setLoaded($loaded);
+        $translator = new Translator(new ArrayLoader, $locale);
+        $translator->setLoaded(array_merge_recursive($default, $loaded));
 
         return $translator;
     }


### PR DESCRIPTION
Fixes #58783

When a ValidationException has multiple errors, Laravel shows a summary like
"The foo field is required (and 2 more errors)". Previously, this suffix
was resolved from JSON translation files only, not from validation.php.

This caused mixed-language output in apps that use validation.php but not
JSON translations. For example, a German app would show: "Das foo-Feld ist
erforderlich. (and 2 more errors)"

This change introduces a `validation.and_more` key in validation.php so the
suffix can be translated along with other validation messages. Apps can now
translate the entire validation summary using their existing validation
translations, without needing JSON language files.

**Changes:**
- Add `and_more` to the validation language file with plural forms
- Update `ValidationException::summarize()` to use `validation.and_more`
  instead of raw translation keys
- Adjust tests to reflect the new translation structure