### PR TITLE
[13.x] Add Aliases Attribute for Command

### DIFF
--- a/src/Illuminate/Console/Attributes/Aliases.php
+++ b/src/Illuminate/Console/Attributes/Aliases.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Aliases
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string[]  $aliases
+     */
+    public function __construct(public array $aliases)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Console\Attributes\Aliases;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\View\Components\Factory;
@@ -148,6 +149,12 @@ class Command extends SymfonyCommand
 
         if (count($description) > 0) {
             $this->description = $description[0]->newInstance()->description;
+        }
+
+        $aliases = $reflection->getAttributes(Aliases::class);
+
+        if (count($aliases) > 0) {
+            $this->aliases = $aliases[0]->newInstance()->aliases;
         }
     }
 


### PR DESCRIPTION
Seeing as 13.x has a bunch of attributes, this adds the ability to do the below: 

```php
// Rather than currently... 
#[Signature('mail:send {user} {--queue}')]
#[Description('Send a marketing email to a user')]
class SendMailCommand extends Command
{
    protected $aliases = ['mail:dispatch'];
}


// We can do... 
#[Signature('mail:send {user} {--queue}')]
#[Description('Send a marketing email to a user')]
#[Aliases(['mail:dispatch'])]
class SendMailCommand extends Command
{
}
```

While Symfony's `#[AsCommand]` supports aliases, most Laravel developers use the properties so felt valid as a PR. As I use aliases often.

No test cause didn't see any for the others- and a simple one.

Thanks!