### PR TITLE
[12.x] Ensure HttpClientTest doesnt flake in Windows CI

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3751,7 +3751,7 @@ class HttpClientTest extends TestCase
                     $onStatsFunctionCalled = true;
                 },
             ])
-            ->get('https://example.com')
+            ->get('http://example.com')
             ->handlerStats();
 
         $this->assertIsArray($stats);


### PR DESCRIPTION
This test is failing on Windows CI for main (https://github.com/laravel/framework/actions/runs/22018381865/job/63623484837)  and a bunch of PRs (such as https://github.com/laravel/framework/actions/runs/22020748052/job/63629394985) cause its the only test that makes a real http request and awaits the result from what I can see. 

Rather than use https:// i've changed it to just use http:// as it doesn't matter - which means we have no failure.