### PR TITLE
[12.x] Fix $model->incrementEach() and decrementEach() to scope query to model's primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1155,6 +1155,64 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Increment each given column's value by the given amount.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    protected function incrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementOrDecrementEach($columns, $extra, 'incrementEach');
+    }
+
+    /**
+     * Decrement each given column's value by the given amount.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    protected function decrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementOrDecrementEach($columns, $extra, 'decrementEach');
+    }
+
+    /**
+     * Run the incrementEach or decrementEach method on the model.
+     *
+     * @param  array<string, float|int>  $columns
+     * @param  array<string, mixed>  $extra
+     * @param  string  $method
+     * @return int
+     */
+    protected function incrementOrDecrementEach(array $columns, array $extra, string $method)
+    {
+        if (! $this->exists) {
+            return $this->newQueryWithoutRelationships()->{$method}($columns, $extra);
+        }
+
+        if ($this->fireModelEvent('updating') === false) {
+            return false;
+        }
+
+        return tap($this->setKeysForSaveQuery($this->newQueryWithoutScopes())->{$method}($columns, $extra), function () use ($columns, $extra, $method) {
+            $this->forceFill(array_merge(
+                collect($columns)->mapWithKeys(function ($amount, $column) use ($method) {
+                    return [$column => $this->{$column} + ($method === 'incrementEach' ? $amount : $amount * -1)];
+                })->all(),
+                $extra
+            ));
+
+            $this->syncChanges();
+
+            $this->fireModelEvent('updated', false);
+
+            $this->syncOriginal();
+        });
+    }
+
+    /**
      * Save the model and all of its relationships.
      *
      * @return bool
@@ -2524,7 +2582,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly'])) {
+        if (in_array($method, ['increment', 'decrement', 'incrementQuietly', 'decrementQuietly', 'incrementEach', 'decrementEach'])) {
             return $this->$method(...$parameters);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2636,6 +2636,46 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('category'));
     }
 
+    public function testIncrementEachOnExistingModelScopesQueryToModelKey()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 2;
+        $model->bar = 5;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('incrementEach')->once()->with(['foo' => 1, 'bar' => 2], [])->andReturn(1);
+
+        $result = $model->publicIncrementEach(['foo' => 1, 'bar' => 2]);
+
+        $this->assertEquals(1, $result);
+        $this->assertEquals(3, $model->foo);
+        $this->assertEquals(7, $model->bar);
+    }
+
+    public function testDecrementEachOnExistingModelScopesQueryToModelKey()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutScopes]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 10;
+        $model->bar = 5;
+
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
+        $query->shouldReceive('decrementEach')->once()->with(['foo' => 3, 'bar' => 2], [])->andReturn(1);
+
+        $result = $model->publicDecrementEach(['foo' => 3, 'bar' => 2]);
+
+        $this->assertEquals(1, $result);
+        $this->assertEquals(7, $model->foo);
+        $this->assertEquals(3, $model->bar);
+    }
+
     public function testRelationshipTouchOwnersIsPropagated()
     {
         $relation = $this->getMockBuilder(BelongsTo::class)->onlyMethods(['touch'])->disableOriginalConstructor()->getMock();
@@ -3668,6 +3708,16 @@ class EloquentModelStub extends Model
     public function publicDecrementQuietly($column, $amount = 1, $extra = [])
     {
         return $this->decrementQuietly($column, $amount, $extra);
+    }
+
+    public function publicIncrementEach(array $columns, array $extra = [])
+    {
+        return $this->incrementEach($columns, $extra);
+    }
+
+    public function publicDecrementEach(array $columns, array $extra = [])
+    {
+        return $this->decrementEach($columns, $extra);
     }
 
     public function belongsToStub()


### PR DESCRIPTION
## Description

Fixes #57262

When calling `$model->incrementEach()` or `$model->decrementEach()` on an existing Eloquent model instance, the call was forwarded via `__call()` to the query builder **without** a `WHERE` clause scoped to the model's primary key. This caused **ALL rows in the table** to be updated instead of just the specific model instance — a serious data corruption bug.

```php
// Correctly scoped to $model — only updates this record
$model->increment('number');

// BUG: updates ALL records in the table 😢
$model->incrementEach([
    'number' => 1,
    'another_number' => 1,
]);
```

## Root Cause

`increment()` and `decrement()` are listed in `__call()` and dispatched to the model's own `increment()` and `decrement()` are listed in `__cto`increment()` and `decrent`increment()`decrementEach()` were **not** in that list, so they fell th`increment()` and `decrement()` are listed in `__call()` and dispatched to the model's own `incremeus`increment()` and `dncr`increment` and `decrementEach()` protected methods on `Model`, mirroring the existing `increment()`/`decrement()` pattern.
- Added a shared `incrementOrDecrementEach()` helper that uses `setKeysForSaveQuery()` to scope the update to the model's primary key, fires `updating`/`updated` model events, and syncs the model's in-memory attributes after the update.
- Regist- Registh - Regist- Registh - Regist- Registh - Regist- Registh - Reng forwarded to the query builder.

## Tests

Added two unit tests to `DatabaseEloquentModelTest`:
- \- \- \- \- \- \- hO- \- \- \- \- \- \- hO- yToModelKey`
-------------mentEachOnExistingModelScopesQueryToModelKey`

Both verify that `WHERE id = ?` is applied ande model's in-memory attributes are updated correctly.