### PR TITLE
[12.x] Refactor: simplify code

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4541,11 +4541,7 @@ class Builder implements BuilderContract
      */
     public function castBinding($value)
     {
-        if ($value instanceof UnitEnum) {
-            return enum_value($value);
-        }
-
-        return $value;
+        return enum_value($value);
     }
 
     /**


### PR DESCRIPTION
## Simplify `castBinding()` by removing redundant enum check

### Changes
This PR simplifies the `castBinding` method by removing the redundant `instanceof UnitEnum` check and directly calling `enum_value()`.

### Rationale
The current implementation checks if the value is a `UnitEnum` before calling `enum_value()`:
```php
public function castBinding($value)
{
    if ($value instanceof UnitEnum) {
        return enum_value($value);
    }

    return $value;
}
```

However, the `enum_value()` helper already handles all these cases internally using a match expression:
```php
function enum_value($value, $default = null)
{
    return match (true) {
        $value instanceof \BackedEnum => $value->value,
        $value instanceof \UnitEnum => $value->name,
        default => $value ?? value($default),
    };
}
```

Since `enum_value()` already returns the original value when it's not an enum (via the `default` case), we can simplify `castBinding` to:
```php
public function castBinding($value)
{
    return enum_value($value);
}
```

### Benefits
- **Removes duplication**: Eliminates redundant enum type checking
- **Cleaner code**: Reduces one conditional statement and one return statement
- **Single source of truth**: All enum handling logic stays in `enum_value()`
- **Same behavior**: No functional changes, just simplified code