### PR TITLE
[12.x] Allow Scheduled Command `Event` macros to be applied to schedule groups

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -486,7 +486,7 @@ class Schedule
             return $this->macroCall($method, $parameters);
         }
 
-        if (method_exists(PendingEventAttributes::class, $method)) {
+        if (method_exists(PendingEventAttributes::class, $method) || Event::hasMacro($method)) {
             $this->attributes ??= $this->groupStack ? clone array_last($this->groupStack) : new PendingEventAttributes($this);
 
             return $this->attributes->$method(...$parameters);


### PR DESCRIPTION
This PR allows `Event` macros registered by third-party packages (such as Sentry, Oh Dear, etc.) to be applied to schedule groups.

Currently, built-in attributes like `onOneServer()` and `runInBackground()` work on groups, but package-level macros must be applied to each command individually:

https://docs.sentry.io/platforms/php/guides/laravel/crons/#job-monitoring

https://github.com/getsentry/sentry-laravel/blob/dbaeb9a469a92414b5d3d294c7c971a47bcab9a3/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php#L69

```php
$schedule
    ->onOneServer()
    ->group(function (Schedule $schedule) {
        $schedule->command('foo')->sentryMonitor();
        $schedule->command('bar')->sentryMonitor();
        $schedule->command('baz')->sentryMonitor();
    });
```

With this change, macros registered on `Illuminate\Console\Scheduling\Event` are automatically recorded and replayed onto each event in the group:

```php
$schedule
    ->onOneServer()
    ->sentryMonitor()
    ->group(function (Schedule $schedule) {
        $schedule->command('foo');
        $schedule->command('bar');
        $schedule->command('baz');
    });
```