### PR TITLE
[12.x] Add `Event::capture()` method

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -863,6 +863,34 @@ class Dispatcher implements DispatcherContract
     }
 
     /**
+     * Execute the given callback while capturing events.
+     *
+     * @param  callable  $callback
+     * @param  string[]|null  $events
+     * @return array
+     */
+    public function capture(callable $callback, ?array $events = null)
+    {
+        $wasDeferring = $this->deferringEvents;
+        $previousDeferredEvents = $this->deferredEvents;
+        $previousEventsToDefer = $this->eventsToDefer;
+
+        $this->deferringEvents = true;
+        $this->deferredEvents = [];
+        $this->eventsToDefer = $events;
+
+        try {
+            $callback();
+
+            return $this->deferredEvents;
+        } finally {
+            $this->deferringEvents = $wasDeferring;
+            $this->deferredEvents = $previousDeferredEvents;
+            $this->eventsToDefer = $previousEventsToDefer;
+        }
+    }
+
+    /**
      * Determine if the given event should be deferred.
      *
      * @param  string  $event

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -867,7 +867,7 @@ class Dispatcher implements DispatcherContract
      *
      * @param  callable  $callback
      * @param  string[]|null  $events
-     * @return array
+     * @return \Illuminate\Events\EventCollection
      */
     public function capture(callable $callback, ?array $events = null)
     {
@@ -882,7 +882,7 @@ class Dispatcher implements DispatcherContract
         try {
             $callback();
 
-            return $this->deferredEvents;
+            return (new EventCollection($this->deferredEvents))->setDispatcher($this);
         } finally {
             $this->deferringEvents = $wasDeferring;
             $this->deferredEvents = $previousDeferredEvents;

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -863,7 +863,7 @@ class Dispatcher implements DispatcherContract
     }
 
     /**
-     * Execute the given callback while capturing events.
+     * Execute the given callback while capturing events, and then return the events.
      *
      * @param  callable  $callback
      * @param  string[]|null  $events

--- a/src/Illuminate/Events/EventCollection.php
+++ b/src/Illuminate/Events/EventCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Collection;
+
+class EventCollection extends Collection
+{
+    /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
+     */
+    protected $dispatcher;
+
+    /**
+     * Set the event dispatcher instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return static
+     */
+    public function setDispatcher(Dispatcher $dispatcher): static
+    {
+        $this->dispatcher = $dispatcher;
+
+        return $this;
+    }
+
+    /**
+     * Dispatch all captured events.
+     *
+     * @return void
+     */
+    public function dispatch(): void
+    {
+        foreach ($this->items as $args) {
+            $this->dispatcher->dispatch(...$args);
+        }
+    }
+}

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static \Illuminate\Events\Dispatcher setQueueResolver(callable $resolver)
  * @method static \Illuminate\Events\Dispatcher setTransactionManagerResolver(callable|null $resolver)
  * @method static mixed defer(callable $callback, string[]|null $events = null)
+ * @method static array capture(callable $callback, string[]|null $events = null)
  * @method static array getRawListeners()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static \Illuminate\Events\Dispatcher setQueueResolver(callable $resolver)
  * @method static \Illuminate\Events\Dispatcher setTransactionManagerResolver(callable|null $resolver)
  * @method static mixed defer(callable $callback, string[]|null $events = null)
- * @method static array capture(callable $callback, string[]|null $events = null)
+ * @method static \Illuminate\Events\EventCollection capture(callable $callback, string[]|null $events = null)
  * @method static array getRawListeners()
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -326,7 +326,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
 
         $captured = $d->capture(function () {
-            // no events dispatched
+            // No events dispatched
         });
 
         $this->assertIsArray($captured);

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -189,9 +189,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertInstanceOf(EventCollection::class, $captured);
         $this->assertCount(1, $captured);
 
-        foreach ($captured as $args) {
-            $d->dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
@@ -216,9 +214,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame([], $_SERVER['__event.test']);
         $this->assertCount(2, $captured);
 
-        foreach ($captured as $args) {
-            $d->dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame(['foo', 'bar'], $_SERVER['__event.test']);
     }
@@ -250,15 +246,11 @@ class EventsDispatcherTest extends TestCase
         $this->assertCount(2, $outerCaptured);
         $this->assertCount(1, $innerCaptured);
 
-        foreach ($innerCaptured as $args) {
-            $d->dispatch(...$args);
-        }
+        $innerCaptured->dispatch();
 
         $this->assertSame(['inner'], $_SERVER['__event.test']);
 
-        foreach ($outerCaptured as $args) {
-            $d->dispatch(...$args);
-        }
+        $outerCaptured->dispatch();
 
         $this->assertSame(['inner', 'outer1', 'outer2'], $_SERVER['__event.test']);
     }
@@ -286,9 +278,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame(['immediate'], $_SERVER['__event.test']);
         $this->assertCount(1, $captured);
 
-        foreach ($captured as $args) {
-            $d->dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame(['immediate', 'captured'], $_SERVER['__event.test']);
     }
