### PR TITLE
[12.x] Refactor: add missing `@throws`

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -110,6 +110,8 @@ class BroadcastEvent implements ShouldQueue
      *
      * @param  mixed  $event
      * @return array
+     *
+     * @throws \ReflectionException
      */
     protected function getPayloadFromEvent($event)
     {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -270,6 +270,8 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @param  \Illuminate\Console\Command|string  $command
      * @return \Symfony\Component\Console\Command\Command|null
+     *
+     * @throws \ReflectionException
      */
     public function resolve($command)
     {

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -320,6 +320,8 @@ class ScheduleListCommand extends Command
      *
      * @param  \Illuminate\Console\Scheduling\CallbackEvent  $event
      * @return string
+     *
+     * @throws \ReflectionException
      */
     private function getClosureLocation(CallbackEvent $event)
     {

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -684,6 +684,8 @@ class Dispatcher implements DispatcherContract
      * @param  string  $method
      * @param  array  $arguments
      * @return array{TListener, mixed}
+     *
+     * @throws \ReflectionException
      */
     protected function createListenerAndJob($class, $method, $arguments)
     {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -218,6 +218,8 @@ class RouteListCommand extends Command
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return bool
+     *
+     * @throws \ReflectionException
      */
     protected function isVendorRoute(Route $route)
     {

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -34,6 +34,8 @@ class ClearCommand extends Command
      * Execute the console command.
      *
      * @return int|null
+     *
+     * @throws \ReflectionException
      */
     public function handle()
     {


### PR DESCRIPTION
## Add `\ReflectionException` to docblocks

The `ReflectionClass` can throw `\ReflectionException`, so I've added this exception to the docblocks wherever reflection is used to improve type safety and code documentation.

**Changes:**
- Added `@throws \ReflectionException` to methods using `ReflectionClass`