### PR TITLE
[12.x] Feat: add `mostCommon()` and `leastCommon()`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1997,4 +1997,44 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * @param  int  $limit
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
+     * @return static<mixed, int>
+     */
+    public function mostCommon($limit = 1, $callback = null)
+    {
+        if ($this->isEmpty()) {
+            return new static;
+        }
+
+        $values = is_null($callback)
+            ? $this
+            : $this->map($this->valueRetriever($callback));
+
+        $counted = $values->countBy()->sortDesc();
+
+        return $counted->take($limit);
+    }
+
+    /**
+     * @param  int  $limit
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
+     * @return static<mixed, int>
+     */
+    public function leastCommon($limit = 1, $callback = null)
+    {
+        if ($this->isEmpty()) {
+            return new static;
+        }
+
+        $values = is_null($callback)
+            ? $this
+            : $this->map($this->valueRetriever($callback));
+
+        $counted = $values->countBy()->sort();
+
+        return $counted->take($limit);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6031,6 +6031,78 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testMostCommonWithoutCallback()
+    {
+        $collection = collect(['a', 'b', 'a', 'c', 'a', 'b']);
+
+        $result = $collection->mostCommon(2);
+
+        $this->assertEquals(['a' => 3, 'b' => 2], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMostCommonWithCallback()
+    {
+        $collection = collect([
+            ['product' => 'Laptop'],
+            ['product' => 'Mouse'],
+            ['product' => 'Laptop'],
+            ['product' => 'Keyboard'],
+            ['product' => 'Laptop'],
+        ]);
+
+        $result = $collection->mostCommon(2, 'product');
+
+        $this->assertEquals(['Laptop' => 3, 'Mouse' => 1], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMostCommonWithLimit()
+    {
+        $collection = collect(['x', 'y', 'x', 'z', 'x', 'y', 'z', 'z']);
+
+        $result = $collection->mostCommon();
+
+        $this->assertEquals(['x' => 3], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLeastCommonWithoutCallback()
+    {
+        $collection = collect(['a', 'b', 'a', 'c', 'a', 'b']);
+
+        $result = $collection->leastCommon(2);
+
+        $this->assertEquals(['c' => 1, 'b' => 2], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLeastCommonWithCallback()
+    {
+        $collection = collect([
+            ['country' => 'Iran'],
+            ['country' => 'USA'],
+            ['country' => 'Iran'],
+            ['country' => 'UK'],
+            ['country' => 'Iran'],
+        ]);
+
+        $result = $collection->leastCommon(2, 'country');
+
+        $this->assertEquals(['USA' => 1, 'UK' => 1], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testLeastCommonWithLimit()
+    {
+        $collection = collect(['x', 'y', 'x', 'z', 'x', 'y']);
+
+        $result = $collection->leastCommon();
+
+        $this->assertEquals(['z' => 1], $result->all());
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
# Add `mostCommon()` and `leastCommon()` methods to `Collection`

## Summary
This PR adds two new methods to the `Collection` class for frequency analysis: `mostCommon()` and `leastCommon()`.

## Methods

### `mostCommon($limit = 1, $callback = null)`
Returns the most frequently occurring items in descending order.

### `leastCommon($limit = 1, $callback = null)`
Returns the least frequently occurring items in ascending order.

## Usage Examples
```php
// Simple usage
collect(['a', 'b', 'a', 'c', 'a', 'b'])->mostCommon(2);
// => ['a' => 3, 'b' => 2]

// With key
collect($orders)->mostCommon(5, 'product');
// => Top 5 products by order count

// With closure
collect($users)->leastCommon(3, fn($user) => $user['country']);
// => Bottom 3 countries by user count
```

## Use Cases
- Analytics dashboards (bestsellers, top customers)
- Log analysis (most common errors)
- User behavior tracking (popular actions)
- Inventory management (slow-moving products)