### PR TITLE
[13.x] Throw exception when served disks share the same URI

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -91,19 +91,19 @@ class FilesystemServiceProvider extends ServiceProvider
                 continue;
             }
 
-            $uri = isset($config['url'])
-                ? rtrim(parse_url($config['url'])['path'], '/')
-                : '/storage';
+            $this->app->booted(function ($app) use ($disk, $config, &$served) {
+                $uri = isset($config['url'])
+                    ? rtrim(parse_url($config['url'])['path'], '/')
+                    : '/storage';
 
-            if (isset($served[$uri])) {
-                throw new InvalidArgumentException(
-                    "The [{$disk}] disk conflicts with the [{$served[$uri]}] disk at [{$uri}]. Each served disk must have a unique [url]."
-                );
-            }
+                if (isset($served[$uri])) {
+                    throw new InvalidArgumentException(
+                        "The [{$disk}] disk conflicts with the [{$served[$uri]}] disk at [{$uri}]. Each served disk must have a unique [url]."
+                    );
+                }
 
-            $served[$uri] = $disk;
+                $served[$uri] = $disk;
 
-            $this->app->booted(function ($app) use ($disk, $config, $uri) {
                 $isProduction = $app->isProduction();
 
                 Route::get($uri.'/{path}', function (Request $request, string $path) use ($disk, $config, $isProduction) {

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -98,7 +98,7 @@ class FilesystemServiceProvider extends ServiceProvider
 
                 if (isset($served[$uri])) {
                     throw new InvalidArgumentException(
-                        "The [{$disk}] disk conflicts with the [{$served[$uri]}] disk at [{$uri}]. Each served disk must have a unique [url]."
+                        "The [{$disk}] disk conflicts with the [{$served[$uri]}] disk at [{$uri}]. Each served disk must have a unique URL."
                     );
                 }
 

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -95,13 +95,13 @@ class FilesystemServiceProvider extends ServiceProvider
                 ? rtrim(parse_url($config['url'])['path'], '/')
                 : '/storage';
 
-            if (in_array($uri, $served)) {
+            if (isset($served[$uri])) {
                 throw new InvalidArgumentException(
-                    "The [{$disk}] disk conflicts with another served disk at [{$uri}]. Each served disk must have a unique [url]."
+                    "The [{$disk}] disk conflicts with the [{$served[$uri]}] disk at [{$uri}]. Each served disk must have a unique [url]."
                 );
             }
 
-            $served[] = $uri;
+            $served[$uri] = $disk;
 
             $this->app->booted(function ($app) use ($disk, $config, $uri) {
                 $isProduction = $app->isProduction();

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 
 class FilesystemServiceProviderTest extends TestCase
 {
-    public function test_it_throws_when_served_disks_have_conflicting_uris()
+    public function test_it_throws_when_served_disks_have_conflicting_uris(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique [url].');
@@ -28,5 +28,27 @@ class FilesystemServiceProviderTest extends TestCase
         ]]);
 
         (new FilesystemServiceProvider($this->app))->boot();
+    }
+
+    public function test_served_disks_with_unique_urls_do_not_conflict(): void
+    {
+        config(['filesystems.disks' => [
+            'local' => [
+                'driver' => 'local',
+                'root' => storage_path('app'),
+                'serve' => true,
+                'url' => '/storage',
+            ],
+            'other' => [
+                'driver' => 'local',
+                'root' => storage_path('other'),
+                'serve' => true,
+                'url' => '/other',
+            ],
+        ]]);
+
+        (new FilesystemServiceProvider($this->app))->boot();
+
+        $this->assertCount(2, $this->app->make('config')->get('filesystems.disks'));
     }
 }

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Filesystem;
+
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Support\Facades\Route;
+use InvalidArgumentException;
+use Orchestra\Testbench\TestCase;
+
+class FilesystemServiceProviderTest extends TestCase
+{
+    public function test_it_throws_when_served_disks_have_conflicting_uris()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [other] disk conflicts with another served disk at [/storage]. Each served disk must have a unique [url].');
+
+        config(['filesystems.disks' => [
+            'local' => [
+                'driver' => 'local',
+                'root' => storage_path('app'),
+                'serve' => true,
+            ],
+            'other' => [
+                'driver' => 'local',
+                'root' => storage_path('other'),
+                'serve' => true,
+            ],
+        ]]);
+
+        (new FilesystemServiceProvider($this->app))->boot();
+    }
+}

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Filesystem;
 
 use Illuminate\Filesystem\FilesystemServiceProvider;
-use Illuminate\Support\Facades\Route;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -11,7 +11,7 @@ class FilesystemServiceProviderTest extends TestCase
     public function test_it_throws_when_served_disks_have_conflicting_uris(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique [url].');
+        $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique URL.');
 
         config(['filesystems.disks' => [
             'local' => [

--- a/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
+++ b/tests/Integration/Filesystem/FilesystemServiceProviderTest.php
@@ -12,7 +12,7 @@ class FilesystemServiceProviderTest extends TestCase
     public function test_it_throws_when_served_disks_have_conflicting_uris()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The [other] disk conflicts with another served disk at [/storage]. Each served disk must have a unique [url].');
+        $this->expectExceptionMessage('The [other] disk conflicts with the [local] disk at [/storage]. Each served disk must have a unique [url].');
 
         config(['filesystems.disks' => [
             'local' => [


### PR DESCRIPTION
The default local disk ships with `serve => true` and no url configured, which falls back to `/storage`. 

If a developer adds a second local disk with `serve => true`  also without a url  both disks silently resolve to the same URI 

The actual failure only surfaces later (e.g. when using temporaryUploadUrl), making it difficult to debug, as you may have the wrong content, or missing files - or you just get straight up route missing exception.

This adds an early `InvalidArgumentException` when a URI collision is detected that tells the developer to use the `url` config.

This happened to me when moving s3 disks to local for testing and removing Minio, which is why I think it may be useful 🫡 - as I was a bit confused at first.

Targeted 13.x as may affect applications with multiple served disks using the same url- though already broken behavior I guess.