### PR TITLE
[12.x] Fix model serialization in queue jobs

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -88,11 +88,11 @@ class ModelIdentifier
      */
     public function getClass(): ?string
     {
-        if ($this->class === null) {
-            return null;
+        if (self::$useMorphMap && $this->class !== null) {
+            return Relation::getMorphedModel($this->class) ?? $this->class;
         }
 
-        return Relation::getMorphedModel($this->class) ?? $this->class;
+        return $this->class;
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -71,18 +71,20 @@ trait SerializesAndRestoresModelIdentifiers
      */
     protected function restoreCollection($value)
     {
-        if (! $value->class || count($value->id) === 0) {
+        $class = $value->getClass();
+
+        if (! $class || count($value->id) === 0) {
             return ! is_null($value->collectionClass ?? null)
                 ? new $value->collectionClass
                 : new EloquentCollection;
         }
 
         $collection = $this->getQueryForModelRestoration(
-            (new $value->class)->setConnection($value->connection), $value->id
+            (new $class)->setConnection($value->connection), $value->id
         )->useWritePdo()->get();
 
-        if (is_a($value->class, Pivot::class, true) ||
-            in_array(AsPivot::class, class_uses($value->class))) {
+        if (is_a($class, Pivot::class, true) ||
+            in_array(AsPivot::class, class_uses($class))) {
             return $collection;
         }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -449,6 +449,35 @@ class ModelSerializationTest extends TestCase
 
         $this->assertTrue($unserialized->user->is($user));
     }
+
+    #[WithConfig('database.default', 'testing')]
+    public function test_it_users_morphmap_for_serialization_of_collection()
+    {
+        Relation::morphMap([
+            'user' => User::class,
+        ]);
+
+        ModelIdentifier::useMorphMap();
+
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $serialized = serialize(new CollectionSerializationTestClass(
+            new Collection([$user]),
+        ));
+
+        $this->assertSame(
+            'O:67:"Illuminate\Tests\Integration\Queue\CollectionSerializationTestClass":1:{s:5:"users";O:45:"Illuminate\Contracts\Database\ModelIdentifier":5:{s:5:"class";s:4:"user";s:2:"id";a:1:{i:0;i:1;}s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}}',
+            $serialized
+        );
+
+        /** @var CollectionSerializationTestClass $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf(Collection::class, $unserialized->users);
+        $this->assertTrue($unserialized->users->sole()->is($user));
+    }
 }
 
 trait TraitBootsAndInitializersTest


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/58482 introduced morph map support for model identifiers, this PR addresses 2 bugs introduced by that PR.

1. Deserialization always uses the morph map, even when not enabled. If a class happens to be registered as a morph alias, jobs using that model will be unable tk unserialize, e.g.:
    ```php
        Relation::enforceMorphMap([
            'user' => User::class,
            'App\\Models\\User' => SomeOtherUser::class,
        ]);
    ```
2. The above bug can be avoided by enabling morph maps (so opting in to the new feature), because then the model identifier will always use the morph map making serialization and deserialization be in sync again. However, you then run into the second issue; which is that collection deserialization was not updated to support morph maps and will then break

Edit: small note; `ModelIdentifier::$class` should probably be made protected/private on 13.x, consumers should not be using it directly and should instead be calling `ModelIdentifier::getClass()`