### PR TITLE
docs: Clarify controller instantiation behavior for middleware and re…

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -9,6 +9,11 @@ abstract class Controller
     /**
      * The middleware registered on the controller.
      *
+     * Note: Controllers extending this class and using the middleware() method will be instantiated
+     * early during routing to gather the middleware. If you need to access session or auth data
+     * in your constructor, do not extend this class. Instead, implement the
+     * \Illuminate\Routing\Controllers\HasMiddleware interface to define your middleware statically.
+     *
      * @var array
      */
     protected $middleware = [];
@@ -66,7 +71,9 @@ abstract class Controller
     public function __call($method, $parameters)
     {
         throw new BadMethodCallException(sprintf(
-            'Method %s::%s does not exist.', static::class, $method
+            'Method %s::%s does not exist.',
+            static::class,
+            $method
         ));
     }
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -9,11 +9,6 @@ abstract class Controller
     /**
      * The middleware registered on the controller.
      *
-     * Note: Controllers extending this class and using the middleware() method will be instantiated
-     * early during routing to gather the middleware. If you need to access session or auth data
-     * in your constructor, do not extend this class. Instead, implement the
-     * \Illuminate\Routing\Controllers\HasMiddleware interface to define your middleware statically.
-     *
      * @var array
      */
     protected $middleware = [];
@@ -39,6 +34,11 @@ abstract class Controller
 
     /**
      * Get the middleware assigned to the controller.
+     *
+     * Note: Controllers extending this class and using the middleware() method will be instantiated
+     * early during routing to gather the middleware. If you need to access session or auth data
+     * in your constructor, do not extend this class. Instead, implement the
+     * \Illuminate\Routing\Controllers\HasMiddleware interface to define your middleware statically.
      *
      * @return array
      */


### PR DESCRIPTION
This pull request adds an explanatory note to the `$middleware` docblock in `Illuminate\Routing\Controller`. 

Currently, many developers encounter issues when trying to access session state or the authenticated user (`auth()->user()`) within their controller's [__construct()](cci:1://file:///Users/comestro/framework/src/Illuminate/Routing/Route.php:166:4-184:5) method when extending the base [Controller](cci:2://file:///Users/comestro/framework/src/Illuminate/Routing/Controller.php:6:0-78:1). Because the base controller implements [getMiddleware()](cci:1://file:///Users/comestro/framework/src/Illuminate/Routing/Controller.php:39:4-47:5), the router is forced into **eager instantiation** to gather the middlewares before executing the route pipeline.

This clarifies that behavior directly in the code and directs developers to implement the `Illuminate\Routing\Controllers\HasMiddleware` interface instead, allowing them to define middlewares statically and maintain **lazy instantiation**.

Related to issue #58976.
