### PR TITLE
[12.x] Refactor `convertValuesToBoolean` to use `match` for cleaner logic

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2450,13 +2450,11 @@ trait ValidatesAttributes
     protected function convertValuesToBoolean($values)
     {
         return array_map(function ($value) {
-            if ($value === 'true') {
-                return true;
-            } elseif ($value === 'false') {
-                return false;
-            }
-
-            return $value;
+            return match ($value) {
+                'true' => true,
+                'false' => false,
+                default => $value,
+            };
         }, $values);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2449,12 +2449,10 @@ trait ValidatesAttributes
      */
     protected function convertValuesToBoolean($values)
     {
-        return array_map(function ($value) {
-            return match ($value) {
-                'true' => true,
-                'false' => false,
-                default => $value,
-            };
+        return array_map(fn ($value) => match ($value) {
+            'true' => true,
+            'false' => false,
+            default => $value,
         }, $values);
     }
 


### PR DESCRIPTION
Similar to https://github.com/laravel/framework/pull/58824 which improves code readability by using the `match` statement.