### PR TITLE
[13.x] Add Authorize controller middleware attribute

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
@@ -5,17 +5,17 @@ namespace Illuminate\Routing\Attributes\Controllers;
 use Attribute;
 use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
 use Illuminate\Support\Arr;
+use UnitEnum;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Authorize extends Middleware
 {
     /**
-     * @param  \UnitEnum|string  $ability
-     * @param  string|array<string>|null  $models
+     * @param  array<string>|string|null  $models
      */
     public function __construct(
-        $ability,
-        $models = null,
+        UnitEnum|string $ability,
+        array|string|null $models = null,
         ?array $only = null,
         ?array $except = null,
     ) {

--- a/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Routing\Attributes\Controllers;
+
+use Attribute;
+use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
+use Illuminate\Support\Arr;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Authorize extends Middleware
+{
+    /**
+     * @param  \UnitEnum|string  $ability
+     * @param  string|array<string>|null  $models
+     */
+    public function __construct(
+        $ability,
+        $models = null,
+        ?array $only = null,
+        ?array $except = null,
+    ) {
+        $middleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($models));
+
+        parent::__construct($middleware, $only, $except);
+    }
+}

--- a/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Attributes\Controllers\Authorize;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class AuthorizeMiddlewareAttributeTest extends TestCase
+{
+    public function test_attribute_is_respected(): void
+    {
+        $route = Route::get('/', [AuthorizeMiddlewareAttributeController::class, 'index']);
+        $this->assertEquals([
+            'Illuminate\Auth\Middleware\Authorize:all',
+            'Illuminate\Auth\Middleware\Authorize:only-index,a',
+            'Illuminate\Auth\Middleware\Authorize:also-index',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/', [AuthorizeMiddlewareAttributeController::class, 'show']);
+        $this->assertEquals([
+            'Illuminate\Auth\Middleware\Authorize:all',
+            'Illuminate\Auth\Middleware\Authorize:except-index,a,b',
+        ], $route->controllerMiddleware());
+    }
+}
+
+#[Authorize('all')]
+#[Authorize('only-index', 'a', only: ['index'])]
+#[Authorize('except-index', ['a', 'b'], except: ['index'])]
+class AuthorizeMiddlewareAttributeController
+{
+    #[Authorize('also-index')]
+    public function index(): void
+    {
+        // ...
+    }
+
+    public function show(): void
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
Now that Laravel supports adding middleware to controllers via attributes, I want to make my attempt adding some syntactic sugar for authorization.

Currently, I have a mix of `Gate::authorize` in the controller and `authorize` method in the form requests. By adding an `Authorize` attribute, it would provide one consistent way to handle authorization.

```php
<?php

namespace App\Http\Controllers;

use App\Http\Requests\StoreCommentRequest;
use App\Models\Comment;
use App\Models\Post;
use Illuminate\Routing\Attributes\Controllers\Authorize;

class CommentController
{
    #[Authorize('create', [Comment::class, 'post'])]
    public function store(StoreCommentRequest $request, Post $post) {
        // ...
    }

    #[Authorize('delete', 'comment')]
    public function destroy(Comment $comment) {
        // ...
    }
}
```

<details open>

<summary>vs no syntactic sugar</summary>

```php
<?php

namespace App\Http\Controllers;

use App\Http\Requests\StoreCommentRequest;
use App\Models\Comment;
use App\Models\Post;
use Illuminate\Routing\Attributes\Controllers\Middleware;

class CommentController
{
    #[Middleware('can:create,App\Models\Comment,post')]
    public function store(StoreCommentRequest $request, Post $post) {
        // ...
    }

    #[Middleware('can:delete,comment')]
    public function destroy(Comment $comment) {
        // ...
    }
}
```

</details>

<details open>

<summary>vs before attributes</summary>

```php
<?php

namespace App\Http\Controllers;

use App\Http\Requests\StoreCommentRequest;
use App\Models\Comment;
use App\Models\Post;
use Illuminate\Support\Facades\Gate;

class CommentController
{
    public function store(StoreCommentRequest $request, Post $post) {
        // ...
    }

    public function destroy(Comment $comment) {
        Gate::authorize('delete', $comment);
        // ...
    }
}
```

```php
namespace App\Http\Requests;

use App\Models\Comment;
use Illuminate\Foundation\Http\FormRequest;

class StoreCommentRequest extends FormRequest
{
    /**
     * Determine if the user is authorized to make this request.
     *
     * @return bool
     */
    public function authorize(): bool
    {
        return $this->user()->can('create', [Comment::class, $this->route('post')]);
    }

    // ...
}
```

</details>

This would also make it possible to add a test in userland to ensure your application has authorization with less than 50 lines of code!

<details>

<summary>Example test</summary>

```php
<?php

namespace Tests\Unit;

use Illuminate\Routing\Attributes\Controllers\Authorize;
use PHPUnit\Framework\TestCase;
use RecursiveDirectoryIterator;
use RecursiveIteratorIterator;
use ReflectionClass;

final class ValidateControllerAuthorizationTest extends TestCase
{
    public function testControllerMethodsHaveAuthorizationAttribute(): void
    {
        $appPath = __DIR__ . '/../../app/';
        $controllerFiles = [];
        $directory = new RecursiveDirectoryIterator($appPath . 'Http/Controllers');
        $iterator = new RecursiveIteratorIterator($directory);

        foreach ($iterator as $file) {
            if ($file->isFile() && $file->getExtension() === 'php') {
                $controllerFiles[] = $file->getPathname();
            }
        }

        $except = [];

        foreach ($controllerFiles as $file) {
            $className = str_replace(
                [$appPath, '.php', '/'],
                ['App\\', '', '\\'],
                $file,
            );

            if (class_exists($className) && !in_array($className, $except, true)) {
                $reflectionClass = new ReflectionClass($className);

                foreach ($reflectionClass->getMethods() as $method) {
                    $this->assertNotEmpty(
                        $method->getAttributes(Authorize::class),
                        "Method {$method->getName()} in {$className} does not have the Authorize attribute." . PHP_EOL . $file,
                    );
                }
            }
        }
    }
}
```

</details>
