### PR TITLE
[12.x] Refactor: convert switch to match in operatorForWhere()

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -1136,20 +1136,18 @@ trait EnumeratesValues
                 return in_array($operator, ['!=', '<>', '!==']);
             }
 
-            switch ($operator) {
-                default:
-                case '=':
-                case '==':  return $retrieved == $value;
-                case '!=':
-                case '<>':  return $retrieved != $value;
-                case '<':   return $retrieved < $value;
-                case '>':   return $retrieved > $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
-                case '===': return $retrieved === $value;
-                case '!==': return $retrieved !== $value;
-                case '<=>': return $retrieved <=> $value;
-            }
+            return match ($operator) {
+                '=', '=='   => $retrieved == $value,
+                '!=', '<>'  => $retrieved != $value,
+                '<'         => $retrieved < $value,
+                '>'         => $retrieved > $value,
+                '<='        => $retrieved <= $value,
+                '>='        => $retrieved >= $value,
+                '==='       => $retrieved === $value,
+                '!=='       => $retrieved !== $value,
+                '<=>'       => $retrieved <=> $value,
+                default     => $retrieved == $value,
+            };
         };
     }
 


### PR DESCRIPTION
The `switch` in `operatorForWhere()` had an awkward `default` at the top, which is easy to miss. Replaced it with a `match` expression where `default` sits naturally at the end — same logic, just clearer.