@@ -315,9 +305,7 @@ class EventsDispatcherTest extends TestCase
 
         $this->assertSame(['ImmediateTestEvent'], $_SERVER['__event.test']);
 
-        foreach ($captured as $args) {
-            $d->dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame(['ImmediateTestEvent', 'DeferTestEvent'], $_SERVER['__event.test']);
     }
@@ -399,9 +387,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame(['deferred'], $_SERVER['__event.test']);
         $this->assertCount(2, $captured);
 
-        foreach ($captured as $args) {
-            $d->dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame(['deferred', 'captured1', 'captured2'], $_SERVER['__event.test']);
     }
@@ -432,9 +418,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame(['deferred1', 'deferred2'], $_SERVER['__event.test']);
         $this->assertCount(1, $innerCaptured);
 
-        foreach ($innerCaptured as $args) {
-            $d->dispatch(...$args);
-        }
+        $innerCaptured->dispatch();
 
         $this->assertSame(['deferred1', 'deferred2', 'captured'], $_SERVER['__event.test']);
     }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -212,6 +212,7 @@ class EventsDispatcherTest extends TestCase
         });
 
         $this->assertSame([], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
         $this->assertCount(2, $captured);
 
         $captured->dispatch();
@@ -243,6 +244,8 @@ class EventsDispatcherTest extends TestCase
         });
 
         $this->assertSame([], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $outerCaptured);
+        $this->assertInstanceOf(EventCollection::class, $innerCaptured);
         $this->assertCount(2, $outerCaptured);
         $this->assertCount(1, $innerCaptured);
 
@@ -276,6 +279,7 @@ class EventsDispatcherTest extends TestCase
         }, ['foo']);
 
         $this->assertSame(['immediate'], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
         $this->assertCount(1, $captured);
 
         $captured->dispatch();
@@ -304,6 +308,7 @@ class EventsDispatcherTest extends TestCase
         }, [DeferTestEvent::class]);
 
         $this->assertSame(['ImmediateTestEvent'], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->dispatch();
 
@@ -336,6 +341,7 @@ class EventsDispatcherTest extends TestCase
         });
 
         $this->assertSame([], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->dispatch();
 
@@ -357,6 +363,8 @@ class EventsDispatcherTest extends TestCase
             $d->dispatch('foo', ['foo_value']);
             $d->dispatch('bar', ['bar_value']);
         });
+
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->filter(fn ($args) => $args[0] === 'foo')->setDispatcher($d)->dispatch();
 
@@ -385,6 +393,7 @@ class EventsDispatcherTest extends TestCase
         });
 
         $this->assertSame(['deferred'], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
         $this->assertCount(2, $captured);
 
         $captured->dispatch();
@@ -416,6 +425,7 @@ class EventsDispatcherTest extends TestCase
         });
 
         $this->assertSame(['deferred1', 'deferred2'], $_SERVER['__event.test']);
+        $this->assertInstanceOf(EventCollection::class, $innerCaptured);
         $this->assertCount(1, $innerCaptured);
 
         $innerCaptured->dispatch();

--- a/tests/Integration/Events/CaptureEventsTest.php
+++ b/tests/Integration/Events/CaptureEventsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class CaptureEventsTest extends TestCase
+{
+    public function testCaptureEvents()
+    {
+        unset($_SERVER['__event.test']);
+
+        Event::listen('foo', function ($foo) {
+            $_SERVER['__event.test'] = $foo;
+        });
+
+        $captured = Event::capture(function () {
+            Event::dispatch('foo', ['bar']);
+
+            $this->assertArrayNotHasKey('__event.test', $_SERVER);
+        });
+
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
+
+        foreach ($captured as $args) {
+            Event::dispatch(...$args);
+        }
+
+        $this->assertSame('bar', $_SERVER['__event.test']);
+    }
+
+    public function testCaptureModelEvents()
+    {
+        $_SERVER['__model_event.test'] = [];
+
+        CaptureTestModel::saved(function () {
+            $_SERVER['__model_event.test'][] = 'saved';
+        });
+
+        $captured = Event::capture(function () {
+            $model = new CaptureTestModel();
+            $model->fireModelEvent('saved', false);
+
+            $this->assertSame([], $_SERVER['__model_event.test']);
+        });
+
+        $this->assertSame([], $_SERVER['__model_event.test']);
+
+        foreach ($captured as $args) {
+            Event::dispatch(...$args);
+        }
+
+        $this->assertContains('saved', $_SERVER['__model_event.test']);
+    }
+
+    public function testCaptureSpecificModelEvents()
+    {
+        $_SERVER['__model_events'] = [];
+
+        CaptureTestModel::creating(function () {
+            $_SERVER['__model_events'][] = 'creating';
+        });
+
+        CaptureTestModel::saved(function () {
+            $_SERVER['__model_events'][] = 'saved';
+        });
+
+        $captured = Event::capture(function () {
+            $model = new CaptureTestModel();
+            $model->fireModelEvent('creating');
+            $model->fireModelEvent('saved');
+
+            $this->assertSame(['creating'], $_SERVER['__model_events']);
+        }, ['eloquent.saved: '.CaptureTestModel::class]);
+
+        $this->assertSame(['creating'], $_SERVER['__model_events']);
+
+        foreach ($captured as $args) {
+            Event::dispatch(...$args);
+        }
+
+        $this->assertSame(['creating', 'saved'], $_SERVER['__model_events']);
+    }
+
+    public function testCaptureEmptyEvents()
+    {
+        $captured = Event::capture(function () {
+            // no events dispatched
+        });
+
+        $this->assertIsArray($captured);
+        $this->assertEmpty($captured);
+    }
+}
+
+class CaptureTestModel extends Model
+{
+    public function fireModelEvent($event, $halt = true)
+    {
+        return parent::fireModelEvent($event, $halt);
+    }
+}

