### PR TITLE
[12.x] Feature: prevent macro overrides

### DIFF
--- a/src/Illuminate/Macroable/Exceptions/MacroAlreadyDefinedException.php
+++ b/src/Illuminate/Macroable/Exceptions/MacroAlreadyDefinedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Macroable\Exceptions;
+
+use LogicException;
+
+class MacroAlreadyDefinedException extends LogicException
+{
+}

--- a/src/Illuminate/Macroable/MacroOverrides.php
+++ b/src/Illuminate/Macroable/MacroOverrides.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support;
+
+class MacroOverrides
+{
+    protected static $preventMacroOverrides = false;
+
+    public static function preventGlobally($prevent = true)
+    {
+        static::$preventMacroOverrides = $prevent;
+    }
+
+    public static function shouldPrevent(): bool
+    {
+        return static::$preventMacroOverrides;
+    }
+}

--- a/src/Illuminate/Macroable/MacroOverrides.php
+++ b/src/Illuminate/Macroable/MacroOverrides.php
@@ -6,13 +6,29 @@ namespace Illuminate\Support;
 
 class MacroOverrides
 {
+    /**
+     * Indicates if a macros should not be overridden when it already exists.
+     *
+     * @var bool
+     */
     protected static $preventMacroOverrides = false;
 
-    public static function prevent($prevent = true)
+    /**
+     * Prevents macro overrides.
+     *
+     * @param  bool  $prevent
+     * @return void
+     */
+    public static function prevent($prevent = true): void
     {
         static::$preventMacroOverrides = $prevent;
     }
 
+    /**
+     * Determines if macro overrides should be prevented.
+     *
+     * @return bool
+     */
     public static function shouldPrevent(): bool
     {
         return static::$preventMacroOverrides;

--- a/src/Illuminate/Macroable/MacroOverrides.php
+++ b/src/Illuminate/Macroable/MacroOverrides.php
@@ -8,7 +8,7 @@ class MacroOverrides
 {
     protected static $preventMacroOverrides = false;
 
-    public static function preventGlobally($prevent = true)
+    public static function prevent($prevent = true)
     {
         static::$preventMacroOverrides = $prevent;
     }

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -4,6 +4,8 @@ namespace Illuminate\Support\Traits;
 
 use BadMethodCallException;
 use Closure;
+use Illuminate\Macroable\Exceptions\MacroAlreadyDefinedException;
+use Illuminate\Support\MacroOverrides;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -17,6 +19,13 @@ trait Macroable
     protected static $macros = [];
 
     /**
+     * Indicates if a macros should not be overridden when it already exists.
+     *
+     * @var bool
+     */
+    protected static $preventMacroOverrides = false;
+
+    /**
      * Register a custom macro.
      *
      * @param  string  $name
@@ -28,7 +37,34 @@ trait Macroable
      */
     public static function macro($name, $macro)
     {
+        if (static::shouldPreventMacroOverrides() && static::hasMacro($name)) {
+            throw new MacroAlreadyDefinedException(sprintf(
+                'Macro %s::%s already exists.', static::class, $name
+            ));
+        }
+
         static::$macros[$name] = $macro;
+    }
+
+    /**
+     * Prevents macro overrides.
+     *
+     * @param  bool  $prevent
+     * @return void
+     */
+    public static function preventMacroOverrides($prevent = true): void
+    {
+        static::$preventMacroOverrides = $prevent;
+    }
+
+    /**
+     * Determines if macro overrides should be prevented.
+     *
+     * @return bool
+     */
+    public static function shouldPreventMacroOverrides(): bool
+    {
+        return static::$preventMacroOverrides === null ? MacroOverrides::shouldPrevent() : static::$preventMacroOverrides;
     }
 
     /**


### PR DESCRIPTION
This Pull Request introduces the ability to prevent macro overriding. It is especially useful in modular systems, where independent modules extend base classes.

The PR allows preventing overrides per class that uses the `Macroable` trait, for example:

```php
Request::preventMacroOverrides();
```

or globally:

```php
use Illuminate\Support\MacroOverrides;

MacroOverrides::prevent();
```

By default, overriding is allowed, so there is no breaking change.
