### PR TITLE
Use validation.and_more key for ValidationException summary suffix Fixes #58783

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -197,4 +197,6 @@ return [
 
     'attributes' => [],
 
+    'and_more' => '(and :count more error)|(and :count more errors)',
+
 ];

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -93,9 +93,7 @@ class ValidationException extends Exception
         $message = array_shift($messages);
 
         if ($count = count($messages)) {
-            $pluralized = $count === 1 ? 'error' : 'errors';
-
-            $message .= ' '.$validator->getTranslator()->choice("(and :count more $pluralized)", $count, compact('count'));
+            $message .= ' '.$validator->getTranslator()->choice('validation.and_more', $count, compact('count'));
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -46,10 +46,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -67,10 +66,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -89,10 +87,9 @@ class ValidationExceptionTest extends TestCase
     {
         $translator = $this->getTranslator('uk', [
             '*' => [
-                '*' => [
+                'validation' => [
                     'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
+                        'and_more' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
                     ],
                 ],
             ],
@@ -180,7 +177,19 @@ class ValidationExceptionTest extends TestCase
 
     protected function getTranslator($locale = 'en', $loaded = [])
     {
-        $translator ??= new Translator(new ArrayLoader, $locale);
+        $translator = new Translator(new ArrayLoader, $locale);
+
+        if ($loaded === []) {
+            $loaded = [
+                '*' => [
+                    'validation' => [
+                        'en' => [
+                            'and_more' => '(and :count more error)|(and :count more errors)',
+                        ],
+                    ],
+                ],
+            ];
+        }
 
         $translator->setLoaded($loaded);
 


### PR DESCRIPTION
Fixes #58783. The summary suffix "(and :count more errors)" was resolved from JSON lang files only, causing mixed-language messages when apps use only lang/*/validation.php. Now uses the validation.and_more key so translations can live in validation.php.

- ValidationException::summarize() uses choice('validation.and_more', ...)
- Add 'and_more' to framework lang/en/validation.php
- Update ValidationExceptionTest to load validation.and_more for translated tests and seed default English when using ArrayLoader

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
