### PR TITLE
[13.x] Add controller middleware attribute

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Routing\Controllers\Attributes;
+namespace Illuminate\Routing\Attributes\Controllers;
 
 use Attribute;
 

--- a/src/Illuminate/Routing/Controllers/Attributes/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Attributes/Middleware.php
@@ -15,5 +15,6 @@ class Middleware
         public string $value,
         public ?array $only = null,
         public ?array $except = null,
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Routing/Controllers/Attributes/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Attributes/Middleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Routing\Controllers\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Middleware
+{
+    /**
+     * @param  array<string>|null  $only
+     * @param  array<string>|null  $except
+     */
+    public function __construct(
+        public string $value,
+        public ?array $only = null,
+        public ?array $except = null,
+    ) {}
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -26,6 +26,7 @@ use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionException;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 use function Illuminate\Support\enum_value;
@@ -1149,8 +1150,12 @@ class Route
      */
     protected function attributeProvidedControllerMiddleware(string $class, string $method)
     {
-        $reflectionClass = new ReflectionClass($class);
-        $reflectionMethod = $reflectionClass->getMethod($method);
+        try {
+            $reflectionClass = new ReflectionClass($class);
+            $reflectionMethod = $reflectionClass->getMethod($method);
+        } catch (ReflectionException) {
+            return [];
+        }
 
         return (new Collection(array_merge(
             $reflectionClass->getAttributes(MiddlewareAttribute::class, ReflectionAttribute::IS_INSTANCEOF),

--- a/tests/Integration/Routing/MiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/MiddlewareAttributeTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
-use Illuminate\Routing\Controllers\Attributes\Middleware;
+use Illuminate\Routing\Attributes\Controllers\Middleware;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Routing/MiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/MiddlewareAttributeTest.php
@@ -11,10 +11,17 @@ class MiddlewareAttributeTest extends TestCase
     public function test_attribute_middleware_is_respected(): void
     {
         $route = Route::get('/', [MiddlewareAttributeController::class, 'index']);
-        $this->assertEquals($route->controllerMiddleware(), ['all', 'only-index', 'also-index']);
+        $this->assertEquals([
+            'all',
+            'only-index',
+            'also-index',
+        ], $route->controllerMiddleware());
 
         $route = Route::get('/', [MiddlewareAttributeController::class, 'show']);
-        $this->assertEquals($route->controllerMiddleware(), ['all', 'except-index']);
+        $this->assertEquals([
+            'all',
+            'except-index',
+        ], $route->controllerMiddleware());
     }
 }
 
@@ -24,7 +31,13 @@ class MiddlewareAttributeTest extends TestCase
 class MiddlewareAttributeController
 {
     #[Middleware('also-index')]
-    public function index(): void {}
+    public function index(): void
+    {
+        // ...
+    }
 
-    public function show(): void {}
+    public function show(): void
+    {
+        // ...
+    }
 }

--- a/tests/Integration/Routing/MiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/MiddlewareAttributeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Controllers\Attributes\Middleware;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class MiddlewareAttributeTest extends TestCase
+{
+    public function test_attribute_middleware_is_respected(): void
+    {
+        $route = Route::get('/', [MiddlewareAttributeController::class, 'index']);
+        $this->assertEquals($route->controllerMiddleware(), ['all', 'only-index', 'also-index']);
+
+        $route = Route::get('/', [MiddlewareAttributeController::class, 'show']);
+        $this->assertEquals($route->controllerMiddleware(), ['all', 'except-index']);
+    }
+}
+
+#[Middleware('all')]
+#[Middleware('only-index', only: ['index'])]
+#[Middleware('except-index', except: ['index'])]
+class MiddlewareAttributeController
+{
+    #[Middleware('also-index')]
+    public function index(): void {}
+
+    public function show(): void {}
+}


### PR DESCRIPTION
I really like the attributes in Laravel 13!

For some time now, I've been thinking about better ways to authorize access to controller actions, and I think attributes are a great fit for that.

This PR is an attempt to set up the basics needed for controller middleware via attributes.

<details open>

<summary>Example usage</summary>

This example is based on the current doc example with [HasMiddleware](https://laravel.com/docs/12.x/controllers#controller-middleware). 

```php
<?php

namespace App\Http\Controllers;

use Illuminate\Routing\Controllers\Attributes\Middleware;

#[Middleware('auth')]
#[Middleware('log', only: ['index'])]
#[Middleware('subscribed', except: ['store'])]
class UserController
{
    // ...
}
```

You can also place attributes on individual methods, and they will be merged with the class attributes.

```php
<?php

namespace App\Http\Controllers;

use Illuminate\Routing\Controllers\Attributes\Middleware;

#[Middleware('auth')]
class UserController
{
    #[Middleware('log')]
    #[Middleware('subscribed')]
    public function index() {
        // ...
    }

    public function store() {
        // ...
    }

    #[Middleware('subscribed')]
    public function show() {
        // ...
    }
}
```

</details>

By using `ReflectionAttribute::IS_INSTANCEOF`, it will be possible to extend the `Middleware` both in the framework and in userland.

<details>

<summary>Example for my ultimate goal of having an Authorize attribute</summary>

```php
<?php

namespace Illuminate\Routing\Controllers\Attributes;

use Attribute;
use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
use Illuminate\Support\Arr;

#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
class Authorize extends Middleware
{
    public function __construct(string $ability, mixed $arguments = null, ?array $only = null, ?array $except = null)
    {
        $middleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($arguments));

        parent::__construct($middleware, $only, $except);
    }
}
```

```php
<?php

namespace App\Http\Controllers;

use App\Models\Comment;
use App\Models\Post;
use Illuminate\Routing\Controllers\Attributes\Authorize;

class CommentController
{
    #[Authorize('viewAny', [Comment::class, 'post'])]
    public function index(Post $post) {
        // ...
    }

    #[Authorize('view', 'comment')]
    public function show(Comment $comment) {
        // ...
    }
}
```

</details>
