### PR TITLE
[Support] Add once_keyed helper for explicit memoization keys

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -256,6 +256,26 @@ if (! function_exists('once')) {
     }
 }
 
+if (! function_exists('once_keyed')) {
+    /**
+     * Ensures a callable is only called once for the given key at the current call site.
+     *
+     * @template  TReturnType
+     *
+     * @param  string  $key
+     * @param  callable(): TReturnType  $callback
+     * @return TReturnType
+     */
+    function once_keyed(string $key, callable $callback)
+    {
+        return Once::instance()->value(Onceable::fromKey(
+            debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2),
+            $key,
+            $callback,
+        ));
+    }
+}
+
 if (! function_exists('optional')) {
     /**
      * Provide access to optional objects.

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -22,6 +22,7 @@ assertType('mixed', object_get(new User(), 'name'));
 assertType('1', once(fn () => 1));
 assertType('null', once(function () { /** @phpstan-ignore function.void (testing void) */
 }));
+assertType('1', once_keyed('foo', fn () => 1));
 
 assertType('Illuminate\Support\Optional', optional());
 assertType('null', optional(null, fn () => 1));


### PR DESCRIPTION
This PR adds a new `once_keyed(string $key, callable $callback)` helper to provide explicit memoization keys for `once()`-style caching.

`once()` derives its cache key from the call site and closure metadata, which can collide when multiple calls happen on the same line. A skipped test already documents this limitation.

`once_keyed()` provides an explicit escape hatch without changing the existing `once()` behavior.