### PR TITLE
[12.x] Rollback lingering PDO transaction before retrying on commit deadlock

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -234,6 +234,12 @@ trait ManagesTransactions
         $this->transactions = max(0, $this->transactions - 1);
 
         if ($this->causedByConcurrencyError($e) && $currentAttempt < $maxAttempts) {
+            $pdo = $this->getPdo();
+
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+
             return;
         }
 


### PR DESCRIPTION
Fixes #58894

When `DB::transaction()` retries after a deadlock during commit, the PDO connection may still have an active (implicit) transaction because MySQL keeps autocommit disabled for the session. The next `beginTransaction()` call then throws `PDOException: "There is already an active transaction"`.

This adds a simple `$pdo->rollBack()` in `handleCommitTransactionException` before returning for retry, matching how `handleTransactionException` already cleans up PDO state through `performRollback()` when deadlocks occur during the callback.