### PR TITLE
[12.x] Add array key support for `buildMorphMapFromModels()` function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -486,7 +486,7 @@ abstract class Relation implements BuilderContract
     /**
      * Builds a table-keyed array from model class names.
      *
-     * @param  list<class-string<\Illuminate\Database\Eloquent\Model>>|null  $models
+     * @param  array<array-key, class-string<\Illuminate\Database\Eloquent\Model>>|null  $models
      * @return array<string, class-string<\Illuminate\Database\Eloquent\Model>>|null
      */
     protected static function buildMorphMapFromModels(?array $models = null)


### PR DESCRIPTION
Builds on https://github.com/laravel/framework/pull/58668 to allow for all `array-key` types to be used as array keys on the `$models` parameter for the `buildMorphMapFromModels()` function. It also corrects the variable from a `list` type to a regular `array` type.