### PR TITLE
[13.x] Add get_class_to_class_keyword to pint.json

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -42,6 +42,7 @@
         "encoding": true,
         "full_opening_tag": true,
         "function_declaration": true,
+        "get_class_to_class_keyword": true,
         "heredoc_to_nowdoc": true,
         "include": true,
         "increment_style": {

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -477,7 +477,7 @@ class Gate implements GateContract
         }
 
         if (is_array($class)) {
-            $className = is_string($class[0]) ? $class[0] : get_class($class[0]);
+            $className = is_string($class[0]) ? $class[0] : $class[0]::class;
 
             return $this->methodAllowsGuests($className, $class[1]);
         }
@@ -659,7 +659,7 @@ class Gate implements GateContract
     public function getPolicyFor($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $class = $class::class;
         }
 
         if (! is_string($class)) {

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -89,7 +89,7 @@ class BroadcastEvent implements ShouldQueue
     {
         $name = method_exists($this->event, 'broadcastAs')
             ? $this->event->broadcastAs()
-            : get_class($this->event);
+            : $this->event::class;
 
         $channels = Arr::wrap($this->event->broadcastOn());
 
@@ -221,7 +221,7 @@ class BroadcastEvent implements ShouldQueue
      */
     public function displayName()
     {
-        return get_class($this->event);
+        return $this->event::class;
     }
 
     /**

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -182,7 +182,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function hasCommandHandler($command)
     {
-        return array_key_exists(get_class($command), $this->handlers);
+        return array_key_exists($command::class, $this->handlers);
     }
 
     /**
@@ -194,7 +194,7 @@ class Dispatcher implements QueueingDispatcher
     public function getCommandHandler($command)
     {
         if ($this->hasCommandHandler($command)) {
-            return $this->container->make($this->handlers[get_class($command)]);
+            return $this->container->make($this->handlers[$command::class]);
         }
 
         return false;

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -365,7 +365,7 @@ trait Queueable
         if ((new Collection($expectedChain))->contains(fn ($job) => is_object($job))) {
             $expectedChain = (new Collection($expectedChain))->map(fn ($job) => serialize($job))->all();
         } else {
-            $chain = (new Collection($this->chained))->map(fn ($job) => get_class(unserialize($job)))->all();
+            $chain = (new Collection($this->chained))->map(fn ($job) => unserialize($job)::class)->all();
         }
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -75,7 +75,7 @@ class UniqueLock
 
         $jobName = method_exists($job, 'displayName')
             ? $job->displayName()
-            : get_class($job);
+            : $job::class;
 
         return 'laravel_unique_job:'.$jobName.':'.$uniqueId;
     }

--- a/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
+++ b/src/Illuminate/Collections/Traits/TransformsToResourceCollection.php
@@ -46,7 +46,7 @@ trait TransformsToResourceCollection
         throw_unless(is_object($model), LogicException::class, 'Resource collection guesser expects the collection to contain objects.');
 
         /** @var class-string<Model> $className */
-        $className = get_class($model);
+        $className = $model::class;
 
         throw_unless(method_exists($className, 'guessResourceName'), LogicException::class, sprintf('Expected class %s to implement guessResourceName method. Make sure the model uses the TransformsToResource trait.', $className));
 

--- a/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
+++ b/src/Illuminate/Concurrency/Console/InvokeSerializedClosureCommand.php
@@ -70,7 +70,7 @@ class InvokeSerializedClosureCommand extends Command
 
             $this->output->write(json_encode([
                 'successful' => false,
-                'exception' => get_class($e),
+                'exception' => $e::class,
                 'message' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -180,7 +180,7 @@ class Application extends SymfonyApplication implements ApplicationContract
             $callingClass = true;
 
             if (is_object($command)) {
-                $command = get_class($command);
+                $command = $command::class;
             }
 
             $command = $this->laravel->make($command)->getName();

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -157,7 +157,7 @@ class Schedule
     public function command($command, array $parameters = [])
     {
         if ($command instanceof SymfonyCommand) {
-            $command = get_class($command);
+            $command = $command::class;
 
             $command = Container::getInstance()->make($command);
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -104,7 +104,7 @@ class BoundMethod
      */
     protected static function normalizeMethod($callback)
     {
-        $class = is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        $class = is_string($callback[0]) ? $callback[0] : $callback[0]::class;
 
         return "{$class}@{$callback[1]}";
     }

--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -20,7 +20,7 @@ class ClassMorphViolationException extends RuntimeException
      */
     public function __construct($model)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("No morph map defined for model [{$class}].");
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -213,7 +213,7 @@ class Builder implements BuilderContract
     public function withoutGlobalScope($scope)
     {
         if (! is_string($scope)) {
-            $scope = get_class($scope);
+            $scope = $scope::class;
         }
 
         unset($this->scopes[$scope]);
@@ -622,7 +622,7 @@ class Builder implements BuilderContract
         if (is_array($id)) {
             if (count($result) !== count(array_unique($id))) {
                 throw (new ModelNotFoundException)->setModel(
-                    get_class($this->model), array_diff($id, $result->modelKeys())
+                    $this->model::class, array_diff($id, $result->modelKeys())
                 );
             }
 
@@ -631,7 +631,7 @@ class Builder implements BuilderContract
 
         if (is_null($result)) {
             throw (new ModelNotFoundException)->setModel(
-                get_class($this->model), $id
+                $this->model::class, $id
             );
         }
 
@@ -780,7 +780,7 @@ class Builder implements BuilderContract
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->model));
+        throw (new ModelNotFoundException)->setModel($this->model::class);
     }
 
     /**
@@ -821,7 +821,7 @@ class Builder implements BuilderContract
         try {
             return $this->baseSole($columns);
         } catch (RecordsNotFoundException) {
-            throw (new ModelNotFoundException)->setModel(get_class($this->model));
+            throw (new ModelNotFoundException)->setModel($this->model::class);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -76,7 +76,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $ids = is_array($key) ? array_diff($key, $result->modelKeys()) : $key;
 
-        $exception->setModel(get_class($model), $ids);
+        $exception->setModel($model::class, $ids);
 
         throw $exception;
     }
@@ -320,7 +320,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
+            ->groupBy(fn ($model) => $model::class)
             ->each(fn ($models, $className) => static::make($models)->load($relations[$className] ?? []));
 
         return $this;
@@ -337,7 +337,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(fn ($model) => get_class($model))
+            ->groupBy(fn ($model) => $model::class)
             ->each(fn ($models, $className) => static::make($models)->loadCount($relations[$className] ?? []));
 
         return $this;
@@ -843,7 +843,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return method_exists($model, 'getQueueableClassName')
             ? $model->getQueueableClassName()
-            : get_class($model);
+            : $model::class;
     }
 
     /**
@@ -923,7 +923,7 @@ class Collection extends BaseCollection implements QueueableCollection
             throw new LogicException('Unable to create query for empty collection.');
         }
 
-        $class = get_class($model);
+        $class = $model::class;
 
         if ($this->reject(fn ($model) => $model instanceof $class)->isNotEmpty()) {
             throw new LogicException('Unable to create query for collection with mixed types.');

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -246,7 +246,7 @@ trait GuardsAttributes
             return true;
         }
 
-        if (! isset(static::$guardableColumns[get_class($this)])) {
+        if (! isset(static::$guardableColumns[$this::class])) {
             $columns = $this->getConnection()
                 ->getSchemaBuilder()
                 ->getColumnListing($this->getTable());
@@ -255,10 +255,10 @@ trait GuardsAttributes
                 return true;
             }
 
-            static::$guardableColumns[get_class($this)] = $columns;
+            static::$guardableColumns[$this::class] = $columns;
         }
 
-        return in_array($key, static::$guardableColumns[get_class($this)]);
+        return in_array($key, static::$guardableColumns[$this::class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -669,17 +669,17 @@ trait HasAttributes
      */
     public function hasAttributeMutator($key)
     {
-        if (isset(static::$attributeMutatorCache[get_class($this)][$key])) {
-            return static::$attributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$attributeMutatorCache[$this::class][$key])) {
+            return static::$attributeMutatorCache[$this::class][$key];
         }
 
         if (! method_exists($this, $method = Str::camel($key))) {
-            return static::$attributeMutatorCache[get_class($this)][$key] = false;
+            return static::$attributeMutatorCache[$this::class][$key] = false;
         }
 
         $returnType = (new ReflectionMethod($this, $method))->getReturnType();
 
-        return static::$attributeMutatorCache[get_class($this)][$key] =
+        return static::$attributeMutatorCache[$this::class][$key] =
                     $returnType instanceof ReflectionNamedType &&
                     $returnType->getName() === Attribute::class;
     }
@@ -692,15 +692,15 @@ trait HasAttributes
      */
     public function hasAttributeGetMutator($key)
     {
-        if (isset(static::$getAttributeMutatorCache[get_class($this)][$key])) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key];
+        if (isset(static::$getAttributeMutatorCache[$this::class][$key])) {
+            return static::$getAttributeMutatorCache[$this::class][$key];
         }
 
         if (! $this->hasAttributeMutator($key)) {
-            return static::$getAttributeMutatorCache[get_class($this)][$key] = false;
+            return static::$getAttributeMutatorCache[$this::class][$key] = false;
         }
 
-        return static::$getAttributeMutatorCache[get_class($this)][$key] = is_callable($this->{Str::camel($key)}()->get);
+        return static::$getAttributeMutatorCache[$this::class][$key] = is_callable($this->{Str::camel($key)}()->get);
     }
 
     /**
@@ -769,8 +769,8 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif (isset(static::$getAttributeMutatorCache[$this::class][$key]) &&
+                  static::$getAttributeMutatorCache[$this::class][$key] === true) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface
@@ -1147,7 +1147,7 @@ trait HasAttributes
      */
     public function hasAttributeSetMutator($key)
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (isset(static::$setAttributeMutatorCache[$class][$key])) {
             return static::$setAttributeMutatorCache[$class][$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -113,7 +113,7 @@ trait HasEvents
     private function resolveObserverClassName($class)
     {
         if (is_object($class)) {
-            return get_class($class);
+            return $class::class;
         }
 
         if (class_exists($class)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -108,7 +108,7 @@ trait HasGlobalScopes
         }
 
         return Arr::get(
-            static::$globalScopes, static::class.'.'. $scope::class
+            static::$globalScopes, static::class.'.'.$scope::class
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -59,7 +59,7 @@ trait HasGlobalScopes
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
         } elseif ($scope instanceof Scope) {
-            return static::$globalScopes[static::class][get_class($scope)] = $scope;
+            return static::$globalScopes[static::class][$scope::class] = $scope;
         } elseif (is_string($scope) && class_exists($scope) && is_subclass_of($scope, Scope::class)) {
             return static::$globalScopes[static::class][$scope] = new $scope;
         }
@@ -108,7 +108,7 @@ trait HasGlobalScopes
         }
 
         return Arr::get(
-            static::$globalScopes, static::class.'.'.get_class($scope)
+            static::$globalScopes, static::class.'.'. $scope::class
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -181,7 +181,7 @@ trait HasRelationships
      */
     protected function invokeRelationAutoloadCallbackFor($key, $tuples)
     {
-        $tuples = array_merge([[$key, get_class($this)]], $tuples);
+        $tuples = array_merge([[$key, $this::class]], $tuples);
 
         call_user_func($this->relationAutoloadCallback, $tuples);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUniqueStringIds.php
@@ -103,6 +103,6 @@ trait HasUniqueStringIds
      */
     protected function handleInvalidUniqueId($value, $field)
     {
-        throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        throw (new ModelNotFoundException)->setModel($this::class, $value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -44,7 +44,7 @@ trait TransformsToResource
             }
         }
 
-        throw new LogicException(sprintf('Failed to find resource class for model [%s].', get_class($this)));
+        throw new LogicException(sprintf('Failed to find resource class for model [%s].', $this::class));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -769,7 +769,7 @@ abstract class Factory
                 ->merge(
                     Collection::wrap($model instanceof Model ? func_get_args() : $model)
                         ->flatten()
-                )->groupBy(fn ($model) => get_class($model)),
+                )->groupBy(fn ($model) => $model::class),
         ]);
     }
 
@@ -1137,7 +1137,7 @@ abstract class Factory
 
         $relationship = Str::camel(Str::substr($method, 3));
 
-        $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
+        $relatedModel = $this->newModel()->{$relationship}()->getRelated()::class;
 
         if (method_exists($relatedModel, 'newFactory')) {
             $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);

--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -36,7 +36,7 @@ class InvalidCastException extends RuntimeException
      */
     public function __construct($model, $column, $castType)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");
 

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -15,7 +15,7 @@ class JsonEncodingException extends RuntimeException
      */
     public static function forModel($model, $message)
     {
-        return new static('Error encoding model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding model ['. $model::class .'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**
@@ -29,7 +29,7 @@ class JsonEncodingException extends RuntimeException
     {
         $model = $resource->resource;
 
-        return new static('Error encoding resource ['.get_class($resource).'] with model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding resource ['. $resource::class .'] with model ['. $model::class .'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**
@@ -42,7 +42,7 @@ class JsonEncodingException extends RuntimeException
      */
     public static function forAttribute($model, $key, $message)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         return new static("Unable to encode attribute [{$key}] for model [{$class}] to JSON: {$message}.");
     }

--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -15,7 +15,7 @@ class JsonEncodingException extends RuntimeException
      */
     public static function forModel($model, $message)
     {
-        return new static('Error encoding model ['. $model::class .'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding model ['.$model::class.'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**
@@ -29,7 +29,7 @@ class JsonEncodingException extends RuntimeException
     {
         $model = $resource->resource;
 
-        return new static('Error encoding resource ['. $resource::class .'] with model ['. $model::class .'] with ID ['.$model->getKey().'] to JSON: '.$message);
+        return new static('Error encoding resource ['.$resource::class.'] with model ['.$model::class.'] with ID ['.$model->getKey().'] to JSON: '.$message);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/MissingAttributeException.php
+++ b/src/Illuminate/Database/Eloquent/MissingAttributeException.php
@@ -16,7 +16,7 @@ class MissingAttributeException extends OutOfBoundsException
     {
         parent::__construct(sprintf(
             'The attribute [%s] either does not exist or was not retrieved for model [%s].',
-            $key, get_class($model)
+            $key, $model::class
         ));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -678,7 +678,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 } else {
                     throw new MassAssignmentException(sprintf(
                         'Add [%s] to fillable property to allow mass assignment on [%s].',
-                        $key, get_class($this)
+                        $key, $this::class
                     ));
                 }
             }
@@ -694,7 +694,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 throw new MassAssignmentException(sprintf(
                     'Add fillable property [%s] to allow mass assignment on [%s].',
                     implode(', ', $keys),
-                    get_class($this)
+                    $this::class
                 ));
             }
         }
@@ -870,7 +870,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this;
         }
 
-        $className = get_class($this->{$relation});
+        $className = $this->{$relation}::class;
 
         $this->{$relation}->load($relations[$className] ?? []);
 
@@ -994,7 +994,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this;
         }
 
-        $className = get_class($this->{$relation});
+        $className = $this->{$relation}::class;
 
         $this->{$relation}->loadAggregate($relations[$className] ?? [], $column, $function);
 
@@ -2454,7 +2454,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannelRoute()
     {
-        return str_replace('\\', '.', get_class($this)).'.{'.Str::camel(class_basename($this)).'}';
+        return str_replace('\\', '.', $this::class).'.{'.Str::camel(class_basename($this)).'}';
     }
 
     /**
@@ -2464,7 +2464,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function broadcastChannel()
     {
-        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
+        return str_replace('\\', '.', $this::class).'.'.$this->getKey();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/ModelInspector.php
+++ b/src/Illuminate/Database/Eloquent/ModelInspector.php
@@ -193,8 +193,8 @@ class ModelInspector
 
                 return [
                     'name' => $method->getName(),
-                    'type' => Str::afterLast(get_class($relation), '\\'),
-                    'related' => get_class($relation->getRelated()),
+                    'type' => Str::afterLast($relation::class, '\\'),
+                    'related' => $relation->getRelated()::class,
                 ];
             })
             ->filter()

--- a/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
@@ -30,7 +30,7 @@ class RelationNotFoundException extends RuntimeException
      */
     public static function make($model, $relation, $type = null)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         $instance = new static(
             is_null($type)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -797,7 +797,7 @@ class BelongsToMany extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new ModelNotFoundException)->setModel($this->related::class, $id);
     }
 
     /**
@@ -878,7 +878,7 @@ class BelongsToMany extends Relation
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new ModelNotFoundException)->setModel($this->related::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsInverseRelations.php
@@ -81,7 +81,7 @@ trait SupportsInverseRelations
             Str::camel(Str::beforeLast($this->getParent()->getForeignKey(), $this->getParent()->getKeyName())),
             Str::camel(class_basename($this->getParent())),
             'owner',
-            get_class($this->getParent()) === get_class($this->getModel()) ? 'parent' : null,
+            $this->getParent()::class === $this->getModel()::class ? 'parent' : null,
         ]));
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -305,7 +305,7 @@ abstract class HasOneOrManyThrough extends Relation
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new ModelNotFoundException)->setModel($this->related::class);
     }
 
     /**
@@ -410,7 +410,7 @@ abstract class HasOneOrManyThrough extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new ModelNotFoundException)->setModel($this->related::class, $id);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -155,13 +155,13 @@ class MorphTo extends BelongsTo
             ->mergeConstraintsFrom($this->getQuery())
             ->with(array_merge(
                 $this->getQuery()->getEagerLoads(),
-                (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
+                (array) ($this->morphableEagerLoads[$instance::class] ?? [])
             ))
             ->withCount(
-                (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
+                (array) ($this->morphableEagerLoadCounts[$instance::class] ?? [])
             );
 
-        if ($callback = ($this->morphableConstraints[get_class($instance)] ?? null)) {
+        if ($callback = ($this->morphableConstraints[$instance::class] ?? null)) {
             $callback($query);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -191,7 +191,7 @@ abstract class Relation implements BuilderContract
         $count = $result->count();
 
         if ($count === 0) {
-            throw (new ModelNotFoundException)->setModel(get_class($this->related));
+            throw (new ModelNotFoundException)->setModel($this->related::class);
         }
 
         if ($count > 1) {

--- a/src/Illuminate/Database/LazyLoadingViolationException.php
+++ b/src/Illuminate/Database/LazyLoadingViolationException.php
@@ -28,7 +28,7 @@ class LazyLoadingViolationException extends RuntimeException
      */
     public function __construct($model, $relation)
     {
-        $class = get_class($model);
+        $class = $model::class;
 
         parent::__construct("Attempted to lazy load [{$relation}] on model [{$class}] but lazy loading is disabled.");
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -460,7 +460,7 @@ class Migrator
      */
     protected function pretendToRun($migration, $method)
     {
-        $name = get_class($migration);
+        $name = $migration::class;
 
         $reflectionClass = new ReflectionClass($migration);
 

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -59,7 +59,7 @@ class JoinClause extends Builder
     {
         $this->type = $type;
         $this->table = $table;
-        $this->parentClass = get_class($parentQuery);
+        $this->parentClass = $parentQuery::class;
         $this->parentGrammar = $parentQuery->getGrammar();
         $this->parentProcessor = $parentQuery->getProcessor();
         $this->parentConnection = $parentQuery->getConnection();

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -177,7 +177,7 @@ abstract class Seeder
     public function __invoke(array $parameters = [])
     {
         if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from '. $this::class);
+            throw new InvalidArgumentException('Method [run] missing from '.$this::class);
         }
 
         $callback = fn () => isset($this->container)

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -47,7 +47,7 @@ abstract class Seeder
         foreach ($classes as $class) {
             $seeder = $this->resolve($class);
 
-            $name = get_class($seeder);
+            $name = $seeder::class;
 
             if ($silent === false && isset($this->command)) {
                 (new TwoColumnDetail($this->command->getOutput()))
@@ -177,7 +177,7 @@ abstract class Seeder
     public function __invoke(array $parameters = [])
     {
         if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
+            throw new InvalidArgumentException('Method [run] missing from '. $this::class);
         }
 
         $callback = fn () => isset($this->container)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -230,7 +230,7 @@ class Dispatcher implements DispatcherContract
             foreach ($events as $event => $listeners) {
                 foreach (Arr::wrap($listeners) as $listener) {
                     if (is_string($listener) && method_exists($subscriber, $listener)) {
-                        $this->listen($event, [get_class($subscriber), $listener]);
+                        $this->listen($event, [$subscriber::class, $listener]);
 
                         continue;
                     }
@@ -357,7 +357,7 @@ class Dispatcher implements DispatcherContract
     protected function parseEventAndPayload($event, $payload)
     {
         if (is_object($event)) {
-            [$payload, $event] = [[$event], get_class($event)];
+            [$payload, $event] = [[$event], $event::class];
         }
 
         return [$event, Arr::wrap($payload)];

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -932,7 +932,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function getProvider($provider)
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return $this->serviceProviders[$name] ?? null;
     }
@@ -945,7 +945,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function getProviders($provider)
     {
-        $name = is_string($provider) ? $provider : get_class($provider);
+        $name = is_string($provider) ? $provider : $provider::class;
 
         return Arr::where($this->serviceProviders, fn ($value) => $value instanceof $name);
     }
@@ -969,7 +969,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected function markAsRegistered($provider)
     {
-        $class = get_class($provider);
+        $class = $provider::class;
 
         $this->serviceProviders[$class] = $provider;
 

--- a/src/Illuminate/Foundation/Console/ConfigShowCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigShowCommand.php
@@ -114,7 +114,7 @@ class ConfigShowCommand extends Command
             is_null($value) => '<fg=#ef8414;options=bold>null</>',
             is_numeric($value) => "<fg=#ef8414;options=bold>{$value}</>",
             is_array($value) => '[]',
-            is_object($value) => get_class($value),
+            is_object($value) => $value::class,
             is_string($value) => $value,
             default => print_r($value, true),
         };

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -52,7 +52,7 @@ class EventCacheCommand extends Command
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
             $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
 
-            $events[get_class($provider)] = $providerEvents;
+            $events[$provider::class] = $providerEvents;
         }
 
         return $events;

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -131,7 +131,7 @@ class EventListCommand extends Command
                     $events[$event][] = $this->stringifyClosure($rawListener);
                 } elseif (is_array($rawListener) && count($rawListener) === 2) {
                     if (is_object($rawListener[0])) {
-                        $rawListener[0] = get_class($rawListener[0]);
+                        $rawListener[0] = $rawListener[0]::class;
                     }
 
                     $events[$event][] = $this->appendListenerInterfaces(implode('@', $rawListener));

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -546,7 +546,7 @@ class Kernel implements KernelContract
      */
     protected function shouldDiscoverCommands()
     {
-        return get_class($this) === __CLASS__;
+        return $this::class === __CLASS__;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -1022,7 +1022,7 @@ class Handler implements ExceptionHandlerContract
     {
         return config('app.debug') ? [
             'message' => $e->getMessage(),
-            'exception' => get_class($e),
+            'exception' => $e::class,
             'file' => $e->getFile(),
             'line' => $e->getLine(),
             'trace' => (new Collection($e->getTrace()))->map(fn ($trace) => Arr::except($trace, ['args']))->all(),

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -107,7 +107,7 @@ class EventServiceProvider extends ServiceProvider
         if ($this->app->eventsAreCached()) {
             $cache = require $this->app->getCachedEventsPath();
 
-            return $cache[get_class($this)] ?? [];
+            return $cache[$this::class] ?? [];
         } else {
             return array_merge_recursive(
                 $this->discoveredEvents(),
@@ -135,7 +135,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents()
     {
-        return get_class($this) === __CLASS__ && static::$shouldDiscoverEvents === true;
+        return $this::class === __CLASS__ && static::$shouldDiscoverEvents === true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -104,7 +104,7 @@ trait InteractsWithAuthentication
         $this->assertNotNull($expected, 'The current user is not authenticated.');
 
         $this->assertInstanceOf(
-            get_class($expected), $user,
+            $expected::class, $user,
             'The currently authenticated user is not who was expected'
         );
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -229,7 +229,7 @@ trait InteractsWithExceptionHandling
         } catch (Throwable $exception) {
             $thrown = true;
 
-            $exceptionClass = get_class($exception);
+            $exceptionClass = $exception::class;
             $exceptionMessage = $exception->getMessage();
         }
 

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -70,8 +70,8 @@ trait CollectsResources
         } elseif ($this->collects) {
             $collects = $this->collects;
         } elseif (str_ends_with(class_basename($this), 'Collection') &&
-            (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
-             class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
+            (class_exists($class = Str::replaceLast('Collection', '', $this::class)) ||
+             class_exists($class = Str::replaceLast('Collection', 'Resource', $this::class)))) {
             $collects = $class;
         }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -109,7 +109,7 @@ class ResourceResponse implements Responsable
      */
     protected function wrapper()
     {
-        return get_class($this->resource)::$wrap;
+        return $this->resource::class::$wrap;
     }
 
     /**

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -30,7 +30,7 @@ class Serializer
             Types\NumberType::class => 'number',
             Types\ObjectType::class => 'object',
             Types\StringType::class => 'string',
-            default => throw new RuntimeException('Unsupported ['. $type::class .'] type.'),
+            default => throw new RuntimeException('Unsupported ['.$type::class.'] type.'),
         };
 
         $nullable = static::isNullable($type);

--- a/src/Illuminate/JsonSchema/Serializer.php
+++ b/src/Illuminate/JsonSchema/Serializer.php
@@ -23,14 +23,14 @@ class Serializer
         /** @var array<string, mixed> $attributes */
         $attributes = (fn () => get_object_vars($type))->call($type);
 
-        $attributes['type'] = match (get_class($type)) {
+        $attributes['type'] = match ($type::class) {
             Types\ArrayType::class => 'array',
             Types\BooleanType::class => 'boolean',
             Types\IntegerType::class => 'integer',
             Types\NumberType::class => 'number',
             Types\ObjectType::class => 'object',
             Types\StringType::class => 'string',
-            default => throw new RuntimeException('Unsupported ['.get_class($type).'] type.'),
+            default => throw new RuntimeException('Unsupported ['. $type::class .'] type.'),
         };
 
         $nullable = static::isNullable($type);

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -395,7 +395,7 @@ class Mailable implements MailableContract, Renderable
     protected function additionalMessageData(): array
     {
         return [
-            '__laravel_mailable' => get_class($this),
+            '__laravel_mailable' => $this::class,
         ];
     }
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -139,7 +139,7 @@ class SendQueuedMailable
      */
     public function displayName()
     {
-        return get_class($this->mailable);
+        return $this->mailable::class;
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -34,7 +34,7 @@ class DatabaseChannel
             'id' => $notification->id,
             'type' => method_exists($notification, 'databaseType')
                 ? $notification->databaseType($notifiable)
-                : get_class($notification),
+                : $notification::class,
             'data' => $this->getData($notifiable, $notification),
             'read_at' => method_exists($notification, 'initialDatabaseReadAtValue')
                 ? $notification->initialDatabaseReadAtValue($notifiable)

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -154,7 +154,7 @@ class MailChannel
     {
         return [
             '__laravel_notification_id' => $notification->id,
-            '__laravel_notification' => get_class($notification),
+            '__laravel_notification' => $notification::class,
             '__laravel_notification_queued' => in_array(
                 ShouldQueue::class,
                 class_implements($notification)

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -66,7 +66,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $this->notifiable->receivesBroadcastNotificationsOn($this->notification);
         }
 
-        $class = str_replace('\\', '.', get_class($this->notifiable));
+        $class = str_replace('\\', '.', $this->notifiable::class);
 
         return $class.'.'.$this->notifiable->getKey();
     }
@@ -97,7 +97,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     {
         return method_exists($this->notification, 'broadcastType')
             ? $this->notification->broadcastType()
-            : get_class($this->notification);
+            : $this->notification::class;
     }
 
     /**

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -137,7 +137,7 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
-        return get_class($this->notification);
+        return $this->notification::class;
     }
 
     /**

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -159,7 +159,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception,
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['.$exception.'] but job failed with ['.get_class($this->job->failedWith).'].'
+                'Expected job to be manually failed with ['.$exception.'] but job failed with ['. $this->job->failedWith::class .'].'
             );
 
             return $this;
@@ -171,9 +171,9 @@ trait InteractsWithQueue
 
         if ($exception instanceof Throwable) {
             PHPUnit::assertInstanceOf(
-                get_class($exception),
+                $exception::class,
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['.get_class($exception).'] but job failed with ['.get_class($this->job->failedWith).'].'
+                'Expected job to be manually failed with ['. $exception::class .'] but job failed with ['. $this->job->failedWith::class .'].'
             );
 
             PHPUnit::assertEquals(

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -159,7 +159,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception,
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['.$exception.'] but job failed with ['. $this->job->failedWith::class .'].'
+                'Expected job to be manually failed with ['.$exception.'] but job failed with ['.$this->job->failedWith::class.'].'
             );
 
             return $this;
@@ -173,7 +173,7 @@ trait InteractsWithQueue
             PHPUnit::assertInstanceOf(
                 $exception::class,
                 $this->job->failedWith,
-                'Expected job to be manually failed with ['. $exception::class .'] but job failed with ['. $this->job->failedWith::class .'].'
+                'Expected job to be manually failed with ['.$exception::class.'] but job failed with ['.$this->job->failedWith::class.'].'
             );
 
             PHPUnit::assertEquals(

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -258,7 +258,7 @@ class ThrottlesExceptions
 
         $jobName = method_exists($job, 'displayName')
             ? $job->displayName()
-            : get_class($job);
+            : $job::class;
 
         return $this->prefix.hash('xxh128', $jobName);
     }

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -160,7 +160,7 @@ class WithoutOverlapping
 
         $jobName = method_exists($job, 'displayName')
             ? $job->displayName()
-            : get_class($job);
+            : $job::class;
 
         return $this->prefix.$jobName.':'.$this->key;
     }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -191,7 +191,7 @@ abstract class Queue
                 : serialize(clone $job);
         } catch (Throwable $e) {
             throw new RuntimeException(
-                sprintf('Failed to serialize job of type [%s]: %s', get_class($job), $e->getMessage()),
+                sprintf('Failed to serialize job of type [%s]: %s', $job::class, $e->getMessage()),
                 0,
                 $e
             );
@@ -199,7 +199,7 @@ abstract class Queue
 
         return array_merge($payload, [
             'data' => array_merge($payload['data'], [
-                'commandName' => get_class($job),
+                'commandName' => $job::class,
                 'command' => $command,
             ]),
         ]);
@@ -215,7 +215,7 @@ abstract class Queue
     {
         return method_exists($job, 'displayName')
             ? $job->displayName()
-            : get_class($job);
+            : $job::class;
     }
 
     /**

--- a/src/Illuminate/Queue/QueueRoutes.php
+++ b/src/Illuminate/Queue/QueueRoutes.php
@@ -62,7 +62,7 @@ class QueueRoutes
         }
 
         $classes = array_merge(
-            [get_class($queueable)],
+            [$queueable::class],
             class_parents($queueable) ?: [],
             class_implements($queueable) ?: [],
             class_uses_recursive($queueable)

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -28,7 +28,7 @@ trait SerializesAndRestoresModelIdentifiers
                 $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
             ))->useCollectionClass(
-                ($collectionClass = get_class($value)) !== EloquentCollection::class
+                ($collectionClass = $value::class) !== EloquentCollection::class
                     ? $collectionClass
                     : null
             );
@@ -36,7 +36,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         if ($value instanceof QueueableEntity) {
             return new ModelIdentifier(
-                get_class($value),
+                $value::class,
                 $value->getQueueableId(),
                 $withRelations ? $value->getQueueableRelations() : [],
                 $value->getQueueableConnection()
@@ -88,7 +88,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $collection->keyBy->getKey();
 
-        $collectionClass = get_class($collection);
+        $collectionClass = $collection::class;
 
         return (new $collectionClass(
             (new Collection($value->id))

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -22,7 +22,7 @@ trait SerializesModels
         $reflectionClass = new ReflectionClass($this);
 
         [$class, $properties, $classLevelWithoutRelations] = [
-            get_class($this),
+            $this::class,
             $reflectionClass->getProperties(),
             ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
         ];
@@ -74,7 +74,7 @@ trait SerializesModels
     {
         $properties = (new ReflectionClass($this))->getProperties();
 
-        $class = get_class($this);
+        $class = $this::class;
 
         foreach ($properties as $property) {
             if ($property->isStatic()) {

--- a/src/Illuminate/Reflection/Reflector.php
+++ b/src/Illuminate/Reflection/Reflector.php
@@ -34,7 +34,7 @@ class Reflector
             return true;
         }
 
-        $class = is_object($var[0]) ? get_class($var[0]) : $var[0];
+        $class = is_object($var[0]) ? $var[0]::class : $var[0];
 
         $method = $var[1];
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -55,10 +55,10 @@ class ImplicitRouteBinding
                 if (! $model = $parent->{$childRouteBindingMethod}(
                     $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
                 )) {
-                    throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+                    throw (new ModelNotFoundException)->setModel($instance::class, [$parameterValue]);
                 }
             } elseif (! $model = $instance->{$routeBindingMethod}($parameterValue, $route->bindingFieldFor($parameterName))) {
-                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+                throw (new ModelNotFoundException)->setModel($instance::class, [$parameterValue]);
             }
 
             $route->setParameter($parameterName, $model);

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -207,7 +207,7 @@ class ThrottleRequests
         if (! is_numeric($maxAttempts)) {
             is_null($request->user())
                 ? throw MissingRateLimiterException::forLimiter($maxAttempts)
-                : throw MissingRateLimiterException::forLimiterAndUser($maxAttempts, get_class($request->user()));
+                : throw MissingRateLimiterException::forLimiterAndUser($maxAttempts, $request->user()::class);
         }
 
         return (int) $maxAttempts;

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -169,7 +169,7 @@ abstract class Facade
     protected static function getMockableClass()
     {
         if ($root = static::getFacadeRoot()) {
-            return get_class($root);
+            return $root::class;
         }
     }
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -523,7 +523,7 @@ abstract class ServiceProvider
      */
     protected function getProviderKey(?string $key = null): string
     {
-        $key ??= (string) Str::of(get_class($this))
+        $key ??= (string) Str::of($this::class)
             ->classBasename()
             ->before('ServiceProvider')
             ->kebab()
@@ -531,7 +531,7 @@ abstract class ServiceProvider
             ->trim();
 
         if (empty($key)) {
-            $key = class_basename(get_class($this));
+            $key = class_basename($this::class);
         }
 
         return $key;

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -370,7 +370,7 @@ class BusFake implements Fake, QueueingDispatcher
         } elseif (! is_string($command)) {
             $instance = $command;
 
-            $command = get_class($instance);
+            $command = $instance::class;
 
             $callback = function ($job) use ($instance) {
                 return serialize($this->resetChainPropertiesToDefaults($job)) === serialize($instance);
@@ -471,7 +471,7 @@ class BusFake implements Fake, QueueingDispatcher
                             return false;
                         }
                     } elseif (is_string($chain[$index])) {
-                        if ($chain[$index] != get_class(unserialize($serializedChainedJob))) {
+                        if ($chain[$index] != unserialize($serializedChainedJob)::class) {
                             return false;
                         }
                     } elseif (serialize($chain[$index]) != $serializedChainedJob) {
@@ -533,7 +533,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function assertNothingBatched()
     {
         $jobNames = (new Collection($this->batches))
-            ->map(fn ($batch) => $batch->jobs->map(fn ($job) => get_class($job)))
+            ->map(fn ($batch) => $batch->jobs->map(fn ($job) => $job::class))
             ->flatten()
             ->join("\n- ");
 
@@ -662,7 +662,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatch($command)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatch($command);
         }
@@ -680,7 +680,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchSync($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commandsSync[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commandsSync[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchSync($command, $handler);
         }
@@ -696,7 +696,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchNow($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchNow($command, $handler);
         }
@@ -711,7 +711,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchToQueue($command)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commands[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             return $this->dispatcher->dispatchToQueue($command);
         }
@@ -727,7 +727,7 @@ class BusFake implements Fake, QueueingDispatcher
     public function dispatchAfterResponse($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commandsAfterResponse[get_class($command)][] = $this->getCommandRepresentation($command);
+            $this->commandsAfterResponse[$command::class][] = $this->getCommandRepresentation($command);
         } else {
             $this->dispatcher->dispatchAfterResponse($command, $handler);
         }
@@ -813,7 +813,7 @@ class BusFake implements Fake, QueueingDispatcher
             ->filter(function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
-                    : $job === get_class($command);
+                    : $job === $command::class;
             })->isNotEmpty();
     }
 
@@ -829,7 +829,7 @@ class BusFake implements Fake, QueueingDispatcher
             ->filter(function ($job) use ($command) {
                 return $job instanceof Closure
                     ? $job($command)
-                    : $job === get_class($command);
+                    : $job === $command::class;
             })->isNotEmpty();
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -321,7 +321,7 @@ class EventFake implements Dispatcher, Fake
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
-        $name = is_object($event) ? get_class($event) : (string) $event;
+        $name = is_object($event) ? $event::class : (string) $event;
 
         if ($this->shouldFakeEvent($name, $payload)) {
             $this->fakeEvent($event, $name, func_get_args());

--- a/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/ExceptionHandlerFake.php
@@ -81,7 +81,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
 
         Assert::assertTrue(
             (new Collection($this->reported))->contains(
-                fn (Throwable $e) => $this->firstClosureParameterType($exception) === get_class($e)
+                fn (Throwable $e) => $this->firstClosureParameterType($exception) === $e::class
                     && $exception($e) === true,
             ), $message,
         );
@@ -172,7 +172,7 @@ class ExceptionHandlerFake implements ExceptionHandler, Fake
      */
     protected function isFakedException(Throwable $e)
     {
-        return count($this->exceptions) === 0 || in_array(get_class($e), $this->exceptions, true);
+        return count($this->exceptions) === 0 || in_array($e::class, $this->exceptions, true);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -178,7 +178,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingSent()
     {
         $mailableNames = (new Collection($this->mailables))->map(
-            fn ($mailable) => get_class($mailable)
+            fn ($mailable) => $mailable::class
         )->join("\n- ");
 
         PHPUnit::assertEmpty($this->mailables, "The following mailables were sent unexpectedly:\n\n- $mailableNames\n");
@@ -277,7 +277,7 @@ class MailFake implements Factory, Fake, Mailer, MailQueue
     public function assertNothingQueued()
     {
         $mailableNames = (new Collection($this->queuedMailables))->map(
-            fn ($mailable) => get_class($mailable)
+            fn ($mailable) => $mailable::class
         )->join("\n- ");
 
         PHPUnit::assertEmpty($this->queuedMailables, "The following mailables were queued unexpectedly:\n\n- $mailableNames\n");

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -195,7 +195,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
         }
 
         PHPUnit::assertEmpty(
-            $this->notifications[get_class($notifiable)][$notifiable->getKey() ?? ''] ?? [],
+            $this->notifications[$notifiable::class][$notifiable->getKey() ?? ''] ?? [],
             'Notifications were sent unexpectedly.',
         );
     }
@@ -283,7 +283,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
      */
     protected function notificationsFor($notifiable, $notification)
     {
-        return $this->notifications[get_class($notifiable)][(string) $notifiable->getKey()][$notification] ?? [];
+        return $this->notifications[$notifiable::class][(string) $notifiable->getKey()][$notification] ?? [];
     }
 
     /**
@@ -330,7 +330,7 @@ class NotificationFake implements Fake, NotificationDispatcher, NotificationFact
                 continue;
             }
 
-            $this->notifications[get_class($notifiable)][(string) $notifiable->getKey()][get_class($notification)][] = [
+            $this->notifications[$notifiable::class][(string) $notifiable->getKey()][$notification::class][] = [
                 'notification' => $this->serializeAndRestore && $notification instanceof ShouldQueue
                     ? $this->serializeAndRestoreNotification($notification)
                     : $notification,

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -74,7 +74,7 @@ class PendingBatchFake extends PendingBatch
                     return false;
                 }
             } elseif (is_string($expectedJob)) {
-                if ($expectedJob != get_class($this->jobs[$index])) {
+                if ($expectedJob != $this->jobs[$index]::class) {
                     return false;
                 }
             } elseif (serialize($expectedJob) != serialize($this->jobs[$index])) {

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -240,7 +240,7 @@ class QueueFake extends QueueManager implements Fake, Queue
     {
         $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
             return (new Collection($chain))->map(function ($job) {
-                return get_class(unserialize($job));
+                return unserialize($job)::class;
             });
         })->filter(function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;
@@ -482,7 +482,7 @@ class QueueFake extends QueueManager implements Fake, Queue
                 $job = CallQueuedClosure::create($job);
             }
 
-            $this->jobs[is_object($job) ? get_class($job) : $job][] = [
+            $this->jobs[is_object($job) ? $job::class : $job][] = [
                 'job' => $this->serializeAndRestore ? $this->serializeAndRestoreJob($job) : $job,
                 'queue' => $queue,
                 'data' => $data,

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -28,7 +28,7 @@ trait ForwardsCalls
                 throw $e;
             }
 
-            if ($matches['class'] != get_class($object) ||
+            if ($matches['class'] != $object::class ||
                 $matches['method'] != $method) {
                 throw $e;
             }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -84,7 +84,7 @@ if (! function_exists('class_basename')) {
      */
     function class_basename($class): string
     {
-        $class = is_object($class) ? get_class($class) : $class;
+        $class = is_object($class) ? $class::class : $class;
 
         return basename(str_replace('\\', '/', $class));
     }
@@ -100,7 +100,7 @@ if (! function_exists('class_uses_recursive')) {
     function class_uses_recursive($class): array
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $class = $class::class;
         }
 
         $results = [];

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -44,7 +44,7 @@ trait TestDatabases
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {
-            $uses = array_flip(class_uses_recursive(get_class($testCase)));
+            $uses = array_flip(class_uses_recursive($testCase::class));
 
             $databaseTraits = [
                 Testing\DatabaseMigrations::class,

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -288,8 +288,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             }
 
             if (is_object($value)) {
-                $value = isset($this->stringableHandlers[get_class($value)])
-                    ? call_user_func($this->stringableHandlers[get_class($value)], $value)
+                $value = isset($this->stringableHandlers[$value::class])
+                    ? call_user_func($this->stringableHandlers[$value::class], $value)
                     : enum_value($value);
             }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -941,8 +941,8 @@ class Validator implements ValidatorContract
 
         if (! $rule->passes($attribute, $value)) {
             $ruleClass = $rule instanceof InvokableValidationRule ?
-                get_class($rule->invokable()) :
-                get_class($rule);
+                $rule->invokable()::class :
+                $rule::class;
 
             $this->failedRules[$originalAttribute][$ruleClass] = [];
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -158,8 +158,8 @@ trait CompilesEchos
      */
     public function applyEchoHandler($value)
     {
-        if (is_object($value) && isset($this->echoHandlers[get_class($value)])) {
-            return call_user_func($this->echoHandlers[get_class($value)], $value);
+        if (is_object($value) && isset($this->echoHandlers[$value::class])) {
+            return call_user_func($this->echoHandlers[$value::class], $value);
         }
 
         if (is_iterable($value) && isset($this->echoHandlers['iterable'])) {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -235,7 +235,7 @@ abstract class Component
      */
     protected function extractPublicProperties()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$propertyCache[$class])) {
             $reflection = new ReflectionClass($this);
@@ -263,7 +263,7 @@ abstract class Component
      */
     protected function extractPublicMethods()
     {
-        $class = get_class($this);
+        $class = $this::class;
 
         if (! isset(static::$methodCache[$class])) {
             $reflection = new ReflectionClass($this);

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -91,7 +91,7 @@ class AuthorizesResourcesTest extends TestCase
         $router = new Router(new Dispatcher);
 
         $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
-        $router->get($method)->uses($controller::class .'@'.$method);
+        $router->get($method)->uses($controller::class.'@'.$method);
 
         $this->assertSame(
             'caught '.$middleware,

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -91,7 +91,7 @@ class AuthorizesResourcesTest extends TestCase
         $router = new Router(new Dispatcher);
 
         $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
-        $router->get($method)->uses(get_class($controller).'@'.$method);
+        $router->get($method)->uses($controller::class .'@'.$method);
 
         $this->assertSame(
             'caught '.$middleware,

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -403,8 +403,8 @@ class BusBatchTest extends TestCase
                     $_SERVER['__failure3.batch'] = $batch;
                     $_SERVER['__failure3.exception'] = $e;
                     $_SERVER['__failure3.batch_id'] = $batch->id;
-                    $_SERVER['__failure3.batch_class'] = get_class($batch);
-                    $_SERVER['__failure3.exception_class'] = get_class($e);
+                    $_SERVER['__failure3.batch_class'] = $batch::class;
+                    $_SERVER['__failure3.exception_class'] = $e::class;
                     $_SERVER['__failure3.exception_message'] = $e->getMessage();
                     $_SERVER['__failure3.param_count'] = func_num_args();
                 },

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -84,8 +84,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testSingleConnectionNotCreatedUntilNeeded()
     {
         $connection = $this->db->getConnection();
-        $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
+        $pdo = new ReflectionProperty($connection::class, 'pdo');
+        $readPdo = new ReflectionProperty($connection::class, 'readPdo');
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
@@ -94,8 +94,8 @@ class DatabaseConnectionFactoryTest extends TestCase
     public function testReadWriteConnectionsNotCreatedUntilNeeded()
     {
         $connection = $this->db->getConnection('read_write');
-        $pdo = new ReflectionProperty(get_class($connection), 'pdo');
-        $readPdo = new ReflectionProperty(get_class($connection), 'readPdo');
+        $pdo = new ReflectionProperty($connection::class, 'pdo');
+        $readPdo = new ReflectionProperty($connection::class, 'readPdo');
 
         $this->assertNotInstanceOf(PDO::class, $pdo->getValue($connection));
         $this->assertNotInstanceOf(PDO::class, $readPdo->getValue($connection));
@@ -105,7 +105,7 @@ class DatabaseConnectionFactoryTest extends TestCase
     {
         $connection = $this->db->getConnection('read_write');
 
-        $readPdoConfig = new ReflectionProperty(get_class($connection), 'readPdoConfig');
+        $readPdoConfig = new ReflectionProperty($connection::class, 'readPdoConfig');
 
         $config = $readPdoConfig->getValue($connection);
 

--- a/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyCreateOrFirstTest.php
@@ -481,7 +481,7 @@ class DatabaseEloquentBelongsToManyCreateOrFirstTest extends TestCase
 
         foreach ($models as $model) {
             /** @var Model $model */
-            $class = get_class($model);
+            $class = $model::class;
             $class::setConnectionResolver($resolver);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentBuilderCreateOrFirstTest.php
@@ -496,7 +496,7 @@ class DatabaseEloquentBuilderCreateOrFirstTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
 
-        $class = get_class($model);
+        $class = $model::class;
         $class::setConnectionResolver($resolver);
 
         $connection->shouldReceive('getPdo')->andReturn($pdo = m::mock(PDO::class));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2831,7 +2831,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
-        $class = get_class($model);
+        $class = $model::class;
         $class::setConnectionResolver($resolver);
 
         return $connection;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -355,7 +355,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return 'not-a-model';
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertEquals(BaseCollection::class, $c::class);
     }
 
     public function testMapWithKeys()
@@ -384,7 +384,7 @@ class DatabaseEloquentCollectionTest extends TestCase
             return [$key++ => 'not-a-model'];
         });
 
-        $this->assertEquals(BaseCollection::class, get_class($c));
+        $this->assertEquals(BaseCollection::class, $c::class);
     }
 
     public function testCollectionDiffsWithGivenCollection()
@@ -612,15 +612,15 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
         $b = new Collection(['a', 'b', 'c']);
-        $this->assertEquals(BaseCollection::class, get_class($a->pluck('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($a->keys()));
-        $this->assertEquals(BaseCollection::class, get_class($a->collapse()));
-        $this->assertEquals(BaseCollection::class, get_class($a->flatten()));
-        $this->assertEquals(BaseCollection::class, get_class($a->zip(['a', 'b'], ['c', 'd'])));
-        $this->assertEquals(BaseCollection::class, get_class($a->countBy('foo')));
-        $this->assertEquals(BaseCollection::class, get_class($b->flip()));
-        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', '=', 'bar')));
-        $this->assertEquals(BaseCollection::class, get_class($a->partition('foo', 'bar')));
+        $this->assertEquals(BaseCollection::class, $a->pluck('foo')::class);
+        $this->assertEquals(BaseCollection::class, $a->keys()::class);
+        $this->assertEquals(BaseCollection::class, $a->collapse()::class);
+        $this->assertEquals(BaseCollection::class, $a->flatten()::class);
+        $this->assertEquals(BaseCollection::class, $a->zip(['a', 'b'], ['c', 'd'])::class);
+        $this->assertEquals(BaseCollection::class, $a->countBy('foo')::class);
+        $this->assertEquals(BaseCollection::class, $b->flip()::class);
+        $this->assertEquals(BaseCollection::class, $a->partition('foo', '=', 'bar')::class);
+        $this->assertEquals(BaseCollection::class, $a->partition('foo', 'bar')::class);
     }
 
     public function testMakeVisibleRemovesHiddenAndIncludesVisible()

--- a/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyCreateOrFirstTest.php
@@ -343,7 +343,7 @@ class DatabaseEloquentHasManyCreateOrFirstTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
 
-        $class = get_class($model);
+        $class = $model::class;
         $class::setConnectionResolver($resolver);
 
         $connection->shouldReceive('getPdo')->andReturn($pdo = m::mock(PDO::class));

--- a/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughCreateOrFirstTest.php
@@ -404,7 +404,7 @@ class DatabaseEloquentHasManyThroughCreateOrFirstTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
 
-        $class = get_class($model);
+        $class = $model::class;
         $class::setConnectionResolver($resolver);
 
         $connection->shouldReceive('getPdo')->andReturn($pdo = m::mock(PDO::class));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -822,10 +822,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->foo = 'bar';
@@ -861,7 +861,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(false);
         $model->exists = true;
 
         $this->assertFalse($model->save());
@@ -873,8 +873,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(false);
         $model->exists = true;
         $model->foo = 'bar';
 
@@ -920,10 +920,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->syncOriginal();
@@ -1066,10 +1066,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '. $model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -1086,10 +1086,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setIncrementing(false);
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '. $model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -1105,8 +1105,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(false);
 
         $this->assertFalse($model->save());
         $this->assertFalse($model->exists);
@@ -2535,7 +2535,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
+        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '. $model::class, m::on(function ($m) use ($model) {
             return $model->is($m);
         }));
 
@@ -2552,7 +2552,7 @@ class DatabaseEloquentModelTest extends TestCase
         $replicated = $model->replicateQuietly();
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '. $model::class, $model)->andReturn(true);
 
         $this->assertNull($replicated->id);
         $this->assertSame('bar', $replicated->foo);
@@ -2595,10 +2595,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('increment');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
 
         $model->publicIncrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());
@@ -2622,10 +2622,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('decrement');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
 
         $model->publicDecrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -822,10 +822,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->foo = 'bar';
@@ -861,7 +861,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(false);
         $model->exists = true;
 
         $this->assertFalse($model->save());
@@ -873,8 +873,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(false);
         $model->exists = true;
         $model->foo = 'bar';
 
@@ -920,10 +920,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->id = 1;
         $model->syncOriginal();
@@ -1066,10 +1066,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '. $model::class, $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.$model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -1086,10 +1086,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setIncrementing(false);
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '. $model::class, $model);
-        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '. $model::class, $model);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.$model::class, $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.$model::class, $model);
 
         $model->name = 'taylor';
         $model->exists = false;
@@ -1105,8 +1105,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '. $model::class, $model)->andReturn(false);
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.$model::class, $model)->andReturn(false);
 
         $this->assertFalse($model->save());
         $this->assertFalse($model->exists);
@@ -2535,7 +2535,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '. $model::class, m::on(function ($m) use ($model) {
+        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.$model::class, m::on(function ($m) use ($model) {
             return $model->is($m);
         }));
 
@@ -2552,7 +2552,7 @@ class DatabaseEloquentModelTest extends TestCase
         $replicated = $model->replicateQuietly();
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.$model::class, $model)->andReturn(true);
 
         $this->assertNull($replicated->id);
         $this->assertSame('bar', $replicated->foo);
@@ -2595,10 +2595,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('increment');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->publicIncrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());
@@ -2622,10 +2622,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('decrement');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->never()->with('eloquent.saving: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('until')->never()->with('eloquent.updating: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '. $model::class, $model)->andReturn(true);
-        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '. $model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.saving: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('until')->never()->with('eloquent.updating: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.$model::class, $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.$model::class, $model)->andReturn(true);
 
         $model->publicDecrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -34,7 +34,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('string');
         $relation->getQuery()->shouldReceive('whereIn')->once()->with('table.morph_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', $relation->getParent()::class);
 
         $model1 = new EloquentMorphResetModelStub;
         $model1->id = 1;
@@ -58,7 +58,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->once()->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('table.morph_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('table.morph_type', $relation->getParent()::class);
 
         $model1 = new EloquentMorphResetModelStub;
         $model1->id = 1;
@@ -111,7 +111,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $instance = m::mock(Model::class);
         $instance->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $instance->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $instance->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $instance->shouldReceive('save')->never();
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($instance);
 
@@ -124,7 +124,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $created = m::mock(Model::class);
         $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $created->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->shouldReceive('save')->once()->andReturn(true);
 
@@ -148,7 +148,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
@@ -185,7 +185,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
@@ -198,7 +198,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->never();
 
         $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
@@ -236,7 +236,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
@@ -250,7 +250,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(fn ($scope) => $scope());
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
@@ -262,7 +262,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andThrow(
             new UniqueConstraintViolationException('mysql', 'example mysql', [], new Exception('SQLSTATE[23000]: Integrity constraint violation: 1062')),
         );
@@ -283,7 +283,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andThrow(
             new UniqueConstraintViolationException('mysql', 'example mysql', [], new Exception('SQLSTATE[23000]: Integrity constraint violation: 1062')),
         );
@@ -304,7 +304,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
@@ -322,7 +322,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $relation->getQuery()->shouldReceive('withSavepointIfNeeded')->once()->andReturnUsing(function ($scope) {
@@ -361,7 +361,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
         $model->wasRecentlyCreated = true;
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
-        $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+        $model->shouldReceive('setAttribute')->once()->with('morph_type', $relation->getParent()::class);
         $model->shouldReceive('save')->once()->andReturn(true);
 
         $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
@@ -489,8 +489,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
-        $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
+        $builder->shouldReceive('where')->once()->with('table.morph_type', $parent::class);
 
         return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
@@ -504,8 +504,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
-        $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
+        $builder->shouldReceive('where')->once()->with('table.morph_type', $parent::class);
 
         return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation->getParent()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getParent()->shouldReceive('getKeyType')->once()->andReturn('int');
         $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('taggables.taggable_id', [1, 2]);
-        $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($relation->getParent()));
+        $relation->getQuery()->shouldReceive('where')->once()->with('taggables.taggable_type', $relation->getParent()::class);
         $model1 = new EloquentMorphToManyModelStub;
         $model1->id = 1;
         $model2 = new EloquentMorphToManyModelStub;
@@ -32,7 +32,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
+        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => $relation->getParent()::class, 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
         $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -45,7 +45,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_type', $relation->getParent()::class)->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
@@ -60,7 +60,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggable_type', $relation->getParent()::class)->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->getQuery()->shouldReceive('newQuery')->once()->andReturn($query);
@@ -104,11 +104,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     public function getRelationArguments(): array
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $parent->shouldReceive('getMorphClass')->andReturn($parent::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 
         $builder = m::mock(Builder::class);
@@ -118,11 +118,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $related->shouldReceive('getTable')->andReturn('tags');
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('qualifyColumn')->with('id')->andReturn('tags.id');
-        $related->shouldReceive('getMorphClass')->andReturn(get_class($related));
+        $related->shouldReceive('getMorphClass')->andReturn($related::class);
 
         $builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
         $builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);
-        $builder->shouldReceive('where')->once()->with('taggables.taggable_type', get_class($parent));
+        $builder->shouldReceive('where')->once()->with('taggables.taggable_type', $parent::class);
 
         $grammar = m::mock(Grammar::class);
         $grammar->shouldReceive('isExpression')->with(m::type(Expression::class))->andReturnTrue();

--- a/tests/Database/DatabaseMariaDbSchemaStateTest.php
+++ b/tests/Database/DatabaseMariaDbSchemaStateTest.php
@@ -22,13 +22,13 @@ class DatabaseMariaDbSchemaStateTest extends TestCase
         $versionInfo = ['version' => '11.8.3', 'isMariaDb' => true];
 
         // test connectionString
-        $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
+        $method = new ReflectionMethod($schemaState::class, 'connectionString');
         $connString = $method->invoke($schemaState, $versionInfo);
 
         self::assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
-        $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $method = new ReflectionMethod($schemaState::class, 'baseVariables');
         $variables = $method->invoke($schemaState, $dbConfig);
 
         self::assertEquals($expectedVariables, $variables);

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -24,13 +24,13 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $versionInfo = ['version' => '8.0.0', 'isMariaDb' => false];
 
         // test connectionString
-        $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
+        $method = new ReflectionMethod($schemaState::class, 'connectionString');
         $connString = $method->invoke($schemaState, $versionInfo);
 
         self::assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
-        $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $method = new ReflectionMethod($schemaState::class, 'baseVariables');
         $variables = $method->invoke($schemaState, $dbConfig);
 
         self::assertEquals($expectedVariables, $variables);
@@ -159,7 +159,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $this->expectExceptionMessage('Dump execution exceeded maximum depth of 30.');
 
         // test executeDumpProcess
-        $method = new ReflectionMethod(get_class($schemaState), 'executeDumpProcess');
+        $method = new ReflectionMethod($schemaState::class, 'executeDumpProcess');
         $method->invoke($schemaState, $mockProcess, $mockOutput, $mockVariables, 31);
     }
 }

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -238,13 +238,13 @@ class PruneCommandTest extends TestCase
         $dispatcher = m::mock(DispatcherContract::class);
 
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
-            return get_class($event) === ModelPruningStarting::class &&
+            return $event::class === ModelPruningStarting::class &&
                 $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('listen')->once()->with(ModelsPruned::class, m::type(Closure::class));
         $dispatcher->shouldReceive('dispatch')->twice()->with(m::type(ModelsPruned::class));
         $dispatcher->shouldReceive('dispatch')->once()->withArgs(function ($event) {
-            return get_class($event) === ModelPruningFinished::class &&
+            return $event::class === ModelPruningFinished::class &&
                 $event->models === [Pruning\Models\PrunableTestModelWithPrunableRecords::class];
         });
         $dispatcher->shouldReceive('forget')->once()->with(ModelsPruned::class);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -36,7 +36,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersAreCorrectlyRegistered()
     {
         $provider = m::mock(ApplicationBasicServiceProviderStub::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -54,7 +54,7 @@ class FoundationApplicationTest extends TestCase
             ];
         });
 
-        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+        $this->assertArrayHasKey($provider::class, $app->getLoadedProviders());
 
         $instance = $app->make(AbstractClass::class);
 
@@ -73,7 +73,7 @@ class FoundationApplicationTest extends TestCase
             ];
         });
 
-        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+        $this->assertArrayHasKey($provider::class, $app->getLoadedProviders());
 
         $instance = $app->make(AbstractClass::class);
 
@@ -89,7 +89,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotFilled()
     {
         $provider = m::mock(ServiceProvider::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);
@@ -100,7 +100,7 @@ class FoundationApplicationTest extends TestCase
     public function testServiceProvidersCouldBeLoaded()
     {
         $provider = m::mock(ServiceProvider::class);
-        $class = get_class($provider);
+        $class = $provider::class;
         $provider->shouldReceive('register')->once();
         $app = new Application;
         $app->register($provider);

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -35,7 +35,7 @@ class InteractsWithViewsTest extends TestCase
             }
         };
 
-        $component = $this->component(get_class($exampleComponent));
+        $component = $this->component($exampleComponent::class);
 
         $this->assertSame('bar', $component->foo);
         $this->assertSame('hello', $component->speak());
@@ -54,7 +54,7 @@ class InteractsWithViewsTest extends TestCase
             }
         };
 
-        $component = $this->component(get_class($exampleComponent));
+        $component = $this->component($exampleComponent::class);
 
         $this->assertSame('bar', $component->foo());
     }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -18,7 +18,7 @@ class CanConfigureMigrationCommandsTest extends TestCase
     private function __reflectAndSetupAccessibleForProtectedTraitMethod($methodName)
     {
         return new ReflectionMethod(
-            get_class($this->traitObject),
+            $this->traitObject::class,
             $methodName
         );
     }

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -35,7 +35,7 @@ class EloquentHasOneOfManyTest extends DatabaseTestCase
         $this->retrievedLogins = 0;
         User::getEventDispatcher()->listen('eloquent.retrieved:*', function ($event, $models) {
             foreach ($models as $model) {
-                if (get_class($model) == Login::class) {
+                if ($model::class == Login::class) {
                     $this->retrievedLogins++;
                 }
             }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -153,7 +153,7 @@ class SendingMailNotificationsTest extends TestCase
 
             $expected = array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]);
 
@@ -287,7 +287,7 @@ class SendingMailNotificationsTest extends TestCase
             ['html', 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {
@@ -319,7 +319,7 @@ class SendingMailNotificationsTest extends TestCase
             'html',
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {
@@ -351,7 +351,7 @@ class SendingMailNotificationsTest extends TestCase
             [null, 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
-                '__laravel_notification' => get_class($notification),
+                '__laravel_notification' => $notification::class,
                 '__laravel_notification_queued' => false,
             ]),
             m::on(function ($closure) {

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -363,7 +363,7 @@ class ThrottlesExceptionsTest extends TestCase
             }
         };
 
-        $expectedKey = 'laravel_throttles_exceptions:'.hash('xxh128', get_class($job));
+        $expectedKey = 'laravel_throttles_exceptions:'.hash('xxh128', $job::class);
 
         $rateLimiter->shouldReceive('tooManyAttempts')
             ->once()

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -192,7 +192,7 @@ class UniqueJobTest extends QueueTestCase
 
     protected function getLockKey($job)
     {
-        return 'laravel_unique_job:'.(is_string($job) ? $job : get_class($job)).':';
+        return 'laravel_unique_job:'.(is_string($job) ? $job : $job::class).':';
     }
 
     public function testLockUsesDisplayNameWhenAvailable()

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -143,7 +143,7 @@ class LogManagerTest extends TestCase
         $this->assertEquals(Level::Notice, $handlers[0]->getLevel());
         $this->assertFalse($handlers[0]->getBubble());
 
-        $url = new ReflectionProperty(get_class($handlers[0]), 'url');
+        $url = new ReflectionProperty($handlers[0]::class, 'url');
         $this->assertSame('php://stderr', $url->getValue($handlers[0]));
 
         $config->set('logging.channels.logentries', [
@@ -158,7 +158,7 @@ class LogManagerTest extends TestCase
         $logger = $manager->channel('logentries');
         $handlers = $logger->getLogger()->getHandlers();
 
-        $logToken = new ReflectionProperty(get_class($handlers[0]), 'logToken');
+        $logToken = new ReflectionProperty($handlers[0]::class, 'logToken');
 
         $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
         $this->assertSame('123456789', $logToken->getValue($handlers[0]));
@@ -200,7 +200,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(NewRelicHandler::class, $handler);
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -260,7 +260,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(MemoryUsageProcessor::class, $processors[1]);
         $this->assertInstanceOf(PsrLogMessageProcessor::class, $processors[2]);
 
-        $removeUsedContextFields = new ReflectionProperty(get_class($processors[2]), 'removeUsedContextFields');
+        $removeUsedContextFields = new ReflectionProperty($processors[2]::class, 'removeUsedContextFields');
 
         $this->assertTrue($removeUsedContextFields->getValue($processors[2]));
     }
@@ -340,7 +340,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertCount(1, $logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -385,7 +385,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertCount(1, $logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -428,7 +428,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(HtmlFormatter::class, $formatter);
         $this->assertCount(1, $logger->getLogger()->getProcessors());
 
-        $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
+        $dateFormat = new ReflectionProperty($formatter::class, 'dateFormat');
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
@@ -460,7 +460,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(StreamHandler::class, $handler);
 
-        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url = new ReflectionProperty($handler::class, 'url');
 
         $this->assertSame(storage_path('logs/on-demand.log'), $url->getValue($handler));
     }
@@ -485,7 +485,7 @@ class LogManagerTest extends TestCase
         };
         $channel = $manager->build([
             'driver' => 'custom',
-            'via' => get_class($factory),
+            'via' => $factory::class,
         ]);
         $logger = $manager->stack(['test', $channel]);
 
@@ -495,7 +495,7 @@ class LogManagerTest extends TestCase
         $this->assertInstanceOf(StreamHandler::class, $handler);
         $this->assertInstanceOf(UidProcessor::class, $processor);
 
-        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url = new ReflectionProperty($handler::class, 'url');
 
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
@@ -527,10 +527,10 @@ class LogManagerTest extends TestCase
         $expectedFingersCrossedHandler = $handlers[0];
         $this->assertInstanceOf(FingersCrossedHandler::class, $expectedFingersCrossedHandler);
 
-        $activationStrategyProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'activationStrategy');
+        $activationStrategyProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'activationStrategy');
         $activationStrategyValue = $activationStrategyProp->getValue($expectedFingersCrossedHandler);
 
-        $actionLevelProp = new ReflectionProperty(get_class($activationStrategyValue), 'actionLevel');
+        $actionLevelProp = new ReflectionProperty($activationStrategyValue::class, 'actionLevel');
         $actionLevelValue = $actionLevelProp->getValue($activationStrategyValue);
 
         $this->assertEquals(Level::Critical, $actionLevelValue);
@@ -538,7 +538,7 @@ class LogManagerTest extends TestCase
         if (method_exists($expectedFingersCrossedHandler, 'getHandler')) {
             $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
         } else {
-            $handlerProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'handler');
+            $handlerProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'handler');
             $expectedStreamHandler = $handlerProp->getValue($expectedFingersCrossedHandler);
         }
         $this->assertInstanceOf(StreamHandler::class, $expectedStreamHandler);
@@ -568,7 +568,7 @@ class LogManagerTest extends TestCase
 
         $expectedFingersCrossedHandler = $handlers[0];
 
-        $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
+        $stopBufferingProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'stopBuffering');
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertTrue($stopBufferingValue);
@@ -598,7 +598,7 @@ class LogManagerTest extends TestCase
 
         $expectedFingersCrossedHandler = $handlers[0];
 
-        $stopBufferingProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'stopBuffering');
+        $stopBufferingProp = new ReflectionProperty($expectedFingersCrossedHandler::class, 'stopBuffering');
         $stopBufferingValue = $stopBufferingProp->getValue($expectedFingersCrossedHandler);
 
         $this->assertFalse($stopBufferingValue);
@@ -724,7 +724,7 @@ class LogManagerTest extends TestCase
 
         $this->assertInstanceOf(LineFormatter::class, $formatter);
 
-        $format = new ReflectionProperty(get_class($formatter), 'format');
+        $format = new ReflectionProperty($formatter::class, 'format');
 
         $this->assertEquals(
             '[%datetime%] %channel%.%level_name%: %message% %context% %extra%',

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -13,7 +13,7 @@ class MailMailableDataTest extends TestCase
 
         $testData = [
             'first_name' => 'James',
-            '__laravel_mailable' => get_class($mailable),
+            '__laravel_mailable' => $mailable::class,
         ];
 
         $mailable->build(function ($m) use ($testData) {

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -557,7 +557,7 @@ class MailMailableTest extends TestCase
             'first_name' => 'Taylor',
             'lastName' => 'Otwell',
             'framework' => 'Laravel',
-            '__laravel_mailable' => get_class($mailable),
+            '__laravel_mailable' => $mailable::class,
         ];
 
         $this->assertSame($expected, $mailable->buildViewData());

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -19,7 +19,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification::class,
             'data' => ['invoice_id' => 1],
             'read_at' => null,
         ]);
@@ -36,7 +36,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification::class,
             'data' => ['invoice_id' => 1],
             'read_at' => null,
             'something' => 'else',

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2397,7 +2397,7 @@ class RouteTestControllerMiddleware
     {
         $_SERVER['route.test.controller.middleware'] = true;
         $response = $next($request);
-        $_SERVER['route.test.controller.middleware.class'] = get_class($response);
+        $_SERVER['route.test.controller.middleware.class'] = $response::class;
 
         return $response;
     }

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -35,41 +35,41 @@ class DateFacadeTest extends TestCase
     public function testUseClosure()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertSame(DateTime::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testUseClassName()
     {
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
         DateFactory::use(DateTime::class);
         $start = Carbon::now()->getTimestamp();
-        $this->assertSame(DateTime::class, get_class(Date::now()));
+        $this->assertSame(DateTime::class, Date::now()::class);
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
     }
 
     public function testCarbonImmutable()
     {
         DateFactory::use(CarbonImmutable::class);
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertSame(CarbonImmutable::class, Date::now()::class);
         DateFactory::use(Carbon::class);
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
         DateFactory::use(function (Carbon $date) {
             return $date->toImmutable();
         });
-        $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
+        $this->assertSame(CarbonImmutable::class, Date::now()::class);
         DateFactory::use(function ($date) {
             return $date;
         });
-        $this->assertSame(Carbon::class, get_class(Date::now()));
+        $this->assertSame(Carbon::class, Date::now()::class);
 
         DateFactory::use(new Factory([
             'locale' => 'fr',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5966,7 +5966,7 @@ class SupportCollectionTest extends TestCase
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, get_class($wrongType), 2));
+        $this->expectExceptionMessage(sprintf("Collection should only include [%s] items, but '%s' found at position %d.", \Throwable::class, $wrongType::class, 2));
         $data->ensure(\Throwable::class);
     }
 
@@ -5979,7 +5979,7 @@ class SupportCollectionTest extends TestCase
         $wrongType = new $collection;
         $data = $collection::make([new \Error, new \Error, $wrongType]);
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), get_class($wrongType), 2));
+        $this->expectExceptionMessage(sprintf('Collection should only include [%s] items, but \'%s\' found at position %d.', implode(', ', [\Throwable::class, 'int']), $wrongType::class, 2));
         $data->ensure([\Throwable::class, 'int']);
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -684,7 +684,7 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fake->assertNothingBatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The following batched jobs were dispatched unexpectedly:\n\n- ". $job::class, $e->getMessage());
+            $this->assertStringContainsString("The following batched jobs were dispatched unexpectedly:\n\n- ".$job::class, $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -684,7 +684,7 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fake->assertNothingBatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The following batched jobs were dispatched unexpectedly:\n\n- ".get_class($job), $e->getMessage());
+            $this->assertStringContainsString("The following batched jobs were dispatched unexpectedly:\n\n- ". $job::class, $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -116,7 +116,7 @@ class SupportTestingNotificationFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The following notifications were sent unexpectedly:\n\n- ". (new NotificationStub)::class, $e->getMessage());
+            $this->assertStringContainsString("The following notifications were sent unexpectedly:\n\n- ".(new NotificationStub)::class, $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -116,7 +116,7 @@ class SupportTestingNotificationFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertStringContainsString("The following notifications were sent unexpectedly:\n\n- ".get_class(new NotificationStub), $e->getMessage());
+            $this->assertStringContainsString("The following notifications were sent unexpectedly:\n\n- ". (new NotificationStub)::class, $e->getMessage());
         }
     }
 

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -197,7 +197,7 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('The following jobs were pushed unexpectedly', $e->getMessage());
-            $this->assertStringContainsString(get_class($this->job), $e->getMessage());
+            $this->assertStringContainsString($this->job::class, $e->getMessage());
             $this->assertStringContainsString(CallQueuedClosure::class, $e->getMessage());
         }
     }
@@ -335,7 +335,7 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->fake->undefinedMethod();
         } catch (BadMethodCallException $e) {
             $this->assertSame(sprintf(
-                'Call to undefined method %s::%s()', get_class($this->fake), 'undefinedMethod'
+                'Call to undefined method %s::%s()', $this->fake::class, 'undefinedMethod'
             ), $e->getMessage());
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add [get_class_to_class_keyword](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.88|fixer:get_class_to_class_keyword) to pint.json and apply the rule on the codebase.
