### PR TITLE
[12.x] Refactor: convert switch to match in Env::getOption()

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -252,27 +252,12 @@ class Env
     protected static function getOption($key)
     {
         return Option::fromValue(static::getRepository()->get($key))
-            ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
+            ->map(fn ($value) => match (strtolower($value)) {
+                'true', '(true)'   => true,
+                'false', '(false)' => false,
+                'empty', '(empty)' => '',
+                'null', '(null)'   => null,
+                default => preg_match('/\A([\'"])(.*)\1\z/', $value, $matches) ? $matches[2] : $value,
             });
     }
 


### PR DESCRIPTION
The `getOption()` method had a `switch` with a trailing `if` and separate `return`. Replaced it with a single `match` expression and an arrow function — same behaviour, fewer lines, easier to read at a glance.