### PR TITLE
[12.x] Simplify queue resolution using `match` expression

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -189,15 +189,12 @@ class BroadcastManager implements FactoryContract
                 : $dispatch();
         }
 
-        $queue = null;
-
-        if (method_exists($event, 'broadcastQueue')) {
-            $queue = $event->broadcastQueue();
-        } elseif (isset($event->broadcastQueue)) {
-            $queue = $event->broadcastQueue;
-        } elseif (isset($event->queue)) {
-            $queue = $event->queue;
-        }
+        $queue = match (true) {
+            method_exists($event, 'broadcastQueue') => $event->broadcastQueue(),
+            isset($event->broadcastQueue) => $event->broadcastQueue,
+            isset($event->queue) => $event->queue,
+            default => null,
+        };
 
         $broadcastEvent = new BroadcastEvent(clone $event);
 


### PR DESCRIPTION
Again, similar to https://github.com/laravel/framework/pull/58824 to refactor some if/elseif/else statements to use a `match` statement to make code more readable. 