### PR TITLE
Fix type() method return type in Illuminate\Filesystem\Filesystem

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -453,7 +453,7 @@ class Filesystem
      * Get the file type of a given file.
      *
      * @param  string  $path
-     * @return string
+     * @return string|false
      */
     public function type($path)
     {


### PR DESCRIPTION
The phpdoc might be outdated according to the [current](https://www.php.net/manual/en/function.filetype.php) description of the function, which reports `string|false`.

Quoting:

> **Return Values**[ ¶](https://www.php.net/manual/en/function.filetype.php#refsect1-function.filetype-returnvalues)
> 
> Returns the type of the file. Possible values are fifo, char, dir, block, link, file, socket and unknown.
> 
> Returns [false](https://www.php.net/manual/en/reserved.constants.php#constant.false) if an error occurs. filetype() will also produce an [E_NOTICE](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-notice) message if the stat call fails or if the file type is unknown.
>
> **Errors/Exceptions**[ ¶](https://www.php.net/manual/en/function.filetype.php#refsect1-function.filetype-errors)
> 
> Upon failure, an [E_WARNING](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-warning) is emitted.

When executing this simple test i find that depending on the error_reporting level it can either generate an `ErrorException: filetype(): Lstat failed for /dasdasadfasdbfbadfabd` or `false`

```
test('type can return false', function () {
    $default = error_reporting();
    error_reporting(~E_ALL);

    $type = \Illuminate\Support\Facades\File::type('/dasdasadfasdbfbadfabd');
    expect($type)->toBeFalse();

    $type = \Illuminate\Support\Facades\File::type(base_path() . '/artisan');
    expect($type)->toBeString();

    error_reporting($default);
});
```
