### PR TITLE
[12.x] Fix division by zero error in `repeatEvery()` method

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -145,11 +145,17 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run multiple times per minute.
      *
-     * @param  int<0, 59>  $seconds
+     * @param  int<1, 59>  $seconds
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     protected function repeatEvery($seconds)
     {
+        if ($seconds <= 0) {
+            throw new InvalidArgumentException("The seconds [$seconds] must be greater than zero.");
+        }
+
         if (60 % $seconds !== 0) {
             throw new InvalidArgumentException("The seconds [$seconds] are not evenly divisible by 60.");
         }


### PR DESCRIPTION
`repeatEvery()` performs a modulo operation (`60 % $seconds`) without first validating that `$seconds` is greater than zero. Passing `0` causes a **division by zero error** before the existing `InvalidArgumentException` can be thrown.

This is made more likely by the PHPDoc annotation `@param int<0, 59>`, which explicitly includes `0` as a valid value, potentially misleading callers.