### PR TITLE
Add saveOrIgnore Eloquent Model method for conflict-safe inserts

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1118,7 +1118,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1143,7 +1143,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
@@ -1165,7 +1165,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $baseQuery = m::mock(BaseBuilder::class);
         $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
-        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1112,6 +1112,88 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->exists);
     }
 
+    public function testInsertOrIgnoreProcessWithIncrementing()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $baseQuery = m::mock(BaseBuilder::class);
+        $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection([(object) ['id' => 1, 'name' => 'taylor']]));
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+
+        $model->name = 'taylor';
+        $model->exists = false;
+        $this->assertTrue($model->saveOrIgnore(['name']));
+        $this->assertEquals(1, $model->id);
+        $this->assertTrue($model->exists);
+        $this->assertTrue($model->wasRecentlyCreated);
+    }
+
+    public function testInsertOrIgnoreProcessWithConflict()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $baseQuery = m::mock(BaseBuilder::class);
+        $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection);
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+
+        $model->name = 'taylor';
+        $model->exists = false;
+        $this->assertFalse($model->saveOrIgnore(['name']));
+        $this->assertFalse($model->exists);
+        $this->assertFalse($model->wasRecentlyCreated);
+    }
+
+    public function testInsertOrIgnoreProcessWithNonIncrementing()
+    {
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $query = m::mock(Builder::class);
+        $baseQuery = m::mock(BaseBuilder::class);
+        $query->shouldReceive('toBase')->once()->andReturn($baseQuery);
+        $baseQuery->shouldReceive('insertOrIgnoreReturning')->once()->with(['name' => 'taylor'], ['name'], ['*'])->andReturn(new BaseCollection([(object) ['name' => 'taylor']]));
+        $query->shouldReceive('getConnection')->once();
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->once())->method('updateTimestamps');
+        $model->setIncrementing(false);
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
+
+        $model->name = 'taylor';
+        $model->exists = false;
+        $this->assertTrue($model->saveOrIgnore(['name']));
+        $this->assertNull($model->id);
+        $this->assertTrue($model->exists);
+        $this->assertTrue($model->wasRecentlyCreated);
+    }
+
+    public function testInsertOrIgnoreThrowsOnExistingModel()
+    {
+        $this->expectException(\LogicException::class);
+
+        $model = new EloquentModelStub;
+        $model->exists = true;
+        $model->saveOrIgnore(['name']);
+    }
+
     public function testDeleteProperlyDeletesModel()
     {
         $model = $this->getMockBuilder(Model::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'touchOwners'])->getMock();


### PR DESCRIPTION
- Follow up: #59025

## Problem

When creating records with unique constraints, `save()` throws `UniqueConstraintViolationException`:

```php
// Race condition: two requests register same user for same contest
$model = new ContestRegistration();
$model->user_id = $userId;
$model->contest_code = $contestCode;
$model->save(); // SQLSTATE[23505]: Unique violation
```

Current workarounds are verbose and suboptimal:

```php
// Workaround 1: try/catch — error handling after the fact, not prevention;
// generates error entries in DB logs that aren't actual errors by business logic
try {
    $model->save();
} catch (UniqueConstraintViolationException) {
    // silently ignore
    // ...or perform other logic to implement idempotency
}

// Workaround 2: firstOrCreate — extra SELECT before every INSERT
ContestRegistration::firstOrCreate(
    ['user_id' => $authUserId, 'contest_code' => $code],
);
```

## Solution: `saveOrIgnore()`

Uses the SQL-level `INSERT ... ON CONFLICT (columns) DO NOTHING RETURNING *` — no exceptions, no extra queries:

```php
$model = new ContestRegistration();
$model->user_id = $userId;
$model->contest_code = $contestCode;
$model->saveOrIgnore(uniqueBy: ['user_id', 'contest_code']);
// true -> record inserted
// false -> conflict, nothing inserted
// exception -> something bad happened
```

## Use Cases

### 1. Idempotent event handlers

```php
// Processing webhook that may arrive multiple times
$payment = new Payment();
$payment->external_id = $webhook->paymentId;
$payment->amount = $webhook->amount;
$payment->saveOrIgnore(uniqueBy: ['external_id']);
```

### 2. Race-condition-safe registration

```php
$subscription = new Subscription();
$subscription->user_id = $user->id;
$subscription->plan_id = $plan->id;
$subscription->saveOrIgnore(uniqueBy: ['user_id', 'plan_id']);
```

### 3. One-time actions / feature flags

```php
$flag = new UserFeatureFlag();
$flag->user_id = $user->id;
$flag->feature = 'onboarding_completed';
$flag->saveOrIgnore(uniqueBy: ['user_id', 'feature']);
```

### 4. Conditional logic based on insert result

```php
$like = new PostLike();
$like->user_id = $user->id;
$like->post_id = $post->id;

if ($like->saveOrIgnore(uniqueBy: ['user_id', 'post_id'])) {
    $post->increment('likes_count');
}
```

## API Properties

- Returns `bool` — `true` if inserted, `false` if conflict
- Full model lifecycle: events (`saving`, `creating`, `created`, `saved`), timestamps, unique IDs
- On conflict: `created`/`saved` events do NOT fire, `exists` stays `false`
- Auto-increment ID is captured from `RETURNING` clause

## Current Limitations

### Not all databases suported

- Only PostgreSQL & SQLite supports this feature at this moment
- Details: https://github.com/laravel/framework/pull/59025

## UPDATE not available

`saveOrIgnore()` throws `LogicException` if called on an existing model (`$model->exists === true`).

The UPDATE path is intentionally not supported because `UPDATE` modifies existing rows and does not create new ones, so unique constraint conflicts on the target columns can only occur if you are changing a unique column's value to one that already exists in another row. This is a fundamentally different (and rare) scenario that should be handled explicitly, not silently ignored.

AFAIK, PostgreSQL does not support it; SQLite does.

## Possible methods naming

- saveOrIgnoreOnConflict
- createOrIgnore
- createOrIgnoreOnConflict
- ... your name