### PR TITLE
[12.x] Add tsvector column type for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1519,6 +1519,17 @@ class Blueprint
     }
 
     /**
+     * Create a new tsvector column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function tsvector($column)
+    {
+        return $this->addColumn('tsvector', $column);
+    }
+
+    /**
      * Add the proper columns for a polymorphic table.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -362,6 +362,19 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Create the column definition for a tsvector type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function typeTsvector(Fluent $column)
+    {
+        throw new RuntimeException('This database driver does not support the tsvector type.');
+    }
+
+    /**
      * Create the column definition for a raw column type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1182,6 +1182,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tsvector type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTsvector(Fluent $column)
+    {
+        return 'tsvector';
+    }
+
+    /**
      * Get the SQL for a collation column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -51,6 +51,36 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "embeddings" add column "embedding" vector(384) not null', $statements[0]);
     }
 
+    public function testAddingTsvectorColumn()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'test');
+        $blueprint->tsvector('search_vector');
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "test" add column "search_vector" tsvector not null', $statements[0]);
+    }
+
+    public function testAddingNullableTsvectorColumn()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'test');
+        $blueprint->tsvector('search_vector')->nullable();
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "test" add column "search_vector" tsvector null', $statements[0]);
+    }
+
+    public function testAddingTsvectorColumnWithStoredAs()
+    {
+        $blueprint = new Blueprint($this->getConnection(), 'test');
+        $blueprint->tsvector('search_vector')->nullable()->storedAs("to_tsvector('english', coalesce(name, ''))");
+        $statements = $blueprint->toSql();
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "test" add column "search_vector" tsvector null generated always as (to_tsvector(\'english\', coalesce(name, \'\'))) stored', $statements[0]);
+    }
+
     public function testCreateTableWithAutoIncrementStartingValue()
     {
         $connection = $this->getConnection();


### PR DESCRIPTION
## Summary

Adds a `tsvector()` column type method to Blueprint and the corresponding type handler in PostgresGrammar. This allows creating PostgreSQL tsvector columns using the fluent schema builder instead of raw `DB::statement()` calls.

## Motivation

PostgreSQL's `tsvector` type is essential for full-text search. Currently, creating tsvector columns (especially generated ones with `storedAs()`) requires raw SQL:

```php
DB::statement("
    ALTER TABLE articles
    ADD COLUMN search_vector tsvector
    GENERATED ALWAYS AS (
        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
        setweight(to_tsvector('english', coalesce(body, '')), 'B')
    ) STORED
");
```

With this PR, the same can be expressed fluently:

```php
Schema::table('articles', function (Blueprint $table) {
    $table->tsvector('search_vector')->nullable()->storedAs(
        "setweight(to_tsvector('english', coalesce(title, '')), 'A') || " .
        "setweight(to_tsvector('english', coalesce(body, '')), 'B')"
    );
});
```

This follows the same pattern as the existing `vector()` column type.

## Changes

- `Blueprint::tsvector()` — adds column of type `tsvector`
- `PostgresGrammar::typeTsvector()` — returns the `tsvector` SQL type string
- 3 new test cases in `DatabasePostgresSchemaGrammarTest`


🤖 Generated with [Claude Code](https://claude.com/claude-code)