### PR TITLE
[12.x] feat: Add --list and --select options to db:seed command

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -7,9 +7,15 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Finder\Finder;
+
+use function Laravel\Prompts\multisearch;
 
 #[AsCommand(name: 'db:seed')]
 class SeedCommand extends Command
@@ -56,9 +62,21 @@ class SeedCommand extends Command
      */
     public function handle()
     {
+        if ($this->option('list')) {
+            return $this->listSeeders();
+        }
+
         if ($this->isProhibited() ||
             ! $this->confirmToProceed()) {
             return Command::FAILURE;
+        }
+
+        $seeders = $this->option('select')
+            ? $this->selectSeeders()
+            : [$this->getSeeder()];
+
+        if (empty($seeders)) {
+            return Command::SUCCESS;
         }
 
         $this->components->info('Seeding database.');
@@ -67,15 +85,108 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
+        Model::unguarded(function () use ($seeders) {
+            foreach ($seeders as $seeder) {
+                $seeder->__invoke();
+            }
         });
 
         if ($previousConnection) {
             $this->resolver->setDefaultConnection($previousConnection);
         }
 
-        return 0;
+        return Command::SUCCESS;
+    }
+
+    /**
+     * List all available seeders.
+     *
+     * @return int
+     */
+    protected function listSeeders()
+    {
+        $seeders = $this->getAvailableSeeders();
+
+        if ($seeders->isEmpty()) {
+            $this->components->info('No seeders found.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->newLine();
+        $seeders->each(fn ($class, $name) => $this->components->twoColumnDetail($name, $class));
+        $this->newLine();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Interactively select seeders to run.
+     *
+     * @return array<\Illuminate\Database\Seeder>
+     */
+    protected function selectSeeders()
+    {
+        $seeders = $this->getAvailableSeeders();
+
+        if ($seeders->isEmpty()) {
+            $this->components->info('No seeders found.');
+
+            return [];
+        }
+
+        $selected = multisearch(
+            label: 'Which seeders would you like to run?',
+            options: fn (string $search) => $seeders
+                ->filter(fn ($class, $name) => str_contains(strtolower($name), strtolower($search)))
+                ->keys()
+                ->values()
+                ->all(),
+            placeholder: 'Search seeders...',
+        );
+
+        if (empty($selected)) {
+            return [];
+        }
+
+        return array_map(
+            fn ($name) => $this->laravel->make($seeders[$name])
+                ->setContainer($this->laravel)
+                ->setCommand($this),
+            $selected
+        );
+    }
+
+    /**
+     * Get all available seeder classes from the seeders directory.
+     *
+     * @return \Illuminate\Support\Collection<string, string>
+     */
+    protected function getAvailableSeeders()
+    {
+        $seedersPath = $this->laravel->databasePath('seeders');
+
+        if (! is_dir($seedersPath)) {
+            return new Collection;
+        }
+
+        return (new Collection(
+            Finder::create()->files()->name('*.php')->in($seedersPath)
+        ))
+            ->map(function ($file) use ($seedersPath) {
+                $name = str_replace([DIRECTORY_SEPARATOR, '.php'], ['/', ''],
+                    Str::after($file->getRealPath(), realpath($seedersPath).DIRECTORY_SEPARATOR)
+                );
+                $class = 'Database\\Seeders\\'.str_replace('/', '\\', $name);
+
+                return compact('name', 'class');
+            })
+            ->filter(fn ($item) => class_exists($item['class'])
+                && is_subclass_of($item['class'], Seeder::class)
+                && ! (new \ReflectionClass($item['class']))->isAbstract())
+            ->sortBy('name')
+            ->values()
+            ->mapWithKeys(fn ($item) => [$item['name'] => $item['class']]);
     }
 
     /**
@@ -136,6 +247,8 @@ class SeedCommand extends Command
             ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+            ['list', null, InputOption::VALUE_NONE, 'List available seeders without running them'],
+            ['select', null, InputOption::VALUE_NONE, 'Interactively select seeders to run'],
         ];
     }
 }


### PR DESCRIPTION
## Description

This PR adds two new options to the `db:seed` Artisan command:

### `--list`
Lists all available seeder classes by recursively scanning `database/seeders/`.
Subdirectory seeders are displayed with `/` separators for clarity.

```
$ php artisan db:seed --list

  Seeder .......................... Class
  DatabaseSeeder .................. Database\Seeders\DatabaseSeeder
  UserSeeder ...................... Database\Seeders\UserSeeder
  Admin/RoleSeeder ................ Database\Seeders\Admin\RoleSeeder
```

### `--select`
Presents an interactive multi-search prompt (using Laravel Prompts)
allowing developers to select one or more seeders to run.

### Motivation

When projects grow to have many seeders organized in subdirectories, there's no built-in way to discover available seeders from the CLI. The `--class` option requires knowing the exact class name. These two options solve discoverability and selection ergonomically.