### PR TITLE
[12.x] Show all mismatched values in `assertSessionHasAll` failure output

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1564,12 +1564,22 @@ class TestResponse implements ArrayAccess
      */
     public function assertSessionHasAll(array $bindings)
     {
+        $actual = [];
+        $expected = [];
+
         foreach ($bindings as $key => $value) {
             if (is_int($key)) {
                 $this->assertSessionHas($value);
-            } else {
+            } elseif ($value instanceof Closure) {
                 $this->assertSessionHas($key, $value);
+            } else {
+                $expected[$key] = $value;
+                $actual[$key] = $this->session()->get($key);
             }
+        }
+
+        if (! empty($expected)) {
+            PHPUnit::withResponse($this)->assertEquals($expected, $actual);
         }
 
         return $this;


### PR DESCRIPTION
When using `assertSessionHasAll` with multiple key-value pairs, the current implementation fails on the first mismatch and only shows that single comparison. This often hides the most useful context.

### Before
```php
$response->assertSessionHasAll([
    'status' => 'success',
    'message' => 'Your order has been placed.',
]);

Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'success'
+'error'
```

You know the status was wrong, but have to reorder your assertions or dig into the session to find out why.

### After

```php
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'status' => 'success'
-    'message' => 'Your order has been placed.'
+    'status' => 'error'
+    'message' => 'Insufficient inventory for the requested items.'
)
```

The actual error message is immediately visible alongside the status.

Instead of asserting each key-value pair individually through `assertSessionHas`, `assertSessionHasAll` now collects all expected and actual values and performs a single `assertEquals` on the two arrays.

Integer keys and closure values are still asserted individually. Closures are handled explicitly in `assertSessionHasAll` rather than as a side effect of delegating to `assertSessionHas`.

Refs #58920