### PR TITLE
[12.x] Fix SQL Server datetime/time/float precision handling

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -686,7 +686,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeFloat(Fluent $column)
     {
-        return ! is_null($column->precision) ? "float($column->precision)" : 'float';
+        return ! is_null($column->precision) && $column->precision > 0 ? "float($column->precision)" : 'float';
     }
 
     /**
@@ -804,7 +804,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return ! is_null($column->precision) ? "time($column->precision)" : 'time';
+        return ! is_null($column->precision) && $column->precision > 0 ? "time($column->precision)" : 'time';
     }
 
     /**
@@ -830,7 +830,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return ! is_null($column->precision) ? "datetime2($column->precision)" : 'datetime';
+        return ! is_null($column->precision) && $column->precision > 0 ? "datetime2($column->precision)" : 'datetime';
     }
 
     /**
@@ -847,7 +847,7 @@ class SqlServerGrammar extends Grammar
             $column->default(new Expression('CURRENT_TIMESTAMP'));
         }
 
-        return ! is_null($column->precision) ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        return ! is_null($column->precision) && $column->precision > 0 ? "datetimeoffset($column->precision)" : 'datetimeoffset';
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -666,7 +666,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -684,7 +684,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" datetimeoffset(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -702,7 +702,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -720,7 +720,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" time(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -738,7 +738,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetime2(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -756,7 +756,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql();
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "created_at" datetimeoffset(0) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()


### PR DESCRIPTION
This PR fixes a backward compatibility issue introduced by PR #58602 where SQL Server migrations generate `datetime2(0)` instead of `datetime` when no precision is specified.

**Problem:**
```php
$table->dateTime('created_at');  // generates datetime2(0) instead of datetime
$table->float('price', 0);       // throws error: "precision specification 0 is invalid"
```

**Solution:**
Treat precision `0` the same as `null` for SQL Server to maintain backward compatibility.

**Changes:**
- Modified `typeFloat()`, `typeTime()`, `typeTimestamp()`, `typeTimestampTz()` to check `$column->precision > 0`
- Updated unit tests

Fixes #58797
