### PR TITLE
[12.x] Add throwIfRedirect function for the Http Client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -441,6 +441,18 @@ class Response implements ArrayAccess, Stringable
     }
 
     /**
+     * Throw an exception if the response status code is a 3xx level code.
+     *
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwIfRedirect()
+    {
+        return $this->redirect() ? throw new RequestException($this, $this->truncateExceptionsAt) : $this;
+    }
+
+    /**
      * Indicate that request exceptions should be truncated to the given length.
      *
      * @param  int<1, max>  $length

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3607,6 +3607,69 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
+    public function testRequestExceptionIsThrownIfIsRedirect()
+    {
+        $this->factory->fake([
+            'http://foo.com/api/200' => $this->factory::response('', 200),
+            'http://foo.com/api/301' => $this->factory::response('', 301),
+            'http://foo.com/api/302' => $this->factory::response('', 302),
+            'http://foo.com/api/400' => $this->factory::response('', 400),
+            'http://foo.com/api/500' => $this->factory::response('', 500),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api/301')->throwIfRedirect();
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api/302')->throwIfRedirect();
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api/200')->throwIfRedirect();
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNull($exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api/400')->throwIfRedirect();
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNull($exception);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api/500')->throwIfRedirect();
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNull($exception);
+    }
+
     public function testItCanEnforceFaking()
     {
         $this->factory->preventStrayRequests();


### PR DESCRIPTION
Adds a `throwIfRedirect` function for the Http Client, which will throw a `RequestException` if the response is a redirect. 

Often with API integrations, if there is a configuration error on either side, and we're making a POST / PATCH / PUT request the API can return a redirect instead of processing the API call. However, the code thinks the call was successful because 3xx responses are considered successful. 

This allows the developer to add an additional safe guard with their API integrations. This is a new public method and doesn't break any existing features. 

I'm currently experiencing this with the PATCH request for updating an environment on the Laravel Cloud API and didn't catch the error. 