### PR TITLE
[13.x] Allow aliases to be set in Signature Attribute

### DIFF
--- a/src/Illuminate/Console/Attributes/Signature.php
+++ b/src/Illuminate/Console/Attributes/Signature.php
@@ -11,8 +11,9 @@ class Signature
      * Create a new attribute instance.
      *
      * @param  string  $signature
+     * @param  string[]  $aliases
      */
-    public function __construct(public string $signature)
+    public function __construct(public string $signature, public array $aliases = [])
     {
         //
     }

--- a/src/Illuminate/Console/Attributes/Signature.php
+++ b/src/Illuminate/Console/Attributes/Signature.php
@@ -11,9 +11,9 @@ class Signature
      * Create a new attribute instance.
      *
      * @param  string  $signature
-     * @param  string[]  $aliases
+     * @param  string[]|null  $aliases
      */
-    public function __construct(public string $signature, public array $aliases = [])
+    public function __construct(public string $signature, public ?array $aliases = null)
     {
         //
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -145,7 +145,7 @@ class Command extends SymfonyCommand
 
             $this->signature = $signatureInstance->signature;
 
-            if (! empty($signatureInstance->aliases)) {
+            if ($signatureInstance->aliases !== null) {
                 $this->aliases = $signatureInstance->aliases;
             }
         }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -141,7 +141,13 @@ class Command extends SymfonyCommand
         $signature = $reflection->getAttributes(Signature::class);
 
         if (count($signature) > 0) {
-            $this->signature = $signature[0]->newInstance()->signature;
+            $signatureInstance = $signature[0]->newInstance();
+
+            $this->signature = $signatureInstance->signature;
+
+            if (! empty($signatureInstance->aliases)) {
+                $this->aliases = $signatureInstance->aliases;
+            }
         }
 
         $description = $reflection->getAttributes(Description::class);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Application;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
@@ -209,5 +210,21 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
+    }
+
+    public function testSignatureAttributeCanSetAliases()
+    {
+        $command = new SignatureWithAliasesCommand;
+
+        $this->assertSame('foo:bar', $command->getName());
+        $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
+    }
+}
+
+#[Signature('foo:bar', aliases: ['bar:baz', 'baz:qux'])]
+class SignatureWithAliasesCommand extends Command
+{
+    public function handle()
+    {
     }
 }


### PR DESCRIPTION
Re submittion of https://github.com/laravel/framework/pull/58845 but within the Signature Attribute, rather than a new Attribute. 

 Means:

```php

// Rather than...
#[Signature('mail:send {user} {--queue}')]
#[Description('Send a marketing email to a user')]
class SendMailCommand extends Command
{
    protected $aliases = ['mail:dispatch'];
}


// We can do... 
#[Signature('mail:send {user} {--queue}', aliases: ['mail:dispatch'])]
#[Description('Send a marketing email to a user')]
class SendMailCommand extends Command
{
}
```

13.x cause that's all the attribute fun.



Thanks Big T!