### PR TITLE
[13.x] Enhance DatePeriod support in whereBetween/havingBetween with inclusion/exclusion flags

### DIFF
--- a/tests/Integration/Database/QueryBuilderDatePeriodTest.php
+++ b/tests/Integration/Database/QueryBuilderDatePeriodTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Carbon\CarbonPeriod;
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class QueryBuilderDatePeriodTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->dateTime('event_date');
+        });
+
+        DB::table('events')->insert([
+            ['name' => 'Event 1', 'event_date' => '2024-01-05 10:00:00'],
+            ['name' => 'Event 2', 'event_date' => '2024-01-10 10:00:00'],
+            ['name' => 'Event 3', 'event_date' => '2024-01-15 10:00:00'],
+            ['name' => 'Event 4', 'event_date' => '2024-01-20 10:00:00'],
+            ['name' => 'Event 5', 'event_date' => '2024-01-25 10:00:00'],
+        ]);
+    }
+
+    public function testWhereBetweenWithDatePeriod()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20')
+        );
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        $this->assertEquals(['Event 2', 'Event 3'], $results);
+    }
+
+    public function testWhereBetweenWithCarbonPeriod()
+    {
+        $period = CarbonPeriod::create('2024-01-10', '2024-01-20');
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        $this->assertEquals(['Event 2', 'Event 3'], $results);
+    }
+
+    public function testWhereBetweenWithDatePeriodUsingRecurrences()
+    {
+        // Start date + 10 days (10 recurrences)
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            10
+        );
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        $this->assertEquals(['Event 2', 'Event 3'], $results);
+    }
+
+    public function testWhereBetweenWithDatePeriodExcludeStartDate()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20'),
+            DatePeriod::EXCLUDE_START_DATE
+        );
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        // Event 2 (2024-01-10) should be excluded
+        $this->assertEquals(['Event 3'], $results);
+    }
+
+    public function testWhereBetweenWithDatePeriodIncludeEndDate()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20'),
+            DatePeriod::INCLUDE_END_DATE
+        );
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        // Event 4 (2024-01-20) should be included
+        $this->assertEquals(['Event 2', 'Event 3', 'Event 4'], $results);
+    }
+
+    public function testWhereBetweenWithDatePeriodExcludeStartAndIncludeEnd()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20'),
+            DatePeriod::EXCLUDE_START_DATE | DatePeriod::INCLUDE_END_DATE
+        );
+
+        $results = DB::table('events')
+            ->whereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        // Event 2 excluded, Event 4 included
+        $this->assertEquals(['Event 3', 'Event 4'], $results);
+    }
+
+    public function testWhereNotBetweenWithDatePeriod()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20')
+        );
+
+        $results = DB::table('events')
+            ->whereNotBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        // Should return events outside the period
+        $this->assertEquals(['Event 1', 'Event 4', 'Event 5'], $results);
+    }
+
+    public function testWhereNotBetweenWithDatePeriodExcludeStartDate()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20'),
+            DatePeriod::EXCLUDE_START_DATE
+        );
+
+        $results = DB::table('events')
+            ->whereNotBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        // Event 2 (2024-01-10) should be included since it's excluded from the period
+        $this->assertEquals(['Event 1', 'Event 2', 'Event 4', 'Event 5'], $results);
+    }
+
+    public function testHavingBetweenWithDatePeriod()
+    {
+        Schema::create('sales', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('product');
+            $table->integer('quantity');
+            $table->date('sale_date');
+        });
+
+        DB::table('sales')->insert([
+            ['product' => 'A', 'quantity' => 10, 'sale_date' => '2024-01-05'],
+            ['product' => 'A', 'quantity' => 20, 'sale_date' => '2024-01-15'],
+            ['product' => 'B', 'quantity' => 15, 'sale_date' => '2024-01-10'],
+            ['product' => 'B', 'quantity' => 25, 'sale_date' => '2024-01-20'],
+        ]);
+
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20')
+        );
+
+        $results = DB::table('sales')
+            ->select('product')
+            ->selectRaw('MIN(sale_date) as first_sale')
+            ->groupBy('product')
+            ->havingBetween('first_sale', $period)
+            ->pluck('product')
+            ->all();
+
+        // Product B has first sale on 2024-01-10 (within period)
+        $this->assertEquals(['B'], $results);
+    }
+
+    public function testHavingNotBetweenWithDatePeriod()
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('customer');
+            $table->integer('amount');
+            $table->date('order_date');
+        });
+
+        DB::table('orders')->insert([
+            ['customer' => 'John', 'amount' => 100, 'order_date' => '2024-01-05'],
+            ['customer' => 'John', 'amount' => 200, 'order_date' => '2024-01-25'],
+            ['customer' => 'Jane', 'amount' => 150, 'order_date' => '2024-01-15'],
+        ]);
+
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-20')
+        );
+
+        $results = DB::table('orders')
+            ->select('customer')
+            ->selectRaw('MIN(order_date) as first_order')
+            ->groupBy('customer')
+            ->havingNotBetween('first_order', $period)
+            ->pluck('customer')
+            ->all();
+
+        // John's first order is 2024-01-05 (outside period)
+        $this->assertEquals(['John'], $results);
+    }
+
+    public function testOrWhereBetweenWithDatePeriod()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-16')
+        );
+
+        $results = DB::table('events')
+            ->where('name', 'Event 1')
+            ->orWhereBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        $this->assertEquals(['Event 1', 'Event 2', 'Event 3'], $results);
+    }
+
+    public function testOrWhereNotBetweenWithDatePeriod()
+    {
+        $period = new DatePeriod(
+            new DateTime('2024-01-10'),
+            new DateInterval('P1D'),
+            new DateTime('2024-01-16')
+        );
+
+        $results = DB::table('events')
+            ->where('name', 'Event 2')
+            ->orWhereNotBetween('event_date', $period)
+            ->pluck('name')
+            ->all();
+
+        $this->assertEquals(['Event 1', 'Event 2', 'Event 4', 'Event 5'], $results);
+    }
+}
+


