### PR TITLE
[12.x] Refactor: `match` expression

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -443,13 +443,11 @@ class MySqlGrammar extends Grammar
      */
     protected function compileJsonUpdateColumn($key, $value)
     {
-        if (is_bool($value)) {
-            $value = $value ? 'true' : 'false';
-        } elseif (is_array($value)) {
-            $value = 'cast(? as json)';
-        } else {
-            $value = $this->parameter($value);
-        }
+        $value = match (true) {
+            is_bool($value) => $value ? 'true' : 'false',
+            is_array($value) => 'cast(? as json)',
+            default => $this->parameter($value),
+        };
 
         [$field, $path] = $this->wrapJsonFieldAndPath($key);
 


### PR DESCRIPTION
## Refactor: Convert if-else to match expression in compileJsonUpdateColumn

### Changes
- Refactored the conditional logic in `compileJsonUpdateColumn()` method from traditional `if-elseif-else` statements to PHP 8's `match` expression

### Benefits
- **More concise**: Reduces code verbosity while maintaining readability
- **Type-safe**: `match` performs strict comparisons by default
- **Expression-based**: Returns a value directly, eliminating the need for intermediate variable assignments
- **Better error handling**: `match` throws an `UnhandledMatchError` if no case matches (when `default` is not provided)

### Technical Details
The refactoring maintains the exact same functionality:
- Boolean values are converted to string literals `'true'` or `'false'`
- Array values are cast to JSON using `'cast(? as json)'`
- All other values are processed through `$this->parameter()`

This change leverages modern PHP 8+ syntax for cleaner, more maintainable code.