### PR TITLE
[12.x] Add `StorageUri` value object for portable file references

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsStorageUri.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsStorageUri.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\StorageUri;
+
+class AsStorageUri implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\StorageUri, string|StorageUri>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes
+        {
+            public function get($model, $key, $value, $attributes)
+            {
+                return isset($value) ? StorageUri::parse($value) : null;
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if ($value instanceof StorageUri) {
+                    return $value->toUri();
+                }
+
+                return isset($value) ? (string) $value : null;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Http\File;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\StorageUri;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -98,6 +98,13 @@ class FilesystemAdapter implements CloudFilesystemContract
     protected $temporaryUploadUrlCallback;
 
     /**
+     * The name of the disk.
+     *
+     * @var string|null
+     */
+    protected $diskName;
+
+    /**
      * Create a new filesystem adapter instance.
      *
      * @param  \League\Flysystem\FilesystemOperator  $driver
@@ -282,6 +289,30 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function path($path)
     {
         return $this->prefixer->prefixPath($path);
+    }
+
+    /**
+     * Specify the name of the disk.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function diskName(string $name): static
+    {
+        $this->diskName = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get a StorageUri instance for the given path.
+     *
+     * @param  string  $path
+     * @return \Illuminate\Support\StorageUri
+     */
+    public function uri(string $path): StorageUri
+    {
+        return new StorageUri($this->diskName, $path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -200,9 +200,10 @@ class FilesystemManager implements FactoryContract
      * Create an instance of the ftp driver.
      *
      * @param  array  $config
+     * @param  string  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
-    public function createFtpDriver(array $config)
+    public function createFtpDriver(array $config, string $name = 'ftp')
     {
         if (! isset($config['root'])) {
             $config['root'] = '';
@@ -210,16 +211,17 @@ class FilesystemManager implements FactoryContract
 
         $adapter = new FtpAdapter(FtpConnectionOptions::fromArray($config));
 
-        return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);
+        return (new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config))->diskName($name);
     }
 
     /**
      * Create an instance of the sftp driver.
      *
      * @param  array  $config
+     * @param  string  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
-    public function createSftpDriver(array $config)
+    public function createSftpDriver(array $config, string $name = 'sftp')
     {
         $provider = SftpConnectionProvider::fromArray($config);
 
@@ -231,16 +233,17 @@ class FilesystemManager implements FactoryContract
 
         $adapter = new SftpAdapter($provider, $root, $visibility);
 
-        return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);
+        return (new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config))->diskName($name);
     }
 
     /**
      * Create an instance of the Amazon S3 driver.
      *
      * @param  array  $config
+     * @param  string  $name
      * @return \Illuminate\Contracts\Filesystem\Cloud
      */
-    public function createS3Driver(array $config)
+    public function createS3Driver(array $config, string $name = 's3')
     {
         $s3Config = $this->formatS3Config($config);
 
@@ -256,9 +259,9 @@ class FilesystemManager implements FactoryContract
 
         $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, $config['options'] ?? [], $streamReads);
 
-        return new AwsS3V3Adapter(
+        return (new AwsS3V3Adapter(
             $this->createFlysystem($adapter, $config), $adapter, $s3Config, $client
-        );
+        ))->diskName($name);
     }
 
     /**

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Filesystem;
 
 use Closure;
+use Illuminate\Support\StorageUri;
 use Illuminate\Support\Traits\Conditionable;
 use RuntimeException;
 

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -124,11 +124,22 @@ class LocalFilesystemAdapter extends FilesystemAdapter
      * @param  string  $disk
      * @return $this
      */
-    public function diskName(string $disk)
+    public function diskName(string $disk): static
     {
         $this->disk = $disk;
 
         return $this;
+    }
+
+    /**
+     * Get a StorageUri instance for the given path.
+     *
+     * @param  string  $path
+     * @return \Illuminate\Support\StorageUri
+     */
+    public function uri(string $path): StorageUri
+    {
+        return new StorageUri($this->disk, $path);
     }
 
     /**

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -97,6 +97,47 @@ class UploadedFile extends SymfonyUploadedFile
     }
 
     /**
+     * Store the uploaded file on a filesystem disk and return a StorageUri.
+     *
+     * @param  string  $path
+     * @param  array|string  $options
+     * @return \Illuminate\Support\StorageUri|false
+     */
+    public function storeUri($path = '', $options = [])
+    {
+        return $this->storeUriAs($path, $this->hashName(), $this->parseOptions($options));
+    }
+
+    /**
+     * Store the uploaded file on a filesystem disk and return a StorageUri.
+     *
+     * @param  string  $path
+     * @param  array|string|null  $name
+     * @param  array|string  $options
+     * @return \Illuminate\Support\StorageUri|false
+     */
+    public function storeUriAs($path, $name = null, $options = [])
+    {
+        if (is_null($name) || is_array($name)) {
+            [$path, $name, $options] = ['', $path, $name ?? []];
+        }
+
+        $options = $this->parseOptions($options);
+
+        $disk = Arr::pull($options, 'disk');
+
+        $filesystem = Container::getInstance()->make(FilesystemFactory::class)->disk($disk);
+
+        $storedPath = $filesystem->putFileAs($path, $this, $name, $options);
+
+        if ($storedPath === false) {
+            return false;
+        }
+
+        return $filesystem->uri($storedPath);
+    }
+
+    /**
      * Get the contents of the uploaded file.
      *
      * @return false|string

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -132,6 +132,17 @@ class Attachment
     }
 
     /**
+     * Create a mail attachment from a StorageUri instance.
+     *
+     * @param  \Illuminate\Support\StorageUri  $uri
+     * @return static
+     */
+    public static function fromStorageUri(StorageUri $uri)
+    {
+        return static::fromStorageDisk($uri->disk(), $uri->path());
+    }
+
+    /**
      * Create a mail attachment from a file on the cloud storage disk.
      *
      * @param  string  $path

--- a/src/Illuminate/Support/StorageUri.php
+++ b/src/Illuminate/Support/StorageUri.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace Illuminate\Support;
+
+use DateTimeInterface;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\Eloquent\Casts\AsStorageUri;
+use Illuminate\Mail\Attachment;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Dumpable;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+use InvalidArgumentException;
+use JsonSerializable;
+use Stringable;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class StorageUri implements Arrayable, Castable, Jsonable, JsonSerializable, Stringable
+{
+    use Conditionable, Dumpable, Macroable, Tappable;
+
+    /**
+     * The URI scheme.
+     *
+     * @var string
+     */
+    public const SCHEME = 'storage';
+
+    /**
+     * The storage disk name.
+     */
+    protected ?string $disk;
+
+    /**
+     * The path within the disk.
+     */
+    protected string $path;
+
+    /**
+     * Create a new storage URI instance.
+     */
+    public function __construct(?string $disk, string $path)
+    {
+        $this->disk = $disk;
+        $this->path = ltrim($path, '/');
+    }
+
+    /**
+     * Create a new storage URI instance from a URI string.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function of(string $uri): static
+    {
+        return static::parse($uri);
+    }
+
+    /**
+     * Parse a storage URI string into a StorageUri instance.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function parse(string $uri): static
+    {
+        $parsed = parse_url($uri);
+
+        if ($parsed === false) {
+            throw new InvalidArgumentException("Invalid storage URI: {$uri}");
+        }
+
+        $scheme = $parsed['scheme'] ?? null;
+
+        if ($scheme !== static::SCHEME) {
+            throw new InvalidArgumentException(
+                "Invalid storage URI scheme [{$scheme}]. Expected [".static::SCHEME.'].'
+            );
+        }
+
+        $disk = $parsed['host'] ?? null;
+        $path = ltrim($parsed['path'] ?? '', '/');
+
+        if ($path === '') {
+            throw new InvalidArgumentException("Storage URI is missing a path: {$uri}");
+        }
+
+        return new static($disk, $path);
+    }
+
+    /**
+     * Create a storage URI for the default disk.
+     */
+    public static function make(string $path): static
+    {
+        return new static(null, $path);
+    }
+
+    /**
+     * Create a storage URI for a specific disk.
+     */
+    public static function onDisk(string $disk, string $path): static
+    {
+        return new static($disk, $path);
+    }
+
+    /**
+     * Get the storage disk name.
+     */
+    public function disk(): ?string
+    {
+        return $this->disk;
+    }
+
+    /**
+     * Get the path within the disk.
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the file's extension.
+     */
+    public function extension(): string
+    {
+        return pathinfo($this->path, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Get the file's directory name.
+     */
+    public function dirname(): string
+    {
+        $dirname = pathinfo($this->path, PATHINFO_DIRNAME);
+
+        return $dirname === '.' ? '' : $dirname;
+    }
+
+    /**
+     * Get the file's basename.
+     */
+    public function basename(): string
+    {
+        return pathinfo($this->path, PATHINFO_BASENAME);
+    }
+
+    /**
+     * Get the file's filename without extension.
+     */
+    public function filename(): string
+    {
+        return pathinfo($this->path, PATHINFO_FILENAME);
+    }
+
+    /**
+     * Get a new storage URI with a different disk.
+     */
+    public function withDisk(?string $disk): static
+    {
+        return new static($disk, $this->path);
+    }
+
+    /**
+     * Get a new storage URI with a different path.
+     */
+    public function withPath(string $path): static
+    {
+        return new static($this->disk, $path);
+    }
+
+    /**
+     * Get the filesystem adapter for this URI's disk.
+     */
+    protected function storage()
+    {
+        return Container::getInstance()
+            ->make(FilesystemFactory::class)
+            ->disk($this->disk);
+    }
+
+    /**
+     * Determine if the file exists.
+     */
+    public function exists(): bool
+    {
+        return $this->storage()->exists($this->path);
+    }
+
+    /**
+     * Determine if the file is missing.
+     */
+    public function missing(): bool
+    {
+        return $this->storage()->missing($this->path);
+    }
+
+    /**
+     * Get the file's contents.
+     */
+    public function get(): ?string
+    {
+        return $this->storage()->get($this->path);
+    }
+
+    /**
+     * Get the file's contents as a decoded JSON array.
+     */
+    public function json(int $flags = 0): ?array
+    {
+        return $this->storage()->json($this->path, $flags);
+    }
+
+    /**
+     * Get a read-stream for the file.
+     *
+     * @return resource|null
+     */
+    public function readStream()
+    {
+        return $this->storage()->readStream($this->path);
+    }
+
+    /**
+     * Get the URL for the file.
+     *
+     * @return string
+     */
+    public function url(): string
+    {
+        return $this->storage()->url($this->path);
+    }
+
+    /**
+     * Get a temporary URL for the file.
+     *
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return string
+     */
+    public function temporaryUrl(DateTimeInterface $expiration, array $options = []): string
+    {
+        return $this->storage()->temporaryUrl($this->path, $expiration, $options);
+    }
+
+    /**
+     * Get the file's size in bytes.
+     *
+     * @return int
+     */
+    public function size(): int
+    {
+        return $this->storage()->size($this->path);
+    }
+
+    /**
+     * Get the file's MIME type.
+     *
+     * @return string|false
+     */
+    public function mimeType(): string|false
+    {
+        return $this->storage()->mimeType($this->path);
+    }
+
+    /**
+     * Get the file's last modification time.
+     *
+     * @return int
+     */
+    public function lastModified(): int
+    {
+        return $this->storage()->lastModified($this->path);
+    }
+
+    /**
+     * Get the full filesystem path.
+     *
+     * @return string
+     */
+    public function fullPath(): string
+    {
+        return $this->storage()->path($this->path);
+    }
+
+    /**
+     * Get the file's visibility.
+     *
+     * @return string
+     */
+    public function visibility(): string
+    {
+        return $this->storage()->getVisibility($this->path);
+    }
+
+    /**
+     * Delete the file.
+     *
+     * @return bool
+     */
+    public function delete(): bool
+    {
+        return $this->storage()->delete($this->path);
+    }
+
+    /**
+     * Create a streamed response for the file.
+     *
+     * @param  string|null  $name
+     * @param  array  $headers
+     * @param  string  $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function response(?string $name = null, array $headers = [], string $disposition = 'inline'): StreamedResponse
+    {
+        return $this->storage()->response($this->path, $name, $headers, $disposition);
+    }
+
+    /**
+     * Create a streamed download response for the file.
+     *
+     * @param  string|null  $name
+     * @param  array  $headers
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function download(?string $name = null, array $headers = []): StreamedResponse
+    {
+        return $this->storage()->download($this->path, $name, $headers);
+    }
+
+    /**
+     * Convert the storage URI to a mail attachment.
+     *
+     * @return \Illuminate\Mail\Attachment
+     */
+    public function toAttachment(): Attachment
+    {
+        return Attachment::fromStorageDisk($this->disk, $this->path);
+    }
+
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<static, string|static>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return AsStorageUri::castUsing($arguments);
+    }
+
+    /**
+     * Get the URI string representation.
+     *
+     * @return string
+     */
+    public function toUri(): string
+    {
+        $disk = $this->disk ?? '';
+
+        return static::SCHEME.'://'.$disk.'/'.$this->path;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<string, string|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'disk' => $this->disk,
+            'path' => $this->path,
+        ];
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0): string
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return string
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->toUri();
+    }
+
+    /**
+     * Get the string representation of the storage URI.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toUri();
+    }
+}

--- a/tests/Support/SupportStorageUriTest.php
+++ b/tests/Support/SupportStorageUriTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\StorageUri;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class SupportStorageUriTest extends TestCase
+{
+    public function test_can_create_from_disk_and_path()
+    {
+        $uri = new StorageUri('local', 'path/to/file.jpg');
+
+        $this->assertEquals('local', $uri->disk());
+        $this->assertEquals('path/to/file.jpg', $uri->path());
+    }
+
+    public function test_can_create_with_null_disk()
+    {
+        $uri = new StorageUri(null, 'path/to/file.jpg');
+
+        $this->assertNull($uri->disk());
+        $this->assertEquals('path/to/file.jpg', $uri->path());
+    }
+
+    public function test_path_is_normalized_by_removing_leading_slash()
+    {
+        $uri = new StorageUri('local', '/path/to/file.jpg');
+
+        $this->assertEquals('path/to/file.jpg', $uri->path());
+    }
+
+    public function test_of_parses_valid_uri()
+    {
+        $uri = StorageUri::of('storage://local/path/to/file.jpg');
+
+        $this->assertEquals('local', $uri->disk());
+        $this->assertEquals('path/to/file.jpg', $uri->path());
+    }
+
+    public function test_parse_parses_valid_uri()
+    {
+        $uri = StorageUri::parse('storage://s3/avatars/photo.png');
+
+        $this->assertEquals('s3', $uri->disk());
+        $this->assertEquals('avatars/photo.png', $uri->path());
+    }
+
+    public function test_parse_throws_on_invalid_uri()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid storage URI');
+
+        StorageUri::parse(':::invalid');
+    }
+
+    public function test_parse_throws_on_wrong_scheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid storage URI scheme [https]');
+
+        StorageUri::parse('https://example.com/file.jpg');
+    }
+
+    public function test_parse_throws_when_path_is_missing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Storage URI is missing a path');
+
+        StorageUri::parse('storage://local');
+    }
+
+    public function test_make_creates_uri_for_default_disk()
+    {
+        $uri = StorageUri::make('documents/report.pdf');
+
+        $this->assertNull($uri->disk());
+        $this->assertEquals('documents/report.pdf', $uri->path());
+    }
+
+    public function test_on_disk_creates_uri_for_specific_disk()
+    {
+        $uri = StorageUri::onDisk('s3', 'uploads/image.png');
+
+        $this->assertEquals('s3', $uri->disk());
+        $this->assertEquals('uploads/image.png', $uri->path());
+    }
+
+    public function test_extension_returns_file_extension()
+    {
+        $this->assertEquals('jpg', StorageUri::make('photo.jpg')->extension());
+        $this->assertEquals('pdf', StorageUri::make('docs/report.pdf')->extension());
+        $this->assertEquals('gz', StorageUri::make('archive.tar.gz')->extension());
+        $this->assertEquals('', StorageUri::make('no-extension')->extension());
+    }
+
+    public function test_dirname_returns_directory_path()
+    {
+        $this->assertEquals('path/to', StorageUri::make('path/to/file.jpg')->dirname());
+        $this->assertEquals('', StorageUri::make('file.jpg')->dirname());
+        $this->assertEquals('deeply/nested/path', StorageUri::make('deeply/nested/path/file.txt')->dirname());
+    }
+
+    public function test_basename_returns_filename_with_extension()
+    {
+        $this->assertEquals('file.jpg', StorageUri::make('path/to/file.jpg')->basename());
+        $this->assertEquals('file.jpg', StorageUri::make('file.jpg')->basename());
+        $this->assertEquals('archive.tar.gz', StorageUri::make('backups/archive.tar.gz')->basename());
+    }
+
+    public function test_filename_returns_filename_without_extension()
+    {
+        $this->assertEquals('file', StorageUri::make('path/to/file.jpg')->filename());
+        $this->assertEquals('file', StorageUri::make('file.jpg')->filename());
+        $this->assertEquals('archive.tar', StorageUri::make('backups/archive.tar.gz')->filename());
+        $this->assertEquals('no-extension', StorageUri::make('no-extension')->filename());
+    }
+
+    public function test_with_disk_returns_new_instance_with_different_disk()
+    {
+        $original = StorageUri::onDisk('local', 'file.jpg');
+        $modified = $original->withDisk('s3');
+
+        $this->assertEquals('local', $original->disk());
+        $this->assertEquals('s3', $modified->disk());
+        $this->assertEquals('file.jpg', $modified->path());
+        $this->assertNotSame($original, $modified);
+    }
+
+    public function test_with_path_returns_new_instance_with_different_path()
+    {
+        $original = StorageUri::onDisk('local', 'old/path.jpg');
+        $modified = $original->withPath('new/path.png');
+
+        $this->assertEquals('old/path.jpg', $original->path());
+        $this->assertEquals('new/path.png', $modified->path());
+        $this->assertEquals('local', $modified->disk());
+        $this->assertNotSame($original, $modified);
+    }
+
+    public function test_to_uri_returns_string_representation()
+    {
+        $this->assertEquals(
+            'storage://local/path/to/file.jpg',
+            StorageUri::onDisk('local', 'path/to/file.jpg')->toUri()
+        );
+    }
+
+    public function test_to_uri_handles_null_disk()
+    {
+        $this->assertEquals(
+            'storage:///path/to/file.jpg',
+            StorageUri::make('path/to/file.jpg')->toUri()
+        );
+    }
+
+    public function test_to_string_returns_uri()
+    {
+        $uri = StorageUri::onDisk('s3', 'uploads/file.pdf');
+
+        $this->assertEquals('storage://s3/uploads/file.pdf', (string) $uri);
+    }
+
+    public function test_to_array_returns_disk_and_path()
+    {
+        $uri = StorageUri::onDisk('local', 'path/to/file.jpg');
+
+        $this->assertEquals([
+            'disk' => 'local',
+            'path' => 'path/to/file.jpg',
+        ], $uri->toArray());
+    }
+
+    public function test_to_array_handles_null_disk()
+    {
+        $uri = StorageUri::make('file.jpg');
+
+        $this->assertEquals([
+            'disk' => null,
+            'path' => 'file.jpg',
+        ], $uri->toArray());
+    }
+
+    public function test_json_serialize_returns_uri_string()
+    {
+        $uri = StorageUri::onDisk('local', 'file.jpg');
+
+        $this->assertEquals('storage://local/file.jpg', $uri->jsonSerialize());
+    }
+
+    public function test_to_json_returns_json_encoded_uri()
+    {
+        $uri = StorageUri::onDisk('local', 'file.jpg');
+
+        $this->assertEquals('"storage:\/\/local\/file.jpg"', $uri->toJson());
+    }
+
+    public function test_cast_using_returns_casts_attributes_implementation()
+    {
+        $cast = StorageUri::castUsing([]);
+
+        $this->assertInstanceOf(CastsAttributes::class, $cast);
+    }
+
+    public function test_roundtrip_parsing()
+    {
+        $original = StorageUri::onDisk('local', 'path/to/file.jpg');
+        $parsed = StorageUri::parse($original->toUri());
+
+        $this->assertEquals($original->disk(), $parsed->disk());
+        $this->assertEquals($original->path(), $parsed->path());
+        $this->assertEquals($original->toUri(), $parsed->toUri());
+    }
+
+    public function test_complex_paths()
+    {
+        $uri = StorageUri::onDisk('s3', 'users/123/avatars/profile-2024.jpg');
+
+        $this->assertEquals('users/123/avatars/profile-2024.jpg', $uri->path());
+        $this->assertEquals('users/123/avatars', $uri->dirname());
+        $this->assertEquals('profile-2024.jpg', $uri->basename());
+        $this->assertEquals('profile-2024', $uri->filename());
+        $this->assertEquals('jpg', $uri->extension());
+    }
+
+    public function test_storage_uri_is_stringable()
+    {
+        $uri = StorageUri::onDisk('local', 'file.jpg');
+
+        $this->assertInstanceOf(\Stringable::class, $uri);
+    }
+
+    public function test_storage_uri_implements_required_interfaces()
+    {
+        $uri = StorageUri::make('file.jpg');
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Support\Arrayable::class, $uri);
+        $this->assertInstanceOf(\Illuminate\Contracts\Support\Jsonable::class, $uri);
+        $this->assertInstanceOf(\JsonSerializable::class, $uri);
+        $this->assertInstanceOf(\Illuminate\Contracts\Database\Eloquent\Castable::class, $uri);
+    }
+}


### PR DESCRIPTION
This PR introduces a `StorageUri` value object that provides a portable, serializable way to reference files across different storage disks using a URI format: `storage://disk/path/to/file.jpg` as [discussed here](https://github.com/laravel/framework/discussions/58540).

There are some open questions at the bottom, but I am really looking to see if this is something @taylorotwell would be interested in merging before I go further with tests, API feedback and docs 😄

I used Opus 4.5 to generate most of this full disclaimer.

### Motivation

Currently, storing file references in the database requires either:
1. Storing just the path (losing disk context, assuming default disk)
2. Storing disk and path in separate columns
3. Using a custom solution per-project

This becomes problematic when:
- Moving files between disks (local → S3)
- Working with multi-tenant applications with per-tenant storage
- Serializing file references for queues or APIs
- Needing to change the default disk

The `StorageUri` value object solves this by encapsulating both disk and path in a single, portable value.

### Usage Examples

#### Basic Construction

```php
use Illuminate\Support\StorageUri;

// Create with explicit disk
$uri = new StorageUri('s3', 'avatars/photo.jpg');
$uri = StorageUri::onDisk('s3', 'avatars/photo.jpg');

// Create for default disk
$uri = StorageUri::make('documents/report.pdf');

// Parse from URI string
$uri = StorageUri::parse('storage://s3/avatars/photo.jpg');
$uri = StorageUri::of('storage://s3/avatars/photo.jpg');
```

#### Eloquent Integration

```php
use Illuminate\Support\StorageUri;

class User extends Model
{
    protected $casts = [
        'avatar' => StorageUri::class,
    ];
}

// Usage
$user->avatar = StorageUri::onDisk('s3', 'avatars/photo.jpg');
$user->save();

// Database stores: "storage://s3/avatars/photo.jpg"

// Retrieve
$user->avatar->disk();  // "s3"
$user->avatar->path();  // "avatars/photo.jpg"
$user->avatar->url();   // Full public URL
```

#### File Uploads

```php
// New methods on UploadedFile
$uri = $request->file('avatar')->storeUri('avatars', 's3');
$uri = $request->file('avatar')->storeUriAs('avatars', 'custom-name.jpg', 's3');

// Returns StorageUri instance ready for database storage
$user->avatar = $uri;
$user->save();
```

#### Storage Facade Integration

```php
// Get URI from storage operations
$uri = Storage::disk('s3')->uri('path/to/file.jpg');

// StorageUri provides convenient accessors
$uri->path();       // "path/to/file.jpg"
$uri->disk();       // "s3"
$uri->extension();  // "jpg"
$uri->dirname();    // "path/to"
$uri->basename();   // "file.jpg"
$uri->filename();   // "file"
```

#### Storage Operations (via StorageUri)

```php
$uri = StorageUri::parse($user->avatar);

// Proxy methods to Storage facade
$uri->exists();              // Check if file exists
$uri->get();                 // Get file contents
$uri->url();                 // Get public URL
$uri->temporaryUrl($expiry); // Get temporary URL
$uri->download();            // Stream download response
$uri->delete();              // Delete the file
```

#### Email Attachments

```php
use Illuminate\Mail\Attachment;

// New factory method
$attachment = Attachment::fromStorageUri($user->avatar);

// In Mailable
public function attachments(): array
{
    return [
        Attachment::fromStorageUri($this->user->avatar),
    ];
}
```

#### Immutable Modifications

```php
$original = StorageUri::onDisk('local', 'temp/file.jpg');

// Create copies with different disk or path
$onS3 = $original->withDisk('s3');
$renamed = $original->withPath('permanent/file.jpg');

// Original unchanged
$original->disk(); // "local"
$onS3->disk();     // "s3"
```

#### Serialization

```php
$uri = StorageUri::onDisk('s3', 'file.jpg');

(string) $uri;        // "storage://s3/file.jpg"
$uri->toUri();        // "storage://s3/file.jpg"
$uri->toArray();      // ['disk' => 's3', 'path' => 'file.jpg']
$uri->toJson();       // '"storage:\/\/s3\/file.jpg"'
json_encode($uri);    // '"storage:\/\/s3\/file.jpg"'
```

### API Summary

#### StorageUri

| Method                                            | Description                    |
| ------------------------------------------------- | ------------------------------ |
| `new StorageUri(?string $disk, string $path)`     | Constructor                    |
| `StorageUri::make(string $path)`                  | Create for default disk        |
| `StorageUri::onDisk(string $disk, string $path)`  | Create for specific disk       |
| `StorageUri::parse(string $uri)`                  | Parse URI string               |
| `StorageUri::of(string $uri)`                     | Alias for parse                |
| `disk(): ?string`                                 | Get disk name                  |
| `path(): string`                                  | Get file path                  |
| `extension(): string`                             | Get file extension             |
| `dirname(): string`                               | Get directory path             |
| `basename(): string`                              | Get filename with extension    |
| `filename(): string`                              | Get filename without extension |
| `withDisk(?string $disk): self`                   | Copy with different disk       |
| `withPath(string $path): self`                    | Copy with different path       |
| `toUri(): string`                                 | Get URI string                 |
| `toArray(): array`                                | Get as array                   |
| `toJson(): string`                                | Get as JSON                    |
| `exists(): bool`                                  | Check file exists              |
| `get(): string`                                   | Get file contents              |
| `url(): string`                                   | Get public URL                 |
| `temporaryUrl(DateTimeInterface $expiry): string` | Get temporary URL              |
| `download(?string $name): StreamedResponse`       | Stream download                |
| `delete(): bool`                                  | Delete file                    |

#### New Methods on Existing Classes

| Class               | Method                                        | Description                 |
| ------------------- | --------------------------------------------- | --------------------------- |
| `FilesystemAdapter` | `uri(string $path): StorageUri`               | Create URI for path         |
| `UploadedFile`      | `storeUri($path, $disk): StorageUri`          | Store and return URI        |
| `UploadedFile`      | `storeUriAs($path, $name, $disk): StorageUri` | Store with name, return URI |
| `Attachment`        | `fromStorageUri(StorageUri $uri)`             | Create attachment from URI  |

### Zero Breaking Changes

This PR introduces only **additive** changes:
- New `StorageUri` class
- New `AsStorageUri` cast (alias)
- New methods on existing classes (no signature changes)
- No modifications to existing method behavior

---

## My Assessment

### Why I think this is worth doing

1. **Solves a real problem** - I made a similar class  in multiple projects to solve this problem in the past and always thought there should be a better way baked into Laravel.
2. **Clean API** - Follows Laravel conventions (value object, Eloquent cast, facade integration)
3. **Zero breaking changes** - Purely additive, safe for any 12.x or 13.x release
4. **Composable** - Works with existing Laravel primitives (Storage, UploadedFile, Attachment)
5. **Familiar patterns** - Uses existing patterns from the codebase (Uri class, value objects, castables)

### Open Questions

1. **How should null disk URIs serialize?**
   - Currently: `storage:///path/to/file.jpg` (triple slash)
   - Problem: PHP's `parse_url()` returns `false` for this format, so it can't round-trip through `parse()`
   - Alternative A: Use `storage://default/path` as a reserved keyword
   - Alternative B: Require explicit disk always (no null disk support)
   - Alternative C: Document the limitation and accept it

2. **Is `StorageUri` the right name?**
   - `StoragePath` - emphasizes it's a path reference
   - `FileReference` - more generic
   - `StorageLocation` - descriptive but longer

3. **When should null disk resolve to the default?**
   - Currently: at access time (when calling `->url()`, `->exists()`, etc.)
   - Alternative: at serialization time (always store the resolved disk name)