### PR TITLE
[12.x] Add type hints to Str::after(), before(), afterLast(), beforeLast()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -91,7 +91,7 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function after($subject, $search)
+    public static function after(string $subject, string $search): string
     {
         return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
     }
@@ -103,7 +103,7 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function afterLast($subject, $search)
+    public static function afterLast(string $subject, string $search): string
     {
         if ($search === '') {
             return $subject;
@@ -150,7 +150,7 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function before($subject, $search)
+    public static function before(string $subject, string $search): string
     {
         if ($search === '') {
             return $subject;
@@ -168,7 +168,7 @@ class Str
      * @param  string  $search
      * @return string
      */
-    public static function beforeLast($subject, $search)
+    public static function beforeLast(string $subject, string $search): string
     {
         if ($search === '') {
             return $subject;


### PR DESCRIPTION
Add parameter and return type hints to `Str` methods for better IDE support and type safety.

**Changes:**
- `Str::after()`: Added `string` parameter and return type hints
- `Str::afterLast()`: Added `string` parameter and return type hints
- `Str::before()`: Added `string` parameter and return type hints
- `Str::beforeLast()`: Added `string` parameter and return type hints
