### PR TITLE
[13.x] Handle enum instances in ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -5,6 +5,8 @@ namespace Illuminate\Database\Eloquent;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @template TModel of \Illuminate\Database\Eloquent\Model
  */
@@ -28,13 +30,13 @@ class ModelNotFoundException extends RecordsNotFoundException
      * Set the affected Eloquent model and instance ids.
      *
      * @param  class-string<TModel>  $model
-     * @param  array<int, int|string>|int|string  $ids
+     * @param  array<int, int|string|\BackedEnum|\UnitEnum>|int|string|\BackedEnum|\UnitEnum  $ids
      * @return $this
      */
     public function setModel($model, $ids = [])
     {
         $this->model = $model;
-        $this->ids = Arr::wrap($ids);
+        $this->ids = array_map(fn ($id) => enum_value($id), Arr::wrap($ids));
 
         $this->message = "No query results for model [{$model}]";
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1076,6 +1076,55 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::findOrFail(new Collection([1, 1, 2, 3]));
     }
 
+    public function testFindOrFailWithEnumThrowsModelNotFoundExceptionWithEnumValue()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 999');
+
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::findOrFail(EloquentTestUserIdEnum::NotFound);
+    }
+
+    public function testFindOrFailWithMultipleEnumsThrowsModelNotFoundExceptionWithEnumValues()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 998, 999');
+
+        EloquentTestUser::findOrFail([EloquentTestUserIdEnum::AlsoNotFound, EloquentTestUserIdEnum::NotFound]);
+    }
+
+    public function testFindOrFailWithPartialEnumMatchThrowsModelNotFoundExceptionForMissingIds()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 998, 999');
+
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::findOrFail([EloquentTestUserIdEnum::One, EloquentTestUserIdEnum::AlsoNotFound, EloquentTestUserIdEnum::NotFound]);
+    }
+
+    public function testCollectionFindOrFailWithEnumThrowsModelNotFoundExceptionWithEnumValue()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 999');
+
+        $collection = new Collection([
+            EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']),
+        ]);
+
+        $collection->findOrFail(EloquentTestUserIdEnum::NotFound);
+    }
+
+    public function testModelNotFoundExceptionWithUnitEnum()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] Active');
+
+        $exception = new ModelNotFoundException();
+        $exception->setModel(EloquentTestUser::class, EloquentTestUserStatus::Active);
+
+        throw $exception;
+    }
+
     public function testOneToOneRelationship()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -3088,4 +3137,17 @@ enum StringBackedRole: string
 {
     case User = 'user';
     case Admin = 'admin';
+}
+
+enum EloquentTestUserIdEnum: int
+{
+    case One = 1;
+    case AlsoNotFound = 998;
+    case NotFound = 999;
+}
+
+enum EloquentTestUserStatus
+{
+    case Active;
+    case Inactive;
 }


### PR DESCRIPTION
Fixes an issue where using `findOrFail()` with enum instances throws "Object could not be converted to string" when the model isn't found.

**Before:**
```php
User::findOrFail(UserId::Admin);
// Fatal error: Object of class UserId could not be converted to string
```

**After:**
```php
User::findOrFail(UserId::Admin);
// ModelNotFoundException: No query results for model [User] 1
```

The fix converts enum instances to their scalar values in the exception message using the existing `enum_value()` helper.
