### PR TITLE
[12.x] Add missing @throws docblocks to Illuminate/Http

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1497,6 +1497,8 @@ class PendingRequest
      * Build the stub handler.
      *
      * @return \Closure
+     *
+     * @throws \Illuminate\Http\Client\Exceptions\StrayRequestException
      */
     public function buildStubHandler()
     {
@@ -1795,6 +1797,8 @@ class PendingRequest
      *
      * @param  \GuzzleHttp\Exception\ConnectException  $e
      * @return void
+     *
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     protected function marshalConnectionException(ConnectException $e)
     {
@@ -1816,6 +1820,8 @@ class PendingRequest
      *
      * @param  \GuzzleHttp\Exception\RequestException  $e
      * @return void
+     *
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     protected function marshalRequestExceptionWithoutResponse(RequestException $e)
     {
@@ -1837,6 +1843,9 @@ class PendingRequest
      *
      * @param  \GuzzleHttp\Exception\RequestException  $e
      * @return void
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     protected function marshalRequestExceptionWithResponse(RequestException $e)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -588,6 +588,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \Symfony\Component\HttpFoundation\Exception\SessionNotFoundException
      */
     #[\Override]
     public function getSession(): SessionInterface

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -44,6 +44,8 @@ trait CollectsResources
      * Get the resource that this resource collects.
      *
      * @return class-string<\Illuminate\Http\Resources\Json\JsonResource>|null
+     *
+     * @throws \LogicException
      */
     protected function collects()
     {


### PR DESCRIPTION
This PR adds missing `@throws` annotations to several methods within the `Illuminate\Http` component. 
These additions improve IDE completion and static analysis support (like PHPStan/Psalm) for core HTTP-related classes, making the exception behavior of these methods explicit.
