### PR TITLE
[12.x] Refactor: remove nested conditionals

### DIFF
--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -194,12 +194,10 @@ class ShowCommand extends DatabaseInspectionCommand
                     ($tableSize ?? '—').($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>'.Number::format($table['rows']).'</>' : '')
                 );
 
-                if ($this->output->isVerbose()) {
-                    if ($table['comment']) {
-                        $this->components->bulletList([
-                            $table['comment'],
-                        ]);
-                    }
+                if ($this->output->isVerbose() && $table['comment']) {
+                    $this->components->bulletList([
+                        $table['comment'],
+                    ]);
                 }
             });
 


### PR DESCRIPTION
## Refactor: Simplify nested conditionals in `displayForCli()` method

### Changes
- Simplified nested `if` statements by combining conditions using logical AND operator

### Before
```php
if ($this->output->isVerbose()) {
    if ($table['comment']) {
        $this->components->bulletList([
            $table['comment'],
        ]);
    }
}
```

### After
```php
if ($this->output->isVerbose() && $table['comment']) {
    $this->components->bulletList([
        $table['comment'],
    ]);
}
```

### Benefits
- **Improved readability**: Reduces nesting level, making the code easier to read and understand
- **Less indentation**: Flattens the code structure
- **Same functionality**: Maintains identical behavior with cleaner syntax
- **Follows best practices**: Avoids unnecessary nesting when conditions can be combined

This is a minor refactoring that improves code quality without changing any functionality.