### PR TITLE
[12.x] Add `--interval` option to `schedule:work` command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -41,11 +41,13 @@ class ScheduleWorkCommand extends Command
 
         if ($interval <= 0) {
             $this->components->error('The interval must be greater than zero.');
+
             return;
         }
 
         if (60 % $interval !== 0) {
             $this->components->error('The interval is not evenly divisible by 60.');
+
             return;
         }
 


### PR DESCRIPTION
## Description

This PR adds an `--interval` option to the `schedule:work` command, allowing developers to run the scheduler more frequently than once per minute during local development.

By default, `schedule:work` runs `schedule:run` every 60 seconds. This means developers have to wait up to a minute to see their scheduled tasks execute. With `--interval`, they can set a sub-minute interval (e.g. every 10 or 15 seconds) to speed up the feedback loop.

## Usage
```bash
# Run scheduler every 10 seconds
php artisan schedule:work --interval=10

# Run scheduler every 15 seconds
php artisan schedule:work --interval=15

# Default behavior (every 60 seconds)
php artisan schedule:work
```