### PR TITLE
[13.x] Fix when() method to return relation instance instead of query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -23,7 +24,7 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Relation implements BuilderContract
 {
-    use ForwardsCalls, Macroable {
+    use Conditionable, ForwardsCalls, Macroable {
         Macroable::__call as macroCall;
     }
 


### PR DESCRIPTION
This PR fixes an issue where using `when()` on a relationship returns the query builder instead of the relation instance, preventing the use of relationship-specific methods.

## Problem

When calling `when()` on a relationship like `BelongsToMany`, the closure receives an `Eloquent\Builder` instance instead of the relation instance:

```php
$post->tags()
    ->when(true, function ($query) {
        // $query is Eloquent\Builder, not BelongsToMany
        // Cannot use wherePivot() methods
        $query->wherePivotBetween('updated_at', ['2000-01-01', '2024-05-05']);
    });
```

## Solution

Add the `Conditionable` trait to the base `Relation` class. This ensures `when()` is called on the relation itself, not forwarded to the query builder.

```php
$post->tags()
    ->when(true, function ($relation) {
        // $relation is now BelongsToMany instance
        return $relation->wherePivotBetween('updated_at', ['2000-01-01', '2024-05-05']);
    });
```

## Changes

- Added `Conditionable` trait to `Relation` class
- Added test to verify `when()` returns relation instance and allows `wherePivot` methods

## Benefits

- Consistent behavior across all relationship types
- No breaking changes - forwarding still works for methods not on the relation
- Enables use of relationship-specific methods in `when()` closures

Fixes #53292
