### PR TITLE
[12.x] Add missing, remove unused parameters to docblocks

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -1153,7 +1153,6 @@ class Arr
      *
      * @param  array<TKey, TValue>  $array
      * @param  int-mask-of<SORT_REGULAR|SORT_NUMERIC|SORT_STRING|SORT_LOCALE_STRING|SORT_NATURAL|SORT_FLAG_CASE>  $options
-     * @param  int  $options
      * @return array<TKey, TValue>
      */
     public static function sortRecursiveDesc($array, $options = SORT_REGULAR)

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -309,7 +309,7 @@ class Schedule
     /**
      * Create new schedule group.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Closure  $events
      * @return void
      *
      * @throws \RuntimeException

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -51,8 +51,8 @@ class QueryException extends PDOException
      * @param  string  $sql
      * @param  array  $bindings
      * @param  \Throwable  $previous
-     * @param  null|'read'|'write'  $readWriteType
      * @param  array  $connectionDetails
+     * @param  null|'read'|'write'  $readWriteType
      */
     public function __construct($connectionName, $sql, array $bindings, Throwable $previous, array $connectionDetails = [], $readWriteType = null)
     {

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -498,6 +498,7 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
      * Resolve the current cursor or return the default value.
      *
      * @param  string  $cursorName
+     * @param  \Illuminate\Pagination\Cursor|null  $default
      * @return \Illuminate\Pagination\Cursor|null
      */
     public static function resolveCurrentCursor($cursorName = 'cursor', $default = null)

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -9,7 +9,7 @@ class WorkerStarting
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  \Illuminate\Queue\WorkerOptions  $options
+     * @param  \Illuminate\Queue\WorkerOptions  $workerOptions
      */
     public function __construct(
         public $connectionName,

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -291,6 +291,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * Pop the next job off of the queue.
      *
      * @param  string|null  $queue
+     * @param  int  $index
      * @return \Illuminate\Contracts\Queue\Job|null
      */
     public function pop($queue = null, $index = 0)

--- a/src/Illuminate/Reflection/Reflector.php
+++ b/src/Illuminate/Reflection/Reflector.php
@@ -64,6 +64,7 @@ class Reflector
      *
      * @param  object|class-string  $objectOrClass
      * @param  class-string<TAttribute>  $attribute
+     * @param  bool  $ascend
      * @return TAttribute|null
      */
     public static function getClassAttribute($objectOrClass, $attribute, $ascend = false)
@@ -79,6 +80,7 @@ class Reflector
      *
      * @param  TTarget|class-string<TTarget>  $objectOrClass
      * @param  class-string<TAttribute>  $attribute
+     * @param  bool  $includeParents
      * @return ($includeParents is true ? Collection<class-string<contravariant TTarget>, Collection<int, TAttribute>> : Collection<int, TAttribute>)
      */
     public static function getClassAttributes($objectOrClass, $attribute, $includeParents = false)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -137,7 +137,6 @@ class BusFake implements Fake, QueueingDispatcher
      * Assert if a job was pushed exactly once.
      *
      * @param  string|\Closure  $command
-     * @param  int  $times
      * @return void
      */
     public function assertDispatchedOnce($command)

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -151,7 +151,6 @@ class EventFake implements Dispatcher, Fake
      * Assert if an event was dispatched exactly once.
      *
      * @param  string  $event
-     * @param  int  $times
      * @return void
      */
     public function assertDispatchedOnce($event)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -349,6 +349,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
      * @return bool
      */
     public function validateAlpha($attribute, $value, $parameters)
@@ -367,6 +368,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
      * @return bool
      */
     public function validateAlphaDash($attribute, $value, $parameters)
@@ -388,6 +390,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
      * @return bool
      */
     public function validateAlphaNum($attribute, $value, $parameters)

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -58,8 +58,8 @@ abstract class Compiler
      * @param  string  $cachePath
      * @param  string  $basePath
      * @param  bool  $shouldCache
-     * @param  bool  $shouldCheckTimestamps
      * @param  string  $compiledExtension
+     * @param  bool  $shouldCheckTimestamps
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
This PR:
- Changes the order of the params
- Adds some missing params
- Remove unused params