### PR TITLE
[12.x] Display closures and standalone functions correctly in exception trace

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Exception.php
@@ -118,8 +118,17 @@ class Exception
                 return (string) realpath($path);
             }, array_values(ClassLoader::getRegisteredLoaders())[0]->getClassMap());
 
+            $trace = $this->exception->getTrace();
+
+            if (count($trace) > 1 && empty($trace[0]['class']) && empty($trace[0]['function'])) {
+                $trace[0]['class'] = $trace[1]['class'] ?? '';
+                $trace[0]['type'] = $trace[1]['type'] ?? '';
+                $trace[0]['function'] = $trace[1]['function'] ?? '';
+                $trace[0]['args'] = $trace[1]['args'] ?? [];
+            }
+
             $trace = array_values(array_filter(
-                $this->exception->getTrace(), fn ($trace) => isset($trace['file']),
+                $trace, fn ($trace) => isset($trace['file']),
             ));
 
             if (($trace[1]['class'] ?? '') === HandleExceptions::class) {

--- a/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
+++ b/src/Illuminate/Foundation/Exceptions/Renderer/Frame.php
@@ -101,6 +101,10 @@ class Frame
      */
     public function class()
     {
+        if (! empty($this->frame['class'])) {
+            return $this->frame['class'];
+        }
+
         $class = array_search((string) realpath($this->frame['file']), $this->classMap, true);
 
         return $class === false ? null : $class;
@@ -143,7 +147,7 @@ class Frame
      */
     public function operator()
     {
-        return $this->frame['type'];
+        return $this->frame['type'] ?? '';
     }
 
     /**

--- a/src/Illuminate/Foundation/resources/exceptions/renderer/components/formatted-source.blade.php
+++ b/src/Illuminate/Foundation/resources/exceptions/renderer/components/formatted-source.blade.php
@@ -1,14 +1,14 @@
 @props(['frame'])
 
 @php
-    if ($class = $frame->class()) {
-        $source = $class;
+    $class = $frame->class();
+    $operator = $frame->operator();
+    $callable = $frame->callable();
 
-        if ($previous = $frame->previous()) {
-            $source .= $previous->operator();
-            $source .= $previous->callable();
-            $source .= '('.implode(', ', $previous->args()).')';
-        }
+    if ($class && $operator) {
+        $source = $class.$operator.$callable.'('.implode(', ', $frame->args()).')';
+    } elseif ($callable !== 'throw') {
+        $source = $callable.'('.implode(', ', $frame->args()).')';
     } else {
         $source = $frame->source();
     }

--- a/tests/Integration/Foundation/Exceptions/RenderBladeFilesTest.php
+++ b/tests/Integration/Foundation/Exceptions/RenderBladeFilesTest.php
@@ -27,9 +27,14 @@ class RenderBladeFilesTest extends TestCase
                 return null;
             }
 
-            public function previous()
+            public function operator()
             {
-                return null;
+                return '';
+            }
+
+            public function callable()
+            {
+                return 'throw';
             }
 
             public function source()


### PR DESCRIPTION
The exception renderer's trace frames now use each frame's own trace data (`class`, `type`, `function`) instead of stitching together the classmap class with the previous frame's callable. This fixes two issues:

- Standalone functions like `array_map` were concatenated directly onto the class name (e.g. `UserControllerarray_map()`) due to the missing operator
- Closures were never shown — the closure info lived on a frame that had no file and was filtered out

## Before
<img width="2180" height="1506" alt="CleanShot 2026-02-17 at 14 39 31@2x" src="https://github.com/user-attachments/assets/d40ce179-1b32-4593-abc7-4ae7f925f783" />

## After
<img width="2176" height="1512" alt="CleanShot 2026-02-17 at 14 38 49@2x" src="https://github.com/user-attachments/assets/745cac78-111a-4af9-a5ac-63883b83073b" />
