### PR TITLE
[12.x] Refactor: add missing `@throws` tag in dock block

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -230,6 +230,8 @@ class EventListCommand extends Command
      * Gets the raw version of event listeners from the event dispatcher.
      *
      * @return array
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function getRawListeners()
     {
@@ -240,6 +242,8 @@ class EventListCommand extends Command
      * Get the event dispatcher.
      *
      * @return \Illuminate\Events\Dispatcher
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function getEventsDispatcher()
     {


### PR DESCRIPTION
## Add `@throws` annotation for `BindingResolutionException`

Added missing `@throws \Illuminate\Contracts\Container\BindingResolutionException` PHPDoc annotations to methods that can throw this exception.

### Changes:
- Added `@throws` annotation to `getEventsDispatcher()` method since `Container::make()` can throw `BindingResolutionException`
- Propagated the same annotation to `getRawListeners()` method as it calls `getEventsDispatcher()`

This improves code documentation and helps developers handle potential exceptions properly.