### PR TITLE
[12.x] Remove duplicate binding code

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -610,8 +610,6 @@ class Builder implements BuilderContract
             $first($join);
 
             $this->joins[] = $join;
-
-            $this->addBinding($join->getBindings(), 'join');
         }
 
         // If the column is simply a string, we can assume the join simply has a basic
@@ -621,9 +619,9 @@ class Builder implements BuilderContract
             $method = $where ? 'where' : 'on';
 
             $this->joins[] = $join->$method($first, $operator, $second);
-
-            $this->addBinding($join->getBindings(), 'join');
         }
+
+        $this->addBinding($join->getBindings(), 'join');
 
         return $this;
     }


### PR DESCRIPTION
Refactor `join` method to remove duplicate binding code by extracting:

```php
$this->addBinding($join->getBindings(), 'join')
```

outside the if/else, keeping behavior identical and improving readability.

