### PR TITLE
[12.x] Add uniqueItems support to JsonSchema ArrayType

### DIFF
--- a/src/Illuminate/JsonSchema/Types/ArrayType.php
+++ b/src/Illuminate/JsonSchema/Types/ArrayType.php
@@ -20,6 +20,11 @@ class ArrayType extends Type
     protected ?Type $items = null;
 
     /**
+     * Whether the array items must be unique.
+     */
+    protected ?bool $uniqueItems = null;
+
+    /**
      * Set the minimum number of items (inclusive).
      */
     public function min(int $value): static
@@ -45,6 +50,18 @@ class ArrayType extends Type
     public function items(Type $type): static
     {
         $this->items = $type;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that array items must be unique.
+     */
+    public function uniqueItems(bool $uniqueItems = true): static
+    {
+        if ($uniqueItems) {
+            $this->uniqueItems = true;
+        }
 
         return $this;
     }

--- a/src/Illuminate/JsonSchema/Types/ArrayType.php
+++ b/src/Illuminate/JsonSchema/Types/ArrayType.php
@@ -57,9 +57,9 @@ class ArrayType extends Type
     /**
      * Indicate that array items must be unique.
      */
-    public function uniqueItems(bool $uniqueItems = true): static
+    public function unique(bool $unique = true): static
     {
-        if ($uniqueItems) {
+        if ($unique) {
             $this->uniqueItems = true;
         }
 

--- a/src/Illuminate/JsonSchema/Types/ArrayType.php
+++ b/src/Illuminate/JsonSchema/Types/ArrayType.php
@@ -55,7 +55,7 @@ class ArrayType extends Type
     }
 
     /**
-     * Indicate that array items must be unique.
+     * Indicate that the array items must be unique.
      */
     public function unique(bool $unique = true): static
     {

--- a/tests/JsonSchema/ArrayTypeTest.php
+++ b/tests/JsonSchema/ArrayTypeTest.php
@@ -56,7 +56,7 @@ class ArrayTypeTest extends TestCase
 
     public function test_it_may_set_unique_items(): void
     {
-        $type = JsonSchema::array()->items(JsonSchema::string())->uniqueItems();
+        $type = JsonSchema::array()->items(JsonSchema::string())->unique();
 
         $this->assertEquals([
             'type' => 'array',
@@ -69,7 +69,7 @@ class ArrayTypeTest extends TestCase
 
     public function test_it_may_combine_unique_items_with_min_and_max(): void
     {
-        $type = JsonSchema::array()->min(1)->max(5)->uniqueItems();
+        $type = JsonSchema::array()->min(1)->max(5)->unique();
 
         $this->assertEquals([
             'type' => 'array',

--- a/tests/JsonSchema/ArrayTypeTest.php
+++ b/tests/JsonSchema/ArrayTypeTest.php
@@ -54,6 +54,31 @@ class ArrayTypeTest extends TestCase
         ], $type->toArray());
     }
 
+    public function test_it_may_set_unique_items(): void
+    {
+        $type = JsonSchema::array()->items(JsonSchema::string())->uniqueItems();
+
+        $this->assertEquals([
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+            ],
+            'uniqueItems' => true,
+        ], $type->toArray());
+    }
+
+    public function test_it_may_combine_unique_items_with_min_and_max(): void
+    {
+        $type = JsonSchema::array()->min(1)->max(5)->uniqueItems();
+
+        $this->assertEquals([
+            'type' => 'array',
+            'minItems' => 1,
+            'maxItems' => 5,
+            'uniqueItems' => true,
+        ], $type->toArray());
+    }
+
     public function test_it_may_set_enum(): void
     {
         $type = JsonSchema::array()->enum([

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -279,9 +279,9 @@ class TypeTest extends TestCase
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['one', 'two']],
             [JsonSchema::array()->default(['x']), ['x']],
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['b', 'c']],
-            [JsonSchema::array()->uniqueItems(), [1, 2, 3]],
-            [JsonSchema::array()->items(JsonSchema::string())->uniqueItems(), ['a', 'b', 'c']],
-            [JsonSchema::array()->uniqueItems(), []],
+            [JsonSchema::array()->unique(), [1, 2, 3]],
+            [JsonSchema::array()->items(JsonSchema::string())->unique(), ['a', 'b', 'c']],
+            [JsonSchema::array()->unique(), []],
             // additional ArrayType cases
             [JsonSchema::array()->min(0), []], // explicit min zero
             [JsonSchema::array()->max(0), []], // exactly zero length
@@ -375,8 +375,8 @@ class TypeTest extends TestCase
             [JsonSchema::array()->max(1), ['a', 'b']], // too many items
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['four']], // item too long
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['c', 'd']], // not in enum
-            [JsonSchema::array()->uniqueItems(), [1, 1, 2]],
-            [JsonSchema::array()->items(JsonSchema::string())->uniqueItems(), ['a', 'b', 'a']],
+            [JsonSchema::array()->unique(), [1, 1, 2]],
+            [JsonSchema::array()->items(JsonSchema::string())->unique(), ['a', 'b', 'a']],
             // additional ArrayType cases
             [JsonSchema::array()->items(JsonSchema::integer()), ['a']], // wrong item type
             [JsonSchema::array()->min(1), []], // too few

--- a/tests/JsonSchema/TypeTest.php
+++ b/tests/JsonSchema/TypeTest.php
@@ -279,6 +279,9 @@ class TypeTest extends TestCase
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['one', 'two']],
             [JsonSchema::array()->default(['x']), ['x']],
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['b', 'c']],
+            [JsonSchema::array()->uniqueItems(), [1, 2, 3]],
+            [JsonSchema::array()->items(JsonSchema::string())->uniqueItems(), ['a', 'b', 'c']],
+            [JsonSchema::array()->uniqueItems(), []],
             // additional ArrayType cases
             [JsonSchema::array()->min(0), []], // explicit min zero
             [JsonSchema::array()->max(0), []], // exactly zero length
@@ -372,6 +375,8 @@ class TypeTest extends TestCase
             [JsonSchema::array()->max(1), ['a', 'b']], // too many items
             [JsonSchema::array()->items(JsonSchema::string()->max(3)), ['four']], // item too long
             [JsonSchema::array()->enum([['a'], ['b', 'c']]), ['c', 'd']], // not in enum
+            [JsonSchema::array()->uniqueItems(), [1, 1, 2]],
+            [JsonSchema::array()->items(JsonSchema::string())->uniqueItems(), ['a', 'b', 'a']],
             // additional ArrayType cases
             [JsonSchema::array()->items(JsonSchema::integer()), ['a']], // wrong item type
             [JsonSchema::array()->min(1), []], // too few


### PR DESCRIPTION
This PR adds `uniqueItems()` support to `ArrayType` in the JsonSchema package, mapping directly to the standard JSON Schema `uniqueItems` keyword.

This is useful when building schemas for things like tags, permission lists, or category selections — anywhere you'd want to ensure no duplicate values in an array.

**Example:**

```php
JsonSchema::array()->items(JsonSchema::string())->uniqueItems();   //  list of unique tags

JsonSchema::array()->min(1)->max(10)->uniqueItems();  // Between 1 and 10 unique items
```