### PR TITLE
[12.x] Simplify TokenGuard methods

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -96,21 +96,10 @@ class TokenGuard implements Guard
      */
     public function getTokenForRequest()
     {
-        $token = $this->request->query($this->inputKey);
-
-        if (empty($token)) {
-            $token = $this->request->input($this->inputKey);
-        }
-
-        if (empty($token)) {
-            $token = $this->request->bearerToken();
-        }
-
-        if (empty($token)) {
-            $token = $this->request->getPassword();
-        }
-
-        return $token;
+        return $this->request->query($this->inputKey)
+            ?: $this->request->input($this->inputKey)
+            ?: $this->request->bearerToken()
+            ?: $this->request->getPassword();
     }
 
     /**
@@ -127,11 +116,7 @@ class TokenGuard implements Guard
 
         $credentials = [$this->storageKey => $credentials[$this->inputKey]];
 
-        if ($this->provider->retrieveByCredentials($credentials)) {
-            return true;
-        }
-
-        return false;
+        return (bool) $this->provider->retrieveByCredentials($credentials);
     }
 
     /**


### PR DESCRIPTION
Small cleanup for TokenGuard:

`getTokenForRequest()`: Replaced the chain of if (empty()) assignments with a ?: (Elvis operator) chain which reads more naturally and does the same thing return the first non-empty token from query string input bearer header or basic auth password

`validate()`: Replaced the if (...) return true; return false; block with a direct return (bool) cast since retrieveByCredentials already returns Authenticatable|null

No behavioral changes :)