### PR TITLE
[12.x] Add validation and extraction methods to Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -554,7 +554,7 @@ class Str
     }
 
     /**
-     * Determine if a given string is 7 bit ASCII.
+     * Determine if a given value is 7 bit ASCII.
      *
      * @param  string  $value
      * @return bool
@@ -562,6 +562,57 @@ class Str
     public static function isAscii($value)
     {
         return ASCII::is_ascii((string) $value);
+    }
+
+    /**
+     * Determine if a given value contains only alphabetic characters.
+     *
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
+     */
+    public static function isAlpha($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^\pL++$/u', $value) > 0;
+    }
+
+    /**
+     * Determine if a given value contains only alpha-numeric characters.
+     *
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
+     */
+    public static function isAlphanumeric($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\pL\pN]++$/u', $value) > 0;
+    }
+
+    /**
+     * Determine if a given value is a valid hexadecimal string.
+     *
+     * @param  mixed  $value
+     * @return bool
+     *
+     * @phpstan-assert-if-true =non-empty-string $value
+     */
+    public static function isHex($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[a-fA-F0-9]++$/', $value) > 0;
     }
 
     /**
@@ -922,12 +973,34 @@ class Str
     /**
      * Remove all non-numeric characters from a string.
      *
-     * @param  string  $value
-     * @return string
+     * @param  string|array  $value
+     * @return string|array
      */
     public static function numbers($value)
     {
         return preg_replace('/[^0-9]/', '', $value);
+    }
+
+    /**
+     * Remove all non-alphabetic characters from a string.
+     *
+     * @param  string|array  $value
+     * @return string|array
+     */
+    public static function letters($value)
+    {
+        return preg_replace('/[^\pL]/u', '', $value);
+    }
+
+    /**
+     * Remove all non-alphanumeric characters from a string.
+     *
+     * @param  string|array  $value
+     * @return string|array
+     */
+    public static function alphanumeric($value)
+    {
+        return preg_replace('/[^\pL\pN]/u', '', $value);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -382,6 +382,36 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
+     * Determine if a given string contains only alphabetic characters.
+     *
+     * @return bool
+     */
+    public function isAlpha()
+    {
+        return Str::isAlpha($this->value);
+    }
+
+    /**
+     * Determine if a given string contains only alpha-numeric characters.
+     *
+     * @return bool
+     */
+    public function isAlphanumeric()
+    {
+        return Str::isAlphanumeric($this->value);
+    }
+
+    /**
+     * Determine if a given string is a valid hexadecimal string.
+     *
+     * @return bool
+     */
+    public function isHex()
+    {
+        return Str::isHex($this->value);
+    }
+
+    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool
@@ -570,13 +600,33 @@ class Stringable implements JsonSerializable, ArrayAccess, BaseStringable
     }
 
     /**
-     * Remove all non-numeric characters from a string.
+     * Remove all non-numeric characters from the string.
      *
      * @return static
      */
     public function numbers()
     {
         return new static(Str::numbers($this->value));
+    }
+
+    /**
+     * Remove all non-alphabetic characters from the string.
+     *
+     * @return static
+     */
+    public function letters()
+    {
+        return new static(Str::letters($this->value));
+    }
+
+    /**
+     * Remove all non-alphanumeric characters from the string.
+     *
+     * @return static
+     */
+    public function alphanumeric()
+    {
+        return new static(Str::alphanumeric($this->value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -697,6 +697,43 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isUrl('http:///path'));
     }
 
+    public function testIsAlpha()
+    {
+        $this->assertTrue(Str::isAlpha('laravel'));
+        $this->assertTrue(Str::isAlpha('Laravel'));
+        $this->assertTrue(Str::isAlpha('LARA'));
+        $this->assertTrue(Str::isAlpha('Jönköping'));
+        $this->assertFalse(Str::isAlpha('laravel 12'));
+        $this->assertFalse(Str::isAlpha('laravel-12'));
+        $this->assertFalse(Str::isAlpha(' '));
+        $this->assertFalse(Str::isAlpha(''));
+        $this->assertFalse(Str::isAlpha(123));
+    }
+
+    public function testIsAlphanumeric()
+    {
+        $this->assertTrue(Str::isAlphanumeric('laravel12'));
+        $this->assertTrue(Str::isAlphanumeric('Laravel12'));
+        $this->assertTrue(Str::isAlphanumeric('123'));
+        $this->assertTrue(Str::isAlphanumeric('Jönköping12'));
+        $this->assertFalse(Str::isAlphanumeric('laravel-12'));
+        $this->assertFalse(Str::isAlphanumeric('laravel 12'));
+        $this->assertFalse(Str::isAlphanumeric(' '));
+        $this->assertFalse(Str::isAlphanumeric(''));
+        $this->assertFalse(Str::isAlphanumeric(null));
+    }
+
+    public function testIsHex()
+    {
+        $this->assertTrue(Str::isHex('af0123'));
+        $this->assertTrue(Str::isHex('AF0123'));
+        $this->assertTrue(Str::isHex('0123456789abcdef'));
+        $this->assertFalse(Str::isHex('gh0123'));
+        $this->assertFalse(Str::isHex('af0123 '));
+        $this->assertFalse(Str::isHex(''));
+        $this->assertFalse(Str::isHex(null));
+    }
+
     #[DataProvider('validUuidList')]
     public function testIsUuidWithValidUuid($uuid)
     {
@@ -808,6 +845,30 @@ class SupportStrTest extends TestCase
         $arrayValue = ['(555) 123-4567', 'L4r4v3l', 'Laravel!'];
         $arrayExpected = ['5551234567', '443', ''];
         $this->assertSame($arrayExpected, Str::numbers($arrayValue));
+    }
+
+    public function testLetters()
+    {
+        $this->assertSame('Lrvl', Str::letters('L4r4v3l!'));
+        $this->assertSame('Laravel', Str::letters('Laravel 12!'));
+        $this->assertSame('Jönköping', Str::letters('Jönköping 12!'));
+        $this->assertSame('', Str::letters('123!'));
+
+        $arrayValue = ['L4r4v3l!', 'Laravel 12!', '123!'];
+        $arrayExpected = ['Lrvl', 'Laravel', ''];
+        $this->assertSame($arrayExpected, Str::letters($arrayValue));
+    }
+
+    public function testAlphanumeric()
+    {
+        $this->assertSame('L4r4v3l', Str::alphanumeric('L4r4v3l!'));
+        $this->assertSame('Laravel12', Str::alphanumeric('Laravel 12!'));
+        $this->assertSame('Jönköping12', Str::alphanumeric('Jönköping 12!'));
+        $this->assertSame('123', Str::alphanumeric('123!'));
+
+        $arrayValue = ['L4r4v3l!', 'Laravel 12!', '123!'];
+        $arrayExpected = ['L4r4v3l', 'Laravel12', '123'];
+        $this->assertSame($arrayExpected, Str::alphanumeric($arrayValue));
     }
 
     public function testRandom()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -37,8 +37,26 @@ class SupportStringableTest extends TestCase
 
     public function testIsAscii()
     {
-        $this->assertTrue($this->stringable('A')->isAscii());
-        $this->assertFalse($this->stringable('ù')->isAscii());
+        $this->assertTrue($this->stringable('hannah')->isAscii());
+        $this->assertFalse($this->stringable('有机')->isAscii());
+    }
+
+    public function testIsAlpha()
+    {
+        $this->assertTrue($this->stringable('laravel')->isAlpha());
+        $this->assertFalse($this->stringable('laravel 12')->isAlpha());
+    }
+
+    public function testIsAlphanumeric()
+    {
+        $this->assertTrue($this->stringable('laravel12')->isAlphanumeric());
+        $this->assertFalse($this->stringable('laravel-12')->isAlphanumeric());
+    }
+
+    public function testIsHex()
+    {
+        $this->assertTrue($this->stringable('af0123')->isHex());
+        $this->assertFalse($this->stringable('gh0123')->isHex());
     }
 
     public function testIsUrl()
@@ -1210,6 +1228,24 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(null, $this->stringable('Привет, мир!')->charAt('Привет, мир!', 100));
     }
 
