### PR TITLE
[12.x] Add MySQL inRandomOrder regression tests

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2250,6 +2250,20 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" order by RANDOM()', $builder->toSql());
     }
 
+    public function testInRandomOrderMySqlGrammarWithoutSeed()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->inRandomOrder();
+        $this->assertSame('select * from `users` order by RAND()', $builder->toSql());
+    }
+
+    public function testInRandomOrderMySqlGrammarWithSeed()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->inRandomOrder(123);
+        $this->assertSame('select * from `users` order by RAND(123)', $builder->toSql());
+    }
+
     public function testInRandomOrderPostgres()
     {
         $builder = $this->getPostgresBuilder();


### PR DESCRIPTION
Refs [#58520](https://github.com/laravel/framework/issues/58520)

This PR adds MySQL-specific query builder regression tests for `inRandomOrder()`.

It ensures:

calling `inRandomOrder()` without a seed compiles to `ORDER BY RAND()`

calling `inRandomOrder(123)` compiles to `ORDER BY RAND(123)`

These tests prevent regressions where MySQL/MariaDB random ordering becomes deterministic (e.g. RAND(0)), causing repeated "random" queries to return the same ordering.

This is test-only and does not change runtime behavior; it documents and protects the intended MySQL grammar output.