### PR TITLE
[12.x] Allow app.editor.base_path to be an empty string

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -171,7 +171,7 @@ trait ResolvesDumpSource
             : ($this->editorHrefs[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
 
         $basePath = $editor['base_path'] ?? false;
-        
+
         if ($basePath !== false) {
             $file = Str::replaceStart($this->basePath, $basePath, $file);
         }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -170,7 +170,9 @@ trait ResolvesDumpSource
             ? $editor['href']
             : ($this->editorHrefs[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
 
-        if ($basePath = $editor['base_path'] ?? false) {
+        $basePath = $editor['base_path'] ?? false;
+        
+        if ($basePath !== false) {
             $file = Str::replaceStart($this->basePath, $basePath, $file);
         }
 


### PR DESCRIPTION
This change allows `app.editor.base_path` to be an empty string
