### PR TITLE
[13.x] Resolve DeleteNotificationWhenMissingModelTest 

### DIFF
--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -22,7 +22,7 @@ class DeleteModelWhenMissingTest extends QueueTestCase
         $this->driver = 'database';
     }
 
-    protected function defineDatabaseMigrations()
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         Schema::create('delete_model_test_models', function (Blueprint $table) {
             $table->id();

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -25,7 +25,7 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
         $this->driver = 'database';
     }
 
-    protected function defineDatabaseMigrations()
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         Schema::create('delete_notification_test_models', function (Blueprint $table) {
             $table->id();


### PR DESCRIPTION
This is failing heavy on 13.x https://github.com/laravel/framework/actions/runs/22160696656/job/64076395590 so thought I'd poke it.

Basically the table gets wiped before the test runs cause of `DatabaseMigrations`, so  changing `defineDatabaseMigrations` to `defineDatabaseMigrationsAfterDatabaseRefreshed` ensures tis' ran after the wipe.. 

I've updated both just to ensure it doesn't cause freak behavior again. 