### PR TITLE
[13.x] Add native JSON datatype support for SQL Server 2025

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -745,14 +745,8 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
-        try {
-            $version = $this->connection->getServerVersion();
-
-            if (version_compare($version, '16.0', '>=')) {
-                return 'json';
-            }
-        } catch (\Exception) {
-            // Fall back to nvarchar(max) if version cannot be determined
+        if (version_compare($this->connection->getServerVersion(), '16.0', '>=')) {
+            return 'json';
         }
 
         return 'nvarchar(max)';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -745,10 +745,14 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
-        $version = $this->connection->getServerVersion();
+        try {
+            $version = $this->connection->getServerVersion();
 
-        if (version_compare($version, '16.0', '>=')) {
-            return 'json';
+            if (version_compare($version, '16.0', '>=')) {
+                return 'json';
+            }
+        } catch (\Exception) {
+            // Fall back to nvarchar(max) if version cannot be determined
         }
 
         return 'nvarchar(max)';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -745,6 +745,12 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
+        $version = $this->connection->getServerVersion();
+
+        if (version_compare($version, '16.0', '>=')) {
+            return 'json';
+        }
+
         return 'nvarchar(max)';
     }
 
@@ -756,7 +762,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'nvarchar(max)';
+        return $this->typeJson($column);
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -604,7 +604,10 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingJson()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('15.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->json('foo');
         $statements = $blueprint->toSql();
 
@@ -612,14 +615,43 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
+    public function testAddingJsonOnSqlServer2025()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('16.0');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->json('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" json not null', $statements[0]);
+    }
+
     public function testAddingJsonb()
     {
-        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('15.0');
+
+        $blueprint = new Blueprint($conn, 'users');
         $blueprint->jsonb('foo');
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
+    }
+
+    public function testAddingJsonbOnSqlServer2025()
+    {
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getServerVersion')->andReturn('16.0');
+
+        $blueprint = new Blueprint($conn, 'users');
+        $blueprint->jsonb('foo');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" json not null', $statements[0]);
     }
 
     public function testAddingDate()


### PR DESCRIPTION
SQL Server 2025 introduces a native `json` datatype. This PR adds support for it while maintaining backward compatibility with older versions.

**Changes:**
- Detects SQL Server version using `getServerVersion()`
- Uses native `json` type for SQL Server 2025+ (version >= 16.0)
- Falls back to `nvarchar(max)` for older versions
- Added tests for both old and new versions

**Example:**

SQL Server 2025:
```sql
ALTER TABLE users ADD metadata json NOT NULL
```

SQL Server 2022 and earlier:
```sql
ALTER TABLE users ADD metadata nvarchar(max) NOT NULL
```

Follows the same pattern as MariaDB's UUID support.

Fixes #57965
