### PR TITLE
[13.x] feat: add Casts attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/Casts.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/Casts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+use Closure;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Casts
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<string, mixed>|(Closure(): array<string, mixed>)  $casts
+     */
+    public function __construct(public array|Closure $casts)
+    {
+    }
+}

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -287,8 +287,6 @@ class Mailable implements MailableContract, Renderable
     protected function newQueuedJob()
     {
         $messageGroup = $this->messageGroup ?? (method_exists($this, 'messageGroup') ? $this->messageGroup() : null);
-
-        /** @phpstan-ignore callable.nonNativeMethod (false positive since method_exists guard is used) */
         $deduplicator = $this->deduplicator ?? (method_exists($this, 'deduplicationId') ? $this->deduplicationId(...) : null);
 
         return Container::getInstance()->make(SendQueuedMailable::class, ['mailable' => $this])


### PR DESCRIPTION
Hello!

This is motivated by #51948 and adds a `Casts` attribute for resolving model casts. **One of the biggest benefits is static analysis support, especially when included on a trait from a 3rd party package.**

### Examples

```php
#[Casts(['foo' => 'int'])]
trait SomeTrait {}

class Post extends Model
{
    use SomeTrait;
}

new Post(['foo' => '3'])->foo; // int!
```

Additionally, PHP 8.5+ supports static closures in attributes, so this opens to door to allowing static method calls with constant values (to avoid having to concatenate with strings):

```php
#[Casts(static function () { return [
    'items' => AsCollection::using(ItemCollection::class),
];})]
class Cart extends Model {}
```

### Priority
Attribute casts have lowest priority and can be overridden:
1. `#[Casts]` attribute (lowest)
2. `$casts` property  
3. `casts()` method (highest)


CC: @kontoulis

Thanks!