### PR TITLE
Fix after-commit observers breaking -ing event cancellation

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -536,7 +536,7 @@ class Dispatcher implements DispatcherContract
         $listener = $this->container->make($class);
 
         return $this->handlerShouldBeDispatchedAfterDatabaseTransactions($listener)
-                && ! $this->methodShouldBeHandledImmediately($method)
+                && ! in_array($method, ['creating', 'updating', 'saving', 'deleting', 'restoring', 'forceDeleting'])
             ? $this->createCallbackForListenerRunningAfterCommits($listener, $method)
             : [$listener, $method];
     }
@@ -602,20 +602,6 @@ class Dispatcher implements DispatcherContract
         return (($listener->afterCommit ?? null) ||
                 $listener instanceof ShouldHandleEventsAfterCommit) &&
                 $this->resolveTransactionManager();
-    }
-
-    /**
-     * Determine if the given method should be handled immediately regardless of after commit configuration.
-     *
-     * @param  string  $method
-     * @return bool
-     */
-    protected function methodShouldBeHandledImmediately($method)
-    {
-        return in_array($method, [
-            'creating', 'updating', 'saving',
-            'deleting', 'restoring', 'forceDeleting',
-        ]);
     }
 
     /**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -536,6 +536,7 @@ class Dispatcher implements DispatcherContract
         $listener = $this->container->make($class);
 
         return $this->handlerShouldBeDispatchedAfterDatabaseTransactions($listener)
+                && ! $this->methodShouldBeHandledImmediately($method)
             ? $this->createCallbackForListenerRunningAfterCommits($listener, $method)
             : [$listener, $method];
     }
@@ -601,6 +602,20 @@ class Dispatcher implements DispatcherContract
         return (($listener->afterCommit ?? null) ||
                 $listener instanceof ShouldHandleEventsAfterCommit) &&
                 $this->resolveTransactionManager();
+    }
+
+    /**
+     * Determine if the given method should be handled immediately regardless of after commit configuration.
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    protected function methodShouldBeHandledImmediately($method)
+    {
+        return in_array($method, [
+            'creating', 'updating', 'saving',
+            'deleting', 'restoring', 'forceDeleting',
+        ]);
     }
 
     /**

--- a/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
+++ b/tests/Integration/Database/EloquentTransactionWithAfterCommitTests.php
@@ -102,6 +102,47 @@ trait EloquentTransactionWithAfterCommitTests
         $this->assertEquals(1, $observer::$calledTimes, 'Failed to assert the observer was called once.');
     }
 
+    public function testAfterCommitObserverCreatingEventFiresImmediately()
+    {
+        User::observe($observer = EloquentTransactionWithAfterCommitTestsCreatingObserver::resetting());
+
+        DB::transaction(function () use ($observer) {
+            User::create(UserFactory::new()->raw());
+
+            $this->assertTrue($observer::$creatingCalled, 'creating should fire immediately inside the transaction');
+            $this->assertFalse($observer::$createdCalled, 'created should not fire until after commit');
+        });
+
+        $this->assertTrue($observer::$createdCalled, 'created should fire after commit');
+    }
+
+    public function testAfterCommitObserverUpdatingEventFiresImmediately()
+    {
+        User::observe($observer = EloquentTransactionWithAfterCommitTestsUpdatingObserver::resetting());
+
+        $user = User::create(UserFactory::new()->raw());
+
+        DB::transaction(function () use ($user, $observer) {
+            $user->update(['name' => 'Updated Name']);
+
+            $this->assertTrue($observer::$updatingCalled, 'updating should fire immediately inside the transaction');
+            $this->assertFalse($observer::$updatedCalled, 'updated should not fire until after commit');
+        });
+
+        $this->assertTrue($observer::$updatedCalled, 'updated should fire after commit');
+    }
+
+    public function testAfterCommitObserverCreatingCanCancelOperation()
+    {
+        User::observe($observer = EloquentTransactionWithAfterCommitTestsCancellingObserver::resetting());
+
+        $user = DB::transaction(fn () => User::create(UserFactory::new()->raw()));
+
+        $this->assertFalse($user->exists, 'Model should not be persisted when creating returns false');
+        $this->assertTrue($observer::$creatingCalled, 'creating should have been called');
+        $this->assertFalse($observer::$createdCalled, 'created should not fire when creating was cancelled');
+    }
+
     public function testTransactionCallbackExceptions()
     {
         [$firstObject, $secondObject] = [
@@ -200,5 +241,88 @@ class EloquentTransactionWithAfterCommitTestsTestObjectForTransactions
     {
         $this->ran = true;
         $this->runs++;
+    }
+}
+
+class EloquentTransactionWithAfterCommitTestsCreatingObserver
+{
+    public static $creatingCalled = false;
+
+    public static $createdCalled = false;
+
+    public $afterCommit = true;
+
+    public static function resetting()
+    {
+        static::$creatingCalled = false;
+        static::$createdCalled = false;
+
+        return new static();
+    }
+
+    public function creating($user)
+    {
+        static::$creatingCalled = true;
+    }
+
+    public function created($user)
+    {
+        static::$createdCalled = true;
+    }
+}
+
+class EloquentTransactionWithAfterCommitTestsUpdatingObserver
+{
+    public static $updatingCalled = false;
+
+    public static $updatedCalled = false;
+
+    public $afterCommit = true;
+
+    public static function resetting()
+    {
+        static::$updatingCalled = false;
+        static::$updatedCalled = false;
+
+        return new static();
+    }
+
+    public function updating($user)
+    {
+        static::$updatingCalled = true;
+    }
+
+    public function updated($user)
+    {
+        static::$updatedCalled = true;
+    }
+}
+
+class EloquentTransactionWithAfterCommitTestsCancellingObserver
+{
+    public static $creatingCalled = false;
+
+    public static $createdCalled = false;
+
+    public $afterCommit = true;
+
+    public static function resetting()
+    {
+        static::$creatingCalled = false;
+        static::$createdCalled = false;
+
+        return new static();
+    }
+
+    public function creating($user)
+    {
+        static::$creatingCalled = true;
+
+        return false;
+    }
+
+    public function created($user)
+    {
+        static::$createdCalled = true;
     }
 }


### PR DESCRIPTION
Fixes #56400

When an observer has `$afterCommit = true` or implements `ShouldHandleEventsAfterCommit`, all
of its methods get wrapped to run after transaction commit. This includes `-ing` events like
`creating` and `updating`, which need to run synchronously because they rely on returning
`false` to cancel the operation.

With the wrapping, the return value is lost and cancellation stops working. The `-ing` events
just become delayed duplicates of the `-ed` events.

This adds a check in `Dispatcher::createClassCallable()` that skips the after-commit wrapping
for the six halting event methods (`creating`, `updating`, `saving`, `deleting`, `restoring`,
`forceDeleting`). The `-ed` events still fire after commit as before.
