### PR TITLE
[12.x] Add multipleOf support to JsonSchema numeric types

### DIFF
--- a/src/Illuminate/JsonSchema/Types/IntegerType.php
+++ b/src/Illuminate/JsonSchema/Types/IntegerType.php
@@ -35,6 +35,21 @@ class IntegerType extends Type
     }
 
     /**
+     * The value must be a multiple of this number.
+     */
+    protected ?int $multipleOf = null;
+
+    /**
+     * Set the multipleOf constraint.
+     */
+    public function multipleOf(int $value): static
+    {
+        $this->multipleOf = $value;
+
+        return $this;
+    }
+
+    /**
      * Set the type's default value.
      */
     public function default(int $value): static

--- a/src/Illuminate/JsonSchema/Types/IntegerType.php
+++ b/src/Illuminate/JsonSchema/Types/IntegerType.php
@@ -15,6 +15,11 @@ class IntegerType extends Type
     protected ?int $maximum = null;
 
     /**
+     * The number the value must be a multiple of.
+     */
+    protected ?int $multipleOf = null;
+
+    /**
      * Set the minimum value (inclusive).
      */
     public function min(int $value): static
@@ -35,12 +40,7 @@ class IntegerType extends Type
     }
 
     /**
-     * The value must be a multiple of this number.
-     */
-    protected ?int $multipleOf = null;
-
-    /**
-     * Set the multipleOf constraint.
+     * Set the number the value must be a multiple of.
      */
     public function multipleOf(int $value): static
     {

--- a/src/Illuminate/JsonSchema/Types/NumberType.php
+++ b/src/Illuminate/JsonSchema/Types/NumberType.php
@@ -35,6 +35,21 @@ class NumberType extends Type
     }
 
     /**
+     * The value must be a multiple of this number.
+     */
+    protected int|float|null $multipleOf = null;
+
+    /**
+     * Set the multipleOf constraint.
+     */
+    public function multipleOf(int|float $value): static
+    {
+        $this->multipleOf = $value;
+
+        return $this;
+    }
+
+    /**
      * Set the type's default value.
      */
     public function default(int|float $value): static

--- a/src/Illuminate/JsonSchema/Types/NumberType.php
+++ b/src/Illuminate/JsonSchema/Types/NumberType.php
@@ -15,6 +15,11 @@ class NumberType extends Type
     protected int|float|null $maximum = null;
 
     /**
+     * The number the value must be a multiple of.
+     */
+    protected int|float|null $multipleOf = null;
+
+    /**
      * Set the minimum value (inclusive).
      */
     public function min(int|float $value): static
@@ -35,12 +40,7 @@ class NumberType extends Type
     }
 
     /**
-     * The value must be a multiple of this number.
-     */
-    protected int|float|null $multipleOf = null;
-
-    /**
-     * Set the multipleOf constraint.
+     * Set the number the value must be a multiple of.
      */
     public function multipleOf(int|float $value): static
     {

--- a/tests/JsonSchema/IntegerTypeTest.php
+++ b/tests/JsonSchema/IntegerTypeTest.php
@@ -39,6 +39,28 @@ class IntegerTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_multiple_of(): void
+    {
+        $type = JsonSchema::integer()->multipleOf(5);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'multipleOf' => 5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_multiple_of_with_min_and_max(): void
+    {
+        $type = JsonSchema::integer()->min(0)->max(100)->multipleOf(10);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'minimum' => 0,
+            'maximum' => 100,
+            'multipleOf' => 10,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::integer()->enum([1, 2, 3]);

--- a/tests/JsonSchema/NumberTypeTest.php
+++ b/tests/JsonSchema/NumberTypeTest.php
@@ -61,6 +61,38 @@ class NumberTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_multiple_of_as_float(): void
+    {
+        $type = JsonSchema::number()->multipleOf(0.5);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'multipleOf' => 0.5,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_set_multiple_of_as_int(): void
+    {
+        $type = JsonSchema::number()->multipleOf(3);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'multipleOf' => 3,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_multiple_of_with_min_and_max(): void
+    {
+        $type = JsonSchema::number()->min(0.0)->max(10.0)->multipleOf(0.25);
+
+        $this->assertEquals([
+            'type' => 'number',
+            'minimum' => 0.0,
+            'maximum' => 10.0,
+            'multipleOf' => 0.25,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::number()->enum([1, 2.5, 3]);

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -160,6 +160,9 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(120), 120],
             [JsonSchema::integer()->default(18), 18],
             [JsonSchema::integer()->enum([1, 2, 3]), 2],
+            [JsonSchema::integer()->multipleOf(5), 10],
+            [JsonSchema::integer()->multipleOf(3), 9],
+            [JsonSchema::integer()->multipleOf(7), 0],
             // additional IntegerType cases
             [JsonSchema::integer()->min(-5), -5], // negative boundary
             [JsonSchema::integer()->max(10), 9], // below max
@@ -176,6 +179,9 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(100.0), 99.9],
             [JsonSchema::number()->default(9.99), 9.99],
             [JsonSchema::number()->enum([1, 2.5, 3]), 2.5],
+            [JsonSchema::number()->multipleOf(0.5), 2.5],
+            [JsonSchema::number()->multipleOf(3), 9],
+            [JsonSchema::number()->multipleOf(0.1), 0.3],
             // additional NumberType cases
             [JsonSchema::number()->min(-10.5), -10.5], // negative boundary
             [JsonSchema::number()->min(0)->max(1), 1.0], // boundary at max
@@ -309,6 +315,8 @@ class TypeTest extends TestCase
             [JsonSchema::integer()->max(5), 6], // above max
             [JsonSchema::integer()->default(1), '1'], // wrong type
             [JsonSchema::integer()->enum([1, 2, 3]), 4], // not in enum
+            [JsonSchema::integer()->multipleOf(5), 7], // not a multiple
+            [JsonSchema::integer()->multipleOf(3), 10], // not a multiple
             // additional IntegerType cases
             [JsonSchema::integer()->min(0), -1], // below min boundary
             [JsonSchema::integer()->max(0), 1], // above max boundary
@@ -324,6 +332,8 @@ class TypeTest extends TestCase
             [JsonSchema::number()->max(1.5), 1.6], // above max
             [JsonSchema::number()->default(1.1), '1.1'], // wrong type
             [JsonSchema::number()->enum([1, 2.5, 3]), 4], // not in enum
+            [JsonSchema::number()->multipleOf(0.5), 1.3], // not a multiple
+            [JsonSchema::number()->multipleOf(3), 10], // not a multiple
             // additional NumberType cases
             [JsonSchema::number()->min(0), -0.0001], // below min
             [JsonSchema::number()->max(10), 10.0001], // above max


### PR DESCRIPTION
**Summary:**
- Adds `multipleOf()` fluent method to `IntegerType` and `NumberType` in the JsonSchema package
- Maps directly to the standard JSON Schema `multipleOf` keyword
- No changes to the `Serializer` were needed as it already handles new properties via `get_object_vars()`

**Motivation:**

The JSON Schema specification defines `multipleOf` as a standard keyword for numeric validation, ensuring a value is a multiple of a given number. This is commonly used for constraints like "must be even" (`multipleOf(2)`), step-based inputs (`multipleOf(0.25)`), or currency precision (`multipleOf(0.01)`).

**Example:**

```php
// Even numbers only
JsonSchema::integer()->multipleOf(2);

// Price with quarter-dollar precision
JsonSchema::number()->min(0.0)->max(100.0)->multipleOf(0.25);
```