### PR TITLE
[12.x] Refactor: remove redundant sprintf('%s', ...) in ShowModelCommand

### DIFF
--- a/src/Illuminate/Database/Console/ShowModelCommand.php
+++ b/src/Illuminate/Database/Console/ShowModelCommand.php
@@ -196,8 +196,8 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
         if ($events->count()) {
             foreach ($events as $event) {
                 $this->components->twoColumnDetail(
-                    sprintf('%s', $event['event']),
-                    sprintf('%s', $event['class']),
+                    $event['event'],
+                    $event['class'],
                 );
             }
         }
@@ -209,7 +209,7 @@ class ShowModelCommand extends DatabaseInspectionCommand implements PromptsForMi
         if ($observers->count()) {
             foreach ($observers as $observer) {
                 $this->components->twoColumnDetail(
-                    sprintf('%s', $observer['event']),
+                    $observer['event'],
                     implode(', ', $observer['observer'])
                 );
             }


### PR DESCRIPTION
Found three `sprintf('%s', $value)` calls where the values are already strings — so `sprintf` isn't doing anything useful. Removed the wrapping and passed the values directly.