### PR TITLE
[12.x] Fix facade cache file permissions

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -110,6 +110,9 @@ class AliasLoader
         // Atomic write to prevent race conditions...
         $tempPath = tempnam(dirname($path), 'facade-');
 
+        // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
+        chmod($tempPath, 0777 - umask());
+
         file_put_contents($tempPath, $stub);
 
         rename($tempPath, $path);


### PR DESCRIPTION
**Description:**
This PR fixes a bug introduced in commit `6127ecf` / PR #58947 (`[12.x] Fix race condition on creating the real-time facade cache file`), which updated `Illuminate\Foundation\AliasLoader.php` to use atomic writes for the facade cache stub.

**The Issue:**
To achieve the atomic write, the previous commit used PHP's `tempnam()` function. By default, `tempnam()` generates temporary files with restrictive `0600` permissions. Because the file is then renamed to its final path without modifying these permissions, the newly created real-time facade cache files end up with `0600` permissions. This can cause "Permission Denied" errors in environments where the web server and CLI processes run under different users.

**The Fix:**
This PR adds a `chmod` step right after the temporary file is created:
`chmod($tempPath, 0777 - umask());`

This approach mirrors the same logic already used in the framework's `Illuminate\Filesystem\Filesystem::replace()` method to handle permissions during atomic writes. It ensures the newly generated cache file respects the system's umask settings.

**Benefit to End Users:**
Prevents permission-related crashes when accessing real-time facades, ensuring applications behave reliably regardless of whether the cache file was generated via a CLI command or a web request.

**Backwards Compatibility:**
This does not break any existing features. It simply restores the expected file permission behavior that existed prior to the race condition fix, while keeping the atomic write safety intact.