### PR TITLE
[12.x] Improve return types for Wormhole and InteractsWithTime

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -8,10 +8,12 @@ use Illuminate\Support\Carbon;
 trait InteractsWithTime
 {
     /**
+     * @template TReturn of mixed
+     *
      * Freeze time.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? \Illuminate\Support\Carbon : TReturn)
      */
     public function freezeTime($callback = null)
     {
@@ -21,10 +23,12 @@ trait InteractsWithTime
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Freeze time at the beginning of the current second.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? \Illuminate\Support\Carbon : TReturn)
      */
     public function freezeSecond($callback = null)
     {
@@ -45,11 +49,13 @@ trait InteractsWithTime
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel to another time.
      *
      * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null  $date
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function travelTo($date, $callback = null)
     {

--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -24,10 +24,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of microseconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function microsecond($callback = null)
     {
@@ -35,10 +37,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of microseconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function microseconds($callback = null)
     {
@@ -48,10 +52,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of milliseconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function millisecond($callback = null)
     {
@@ -59,10 +65,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of milliseconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function milliseconds($callback = null)
     {
@@ -72,10 +80,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of seconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function second($callback = null)
     {
@@ -83,10 +93,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of seconds.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function seconds($callback = null)
     {
@@ -96,10 +108,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of minutes.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function minute($callback = null)
     {
@@ -107,10 +121,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of minutes.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function minutes($callback = null)
     {
@@ -120,10 +136,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of hours.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function hour($callback = null)
     {
@@ -131,10 +149,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of hours.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function hours($callback = null)
     {
@@ -144,10 +164,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of days.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function day($callback = null)
     {
@@ -155,10 +177,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of days.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function days($callback = null)
     {
@@ -168,10 +192,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of weeks.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function week($callback = null)
     {
@@ -179,10 +205,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of weeks.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function weeks($callback = null)
     {
@@ -192,10 +220,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of months.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function month($callback = null)
     {
@@ -203,10 +233,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of months.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function months($callback = null)
     {
@@ -216,10 +248,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of years.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function year($callback = null)
     {
@@ -227,10 +261,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Travel forward the given number of years.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     public function years($callback = null)
     {
@@ -252,10 +288,12 @@ class Wormhole
     }
 
     /**
+     * @template TReturn of mixed
+     *
      * Handle the given optional execution callback.
      *
-     * @param  callable|null  $callback
-     * @return mixed
+     * @param  (callable(): TReturn)|null  $callback
+     * @return ($callback is null ? void : TReturn)
      */
     protected function handleCallback($callback)
     {

--- a/types/Foundation/Testing/InteractsWithTime.php
+++ b/types/Foundation/Testing/InteractsWithTime.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Types\Foundation\Testing;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithTime;
+use Illuminate\Support\Carbon;
+
+use function PHPStan\Testing\assertType;
+
+class InteractsWithTimeTestCase
+{
+    use InteractsWithTime;
+
+    public function test(): void
+    {
+        assertType(Carbon::class, $this->freezeTime());
+        assertType('42', $this->freezeTime(fn () => 42));
+
+        assertType(Carbon::class, $this->freezeSecond());
+        assertType('42', $this->freezeSecond(fn () => 42));
+
+        // @phpstan-ignore method.void
+        assertType('null', $this->travelTo(Carbon::now(), function () {
+        }));
+        assertType('42', $this->travelTo(Carbon::now(), fn () => 42));
+    }
+}

--- a/types/Foundation/Testing/Wormhole.php
+++ b/types/Foundation/Testing/Wormhole.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Foundation\Testing\Wormhole;
+
+use function PHPStan\Testing\assertType;
+
+$wormhole = new Wormhole(1);
+
+$voidFunction = function () {
+};
+
+assertType('42', $wormhole->seconds(fn () => 42));
+assertType('42', $wormhole->second(fn () => 42));
+assertType('42', $wormhole->minutes(fn () => 42));
+assertType('42', $wormhole->minute(fn () => 42));
+assertType('42', $wormhole->hours(fn () => 42));
+assertType('42', $wormhole->hour(fn () => 42));
+assertType('42', $wormhole->days(fn () => 42));
+assertType('42', $wormhole->day(fn () => 42));
+assertType('42', $wormhole->weeks(fn () => 42));
+assertType('42', $wormhole->week(fn () => 42));
+assertType('42', $wormhole->months(fn () => 42));
+assertType('42', $wormhole->month(fn () => 42));
+assertType('42', $wormhole->years(fn () => 42));
+assertType('42', $wormhole->year(fn () => 42));
+assertType('42', $wormhole->microseconds(fn () => 42));
+assertType('42', $wormhole->microsecond(fn () => 42));
+assertType('42', $wormhole->milliseconds(fn () => 42));
+assertType('42', $wormhole->millisecond(fn () => 42));
+
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->seconds($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->second($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->minutes($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->minute($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->hours($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->hour($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->days($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->day($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->weeks($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->week($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->months($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->month($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->years($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->year($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->microseconds($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->microsecond($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->milliseconds($voidFunction));
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->millisecond($voidFunction));
+
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->seconds());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->second());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->minutes());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->minute());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->hours());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->hour());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->days());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->day());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->weeks());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->week());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->months());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->month());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->years());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->year());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->microseconds());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->microsecond());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->milliseconds());
+/** @phpstan-ignore method.void */
+assertType('null', $wormhole->millisecond());


### PR DESCRIPTION
Similar to the templated return types of `DB::transaction()` (#53357), `Model::unguarded()` (#55932), and `Context::scope()` (#58012), this PR replaces `@return mixed` with `@template TReturn` and conditional return types on `Wormhole` (18 public methods + `handleCallback`) and `InteractsWithTime` (`freezeTime`, `freezeSecond`, `travelTo`).

This allows PHPStan and IDEs like PhpStorm to infer the return type based on whether a callback is provided:

- `$this->travel(5)->seconds(fn () => 42)` → `int`
- `$this->freezeTime()` → `Carbon` (no callback)
- `$this->travelTo($date)` → `void` (no callback)
- `$this->freezeTime(fn () => 'value')` → `string`

Unlike #48562, which was reverted because `Closure(): void` annotations were incompatible with arrow functions, this PR uses a `@template TReturn` so the return type is inferred rather than fixed. The type tests cover all callable forms — typed callbacks, void-returning callbacks, and no-callback calls — to verify this.

DocBlock-only changes — no runtime behavior is affected. Type tests included in `types/Foundation/Testing/`.