### PR TITLE
[13.x] Display route binding fields in `route:list` output

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -142,7 +142,7 @@ class RouteListCommand extends Command
         return $this->filterRoute([
             'domain' => $route->domain(),
             'method' => implode('|', $route->methods()),
-            'uri' => $route->uri(),
+            'uri' => $this->resolveUri($route),
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
@@ -198,6 +198,23 @@ class RouteListCommand extends Command
         $this->output->writeln(
             $this->option('json') ? $this->asJson($routes) : $this->forCli($routes)
         );
+    }
+
+    /**
+     * Get the URI for the given route, including any binding fields.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return string
+     */
+    protected function resolveUri(Route $route)
+    {
+        $uri = $route->uri();
+
+        foreach ($route->bindingFields() as $parameter => $field) {
+            $uri = str_replace("{{$parameter}}", "{{$parameter}:{$field}}", $uri);
+        }
+
+        return $uri;
     }
 
     /**

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -161,6 +161,34 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('                                                  Showing [3] routes')
             ->expectsOutput('');
     }
+
+    public function testDisplayRoutesWithBindingFields()
+    {
+        $this->router->get('users/{user:name}', [FooController::class, 'show']);
+        $this->router->get('users/{user:name}/posts/{post:slug}', function () {
+            //
+        });
+
+        $this->artisan(RouteListCommand::class, ['-v' => true])
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD       users/{user:name} Illuminate\Tests\Testing\Console\FooController@show')
+            ->expectsOutput('  GET|HEAD       users/{user:name}/posts/{post:slug} ............... ')
+            ->expectsOutput('')
+            ->expectsOutput('                                                  Showing [2] routes')
+            ->expectsOutput('');
+    }
+
+    public function testDisplayRoutesWithBindingFieldsAsJson()
+    {
+        $this->router->get('users/{user:name}/posts/{post:slug}', function () {
+            //
+        });
+
+        $this->artisan(RouteListCommand::class, ['--json' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('users\/{user:name}\/posts\/{post:slug}');
+    }
 }
 
 class FooController extends Controller


### PR DESCRIPTION
Rather than seeing: 
```
  POST       profile/user/{user} 
```

in `route:list` 

It would be nice to see the actual binding.. if there's one set

```
  POST       profile/user/{user:id}
``` 
If there's no binding it works normally, as the other tests show.  
  
Targeted 13.x as it's a slight change in output. but can target master if you prefer, as presume 13.x is verrrry soon.

