### PR TITLE
[12x]Refactor: remove unnecessary \BackedEnum in HasAttributes.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1293,7 +1293,7 @@ trait HasAttributes
      *
      * @param  string  $enumClass
      * @param  string|int  $value
-     * @return \UnitEnum|\BackedEnum
+     * @return \UnitEnum
      */
     protected function getEnumCaseFromValue($enumClass, $value)
     {
@@ -1306,7 +1306,7 @@ trait HasAttributes
      * Get the storable value from the given enum.
      *
      * @param  string  $expectedEnum
-     * @param  \UnitEnum|\BackedEnum  $value
+     * @param  \UnitEnum  $value
      * @return string|int
      */
     protected function getStorableEnumValue($expectedEnum, $value)


### PR DESCRIPTION
Continuations of: https://github.com/laravel/framework/pull/58807
remove from  in HasAttributes.php