### PR TITLE
[12.x] Test Improvements

### DIFF
--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -117,7 +117,7 @@ class WorkCommandTest extends QueueTestCase
         $this->artisan('queue:work', [
             '--daemon' => true,
             '--stop-when-empty' => true,
-            '--memory' => 0.1,
+            '--memory' => 1,
         ])->assertExitCode(12);
 
         // Memory limit isn't checked until after the first job is attempted.

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -176,7 +176,7 @@ class WorkCommandTest extends QueueTestCase
         Queue::push(new SecondJob);
 
         $this->artisan('queue:work', [
-            '--memory' => 0.1,
+            '--memory' => 1,
         ])->assertExitCode(0);
 
         // Memory limit isn't checked until after the first job is attempted.


### PR DESCRIPTION
Fixed test regression introduced via #59049

Using (int) on `"0.1"` would cast the value to `0` instead of `0.1`. 