### PR TITLE
[12.x] Replace func_num_args() with is_null() in PendingRequest::get() and head()

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -846,7 +846,7 @@ class PendingRequest
      */
     public function get(string $url, $query = null)
     {
-        return $this->send('GET', $url, func_num_args() === 1 ? [] : [
+        return $this->send('GET', $url, is_null($query) ? [] : [
             'query' => $query,
         ]);
     }
@@ -864,7 +864,7 @@ class PendingRequest
      */
     public function head(string $url, $query = null)
     {
-        return $this->send('HEAD', $url, func_num_args() === 1 ? [] : [
+        return $this->send('HEAD', $url, is_null($query) ? [] : [
             'query' => $query,
         ]);
     }


### PR DESCRIPTION
The `get()` and `head()` methods in `PendingRequest` use `func_num_args() === 1` to detect whether a `$query` argument was passed. Since `$query` already defaults to `null`, a simple `is_null($query)` check does exactly the same thing and is far easier to read — no need to think about argument counts at all.

This is the same pattern that was already cleaned up in `Arr::prepend()` (#59045). No behaviour change, no breaking changes.