### PR TITLE
[12.x] Add vector option to whereFullText for pre-computed tsvector columns

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -167,8 +167,12 @@ class PostgresGrammar extends Grammar
             $language = 'english';
         }
 
+        $isVector = $where['options']['vector'] ?? false;
+
         $columns = (new Collection($where['columns']))
-            ->map(fn ($column) => "to_tsvector('{$language}', {$this->wrap($column)})")
+            ->map(fn ($column) => $isVector
+                ? $this->wrap($column)
+                : "to_tsvector('{$language}', {$this->wrap($column)})")
             ->implode(' || ');
 
         $mode = 'plainto_tsquery';


### PR DESCRIPTION
PostgreSQL's `whereFullText` always wraps columns in `to_tsvector()`, computing the vector at query time. This prevents using pre-computed tsvector columns with GIN indexes — a standard PostgreSQL optimization for full-text search that avoids recomputing vectors on every query.

This adds a `vector` option that tells the grammar to use the column as-is, assuming it already contains a tsvector value.

**Before** (forced to use whereRaw):
```php
$query->whereRaw("search_vector @@ plainto_tsquery('dutch', ?)", [$term]);
```

**After** (fluent API):
```php
$query->whereFullText('search_vector', $term, [
    'language' => 'dutch',
    'vector' => true,
]);
// Generates: ("search_vector") @@ plainto_tsquery('dutch', ?)
```

The option composes with all existing options (`language`, `mode`):
```php
$query->whereFullText('search_vector', $term, [
    'vector' => true,
    'mode' => 'websearch',
    'language' => 'dutch',
]);
// Generates: ("search_vector") @@ websearch_to_tsquery('dutch', ?)
```

Multiple pre-computed tsvector columns are also supported:
```php
$query->whereFullText(['tsv_title', 'tsv_body'], $term, ['vector' => true]);
// Generates: ("tsv_title" || "tsv_body") @@ plainto_tsquery('english', ?)
```

The change is a 3-line addition to `PostgresGrammar::whereFullText()` — no changes to the Builder, MySQL grammar, or base grammar. Four test cases added.