### PR TITLE
[12.x] Allow `down` command to refresh maintenance mode options

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -59,7 +59,7 @@ class DownCommand extends Command
             $this->laravel->get('events')->dispatch(new MaintenanceModeEnabled());
 
             $this->components->info($wasAlreadyDown
-                ? 'Maintenance mode refreshed.'
+                ? 'Maintenance mode options updated.'
                 : 'Application is now in maintenance mode.'
             );
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -45,11 +45,7 @@ class DownCommand extends Command
     public function handle()
     {
         try {
-            if ($this->laravel->maintenanceMode()->active() && ! $this->getSecret()) {
-                $this->components->info('Application is already down.');
-
-                return 0;
-            }
+            $wasAlreadyDown = $this->laravel->maintenanceMode()->active();
 
             $downFilePayload = $this->getDownFilePayload();
 
@@ -62,7 +58,10 @@ class DownCommand extends Command
 
             $this->laravel->get('events')->dispatch(new MaintenanceModeEnabled());
 
-            $this->components->info('Application is now in maintenance mode.');
+            $this->components->info($wasAlreadyDown
+                ? 'Maintenance mode refreshed.'
+                : 'Application is now in maintenance mode.'
+            );
 
             if ($downFilePayload['secret'] !== null) {
                 $this->components->info('You may bypass maintenance mode via ['.config('app.url')."/{$downFilePayload['secret']}].");

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -266,7 +266,7 @@ class MaintenanceModeTest extends TestCase
         $this->assertSame(60, $data['retry']);
 
         $this->artisan(DownCommand::class, ['--retry' => 120])
-            ->expectsOutputToContain('Maintenance mode refreshed.');
+            ->expectsOutputToContain('Maintenance mode options updated.');
 
         $data = json_decode(file_get_contents(storage_path('framework/down')), true);
         $this->assertSame(120, $data['retry']);

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -257,6 +257,21 @@ class MaintenanceModeTest extends TestCase
         $this->assertSame($expectedDate, $data['retry']);
     }
 
+    public function testMaintenanceModeCanBeRefreshedWithNewOptions()
+    {
+        $this->artisan(DownCommand::class, ['--retry' => 60])
+            ->expectsOutputToContain('Application is now in maintenance mode.');
+
+        $data = json_decode(file_get_contents(storage_path('framework/down')), true);
+        $this->assertSame(60, $data['retry']);
+
+        $this->artisan(DownCommand::class, ['--retry' => 120])
+            ->expectsOutputToContain('Maintenance mode refreshed.');
+
+        $data = json_decode(file_get_contents(storage_path('framework/down')), true);
+        $this->assertSame(120, $data['retry']);
+    }
+
     public function testMaintenanceModeRespectsBootstrapConfiguredExcludedPaths()
     {
         PreventRequestsDuringMaintenance::except([


### PR DESCRIPTION
Previously, running `artisan down` when the application was already in maintenance mode would early-return with "Application is already down" and ignore any new options. This made it impossible to update `--retry`, `--render`, `--refresh`, or other options without first running `up` (which briefly exposes the app). The workaround was to use `--with-secret` option, what was not so obvious.

Now the command always re-activates maintenance mode with the provided options, displaying "Maintenance mode refreshed." when updating an existing maintenance state.

**Example use case:** a deploy script puts the app in maintenance mode, then later needs to update the retry header:

```bash
php artisan down --retry=60
# ... later in the script ...
php artisan down --retry="+90 mins" --render="pages.errors.503"
# Previously: "Application is already down." (options ignored)
# Now: "Maintenance mode refreshed." (options applied)
```