### PR TITLE
[13.x] Rename $key to $offset in ArrayAccess methods to match PHP interface contract

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -611,46 +611,46 @@ abstract class AbstractCursorPaginator implements Htmlable, Stringable
     /**
      * Determine if the given item exists.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->items->has($key);
+        return $this->items->has($offset);
     }
 
     /**
      * Get the item at the given offset.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return TValue|null
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->items->get($key);
+        return $this->items->get($offset);
     }
 
     /**
      * Set the item at the given offset.
      *
-     * @param  TKey|null  $key
+     * @param  TKey|null  $offset
      * @param  TValue  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        $this->items->put($key, $value);
+        $this->items->put($offset, $value);
     }
 
     /**
      * Unset the item at the given key.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        $this->items->forget($key);
+        $this->items->forget($offset);
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -739,46 +739,46 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, Htmlab
     /**
      * Determine if the given item exists.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->items->has($key);
+        return $this->items->has($offset);
     }
 
     /**
      * Get the item at the given offset.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return TValue|null
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->items->get($key);
+        return $this->items->get($offset);
     }
 
     /**
      * Set the item at the given offset.
      *
-     * @param  TKey|null  $key
+     * @param  TKey|null  $offset
      * @param  TValue  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        $this->items->put($key, $value);
+        $this->items->put($offset, $value);
     }
 
     /**
      * Unset the item at the given key.
      *
-     * @param  TKey  $key
+     * @param  TKey  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        $this->items->forget($key);
+        $this->items->forget($offset);
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -168,50 +168,50 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists($offset): bool
     {
-        return $this->exists($key);
+        return $this->exists($offset);
     }
 
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @return mixed
      */
-    public function offsetGet($key): mixed
+    public function offsetGet($offset): mixed
     {
-        return $this->input($key);
+        return $this->input($offset);
     }
 
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  mixed  $offset
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($key, $value): void
+    public function offsetSet($offset, $value): void
     {
-        if (is_null($key)) {
+        if (is_null($offset)) {
             $this->input[] = $value;
         } else {
-            $this->input[$key] = $value;
+            $this->input[$offset] = $value;
         }
     }
 
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  string  $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset($offset): void
     {
-        unset($this->input[$key]);
+        unset($this->input[$offset]);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR completes the cleanup of `ArrayAccess` method signatures by renaming `$key` to `$offset` in the last three classes that had not been updated.

**Files changed:**
- `Illuminate\Pagination\AbstractPaginator`
- `Illuminate\Pagination\AbstractCursorPaginator`
- `Illuminate\Support\ValidatedInput`

## Why

The PHP `ArrayAccess` interface defines its parameters as `$offset`. Using `$key` is inconsistent with the interface contract and can cause:
- **Named argument incompatibility** in PHP 8+: callers using named arguments against the interface signature will break if the implementation uses a different name.
- **Static analysis warnings** from PHPStan / Psalm (parameter name mismatch).
- **LSP violation**: subclasses should strictly follow the contract defined by the interface.

## Changes

Pure rename — no logic changes, no behaviour changes, no breaking changes.