### PR TITLE
Fix HTTP client JSON caching when decoded value is falsey

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -35,6 +35,11 @@ class Response implements ArrayAccess, Stringable
     protected $decoded;
 
     /**
+     * Indicates whether the JSON response has been decoded.
+     */
+    protected bool $decodedIsSet = false;
+
+    /**
      * The flags that were used when decoding the JSON response.
      *
      * @var int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>
@@ -101,12 +106,13 @@ class Response implements ArrayAccess, Stringable
     {
         $flags = $flags ?? self::$defaultJsonDecodingFlags;
 
-        if (! $this->decoded || (isset($this->decodingFlags) && $this->decodingFlags !== $flags)) {
+        if (! $this->decodedIsSet || (isset($this->decodingFlags) && $this->decodingFlags !== $flags)) {
             $this->decoded = json_decode(
                 $this->body(), true, flags: $flags
             );
 
             $this->decodingFlags = $flags;
+            $this->decodedIsSet = true;
         }
 
         if (is_null($key)) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -4413,6 +4413,30 @@ class HttpClientTest extends TestCase
         $response->json();
         $this->assertSame(3, $response->bodyCallCount);
     }
+
+    #[DataProvider('falseyJsonResponses')]
+    public function testJsonDecodingIsCachedWhenDecodedValueIsFalsey(string $json, mixed $expected): void
+    {
+        $response = new BodyTrackingResponse(Factory::psr7Response($json));
+
+        $this->assertSame($expected, $response->json());
+        $this->assertSame(1, $response->bodyCallCount);
+
+        $this->assertSame($expected, $response->json());
+        $this->assertSame(1, $response->bodyCallCount);
+    }
+
+    public static function falseyJsonResponses(): array
+    {
+        return [
+            'empty array' => ['[]', []],
+            'empty object' => ['{}', []],
+            'zero' => ['0', 0],
+            'false' => ['false', false],
+            'null' => ['null', null],
+            'empty string' => ['""', ''],
+        ];
+    }
 }
 
 class CustomFactory extends Factory


### PR DESCRIPTION
Summary:
When calling `Illuminate\Http\Client\Response::json()`, Laravel cached the decoded JSON using a truthy check on the decoded value. That meant responses that decode to a *falsey* value (like `[]`, `{}`, `0`, `false`, `null`, or `""`) weren’t treated as “cached”, so the JSON would be decoded again on every call.

What was the impact?
- Extra `json_decode` work on repeated `json()` calls.
- Re-reading the response body more than necessary (which can be surprising with stream-based bodies).

What changed?
- Track whether the JSON body has been decoded with an explicit internal flag, instead of relying on whether the decoded value is truthy.
- Added a regression test covering common falsey JSON payloads to ensure `json()` only reads/decodes once when flags don’t change.

Why it’s safe:
This doesn’t change the public API or the decoded result—only avoids unnecessary re-decoding and repeated body reads for falsey payloads.