### PR TITLE
[12.x] fix: respect `DeleteWhenMissingModels` attribute on queued notifications

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -8,9 +8,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use ReflectionClass;
 
 class SendQueuedNotifications implements ShouldQueue
 {
@@ -66,6 +68,11 @@ class SendQueuedNotifications implements ShouldQueue
     public $shouldBeEncrypted = false;
 
     /**
+     * Indicates if the job should be deleted when models are missing.
+     */
+    public bool $deleteWhenMissingModels = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
@@ -88,6 +95,10 @@ class SendQueuedNotifications implements ShouldQueue
         }
 
         $this->shouldBeEncrypted = $notification instanceof ShouldBeEncrypted;
+
+        $this->deleteWhenMissingModels = property_exists($notification, 'deleteWhenMissingModels')
+            ? $notification->deleteWhenMissingModels
+            : (new ReflectionClass($notification))->getAttributes(DeleteWhenMissingModels::class) !== [];
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -253,6 +253,11 @@ class CallQueuedHandler
 
             $shouldDelete = $reflectionClass->getDefaultProperties()['deleteWhenMissingModels']
                 ?? count($reflectionClass->getAttributes(DeleteWhenMissingModels::class)) !== 0;
+
+            if (! $shouldDelete) {
+                $command = $job->payload()['data']['command'] ?? null;
+                $shouldDelete = str_contains((string) $command, '"deleteWhenMissingModels";b:1;');
+            }
         } catch (Exception) {
             $shouldDelete = false;
         }

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\WithMigration;
+
+#[WithMigration]
+#[WithMigration('queue')]
+class DeleteNotificationWhenMissingModelTest extends QueueTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+        $app['config']->set('queue.default', 'database');
+        $this->driver = 'database';
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        Schema::create('delete_notification_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::dropIfExists('delete_notification_test_models');
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        DeleteWhenMissingNotification::$sent = false;
+
+        parent::tearDown();
+    }
+
+    public function test_deleteModelWhenMissing_on_queued_notification(): void
+    {
+        $model = DeleteNotificationTestModel::query()->create(['name' => 'test']);
+
+        NotificationFacade::send($model, new DeleteWhenMissingNotification($model));
+
+        DeleteNotificationTestModel::query()->where('name', 'test')->delete();
+
+        $this->runQueueWorkerCommand(['--once' => '1']);
+
+        $this->assertFalse(DeleteWhenMissingNotification::$sent);
+        $this->assertNull(\DB::table('failed_jobs')->first());
+    }
+}
+
+class DeleteNotificationTestModel extends Model
+{
+    use Notifiable;
+
+    protected $table = 'delete_notification_test_models';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+#[DeleteWhenMissingModels]
+class DeleteWhenMissingNotification extends Notification implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public static bool $sent = false;
+
+    public function __construct(public DeleteNotificationTestModel $model)
+    {
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        static::$sent = true;
+
+        return new \Illuminate\Notifications\Messages\MailMessage;
+    }
+}

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Support\Collection;
 use Mockery as m;
@@ -16,11 +17,12 @@ class NotificationSendQueuedNotificationTest extends TestCase
 {
     public function testNotificationsCanBeSent()
     {
-        $job = new SendQueuedNotifications('notifiables', 'notification');
+        $notification = new TestNotification;
+        $job = new SendQueuedNotifications('notifiables', $notification);
         $manager = m::mock(ChannelManager::class);
         $manager->shouldReceive('sendNow')->once()->withArgs(function ($notifiables, $notification, $channels) {
             return $notifiables instanceof Collection && $notifiables->toArray() === ['notifiables']
-                && $notification === 'notification'
+                && $notification instanceof TestNotification
                 && $channels === null;
         });
         $job->handle($manager);
@@ -31,7 +33,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
         $identifier = new ModelIdentifier(NotifiableUser::class, [null], [], null);
         $serializedIdentifier = serialize($identifier);
 
-        $job = new SendQueuedNotifications(new NotifiableUser, 'notification');
+        $job = new SendQueuedNotifications(new NotifiableUser, new TestNotification);
         $serialized = serialize($job);
 
         $this->assertStringContainsString($serializedIdentifier, $serialized);
@@ -42,7 +44,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
         $notifiable = new AnonymousNotifiable;
         $serializedNotifiable = serialize($notifiable);
 
-        $job = new SendQueuedNotifications($notifiable, 'notification');
+        $job = new SendQueuedNotifications($notifiable, new TestNotification);
         $serialized = serialize($job);
 
         $this->assertStringContainsString($serializedNotifiable, $serialized);
@@ -68,4 +70,8 @@ class NotifiableUser extends Model
 
     public $table = 'users';
     public $timestamps = false;
+}
+
+class TestNotification extends Notification
+{
 }


### PR DESCRIPTION
Hello!

Queued notifications now properly respect the `#[DeleteWhenMissingModels]` attribute and `$deleteWhenMissingModels` property on notification classes.

Previously, when a notification with this attribute had a missing model, the job would fail instead of being silently deleted because the handler only checked the SendQueuedNotifications wrapper class, not the actual notification class.

Thanks!