### PR TITLE
Add insertOrIgnoreReturning method

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1239,6 +1239,22 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an insert or ignore statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $returning
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    {
+        throw new RuntimeException('This database engine does not support insert or ignore with returning.');
+    }
+
+    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -374,6 +374,22 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an insert or ignore statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    {
+        return $this->compileInsert($query, $values)
+            .' on conflict ('.$this->columnize($uniqueBy).') do nothing'
+            .' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile an insert ignore statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -296,6 +296,22 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an insert or ignore statement with a returning clause into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    {
+        return $this->compileInsert($query, $values)
+            .' on conflict ('.$this->columnize($uniqueBy).') do nothing'
+            .' returning '.$this->columnize($returning);
+    }
+
+    /**
      * Compile an insert ignore statement using a subquery into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
## Problem

The current `insertOrIgnore` method has two limitations:

1. **No conflict target** — it generates `ON CONFLICT DO NOTHING` without specifying which unique constraint to check. This silently swallows **all** constraint violations, not just the intended one, FK, CHECK, UNIQUE (it may be many uniques and you can't define which one could be ignored).

2. **No way to know what was actually inserted** — it returns an `int` (affected rows count), so the caller has no way to retrieve the inserted rows or distinguish which records were skipped due to conflicts.

A common real-world need is: "Insert these rows, skip duplicates by a specific key, and tell me exactly which rows were inserted."

## Related discussions

- https://github.com/laravel/framework/discussions/39487

## Why a separate method instead of extending `insertOrIgnore`

Making `$uniqueBy` and `$returning` optional parameters on `insertOrIgnore` was considered, but this creates a return type ambiguity:

- Without `$returning` → returns `int` (affected row count)
- With `$returning` → returns `Collection` (actual row data)

A method that changes its return type based on which arguments are passed is confusing, hard to type-hint, and breaks static analysis. A dedicated method with a clear and consistent return type is the better API.

## Solution

A new `insertOrIgnoreReturning` method:

```php
DB::table('users')->insertOrIgnoreReturning(
    [['email' => 'a@b.com', 'name' => 'A'], ['email' => 'c@d.com', 'name' => 'C']],
    'email',
    ['id', 'email']
);
// => Collection of actually inserted rows (conflicting rows are not returned)
```

Generates:

```sql
INSERT INTO "users" ("email", "name") VALUES (?, ?), (?, ?)
ON CONFLICT ("email") DO NOTHING
RETURNING "id", "email"
```

### Signature

```php
public function insertOrIgnoreReturning(
    array $values,
    array|string $uniqueBy,
    array $returning = ['*']
): Collection
```

- `$values` — records to insert
- `$uniqueBy` — column(s) for the conflict target (required)
- `$returning` — columns to return from inserted rows (defaults to `*`)
- Always returns a `Collection` — empty if nothing was inserted

### Database support

| Engine     | `RETURNING` | `ON CONFLICT` target | This PR | Notes                                         |
|------------|:-----------:|:--------------------:|:-------:|-----------------------------------------------|
| PostgreSQL | Yes         | Yes                  | Yes     | `ON CONFLICT (col) DO NOTHING RETURNING ...`  |
| SQLite     | Yes (3.35+) | Yes                  | Yes     | Same syntax as PostgreSQL                     |
| MariaDB    | Yes (10.5+) | No                   | No      | Has `RETURNING` but no `ON CONFLICT` target   |
| MySQL      | No          | No                   | No      | No `RETURNING` clause                         |
| SQL Server | Via `OUTPUT`| Via `MERGE`          | No      | Possible but requires different SQL structure  |
