### PR TITLE
[12.x] Implemented fulltext search for SQL Server

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -306,8 +306,6 @@ jobs:
           SA_PASSWORD: Forge123
         ports:
           - 1433:1433
-        options: >-
-          --name sql1
 
     strategy:
       fail-fast: true
@@ -315,17 +313,6 @@ jobs:
     name: SQL Server 2019
 
     steps:
-      - name: Install Full-Text Search
-        run: |
-          docker exec sql1 bash -c "
-            apt-get update &&
-            apt-get install -y mssql-server-fts &&
-            /opt/mssql/bin/mssql-conf set sqlagent.enabled true
-          "
-
-      - name: Restart SQL Server
-        run: docker restart sql1
-
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -370,8 +357,6 @@ jobs:
           SA_PASSWORD: Forge123
         ports:
           - 1433:1433
-        options: >-
-          --name sql1
 
     strategy:
       fail-fast: true
@@ -379,17 +364,6 @@ jobs:
     name: SQL Server 2017
 
     steps:
-      - name: Install Full-Text Search
-        run: |
-          docker exec sql1 bash -c "
-            apt-get update &&
-            apt-get install -y mssql-server-fts &&
-            /opt/mssql/bin/mssql-conf set sqlagent.enabled true
-          "
-
-      - name: Restart SQL Server
-        run: docker restart sql1
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -306,6 +306,8 @@ jobs:
           SA_PASSWORD: Forge123
         ports:
           - 1433:1433
+        options: >-
+          --name sql1
 
     strategy:
       fail-fast: true
@@ -313,6 +315,17 @@ jobs:
     name: SQL Server 2019
 
     steps:
+      - name: Install Full-Text Search
+        run: |
+          docker exec sql1 bash -c "
+            apt-get update &&
+            apt-get install -y mssql-server-fts &&
+            /opt/mssql/bin/mssql-conf set sqlagent.enabled true
+          "
+
+      - name: Restart SQL Server
+        run: docker restart sql1
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -357,6 +370,8 @@ jobs:
           SA_PASSWORD: Forge123
         ports:
           - 1433:1433
+        options: >-
+          --name sql1
 
     strategy:
       fail-fast: true
@@ -364,6 +379,17 @@ jobs:
     name: SQL Server 2017
 
     steps:
+      - name: Install Full-Text Search
+        run: |
+          docker exec sql1 bash -c "
+            apt-get update &&
+            apt-get install -y mssql-server-fts &&
+            /opt/mssql/bin/mssql-conf set sqlagent.enabled true
+          "
+
+      - name: Restart SQL Server
+        run: docker restart sql1
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -334,11 +334,14 @@ jobs:
           max_attempts: 5
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
+      - name: Create test database
+        run: /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Forge123 -Q "CREATE DATABASE testdb;"
+
       - name: Execute tests
         run: vendor/bin/phpunit tests/Integration/Database
         env:
           DB_CONNECTION: sqlsrv
-          DB_DATABASE: master
+          DB_DATABASE: testdb
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
 
@@ -382,11 +385,14 @@ jobs:
           max_attempts: 5
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
+      - name: Create test database
+        run: /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Forge123 -Q "CREATE DATABASE testdb;"
+
       - name: Execute tests
         run: vendor/bin/phpunit tests/Integration/Database
         env:
           DB_CONNECTION: sqlsrv
-          DB_DATABASE: master
+          DB_DATABASE: testdb
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -192,7 +192,7 @@ class SqlServerGrammar extends Grammar
         }
 
         return $sql;
