### PR TITLE
[13.x] Add AfterCommit and BeforeCommit queue attributes

### DIFF
--- a/src/Illuminate/Queue/Attributes/AfterCommit.php
+++ b/src/Illuminate/Queue/Attributes/AfterCommit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AfterCommit
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  bool  $afterCommit
+     */
+    public function __construct(public bool $afterCommit = true)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Queue/Attributes/BeforeCommit.php
+++ b/src/Illuminate/Queue/Attributes/BeforeCommit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class BeforeCommit
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  bool  $beforeCommit
+     */
+    public function __construct(public bool $beforeCommit = true)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds two queue class attributes for commit dispatch behavior:

- `#[AfterCommit]`
- `#[BeforeCommit]`

These provide a declarative, class-level alternative to setting `$afterCommit` manually.

- Added:
  - `Illuminate\Queue\Attributes\AfterCommit`
  - `Illuminate\Queue\Attributes\BeforeCommit`
- Updated `Queue::shouldDispatchAfterCommit()` to read the new attributes.


Dispatch behavior is resolved in this order:

1. Runtime value (`$job->afterCommit`, including `->afterCommit()` / `->beforeCommit()`)
2. Attributes (`#[BeforeCommit]` / `#[AfterCommit]`)
3. `ShouldQueueAfterCommit` contract
4. Queue connection default (`$dispatchAfterCommit`)

This keeps runtime overrides intuitive while still enabling clear class-level defaults.
