### PR TITLE
[12.x] Feature: allow string as an argument in Number class methods

### DIFF
--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -27,15 +27,19 @@ class Number
     /**
      * Format the given number according to the current locale.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  int|null  $precision
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function format(int|float $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
+    public static function format(int|float|string $number, ?int $precision = null, ?int $maxPrecision = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
 
@@ -92,15 +96,19 @@ class Number
     /**
      * Spell out the given number in the given locale.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  string|null  $locale
      * @param  int|null  $after
      * @param  int|null  $until
      * @return string
      */
-    public static function spell(int|float $number, ?string $locale = null, ?int $after = null, ?int $until = null)
+    public static function spell(int|float|string $number, ?string $locale = null, ?int $after = null, ?int $until = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         if (! is_null($after) && $number <= $after) {
             return static::format($number, locale: $locale);
@@ -118,13 +126,17 @@ class Number
     /**
      * Convert the given number to ordinal form.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  string|null  $locale
      * @return string
      */
-    public static function ordinal(int|float $number, ?string $locale = null)
+    public static function ordinal(int|float|string $number, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::ORDINAL);
 
@@ -134,13 +146,17 @@ class Number
     /**
      * Spell out the given number in the given locale in ordinal form.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  string|null  $locale
      * @return string
      */
-    public static function spellOrdinal(int|float $number, ?string $locale = null)
+    public static function spellOrdinal(int|float|string $number, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
 
@@ -152,15 +168,19 @@ class Number
     /**
      * Convert the given number to its percentage equivalent.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @param  string|null  $locale
      * @return string|false
      */
-    public static function percentage(int|float $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
+    public static function percentage(int|float|string $number, int $precision = 0, ?int $maxPrecision = null, ?string $locale = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::PERCENT);
 
@@ -176,15 +196,19 @@ class Number
     /**
      * Convert the given number to its currency equivalent.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  string  $in
      * @param  string|null  $locale
      * @param  int|null  $precision
      * @return string|false
      */
-    public static function currency(int|float $number, string $in = '', ?string $locale = null, ?int $precision = null)
+    public static function currency(int|float|string $number, string $in = '', ?string $locale = null, ?int $precision = null)
     {
         static::ensureIntlExtensionIsInstalled();
+
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+        }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
 
@@ -198,13 +222,17 @@ class Number
     /**
      * Convert the given number to its file size equivalent.
      *
-     * @param  int|float  $bytes
+     * @param  int|float|string  $bytes
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @return string
      */
-    public static function fileSize(int|float $bytes, int $precision = 0, ?int $maxPrecision = null)
+    public static function fileSize(int|float|string $bytes, int $precision = 0, ?int $maxPrecision = null)
     {
+        if (is_string($bytes)) {
+            $bytes = self::parse($bytes, NumberFormatter::TYPE_DOUBLE);
+        }
+
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
         $unitCount = count($units);
@@ -219,12 +247,12 @@ class Number
     /**
      * Convert the number to its human-readable equivalent.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @return string|false
      */
-    public static function abbreviate(int|float $number, int $precision = 0, ?int $maxPrecision = null)
+    public static function abbreviate(int|float|string $number, int $precision = 0, ?int $maxPrecision = null)
     {
         return static::forHumans($number, $precision, $maxPrecision, abbreviate: true);
     }
@@ -232,14 +260,18 @@ class Number
     /**
      * Convert the number to its human-readable equivalent.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  int  $precision
      * @param  int|null  $maxPrecision
      * @param  bool  $abbreviate
      * @return string|false
      */
-    public static function forHumans(int|float $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
+    public static function forHumans(int|float|string $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
     {
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+        }
+
         return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [
             3 => 'K',
             6 => 'M',
@@ -295,27 +327,35 @@ class Number
     /**
      * Clamp the given number between the given minimum and maximum.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @param  int|float  $min
      * @param  int|float  $max
      * @return int|float
      */
-    public static function clamp(int|float $number, int|float $min, int|float $max)
+    public static function clamp(int|float|string $number, int|float $min, int|float $max)
     {
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+        }
+
         return min(max($number, $min), $max);
     }
 
     /**
      * Split the given number into pairs of min/max values.
      *
-     * @param  int|float  $to
+     * @param  int|float|string  $to
      * @param  int|float  $by
      * @param  int|float  $start
      * @param  int|float  $offset
      * @return list<array{int|float, int|float}>
      */
-    public static function pairs(int|float $to, int|float $by, int|float $start = 0, int|float $offset = 1)
+    public static function pairs(int|float|string $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
+        if (is_string($to)) {
+            $to = self::parse($to, NumberFormatter::TYPE_DOUBLE);
+        }
+
         $output = [];
 
         for ($lower = $start; $lower < $to; $lower += $by) {
@@ -334,11 +374,15 @@ class Number
     /**
      * Remove any trailing zero digits after the decimal point of the given number.
      *
-     * @param  int|float  $number
+     * @param  int|float|string  $number
      * @return int|float
      */
-    public static function trim(int|float $number)
+    public static function trim(int|float|string $number)
     {
+        if (is_string($number)) {
+            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+        }
+
         return json_decode(json_encode($number));
     }
 

--- a/src/Illuminate/Support/Number.php
+++ b/src/Illuminate/Support/Number.php
@@ -38,7 +38,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::DECIMAL);
@@ -78,7 +78,7 @@ class Number
      */
     public static function parseInt(string $string, ?string $locale = null): int|false
     {
-        return self::parse($string, NumberFormatter::TYPE_INT32, $locale);
+        return static::parse($string, NumberFormatter::TYPE_INT32, $locale);
     }
 
     /**
@@ -90,7 +90,7 @@ class Number
      */
     public static function parseFloat(string $string, ?string $locale = null): float|false
     {
-        return self::parse($string, NumberFormatter::TYPE_DOUBLE, $locale);
+        return static::parse($string, NumberFormatter::TYPE_DOUBLE, $locale);
     }
 
     /**
@@ -107,7 +107,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         if (! is_null($after) && $number <= $after) {
@@ -135,7 +135,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::ORDINAL);
@@ -155,7 +155,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::SPELLOUT);
@@ -179,7 +179,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::PERCENT);
@@ -207,7 +207,7 @@ class Number
         static::ensureIntlExtensionIsInstalled();
 
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
         }
 
         $formatter = new NumberFormatter($locale ?? static::$locale, NumberFormatter::CURRENCY);
@@ -230,7 +230,7 @@ class Number
     public static function fileSize(int|float|string $bytes, int $precision = 0, ?int $maxPrecision = null)
     {
         if (is_string($bytes)) {
-            $bytes = self::parse($bytes, NumberFormatter::TYPE_DOUBLE);
+            $bytes = static::parse($bytes, NumberFormatter::TYPE_DOUBLE);
         }
 
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -269,7 +269,7 @@ class Number
     public static function forHumans(int|float|string $number, int $precision = 0, ?int $maxPrecision = null, bool $abbreviate = false)
     {
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE);
         }
 
         return static::summarize($number, $precision, $maxPrecision, $abbreviate ? [
@@ -335,7 +335,7 @@ class Number
     public static function clamp(int|float|string $number, int|float $min, int|float $max)
     {
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE);
         }
 
         return min(max($number, $min), $max);
@@ -353,7 +353,7 @@ class Number
     public static function pairs(int|float|string $to, int|float $by, int|float $start = 0, int|float $offset = 1)
     {
         if (is_string($to)) {
-            $to = self::parse($to, NumberFormatter::TYPE_DOUBLE);
+            $to = static::parse($to, NumberFormatter::TYPE_DOUBLE);
         }
 
         $output = [];
@@ -380,7 +380,7 @@ class Number
     public static function trim(int|float|string $number)
     {
         if (is_string($number)) {
-            $number = self::parse($number, NumberFormatter::TYPE_DOUBLE);
+            $number = static::parse($number, NumberFormatter::TYPE_DOUBLE);
         }
 
         return json_decode(json_encode($number));

--- a/tests/Support/SupportNumberTest.php
+++ b/tests/Support/SupportNumberTest.php
@@ -79,6 +79,13 @@ class SupportNumberTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
+    public function testSpelloutWithString()
+    {
+        $this->assertSame('ten', Number::spell('10'));
+        $this->assertSame('one thousand two hundred thirty-four', Number::spell('1,234'));
+    }
+
+    #[RequiresPhpExtension('intl')]
     public function testSpelloutWithLocale()
     {
         $this->assertSame('trois', Number::spell(3, 'fr'));
@@ -107,11 +114,27 @@ class SupportNumberTest extends TestCase
     }
 
     #[RequiresPhpExtension('intl')]
+    public function testOrdinalWithString()
+    {
+        $this->assertSame('1st', Number::ordinal('1'));
+        $this->assertSame('2nd', Number::ordinal('2'));
+        $this->assertSame('1,234th', Number::ordinal('1,234'));
+    }
+
+    #[RequiresPhpExtension('intl')]
     public function testSpellOrdinal()
     {
         $this->assertSame('first', Number::spellOrdinal(1));
         $this->assertSame('second', Number::spellOrdinal(2));
         $this->assertSame('third', Number::spellOrdinal(3));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testSpellOrdinalWithString()
+    {
+        $this->assertSame('first', Number::spellOrdinal('1'));
+        $this->assertSame('second', Number::spellOrdinal('2'));
+        $this->assertSame('one thousand two hundred thirty-fourth', Number::spellOrdinal('1,234'));
     }
 
     #[RequiresPhpExtension('intl')]
@@ -135,6 +158,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('0.00%', Number::percentage(0, precision: 2));
         $this->assertSame('0.12%', Number::percentage(0.12345, precision: 2));
         $this->assertSame('0.1235%', Number::percentage(0.12345, precision: 4));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testToPercentWithString()
+    {
+        $this->assertSame('10%', Number::percentage('10'));
+        $this->assertSame('1,000%', Number::percentage('1,000'));
+        $this->assertSame('1,234.56%', Number::percentage('1,234.56', precision: 2));
     }
 
     #[RequiresPhpExtension('intl')]
@@ -168,7 +199,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('123.456.789,12 €', Number::currency(123456789.12345, 'EUR', 'de'));
         $this->assertSame('1 234,56 $US', Number::currency(1234.56, 'USD', 'fr'));
     }
-
+    #[RequiresPhpExtension('intl')]
+    public function testToCurrencyWithString()
+    {
+        $this->assertSame('$1.00', Number::currency('1'));
+        $this->assertSame('$1,234.00', Number::currency('1,234'));
+        $this->assertSame('$1,234.56', Number::currency('1,234.56'));
+        $this->assertSame('€1,234.56', Number::currency('1,234.56', 'EUR'));
+    }
     public function testBytesToHuman()
     {
         $this->assertSame('0 B', Number::fileSize(0));
@@ -188,6 +226,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('1,024 YB', Number::fileSize(1024 ** 9));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testBytesToHumanWithString()
+    {
+        $this->assertSame('1 KB', Number::fileSize('1,024'));
+        $this->assertSame('2 KB', Number::fileSize('2,048'));
+        $this->assertSame('1.23 KB', Number::fileSize('1,264', precision: 2));
+    }
+
     public function testClamp()
     {
         $this->assertSame(2, Number::clamp(1, 2, 3));
@@ -195,6 +241,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(5, Number::clamp(5, 1, 10));
         $this->assertSame(4.5, Number::clamp(4.5, 1, 10));
         $this->assertSame(1, Number::clamp(-10, 1, 5));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testClampWithString()
+    {
+        $this->assertSame(5.0, Number::clamp('5', 1, 10));
+        $this->assertSame(2, Number::clamp('1', 2, 3));
+        $this->assertSame(1000.0, Number::clamp('1,000', 1, 2000));
     }
 
     public function testToHuman()
@@ -253,6 +307,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1 thousand quadrillion', Number::forHumans(-1000000000000000000));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testToHumanWithString()
+    {
+        $this->assertSame('1 thousand', Number::forHumans('1,000'));
+        $this->assertSame('1.23 thousand', Number::forHumans('1,234', precision: 2));
+        $this->assertSame('1 million', Number::forHumans('1,000,000'));
+    }
+
     public function testSummarize()
     {
         $this->assertSame('1', Number::abbreviate(1));
@@ -309,6 +371,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame('-1KQ', Number::abbreviate(-1000000000000000000));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testSummarizeWithString()
+    {
+        $this->assertSame('1K', Number::abbreviate('1,000'));
+        $this->assertSame('1.23K', Number::abbreviate('1,234', precision: 2));
+        $this->assertSame('1M', Number::abbreviate('1,000,000'));
+    }
+
     public function testPairs()
     {
         $this->assertSame([[0, 10], [10, 20], [20, 25]], Number::pairs(25, 10, 0, 0));
@@ -325,6 +395,13 @@ class SupportNumberTest extends TestCase
         $this->assertSame([[0.5, 2.5], [3.0, 5.0], [5.5, 7.5], [8.0, 10.0]], Number::pairs(10, 2.5, 0.5, 0.5));
     }
 
+    #[RequiresPhpExtension('intl')]
+    public function testPairsWithString()
+    {
+        $this->assertSame([[0, 9], [10, 19], [20, 25.0]], Number::pairs('25', 10, 0, 1));
+        $this->assertSame([[0, 999], [1000, 1999], [2000, 2500.0]], Number::pairs('2,500', 1000, 0, 1));
+    }
+
     public function testTrim()
     {
         $this->assertSame(12, Number::trim(12));
@@ -334,6 +411,14 @@ class SupportNumberTest extends TestCase
         $this->assertSame(12.3, Number::trim(12.30));
         $this->assertSame(12.3456789, Number::trim(12.3456789));
         $this->assertSame(12.3456789, Number::trim(12.34567890000));
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testTrimWithString()
+    {
+        $this->assertSame(12, Number::trim('12'));
+        $this->assertSame(1234, Number::trim('1,234'));
+        $this->assertSame(1234.56, Number::trim('1,234.56'));
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
This PR introduces support for passing a string as an argument to the following methods of the `Number` class:

* `format`
* `spell`
* `ordinal`
* `spellOrdinal`
* `percentage`
* `currency`
* `fileSize`
* `abbreviate`
* `forHumans`
* `clamp`
* `pairs`
* `trim`

Corresponding tests have been added.

The reason for allowing a string as an argument is:

* better support for BCMath, which by default casts values to string,
* better support for the `"decimal"` cast type, which also returns a string.

I’m not sure whether in this part of the code:

```
if (is_string($number)) {
    $number = self::parse($number, NumberFormatter::TYPE_DOUBLE, $locale);
}
```

I should use the `NumberFormatter::TYPE_DEFAULT` constant instead, in order to properly detect int or float/double. Unfortunately, on PHP 8.5.3, using this constant results in the following error:

```
NumberFormatter::parse(): Argument #2 ($type) must be a NumberFormatter::TYPE_* constant
```

so it appears to be an issue with PHP itself.
