### PR TITLE
Improve route matching by prioritizing static routes over dynamic par…

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -79,15 +79,28 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
         $fallbackRoute = null;
+        $dynamicRoutes = [];
 
         foreach ($routes as $route) {
+            if ($route->isFallback) {
+                $fallbackRoute ??= $route;
+
+                continue;
+            }
+
+            if (! empty($route->parameterNames())) {
+                $dynamicRoutes[] = $route;
+
+                continue;
+            }
+
             if ($route->matches($request, $includingMethod)) {
-                if ($route->isFallback) {
-                    $fallbackRoute ??= $route;
+                return $route;
+            }
+        }
 
-                    continue;
-                }
-
+        foreach ($dynamicRoutes as $route) {
+            if ($route->matches($request, $includingMethod)) {
                 return $route;
             }
         }

--- a/tests/Routing/RouteMatchingPriorityTest.php
+++ b/tests/Routing/RouteMatchingPriorityTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Routing\Router;
+use Illuminate\Http\Request;
+use Orchestra\Testbench\TestCase;
+
+class RouteMatchingPriorityTest extends TestCase
+{
+    public function test_static_route_is_prioritized_over_dynamic_route()
+    {
+        $router = $this->app['router'];
+
+        $router->get('/users/{user}', function ($user) {
+            return 'dynamic-'.$user;
+        });
+
+        $router->get('/users/export', function () {
+            return 'static-export';
+        });
+
+        $response = $router->dispatch(Request::create('/users/export', 'GET'));
+
+        $this->assertEquals('static-export', $response->getContent());
+    }
+}


### PR DESCRIPTION
Summary

This PR improves route matching behavior by prioritizing static routes over dynamic parameter routes during request resolution.

Problem

Currently, when both static and dynamic routes share a similar URI pattern, dynamic routes (e.g. /users/{user}) may capture requests intended for static routes (e.g. /users/export) depending on registration order.

Example:

Route::resource('users', UserController::class);
Route::get('/users/export', [UserController::class, 'export']);

In this case, /users/export may be matched by /users/{user}, treating export as a route parameter instead of resolving the intended static route.

Proposed Solution

Separate static routes from dynamic parameter routes during route matching and evaluate static routes first.

New matching priority:

Static routes (no URI parameters)

Dynamic routes (contain parameters)

Fallback routes

This ensures more predictable and intuitive behavior without requiring developers to manually reorder routes.

Backward Compatibility

This change does not modify route registration behavior.
It only improves resolution priority when both static and dynamic routes are present.

No existing public API is modified.

Tests

Added test covering static route priority over dynamic parameter route.

All existing tests pass.