### PR TITLE
[13.x] Add cache `flushLocks()` events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
@@ -14,7 +14,7 @@ class CacheLocksFlushFailed
     /**
      * Create a new event instance.
      *
-     * @param string|null $storeName
+     * @param  string|null  $storeName
      */
     public function __construct(?string $storeName)
     {

--- a/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheLocksFlushFailed
+{
+    /**
+     * The name of the cache store.
+     *
+     * @var string|null
+     */
+    public ?string $storeName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param string|null $storeName
+     */
+    public function __construct(?string $storeName)
+    {
+        $this->storeName = $storeName;
+    }
+}

--- a/src/Illuminate/Cache/Events/CacheLocksFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushed.php
@@ -14,7 +14,7 @@ class CacheLocksFlushed
     /**
      * Create a new event instance.
      *
-     * @param string|null $storeName
+     * @param  string|null  $storeName
      */
     public function __construct(?string $storeName)
     {

--- a/src/Illuminate/Cache/Events/CacheLocksFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushed.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheLocksFlushed
+{
+    /**
+     * The name of the cache store.
+     *
+     * @var string|null
+     */
+    public ?string $storeName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param string|null $storeName
+     */
+    public function __construct(?string $storeName)
+    {
+        $this->storeName = $storeName;
+    }
+}

--- a/src/Illuminate/Cache/Events/CacheLocksFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushing.php
@@ -14,7 +14,7 @@ class CacheLocksFlushing
     /**
      * Create a new event instance.
      *
-     * @param string|null $storeName
+     * @param  string|null  $storeName
      */
     public function __construct(?string $storeName)
     {

--- a/src/Illuminate/Cache/Events/CacheLocksFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushing.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Cache\Events;
+
+class CacheLocksFlushing
+{
+    /**
+     * The name of the cache store.
+     *
+     * @var string|null
+     */
+    public ?string $storeName;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param string|null $storeName
+     */
+    public function __construct(?string $storeName)
+    {
+        $this->storeName = $storeName;
+    }
+}

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Events\CacheFlushed;
 use Illuminate\Cache\Events\CacheFlushing;
+use Illuminate\Cache\Events\CacheLocksFlushed;
+use Illuminate\Cache\Events\CacheLocksFlushing;
 use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -98,6 +100,17 @@ class SupportFacadesEventTest extends TestCase
 
         Event::assertDispatched(CacheFlushing::class);
         Event::assertDispatched(CacheFlushed::class);
+    }
+
+    public function testCacheFlushLocksDispatchesEvent()
+    {
+        $arrayRepository = Cache::store('array');
+        Event::fake();
+
+        $arrayRepository->flushLocks();
+
+        Event::assertDispatched(CacheLocksFlushing::class);
+        Event::assertDispatched(CacheLocksFlushed::class);
     }
 
     protected function getCacheConfig()


### PR DESCRIPTION
## Summary

This PR adds events to the `flushLocks()` method (#58907) in cache stores. While `flushLocks()` already allows clearing all locks from a store, there is currently no way to observe this action.
Adding events aligns with Laravel’s existing cache `flush()` events (`CacheFlushing`, `CacheFlushed`, `CacheFlushFailed`) and provides operational visibility in distributed environments.

## Motivation
- Distributed locks are critical in queue and scheduler coordination.
- Flushing all locks is destructive and can affect runtime behavior.
- Currently, developers have no way to observe when locks are cleared.
- Events enable logging, monitoring, and observability in multi-node systems.