### PR TITLE
[12.x] Implemented fulltext search for SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -108,7 +108,11 @@ class Grammar extends BaseGrammar
     {
         $sql = [];
 
-        foreach ($this->selectComponents as $component) {
+        // Reverse so that each component can add parts to earlier
+        // components if necessary. For example, a "where" component can
+        // add a "join" component if it needs to create a where clause
+        // on a joined table.
+        foreach (array_reverse($this->selectComponents) as $component) {
             if (isset($query->$component)) {
                 $method = 'compile'.ucfirst($component);
 
@@ -116,7 +120,8 @@ class Grammar extends BaseGrammar
             }
         }
 
-        return $sql;
+        // Finally, we will reverse the components back to the original order
+        return array_reverse($sql);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -436,7 +436,8 @@ class SQLiteGrammar extends Grammar
     public function compileFulltext(Blueprint $blueprint, Fluent $command)
     {
         $new = join(', ', array_map(fn ($col) => 'new.'.$this->wrap($col), $command->columns));
-        $cols = join(', ', array_map(fn ($col) => $this->wrap($col), $command->columns));
+        $cols = $this->columnize($command->columns);
+        $len = $command->prefixlength ?: '3 4';
 
         $ftsTable = $this->wrapTable($blueprint->getTable().'_fts');
         $table = $this->wrapTable($blueprint->getTable());
@@ -444,7 +445,7 @@ class SQLiteGrammar extends Grammar
 
         return [
             // Create FTS virtual table
-            sprintf('create virtual table %s using fts5(%s, prefix=3)', $ftsTable, $cols),
+            sprintf('create virtual table %s using fts5(%s, prefix=\'%s\')', $ftsTable, $cols, $len),
 
             // Insert trigger
             sprintf(

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -254,7 +254,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql();
 
         $this->assertCount(4, $statements);
-        $this->assertSame('create virtual table "users_fts" using fts5("body", prefix=3)', $statements[0]);
+        $this->assertSame('create virtual table "users_fts" using fts5("body", prefix=\'3 4\')', $statements[0]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -247,6 +247,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame(['create index "foo"."baz" on "users" ("foo", "bar")'], $blueprint->toSql());
     }
 
+    public function testAddingFulltextIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fulltext('body');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(4, $statements);
+        $this->assertSame('create virtual table "users_fts" using fts5("body", prefix=3)', $statements[0]);
+    }
+
     public function testAddingSpatialIndex()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Integration/Database/Sqlite/FulltextTest.php
+++ b/tests/Integration/Database/Sqlite/FulltextTest.php
@@ -28,7 +28,7 @@ class FulltextTest extends DatabaseTestCase
             $table->id('id');
             $table->string('title', 200);
             $table->text('body');
-            $table->fulltext(['title', 'body']);
+            $table->fulltext(['title', 'body'])->prefixlength('2 3');
         });
     }
 

--- a/tests/Integration/Database/Sqlite/FulltextTest.php
+++ b/tests/Integration/Database/Sqlite/FulltextTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Sqlite;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+
+#[RequiresDatabase('sqlite')]
+class FulltextTest extends DatabaseTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('database.default', 'conn1');
+
+        $app['config']->set('database.connections.conn1', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title', 200);
+            $table->text('body');
+            $table->fulltext(['title', 'body']);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('articles');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('articles')->insert([
+            ['title' => 'SQLite Tutorial', 'body' => 'DBMS stands for DataBase ...'],
+            ['title' => 'How To Use SQLite Well', 'body' => 'After you went through a ...'],
+            ['title' => 'Optimizing SQLite', 'body' => 'In this tutorial, we show ...'],
+            ['title' => '1001 SQLite Tricks', 'body' => '1. sqlite3: Use this command. 2. ...'],
+            ['title' => 'SQLite vs. YourSQL', 'body' => 'Databases: In the following database comparison ...'],
+            ['title' => 'SQLite Security', 'body' => 'When configured properly, SQLite ...'],
+        ]);
+    }
+
+    public function testWhereFulltext()
+    {
+        $articles = DB::table('articles')
+            ->select('title')
+            ->whereFullText(['title', 'body'], 'database')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('SQLite Tutorial', $articles[0]->title);
+        $this->assertSame('SQLite vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextMultiple()
+    {
+        $articles = DB::table('articles')
+            ->select('title')
+            ->whereFullText(['title', 'body'], 'sqlite database')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('SQLite Tutorial', $articles[0]->title);
+        $this->assertSame('SQLite vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextPrefix()
+    {
+        $articles = DB::table('articles')
+            ->select(['title'])
+            ->whereFullText(['title', 'body'], 'sql* database*')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('SQLite Tutorial', $articles[0]->title);
+        $this->assertSame('SQLite vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextPhrase()
+    {
+        $articles = DB::table('articles')
+            ->select(['title'])
+            ->whereFullText(['title', 'body'], '"use sqlite"')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(1, $articles);
+        $this->assertSame('How To Use SQLite Well', $articles[0]->title);
+    }
+
+    public function testWhereFulltextBoolean()
+    {
+        $articles = DB::table('articles')
+            ->select(['title'])
+            ->whereFullText(['title', 'body'], 'sqlite NOT database*')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(4, $articles);
+        $this->assertSame('How To Use SQLite Well', $articles[0]->title);
+    }
+}


### PR DESCRIPTION
Adds compileFullText(), compileDropFullText() and whereFullText() to SQLite grammar. It uses SQLite FT5 virtual tables for full text index which requires triggers to keep the FT5 virtual table in sync with the original table.

There's a change in Illuminate/Database/Query/Grammars/Grammar.php that reverses generating the components of the SQL string from last to first so where*() methods can add joins or other components. This is required because the FT5 table has to be joined with the original table when fulltext search is used.

There should be no backward incompatibilites as no code besides the reversal of the component generation has been changed, only added.

Documentation update:
SQLite supports fast prefix indexes which you can configure as list of index lengths:
```
$table->fulltext(['title', 'body'])->prefixlength('2 3');
```