### PR TITLE
Improve handling queue messages published by external services

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -122,4 +122,7 @@ return [
         'table' => 'failed_jobs',
     ],
 
+    'job_handler' => [
+        'default' => 'Illuminate\Queue\CallQueuedHandler@call',
+    ]
 ];

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -189,6 +189,10 @@ abstract class Job
 
         $commandName = $this->payload()['data']['commandName'] ?? false;
 
+        if ($commandName) {
+            $commandName = $this->container->getAlias($commandName);
+        }
+
         // If the exception is due to a job timing out, we need to rollback the current
         // database transaction so that the failed job count can be incremented with
         // the proper value. Otherwise, the current transaction will never commit.

--- a/src/Illuminate/Queue/Jobs/JobName.php
+++ b/src/Illuminate/Queue/Jobs/JobName.php
@@ -14,6 +14,8 @@ class JobName
      */
     public static function parse($job)
     {
+        $job = config('queue.job_handler')[$job] ?? $job;
+
         return Str::parseCallback($job, 'fire');
     }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -162,7 +162,7 @@ abstract class Queue
         $payload = $this->withCreatePayloadHooks($queue, [
             'uuid' => (string) Str::uuid(),
             'displayName' => $this->getDisplayName($job),
-            'job' => 'Illuminate\Queue\CallQueuedHandler@call',
+            'job' => 'default',
             'maxTries' => $this->getJobTries($job),
             'maxExceptions' => $job->maxExceptions ?? null,
             'failOnTimeout' => $job->failOnTimeout ?? false,


### PR DESCRIPTION
### Introduction

In event-driven architectures, it is common for a Laravel application to communicate with non-Laravel services via message brokers (like AWS SQS, RabbitMQ, etc.). Currently, Laravel's queue payload expects fully qualified class names for both the job and the handler.
This creates tight coupling. It forces external, non-Laravel services to be aware of Laravel's internal directory structure and namespaces. Exposing these internal implementation details makes cross-service communication fragile and violates the principle of low coupling, as changing a directory structure in Laravel requires updating the payload generation in external services.

### What is Done?

This PR introduces the ability to use aliases for both the job class and the job handler.

1. Configurable Job Handlers: Added a `queue.job_handler` configuration array. This allows the payload to use a simple string key (like 'default') instead of the hardcoded `Illuminate\Queue\CallQueuedHandler@call`.
2. Container Aliasing for Jobs: Added support for resolving the job command name via the Service Container (`$this->container->getAlias($commandName)`).
3. Agnostic Payloads: We can now expose framework-agnostic string aliases (e.g., 'process-payment') to external services rather than the full project namespace.
4. Reduced Payload Size: Replacing lengthy FQCNs with short aliases naturally shrinks the JSON payload size

## Breaking Changes

To utilize this feature, projects will need to add the new `job_handler` array to their `queue.php` configuration file. Aside from the config file update, this implementation is fully backward-compatible with older job payloads.