### PR TITLE
Improve AddQueuedCookiesToResponse::handle() DocBlock return type

### DIFF
--- a/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php
+++ b/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php
@@ -29,7 +29,7 @@ class AddQueuedCookiesToResponse
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @return mixed
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle($request, Closure $next)
     {


### PR DESCRIPTION
Update the handle() method DocBlock in AddQueuedCookiesToResponse to use @return \Symfony\Component\HttpFoundation\Response instead of @return mixed. The method explicitly returns the response from $next($request) after adding queued cookies to the headers, so the Response type more accurately describes the return value and improves IDE support.