### PR TITLE
Refactor normalizeOutput to use match expression

### DIFF
--- a/src/Illuminate/Process/FakeProcessResult.php
+++ b/src/Illuminate/Process/FakeProcessResult.php
@@ -60,19 +60,22 @@ class FakeProcessResult implements ProcessResultContract
      */
     protected function normalizeOutput(array|string $output)
     {
-        if (empty($output)) {
-            return '';
-        } elseif (is_string($output)) {
-            return rtrim($output, "\n")."\n";
-        } elseif (is_array($output)) {
-            return rtrim(
+        return match (true) {
+            empty($output) => '',
+
+            is_string($output) =>
+                rtrim($output, "\n") . "\n",
+
+            is_array($output) =>
+            rtrim(
                 (new Collection($output))
-                    ->map(fn ($line) => rtrim($line, "\n")."\n")
+                    ->map(fn ($line) => rtrim($line, "\n") . "\n")
                     ->implode(''),
                 "\n"
-            );
-        }
+            ),
+        };
     }
+
 
     /**
      * Get the original command executed by the process.


### PR DESCRIPTION
This PR refactors the normalizeOutput method by replacing multiple conditional statements with a match (true) expression.

The evaluation order remains unchanged to preserve the existing behavior. No functional changes were introduced.