### PR TITLE
[12.x] Simplify `compileSelect` method return

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -33,14 +33,12 @@ class MySqlGrammar extends Grammar
 
         $milliseconds = $query->timeout * 1000;
 
-        $sql = preg_replace(
+        return preg_replace(
             '/^select\b/i',
             'select /*+ MAX_EXECUTION_TIME('.$milliseconds.') */',
             $sql,
             1
         );
-
-        return $sql;
     }
 
     /**


### PR DESCRIPTION
Refactor `compileSelect` to simplify `return` by removing unnecessary `$sql` reassignment.