### PR TITLE
[12.x] Add missing tests for Request::fullUrlWithoutQuery

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -152,6 +152,30 @@ class HttpRequestTest extends TestCase
         $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
     }
 
+    public function testFullUrlWithoutQueryMethod()
+    {
+        $request = Request::create('http://foo.com/foo/bar?name=taylor&age=30');
+        $this->assertSame('http://foo.com/foo/bar?age=30', $request->fullUrlWithoutQuery('name'));
+
+        $request = Request::create('http://foo.com/foo/bar?name=taylor&age=30');
+        $this->assertSame('http://foo.com/foo/bar?age=30', $request->fullUrlWithoutQuery(['name']));
+
+        $request = Request::create('http://foo.com/foo/bar?name=taylor&age=30&city=nyc');
+        $this->assertSame('http://foo.com/foo/bar?city=nyc', $request->fullUrlWithoutQuery(['name', 'age']));
+
+        $request = Request::create('http://foo.com/foo/bar?name=taylor');
+        $this->assertSame('http://foo.com/foo/bar', $request->fullUrlWithoutQuery('name'));
+
+        $request = Request::create('http://foo.com/foo/bar');
+        $this->assertSame('http://foo.com/foo/bar', $request->fullUrlWithoutQuery('name'));
+
+        $request = Request::create('https://foo.com?a=b&c=d');
+        $this->assertSame('https://foo.com/?c=d', $request->fullUrlWithoutQuery('a'));
+
+        $request = Request::create('https://foo.com/?name=taylor&age=30');
+        $this->assertSame('https://foo.com/?age=30', $request->fullUrlWithoutQuery('name'));
+    }
+
     public function testIsMethod()
     {
         $request = Request::create('/foo/bar');


### PR DESCRIPTION
This PR adds test coverage for the `Request::fullUrlWithoutQuery` method which was previously untested.

The new tests cover:
- Removing a single query parameter by string key
- Removing a single query parameter by array
- Removing multiple query parameters at once
- Removing the only query parameter (resulting in no query string)
- Removing a non-existent key from a URL without query string
- Root URL with query string
- URL with trailing slash
