### PR TITLE
[13.x] Adds report rate-limiting

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/PendingReport.php
+++ b/src/Illuminate/Foundation/Exceptions/PendingReport.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Foundation\Exceptions;
+
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Contracts\Cache\Factory as CacheFactoryContract;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
+use Illuminate\Support\Traits\Conditionable;
+use Throwable;
+
+class PendingReport
+{
+    use Conditionable;
+
+    /**
+     * Create a new Pending Report instance.
+     */
+    public function __construct(
+        protected ContainerContract $container,
+        protected CacheFactoryContract $cache,
+        protected ExceptionHandlerContract $handler,
+        protected Throwable $exception,
+        protected ?string $store = null,
+        protected int $times = 1,
+    )
+    {
+        //
+    }
+
+    /**
+     * Reports the exception.
+     *
+     * @return void
+     */
+    protected function report()
+    {
+        $this->handler->report($this->exception);
+    }
+
+    /**
+     * Returns the Rate Limiter using the cache store repository.
+     *
+     * @return \Illuminate\Cache\RateLimiter
+     */
+    protected function limiter()
+    {
+        return $this->container->make(RateLimiter::class, [
+            'cache' => $this->cache->store($this->store),
+        ]);
+    }
+
+    /**
+     * Sets the Cache Store to limit the exception report.
+     *
+     * @param  string|null  $store
+     * @return $this
+     */
+    public function using($store)
+    {
+        $this->store = $store;
+
+        return $this;
+    }
+
+    /**
+     * Reports the exception a limited number of times.
+     *
+     * @param  int  $times
+     * @return $this
+     */
+    public function atMost($times)
+    {
+        $this->times = $times;
+
+        return $this;
+    }
+
+    /**
+     * Reports the exception once during a window of time.
+     *
+     * @param \DateTimeInterface|\DateInterval|int $seconds
+     * @return void
+     */
+    public function every($seconds = 60)
+    {
+        $this->limiter()->attempt(
+            'illuminate:report_attempt:' . get_class($this->exception), $this->times, $this->report(...), $seconds
+        );
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -720,34 +720,18 @@ if (! function_exists('report')) {
     /**
      * Report an exception.
      *
-     * @param  \Throwable|string  $exception
+     * @param  \Throwable|string|null  $exception
+     * @return ($exception is null ? \Illuminate\Foundation\Exceptions\PendingReport : void)
      */
-    function report($exception): void
+    function report($exception = null)
     {
-        if (is_string($exception)) {
-            $exception = new Exception($exception);
+        $report = app(PendingReport::class);
+
+        if (is_null($exception)) {
+            return $report;
         }
 
-        app(ExceptionHandler::class)->report($exception);
-    }
-}
-
-if (! function_exists('report_attempt')) {
-    /**
-     * Report an exception a number of occurrences inside a window of time.
-     *
-     * @param  \Throwable|string  $exception
-     * @return \Illuminate\Foundation\Exceptions\PendingReport
-     */
-    function report_attempt($exception): PendingReport
-    {
-        if (is_string($exception)) {
-            $exception = new Exception($exception);
-        }
-
-        return app(PendingReport::class, [
-            'exception' => $exception,
-        ]);
+        $report->exception($exception)->now();
     }
 }
 
@@ -760,9 +744,7 @@ if (! function_exists('report_if')) {
      */
     function report_if($boolean, $exception): void
     {
-        if ($boolean) {
-            report($exception);
-        }
+        report()->exception($exception)->when($boolean)->now();
     }
 }
 
@@ -775,9 +757,7 @@ if (! function_exists('report_unless')) {
      */
     function report_unless($boolean, $exception): void
     {
-        if (! $boolean) {
-            report($exception);
-        }
+        report()->exception($exception)->unless($boolean)->now();
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -3,6 +3,7 @@
 use Carbon\CarbonInterface;
 use Illuminate\Broadcasting\FakePendingBroadcast;
 use Illuminate\Broadcasting\PendingBroadcast;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
@@ -22,6 +23,7 @@ use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Foundation\Exceptions\PendingReport;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\RedirectResponse;
@@ -727,6 +729,25 @@ if (! function_exists('report')) {
         }
 
         app(ExceptionHandler::class)->report($exception);
+    }
+}
+
+if (! function_exists('report_attempt')) {
+    /**
+     * Report an exception a number of occurrences inside a window of time.
+     *
+     * @param  \Throwable|string  $exception
+     * @return \Illuminate\Foundation\Exceptions\PendingReport
+     */
+    function report_attempt($exception): PendingReport
+    {
+        if (is_string($exception)) {
+            $exception = new Exception($exception);
+        }
+
+        return app(PendingReport::class, [
+            'exception' => $exception,
+        ]);
     }
 }
 

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -309,4 +309,5 @@ EOF, __DIR__.'/../../../', ['APP_RUNNING_IN_CONSOLE' => true]);
         $this->assertCount(1, $recordedLogs);
         $this->assertStringContainsString('a really (truncated...)', $recordedLogs[0]['message']);
     }
+
 }

