### PR TITLE
[13.x] Use proper translation keys for validation exception summary

### DIFF
--- a/src/Illuminate/Translation/lang/en/validation.php
+++ b/src/Illuminate/Translation/lang/en/validation.php
@@ -178,6 +178,11 @@ return [
     |
     */
 
+    'summary' => [
+        'one_error' => '(and :count more error)',
+        'multiple_errors' => '(and :count more errors)',
+    ],
+
     'custom' => [
         'attribute-name' => [
             'rule-name' => 'custom-message',

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -93,9 +93,9 @@ class ValidationException extends Exception
         $message = array_shift($messages);
 
         if ($count = count($messages)) {
-            $pluralized = $count === 1 ? 'error' : 'errors';
+            $key = $count === 1 ? 'validation.summary.one_error' : 'validation.summary.multiple_errors';
 
-            $message .= ' '.$validator->getTranslator()->choice("(and :count more $pluralized)", $count, compact('count'));
+            $message .= ' '.$validator->getTranslator()->choice($key, $count, compact('count'));
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -44,16 +44,15 @@ class ValidationExceptionTest extends TestCase
 
     public function testExceptionTranslatedSummarizesTwoErrors()
     {
-        $translator = $this->getTranslator('uk', [
-            '*' => [
-                '*' => [
-                    'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
-                    ],
-                ],
+        $loader = new ArrayLoader;
+        $loader->addMessages('uk', 'validation', [
+            'summary' => [
+                'one_error' => '(та ще :count помилка)',
+                'multiple_errors' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
             ],
         ]);
+
+        $translator = new Translator($loader, 'uk');
 
         $exception = $this->getException([], [
             'foo' => 'required',
@@ -65,16 +64,15 @@ class ValidationExceptionTest extends TestCase
 
     public function testExceptionTranslatedSummarizesThreeOrMoreErrors()
     {
-        $translator = $this->getTranslator('uk', [
-            '*' => [
-                '*' => [
-                    'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
-                    ],
-                ],
+        $loader = new ArrayLoader;
+        $loader->addMessages('uk', 'validation', [
+            'summary' => [
+                'one_error' => '(та ще :count помилка)',
+                'multiple_errors' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
             ],
         ]);
+
+        $translator = new Translator($loader, 'uk');
 
         $exception = $this->getException([], [
             'foo' => 'required',
@@ -87,16 +85,15 @@ class ValidationExceptionTest extends TestCase
 
     public function testExceptionTranslatedSummarizesFiveOrMoreErrors()
     {
-        $translator = $this->getTranslator('uk', [
-            '*' => [
-                '*' => [
-                    'uk' => [
-                        '(and :count more error)' => '(та ще :count помилка)',
-                        '(and :count more errors)' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
-                    ],
-                ],
+        $loader = new ArrayLoader;
+        $loader->addMessages('uk', 'validation', [
+            'summary' => [
+                'one_error' => '(та ще :count помилка)',
+                'multiple_errors' => '(та ще :count помилка)|(та ще :count помилки)|(та ще :count помилок)',
             ],
         ]);
+
+        $translator = new Translator($loader, 'uk');
 
         $exception = $this->getException([], [
             'foo' => 'required',
@@ -180,7 +177,16 @@ class ValidationExceptionTest extends TestCase
 
     protected function getTranslator($locale = 'en', $loaded = [])
     {
-        $translator ??= new Translator(new ArrayLoader, $locale);
+        $loader = new ArrayLoader;
+
+        $loader->addMessages('en', 'validation', [
+            'summary' => [
+                'one_error' => '(and :count more error)',
+                'multiple_errors' => '(and :count more errors)',
+            ],
+        ]);
+
+        $translator = new Translator($loader, $locale);
 
         $translator->setLoaded($loaded);
 


### PR DESCRIPTION
This PR fixes the issue where ValidationException summary messages use raw translation strings instead of proper translation keys, making it difficult to translate them in validation.php files.

Previously, the summary used raw strings like "(and :count more error)" which could only be translated via JSON language files. Now it uses proper translation keys "validation.summary.one_error" and "validation.summary.multiple_errors" that can be translated in standard validation.php files.

Fixes #58783