### PR TITLE
Add key access support to getChanges() and getPrevious()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2300,21 +2300,32 @@ trait HasAttributes
     /**
      * Get the attributes that were changed when the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @return array<string, mixed>|mixed
      */
-    public function getChanges()
+    public function getChanges($key = null)
     {
-        return $this->changes;
+        if (is_null($key)) {
+            return $this->changes;
+        }
+
+        return $this->changes[$key] ?? null;
     }
+
 
     /**
      * Get the attributes that were previously original before the model was last saved.
      *
-     * @return array<string, mixed>
+     * @param  string|null  $key
+     * @return array<string, mixed>|mixed
      */
-    public function getPrevious()
+    public function getPrevious($key = null)
     {
-        return $this->previous;
+        if (is_null($key)) {
+            return $this->previous;
+        }
+
+        return $this->previous[$key] ?? null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3435,6 +3435,35 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($user->name);
     }
 
+
+    public function testGetChangesWithKey()
+    {
+        $model = new EloquentModelStub;
+        $model->setRawAttributes(['name' => 'John', 'email' => 'john@example.com']);
+        $model->syncOriginal();
+
+        $model->name = 'Jack';
+        $model->email = 'jack@example.com';
+        $model->syncChanges();
+
+        $this->assertSame('Jack', $model->getChanges('name'));
+        $this->assertNull($model->getChanges('missing_key'));
+    }
+
+    public function testGetPreviousWithKey()
+    {
+        $model = new EloquentModelStub;
+        $model->setRawAttributes(['name' => 'John', 'email' => 'john@example.com']);
+        $model->syncOriginal();
+
+        $model->name = 'Jack';
+        $model->email = 'jack@example.com';
+        $model->syncChanges();
+
+        $this->assertSame('John', $model->getPrevious('name'));
+        $this->assertNull($model->getPrevious('missing_key'));
+    }
+
     public function testDiscardChanges()
     {
         $user = new EloquentModelStub([


### PR DESCRIPTION
```
The `getOriginal()` method accepts an optional `$key` to retrieve 
a single attribute value. However `getChanges()` and `getPrevious()` 
do not, forcing developers to do this manually:

$changes = $user->getChanges();
$name = $changes['name'] ?? null;

This PR makes both methods consistent with `getOriginal()`:

$user->getChanges('name');  // 'Jack'
$user->getPrevious('name'); // 'John'

## Changes
- Added optional `$key` to `getChanges()` in `HasAttributes.php`
- Added optional `$key` to `getPrevious()` in `HasAttributes.php`
- Added tests for both methods