### PR TITLE
[12.x] Refactor: replace func_num_args() with is_null() in Arr::prepend()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -903,7 +903,7 @@ class Arr
      */
     public static function prepend($array, $value, $key = null)
     {
-        if (func_num_args() == 2) {
+        if (is_null($key)) {
             array_unshift($array, $value);
         } else {
             $array = [$key => $value] + $array;


### PR DESCRIPTION
`func_num_args()` was used to detect whether a `$key` was passed, but since `$key` already defaults to `null`, a simple `is_null($key)` check does the same job and is much easier to read.