### PR TITLE
feat(database): add --preserve-data option for migrate:fresh

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -6,10 +6,14 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Events\DatabaseRefreshed;
 use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Support\Arr;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 #[AsCommand(name: 'migrate:fresh')]
 class FreshCommand extends Command
@@ -62,9 +66,16 @@ class FreshCommand extends Command
         }
 
         $database = $this->input->getOption('database');
+        $snapshotPath = null;
 
-        $this->migrator->usingConnection($database, function () use ($database) {
+        $this->migrator->usingConnection($database, function () use ($database, &$snapshotPath) {
             if ($this->migrator->repositoryExists()) {
+                if ($this->shouldPreserveData()) {
+                    $this->newLine();
+
+                    $snapshotPath = $this->createDataSnapshot($database);
+                }
+
                 $this->newLine();
 
                 $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
@@ -78,7 +89,7 @@ class FreshCommand extends Command
 
         $this->newLine();
 
-        $this->call('migrate', array_filter([
+        $migrateStatus = $this->call('migrate', array_filter([
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
@@ -86,6 +97,26 @@ class FreshCommand extends Command
             '--force' => true,
             '--step' => $this->option('step'),
         ]));
+
+        if ($migrateStatus !== Command::SUCCESS) {
+            if ($snapshotPath) {
+                $this->components->warn("The data snapshot is available at [{$snapshotPath}].");
+            }
+
+            return $migrateStatus;
+        }
+
+        if ($snapshotPath) {
+            try {
+                $this->newLine();
+
+                $this->restoreDataSnapshot($database, $snapshotPath);
+            } catch (Throwable $e) {
+                $this->components->error("Unable to restore the data snapshot. The snapshot is still available at [{$snapshotPath}].");
+
+                throw $e;
+            }
+        }
 
         if ($this->laravel->bound(Dispatcher::class)) {
             $this->laravel[Dispatcher::class]->dispatch(
@@ -97,7 +128,310 @@ class FreshCommand extends Command
             $this->runSeeder($database);
         }
 
-        return 0;
+        if ($snapshotPath && is_file($snapshotPath)) {
+            @unlink($snapshotPath);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Determine if the developer has requested data preservation.
+     *
+     * @return bool
+     */
+    protected function shouldPreserveData()
+    {
+        return $this->option('preserve-data');
+    }
+
+    /**
+     * Create a temporary data snapshot file.
+     *
+     * @param  string|null  $database
+     * @return string|null
+     */
+    protected function createDataSnapshot($database)
+    {
+        $snapshotPath = null;
+
+        $this->components->task('Exporting table data', function () use ($database, &$snapshotPath) {
+            $snapshot = $this->gatherDataSnapshot($database);
+
+            if ($snapshot === []) {
+                return true;
+            }
+
+            $snapshotPath = tempnam(sys_get_temp_dir(), 'migrate-fresh-');
+
+            if ($snapshotPath === false) {
+                throw new RuntimeException('Unable to create a temporary data snapshot file.');
+            }
+
+            if (file_put_contents($snapshotPath, serialize($snapshot), LOCK_EX) === false) {
+                throw new RuntimeException('Unable to write the temporary data snapshot file.');
+            }
+
+            return true;
+        });
+
+        return $snapshotPath;
+    }
+
+    /**
+     * Gather table data that can be safely restored after a fresh migration.
+     *
+     * @param  string|null  $database
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    protected function gatherDataSnapshot($database)
+    {
+        $connection = $this->migrator->resolveConnection($database);
+
+        $migrationTables = $this->migrationTableNames($connection);
+
+        $tables = array_values(array_filter(
+            $connection->getSchemaBuilder()->getTableListing(null, false),
+            fn ($table) => ! in_array($table, $migrationTables, true)
+        ));
+
+        $snapshot = [];
+
+        foreach ($tables as $table) {
+            $columns = $this->getInsertableColumns($connection, $table);
+
+            if ($columns === []) {
+                continue;
+            }
+
+            $rows = array_map(
+                fn ($row) => (array) $row,
+                $connection->table($table)->useWritePdo()->get($columns)->all()
+            );
+
+            if ($rows !== []) {
+                $snapshot[$table] = $rows;
+            }
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Restore a previously captured data snapshot.
+     *
+     * @param  string|null  $database
+     * @param  string  $snapshotPath
+     * @return void
+     */
+    protected function restoreDataSnapshot($database, $snapshotPath)
+    {
+        $this->components->task('Restoring table data', function () use ($database, $snapshotPath) {
+            if (! is_file($snapshotPath)) {
+                throw new RuntimeException('Unable to read the temporary data snapshot file.');
+            }
+
+            $contents = file_get_contents($snapshotPath);
+
+            if ($contents === false) {
+                throw new RuntimeException('Unable to read the temporary data snapshot file.');
+            }
+
+            $snapshot = unserialize($contents, ['allowed_classes' => false]);
+
+            if (! is_array($snapshot) || $snapshot === []) {
+                return true;
+            }
+
+            $connection = $this->migrator->resolveConnection($database);
+            $schema = $connection->getSchemaBuilder();
+
+            $schema->withoutForeignKeyConstraints(function () use ($connection, $schema, $snapshot) {
+                foreach ($snapshot as $table => $rows) {
+                    if (! is_array($rows) || $rows === [] ||
+                        ! $schema->hasTable($table)) {
+                        continue;
+                    }
+
+                    $insertableColumns = $this->getInsertableColumns($connection, $table);
+
+                    if ($insertableColumns === []) {
+                        continue;
+                    }
+
+                    $preparedRows = array_values(array_filter(array_map(
+                        fn ($row) => Arr::only((array) $row, $insertableColumns),
+                        $rows
+                    ), fn ($row) => $row !== []));
+
+                    if ($preparedRows === []) {
+                        continue;
+                    }
+
+                    $autoIncrementColumns = $this->getAutoIncrementColumns($connection, $table);
+
+                    $this->insertSnapshotRows($connection, $table, $preparedRows, $autoIncrementColumns);
+
+                    if ($connection->getDriverName() === 'pgsql' && $autoIncrementColumns !== []) {
+                        $this->syncPostgresSequences($connection, $table, $autoIncrementColumns);
+                    }
+                }
+            });
+
+            return true;
+        });
+    }
+
+    /**
+     * Get table names that should not be restored.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return array<int, string>
+     */
+    protected function migrationTableNames(Connection $connection)
+    {
+        $table = $this->getMigrationTableName();
+
+        return array_values(array_unique([
+            $table,
+            $connection->getTablePrefix().$table,
+        ]));
+    }
+
+    /**
+     * Resolve the migration repository table name.
+     *
+     * @return string
+     */
+    protected function getMigrationTableName()
+    {
+        $migrations = $this->laravel['config']->get('database.migrations', 'migrations');
+
+        if (is_array($migrations)) {
+            return $migrations['table'] ?? 'migrations';
+        }
+
+        return $migrations;
+    }
+
+    /**
+     * Determine which table columns can be restored.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $table
+     * @return array<int, string>
+     */
+    protected function getInsertableColumns(Connection $connection, $table)
+    {
+        return array_values(array_map(
+            fn ($column) => $column['name'],
+            array_filter(
+                $connection->getSchemaBuilder()->getColumns($table),
+                fn ($column) => is_null($column['generation'])
+            )
+        ));
+    }
+
+    /**
+     * Determine auto-increment columns for the given table.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $table
+     * @return array<int, string>
+     */
+    protected function getAutoIncrementColumns(Connection $connection, $table)
+    {
+        return array_values(array_map(
+            fn ($column) => $column['name'],
+            array_filter(
+                $connection->getSchemaBuilder()->getColumns($table),
+                fn ($column) => $column['auto_increment']
+            )
+        ));
+    }
+
+    /**
+     * Insert a snapshot payload for the given table.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $table
+     * @param  array<int, array<string, mixed>>  $rows
+     * @param  array<int, string>  $autoIncrementColumns
+     * @return void
+     */
+    protected function insertSnapshotRows(Connection $connection, $table, array $rows, array $autoIncrementColumns)
+    {
+        $usesIdentityInsert = $connection->getDriverName() === 'sqlsrv'
+            && $this->rowsContainColumns($rows, $autoIncrementColumns);
+
+        if (! $usesIdentityInsert) {
+            foreach (array_chunk($rows, 1000) as $chunk) {
+                $connection->table($table)->useWritePdo()->insert($chunk);
+            }
+
+            return;
+        }
+
+        $wrappedTable = $connection->getQueryGrammar()->wrapTable($table);
+
+        $connection->statement("SET IDENTITY_INSERT {$wrappedTable} ON");
+
+        try {
+            foreach (array_chunk($rows, 1000) as $chunk) {
+                $connection->table($table)->useWritePdo()->insert($chunk);
+            }
+        } finally {
+            $connection->statement("SET IDENTITY_INSERT {$wrappedTable} OFF");
+        }
+    }
+
+    /**
+     * Determine if any of the rows include one of the given columns.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @param  array<int, string>  $columns
+     * @return bool
+     */
+    protected function rowsContainColumns(array $rows, array $columns)
+    {
+        if ($columns === []) {
+            return false;
+        }
+
+        foreach ($rows as $row) {
+            if (array_intersect($columns, array_keys($row)) !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Sync PostgreSQL sequences after explicit inserts.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $table
+     * @param  array<int, string>  $columns
+     * @return void
+     */
+    protected function syncPostgresSequences(Connection $connection, $table, array $columns)
+    {
+        foreach ($columns as $column) {
+            $sequence = $connection->scalar('select pg_get_serial_sequence(?, ?) as sequence', [$table, $column]);
+
+            if (! is_string($sequence) || $sequence === '') {
+                continue;
+            }
+
+            $max = $connection->table($table)->useWritePdo()->max($column);
+
+            $connection->statement('select setval(?::regclass, ?, ?)', [
+                $sequence,
+                $max ?? 1,
+                ! is_null($max),
+            ]);
+        }
     }
 
     /**
@@ -143,6 +477,7 @@ class FreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
             ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],
+            ['preserve-data', null, InputOption::VALUE_NONE, 'Export and restore table data across the fresh migration'],
         ];
     }
 }

--- a/tests/Integration/Database/MigrateFreshCommandTest.php
+++ b/tests/Integration/Database/MigrateFreshCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\TestCase;
+
+class MigrateFreshCommandTest extends TestCase
+{
+    public function testFreshWithPreserveDataOption()
+    {
+        $this->app->setBasePath(__DIR__);
+
+        $options = [
+            '--path' => 'stubs/',
+        ];
+
+        if ($this->app['config']->get('database.default') !== 'testing') {
+            $this->artisan('db:wipe', ['--drop-views' => true]);
+        }
+
+        $this->beforeApplicationDestroyed(function () use ($options) {
+            $this->artisan('migrate:rollback', $options);
+        });
+
+        $this->artisan('migrate', $options);
+
+        DB::table('members')->insert([
+            ['name' => 'foo', 'email' => 'foo@bar', 'password' => 'secret'],
+            ['name' => 'bar', 'email' => 'bar@foo', 'password' => 'secret'],
+        ]);
+
+        $this->assertSame(2, DB::table('members')->count());
+
+        $this->artisan('migrate:fresh', array_merge($options, [
+            '--preserve-data' => true,
+        ]));
+
+        $this->assertSame(2, DB::table('members')->count());
+        $this->assertSame(['bar@foo', 'foo@bar'], DB::table('members')->orderBy('email')->pluck('email')->all());
+    }
+}


### PR DESCRIPTION
`migrate:fresh` drops all tables and re-runs migrations, which removes existing application data.
This PR introduces a new `--preserve-data` option to keep data across a fresh migration cycle.

### What’s included

- Add `--preserve-data` to `migrate:fresh`.
- Export table data to a temporary snapshot before `db:wipe`.
- Run `migrate` as usual.
- Restore snapshot data into freshly migrated tables.
- Exclude migration repository table from snapshot/restore.
- Skip generated/computed columns during restore.
- Handle SQL Server identity inserts (`IDENTITY_INSERT`).
- Resync PostgreSQL sequences after explicit inserts.
- Keep snapshot file on restore failure for manual recovery; delete it on success.