--- a/tests/Integration/Events/CaptureEventsTest.php
+++ b/tests/Integration/Events/CaptureEventsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Events;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Events\EventCollection;
 use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase;
 
@@ -90,7 +91,7 @@ class CaptureEventsTest extends TestCase
             // no events dispatched
         });
 
-        $this->assertIsArray($captured);
+        $this->assertInstanceOf(EventCollection::class, $captured);
         $this->assertEmpty($captured);
     }
 }

--- a/tests/Integration/Events/CaptureEventsTest.php
+++ b/tests/Integration/Events/CaptureEventsTest.php
@@ -88,7 +88,7 @@ class CaptureEventsTest extends TestCase
     public function testCaptureEmptyEvents()
     {
         $captured = Event::capture(function () {
-            // no events dispatched
+            // No events dispatched
         });
 
         $this->assertInstanceOf(EventCollection::class, $captured);

--- a/tests/Integration/Events/CaptureEventsTest.php
+++ b/tests/Integration/Events/CaptureEventsTest.php
@@ -25,9 +25,7 @@ class CaptureEventsTest extends TestCase
 
         $this->assertArrayNotHasKey('__event.test', $_SERVER);
 
-        foreach ($captured as $args) {
-            Event::dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame('bar', $_SERVER['__event.test']);
     }
@@ -49,9 +47,7 @@ class CaptureEventsTest extends TestCase
 
         $this->assertSame([], $_SERVER['__model_event.test']);
 
-        foreach ($captured as $args) {
-            Event::dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertContains('saved', $_SERVER['__model_event.test']);
     }
@@ -78,9 +74,7 @@ class CaptureEventsTest extends TestCase
 
         $this->assertSame(['creating'], $_SERVER['__model_events']);
 
-        foreach ($captured as $args) {
-            Event::dispatch(...$args);
-        }
+        $captured->dispatch();
 
         $this->assertSame(['creating', 'saved'], $_SERVER['__model_events']);
     }

--- a/tests/Integration/Events/CaptureEventsTest.php
+++ b/tests/Integration/Events/CaptureEventsTest.php
@@ -24,6 +24,7 @@ class CaptureEventsTest extends TestCase
         });
 
         $this->assertArrayNotHasKey('__event.test', $_SERVER);
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->dispatch();
 
@@ -46,6 +47,7 @@ class CaptureEventsTest extends TestCase
         });
 
         $this->assertSame([], $_SERVER['__model_event.test']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->dispatch();
 
@@ -73,6 +75,7 @@ class CaptureEventsTest extends TestCase
         }, ['eloquent.saved: '.CaptureTestModel::class]);
 
         $this->assertSame(['creating'], $_SERVER['__model_events']);
+        $this->assertInstanceOf(EventCollection::class, $captured);
 
         $captured->dispatch();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an `Event::capture()` method, which is similar to `Event::defer()`, except it returns the captured events instead of dispatching them, so they can be used later on or even serialised and stored.

```
$captured = Event::capture(function () {
    Event::dispatch(new OrderShipped('Alice'));
    Event::dispatch(new OrderShipped('Alice'), [], true);
    Event::dispatch('order.created');
    Event::dispatch('order.created', [$order, $user]);
    Event::dispatch('order.created', 'some-value');
    Event::dispatch('order.created', [$order], true);
});

// Returns an EventCollection instance
// $captured = new EventCollection([
//     [OrderShipped('Alice')],
//     [OrderShipped('Alice'), [], true],
//     ['order.created'],
//     ['order.created', [$order, $user]],
//     ['order.created', 'some-value'],
//     ['order.created', [$order], true],
// ]);

// Which can be filtered, uniqued and then dispatched
$captured->filter(...)->unique(...)->dispatch();
```

Specific events can be targeted by passing an array of event classes like with `Event::defer()`:

```
$captured = Event::capture(function () {
    Event::dispatch(new OrderShipped('Alice'));  // Captured
    Event::dispatch(new PaymentProcessed(100));  // Dispatched
}, [OrderShipped::class]);
```

Internally it uses the same dispatch defer properties so that `Event::defer()` and `Event::capture()` can be nested interchangeably and work fine.

The events are returned in a thin collection wrapper which makes it convenient to filter and dispatch them later, but this could be stripped back to an array if preferred.