### PR TITLE
[12.x] Rename $key to $offset in ArrayAccess methods to match PHP interface contract

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -612,46 +612,46 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Determine if the given item exists.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->items->has($key);
+        return $this->items->has($offset);
     }
 
     /**
      * Get the item at the given offset.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return TValue|null
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->items->get($key);
+        return $this->items->get($offset);
     }
 
     /**
      * Set the item at the given offset.
      *
-     * @param  TKey|null  $key
+     * @param  TKey|null  $offset
      * @param  TValue  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        $this->items->put($key, $value);
+        $this->items->put($offset, $value);
     }
 
     /**
      * Unset the item at the given key.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        $this->items->forget($key);
+        $this->items->forget($offset);
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -739,46 +739,46 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     /**
      * Determine if the given item exists.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->items->has($key);
+        return $this->items->has($offset);
     }
 
     /**
      * Get the item at the given offset.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return TValue|null
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->items->get($key);
+        return $this->items->get($offset);
     }
 
     /**
      * Set the item at the given offset.
      *
-     * @param  TKey|null  $key
+     * @param  TKey|null  $offset
      * @param  TValue  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        $this->items->put($key, $value);
+        $this->items->put($offset, $value);
     }
 
     /**
      * Unset the item at the given key.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        $this->items->forget($key);
+        $this->items->forget($offset);
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -168,50 +168,50 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->exists($key);
+        return $this->exists($offset);
     }
 
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->input($key);
+        return $this->input($offset);
     }
 
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        if (is_null($key)) {
+        if (is_null($offset)) {
             $this->input[] = $value;
         } else {
-            $this->input[$key] = $value;
+            $this->input[$offset] = $value;
         }
     }
 
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        unset($this->input[$key]);
+        unset($this->input[$offset]);
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -372,46 +372,46 @@ class View implements ArrayAccess, Htmlable, Stringable, ViewContract
     /**
      * Determine if a piece of data is bound.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return array_key_exists($key, $this->data);
+        return array_key_exists($offset, $this->data);
     }
 
     /**
      * Get a piece of bound data to the view.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->data[$key];
+        return $this->data[$offset];
     }
 
     /**
      * Set a piece of data on the view.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        $this->with($key, $value);
+        $this->with($offset, $value);
     }
 
     /**
      * Unset a piece of data from the view.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        unset($this->data[$key]);
+        unset($this->data[$offset]);
     }
 
     /**


### PR DESCRIPTION
## Description

While reviewing the codebase for consistency, I noticed that several classes implementing `ArrayAccess` use `$key` as the parameter name in their `offsetExists`, `offsetGet`, `offsetSet`, and `offsetUnset` methods. The PHP `ArrayAccess` interface defines these parameters as `$offset`, so using `$key` is inconsistent with the interface contract.

This PR renames `$key` to `$offset` in the following classes, continuing the cleanup started in #59015:

- `Illuminate\Pagination\AbstractPaginator`
- `Illuminate\Pagination\AbstractCursorPaginator`
- `Illuminate\View\View`
- `Illuminate\Support\ValidatedInput`

## Changes

This is a pure rename — no logic changes, no behaviour changes, nbreaking changes. It simply aligns the parameter names with the PHP `ArrayAccess` interface definition.