### PR TITLE
[12.x]  Ensure `oldest_pending` is displayed in `queue:monitor`

### DIFF
--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -108,7 +108,7 @@ class MonitorCommand extends Command
                 'reserved' => method_exists($this->manager->connection($connection), 'reservedSize')
                     ? $this->manager->connection($connection)->reservedSize($queue)
                     : null,
-                'oldest_pending' => method_exists($this->manager->connection($connection), 'oldestPending')
+                'oldest_pending' => method_exists($this->manager->connection($connection), 'creationTimeOfOldestPendingJob')
                     ? $this->manager->connection($connection)->creationTimeOfOldestPendingJob($queue)
                     : null,
                 'status' => $size >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',


### PR DESCRIPTION
When using:
```
php artisan queue:monitor default --json
```

the oldest pending field is always null, because  `oldestPending` doesnt exist, ever - it should be `creationTimeOfOldestPendingJob`

This just makes sure we can see the output when using --json