### PR TITLE
[13.x] Ensure SyncQueue JobAttempted gets the actual exception

### DIFF
--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Events;
 class JobAttempted
 {
     /**
-     * Create a new event instance.
+     * Create a new event instance. a
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.

--- a/src/Illuminate/Queue/Events/JobAttempted.php
+++ b/src/Illuminate/Queue/Events/JobAttempted.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Events;
 class JobAttempted
 {
     /**
-     * Create a new event instance. a
+     * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
      * @param  \Illuminate\Contracts\Queue\Job  $job  The job instance.

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -132,11 +132,11 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
-            $exceptionOccurred = true;
+            $lastException = $e;
 
             $this->handleException($queueJob, $e);
         } finally {
-            $this->raiseJobAttemptedEvent($queueJob, $exceptionOccurred ?? false);
+            $this->raiseJobAttemptedEvent($queueJob, $lastException ?? null);
         }
 
         return 0;
@@ -184,13 +184,13 @@ class SyncQueue extends Queue implements QueueContract
      * Raise the job attempted event.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  bool  $exceptionOccurred
+     * @param  \Throwable|null  $exception
      * @return void
      */
-    protected function raiseJobAttemptedEvent(Job $job, bool $exceptionOccurred = false)
+    protected function raiseJobAttemptedEvent(Job $job, ?Throwable $exception = null)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exceptionOccurred));
+            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exception));
         }
     }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -187,10 +187,10 @@ class SyncQueue extends Queue implements QueueContract
      * @param  \Throwable|null  $exception
      * @return void
      */
-    protected function raiseJobAttemptedEvent(Job $job, ?Throwable $exception = null)
+    protected function raiseJobAttemptedEvent(Job $job, ?Throwable $exceptionOccurred = null)
     {
         if ($this->container->bound('events')) {
-            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exception));
+            $this->container['events']->dispatch(new JobAttempted($this->connectionName, $job, $exceptionOccurred));
         }
     }
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -132,11 +132,11 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
-            $lastException = $e;
+            $exceptionOccurred = $e;
 
             $this->handleException($queueJob, $e);
         } finally {
-            $this->raiseJobAttemptedEvent($queueJob, $lastException ?? null);
+            $this->raiseJobAttemptedEvent($queueJob, $exceptionOccurred ?? null);
         }
 
         return 0;


### PR DESCRIPTION
Noticed here the exception being passed into the JobAttempted event was wrong.

It was passing in a bool, rather than the actual exception, which it needs in 13.x

This PR makes it so the actual exception is available.

13.x cause thats where JobAttempted has the real exception.