### PR TITLE
[12.x] Fix resource leak and error handling in Filesystem::replace

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -222,7 +222,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         if ($tempPath === false) {
-             throw new \Symfony\Component\HttpFoundation\File\Exception\FileException("Unable to create temporary file in " . dirname($path));
+            throw new RuntimeException("Unable to create temporary file in ".dirname($path));
         }
 
         try {
@@ -234,18 +234,18 @@ class Filesystem
             }
 
             if (file_put_contents($tempPath, $content) === false) {
-                throw new \RuntimeException("Unable to write to temporary file {$tempPath}");
+                throw new RuntimeException("Unable to write to temporary file {$tempPath}");
             }
 
             if (@rename($tempPath, $path) === false) {
                 // If rename fails, we should throw an exception to trigger the cleanup
-                throw new \RuntimeException("Unable to move temporary file to {$path}");
+                throw new RuntimeException("Unable to move temporary file to {$path}");
             }
         } catch (\Throwable $e) {
             if (file_exists($tempPath)) {
                 @unlink($tempPath);
             }
-            
+
             throw $e;
         }
     }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -222,7 +222,7 @@ class Filesystem
         $tempPath = tempnam(dirname($path), basename($path));
 
         if ($tempPath === false) {
-            throw new RuntimeException("Unable to create temporary file in ".dirname($path));
+            throw new RuntimeException('Unable to create temporary file in '.dirname($path));
         }
 
         try {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -727,4 +727,26 @@ class FilesystemTest extends TestCase
         $this->assertCount(1, $allFiles);
         $this->assertEquals('test.txt', $allFiles[0]->getFilename());
     }
+
+    public function testReplaceCleansUpTempFileOnFailure()
+    {
+        $tempDir = self::$tempDir.'/cleanup_test';
+        @mkdir($tempDir);
+        $target = $tempDir.'/target';
+        @mkdir($target);
+
+        $files = new Filesystem;
+
+        try {
+            $files->replace($target, 'content');
+        } catch (\Throwable $e) {
+            // Check that only 'target' exists in $tempDir
+            $contents = array_diff(scandir($tempDir), ['.', '..']);
+            $this->assertCount(1, $contents, 'Temp file should be cleaned up: '.implode(', ', $contents));
+            $this->assertContains('target', $contents);
+            return;
+        }
+
+        $this->fail('Expected exception (due to renaming file to directory) was not thrown.');
+    }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -744,6 +744,7 @@ class FilesystemTest extends TestCase
             $contents = array_diff(scandir($tempDir), ['.', '..']);
             $this->assertCount(1, $contents, 'Temp file should be cleaned up: '.implode(', ', $contents));
             $this->assertContains('target', $contents);
+
             return;
         }
 


### PR DESCRIPTION
### Description
This PR addresses a potential resource leak in the `Filesystem::replace` method. Previously, if `file_put_contents` or `rename` failed (e.g., due to permissions), the temporary file created by `tempnam` would be left behind in the destination directory.

### Why this matters
We’ve all seen those "orphan" temporary files cluttering up our folders when something goes wrong. In high-traffic apps or servers with tight disk quotas, these little files can eventually lead to "Disk Full" headaches or inode exhaustion. This PR makes Laravel's filesystem utilities a bit smarter and more "self-cleaning," ensuring everything stays tidy even when an operation fails.

### Changes
- **Error Prevention:** Explicitly checks if `tempnam` fails to avoid a `TypeError` on PHP 8+ (when passing `false` to `chmod`).
- **Resource Cleanup:** Wraps write and move operations in a `try-catch` block to ensure temporary files are `unlinked` if an error occurs.
- **Explicit Failure:** Checks return values of `file_put_contents` and `rename` to throw a `RuntimeException`, triggering the cleanup process.
- **Testing:** Added a test case to verify that the temporary file is correctly removed when the operation fails (e.g., when attempting to rename a file to a directory path).