### PR TITLE
[12.x] Add missing `@throws` into docblock for various methods

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -272,6 +272,7 @@ class BroadcastManager implements FactoryContract
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      *
      * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     protected function resolve($name)
     {

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -94,6 +94,8 @@ class PendingBatch
      *
      * @param  object|array  $job
      * @return void
+     *
+     * @throws \RuntimeException
      */
     protected function ensureJobIsBatchable(object|array $job): void
     {

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -230,6 +230,8 @@ class DynamoDbStore implements LockProvider, Store
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
+     *
+     * @throws \Aws\DynamoDb\Exception\DynamoDbException
      */
     public function add($key, $value, $seconds)
     {

--- a/src/Illuminate/Cache/MemoizedStore.php
+++ b/src/Illuminate/Cache/MemoizedStore.php
@@ -167,6 +167,8 @@ class MemoizedStore implements LockProvider, Store
      * @param  int  $seconds
      * @param  string|null  $owner
      * @return \Illuminate\Contracts\Cache\Lock
+     *
+     * @throws \BadMethodCallException
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
@@ -183,6 +185,8 @@ class MemoizedStore implements LockProvider, Store
      * @param  string  $name
      * @param  string  $owner
      * @return \Illuminate\Contracts\Cache\Lock
+     *
+     * @throws \BadMethodCallException
      */
     public function restoreLock($name, $owner)
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -685,6 +685,8 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  \UnitEnum|string  $name
      * @return \Illuminate\Cache\Limiters\ConcurrencyLimiterBuilder
+     *
+     * @throws \BadMethodCallException
      */
     public function funnel($name)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -41,6 +41,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Create a new lazy collection instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $source
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($source = null)
     {

--- a/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
+++ b/src/Illuminate/Console/Concerns/ConfiguresPrompts.php
@@ -121,6 +121,8 @@ trait ConfiguresPrompts
      * @param  bool|string  $required
      * @param  (\Closure(PResult): mixed)|null  $validate
      * @return PResult
+     *
+     * @throws \Illuminate\Console\PromptValidationException
      */
     protected function promptUntilValid($prompt, $required, $validate)
     {

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -479,6 +479,8 @@ class Schedule
      * @param  string  $method
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -20,6 +20,8 @@ class Task extends Component
      * @param  (callable(): bool)|null  $task
      * @param  int  $verbosity
      * @return void
+     *
+     * @throws \Throwable
      */
     public function render($description, $task = null, $verbosity = OutputInterface::VERBOSITY_NORMAL)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -871,6 +871,10 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string|class-string<TClass>  $id
      * @return ($id is class-string<TClass> ? TClass : mixed)
+     *
+     * @throws \Illuminate\Contracts\Container\CircularDependencyException
+     * @throws \Illuminate\Container\EntryNotFoundException
+     *
      */
     public function get(string $id)
     {
@@ -1372,6 +1376,8 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve a dependency based on an attribute.
      *
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function resolveFromAttribute(ReflectionAttribute $attribute)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -874,7 +874,6 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @throws \Illuminate\Contracts\Container\CircularDependencyException
      * @throws \Illuminate\Container\EntryNotFoundException
-     *
      */
     public function get(string $id)
     {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -315,6 +315,7 @@ trait BuildsQueries
      * @return \Illuminate\Support\LazyCollection
      *
      * @throws \InvalidArgumentException
+     * @throws \RuntimeException
      */
     protected function orderedLazyById($chunkSize = 1000, $column = null, $alias = null, $descending = false)
     {

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -77,6 +77,8 @@ class MigrateCommand extends BaseCommand implements Isolatable
      * Execute the console command.
      *
      * @return int
+     *
+     * @throws \Throwable
      */
     public function handle()
     {

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -112,6 +112,8 @@ class PruneCommand extends Command
      * Determine the models that should be pruned.
      *
      * @return \Illuminate\Support\Collection
+     *
+     * @throws \InvalidArgumentException
      */
     protected function models()
     {

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -143,6 +143,8 @@ class DatabaseManager implements ConnectionResolverInterface
      * @param  array  $config
      * @param  bool  $force
      * @return \Illuminate\Database\ConnectionInterface
+     *
+     * @throws \RuntimeException
      */
     public function connectUsing(string $name, array $config, bool $force = false)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -718,6 +718,8 @@ class Builder implements BuilderContract
      * @param  array  $attributes
      * @param  (\Closure(): array)|array  $values
      * @return TModel
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     public function createOrFirst(array $attributes = [], Closure|array $values = [])
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsBinary.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsBinary.php
@@ -14,6 +14,8 @@ class AsBinary implements Castable
      *
      * @param  array{string}  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes
+     *
+     * @throws \InvalidArgumentException
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -15,6 +15,8 @@ class AsCollection implements Castable
      *
      * @param  array  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
+     *
+     * @throws \InvalidArgumentException
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -16,6 +16,8 @@ class AsEncryptedCollection implements Castable
      *
      * @param  array  $arguments
      * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
+     *
+     * @throws \InvalidArgumentException
      */
     public static function castUsing(array $arguments)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -596,6 +596,8 @@ trait HasAttributes
      *
      * @param  string  $key
      * @return mixed
+     *
+     * @throws \Illuminate\Database\LazyLoadingViolationException
      */
     protected function handleLazyLoadingViolation($key)
     {
@@ -792,6 +794,8 @@ trait HasAttributes
      *
      * @param  array  $casts
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function ensureCastsAreStringValues($casts)
     {
@@ -1308,6 +1312,8 @@ trait HasAttributes
      * @param  string  $expectedEnum
      * @param  \UnitEnum  $value
      * @return string|int
+     *
+     * @throws \ValueError
      */
     protected function getStorableEnumValue($expectedEnum, $value)
     {
@@ -1358,6 +1364,8 @@ trait HasAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\JsonEncodingException
      */
     protected function castAttributeAsJson($key, $value)
     {
@@ -1467,6 +1475,8 @@ trait HasAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function castAttributeAsHashedString($key, #[\SensitiveParameter] $value)
     {
@@ -1508,6 +1518,8 @@ trait HasAttributes
      * @param  float|string  $value
      * @param  int  $decimals
      * @return string
+     *
+     * @throws \Illuminate\Support\Exceptions\MathException
      */
     protected function asDecimal($value, $decimals)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1002,6 +1002,8 @@ trait HasRelationships
      * Get the class name for polymorphic relations.
      *
      * @return string
+     *
+     * @throws \Illuminate\Database\ClassMorphViolationException
      */
     public function getMorphClass()
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -729,6 +729,7 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @return $this
      *
+     * @throws \InvalidArgumentException
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
@@ -774,8 +775,6 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @param  string|null  $relationshipName
      * @return $this
-     *
-     * @throws \RuntimeException
      */
     public function orWhereBelongsTo($related, $relationshipName = null)
     {
@@ -790,6 +789,7 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @return $this
      *
+     * @throws \InvalidArgumentException
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
      */
     public function whereAttachedTo($related, $relationshipName = null, $boolean = 'and')

--- a/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/TransformsToResource.php
@@ -29,6 +29,8 @@ trait TransformsToResource
      * Guess the resource class for the model.
      *
      * @return \Illuminate\Http\Resources\Json\JsonResource
+     *
+     * @throws \LogicException
      */
     protected function guessResource(): JsonResource
     {

--- a/src/Illuminate/Database/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Database/Eloquent/MassPrunable.php
@@ -42,6 +42,8 @@ trait MassPrunable
      * Get the prunable model query.
      *
      * @return \Illuminate\Database\Eloquent\Builder<static>
+     *
+     * @throws \LogicException
      */
     public function prunable()
     {

--- a/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
+++ b/src/Illuminate/Database/Eloquent/PendingHasThroughRelationship.php
@@ -103,6 +103,8 @@ class PendingHasThroughRelationship
      * @param  string  $method
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \BadMethodCallException
      */
     public function __call($method, $parameters)
     {

--- a/src/Illuminate/Database/Eloquent/Prunable.php
+++ b/src/Illuminate/Database/Eloquent/Prunable.php
@@ -14,6 +14,8 @@ trait Prunable
      *
      * @param  int  $chunkSize
      * @return int
+     *
+     * @throws \Throwable
      */
     public function pruneAll(int $chunkSize = 1000)
     {
@@ -49,6 +51,8 @@ trait Prunable
      * Get the prunable model query.
      *
      * @return \Illuminate\Database\Eloquent\Builder<static>
+     *
+     * @throws \LogicException
      */
     public function prunable()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -673,6 +673,8 @@ class BelongsToMany extends Relation
      * @param  array  $joining
      * @param  bool  $touch
      * @return TRelatedModel&object{pivot: TPivotModel}
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     public function createOrFirst(array $attributes = [], Closure|array $values = [], array $joining = [], $touch = true)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -272,6 +272,8 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $attributes
      * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     public function createOrFirst(array $attributes = [], Closure|array $values = [])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrManyThrough.php
@@ -238,6 +238,8 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  array  $attributes
      * @param  (\Closure(): array)|array  $values
      * @return TRelatedModel
+     *
+     * @throws \Illuminate\Database\UniqueConstraintViolationException
      */
     public function createOrFirst(array $attributes = [], Closure|array $values = [])
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1361,6 +1361,8 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
@@ -4210,6 +4212,8 @@ class Builder implements BuilderContract
      * Update records in a PostgreSQL database using the update from syntax.
      *
      * @return int
+     *
+     * @throws \LogicException
      */
     public function updateFrom(array $values)
     {
@@ -4646,6 +4650,8 @@ class Builder implements BuilderContract
      * Ensure the database connection supports vector queries.
      *
      * @return void
+     *
+     * @throws \RuntimeException
      */
     protected function ensureConnectionSupportsVectors()
     {

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -315,6 +315,8 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function whereLike(Builder $query, $where)
     {
@@ -811,6 +813,8 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function whereFullText(Builder $query, $where)
     {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -363,6 +363,8 @@ class Builder
      * @param  string  $column
      * @param  bool  $fullDefinition
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     public function getColumnType($table, $column, $fullDefinition = false)
     {
@@ -660,6 +662,8 @@ class Builder
      * @param  string  $name
      * @param  string|null  $schema
      * @return void
+     *
+     * @throws \RuntimeException
      */
     public function ensureExtensionExists($name, $schema = null)
     {
@@ -730,6 +734,8 @@ class Builder
      * @param  string  $reference
      * @param  string|bool|null  $withDefaultSchema
      * @return array{string|null, string}
+     *
+     * @throws \InvalidArgumentException
      */
     public function parseSchemaAndTable($reference, $withDefaultSchema = null)
     {

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -67,6 +67,8 @@ abstract class Grammar extends BaseGrammar
      * Compile the query to determine the schemas.
      *
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function compileSchemas()
     {
@@ -284,6 +286,8 @@ abstract class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
     {

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -1256,6 +1256,8 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
+     *
+     * @throws \LogicException
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
     {
@@ -1280,6 +1282,8 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
+     *
+     * @throws \LogicException
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
     {

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -598,6 +598,8 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @return array
+     *
+     * @throws \RuntimeException
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
     {

--- a/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/LocalFilesystemAdapter.php
@@ -62,6 +62,8 @@ class LocalFilesystemAdapter extends FilesystemAdapter
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
@@ -92,6 +94,8 @@ class LocalFilesystemAdapter extends FilesystemAdapter
      * @param  \DateTimeInterface  $expiration
      * @param  array  $options
      * @return array
+     *
+     * @throws \RuntimeException
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])
     {

--- a/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
@@ -194,6 +194,8 @@ class ApplicationBuilder
      * @param  string  $apiPrefix
      * @param  callable|null  $then
      * @return \Closure
+     *
+     * @throws \Throwable
      */
     protected function buildRoutingCallback(array|string|null $web,
         array|string|null $api,

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -97,6 +97,8 @@ class DocsCommand extends Command
      * @param  \Illuminate\Http\Client\Factory  $http
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return int
+     *
+     * @throws \Symfony\Component\Process\Exception\ProcessFailedException
      */
     public function handle(Http $http, Cache $cache)
     {
@@ -368,6 +370,8 @@ class DocsCommand extends Command
      *
      * @param  string  $url
      * @return void
+     *
+     * @throws \Symfony\Component\Process\Exception\ProcessFailedException
      */
     protected function openViaBuiltInStrategy($url)
     {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -408,6 +408,8 @@ class ServeCommand extends Command
      *
      * @param  string  $line
      * @return int
+     * 
+     * @throws \InvalidArgumentException
      */
     public static function getRequestPortFromLine($line)
     {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -408,7 +408,7 @@ class ServeCommand extends Command
      *
      * @param  string  $line
      * @return int
-     * 
+     *
      * @throws \InvalidArgumentException
      */
     public static function getRequestPortFromLine($line)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -916,6 +916,8 @@ class Handler implements ExceptionHandlerContract
      *
      * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
      * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Throwable
      */
     protected function renderHttpException(HttpExceptionInterface $e)
     {

--- a/src/Illuminate/Foundation/Routing/PrecognitionControllerDispatcher.php
+++ b/src/Illuminate/Foundation/Routing/PrecognitionControllerDispatcher.php
@@ -31,6 +31,8 @@ class PrecognitionControllerDispatcher extends ControllerDispatcher
      * @param  object  $controller
      * @param  string  $method
      * @return $this
+     *
+     * @throws \RuntimeException
      */
     protected function ensureMethodExists($controller, $method)
     {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -31,6 +31,8 @@ trait InteractsWithDeprecationHandling
      * Disable deprecation handling for the test.
      *
      * @return $this
+     *
+     * @throws \ErrorException
      */
     protected function withoutDeprecationHandling()
     {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -115,6 +115,8 @@ trait InteractsWithTestCaseLifecycle
      * @internal
      *
      * @return void
+     *
+     * @throws \Throwable
      */
     protected function tearDownTheTestEnvironment(): void
     {

--- a/src/Illuminate/Http/Middleware/ValidatePathEncoding.php
+++ b/src/Illuminate/Http/Middleware/ValidatePathEncoding.php
@@ -14,6 +14,8 @@ class ValidatePathEncoding
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Illuminate\Http\Exceptions\MalformedUrlException
      */
     public function handle(Request $request, Closure $next)
     {

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -186,6 +186,8 @@ class Attachment
      * @param  \Illuminate\Mail\Mailable|\Illuminate\Mail\Message|\Illuminate\Notifications\Messages\MailMessage  $mail
      * @param  array  $options
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public function attachTo($mail, $options = [])
     {

--- a/src/Illuminate/Mail/Transport/ResendTransport.php
+++ b/src/Illuminate/Mail/Transport/ResendTransport.php
@@ -48,6 +48,9 @@ class ResendTransport extends AbstractTransport
 
     /**
      * {@inheritDoc}
+     *
+     * @throws \Symfony\Component\Mailer\Exception\TransportException
+     * @throws \Throwable
      */
     protected function doSend(SentMessage $message): void
     {

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -44,6 +44,8 @@ class SesTransport extends AbstractTransport implements Stringable
 
     /**
      * {@inheritDoc}
+     *
+     * @throws \Symfony\Component\Mailer\Exception\TransportException
      */
     protected function doSend(SentMessage $message): void
     {

--- a/src/Illuminate/Mail/Transport/SesV2Transport.php
+++ b/src/Illuminate/Mail/Transport/SesV2Transport.php
@@ -44,6 +44,8 @@ class SesV2Transport extends AbstractTransport implements Stringable
 
     /**
      * {@inheritDoc}
+     *
+     * @throws \Symfony\Component\Mailer\Exception\TransportException
      */
     protected function doSend(SentMessage $message): void
     {

--- a/src/Illuminate/Process/PendingProcess.php
+++ b/src/Illuminate/Process/PendingProcess.php
@@ -369,6 +369,9 @@ class PendingProcess
      * @param  string  $command
      * @param  \Closure  $fake
      * @return mixed
+     *
+     * @throws \LogicException
+     * @throws \Throwable
      */
     protected function resolveSynchronousFake(string $command, Closure $fake)
     {

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -49,6 +49,8 @@ trait InteractsWithQueue
      *
      * @param  \Throwable|string|null  $exception
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function fail($exception = null)
     {
@@ -259,6 +261,8 @@ trait InteractsWithQueue
      * Ensure that queue interactions have been faked.
      *
      * @return void
+     *
+     * @throws \RuntimeException
      */
     private function ensureQueueInteractionsHaveBeenFaked()
     {

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -103,6 +103,8 @@ class ThrottlesExceptions
      * @param  mixed  $job
      * @param  callable  $next
      * @return mixed
+     *
+     * @throws \Throwable
      */
     public function handle($job, $next)
     {

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -40,6 +40,8 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
      * @param  mixed  $job
      * @param  callable  $next
      * @return mixed
+     *
+     * @throws \Throwable
      */
     public function handle($job, $next)
     {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -8,7 +8,6 @@ use DateTimeInterface;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -156,6 +157,8 @@ abstract class Queue
      * @param  object  $job
      * @param  string  $queue
      * @return array
+     *
+     * @throws \RuntimeException
      */
     protected function createObjectPayload($job, $queue)
     {

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -110,6 +110,8 @@ abstract class Connection
      * @param  string  $method
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Throwable
      */
     public function command($method, array $parameters = [])
     {

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -31,6 +31,8 @@ class SubstituteBindings
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @return mixed
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function handle($request, Closure $next)
     {

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -129,6 +129,8 @@ class RoutingServiceProvider extends ServiceProvider
      * Register a binding for the PSR-7 request implementation.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function registerPsrRequest()
     {
@@ -154,6 +156,8 @@ class RoutingServiceProvider extends ServiceProvider
      * Register a binding for the PSR-7 response implementation.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function registerPsrResponse()
     {

--- a/src/Illuminate/Support/BinaryCodec.php
+++ b/src/Illuminate/Support/BinaryCodec.php
@@ -25,6 +25,8 @@ class BinaryCodec
 
     /**
      * Encode a value to binary.
+     *
+     * @throws \InvalidArgumentException
      */
     public static function encode(UuidInterface|Ulid|string|null $value, string $format): ?string
     {
@@ -53,6 +55,8 @@ class BinaryCodec
 
     /**
      * Decode a binary value to string.
+     *
+     * @throws \InvalidArgumentException
      */
     public static function decode(?string $value, string $format): ?string
     {

--- a/src/Illuminate/Support/Lottery.php
+++ b/src/Illuminate/Support/Lottery.php
@@ -46,6 +46,8 @@ class Lottery
      *
      * @param  int|float  $chances
      * @param  int<1, max>|null  $outOf
+     *
+     * @throws \RuntimeException
      */
     public function __construct($chances, $outOf = null)
     {

--- a/src/Illuminate/Support/Sleep.php
+++ b/src/Illuminate/Support/Sleep.php
@@ -303,6 +303,8 @@ class Sleep
      * Handle the object's destruction.
      *
      * @return void
+     *
+     * @throws \RuntimeException
      */
     protected function goodnight()
     {
@@ -357,6 +359,8 @@ class Sleep
      * Resolve the pending duration.
      *
      * @return int|float
+     *
+     * @throws \RuntimeException
      */
     protected function pullPending()
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -969,6 +969,8 @@ trait ValidatesAttributes
      * @param  mixed  $value
      * @param  array<int, int|string>  $parameters
      * @return bool
+     *
+     * @throws \InvalidArgumentException
      */
     public function validateEncoding($attribute, $value, $parameters)
     {
@@ -1902,6 +1904,8 @@ trait ValidatesAttributes
      * @param  mixed  $value
      * @param  array<int, int|string>  $parameters
      * @return bool
+     *
+     * @throws \Illuminate\Support\Exceptions\MathException
      */
     public function validateMultipleOf($attribute, $value, $parameters)
     {

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -83,6 +83,8 @@ class ComponentSlot implements Htmlable, Stringable
      *
      * @param  callable|string|null  $callable
      * @return bool
+     *
+     * @throws \InvalidArgumentException
      */
     public function hasActualContent(callable|string|null $callable = null)
     {


### PR DESCRIPTION
This PR adds missing `@throws` annotations to various method DocBlocks. These updates improve IDE static analysis and provide better clarity on potential exceptions handled by the codebase.