### PR TITLE
Revert "Update brick/math version constraint to include 0.15"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.11|^0.12|^0.13|^0.14|^0.15",
+        "brick/math": "^0.11|^0.12|^0.13|^0.14",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^3.2.1|^4.0",


### PR DESCRIPTION
Reverts laravel/framework#59005. This is broken because of the use of RoundingMode::HALF_UP. It exists in all versions before 0.15, but not 0.15. It was also incomplete due to missing the other composer.json files.