### PR TITLE
[12.x] chore: don't format notifiables in NotificationSender::send

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -82,8 +82,6 @@ class NotificationSender
      */
     public function send($notifiables, $notification)
     {
-        $notifiables = $this->formatNotifiables($notifiables);
-
         if ($notification instanceof ShouldQueue) {
             return $this->queueNotification($notifiables, $notification);
         }


### PR DESCRIPTION
Hello!

The notifiables are formatted in both the `queueNotification` and `send` methods so this is completely redundant.

Thanks!