### PR TITLE
[13.x] Feat (Added): Provision to specify default connection for migration 

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -131,6 +131,7 @@ return [
     'migrations' => [
         'table' => 'migrations',
         'update_date_on_publish' => true,
+        // 'connection' => 'mysql', // Optional: Default database connection for migrations
     ],
 
     /*

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -80,7 +80,10 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton('migrator', function ($app) {
             $repository = $app['migration.repository'];
 
-            return new Migrator($repository, $app['db'], $app['files'], $app['events']);
+            $migrations = $app['config']['database.migrations'];
+            $defaultMigrationConnection = is_array($migrations) ? ($migrations['connection'] ?? null) : null;
+
+            return new Migrator($repository, $app['db'], $app['files'], $app['events'], $defaultMigrationConnection);
         });
 
         $this->app->bind(Migrator::class, fn ($app) => $app['migrator']);

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -67,6 +67,13 @@ class Migrator
     protected $connection;
 
     /**
+     * The name of the default migration connection from database config (database.migrations.connection).
+     *
+     * @var string|null
+     */
+    protected $defaultMigrationConnection;
+
+    /**
      * The paths to all of the migration files.
      *
      * @var string[]
@@ -101,17 +108,20 @@ class Migrator
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
+     * @param  string|null  $defaultMigrationConnection
      */
     public function __construct(
         MigrationRepositoryInterface $repository,
         Resolver $resolver,
         Filesystem $files,
         ?Dispatcher $dispatcher = null,
+        ?string $defaultMigrationConnection = null,
     ) {
         $this->files = $files;
         $this->events = $dispatcher;
         $this->resolver = $resolver;
         $this->repository = $repository;
+        $this->defaultMigrationConnection = $defaultMigrationConnection;
     }
 
     /**
@@ -703,10 +713,10 @@ class Migrator
             return call_user_func(
                 static::$connectionResolverCallback,
                 $this->resolver,
-                $connection ?: $this->connection
+                $connection ?: $this->connection ?: $this->defaultMigrationConnection
             );
         } else {
-            return $this->resolver->connection($connection ?: $this->connection);
+            return $this->resolver->connection($connection ?: $this->connection ?: $this->defaultMigrationConnection);
         }
     }
 

--- a/tests/Database/DatabaseMigrationDefaultConnectionTest.php
+++ b/tests/Database/DatabaseMigrationDefaultConnectionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Migrations\DatabaseMigrationRepository;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMigrationDefaultConnectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testMigratorUsesDefaultMigrationConnection()
+    {
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $repository = m::mock(DatabaseMigrationRepository::class);
+        $files = m::mock(Filesystem::class);
+
+        // Test case: No specific connection provided, should use default migration connection
+        $migrator = new Migrator($repository, $resolver, $files, null, 'custom_migration');
+
+        $connection = m::mock(Connection::class);
+        $resolver->shouldReceive('connection')->once()->with('custom_migration')->andReturn($connection);
+
+        $result = $migrator->resolveConnection(null);
+
+        $this->assertSame($connection, $result);
+    }
+
+    public function testMigratorUsesSpecificConnectionOverDefault()
+    {
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $repository = m::mock(DatabaseMigrationRepository::class);
+        $files = m::mock(Filesystem::class);
+
+        // Test case: Specific connection provided, should use it instead of default migration connection
+        $migrator = new Migrator($repository, $resolver, $files, null, 'custom_migration');
+
+        $connection = m::mock(Connection::class);
+        $resolver->shouldReceive('connection')->once()->with('specific_connection')->andReturn($connection);
+
+        $result = $migrator->resolveConnection('specific_connection');
+
+        $this->assertSame($connection, $result);
+    }
+
+    public function testMigratorUsesCurrentConnectionOverDefaultMigration()
+    {
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $repository = m::mock(DatabaseMigrationRepository::class);
+        $repository->shouldReceive('setSource')->once()->with('current_connection');
+        $files = m::mock(Filesystem::class);
+
+        // Test case: Current connection is set, should use it over default migration connection
+        $migrator = new Migrator($repository, $resolver, $files, null, 'custom_migration');
+
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('current_connection');
+        $migrator->setConnection('current_connection');
+
+        $connection = m::mock(Connection::class);
+        $resolver->shouldReceive('connection')->once()->with('current_connection')->andReturn($connection);
+
+        $result = $migrator->resolveConnection(null);
+
+        $this->assertSame($connection, $result);
+    }
+
+    public function testMigratorFallsBackToDefaultWhenNoDefaultMigrationConnectionConfigured()
+    {
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $repository = m::mock(DatabaseMigrationRepository::class);
+        $files = m::mock(Filesystem::class);
+
+        // Test case: No default migration connection configured, should fall back to null (default)
+        $migrator = new Migrator($repository, $resolver, $files, null, null);
+
+        $connection = m::mock(Connection::class);
+        $resolver->shouldReceive('connection')->once()->with(null)->andReturn($connection);
+
+        $result = $migrator->resolveConnection(null);
+
+        $this->assertSame($connection, $result);
+    }
+
+    public function testConnectionPriorityOrder()
+    {
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $repository = m::mock(DatabaseMigrationRepository::class);
+        $files = m::mock(Filesystem::class);
+
+        $migrator = new Migrator($repository, $resolver, $files, null, 'default_migration');
+
+        // Mock expectations for first setConnection call
+        $repository->shouldReceive('setSource')->once()->with('current_connection');
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('current_connection');
+        $migrator->setConnection('current_connection');
+
+        $connection = m::mock(Connection::class);
+
+        // Test priority: specific connection > current connection > default migration connection
+        $resolver->shouldReceive('connection')->once()->with('specific_connection')->andReturn($connection);
+        $result = $migrator->resolveConnection('specific_connection');
+        $this->assertSame($connection, $result);
+
+        // Test priority: current connection > default migration connection
+        $resolver->shouldReceive('connection')->once()->with('current_connection')->andReturn($connection);
+        $result = $migrator->resolveConnection(null);
+        $this->assertSame($connection, $result);
+
+        // Test priority: default migration connection when no current connection
+        $repository->shouldReceive('setSource')->once()->with(null);
+        $migrator->setConnection(null);
+        $resolver->shouldReceive('connection')->once()->with('default_migration')->andReturn($connection);
+        $result = $migrator->resolveConnection(null);
+        $this->assertSame($connection, $result);
+    }
+}

--- a/tests/Database/DatabaseMigrationServiceProviderTest.php
+++ b/tests/Database/DatabaseMigrationServiceProviderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\MigrationServiceProvider;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMigrationServiceProviderTest extends TestCase
+{
+    public function testMigratorServiceIncludesDefaultMigrationConnection()
+    {
+        $app = new Application();
+
+        // Set up configuration
+        $app['config'] = [
+            'database.migrations' => [
+                'table' => 'migrations',
+                'connection' => 'custom_migration',
+            ],
+        ];
+
+        // Mock dependencies
+        $app['migration.repository'] = $this->createMock(MigrationRepositoryInterface::class);
+        $app['db'] = $this->createMock(ConnectionResolverInterface::class);
+        $app['files'] = $this->createMock(Filesystem::class);
+        $app['events'] = $this->createMock(Dispatcher::class);
+
+        $provider = new MigrationServiceProvider($app);
+        $provider->register();
+
+        $migrator = $app['migrator'];
+
+        $this->assertInstanceOf(Migrator::class, $migrator);
+    }
+
+    public function testMigratorServiceWorksWithoutConnectionConfiguration()
+    {
+        $app = new Application();
+
+        // Set up configuration without migration connection
+        $app['config'] = [
+            'database.migrations' => [
+                'table' => 'migrations',
+            ],
+        ];
+
+        // Mock dependencies
+        $app['migration.repository'] = $this->createMock(MigrationRepositoryInterface::class);
+        $app['db'] = $this->createMock(ConnectionResolverInterface::class);
+        $app['files'] = $this->createMock(Filesystem::class);
+        $app['events'] = $this->createMock(Dispatcher::class);
+
+        $provider = new MigrationServiceProvider($app);
+        $provider->register();
+
+        $migrator = $app['migrator'];
+
+        $this->assertInstanceOf(Migrator::class, $migrator);
+    }
+
+    public function testMigratorServiceWorksWithLegacyStringConfiguration()
+    {
+        $app = new Application();
+
+        // Set up legacy string configuration
+        $app['config'] = [
+            'database.migrations' => 'migrations',
+        ];
+
+        // Mock dependencies
+        $app['migration.repository'] = $this->createMock(MigrationRepositoryInterface::class);
+        $app['db'] = $this->createMock(ConnectionResolverInterface::class);
+        $app['files'] = $this->createMock(Filesystem::class);
+        $app['events'] = $this->createMock(Dispatcher::class);
+
+        $provider = new MigrationServiceProvider($app);
+        $provider->register();
+
+        $migrator = $app['migrator'];
+
+        $this->assertInstanceOf(Migrator::class, $migrator);
+    }
+}

--- a/tests/Integration/Database/MigrationDefaultConnectionTest.php
+++ b/tests/Integration/Database/MigrationDefaultConnectionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+
+class MigrationDefaultConnectionTest extends TestCase
+{
+    public function testMigratorReceivesDefaultMigrationConnectionFromConfig()
+    {
+        // Set default migration connection in config
+        config()->set('database.migrations.connection', 'custom_migration');
+
+        // Get a fresh migrator instance to ensure it picks up the config
+        $this->app->forgetInstance('migrator');
+        $migrator = app('migrator');
+
+        // Use reflection to access the protected property
+        $reflection = new \ReflectionClass($migrator);
+        $property = $reflection->getProperty('defaultMigrationConnection');
+        $property->setAccessible(true);
+
+        // Assert that the migrator received the correct default connection
+        $this->assertEquals('custom_migration', $property->getValue($migrator));
+    }
+
+    public function testMigratorUsesNullWhenNoDefaultMigrationConnectionConfigured()
+    {
+        // Ensure no default migration connection is set
+        config()->set('database.migrations.connection', null);
+
+        // Get a fresh migrator instance
+        $this->app->forgetInstance('migrator');
+        $migrator = app('migrator');
+
+        // Use reflection to access the protected property
+        $reflection = new \ReflectionClass($migrator);
+        $property = $reflection->getProperty('defaultMigrationConnection');
+        $property->setAccessible(true);
+
+        // Assert that the migrator has no default connection
+        $this->assertNull($property->getValue($migrator));
+    }
+
+    public function testMigratorHandlesLegacyStringMigrationConfig()
+    {
+        // Set legacy string configuration for migrations
+        config()->set('database.migrations', 'migrations_table_name');
+
+        // Get a fresh migrator instance
+        $this->app->forgetInstance('migrator');
+        $migrator = app('migrator');
+
+        // Use reflection to access the protected property
+        $reflection = new \ReflectionClass($migrator);
+        $property = $reflection->getProperty('defaultMigrationConnection');
+        $property->setAccessible(true);
+
+        // Assert that no default connection is set when using legacy config
+        $this->assertNull($property->getValue($migrator));
+    }
+
+    public function testConnectionResolutionPriority()
+    {
+        // Set default migration connection in config
+        config()->set('database.migrations.connection', 'migration_default');
+
+        // Get a fresh migrator instance
+        $this->app->forgetInstance('migrator');
+        $migrator = app('migrator');
+
+        // Test 1: Specific connection parameter takes highest priority
+        $resolver = $this->createMock(\Illuminate\Database\ConnectionResolverInterface::class);
+        $connection = $this->createMock(\Illuminate\Database\Connection::class);
+
+        $resolver->expects($this->once())
+                 ->method('connection')
+                 ->with('specific_connection')
+                 ->willReturn($connection);
+
+        // Use reflection to set the resolver
+        $reflection = new \ReflectionClass($migrator);
+        $resolverProperty = $reflection->getProperty('resolver');
+        $resolverProperty->setAccessible(true);
+        $resolverProperty->setValue($migrator, $resolver);
+
+        // Test that specific connection is used
+        $result = $migrator->resolveConnection('specific_connection');
+        $this->assertSame($connection, $result);
+    }
+}


### PR DESCRIPTION
Closes discussion [#54035](https://github.com/laravel/framework/discussions/54035)

### What it does?

Allows provision to specify default connection for migrations (by specifying config value `database.migrations.connection`).

So the priority for connection will be as below (Highest to Lowest):
1. **Migration-specific connection**: Set via `$connection` property or `Schema::connection()` in the migration file *(Existing)*
2. **CLI option**: `--database=<connection>` when running `php artisan migrate` *(Existing)*
3. **Default migration connection**: `database.migrations.connection` configuration value *(new feature)*
4. **Default connection**: `database.default` configuration value *(Existing)*

### Why?
I have seen Laravel applications following separate connection for application (DML permissions) and migration (DDL permissions) due to some architectural decisions. 
- Mentioning `Schema::connection('connection')->` while writing each migration or running `artisan migrate --database=<connection>` is not always handy.  
- When we setup project initially, the `migrations` table is created using default application connection.
- Some automation scripts like [serversideup](https://serversideup.net/open-source/docker-php/docs/framework-guides/laravel/automations) runs `artisan migrate` command without allowing `--database` option.

This feature provides a **"set once, use everywhere"** solution through configuration, eliminating manual overhead while maintaining full backward compatibility.


