### PR TITLE
[12.x] Fix TwoColumnDetail stripping trailing punctuation from second column values

### DIFF
--- a/src/Illuminate/Console/View/Components/TwoColumnDetail.php
+++ b/src/Illuminate/Console/View/Components/TwoColumnDetail.php
@@ -24,7 +24,6 @@ class TwoColumnDetail extends Component
 
         $second = $this->mutate($second, [
             Mutators\EnsureDynamicContentIsHighlighted::class,
-            Mutators\EnsureNoPunctuation::class,
             Mutators\EnsureRelativePaths::class,
         ]);
 

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -130,6 +130,15 @@ class ComponentsTest extends TestCase
         $this->assertStringContainsString('Second', $result);
     }
 
+    public function testTwoColumnDetailPreservesTrailingPunctuationInValue()
+    {
+        $output = new BufferedOutput();
+
+        (new Components\TwoColumnDetail($output))->render('Key', 'value!');
+        $result = $output->fetch();
+        $this->assertStringContainsString('value!', $result);
+    }
+
     public function testWarn()
     {
         $output = new BufferedOutput();


### PR DESCRIPTION
## Problem

`TwoColumnDetail` applies the `EnsureNoPunctuation` mutator to both columns, but it should only apply to the first. The second column holds data values, not labels, so stripping trailing punctuation (`.`, `?`, `!`, `:`) from it is wrong.

In practice, this means `php artisan config:show` silently truncates config values — `"Welcome to Laravel!"` displays as `"Welcome to Laravel"`.

## Fix

Remove `EnsureNoPunctuation` from the second column's mutator list.

I checked every `TwoColumnDetail` callsite in the framework (`AboutCommand`, `ConfigShowCommand`, `ShowModelCommand`, `TableCommand`, `ShowCommand`, `StatusCommand`, `ListFailedCommand`, `VendorPublishCommand`, `EnvironmentEncryptCommand`, `EnvironmentDecryptCommand`, both `MonitorCommand` variants). None of them were relying on punctuation being stripped from the second column — if anything, a few of them (config values, SQL table comments) were having user data quietly mangled.