### PR TITLE
[12.x] bug: throttle with redis ignores after callback

### DIFF
--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
@@ -47,6 +50,46 @@ class ThrottleRequestsWithRedisTest extends TestCase
                 // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
                 // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
             }
+        });
+    }
+
+    public function testItCanThrottleBasedOnResponse()
+    {
+        $this->ifRedisAvailable(function () {
+            RateLimiter::for('throttle-not-found', function (Request $request) {
+                return Limit::perMinute(1)->after(fn ($response) => $response->status() === 404);
+            });
+            Route::get('/', fn () => match (request('status')) {
+                '404' => abort(404),
+                default => 'ok',
+            })->middleware(ThrottleRequestsWithRedis::using('throttle-not-found'));
+
+            // Non-matching responses should not count toward the limit.
+            $this->get('?status=200')->assertOk();
+            $this->get('?status=200')->assertOk();
+            $this->get('?status=200')->assertOk();
+
+            // A matching response should count and exhaust the limit.
+            $this->get('?status=404')->assertNotFound();
+
+            // Now throttled — even non-matching requests are blocked.
+            $this->get('?status=200')->assertTooManyRequests();
+            $this->get('?status=404')->assertTooManyRequests();
+        });
+    }
+
+    public function testItReturnsConfiguredResponseWhenUsingAfterLimit(): void
+    {
+        $this->ifRedisAvailable(function () {
+            RateLimiter::for('throttle-not-found', function (Request $request) {
+                return Limit::perMinute(1)
+                    ->after(fn ($response) => $response->status() === 404)
+                    ->response(fn () => response('ah ah ah', status: 429));
+            });
+            Route::get('/', fn () => abort(404))->middleware(ThrottleRequestsWithRedis::using('throttle-not-found'));
+
+            $this->get('/')->assertNotFound();
+            $this->get('/')->assertTooManyRequests()->assertContent('ah ah ah');
         });
     }
 }


### PR DESCRIPTION
#57125 by @timacdonald introduced an `after` callback for rate limiting / throttling, which allows certain responses (like a 404) to bypass the rate limiting.

However, when this feature was introduced the logic was added to the `handleRequest` method in `ThrottleRequests`, but `ThrottleRequestsWithRedis` overwrite this method as it checks throttling in a different way. Thus, this feature doesn't work if you're using `$middleware->throttleWithRedis()`, the callback is never used and checked.

I have added the checks in the same way it's done in the parent class. Maybe this is a sign to refactor so the logic doesn't duplicate across two classes, but I'm not sure which approach is preferable.

## Reproducing the issue

Create a rate limiter that only counts successful responses:

```php
// In the boot method of a service provider
RateLimiter::for('success-only', function (Request $request) {
    return Limit::perMinute(1)
        ->by('key:'.$request->ip())
        ->after(fn (Response $response): bool => $response->isSuccessful());
});
```

Create a route that uses the limiter and returns a simple response based on a query parameter:

```php
Route::get('/', fn () => match (request('status')) {
    '404' => abort(404),
    default => 'ok',
})->middleware('throttle:success-only');
```

Now make a request to `/?status=404`, you can hit that endpoint as much as you'd like, you wouldn't get throttled. When you make a request to `/?status=200` it would allow 1 request, then making another would rate limit you. That's all correct.

Now enable throttling with redis:

```php
// bootstrap/app.php
return Application::configure(basePath: dirname(__DIR__))
    ->withMiddleware(function (Middleware $middleware): void {
        $middleware->throttleWithRedis();
    });
```

If you now try the same then you'd see it doesn't account for the response. First request to `/?status=404` would succeed, it shows a 404 page. Make another request to `/?status=404` and you'll get a 429 response. So the `after` callback isn't executed, you'll get rate limited even though you have filters set up that shouldn't count towards the rate limit.