### PR TITLE
[13.x] Adds "unique" callback execution to Rate Limiter

### DIFF
--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -17,6 +17,7 @@ namespace Illuminate\Support\Facades;
  * @method static void clear(string $key)
  * @method static int availableIn(string $key)
  * @method static string cleanRateLimiterKey(string $key)
+ * @method static mixed|false unique(string $key, \DateTimeInterface|\DateInterval|int $decaySeconds, \Closure $callback)
  *
  * @see \Illuminate\Cache\RateLimiter
  */


### PR DESCRIPTION
## What?

Rework of #58237. Introduces the `unique` method to the Rate Limiter to run a callback **only once** across multiple app instances.

It's syntax sugar for `attemp()` with a single try, but **atomic**, **failsafe**, and **without using cache locks**, with a 60-second default window.

```php
use Illuminate\Support\Facades\RateLimiter;

RateLimiter::unique('send-sms', function () {
    // ...
})
```

The callback result will be returned if it was executed, `false` otherwise.

```php
use Illuminate\Support\Facades\RateLimiter;

$result = RateLimiter::unique('send-sms', function () {
    // ...
    
    return true;
})

if ($result) {
    return 'The SMS was sent!'
}

return 'The SMS was not sent, wait for 60 seconds.'
```

Because it uses the Rate Limiter, checking the time remaining for a new execution, or clearing the attempt, can be easily done.

```php
use Illuminate\Support\Facades\RateLimiter;

if ($result === false) {
    $seconds = RateLimiter::availableIn('send-sms');
    
    return "The computation was already done, wait $seconds seconds."
}

return 'Compute done!'
```