### PR TITLE
[12.x] Fix typo in cache `composer.json`

### DIFF
--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -36,7 +36,7 @@
     "suggest": {
         "ext-apcu": "Required to use the APC cache driver.",
         "ext-filter": "Required to use the DynamoDb cache driver.",
-        "ext-memcached": "Required to use the memcache cache driver.",
+        "ext-memcached": "Required to use the memcached cache driver.",
         "illuminate/database": "Required to use the database cache driver (^12.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^12.0).",
         "illuminate/redis": "Required to use the redis cache driver (^12.0).",


### PR DESCRIPTION
Fixes a typo in the suggest section where the `memcached` driver was misspelled.