### PR TITLE
Use atomic writes when creating inline Blade component views

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -199,12 +199,16 @@ abstract class Component
             $directory = Container::getInstance()['config']->get('view.compiled')
         );
 
-        if (! is_file($viewFile = $directory.'/'.hash('xxh128', $contents).'.blade.php')) {
+        $viewFile = $directory.'/'.hash('xxh128', $contents).'.blade.php';
+
+        if (! is_file($viewFile) || filesize($viewFile) === 0) {
+            $files = Container::getInstance()['files'];
+
             if (! is_dir($directory)) {
-                mkdir($directory, 0755, true);
+                $files->makeDirectory($directory, 0755, true, true);
             }
 
-            file_put_contents($viewFile, $contents);
+            $files->replace($viewFile, $contents);
         }
 
         return '__components::'.basename($viewFile, '.blade.php');

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
@@ -202,13 +203,11 @@ abstract class Component
         $viewFile = $directory.'/'.hash('xxh128', $contents).'.blade.php';
 
         if (! is_file($viewFile) || filesize($viewFile) === 0) {
-            $files = Container::getInstance()['files'];
-
             if (! is_dir($directory)) {
-                $files->makeDirectory($directory, 0755, true, true);
+                mkdir($directory, 0755, true);
             }
 
-            $files->replace($viewFile, $contents);
+            (new Filesystem)->replace($viewFile, $contents);
         }
 
         return '__components::'.basename($viewFile, '.blade.php');

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -8,7 +8,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory as FactoryContract;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
@@ -37,7 +36,6 @@ class ComponentTest extends TestCase
         $container->instance('view', $this->viewFactory);
         $container->alias('view', FactoryContract::class);
         $container->instance('config', $this->config);
-        $container->instance('files', new Filesystem);
 
         Container::setInstance($container);
         Facade::setFacadeApplication($container);

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory as FactoryContract;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
@@ -36,6 +37,7 @@ class ComponentTest extends TestCase
         $container->instance('view', $this->viewFactory);
         $container->alias('view', FactoryContract::class);
         $container->instance('config', $this->config);
+        $container->instance('files', new Filesystem);
 
         Container::setInstance($container);
         Facade::setFacadeApplication($container);


### PR DESCRIPTION
## Why
Inline Blade component views (created from strings) are written to `config('view.compiled')` by `Illuminate\View\Component::createBladeViewFromString()`.

Today this uses `file_put_contents()` directly, which can temporarily truncate the target file to 0 bytes while concurrent requests attempt to read/compile it (notably under highly concurrent runtimes like FrankenPHP). This can surface as intermittent empty renders / missing root tags in downstream consumers.

## What
- Write inline `*.blade.php` files using `Illuminate\Filesystem\Filesystem::replace()` (atomic temp file + rename).
- Re-write the file if it exists but is 0 bytes (repairs prior truncated cache artifacts).
- Keep directory creation logic consistent with existing code.

## Tests
- `php vendor/bin/phpunit tests/View/ComponentTest.php`