### PR TITLE
[12.x] fix: array offset deprecation warning

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -398,7 +398,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary();
 
         foreach ($items as $item) {
-            $dictionary[$this->getDictionaryKey($item->getKey())] = $item;
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key !== null) {
+                $dictionary[$key] = $item;
+            }
         }
 
         return new static(array_values($dictionary));
@@ -474,7 +478,9 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
-            if (! isset($dictionary[$this->getDictionaryKey($item->getKey())])) {
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key === null || ! isset($dictionary[$key])) {
                 $diff->add($item);
             }
         }
@@ -499,7 +505,9 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary($items);
 
         foreach ($this->items as $item) {
-            if (isset($dictionary[$this->getDictionaryKey($item->getKey())])) {
+            $key = $this->getDictionaryKey($item->getKey());
+
+            if ($key !== null && isset($dictionary[$key])) {
                 $intersect->add($item);
             }
         }
@@ -668,7 +676,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = [];
 
         foreach ($items as $value) {
-            $dictionary[$this->getDictionaryKey($value->getKey())] = $value;
+            $key = $this->getDictionaryKey($value->getKey());
+
+            if ($key !== null) {
+                $dictionary[$key] = $value;
+            }
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -159,7 +159,9 @@ class BelongsTo extends Relation
         foreach ($results as $result) {
             $attribute = $this->getDictionaryKey($this->getRelatedKeyFrom($result));
 
-            $dictionary[$attribute] = $result;
+            if ($attribute !== null) {
+                $dictionary[$attribute] = $result;
+            }
         }
 
         // Once we have the dictionary constructed, we can loop through all the parents
@@ -168,8 +170,8 @@ class BelongsTo extends Relation
         foreach ($models as $model) {
             $attribute = $this->getDictionaryKey($this->getForeignKeyFrom($model));
 
-            if (isset($dictionary[$attribute ?? ''])) {
-                $model->setRelation($relation, $dictionary[$attribute ?? '']);
+            if ($attribute !== null && isset($dictionary[$attribute])) {
+                $model->setRelation($relation, $dictionary[$attribute]);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -285,7 +285,7 @@ class BelongsToMany extends Relation
         foreach ($models as $model) {
             $key = $this->getDictionaryKey($model->{$this->parentKey});
 
-            if (isset($dictionary[$key])) {
+            if ($key !== null && isset($dictionary[$key])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );
@@ -312,6 +312,10 @@ class BelongsToMany extends Relation
 
         foreach ($results as $key => $result) {
             $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+
+            if ($value === null) {
+                continue;
+            }
 
             if ($isAssociative) {
                 $dictionary[$value][$key] = $result;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -13,12 +13,16 @@ trait InteractsWithDictionary
      * Get a dictionary key attribute - casting it to a string if necessary.
      *
      * @param  mixed  $attribute
-     * @return mixed
+     * @return int|string|null
      *
      * @throws \InvalidArgumentException
      */
     protected function getDictionaryKey($attribute)
     {
+        if ($attribute === null || is_int($attribute) || is_string($attribute)) {
+            return $attribute;
+        }
+
         if (is_object($attribute)) {
             if (method_exists($attribute, '__toString')) {
                 return $attribute->__toString();
@@ -31,6 +35,6 @@ trait InteractsWithDictionary
             throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');
         }
 
-        return $attribute;
+        return (string) $attribute;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -13,13 +13,13 @@ trait InteractsWithDictionary
      * Get a dictionary key attribute - casting it to a string if necessary.
      *
      * @param  mixed  $attribute
-     * @return int|string|null
+     * @return string|int|null
      *
      * @throws \InvalidArgumentException
      */
     protected function getDictionaryKey($attribute)
     {
-        if ($attribute === null || is_int($attribute) || is_string($attribute)) {
+        if (is_null($attribute) || is_string($attribute) || is_int($attribute)) {
             return $attribute;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -204,6 +204,10 @@ abstract class HasOneOrMany extends Relation
         foreach ($results as $key => $item) {
             $pairKey = $this->getDictionaryKey($item->{$foreign});
 
+            if ($pairKey === null) {
+                continue;
+            }
+
             if ($isAssociative) {
                 $dictionary[$pairKey][$key] = $item;
             } else {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -114,6 +114,10 @@ class MorphTo extends BelongsTo
                 $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
                 $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
 
+                if ($morphTypeKey === null || $foreignKeyKey === null) {
+                    continue;
+                }
+
                 if ($isAssociative) {
                     $this->dictionary[$morphTypeKey][$foreignKeyKey][$key] = $model;
                 } else {
@@ -224,7 +228,7 @@ class MorphTo extends BelongsTo
         foreach ($results as $result) {
             $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
 
-            if (isset($this->dictionary[$type][$ownerKey])) {
+            if ($ownerKey !== null && isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
                     $model->setRelation($this->relationName, $result);
                 }


### PR DESCRIPTION
Hello!

We're getting a ton of deprecation warnings in the form of:

```
Using null as an array offset is deprecated, use an empty string instead in vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php on line 210
```

Array keys can only be ints or strings.

Thanks!