### PR TITLE
[12.x] Remove unnecessary `forgetDriver()`from TestCaches

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -50,5 +50,14 @@ trait TestCaches
     protected function switchToCachePrefix($prefix)
     {
         $this->app['config']->set('cache.prefix', $prefix);
+
+        if ($this->app->resolved('cache')) {
+            $store = $this->app['cache']->driver()->getStore();
+
+            if (method_exists($store, 'setPrefix')) {
+                $store->setPrefix($prefix);
+            }
+        }
+
     }
 }

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -50,9 +50,5 @@ trait TestCaches
     protected function switchToCachePrefix($prefix)
     {
         $this->app['config']->set('cache.prefix', $prefix);
-
-        if ($this->app->resolved('cache')) {
-            $this->app['cache']->forgetDriver();
-        }
     }
 }

--- a/src/Illuminate/Testing/Concerns/TestCaches.php
+++ b/src/Illuminate/Testing/Concerns/TestCaches.php
@@ -50,14 +50,5 @@ trait TestCaches
     protected function switchToCachePrefix($prefix)
     {
         $this->app['config']->set('cache.prefix', $prefix);
-
-        if ($this->app->resolved('cache')) {
-            $store = $this->app['cache']->driver()->getStore();
-
-            if (method_exists($store, 'setPrefix')) {
-                $store->setPrefix($prefix);
-            }
-        }
-
     }
 }

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -129,7 +129,7 @@ class TestCachesTest extends TestCase
         unset($_SERVER['LARAVEL_PARALLEL_TESTING_WITHOUT_CACHE']);
     }
 
-    public function testSwitchToCachePrefixDoesNotForgetResolvedDrivers()
+    public function testSwitchToCachePrefixDoesNotRemoveResolvedDrivers()
     {
         $container = Container::getInstance();
 

--- a/tests/Testing/Concerns/TestCachesTest.php
+++ b/tests/Testing/Concerns/TestCachesTest.php
@@ -129,6 +129,22 @@ class TestCachesTest extends TestCase
         unset($_SERVER['LARAVEL_PARALLEL_TESTING_WITHOUT_CACHE']);
     }
 
+    public function testSwitchToCachePrefixDoesNotForgetResolvedDrivers()
+    {
+        $container = Container::getInstance();
+
+        $container->singleton('cache', fn ($app) => new \Illuminate\Cache\CacheManager($app));
+
+        $container['config']->set('cache.default', 'array');
+        $container['config']->set('cache.stores.array', ['driver' => 'array']);
+
+        $driver = $container['cache']->driver();
+
+        $this->switchToCachePrefix('new_prefix_');
+
+        $this->assertSame($driver, $container['cache']->driver());
+    }
+
     protected function getParallelSafeCachePrefix()
     {
         $instance = $this->makeTestCachesInstance();


### PR DESCRIPTION
`forgetDriver()` destroys the resolved store, but classes like the RateLimiter retain a reference to the old instance. This means `Cache::clear()` clears a new store while the RateLimiter is still counting against the old one.

This breaks parallel tests when you clear the cache to reset rate limiters ie the clear essentially does nothing.

The only reason I can think for why this was here is if a cache store was already resolved by another provider — but in that case, forgetting it only makes things worse I guess? 

Not sure if it's a B/C ie I couldnt think of a reason, but maybe you can - in which case we can do something like... (rather than just forgetting it blind)

```php

    if ($this->app->resolved('cache')) {
        $store = $this->app['cache']->driver()->getStore();

        if (method_exists($store, 'setPrefix')) {
            $store->setPrefix($prefix);
        }
    }
    
```

All existing tests still pass and added a regression test to prevent this from being reintroduced.



This closes https://github.com/laravel/framework/issues/58863 if merged :) 

