### PR TITLE
[13.x] Add ping method to Database Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1034,6 +1034,22 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Check if the database connection is still alive.
+     *
+     * @return bool
+     */
+    public function ping(): bool
+    {
+        try {
+            $this->getPdo()->query('SELECT 1');
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
      * Disconnect from the underlying PDO connection.
      *
      * @return void

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -181,4 +181,11 @@ interface ConnectionInterface
      * @return string
      */
     public function getDatabaseName();
+
+    /**
+     * Check if the database connection is still alive.
+     *
+     * @return bool
+     */
+    public function ping(): bool;
 }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -735,6 +735,26 @@ class DatabaseConnectionTest extends TestCase
         }
     }
 
+    public function testPingReturnsTrueWhenConnectionIsAlive()
+    {
+        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['query'])->getMock();
+        $pdo->expects($this->once())->method('query')->with('SELECT 1')->willReturn($this->createMock(PDOStatement::class));
+
+        $connection = $this->getMockConnection([], $pdo);
+
+        $this->assertTrue($connection->ping());
+    }
+
+    public function testPingReturnsFalseWhenQueryFails()
+    {
+        $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->onlyMethods(['query'])->getMock();
+        $pdo->expects($this->once())->method('query')->with('SELECT 1')->will($this->throwException(new PDOException));
+
+        $connection = $this->getMockConnection([], $pdo);
+
+        $this->assertFalse($connection->ping());
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;


### PR DESCRIPTION
This PR introduces a `ping()` method to the database `ConnectionInterface` and its default implementation.

Problem
Currently, to check if a database connection is still alive, developers have to manually run raw SQL queries (e.g., `DB::connection()->select('SELECT 1'))` and catch potential Exceptions. This is a common requirement for long-running processes, workers, and health check endpoints.

Solution
This PR adds a `ping(): bool method` to the `ConnectionInterface` and implements it in the `Connection` class by catching underlying `Throwable` exceptions when executing a `SELECT 1` query.