### PR TITLE
[13.x] Add type hints to Arr::add(), Arr::forget(), and Arr::has()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -64,7 +64,7 @@ class Arr
      * @param  mixed  $value
      * @return array
      */
-    public static function add($array, $key, $value)
+    public static function add(array $array, string|int|float $key, mixed $value): array
     {
         if (is_null(static::get($array, $key))) {
             static::set($array, $key, $value);
@@ -405,7 +405,7 @@ class Arr
      * @param  array|string|int|float  $keys
      * @return void
      */
-    public static function forget(&$array, $keys)
+    public static function forget(array &$array, array|string|int|float $keys): void
     {
         $original = &$array;
 
@@ -512,7 +512,7 @@ class Arr
      * @param  string|array  $keys
      * @return bool
      */
-    public static function has($array, $keys)
+    public static function has(\ArrayAccess|array $array, string|array $keys): bool
     {
         $keys = (array) $keys;
 


### PR DESCRIPTION
Add parameter and return type hints to `Arr::add()`, `Arr::forget()`, and `Arr::has()` methods for better IDE support and type safety.

**Changes:**
- `Arr::add()`: Added `array`, `string|int|float`, `mixed` parameter types and `array` return type
- `Arr::forget()`: Added `array`, `array|string|int|float` parameter types and `void` return type
- `Arr::has()`: Added `\ArrayAccess|array`, `string|array` parameter types and `bool` return type
