### PR TITLE
[13.x] Remove supports for `laravel/serializable-closure` v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^7.8.2",
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.3.0",
-        "laravel/serializable-closure": "^1.3 || ^2.0",
+        "laravel/serializable-closure": "^2.0.10",
         "league/commonmark": "^2.7",
         "league/flysystem": "^3.25.1",
         "league/flysystem-local": "^3.25.1",

--- a/src/Illuminate/Concurrency/composer.json
+++ b/src/Illuminate/Concurrency/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^13.0",
         "illuminate/process": "^13.0",
         "illuminate/support": "^13.0",
-        "laravel/serializable-closure": "^1.3 || ^2.0"
+        "laravel/serializable-closure": "^2.0.10"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -28,7 +28,7 @@
         "illuminate/contracts": "^13.0",
         "illuminate/macroable": "^13.0",
         "illuminate/support": "^13.0",
-        "laravel/serializable-closure": "^1.3 || ^2.0",
+        "laravel/serializable-closure": "^2.0.10",
         "symfony/polyfill-php85": "^1.33"
     },
     "suggest": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -23,7 +23,7 @@
         "illuminate/filesystem": "^13.0",
         "illuminate/pipeline": "^13.0",
         "illuminate/support": "^13.0",
-        "laravel/serializable-closure": "^1.3 || ^2.0",
+        "laravel/serializable-closure": "^2.0.10",
         "ramsey/uuid": "^4.7",
         "symfony/process": "^7.4.5 || ^8.0.5"
     },

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -36,7 +36,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the Composer class (^13.0).",
-        "laravel/serializable-closure": "Required to use the once function (^1.3 || ^2.0).",
+        "laravel/serializable-closure": "Required to use the once function (^2.0.10).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
         "league/uri": "Required to use the Uri class (^7.5.1).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.7).",


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
