### PR TITLE
[13.x] Add ErrorBag attribute support for FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/Attributes/ErrorBag.php
+++ b/src/Illuminate/Foundation/Http/Attributes/ErrorBag.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ErrorBag
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  string  $name
+     */
+    public function __construct(public string $name)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\Attributes\ErrorBag;
 use Illuminate\Foundation\Http\Attributes\RedirectTo;
 use Illuminate\Foundation\Http\Attributes\RedirectToRoute;
 use Illuminate\Foundation\Http\Attributes\StopOnFirstFailure;
@@ -136,6 +137,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         if (count($redirectToRoute) > 0) {
             $this->redirectRoute = $redirectToRoute[0]->newInstance()->route;
+        }
+
+        $errorBag = $reflection->getAttributes(ErrorBag::class);
+
+        if (count($errorBag) > 0) {
+            $this->errorBag = $errorBag[0]->newInstance()->name;
         }
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring a form request error bag via a class attribute:

```php
use Illuminate\Foundation\Http\Attributes\ErrorBag;

#[ErrorBag('login')]
class LoginRequest extends FormRequest
{
    // ...
}
