### PR TITLE
Fix TypeError when retry when callback type-hints Exception and respo…

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1051,7 +1051,8 @@ class PendingRequest
                     }
 
                     try {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this, $this->request->toPsrRequest()->getMethod()) : true;
+                        $exception = $response->toException() ?? new \Illuminate\Http\Client\RequestException($response);
+                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $exception, $this, $this->request->toPsrRequest()->getMethod()) : true;
                     } catch (Exception $exception) {
                         $shouldRetry = false;
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -73,6 +73,23 @@ class HttpClientTest extends TestCase
         Response::flushState();
     }
 
+    public function testRetryWhenCallbackReceivesExceptionForRedirectResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 302),
+        ]);
+
+        $callbackCalled = false;
+
+        $this->factory->retry(2, 0, function (Exception $e) use (&$callbackCalled) {
+            $callbackCalled = true;
+
+            return false;
+        })->get('http://laravel.com');
+
+        $this->assertTrue($callbackCalled);
+    }
+
     public function testStubbedResponsesAreReturnedAfterFaking()
     {
         $this->factory->fake();


### PR DESCRIPTION
Fixes #59012

When `Http::retry()` receives a 3xx response, `$response->toException()` 
returns `null`. Passing `null` to a `when` callback that type-hints 
`Throwable` or `Exception` throws a `TypeError`.

This PR ensures the `when` callback always receives a `Throwable` instance.