### PR TITLE
[12.x] Fix RequestException consuming non-seekable streams when truncation is disabled

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -110,7 +110,7 @@ class RequestException extends HttpClientException
 
         $summary = is_int($truncateExceptionsAt)
             ? Message::bodySummary($response->toPsrResponse(), $truncateExceptionsAt)
-            : Message::toString($response->toPsrResponse());
+            : null;
 
         return is_null($summary) ? $message : $message.":\n{$summary}\n";
     }


### PR DESCRIPTION
When using the HTTP client with streaming responses and non-seekable streams, the RequestException was consuming the stream body when `RequestException::$truncateAt` was set to `false`.

This happened because `prepareMessage()` called `Message::toString()` which reads and consumes non-seekable streams, making the response body unavailable for exception handlers.

The fix skips body reading when truncation is disabled, preserving the stream for exception handlers.

Fixes #58865