+    public function testNumbers()
+    {
+        $this->assertSame('5551234567', (string) $this->stringable('(555) 123-4567')->numbers());
+        $this->assertSame('443', (string) $this->stringable('L4r4v3l!')->numbers());
+        $this->assertSame('', (string) $this->stringable('Laravel!')->numbers());
+    }
+
+    public function testLetters()
+    {
+        $this->assertSame('Lrvl', (string) $this->stringable('L4r4v3l!')->letters());
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel 12!')->letters());
+    }
+
+    public function testAlphanumeric()
+    {
+        $this->assertSame('L4r4v3l', (string) $this->stringable('L4r4v3l!')->alphanumeric());
+        $this->assertSame('Laravel12', (string) $this->stringable('Laravel 12!')->alphanumeric());
+    }
     public function testSubstr()
     {
         $this->assertSame('Ё', (string) $this->stringable('БГДЖИЛЁ')->substr(-1));
@@ -1515,11 +1551,6 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('off')->toBoolean());
         $this->assertTrue($this->stringable('yes')->toBoolean());
         $this->assertFalse($this->stringable('no')->toBoolean());
-    }
-
-    public function testNumbers()
-    {
-        $this->assertSame('5551234567', (string) $this->stringable('(555) 123-4567')->numbers());
     }
 
     public function testToDate()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1246,6 +1246,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('L4r4v3l', (string) $this->stringable('L4r4v3l!')->alphanumeric());
         $this->assertSame('Laravel12', (string) $this->stringable('Laravel 12!')->alphanumeric());
     }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', (string) $this->stringable('БГДЖИЛЁ')->substr(-1));


### PR DESCRIPTION
**What’s New in String Utilities**

I’ve just added a handful of new utility methods to the `Str` and `Stringable` classes to make validating and cleaning up strings a lot easier. If you’re working with form inputs, parsing data, or just need to sanitize some text, these should save you some time.

**Easier Validation**

We’ve added three new checks to help you quickly verify the format of your strings:

* **`isAlpha()`**: Checks if the string is strictly alphabetic (and yes, it supports multibyte).
* **`isAlphanumeric()`**: Confirms if the string is strictly letters and numbers (also multibyte-ready).
* **`isHex()`**: A simple way to verify if a string is a valid hexadecimal value.

**Smarter Extraction**

Sometimes you just want to strip away the noise. These new methods help you pull out exactly what you need:

* **`letters()`**: Grabs only the alphabetic characters, stripping out everything else.
* **`alphanumeric()`**: Keeps your letters and numbers while tossing out any special characters.

These new additions fit right in alongside existing helpers like `numbers()`, `isUuid()`, and `isUrl()`, giving you a much more robust toolbox for your string operations. Plus, just like our other helpers, everything is fully available fluently via the `Stringable` class.

**Examples**

It’s pretty straightforward to use:

```php
// Validation
Str::isAlpha('Laravel');      // true
Str::isAlpha('Laravel 12');   // false

// Extraction
Str::letters('L4r4v3l!');      // 'Lrvl'
Str::alphanumeric('L4r4v3l!'); // 'L4r4v3l'

// Or use it fluently
str('L4r4v3l!')->alphanumeric(); // 'L4r4v3l'

```