### PR TITLE
[13.x] withoutOverlapping docblock

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -680,7 +680,6 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
-     * Remove an item from the cache.
      * Execute a callback while holding an atomic lock on a cache mutex to prevent overlapping calls.
      *
      * @template TReturn


### PR DESCRIPTION
Noticed the `* Remove an item from the cache.` bit is a merge conflict from the forget method - so thought I'd sort it.

Tests are failing cause 13.x needs catching up from 12.x.. or cherry pick the CI fix.