### PR TITLE
[12x] Refactor DatabaseUserProvider to use match expression

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -122,7 +122,6 @@ class DatabaseUserProvider implements UserProvider
             };
         }
 
-
         // Now we are ready to execute the query to see if we have a user matching
         // the given credentials. If not, we will just return null and indicate
         // that there are no matching users from the given credential arrays.

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -116,11 +116,12 @@ class DatabaseUserProvider implements UserProvider
 
         foreach ($credentials as $key => $value) {
             match (true) {
-                (is_array($value) || $value instanceof Arrayable) => $query->whereIn($key, $value),
-                ($value instanceof Closure) => $value($query),
+                is_array($value) || $value instanceof Arrayable => $query->whereIn($key, $value),
+                $value instanceof Closure => $value($query) ?? $query,
                 default => $query->where($key, $value),
             };
         }
+
 
         // Now we are ready to execute the query to see if we have a user matching
         // the given credentials. If not, we will just return null and indicate

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -115,13 +115,11 @@ class DatabaseUserProvider implements UserProvider
         $query = $this->connection->table($this->table);
 
         foreach ($credentials as $key => $value) {
-            if (is_array($value) || $value instanceof Arrayable) {
-                $query->whereIn($key, $value);
-            } elseif ($value instanceof Closure) {
-                $value($query);
-            } else {
-                $query->where($key, $value);
-            }
+            match (true) {
+                (is_array($value) || $value instanceof Arrayable) => $query->whereIn($key, $value),
+                ($value instanceof Closure) => $value($query),
+                default => $query->where($key, $value),
+            };
         }
 
         // Now we are ready to execute the query to see if we have a user matching


### PR DESCRIPTION
This PR refactors the conditional logic in DatabaseUserProvider by replacing if/elseif statements with a match (true) expression.

The behavior remains unchanged. This simply improves readability and leverages PHP 8 syntax.