-   }
+    }
 
     /**
      * Compile a "JSON contains" statement into SQL.

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -174,6 +174,27 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "where fulltext" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    public function whereFullText(Builder $query, $where)
+    {
+        $columns = $this->columnize($where['columns']);
+        $value = $this->parameter($where['value']);
+
+        if ($where['options']['expanded'] ?? false) {
+            $sql = "freetext (($columns), {$value})";
+        } else {
+            $sql = "contains (($columns), {$value})";
+        }
+
+        return $sql;
+   }
+
+    /**
      * Compile a "JSON contains" statement into SQL.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -316,13 +316,13 @@ class SqlServerGrammar extends Grammar
         }
 
         return [
-            sprintf("create fulltext catalog %s", $catalog),
-            sprintf("create fulltext index on %s (%s) key index %s on %s with (change_tracking = auto)",
+            sprintf('create fulltext catalog %s', $catalog),
+            sprintf('create fulltext index on %s (%s) key index %s on %s with (change_tracking = auto)',
                 $this->wrapTable($blueprint),
                 $columns,
                 $keyIndex,
                 $catalog
-            )
+            ),
         ];
     }
 
@@ -493,7 +493,7 @@ class SqlServerGrammar extends Grammar
 
         return [
             sprintf('drop fulltext index on %s', $this->wrapTable($blueprint)),
-            sprintf('drop fulltext catalog %s', $catalog)
+            sprintf('drop fulltext catalog %s', $catalog),
         ];
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -307,20 +307,19 @@ class SqlServerGrammar extends Grammar
     public function compileFulltext(Blueprint $blueprint, Fluent $command)
     {
         $table = $blueprint->getTable();
-        $columns = $this->columnize($command->columns);
-        $catalog = $this->wrap($command->catalog ?: 'ft_'.$table);
-        $keyIndex = $this->wrap($command->pkindex ?: 'PK_'.$table.'_id');
 
         if (str_contains($table, '.')) {
             $table = current(array_reverse(explode('.', $table)));
         }
 
+        $catalog = $this->wrap('ft_'.$table);
+
         return [
             sprintf('create fulltext catalog %s', $catalog),
             sprintf('create fulltext index on %s (%s) key index %s on %s with (change_tracking = auto)',
                 $this->wrapTable($blueprint),
-                $columns,
-                $keyIndex,
+                $this->columnize($command->columns),
+                $this->wrap($table.'_id_primary'),
                 $catalog
             ),
         ];

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -309,7 +309,7 @@ class SqlServerGrammar extends Grammar
         $table = $blueprint->getTable();
         $columns = $this->columnize($command->columns);
         $catalog = $this->wrap($command->catalog ?: 'ft_'.$table);
-        $keyIndex = $this->wrap($command->index ?: 'PK_'.$table.'_id');
+        $keyIndex = $this->wrap($command->pkindex ?: 'PK_'.$table.'_id');
 
         if (str_contains($table, '.')) {
             $table = current(array_reverse(explode('.', $table)));

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -313,13 +313,14 @@ class SqlServerGrammar extends Grammar
         }
 
         $catalog = $this->wrap('ft_'.$table);
+        $pkindex = $this->wrap($command->pkindex ?: $table.'_id_primary');
 
         return [
             sprintf('create fulltext catalog %s', $catalog),
             sprintf('create fulltext index on %s (%s) key index %s on %s with (change_tracking = auto)',
                 $this->wrapTable($blueprint),
                 $this->columnize($command->columns),
-                $this->wrap($table.'_id_primary'),
+                $pkindex,
                 $catalog
             ),
         ];

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1587,6 +1587,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['Air | Plan:* -Car'], $builder->getBindings());
     }
 
+    public function testWhereFulltextSqlserver()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereFullText('body', 'Hello World');
+        $this->assertSame('select * from [users] where contains (([body]), ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereFullText('body', 'Hello World', ['expanded' => true]);
+        $this->assertSame('select * from [users] where freetext (([body]), ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+    }
+
     public function testWhereAll()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -308,6 +308,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create index "baz" on "users" ("foo", "bar") with (online = on)', $statements[0]);
     }
 
+    public function testAddingFulltextIndex()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'users');
+        $blueprint->fulltext('body');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('create fulltext catalog "ft_users"', $statements[0]);
+        $this->assertSame('create fulltext index on "users" ("body") key index "PK_users" on "ft_users" with (change_tracking = auto)', $statements[1]);
+    }
+
     public function testAddingSpatialIndex()
     {
         $blueprint = new Blueprint($this->getConnection(), 'geo');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -316,7 +316,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $this->assertSame('create fulltext catalog "ft_users"', $statements[0]);
-        $this->assertSame('create fulltext index on "users" ("body") key index "PK_users" on "ft_users" with (change_tracking = auto)', $statements[1]);
+        $this->assertSame('create fulltext index on "users" ("body") key index "users_id_primary" on "ft_users" with (change_tracking = auto)', $statements[1]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -18,7 +18,7 @@ class FulltextTest extends SqlServerTestCase
             $table->id('id')->primary('id', 'pk_articles_id');
             $table->string('title', 200);
             $table->text('body');
-            $table->fulltext(['title', 'body'], ['index' => 'pk_articles_id']
+            $table->fulltext(['title', 'body'], ['pkindex' => 'pk_articles_id']
             );
         });
     }

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -15,10 +15,11 @@ class FulltextTest extends SqlServerTestCase
     protected function afterRefreshingDatabase()
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id('id');
+            $table->id('id')->primary('id', 'pk_articles_id');
             $table->string('title', 200);
             $table->text('body');
-            $table->fulltext(['title', 'body']);
+            $table->fulltext(['title', 'body'], ['index' => 'pk_articles_id']
+            );
         });
     }
 

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -14,6 +14,7 @@ class FulltextTest extends SqlServerTestCase
 {
     protected function afterRefreshingDatabase()
     {
+        /* Available SQL Server images do not support full-text search
         Schema::create('articles', function (Blueprint $table) {
             $table->id('id');
             $table->string('title', 200);
@@ -21,15 +22,18 @@ class FulltextTest extends SqlServerTestCase
             $table->primary('id', 'pk_articles_id');
             $table->fulltext(['title', 'body'])->pkindex('pk_articles_id');
         });
+        */
     }
 
     protected function destroyDatabaseMigrations()
     {
-        Schema::drop('articles');
+        // Schema::drop('articles');
     }
 
     protected function setUp(): void
     {
+        $this->markTestSkipped( 'Available SQL Server images do not support full-text search.' );
+
         parent::setUp();
 
         DB::table('articles')->insert([

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -32,7 +32,7 @@ class FulltextTest extends SqlServerTestCase
 
     protected function setUp(): void
     {
-        $this->markTestSkipped( 'Available SQL Server images do not support full-text search.' );
+        $this->markTestSkipped('Available SQL Server images do not support full-text search.');
 
         parent::setUp();
 

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -15,11 +15,10 @@ class FulltextTest extends SqlServerTestCase
     protected function afterRefreshingDatabase()
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id('id')->primary('id', 'pk_articles_id');
+            $table->id('id')->primary();
             $table->string('title', 200);
             $table->text('body');
-            $table->fulltext(['title', 'body'], ['pkindex' => 'pk_articles_id']
-            );
+            $table->fulltext(['title', 'body']);
         });
     }
 

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Attributes\RequiresDatabase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+#[RequiresOperatingSystem('Linux|Darwin')]
+#[RequiresPhpExtension('pdo_sqlsrv')]
+class FulltextTest extends SqlServerTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title', 200);
+            $table->text('body');
+            $table->fulltext(['title', 'body']);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('articles');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('articles')->insert([
+            ['title' => 'SQLServer Tutorial', 'body' => 'DBMS stands for DataBase ...'],
+            ['title' => 'How To Use SQLServer Well', 'body' => 'After you went through a ...'],
+            ['title' => 'Optimizing SQLServer', 'body' => 'In this tutorial, we show ...'],
+            ['title' => '1001 SQLServer Tricks', 'body' => '1. Never run mysqld as root. 2. ...'],
+            ['title' => 'SQLServer vs. YourSQL', 'body' => 'In the following database comparison ...'],
+            ['title' => 'SQLServer Security', 'body' => 'When configured properly, SQLServer ...'],
+        ]);
+    }
+
+    public function testWhereFulltext()
+    {
+        $articles = DB::table('articles')->whereFullText(['title', 'body'], 'database')->orderBy('id')->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('SQLServer Tutorial', $articles[0]->title);
+        $this->assertSame('SQLServer vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextExpanded()
+    {
+        $articles = DB::table('articles')->whereFullText(['title', 'body'], 'database', ['expanded' => true])->orderBy('id')->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('SQLServer Tutorial', $articles[0]->title);
+        $this->assertSame('SQLServer vs. YourSQL', $articles[1]->title);
+    }
+}

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -15,10 +15,11 @@ class FulltextTest extends SqlServerTestCase
     protected function afterRefreshingDatabase()
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id('id')->primary();
+            $table->id('id');
             $table->string('title', 200);
             $table->text('body');
-            $table->fulltext(['title', 'body']);
+            $table->primary('id', 'pk_articles_id');
+            $table->fulltext(['title', 'body'])->pkindex('pk_articles_id');
         });
     }
 

--- a/tests/Integration/Database/SqlServer/FulltextTest.php
+++ b/tests/Integration/Database/SqlServer/FulltextTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Database\SqlServer;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\Attributes\RequiresDatabase;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 


### PR DESCRIPTION
This adds compileFullText(), compileDropFullText() and whereFullText() for fulltext support when using SQL Server. Only code has been added so no breaking change should be included.

Test problem: The official SQL Server images doesn't support fulltext search, so real world tests would fail.