### PR TITLE
[12.x] Add Respond Support To Exceptions Classes

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -637,6 +637,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function finalizeRenderedResponse($request, $response, Throwable $e)
     {
+        if (method_exists($e, 'respond')) {
+            $response = $e->respond($response, $request);
+        }
+
         return $this->finalizeResponseCallback
             ? call_user_func($this->finalizeResponseCallback, $response, $e, $request)
             : $response;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When rendering exceptions, Laravel has support for `render()` and `respond()` in `bootstrap/app.php`. One of which lets you decide how to render and the other letting you tweak the final response. Inside of a given exception class, however, you can add a `render()` method, to specifically define a render process for that exception, but you cannot set a custom `respond()` method that is respected by the framework.

My use case for this was I have an exception that, when thrown, needs to clear a cookie. I don't have any custom exception rending right now, so a quick `respond()` callback in `bootstrap/app.php` got me what I needed. However, my first guess was to put it in the exception class itself, as it's only relevant for that exception and I had to write a guard for that exception in the bootstrap file vs being able to leave it unguarded in the exception file.

All this PR does under the hood is first let the exception modify the response if it has a `respond()` method on it, before letting whatever is configured globally get the final say. It uses the same argument structure as the `respond()` callback would, sans the exception.

I'm unsure if this should be considered a breaking change. It technically is, as existing exceptions that have a public `respond()` method with different arguments would break. That said, I wouldn't expect there to be very many exceptions with a method like that in the wild. I attempted to use sourcegraph's code search to find offenders, and I wasn't able to find any after a few cursory searches. If needed, I can get this PR remade and pointed at `master` instead where the breaking change could then be safely made.