--- a/tests/Integration/Foundation/PendingReportTest.php
+++ b/tests/Integration/Foundation/PendingReportTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Exception;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use function report;
+
+class PendingReportTest extends TestCase
+{
+    protected Container $app;
+    protected Factory $cache;
+    protected ExceptionHandler $handler;
+    protected Repository $store;
+
+    protected function setUp(): void
+    {
+        $this->app = Container::getInstance();
+        $this->app->instance(ContainerContract::class, $this->app);
+        $this->app->instance(Factory::class, $this->cache = m::mock(Factory::class));
+        $this->app->instance(Repository::class, $this->store = new \Illuminate\Cache\Repository(new ArrayStore(false)));
+        $this->app->instance(ExceptionHandler::class, $this->handler = m::mock(ExceptionHandler::class));
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function test_reports_immediately(): void
+    {
+        $e = new Exception('test');
+
+        $this->handler->expects('report')->with($e)->once();
+
+        report($e);
+    }
+
+    public function test_reports_immediately_using_string(): void
+    {
+        $this->handler->expects('report')->withArgs(function (Exception $e) {
+            return $e->getMessage() === 'test';
+        })->once();
+
+        report('test');
+    }
+
+    public function test_reports_once_every_minute(): void
+    {
+        $e = new Exception('test');
+
+        $this->cache->expects('store')->with(null)->twice()->andReturn($this->store);
+        $this->handler->expects('report')->with($e)->once();
+
+        report()->exception($e)->every(60);
+        report()->exception($e)->every(60);
+    }
+
+    public function test_reports_up_to_three_times_every_ten_minutes(): void
+    {
+        $e = new Exception('test');
+
+        $this->cache->expects('store')->with(null)->times(4)->andReturn($this->store);
+        $this->handler->expects('report')->with($e)->times(3);
+
+        report()->exception($e)->atMost(3)->every(60 * 10);
+        report()->exception($e)->atMost(3)->every(60 * 10);
+        report()->exception($e)->atMost(3)->every(60 * 10);
+        report()->exception($e)->atMost(3)->every(60 * 10);
+    }
+
+    public function test_reports_using_custom_store(): void
+    {
+        $e = new Exception('test');
+
+        $this->cache->expects('store')->with('custom')->twice()->andReturn($this->store);
+        $this->handler->expects('report')->with($e)->once();
+
+        report()->exception($e)->using('custom')->every(60);
+        report()->exception($e)->using('custom')->every(60);
+    }
+}

--- a/tests/Integration/Foundation/PendingReportTest.php
+++ b/tests/Integration/Foundation/PendingReportTest.php
@@ -31,6 +31,7 @@ class PendingReportTest extends TestCase
 
     protected function tearDown(): void
     {
+        Container::setInstance();
         m::close();
     }
 


### PR DESCRIPTION
# What?

Expands the reporting mechanism to allow reporting an exception only a given number of occurrences inside a window of time. This avoids excessive reporting that pollute the logs repeatedly.

How? The `report_attempt()` function receives the exception and returns a `PendingReport` object. It exposes the `every()` method to fluently set how many times to report the exception inside a window of time.

```php
use Illuminate\Support\Facades\Http;
use Illuminate\Support\Facades\RateLimiter;
use Illuminate\Http\Exceptions\HttpResponseException

try {
    Http::get('https://some-server.com/shacky')
} catch (HttpResponseException $e) {
    // Before
    RateLimiter::attempt('exception:' . get_class($e), fn() => report($e), 1, 60)

    // After
    report_attempt($e)->every(60);
}
```

The object also supports to report up to a number of occurrences inside a window of time.

```php
report_attempt($e)->atMost(3)->every(60);
```

This is basically sugar syntax to use the included Rate Limiter, but using a custom cache store (since these also may fail). As the report relies on the application cache, the `using()` can be used to change the cache store to other, like `file`.

```php
report_attempt($e)->using('file')->every(60);
```

## WIP

Pending tests.