### PR TITLE
[13.x] make with and with count as attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Attributes/With.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/With.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class With
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<int, string>  $relations
+     */
+    public function __construct(public array $relations)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Attributes/WithCount.php
+++ b/src/Illuminate/Database/Eloquent/Attributes/WithCount.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class WithCount
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  array<int, string>  $relations
+     */
+    public function __construct(public array $relations)
+    {
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -6,6 +6,8 @@ use Closure;
 use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Touches;
+use Illuminate\Database\Eloquent\Attributes\With;
+use Illuminate\Database\Eloquent\Attributes\WithCount;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -79,6 +81,14 @@ trait HasRelationships
     #[Initialize]
     public function initializeHasRelationships()
     {
+        if (empty($this->with)) {
+            $this->with = static::resolveClassAttribute(With::class, 'relations') ?? [];
+        }
+
+        if (empty($this->withCount)) {
+            $this->withCount = static::resolveClassAttribute(WithCount::class, 'relations') ?? [];
+        }
+
         if (empty($this->touches)) {
             $this->touches = static::resolveClassAttribute(Touches::class, 'relations') ?? [];
         }
@@ -1175,6 +1185,26 @@ trait HasRelationships
         $this->relations = [];
 
         return $this;
+    }
+
+    /**
+     * Get the relationships that should be eager loaded on every query.
+     *
+     * @return array
+     */
+    public function getWith()
+    {
+        return $this->with;
+    }
+
+    /**
+     * Get the relationship counts that should be eager loaded on every query.
+     *
+     * @return array
+     */
+    public function getWithCount()
+    {
+        return $this->withCount;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelAttributesTest.php
+++ b/tests/Database/DatabaseEloquentModelAttributesTest.php
@@ -12,6 +12,8 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\Touches;
 use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Attributes\Visible;
+use Illuminate\Database\Eloquent\Attributes\With;
+use Illuminate\Database\Eloquent\Attributes\WithCount;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
 
@@ -240,6 +242,34 @@ class DatabaseEloquentModelAttributesTest extends TestCase
         $this->assertSame(['only_this'], $model->getHidden());
     }
 
+    public function test_with_attribute(): void
+    {
+        $model = new ModelWithWithAttribute;
+
+        $this->assertSame(['posts', 'comments'], $model->getWith());
+    }
+
+    public function test_with_property_takes_precedence(): void
+    {
+        $model = new ModelWithWithAttributeAndProperty;
+
+        $this->assertSame(['tags'], $model->getWith());
+    }
+
+    public function test_with_count_attribute(): void
+    {
+        $model = new ModelWithWithCountAttribute;
+
+        $this->assertSame(['posts', 'comments'], $model->getWithCount());
+    }
+
+    public function test_with_count_property_takes_precedence(): void
+    {
+        $model = new ModelWithWithCountAttributeAndProperty;
+
+        $this->assertSame(['tags'], $model->getWithCount());
+    }
+
     public function test_is_ignoring_touch_with_timestamps_attribute(): void
     {
         $this->assertTrue(ModelWithoutTimestampsAttribute::isIgnoringTouch());
@@ -383,4 +413,28 @@ class ModelWithAppendsAttribute extends Model
 class ModelWithTouchesAttribute extends Model
 {
     //
+}
+
+#[With(['posts', 'comments'])]
+class ModelWithWithAttribute extends Model
+{
+    //
+}
+
+#[With(['posts', 'comments'])]
+class ModelWithWithAttributeAndProperty extends Model
+{
+    protected $with = ['tags'];
+}
+
+#[WithCount(['posts', 'comments'])]
+class ModelWithWithCountAttribute extends Model
+{
+    //
+}
+
+#[WithCount(['posts', 'comments'])]
+class ModelWithWithCountAttributeAndProperty extends Model
+{
+    protected $withCount = ['tags'];
 }


### PR DESCRIPTION
Add `#[With]` and `#[WithCount]` PHP Attributes for Eloquent Models
This PR adds two new PHP attributes — `#[With]`, and `#[WithCount]` — that allow defining eager-loaded relationships and relationship counts directly on the model class, following the same pattern established by existing attributes like 
`#[Fillable], #[Hidden], #[Touches], etc`.

Usage

```
use Illuminate\Database\Eloquent\Attributes\With;
use Illuminate\Database\Eloquent\Attributes\WithCount;

#[With(['posts', 'comments'])]
#[WithCount(['posts', 'comments'])]
class User extends Model
{
    //
}

```

This is equivalent to setting the properties directly:


```
class User extends Model
{
    protected $with = ['posts', 'comments'];
    protected $withCount = ['posts', 'comments'];
}

```