### PR TITLE
[12.x] Replace closures with arrow functions in Redis component

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -64,9 +64,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function mget(array $keys)
     {
-        return array_map(function ($value) {
-            return $value !== false ? $value : null;
-        }, $this->command('mget', [$keys]));
+        return array_map(fn ($value) => $value !== false ? $value : null, $this->command('mget', [$keys]));
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -61,10 +61,9 @@ class PredisConnection extends Connection implements ConnectionContract
     protected function parseParametersForEvent(array $parameters)
     {
         return (new Collection($parameters))
-            ->transform(function ($parameter) {
-                return $parameter instanceof ArrayableArgument
-                    ? $parameter->toArray()
-                    : $parameter;
-            })->all();
+            ->transform(fn ($parameter) => $parameter instanceof ArrayableArgument
+                ? $parameter->toArray()
+                : $parameter
+            )->all();
     }
 }

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -101,9 +101,7 @@ class ConcurrencyLimiter
      */
     protected function acquire($id)
     {
-        $slots = array_map(function ($i) {
-            return $this->name.$i;
-        }, range(1, $this->maxLocks));
+        $slots = array_map(fn ($i) => $this->name.$i, range(1, $this->maxLocks));
 
         return $this->redis->eval(...array_merge(
             [$this->lockScript(), count($slots)],

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -130,9 +130,7 @@ class RedisManager implements Factory
     protected function resolveCluster($name)
     {
         return $this->connector()->connectToCluster(
-            array_map(function ($config) {
-                return $this->parseConnectionConfiguration($config);
-            }, $this->config['clusters'][$name]),
+            array_map(fn ($config) => $this->parseConnectionConfiguration($config), $this->config['clusters'][$name]),
             $this->config['clusters']['options'] ?? [],
             $this->config['options'] ?? []
         );
@@ -192,9 +190,7 @@ class RedisManager implements Factory
             $parsed['scheme'] = $driver;
         }
 
-        return array_filter($parsed, function ($key) {
-            return $key !== 'driver';
-        }, ARRAY_FILTER_USE_KEY);
+        return array_filter($parsed, fn ($key) => $key !== 'driver', ARRAY_FILTER_USE_KEY);
     }
 
     /**


### PR DESCRIPTION
This PR modernizes the Redis component by replacing traditional closures with PHP arrow functions (fn()) for cleaner, more concise code.