### PR TITLE
[12.x] Simplify method_exists ternary to short-circuit && in Worker

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -633,7 +633,7 @@ class Worker
      */
     protected function markJobAsFailedIfItShouldFailOnTimeout($connectionName, $job, Throwable $e)
     {
-        if (method_exists($job, 'shouldFailOnTimeout') ? $job->shouldFailOnTimeout() : false) {
+        if (method_exists($job, 'shouldFailOnTimeout') && $job->shouldFailOnTimeout()) {
             $this->failJob($job, $e);
         }
     }


### PR DESCRIPTION
In `markJobAsFailedIfItShouldFailOnTimeout`, the condition reads:

```php
method_exists($job, 'shouldFailOnTimeout') ? $job->shouldFailOnTimeout() : false
```

This is a classic case where a ternary with a `false` fallback can be replaced by a simple short-circuit `&&`:

```php
method_exists($job, 'shouldFailOnTimeout') && $job->shouldFailOnTimeout()
```

Same behaviour, one less mental step to parse. No breaking changes.