### PR TITLE
[12.x] Fix race condition on creating the real-time facade cache file (#58945)

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -107,10 +107,12 @@ class AliasLoader
             $alias, file_get_contents(__DIR__.'/stubs/facade.stub')
         );
 
-        // "Atomic" write (tmp + rename) to prevent other processes from reading a partially written facade file
-        $tmpPath = tempnam(dirname($path), 'facade-');
-        file_put_contents($tmpPath, $stub);
-        rename($tmpPath, $path);
+        // Atomic write to prevent race conditions...
+        $tempPath = tempnam(dirname($path), 'facade-');
+
+        file_put_contents($tempPath, $stub);
+
+        rename($tempPath, $path);
 
         return $path;
     }

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -103,9 +103,14 @@ class AliasLoader
             return $path;
         }
 
-        file_put_contents($path, $this->formatFacadeStub(
+        $stub = $this->formatFacadeStub(
             $alias, file_get_contents(__DIR__.'/stubs/facade.stub')
-        ));
+        );
+
+        // "Atomic" write (tmp + rename) to prevent other processes from reading a partially written facade file
+        $tmpPath = tempnam(dirname($path), 'facade-');
+        file_put_contents($tmpPath, $stub);
+        rename($tmpPath, $path);
 
         return $path;
     }


### PR DESCRIPTION
This fixes #58945

This PR fixes the race condition when real-time Facades read / create the `storage/framework/cache/facade-XXX.php` file within the `AliasLoader::ensureFacadeExists()` method

Specifically, it ensures that multiple concurrent processes do not interfere with the creation of the same facade cache file, which could otherwise result in partially written files and Class not found errors during autoloading

### Changes

Change the direct `file_put_contents()` call to an atomic write strategy using a temporary file and `rename()` to ensure that the file is fully written before becoming visible to other processes

The issue occurs in high-concurrency environments (e.g., static site generation, CI, parallel workers) where concurrent processes may read a partially written file (when starting with an empty cache)