### PR DESCRIPTION
This PR enhances the DatePeriod support in `whereBetween()` and `havingBetween()` methods to properly handle DatePeriod inclusion/exclusion flags and NOT BETWEEN logic.

## Problem

While PR #58687 added basic DatePeriod support to `whereBetween()` and `havingBetween()`, it has several limitations:

1. **Ignores inclusion/exclusion flags**: DatePeriod supports `EXCLUDE_START_DATE` and `INCLUDE_END_DATE` flags, but the current implementation doesn't respect them
2. **Incorrect NOT BETWEEN logic**: The current implementation doesn't handle `whereNotBetween()` and `havingNotBetween()` correctly with DatePeriod
3. **Limited test coverage**: Only has basic unit tests, lacks comprehensive integration tests

## Solution

This PR enhances the DatePeriod support by:

1. **Respecting inclusion/exclusion flags**: Uses correct operators (`>`, `>=`, `<`, `<=`) based on DatePeriod flags
2. **Fixing NOT BETWEEN logic**: Properly implements NOT BETWEEN using OR logic (`value < start OR value > end`)
3. **Adding comprehensive integration tests**: 12 integration test methods covering all scenarios

## Implementation Details

### whereBetweenDatePeriod() Method

- Extracts start and end dates from DatePeriod
- Calculates end date from recurrences if needed
- Determines operators based on `include_start_date` and `include_end_date` flags
- For NOT BETWEEN: Uses OR logic (`value < start OR value > end`)
- For BETWEEN: Uses AND logic with appropriate operators

### havingBetweenDatePeriod() Method

- Same logic as `whereBetweenDatePeriod()` but for HAVING clauses
- Uses `havingRaw()` for NOT BETWEEN to properly handle OR logic

## Benefits to End Users

### Before (ignores flags):

```php
// Ignores EXCLUDE_START_DATE flag
$period = new DatePeriod(
    new DateTime('2024-01-01'),
    new DateInterval('P1D'),
    new DateTime('2024-01-31'),
    DatePeriod::EXCLUDE_START_DATE
);
User::whereBetween('created_at', $period)->get(); // Still includes Jan 1st ❌

// Ignores INCLUDE_END_DATE flag
$period = new DatePeriod(
    new DateTime('2024-01-01'),
    new DateInterval('P1D'),
    new DateTime('2024-01-31'),
    DatePeriod::INCLUDE_END_DATE
);
User::whereBetween('created_at', $period)->get(); // Doesn't include Jan 31st ❌
```

