### PR TITLE
Fix map callbacks receiving unintended key argument

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -836,10 +836,10 @@ class Arr
     {
         $keys = array_keys($array);
 
-        try {
-            $items = array_map($callback, $array, $keys);
-        } catch (ArgumentCountError) {
+        if (is_string($callback) || (is_array($callback) && count($callback) === 2)) {
             $items = array_map($callback, $array);
+        } else {
+            $items = array_map($callback, $array, $keys);
         }
 
         return array_combine($keys, $items);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support;
 
-use ArgumentCountError;
 use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -802,9 +802,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function map(callable $callback)
     {
-        return new static(function () use ($callback) {
+        $passKey = ! is_string($callback)
+            && ! (is_array($callback) && count($callback) === 2);
+
+        return new static(function () use ($callback, $passKey) {
             foreach ($this as $key => $value) {
-                yield $key => $callback($value, $key);
+                yield $key => $passKey ? $callback($value, $key) : $callback($value);
             }
         });
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use ArgumentCountError;
 use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -1912,7 +1913,7 @@ class SupportArrTest extends TestCase
     public function testMapWithStringCallableArrayCombineThrowsArgumentCountError()
     {
         $array = [['a', 'b', 'c'], ['d', 'e', 'f']];
-        $this->expectException(\ArgumentCountError::class);
+        $this->expectException(ArgumentCountError::class);
         Arr::map($array, 'array_combine');
     }
 
@@ -1937,9 +1938,9 @@ class SupportArrTest extends TestCase
     public function testMapWithArrayCallableDoesNotReceiveKeyAsSecondArgument()
     {
         $array = ['Sample type 1', 'Sample type 1', 'Sample type 1'];
-        $trim = new class 
+        $trim = new class
         {
-            public function trim($string, $characters = "\n\r\t\v\x00") 
+            public function trim($string, $characters = "\n\r\t\v\x00")
             {
                 return trim($string, $characters);
             }
@@ -1951,9 +1952,9 @@ class SupportArrTest extends TestCase
     public function testMapWithStaticArrayCallableDoesNotReceiveKeyAsSecondArgument()
     {
         $array = ['6', '7', '8'];
-        $converter = new class  
+        $converter = new class
         {
-            public static function toInt($value, $base = 10) 
+            public static function toInt($value, $base = 10)
             {
                 return intval($value, $base);
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Support;
 
-use ArgumentCountError;
 use ArrayObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -1913,7 +1912,7 @@ class SupportArrTest extends TestCase
     public function testMapWithStringCallableArrayCombineThrowsArgumentCountError()
     {
         $array = [['a', 'b', 'c'], ['d', 'e', 'f']];
-        $this->expectException(ArgumentCountError::class);
+        $this->expectException(\ArgumentCountError::class);
         Arr::map($array, 'array_combine');
     }
 
@@ -1929,7 +1928,7 @@ class SupportArrTest extends TestCase
     {
         $array = ['a' => 'value1', 'b' => 'value2'];
         $result = Arr::map($array, function ($value, $key) {
-            return $key . ':' . $value;
+            return $key.':'.$value;
         });
 
         $this->assertEquals(['a' => 'a:value1', 'b' => 'b:value2'], $result);
@@ -1938,8 +1937,10 @@ class SupportArrTest extends TestCase
     public function testMapWithArrayCallableDoesNotReceiveKeyAsSecondArgument()
     {
         $array = ['Sample type 1', 'Sample type 1', 'Sample type 1'];
-        $trim = new class {
-            public function trim($string, $characters = "\n\r\t\v\x00") {
+        $trim = new class 
+        {
+            public function trim($string, $characters = "\n\r\t\v\x00") 
+            {
                 return trim($string, $characters);
             }
         };
@@ -1950,8 +1951,10 @@ class SupportArrTest extends TestCase
     public function testMapWithStaticArrayCallableDoesNotReceiveKeyAsSecondArgument()
     {
         $array = ['6', '7', '8'];
-        $converter = new class {
-            public static function toInt($value, $base = 10) {
+        $converter = new class  
+        {
+            public static function toInt($value, $base = 10) 
+            {
                 return intval($value, $base);
             }
         };

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6031,6 +6031,61 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($collection->percentage(fn ($value) => $value === 1));
     }
 
+    #[DataProvider('collectionClassProvider')]
+    public function testMapWithStringCallableTrimDoesNotReceiveKeyAsSecondArgument($collection)
+    {
+        $c = new $collection(['Sample type 1', 'Sample type 1', 'Sample type 1']);
+        $result = $c->map('trim');
+
+        $this->assertEquals(['Sample type 1', 'Sample type 1', 'Sample type 1'], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMapWithStringCallableIntvalDoesNotReceiveKeyAsSecondArgument($collection)
+    {
+        $c = new $collection(['6', '7', '8']);
+        $result = $c->map('intval');
+
+        $this->assertEquals([6, 7, 8], $result->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMapWithArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
+    {
+        $c = new $collection(['Sample type 1', 'Sample type 1', 'Sample type 1']);
+        $trim = new class {
+            public function trim($string, $characters = "\n\r\t\v\x00") {
+                return trim($string, $characters);
+            }
+        };
+
+        $this->assertSame(['Sample type 1', 'Sample type 1', 'Sample type 1'], $c->map([$trim, 'trim'])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMapWithStaticArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
+    {
+        $c = new $collection(['6', '7', '8']);
+        $converter = new class {
+            public static function toInt($value, $base = 10) {
+                return intval($value, $base);
+            }
+        };
+
+        $this->assertSame([6, 7, 8], $c->map([$converter, 'toInt'])->all());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testMapWithClosureReceivesKey($collection)
+    {
+        $c = new $collection(['a' => 'value1', 'b' => 'value2']);
+        $result = $c->map(function ($value, $key) {
+            return $key . ':' . $value;
+        });
+
+        $this->assertEquals(['a' => 'a:value1', 'b' => 'b:value2'], $result->all());
+    }
+
     /**
      * Provides each collection class, respectively.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6053,9 +6053,9 @@ class SupportCollectionTest extends TestCase
     public function testMapWithArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
     {
         $c = new $collection(['Sample type 1', 'Sample type 1', 'Sample type 1']);
-        $trim = new class 
+        $trim = new class
         {
-            public function trim($string, $characters = "\n\r\t\v\x00") 
+            public function trim($string, $characters = "\n\r\t\v\x00")
             {
                 return trim($string, $characters);
             }
@@ -6068,9 +6068,9 @@ class SupportCollectionTest extends TestCase
     public function testMapWithStaticArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
     {
         $c = new $collection(['6', '7', '8']);
-        $converter = new class 
+        $converter = new class
         {
-            public static function toInt($value, $base = 10) 
+            public static function toInt($value, $base = 10)
             {
                 return intval($value, $base);
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -6053,8 +6053,10 @@ class SupportCollectionTest extends TestCase
     public function testMapWithArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
     {
         $c = new $collection(['Sample type 1', 'Sample type 1', 'Sample type 1']);
-        $trim = new class {
-            public function trim($string, $characters = "\n\r\t\v\x00") {
+        $trim = new class 
+        {
+            public function trim($string, $characters = "\n\r\t\v\x00") 
+            {
                 return trim($string, $characters);
             }
         };
@@ -6066,8 +6068,10 @@ class SupportCollectionTest extends TestCase
     public function testMapWithStaticArrayCallableDoesNotReceiveKeyAsSecondArgument($collection)
     {
         $c = new $collection(['6', '7', '8']);
-        $converter = new class {
-            public static function toInt($value, $base = 10) {
+        $converter = new class 
+        {
+            public static function toInt($value, $base = 10) 
+            {
                 return intval($value, $base);
             }
         };
@@ -6080,7 +6084,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection(['a' => 'value1', 'b' => 'value2']);
         $result = $c->map(function ($value, $key) {
-            return $key . ':' . $value;
+            return $key.':'.$value;
         });
 
         $this->assertEquals(['a' => 'a:value1', 'b' => 'b:value2'], $result->all());


### PR DESCRIPTION
## Summary
This PR fixes an edge case where `map()` passes the collection key as a second argument to certain callables, which can silently change results for PHP functions/methods that have meaningful optional second parameters (e.g. `trim`, `ltrim`, `rtrim`, `intval`, `round`).

In particular, `map('trim')` on indexed collections may call `trim($value, $key)`, causing values at key `1` (and others) to be modified unexpectedly.

## End-user benefit
End users can safely use common string/array callables with `Collection::map()` and `LazyCollection::map()` without unexpected data corruption. This aligns `Collection` and `LazyCollection` behavior and prevents subtle bugs when mapping over user input and datasets.

## What changed
- Updated mapping behavior so that:
  - **String callables** (e.g. `'trim'`) and **array callables** (e.g. `[$obj, 'method']` / `['Class', 'method']`) are invoked with **value only**.
  - Closures / invokable objects continue to receive **(value, key)** as before.

This preserves key-aware mapping for callbacks that intentionally accept the key, while avoiding accidental use of the key as an optional parameter for built-in functions/methods.

## Why this does not break existing features
- Closures that rely on receiving `(value, key)` are unchanged.
- The change affects only string/array callables where passing a second argument is typically unintended and can lead to silent corruption due to optional parameters.
- Keys are still preserved in the returned collection.

## Tests
Added regression coverage for both `Collection` and `LazyCollection` via the existing provider:
- `map('trim')` does not remove characters due to key being interpreted as a mask
- `map('intval')` does not interpret the key as a base
- `map([$obj, 'method'])` (array callable) does not receive the key as a second argument
- Closure callbacks still receive the key and can incorporate it in the result

Fixes [#25549
](https://github.com/laravel/framework/issues/25549)