### PR TITLE
Memory Limit passed as string when run from supervisor

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -816,7 +816,7 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return $memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= $memoryLimit;
+        return (int)$memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= (int)$memoryLimit;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -816,7 +816,7 @@ class Worker
      */
     public function memoryExceeded($memoryLimit)
     {
-        return (int)$memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= (int)$memoryLimit;
+        return ((int) $memoryLimit) > 0 && (memory_get_usage(true) / 1024 / 1024) >= ((int) $memoryLimit);
     }
 
     /**


### PR DESCRIPTION
Environment:

Ubuntu 24.04 LTS
PHP 8.4.18
Laravel 12.11.2

Issue:

When using supervisor to manage queue with the parameter --memory=1024 the memoryLimit value is being passed via the WorkerOptions as a string rather than the intended integer. 

This causes the comparison here to always return true

```php
    /**
     * Determine if the memory limit has been exceeded.
     *
     * @param  int  $memoryLimit
     * @return bool
     */
    public function memoryExceeded($memoryLimit)
    {
        return $memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= $memoryLimit;
    }
```

supervisor worker config looks like this:

```php
[program:laravel-worker] 
process_name=%(program_name)s_%(process_num)02d 
command=/usr/bin/php8.4 /current/artisan queue:work redis --sleep=3 --tries=3 --memory=1024 --max-time=3600 
autostart=true 
autorestart=true 
user=www-data 
numprocs=2 
stopwaitsecs=3600
```

The Fix:

Cast $memoryLimit to (int) to ensure comparisons evaluate as intended.

```
    /**
     * Determine if the memory limit has been exceeded.
     *
     * @param  int  $memoryLimit
     * @return bool
     */
    public function memoryExceeded($memoryLimit)
    {
        return (int)$memoryLimit > 0 && (memory_get_usage(true) / 1024 / 1024) >= (int)$memoryLimit;
    }
```