### After (respects flags):

```php
// Respects EXCLUDE_START_DATE flag
$period = new DatePeriod(
    new DateTime('2024-01-01'),
    new DateInterval('P1D'),
    new DateTime('2024-01-31'),
    DatePeriod::EXCLUDE_START_DATE
);
User::whereBetween('created_at', $period)->get(); // Excludes Jan 1st ✅

// Respects INCLUDE_END_DATE flag
$period = new DatePeriod(
    new DateTime('2024-01-01'),
    new DateInterval('P1D'),
    new DateTime('2024-01-31'),
    DatePeriod::INCLUDE_END_DATE
);
User::whereBetween('created_at', $period)->get(); // Includes Jan 31st ✅
```

## Why This Makes Building Web Applications Easier

1. **Natural date range queries**: Developers can use PHP's native DatePeriod objects directly in queries without manual date manipulation
2. **Respects DatePeriod semantics**: The flags work as expected, matching PHP's DatePeriod behavior
3. **Cleaner code**: No need to manually extract dates and build complex where clauses
4. **Type safety**: Works with both DatePeriod and CarbonPeriod objects
5. **Handles edge cases**: Automatically handles recurrences, null end dates, and flag combinations

## Tests Added

### Integration Tests (12 methods):

✅ **whereBetween with DatePeriod** - Basic DatePeriod with start and end dates  
✅ **whereBetween with CarbonPeriod** - Laravel's Carbon extension of DatePeriod  
✅ **whereBetween with recurrences** - DatePeriod using recurrence count instead of end date  
✅ **whereBetween with EXCLUDE_START_DATE flag** - Tests the `DatePeriod::EXCLUDE_START_DATE` flag  
✅ **whereBetween with INCLUDE_END_DATE flag** - Tests the `DatePeriod::INCLUDE_END_DATE` flag  
✅ **whereBetween with both flags** - Tests both inclusion/exclusion flags combined  
✅ **whereNotBetween with DatePeriod** - NOT BETWEEN with DatePeriod  
✅ **whereNotBetween with EXCLUDE_START_DATE** - NOT BETWEEN respecting exclusion flags  
✅ **havingBetween with DatePeriod** - HAVING BETWEEN with grouped queries  
✅ **havingNotBetween with DatePeriod** - HAVING NOT BETWEEN with grouped queries  
✅ **orWhereBetween with DatePeriod** - OR WHERE BETWEEN with DatePeriod  
✅ **orWhereNotBetween with DatePeriod** - OR WHERE NOT BETWEEN with DatePeriod  

All tests use real database queries with actual data to ensure the feature works correctly across all supported database drivers.

## Why It Doesn't Break Existing Features

1. **Backward compatible**: Existing code using arrays or other iterables continues to work unchanged
2. **Only enhances DatePeriod handling**: The changes only affect the DatePeriod code path
3. **Protected methods**: New methods (`whereBetweenDatePeriod`, `havingBetweenDatePeriod`) are protected, not part of public API
4. **Comprehensive tests**: Integration tests verify the feature works correctly without breaking existing functionality

## Breaking Changes

**None.** This is purely additive and enhances existing functionality.

## Code Changes

- **Modified**: `src/Illuminate/Database/Query/Builder.php` (+97 -77 lines)
  - Added `whereBetweenDatePeriod()` protected method
  - Added `havingBetweenDatePeriod()` protected method
  - Enhanced `whereBetween()` to delegate to `whereBetweenDatePeriod()`
  - Enhanced `havingBetween()` to delegate to `havingBetweenDatePeriod()`

- **New file**: `tests/Integration/Database/QueryBuilderDatePeriodTest.php` (268 lines)
  - 12 comprehensive integration test methods
  - Tests all DatePeriod scenarios with real database queries

Fixes #58092