### PR TITLE
[13.x] Fix SQL Server datetime/time precision handling for backward compatibility

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -686,7 +686,11 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        return ! is_null($column->precision) ? "float($column->precision)" : 'float';
+        // SQL Server float precision must be between 1-53, or omitted entirely.
+        // Precision of 0 is invalid and should be treated as no precision specified.
+        return ! is_null($column->precision) && $column->precision > 0
+            ? "float($column->precision)"
+            : 'float';
     }
 
     /**
@@ -804,7 +808,11 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return ! is_null($column->precision) ? "time($column->precision)" : 'time';
+        // Use time without precision when precision is 0 or null for backward compatibility.
+        // SQL Server time precision must be between 0-7 when specified.
+        return ! is_null($column->precision) && $column->precision > 0
+            ? "time($column->precision)"
+            : 'time';
     }
 
     /**
@@ -830,7 +838,11 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return ! is_null($column->precision) ? "datetime2($column->precision)" : 'datetime';
+        // Use datetime2 only when precision is explicitly greater than 0.
+        // Precision of 0 or null uses the standard datetime type for backward compatibility.
+        return ! is_null($column->precision) && $column->precision > 0
+            ? "datetime2($column->precision)"
+            : 'datetime';
     }
 
     /**
@@ -847,7 +859,11 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return ! is_null($column->precision) ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        // Use datetimeoffset with precision only when explicitly greater than 0.
+        // Precision of 0 or null uses datetimeoffset without precision for backward compatibility.
+        return ! is_null($column->precision) && $column->precision > 0
+            ? "datetimeoffset($column->precision)"
+            : 'datetimeoffset';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -686,8 +686,6 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        // SQL Server float precision must be between 1-53, or omitted entirely.
-        // Precision of 0 is invalid and should be treated as no precision specified.
         return ! is_null($column->precision) && $column->precision > 0
             ? "float($column->precision)"
             : 'float';
@@ -808,8 +806,6 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        // Use time without precision when precision is 0 or null for backward compatibility.
-        // SQL Server time precision must be between 0-7 when specified.
         return ! is_null($column->precision) && $column->precision > 0
             ? "time($column->precision)"
             : 'time';
@@ -838,8 +834,6 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        // Use datetime2 only when precision is explicitly greater than 0.
-        // Precision of 0 or null uses the standard datetime type for backward compatibility.
         return ! is_null($column->precision) && $column->precision > 0
             ? "datetime2($column->precision)"
             : 'datetime';
@@ -859,8 +853,6 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        // Use datetimeoffset with precision only when explicitly greater than 0.
-        // Precision of 0 or null uses datetimeoffset without precision for backward compatibility.
         return ! is_null($column->precision) && $column->precision > 0
             ? "datetimeoffset($column->precision)"
             : 'datetimeoffset';

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -139,7 +139,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
-        $this->assertEquals(['alter table "users" add "created" datetime2(0) not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testDefaultCurrentTimestamp()
@@ -153,7 +153,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $getSql('MySql'));
         $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $getSql('Postgres'));
         $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SQLite'));
-        $this->assertEquals(['alter table "users" add "created" datetime2(0) not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $getSql('SqlServer'));
     }
 
     public function testDefaultCurrentYear()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -666,7 +666,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -684,7 +684,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -702,7 +702,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -720,7 +720,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -738,7 +738,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -756,7 +756,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -775,8 +775,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
-            'alter table "users" add "created_at" datetime2(0) null',
-            'alter table "users" add "updated_at" datetime2(0) null',
+            'alter table "users" add "created_at" datetime null',
+            'alter table "users" add "updated_at" datetime null',
         ], $statements);
     }
 
@@ -787,8 +787,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
         $this->assertCount(2, $statements);
         $this->assertSame([
-            'alter table "users" add "created_at" datetimeoffset(0) null',
-            'alter table "users" add "updated_at" datetimeoffset(0) null',
+            'alter table "users" add "created_at" datetimeoffset null',
+            'alter table "users" add "updated_at" datetimeoffset null',
         ], $statements);
     }
 

--- a/tests/Integration/Database/TimestampTypeTest.php
+++ b/tests/Integration/Database/TimestampTypeTest.php
@@ -23,7 +23,6 @@ class TimestampTypeTest extends DatabaseTestCase
         $this->assertSame(
             match ($this->driver) {
                 'mysql', 'mariadb', 'pgsql' => 'timestamp',
-                'sqlsrv' => 'datetime2',
                 default => 'datetime',
             },
             Schema::getColumnType('test', 'datetime_to_timestamp')
@@ -45,7 +44,6 @@ class TimestampTypeTest extends DatabaseTestCase
         $this->assertSame(
             match ($this->driver) {
                 'pgsql' => 'timestamp',
-                'sqlsrv' => 'datetime2',
                 default => 'datetime',
             },
             Schema::getColumnType('test', 'timestamp_to_datetime')


### PR DESCRIPTION
This PR fixes a regression in PR #58602 where SQL Server datetime columns started generating `datetime2(0)` instead of `datetime`, breaking backward compatibility.

## Problem

Laravel's `Builder::$defaultTimePrecision` is `0`. When calling `dateTime()` without precision, it uses this default.

PR #58602 changed the check from `if ($column->precision)` to `if (! is_null($column->precision))`, so precision `0` is now treated as valid, causing:

```php
$table->dateTime('created_at');  // Generated: datetime2(0) instead of datetime
$table->float('amount', 0);      // Error: precision 0 is invalid in SQL Server
```

## Solution

Treat precision `0` the same as `null` for SQL Server - use base types without precision:

| Method | Before | After This PR |
|--------|--------|---------------|
| `dateTime('col')` | `datetime2(0)` ❌ | `datetime` ✅ |
| `dateTime('col', 3)` | `datetime2(3)` ✅ | `datetime2(3)` ✅ |
| `time('col')` | `time(0)` ❌ | `time` ✅ |
| `float('col')` | `float(0)` ❌ | `float` ✅ |

## Changes

Updated 4 methods in `SqlServerGrammar.php` to only add precision when `> 0`:
- `typeFloat()` - SQL Server requires precision 1-53 or omitted
- `typeTime()` 
- `typeTimestamp()`
- `typeTimestampTz()`

All affected tests updated.

Fixes #58797
