### PR TITLE
[12.x] Respect `shouldRun()` in `migrate:status` command

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -260,6 +260,24 @@ class Migrator
     }
 
     /**
+     * Determine if a migration should be skipped.
+     *
+     * @param  string  $migration
+     * @return bool
+     */
+    public function migrationShouldBeSkipped($migration)
+    {
+        $migration = $this->resolvePath($migration);
+
+        // Check if it's a Migration instance and shouldRun() returns false
+        if ($migration instanceof Migration) {
+            return ! $migration->shouldRun();
+        }
+
+        return false;
+    }
+
+    /**
      * Rollback the last migration operation.
      *
      * @param  string[]|string  $paths

--- a/tests/Integration/Database/MigrateStatusCommandTest.php
+++ b/tests/Integration/Database/MigrateStatusCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class MigrateStatusCommandTest extends TestCase
+{
+    protected function migrateOptions()
+    {
+        return [
+            '--path' => realpath(__DIR__ . '/stubs/'),
+            '--realpath' => true,
+        ];
+    }
+
+    public function testMigrateStatusShowsPendingMigrations()
+    {
+        $this->artisan('migrate:install');
+
+        $this->artisan('migrate:status', $this->migrateOptions())
+            ->expectsOutputToContain('Pending')
+            ->assertSuccessful();
+    }
+
+    public function testMigrateStatusShowsRanMigrations()
+    {
+        $this->artisan('migrate', $this->migrateOptions());
+
+        $this->artisan('migrate:status', $this->migrateOptions())
+            ->expectsOutputToContain('Ran')
+            ->assertSuccessful();
+
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+    }
+
+    public function testMigrateStatusShowsBatchNumber()
+    {
+        $this->artisan('migrate', $this->migrateOptions());
+
+        $this->artisan('migrate:status', $this->migrateOptions())
+            ->expectsOutputToContain('[1]')
+            ->assertSuccessful();
+
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+    }
+
+    public function testMigrateStatusShowsSkippedMigrations()
+    {
+        $this->artisan('migrate:install');
+
+        $this->artisan('migrate:status', $this->migrateOptions())
+            ->expectsOutputToContain('Skipped')
+            ->assertSuccessful();
+    }
+
+    public function testMigrateStatusWithSkippedOptionReturnsExitCodeWhenSkipped()
+    {
+        $this->artisan('migrate:install');
+
+        $this->artisan('migrate:status', $this->migrateOptions() + ['--skipped' => true])
+            ->expectsOutputToContain('Skipped')
+            ->assertExitCode(1);
+    }
+
+    public function testMigrateStatusWithSkippedOptionWhenNoSkippedMigrations()
+    {
+        $this->artisan('migrate:install');
+        
+        // We need a path with NO skipped migrations.
+        // We can limit path to just the normal migration.
+        $this->artisan('migrate:status', [
+            '--path' => realpath(__DIR__ . '/stubs/2014_10_12_000000_create_members_table.php'),
+            '--realpath' => true,
+            '--skipped' => true,
+        ])
+        ->expectsOutputToContain('No skipped migrations')
+        ->assertSuccessful();
+    }
+
+    public function testMigrateStatusWithPendingOptionReturnsExitCodeWhenPending()
+    {
+        $this->artisan('migrate:install');
+
+        $this->artisan('migrate:status', $this->migrateOptions() + ['--pending' => 1])
+            ->assertExitCode(1);
+    }
+
+    public function testMigrateStatusWithPendingOptionWhenNoPendingMigrations()
+    {
+        $this->artisan('migrate', $this->migrateOptions());
+
+        $this->artisan('migrate:status', $this->migrateOptions() + ['--pending' => true])
+            ->expectsOutputToContain('No pending migrations')
+            ->assertSuccessful();
+
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+    }
+
+    public function testMigrateStatusWithNoMigrationFiles()
+    {
+        $this->artisan('migrate:install');
+
+        $this->artisan('migrate:status')
+            ->expectsOutputToContain('No migrations found')
+            ->assertSuccessful();
+    }
+
+    public function testMigrateStatusReturnsErrorWhenMigrationTableDoesNotExist()
+    {
+        Schema::dropIfExists('migrations');
+
+        $this->artisan('migrate:status', $this->migrateOptions())
+            ->expectsOutputToContain('Migration table not found')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
This PR updates `migrate:status` to respect the `shouldRun()` method defined on migration classes.

Previously, `migrate:status` would always display a migration as `Pending` even if its `shouldRun()` method returned `false`, which was misleading since the migration would be silently skipped when running `migrate`.

**Changes**

- Added `migrationShouldBeSkipped` method on `Migrator`.
- `migrate:status` now displays a `Skipped` status for any migration whose `shouldRun()` returns `false`.
- A new `--skipped` option has been added to filter and list only skipped migrations.
- Added `MigrateStatusCommandTest` to cover all the behaviour.

**Before**

```
Migration name                                      Batch / Status
2026_01_01_000000_create_users                      [1] Ran
2026_01_01_000000_create_non_skipped                Pending
2026_01_02_000000_create_skipped_migration          Pending   ← misleading, shouldRun() is false
```

**After**

```
Migration name                                      Batch / Status
2026_01_01_000000_create_users                      [1] Ran
2026_01_01_000000_create_non_skipped                Pending
2026_01_02_000000_create_skipped_migration          Skipped
```