### PR TITLE
[13.x] Fix SQL Server double type to use valid float(53) syntax

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -697,7 +697,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeDouble(Fluent $column)
     {
-        return 'double precision';
+        return 'float(53)';
     }
 
     /**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -567,7 +567,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" double precision not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" float(53) not null', $statements[0]);
     }
 
     public function testAddingDecimal()


### PR DESCRIPTION
SQL Server doesn't support 'double precision' as a data type. This fixes the double column type to use the correct SQL Server syntax 'float(53)' which is the equivalent of double precision floating point.