### PR TITLE
Add corner case tests for insertOrIgnoreReturning

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4120,10 +4120,9 @@ class Builder implements BuilderContract
     /**
      * Insert new records into the database while ignoring specific conflicts and returning specified columns.
      *
-    * @param  non-empty-string|non-empty-array<non-empty-string>  $uniqueBy
-    * @param  non-empty-array<non-empty-string>  $returning
-    *
-    * @return \Illuminate\Support\Collection
+     * @param  non-empty-string|non-empty-array<non-empty-string>  $uniqueBy
+     * @param  non-empty-array<non-empty-string>  $returning
+     * @return \Illuminate\Support\Collection
      */
     public function insertOrIgnoreReturning(array $values, array|string $uniqueBy, array $returning = ['*'])
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4128,6 +4128,14 @@ class Builder implements BuilderContract
             return new Collection;
         }
 
+        if ($uniqueBy === [] || $uniqueBy === '') {
+            throw new InvalidArgumentException('The unique columns must not be empty.');
+        }
+
+        if ($returning === []) {
+            throw new InvalidArgumentException('The returning columns must not be empty.');
+        }
+
         if (! is_array(array_first($values))) {
             $values = [$values];
         } else {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4120,7 +4120,10 @@ class Builder implements BuilderContract
     /**
      * Insert new records into the database while ignoring specific conflicts and returning specified columns.
      *
-     * @return \Illuminate\Support\Collection
+    * @param  non-empty-string|non-empty-array<non-empty-string>  $uniqueBy
+    * @param  non-empty-array<non-empty-string>  $returning
+    *
+    * @return \Illuminate\Support\Collection
      */
     public function insertOrIgnoreReturning(array $values, array|string $uniqueBy, array $returning = ['*'])
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4122,6 +4122,30 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
     }
 
+    public function testInsertOrIgnoreReturningWithEmptyUniqueByArray()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], []);
+    }
+
+    public function testInsertOrIgnoreReturningWithEmptyUniqueByString()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The unique columns must not be empty.');
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], '');
+    }
+
+    public function testInsertOrIgnoreReturningWithEmptyReturning()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The returning columns must not be empty.');
+        $builder = $this->getPostgresBuilder();
+        $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', []);
+    }
+
     public function testInsertOrIgnoreUsingMethod()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
- Follow up: #59025

Add empty `uniqueBy` and `returning` validation to `insertOrIgnoreReturning` to throw a clear `InvalidArgumentException` instead of generating invalid SQL.