### PR TITLE
Fix Invalid Types

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -232,7 +232,7 @@ class PendingBatch
      *
      * Optionally, add callbacks to be executed upon each job failure.
      *
-     * @template TParam of (Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
+     * @phpstan-type TParam (Closure(\Illuminate\Bus\Batch, \Throwable|null): mixed)|(callable(\Illuminate\Bus\Batch, \Throwable|null): mixed)
      *
      * @param  bool|TParam|array<array-key, TParam>  $param
      * @return $this

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -236,7 +236,7 @@ class Dispatcher implements DispatcherContract
      * Resolve the subscriber instance.
      *
      * @param  object|class-string  $subscriber
-     * @return $subscriber is object ? object : mixed
+     * @return ($subscriber is object ? object : mixed)
      */
     protected function resolveSubscriber($subscriber)
     {
@@ -557,7 +557,7 @@ class Dispatcher implements DispatcherContract
      * @param  class-string  $class
      * @return bool
      *
-     * @phpstan-assert-if-true \Illuminate\Contracts\Queue\ShouldQueue $class
+     * @phpstan-assert-if-true class-string<\Illuminate\Contracts\Queue\ShouldQueue> $class
      */
     protected function handlerShouldBeQueued($class)
     {
@@ -816,7 +816,7 @@ class Dispatcher implements DispatcherContract
     /**
      * Set the database transaction manager resolver implementation.
      *
-     * @param  (callable(): \Illuminate\Database\DatabaseTransactionsManager|null)  $resolver
+     * @param  (callable(): (\Illuminate\Database\DatabaseTransactionsManager|null))  $resolver
      * @return $this
      */
     public function setTransactionManagerResolver(callable $resolver)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -974,13 +974,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * Register a handler for custom directives.
      *
      * @param  string  $name
-     * @param  \Closure  $handler
+     * @param  ($bind is true ? \Closure : callable)  $handler
      * @param  bool  $bind
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function directive($name, \Closure $handler, bool $bind = false)
+    public function directive($name, callable|\Closure $handler, bool $bind = false)
     {
         if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid. Directive names must only contain alphanumeric characters and underscores.");

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -980,7 +980,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function directive($name, callable|\Closure $handler, bool $bind = false)
+    public function directive($name, callable $handler, bool $bind = false)
     {
         if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid. Directive names must only contain alphanumeric characters and underscores.");

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -974,13 +974,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * Register a handler for custom directives.
      *
      * @param  string  $name
-     * @param  callable  $handler
+     * @param  \Closure  $handler
      * @param  bool  $bind
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function directive($name, callable $handler, bool $bind = false)
+    public function directive($name, \Closure $handler, bool $bind = false)
     {
         if (! preg_match('/^\w+(?:::\w+)?$/x', $name)) {
             throw new InvalidArgumentException("The directive name [{$name}] is not valid. Directive names must only contain alphanumeric characters and underscores.");


### PR DESCRIPTION
Fix Invalid Types

Wanted to get into contributing and I figured fixing some of the strictly invalid types which exist in the codebase is a good place to start (especially with the release of Ranger and Surveyor in the future making good types more important).

Hope this is small enough but want to make further fixes in the future and don't want to seem spammy so I would appreciate feedback on the size of this. Also wondering what branch is best to commit this to. Work in hg all day so some of the git ops are hard for me to wrap my head around sometimes.

##Summary of changes

### PendingBatch.php
235 - Closures cannot act as bounds. Seems like this was just a result of the type being long. Used a type alias instead.

### Dispatcher.php
239 - parens are required for parsing
560 - input is a class string, we cannot assert that the class string is an instance of class, instead we can assert its a class string of the class 819 - Type was resolved to callable|null, it seems the callable should return type|null instead.

### BladeCompiler.php
977+983 - not all callables support bindTo, only Closures do

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
