### PR TITLE
[12.x] Add Arr::collect() and Arr::enum() methods

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1180,6 +1180,46 @@ class Arr
     }
 
     /**
+     * Get a collection item from an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Collection
+     */
+    public static function collect($array, $key = null, $default = null)
+    {
+        return new Collection(static::get($array, $key, $default));
+    }
+
+    /**
+     * Get an enum item from an array using "dot" notation.
+     *
+     * @template TEnum of \BackedEnum
+     * @template TDefault
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @param  TDefault|(\Closure(): TDefault)  $default
+     * @return TEnum|TDefault
+     */
+    public static function enum($array, $key, $enumClass, $default = null)
+    {
+        $value = static::get($array, $key);
+
+        if ($value instanceof $enumClass) {
+            return $value;
+        }
+
+        if (is_null($value) || ! is_a($enumClass, \BackedEnum::class, true)) {
+            return value($default);
+        }
+
+        return $enumClass::tryFrom($value) ?: value($default);
+    }
+
+    /**
      * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array<string, bool>|array<int, string|int>|string  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -628,6 +628,49 @@ class SupportArrTest extends TestCase
         Arr::string($test_array, 'integer');
     }
 
+    public function testItGetsACollection()
+    {
+        $test_array = ['items' => ['foo', 'bar']];
+
+        // Test collection values are returned as collections
+        $collection = Arr::collect($test_array, 'items');
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals(['foo', 'bar'], $collection->all());
+
+        // Test that default values are wrapped in collections
+        $collection = Arr::collect($test_array, 'missing_key', ['default']);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals(['default'], $collection->all());
+
+        // Test null key returns the whole array as a collection
+        $collection = Arr::collect($test_array);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEquals($test_array, $collection->all());
+    }
+
+    public function testItGetsAnEnum()
+    {
+        $test_array = ['status' => 'A', 'invalid' => 'C'];
+
+        // Test string backed enums are returned
+        $enum = Arr::enum($test_array, 'status', TestStringBackedEnum::class);
+        $this->assertInstanceOf(TestStringBackedEnum::class, $enum);
+        $this->assertSame(TestStringBackedEnum::A, $enum);
+
+        // Test that default values are returned for invalid values
+        $enum = Arr::enum($test_array, 'invalid', TestStringBackedEnum::class, TestStringBackedEnum::B);
+        $this->assertSame(TestStringBackedEnum::B, $enum);
+
+        // Test that default values are returned for missing keys
+        $enum = Arr::enum($test_array, 'missing_key', TestStringBackedEnum::class, TestStringBackedEnum::B);
+        $this->assertSame(TestStringBackedEnum::B, $enum);
+
+        // Test with already instantiated enum
+        $test_array = ['status' => TestStringBackedEnum::A];
+        $enum = Arr::enum($test_array, 'status', TestStringBackedEnum::class);
+        $this->assertSame(TestStringBackedEnum::A, $enum);
+    }
+
     public function testItGetsAnInteger()
     {
         $test_array = ['string' => 'foo bar', 'integer' => 1234];
@@ -1676,7 +1719,9 @@ class SupportArrTest extends TestCase
         $this->assertSame($subject, Arr::from($items));
 
         $items = new WeakMap;
-        $items[$temp = new class {}] = 'bar';
+        $items[$temp = new class
+        {
+        }] = 'bar';
         $this->assertSame(['bar'], Arr::from($items));
 
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
This PR adds the `Arr::collect()` and `Arr::enum()` methods to the Arr helper class.

These methods complement the existing type-assertion methods such as `Arr::integer()`, `Arr::boolean()`, and `Arr::string()`, providing a consistent API for retrieving data from arrays as collections or enums. This aligns with the functionality already available on the Request object.

**Implementation Details:**
- `Arr::collect($array, $key, $default)`: Wraps the retrieved value in a Collection instance.
- `Arr::enum($array, $key, $enumClass, $default)`: Attempts to map the value to a specified BackedEnum

**Benefits:**
- Improved consistency within the framework core.
- Cleaner syntax when working with arrays that contain enum-backed values or when needing immediate collection transformation.
