### PR TITLE
Improve File::toKilobytes() DocBlock return type

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -230,7 +230,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * Convert a potentially human-friendly file size to kilobytes.
      *
      * @param  string|int  $size
-     * @return int|float
+     * @return ($size is int ? int : int|float)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -230,7 +230,7 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      * Convert a potentially human-friendly file size to kilobytes.
      *
      * @param  string|int  $size
-     * @return mixed
+     * @return int|float
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
Replace `@return mixed` with `@return int|float` for the `toKilobytes()` method in the File validation rule. The method returns either an integer (when `$size` is passed as int) or a float (from `round()` when processing string sizes with kb/mb/gb/tb suffixes), so the updated DocBlock better reflects the actual return types and improves IDE support.