### PR TITLE
[13.x] Accept CarbonInterval for PendingProcess timeouts

### DIFF
--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -136,7 +136,7 @@ class PendingProcess
      * @param  CarbonInterval|int  $timeout
      * @return $this
      */
-    public function timeout(int|CarbonInterval $timeout)
+    public function timeout(CarbonInterval|int $timeout)
     {
         $this->timeout = $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
 
@@ -149,7 +149,7 @@ class PendingProcess
      * @param  CarbonInterval|int  $timeout
      * @return $this
      */
-    public function idleTimeout(int|CarbonInterval $timeout)
+    public function idleTimeout(CarbonInterval|int $timeout)
     {
         $this->idleTimeout = $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
 

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Process;
 
+use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Support\Collection;
@@ -132,12 +133,12 @@ class PendingProcess
     /**
      * Specify the maximum number of seconds the process may run.
      *
-     * @param  int  $timeout
+     * @param  int|CarbonInterval  $timeout
      * @return $this
      */
-    public function timeout(int $timeout)
+    public function timeout(int|CarbonInterval $timeout)
     {
-        $this->timeout = $timeout;
+        $this->timeout = $this->normalizeTimeout($timeout);
 
         return $this;
     }
@@ -145,12 +146,12 @@ class PendingProcess
     /**
      * Specify the maximum number of seconds a process may go without returning output.
      *
-     * @param  int  $timeout
+     * @param  int|CarbonInterval  $timeout
      * @return $this
      */
-    public function idleTimeout(int $timeout)
+    public function idleTimeout(int|CarbonInterval $timeout)
     {
-        $this->idleTimeout = $timeout;
+        $this->idleTimeout = $this->normalizeTimeout($timeout);
 
         return $this;
     }
@@ -361,6 +362,17 @@ class PendingProcess
     {
         return (new Collection($this->fakeHandlers))
             ->first(fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
+    }
+
+    /**
+     * Normalize a timeout value to a number of seconds.
+     *
+     * @param  int|CarbonInterval  $timeout
+     * @return $this
+     */
+    protected function normalizeTimeout(int|CarbonInterval $timeout): int
+    {
+        return $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
     }
 
     /**

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -133,12 +133,12 @@ class PendingProcess
     /**
      * Specify the maximum number of seconds the process may run.
      *
-     * @param  int|CarbonInterval  $timeout
+     * @param  CarbonInterval|int  $timeout
      * @return $this
      */
     public function timeout(int|CarbonInterval $timeout)
     {
-        $this->timeout = $this->normalizeTimeout($timeout);
+        $this->timeout = $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
 
         return $this;
     }
@@ -146,12 +146,12 @@ class PendingProcess
     /**
      * Specify the maximum number of seconds a process may go without returning output.
      *
-     * @param  int|CarbonInterval  $timeout
+     * @param  CarbonInterval|int  $timeout
      * @return $this
      */
     public function idleTimeout(int|CarbonInterval $timeout)
     {
-        $this->idleTimeout = $this->normalizeTimeout($timeout);
+        $this->idleTimeout = $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
 
         return $this;
     }
@@ -362,17 +362,6 @@ class PendingProcess
     {
         return (new Collection($this->fakeHandlers))
             ->first(fn ($handler, $pattern) => $pattern === '*' || Str::is($pattern, $command));
-    }
-
-    /**
-     * Normalize a timeout value to a number of seconds.
-     *
-     * @param  int|CarbonInterval  $timeout
-     * @return $this
-     */
-    protected function normalizeTimeout(int|CarbonInterval $timeout): int
-    {
-        return $timeout instanceof CarbonInterval ? (int) $timeout->totalSeconds : $timeout;
     }
 
     /**

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Process;
 
+use Carbon\CarbonInterval;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
@@ -634,6 +635,21 @@ class ProcessTest extends TestCase
 
         $factory = new Factory;
         $result = $factory->timeout(1)->path(__DIR__)->run('sleep 2; exit 1;');
+
+        $result->throw();
+    }
+
+    #[RequiresOperatingSystem('Linux|DAR')]
+    public function testATimeoutCanBeSetWithACarbonInterval()
+    {
+        $this->expectException(ProcessTimedOutException::class);
+        $this->expectExceptionMessage(
+            'The process "sleep 2; exit 1;" exceeded the timeout of 1 seconds.'
+        );
+
+        $factory = new Factory;
+        $timeout = CarbonInterval::milliseconds(1_000);
+        $result = $factory->timeout($timeout)->path(__DIR__)->run('sleep 2; exit 1;');
 
         $result->throw();
     }


### PR DESCRIPTION
Before:

```php
use Illuminate\Support\Facades\Process;
use function Illuminate\Support\minutes;

Process::command('some long running command')
    ->timeout((int) minutes(1)->totalSeconds)
    ->idleTimeout((int) minutes(5)->totalSeconds)
    ->run();
```

After:

```php
Process::command('some long running command')
    ->timeout(minutes(1))
    ->idleTimeout(minutes(5))
    ->run();
```