### PR TITLE
[12.x] Batch exists validation for wildcard-expanded attributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -997,6 +997,17 @@ trait ValidatesAttributes
         // that the columns being "verified" shares the given attribute's name.
         $column = $this->getQueryColumn($parameters, $attribute);
 
+        $cacheKey = $attribute.'|'.$table.'|'.$column;
+
+        if (isset($this->batchedExistsResults[$cacheKey])) {
+            return $this->batchedExistsResults[$cacheKey];
+        }
+
+        if ($this->attemptBatchExistsValidation($attribute, $value, $parameters, $connection, $table, $column)
+            && isset($this->batchedExistsResults[$cacheKey])) {
+            return $this->batchedExistsResults[$cacheKey];
+        }
+
         $expected = is_array($value) ? count(array_unique($value)) : 1;
 
         if ($expected === 0) {
@@ -1006,6 +1017,75 @@ trait ValidatesAttributes
         return $this->getExistCount(
             $connection, $table, $column, $value, $parameters
         ) >= $expected;
+    }
+
+    /**
+     * Attempt to batch validate "exists" for all wildcard-expanded sibling attributes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @param  mixed  $connection
+     * @param  string  $table
+     * @param  string  $column
+     * @return bool
+     */
+    protected function attemptBatchExistsValidation($attribute, $value, $parameters, $connection, $table, $column)
+    {
+        $primaryAttribute = $this->getPrimaryAttribute($attribute);
+
+        if ($primaryAttribute === $attribute) {
+            return false;
+        }
+
+        $batchKey = $primaryAttribute.'|'.$table.'|'.$column;
+
+        if (isset($this->existsBatchAttempted[$batchKey])) {
+            return false;
+        }
+
+        $this->existsBatchAttempted[$batchKey] = true;
+
+        if ($this->currentRule instanceof Exists && ! empty($this->currentRule->queryCallbacks())) {
+            return false;
+        }
+
+        $siblings = $this->implicitAttributes[$primaryAttribute] ?? [];
+
+        if (count($siblings) < 2) {
+            return false;
+        }
+
+        $values = [];
+
+        foreach ($siblings as $sibling) {
+            $siblingValue = $this->getValue($sibling);
+
+            if (is_array($siblingValue) || is_object($siblingValue) || is_null($siblingValue)) {
+                return false;
+            }
+
+            $values[$sibling] = $siblingValue;
+        }
+
+        $extra = $this->getExtraConditions(
+            array_values(array_slice($parameters, 2))
+        );
+
+        $verifier = $this->getPresenceVerifier($connection);
+
+        $uniqueValues = array_values(array_unique($values));
+
+        $count = $verifier->getMultiCount($table, $column, $uniqueValues, $extra);
+
+        if ($count >= count($uniqueValues)) {
+            foreach ($siblings as $sibling) {
+                $siblingCacheKey = $sibling.'|'.$table.'|'.$column;
+                $this->batchedExistsResults[$siblingCacheKey] = true;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -118,6 +118,20 @@ class Validator implements ValidatorContract
     protected $distinctValues = [];
 
     /**
+     * The cached results of batch "exists" validation for wildcard attributes.
+     *
+     * @var array
+     */
+    protected $batchedExistsResults = [];
+
+    /**
+     * The attributes for which batch "exists" validation has been attempted.
+     *
+     * @var array
+     */
+    protected $existsBatchAttempted = [];
+
+    /**
      * All of the registered "after" callbacks.
      *
      * @var array
@@ -461,7 +475,7 @@ class Validator implements ValidatorContract
     {
         $this->messages = new MessageBag;
 
-        [$this->distinctValues, $this->failedRules] = [[], []];
+        [$this->distinctValues, $this->failedRules, $this->batchedExistsResults, $this->existsBatchAttempted] = [[], [], [], []];
 
         // We'll spin through each rule, validating the attributes attached to that
         // rule. Any error messages will be added to the containers with each of


### PR DESCRIPTION
## Summary

- When using `'ids.*' => 'exists:users,id'` with `['ids' => [1,2,3,4,5]]`, the validator expands the wildcard into N individual attributes and runs **N separate `WHERE id = X` queries**
- This change makes the first `validateExists()` call for a wildcard group batch **all sibling values into a single `WHERE IN (...)` query** via the existing `getMultiCount()` method
- **Happy path** (all exist): N queries → **1 query**
- **Sad path** (some missing): N queries → **N+1 queries** (1 batch check + N individual), preserving per-element error messages

### Changes

- **`Validator.php`**: Added `$batchedExistsResults` and `$existsBatchAttempted` cache properties, reset in `passes()`
- **`ValidatesAttributes.php`**: Modified `validateExists()` to check batch cache first; added `attemptBatchExistsValidation()` that collects all wildcard-sibling values and validates in one query
- **`ValidationValidatorTest.php`**: 6 new test methods covering happy path, sad path, query callbacks bypass, single element skip, extra conditions, and duplicate values

### Batching is skipped when

- The attribute is not wildcard-expanded (non-implicit attribute)
- The rule uses `Exists->where()` query callbacks (custom closures can't be batched)
- There's only a single element (no benefit)
- Any sibling value is array/object/null (non-scalar)

## Test plan

- [x] All 6 new batch exists tests pass
- [x] All existing exists-related tests pass
- [x] Full validation test suite passes