### PR TITLE
[12.x] Allow closure parameters in docblock for when() helper function

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -272,10 +272,11 @@ if (! function_exists('when')) {
      * Return a value if the given condition is true.
      *
      * @template TValue
+     * @template TArgs
      * @template TDefault
      *
      * @param  mixed  $condition
-     * @param  TValue|\Closure(...): TValue  $value
+     * @param  TValue|\Closure(TArgs): TValue  $value
      * @param  TDefault|\Closure(): TDefault  $default
      * @return ($condition is true|positive-int|non-falsy-string|non-empty-array ? TValue : ($condition is callable ? TValue|TDefault : TDefault))
      */

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -275,7 +275,7 @@ if (! function_exists('when')) {
      * @template TDefault
      *
      * @param  mixed  $condition
-     * @param  TValue|\Closure(): TValue  $value
+     * @param  TValue|\Closure(...): TValue  $value
      * @param  TDefault|\Closure(): TDefault  $default
      * @return ($condition is true|positive-int|non-falsy-string|non-empty-array ? TValue : ($condition is callable ? TValue|TDefault : TDefault))
      */

--- a/types/Collections/helpers.php
+++ b/types/Collections/helpers.php
@@ -15,7 +15,6 @@ assertType("'foo'", when(true, 'foo', 42));
 assertType('null', when(false, 'foo'));
 assertType('42', when(false, 'foo', 42));
 assertType("'foo'", when(true, fn () => 'foo'));
-assertType("'foo'", when(fn () => 'foo', fn ($value) => $value));
 assertType("'foo'", when(true, fn () => 'foo', fn () => 42));
 assertType('null', when(false, fn () => 'foo'));
 assertType('42', when(false, fn () => 'foo', fn () => 42));

--- a/types/Collections/helpers.php
+++ b/types/Collections/helpers.php
@@ -15,6 +15,7 @@ assertType("'foo'", when(true, 'foo', 42));
 assertType('null', when(false, 'foo'));
 assertType('42', when(false, 'foo', 42));
 assertType("'foo'", when(true, fn () => 'foo'));
+assertType("'foo'", when(fn() => 'foo', fn ($value) => $value));
 assertType("'foo'", when(true, fn () => 'foo', fn () => 42));
 assertType('null', when(false, fn () => 'foo'));
 assertType('42', when(false, fn () => 'foo', fn () => 42));

--- a/types/Collections/helpers.php
+++ b/types/Collections/helpers.php
@@ -15,7 +15,7 @@ assertType("'foo'", when(true, 'foo', 42));
 assertType('null', when(false, 'foo'));
 assertType('42', when(false, 'foo', 42));
 assertType("'foo'", when(true, fn () => 'foo'));
-assertType("'foo'", when(fn() => 'foo', fn ($value) => $value));
+assertType("'foo'", when(fn () => 'foo', fn ($value) => $value));
 assertType("'foo'", when(true, fn () => 'foo', fn () => 42));
 assertType('null', when(false, fn () => 'foo'));
 assertType('42', when(false, fn () => 'foo', fn () => 42));


### PR DESCRIPTION
In this merge request https://github.com/laravel/framework/pull/58696 the `when()` function docblock was updated in a way that closure parameters were not allowed. Related comment: https://github.com/laravel/framework/pull/58696#issuecomment-3897482681

The `when()` function calls the `value()` function with the condition parameters, and this should be reflected in the docblock.

