### PR TITLE
[12.x] Remove redundant isset checks in fake dispatch methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -628,7 +628,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function hasDispatched($command)
     {
-        return isset($this->commands[$command]) && ! empty($this->commands[$command]);
+        return ! empty($this->commands[$command]);
     }
 
     /**
@@ -639,7 +639,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function hasDispatchedSync($command)
     {
-        return isset($this->commandsSync[$command]) && ! empty($this->commandsSync[$command]);
+        return ! empty($this->commandsSync[$command]);
     }
 
     /**
@@ -650,7 +650,7 @@ class BusFake implements Fake, QueueingDispatcher
      */
     public function hasDispatchedAfterResponse($command)
     {
-        return isset($this->commandsAfterResponse[$command]) && ! empty($this->commandsAfterResponse[$command]);
+        return ! empty($this->commandsAfterResponse[$command]);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -251,7 +251,7 @@ class EventFake implements Dispatcher, Fake
      */
     public function hasDispatched($event)
     {
-        return isset($this->events[$event]) && ! empty($this->events[$event]);
+        return ! empty($this->events[$event]);
     }
 
     /**


### PR DESCRIPTION
Small cleanup in test fakes:

- **EventFake::hasDispatched()**: Removed redundant `isset()` check since `empty()` already handles non-existent keys.
- **BusFake** (3 methods): Same cleanup in `hasDispatched()`, `hasDispatchedSync()`, and `hasDispatchedAfterResponse()`.

The pattern `isset($array[$key]) && ! empty($array[$key])` is redundant because `empty()` returns `true` for non-existent keys, making the `isset()` check unnecessary.

No behavioral changes.