### PR TITLE
[13.x] Allow aliases to be set in Signature Attribute (#58853)

### DIFF
--- a/src/Illuminate/Console/Attributes/Signature.php
+++ b/src/Illuminate/Console/Attributes/Signature.php
@@ -11,8 +11,9 @@ class Signature
      * Create a new attribute instance.
      *
      * @param  string  $signature
+     * @param  string[]|null  $aliases
      */
-    public function __construct(public string $signature)
+    public function __construct(public string $signature, public ?array $aliases = null)
     {
         //
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -141,7 +141,13 @@ class Command extends SymfonyCommand
         $signature = $reflection->getAttributes(Signature::class);
 
         if (count($signature) > 0) {
-            $this->signature = $signature[0]->newInstance()->signature;
+            $signatureInstance = $signature[0]->newInstance();
+
+            $this->signature = $signatureInstance->signature;
+
+            if ($signatureInstance->aliases !== null) {
+                $this->aliases = $signatureInstance->aliases;
+            }
         }
 
         $description = $reflection->getAttributes(Description::class);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Application;
+use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
@@ -209,5 +210,21 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
+    }
+
+    public function testSignatureAttributeCanSetAliases()
+    {
+        $command = new SignatureWithAliasesCommand;
+
+        $this->assertSame('foo:bar', $command->getName());
+        $this->assertSame(['bar:baz', 'baz:qux'], $command->getAliases());
+    }
+}
+
+#[Signature('foo:bar', aliases: ['bar:baz', 'baz:qux'])]
+class SignatureWithAliasesCommand extends Command
+{
+    public function handle()
+    {
     }
 }


### PR DESCRIPTION
I sent this to master previously (old habit) .. and I didn't realize there was a 13.x branch... :D (so this got merged to master)
 
 Rather than it slip through the cracks I thought I'd target the right place (sorry!) 
 
 Feel free to close if master's gonna be re-synced, but I wasn't sure if it was gonna be 🫡 
 
 Tests are failing - as needs a commit from 12.x, I can port it over if you'd like.
 
 Thank you!