### PR TITLE
[12.x] Add missing assertDontSeeTextInOrder method to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -23,6 +23,7 @@ use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponseAssert as PHPUnit;
 use LogicException;
+use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -837,6 +838,25 @@ class TestResponse implements ArrayAccess
         foreach ($values as $value) {
             PHPUnit::withResponse($this)->assertStringNotContainsString((string) $value, $content);
         }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given strings are not contained in order within the response text.
+     *
+     * @param  array  $values
+     * @param  bool  $escape
+     * @return $this
+     */
+    public function assertDontSeeTextInOrder(array $values, $escape = true)
+    {
+        $values = $escape ? array_map(e(...), $values) : $values;
+
+        PHPUnit::withResponse($this)->assertThat(
+            $values,
+            new LogicalNot(new SeeInOrder(strip_tags($this->getContent())))
+        );
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -630,6 +630,38 @@ class TestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
     }
 
+    public function testAssertDontSeeTextInOrder(): void
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
+        ]);
+
+        // These strings exist but not in this order, so assertion passes
+        $response->assertDontSeeTextInOrder(['baz', 'foobar']);
+    }
+
+    public function testAssertDontSeeTextInOrderEscaped(): void
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<strong>laravel &amp; php</strong> <i>phpstorm &gt; sublime</i>',
+        ]);
+
+        // These strings exist but not in this order, so assertion passes
+        $response->assertDontSeeTextInOrder(['phpstorm > sublime', 'laravel & php']);
+    }
+
+    public function testAssertDontSeeTextInOrderCanFail(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
+        ]);
+
+        // These strings are in order, so the assertion should fail
+        $response->assertDontSeeTextInOrder(['foobar', 'baz']);
+    }
+
     public function testAssertDontSee(): void
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
This PR adds the missing `assertDontSeeTextInOrder` method to `TestResponse`:

This method asserts that the given strings are **not** found in the specified order within the response text (with HTML tags stripped).

**Usage:**

```php
// Passes - strings are not in this order in the response
$response->assertDontSeeTextInOrder(['World', 'Hello']);

// Fails - strings ARE in this order
$response->assertDontSeeTextInOrder(['Hello', 'World']);
