### PR TITLE
[13.x] Refactor: replace switch(true) with if/elseif in QuestionHelper

### DIFF
--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -35,27 +35,15 @@ class QuestionHelper extends SymfonyQuestionHelper
                 : '<comment>Ctrl+D</comment>');
         }
 
-        switch (true) {
-            case null === $default:
-                $text = sprintf('<info>%s</info>', $text);
-
-                break;
-
-            case $question instanceof ConfirmationQuestion:
-                $text = sprintf('<info>%s (yes/no)</info> [<comment>%s</comment>]', $text, $default ? 'yes' : 'no');
-
-                break;
-
-            case $question instanceof ChoiceQuestion:
-                $choices = $question->getChoices();
-                $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($choices[$default] ?? $default));
-
-                break;
-
-            default:
-                $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($default));
-
-                break;
+        if (null === $default) {
+            $text = sprintf('<info>%s</info>', $text);
+        } elseif ($question instanceof ConfirmationQuestion) {
+            $text = sprintf('<info>%s (yes/no)</info> [<comment>%s</comment>]', $text, $default ? 'yes' : 'no');
+        } elseif ($question instanceof ChoiceQuestion) {
+            $choices = $question->getChoices();
+            $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($choices[$default] ?? $default));
+        } else {
+            $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($default));
         }
 
         $output->writeln($text);


### PR DESCRIPTION
`switch (true)` is essentially just an `if/elseif` chain — but harder to scan because you need to know the `switch` mechanics to read it. Replaced it with a straightforward `if/elseif/else` block so the conditions are immediately obvious.