### PR TITLE
[12.x] Add exclusiveMinimum and exclusiveMaximum support to JsonSchema numeric types

### DIFF
--- a/src/Illuminate/JsonSchema/Types/IntegerType.php
+++ b/src/Illuminate/JsonSchema/Types/IntegerType.php
@@ -15,6 +15,16 @@ class IntegerType extends Type
     protected ?int $maximum = null;
 
     /**
+     * The minimum value (exclusive).
+     */
+    protected ?int $exclusiveMinimum = null;
+
+    /**
+     * The maximum value (exclusive).
+     */
+    protected ?int $exclusiveMaximum = null;
+
+    /**
      * Set the minimum value (inclusive).
      */
     public function min(int $value): static
@@ -30,6 +40,26 @@ class IntegerType extends Type
     public function max(int $value): static
     {
         $this->maximum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the minimum value (exclusive).
+     */
+    public function exclusiveMin(int $value): static
+    {
+        $this->exclusiveMinimum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum value (exclusive).
+     */
+    public function exclusiveMax(int $value): static
+    {
+        $this->exclusiveMaximum = $value;
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/NumberType.php
+++ b/src/Illuminate/JsonSchema/Types/NumberType.php
@@ -15,6 +15,16 @@ class NumberType extends Type
     protected int|float|null $maximum = null;
 
     /**
+     * The minimum value (exclusive).
+     */
+    protected int|float|null $exclusiveMinimum = null;
+
+    /**
+     * The maximum value (exclusive).
+     */
+    protected int|float|null $exclusiveMaximum = null;
+
+    /**
      * Set the minimum value (inclusive).
      */
     public function min(int|float $value): static
@@ -30,6 +40,26 @@ class NumberType extends Type
     public function max(int|float $value): static
     {
         $this->maximum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the minimum value (exclusive).
+     */
+    public function exclusiveMin(int|float $value): static
+    {
+        $this->exclusiveMinimum = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum value (exclusive).
+     */
+    public function exclusiveMax(int|float $value): static
+    {
+        $this->exclusiveMaximum = $value;
 
         return $this;
     }

--- a/tests/JsonSchema/IntegerTypeTest.php
+++ b/tests/JsonSchema/IntegerTypeTest.php
@@ -39,6 +39,39 @@ class IntegerTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_exclusive_min_value(): void
+    {
+        $type = JsonSchema::integer()->title('Age')->exclusiveMin(5);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'title' => 'Age',
+            'exclusiveMinimum' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value(): void
+    {
+        $type = JsonSchema::integer()->description('Max age')->exclusiveMax(10);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'description' => 'Max age',
+            'exclusiveMaximum' => 10,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_both_exclusive_bounds(): void
+    {
+        $type = JsonSchema::integer()->exclusiveMin(0)->exclusiveMax(100);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'exclusiveMinimum' => 0,
+            'exclusiveMaximum' => 100,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::integer()->enum([1, 2, 3]);

--- a/tests/JsonSchema/NumberTypeTest.php
+++ b/tests/JsonSchema/NumberTypeTest.php
@@ -61,6 +61,61 @@ class NumberTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_exclusive_min_value_as_float(): void
+    {
+        $type = JsonSchema::number()->title('Price')->exclusiveMin(5.5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'title' => 'Price',
+            'exclusiveMinimum' => 5.5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_min_value_as_int(): void
+    {
+        $type = JsonSchema::number()->title('Price')->exclusiveMin(5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'title' => 'Price',
+            'exclusiveMinimum' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value_as_float(): void
+    {
+        $type = JsonSchema::number()->description('Max price')->exclusiveMax(10.75);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'description' => 'Max price',
+            'exclusiveMaximum' => 10.75,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_exclusive_max_value_as_int(): void
+    {
+        $type = JsonSchema::number()->description('Max price')->exclusiveMax(10);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'description' => 'Max price',
+            'exclusiveMaximum' => 10,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_both_exclusive_bounds(): void
+    {
+        $type = JsonSchema::number()->exclusiveMin(0.0)->exclusiveMax(100.5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'exclusiveMinimum' => 0.0,
+            'exclusiveMaximum' => 100.5,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::number()->enum([1, 2.5, 3]);

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -160,6 +160,9 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(120), 120],
             [JsonSchema::integer()->default(18), 18],
             [JsonSchema::integer()->enum([1, 2, 3]), 2],
+            [JsonSchema::integer()->exclusiveMin(5), 6],
+            [JsonSchema::integer()->exclusiveMax(10), 9],
+            [JsonSchema::integer()->exclusiveMin(0)->exclusiveMax(10), 5],
             // additional IntegerType cases
             [JsonSchema::integer()->min(-5), -5], // negative boundary
             [JsonSchema::integer()->max(10), 9], // below max
@@ -176,6 +179,9 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(100.0), 99.9],
             [JsonSchema::number()->default(9.99), 9.99],
             [JsonSchema::number()->enum([1, 2.5, 3]), 2.5],
+            [JsonSchema::number()->exclusiveMin(5.0), 5.1],
+            [JsonSchema::number()->exclusiveMax(10.5), 10.4],
+            [JsonSchema::number()->exclusiveMin(0.0)->exclusiveMax(1.0), 0.5],
             // additional NumberType cases
             [JsonSchema::number()->min(-10.5), -10.5], // negative boundary
             [JsonSchema::number()->min(0)->max(1), 1.0], // boundary at max
@@ -309,6 +315,9 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(5), 6], // above max
             [JsonSchema::integer()->default(1), '1'], // wrong type
             [JsonSchema::integer()->enum([1, 2, 3]), 4], // not in enum
+            [JsonSchema::integer()->exclusiveMin(5), 5], // boundary not allowed
+            [JsonSchema::integer()->exclusiveMax(10), 10], // boundary not allowed
+            [JsonSchema::integer()->exclusiveMin(0), 0], // zero boundary not allowed
             // additional IntegerType cases
             [JsonSchema::integer()->min(0), -1], // below min boundary
             [JsonSchema::integer()->max(0), 1], // above max boundary
@@ -324,6 +333,9 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(1.5), 1.6], // above max
             [JsonSchema::number()->default(1.1), '1.1'], // wrong type
             [JsonSchema::number()->enum([1, 2.5, 3]), 4], // not in enum
+            [JsonSchema::number()->exclusiveMin(5.0), 5.0], // boundary not allowed
+            [JsonSchema::number()->exclusiveMax(10.5), 10.5], // boundary not allowed
+            [JsonSchema::number()->exclusiveMin(0.0), 0.0], // zero boundary not allowed
             // additional NumberType cases
             [JsonSchema::number()->min(0), -0.0001], // below min
             [JsonSchema::number()->max(10), 10.0001], // above max


### PR DESCRIPTION
**Summary:**

- Adds `exclusiveMin()` and `exclusiveMax()` fluent methods to `IntegerType` and `NumberType` in the JsonSchema package
- These map directly to the standard JSON Schema `exclusiveMinimum` and `exclusiveMaximum` keywords
- No changes to the `Serializer` were needed as it already handles new properties via `get_object_vars()`

**Motivation:**
The JSON Schema specification defines `exclusiveMinimum` and `exclusiveMaximum` as standard keywords for numeric validation. Currently, only inclusive bounds (`minimum` / `maximum`) are supported. This addition completes the numeric range constraint API.

**Example:**

```php
JsonSchema::integer()->exclusiveMin(0)->exclusiveMax(150); // Age must be greater than 0 and less than 150

JsonSchema::number()->exclusiveMin(0.00); // Price must be greater than 0.00
```