### PR TITLE
[12.x] Add toText method to View for plain text rendering

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -494,6 +494,16 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
     }
 
     /**
+     * Get the string contents of the view with trailing newlines trimmed.
+     *
+     * @return string
+     */
+    public function toText()
+    {
+        return rtrim($this->render(), PHP_EOL);
+    }
+
+    /**
      * Get the string contents of the view.
      *
      * @return string

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -99,6 +99,32 @@ class ViewTest extends TestCase
         $this->assertSame('contents', (string) $view);
     }
 
+    public function testToTextTrimsTrailingNewlines()
+    {
+        $view = $this->getView(['foo' => 'bar']);
+        $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
+        $view->getFactory()->shouldReceive('callComposer')->once()->ordered()->with($view);
+        $view->getFactory()->shouldReceive('getShared')->once()->andReturn(['shared' => 'foo']);
+        $view->getEngine()->shouldReceive('get')->once()->with('path', ['foo' => 'bar', 'shared' => 'foo'])->andReturn("contents\n");
+        $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
+        $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->once();
+
+        $this->assertSame('contents', $view->toText());
+    }
+
+    public function testToTextPreservesInternalNewlines()
+    {
+        $view = $this->getView();
+        $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
+        $view->getFactory()->shouldReceive('callComposer')->once()->ordered()->with($view);
+        $view->getFactory()->shouldReceive('getShared')->once()->andReturn(['shared' => 'foo']);
+        $view->getEngine()->shouldReceive('get')->once()->andReturn("line1\nline2\n\n\n");
+        $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
+        $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->once();
+
+        $this->assertSame("line1\nline2", $view->toText());
+    }
+
     public function testViewNestBindsASubView()
     {
         $view = $this->getView();


### PR DESCRIPTION
## Summary
- Adds a `toText()` method to the `View` class as the plain-text counterpart to `toHtml()`
- Returns the rendered view contents with trailing newlines trimmed via `rtrim($this->render(), PHP_EOL)`
- Useful when Blade views are used as plain-text templates (AI prompts, SMS, CLI output) where trailing newlines from Blade are undesirable

**Before:**
```php
rtrim((string) view('prompts.company-profile', $data), PHP_EOL);
```

**After:**
```php
view('prompts.company-profile', $data)->toText();
```

## Test plan
- [x] Added test for trailing newline trimming
- [x] Added test for preserving internal newlines while trimming trailing ones
- [x] All existing View tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)