### PR TITLE
[12.x] Add missing @throws docblocks to `Serializer` and `Type` classes in `Illuminate/JsonSchema`

### DIFF
--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -17,6 +17,8 @@ class Serializer
      * Serialize the given property to an array.
      *
      * @return array<string, mixed>
+     *
+     * @throws \RuntimeException
      */
     public static function serialize(Types\Type $type): array
     {

--- a/src/Illuminate/JsonSchema/Types/Type.php
+++ b/src/Illuminate/JsonSchema/Types/Type.php
@@ -89,6 +89,8 @@ abstract class Type extends JsonSchema
      * Restrict the value to one of the provided enumerated values.
      *
      * @param  class-string<\BackedEnum>|array<int, mixed>  $values
+     *
+     * @throws \InvalidArgumentException
      */
     public function enum(array|string $values): static
     {


### PR DESCRIPTION
This PRs adds missing @throws docblocks to `Serializer` and `Type` classes in `Illuminate/JsonSchema`