### PR TITLE
[12.x] Refactor: `JSON decoded` to `decoded JSON`

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -193,7 +193,7 @@ class Request implements ArrayAccess
     }
 
     /**
-     * Get the JSON decoded body of the request.
+     * Get the decoded JSON body of the request.
      *
      * @return array
      */

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -90,7 +90,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Get the JSON decoded body of the response as an array or scalar value.
+     * Get the decoded JSON body of the response as an array or scalar value.
      *
      * @param  string|null  $key
      * @param  mixed  $default
@@ -117,7 +117,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Get the JSON decoded body of the response as an object.
+     * Get the decoded JSON body of the response as an object.
      *
      * @param  int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>|null  $flags
      * @return object|null
@@ -128,7 +128,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Get the JSON decoded body of the response as a collection.
+     * Get the decoded JSON body of the response as a collection.
      *
      * @param  string|null  $key
      * @param  int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>|null  $flags
@@ -140,7 +140,7 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
-     * Get the JSON decoded body of the response as a fluent object.
+     * Get the decoded JSON body of the response as a fluent object.
      *
      * @param  string|null  $key
      * @param  int-mask<JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR>|null  $flags

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -23,7 +23,7 @@ class RedisJob extends Job implements JobContract
     protected $job;
 
     /**
-     * The JSON decoded version of "$job".
+     * The decoded JSON version of "$job".
      *
      * @var array
      */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1259,7 +1259,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Get the JSON decoded body of the response as a collection.
+     * Get the decoded JSON body of the response as a collection.
      *
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection


### PR DESCRIPTION
continuations of: https://github.com/laravel/framework/pull/58830
rename all JSON decoded to decoded JSON

Thanks to @shaedrich.