### PR TITLE
[13.x] Add support for named arguments in event dispatching and broadcasting

### DIFF
--- a/src/Illuminate/Foundation/Events/Dispatchable.php
+++ b/src/Illuminate/Foundation/Events/Dispatchable.php
@@ -7,11 +7,12 @@ trait Dispatchable
     /**
      * Dispatch the event with the given arguments.
      *
+     * @param  mixed  ...$arguments
      * @return mixed
      */
-    public static function dispatch()
+    public static function dispatch(...$arguments)
     {
-        return event(new static(...func_get_args()));
+        return event(new static(...$arguments));
     }
 
     /**
@@ -45,10 +46,11 @@ trait Dispatchable
     /**
      * Broadcast the event with the given arguments.
      *
+     * @param  mixed  ...$arguments
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public static function broadcast()
+    public static function broadcast(...$arguments)
     {
-        return broadcast(new static(...func_get_args()));
+        return broadcast(new static(...$arguments));
     }
 }

--- a/tests/Events/BroadcastedEventsTest.php
+++ b/tests/Events/BroadcastedEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Events;
 
+use Illuminate\Broadcasting\PendingBroadcast;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
@@ -143,6 +144,38 @@ class BroadcastedEventsTest extends TestCase
 
         $d->dispatch($event);
     }
+
+    public function testEventBroadcastsUsingNamedArguments()
+    {
+        $container = new Container;
+        $broadcast = m::mock(BroadcastFactory::class);
+        $container->instance(BroadcastFactory::class, $broadcast);
+
+        $originalContainer = Container::getInstance();
+        Container::setInstance($container);
+
+        try {
+            $pendingBroadcast = m::mock(PendingBroadcast::class);
+
+            $broadcast->shouldReceive('event')
+                ->once()
+                ->with(m::on(function ($event) {
+                    $this->assertInstanceOf(BroadcastableNamedArgumentsEvent::class, $event);
+                    $this->assertSame('first-value', $event->first);
+                    $this->assertSame('second-value', $event->second);
+
+                    return true;
+                }))
+                ->andReturn($pendingBroadcast);
+
+            $this->assertSame(
+                $pendingBroadcast,
+                BroadcastableNamedArgumentsEvent::broadcast(second: 'second-value', first: 'first-value')
+            );
+        } finally {
+            Container::setInstance($originalContainer);
+        }
+    }
 }
 
 class BroadcastEvent implements ShouldBroadcast
@@ -171,5 +204,16 @@ class BroadcastFalseCondition extends BroadcastEvent
     public function broadcastWhen()
     {
         return false;
+    }
+}
+
+class BroadcastableNamedArgumentsEvent
+{
+    use \Illuminate\Foundation\Events\Dispatchable;
+
+    public function __construct(
+        public string $first,
+        public string $second,
+    ) {
     }
 }


### PR DESCRIPTION
# Cherry pick from https://github.com/laravel/framework/pull/58913
Hi, I want to push this feature to the 13.x branch to enable earlier Laravel 13.x workflows.

-----

**Summary:**
The `Illuminate\Foundation\Events\Dispatchable` trait currently uses `func_get_args()` in `dispatch()` and `broadcast()`.
That pattern does not support named arguments in PHP.
At the same time, other `dispatchable` entry points in the framework already support named arguments (especially in jobs). This PR aligns event dispatching with that existing developer experience.

**Before:**
```php
new UserSubscribed($user, $plan, $metadata);

or

event(new UserSubscribed(
    user: $user,
    plan: $plan,
    metadata: [...]
));
```

**After:**
```php
UserSubscribed::dispatch(
    user: $user,
    plan: $plan,
    metadata: [...]
);
```

**Benefits**

- Consistent API ergonomics across events and jobs/other dispatchable methods.
- Better readability at call sites for events with multiple constructor parameters.
- Safer refactors and fewer bugs caused by parameter ordering mistakes.
- No breaking change for existing positional-argument usage.

**Core framework changes:**

* Updated the `dispatch` and `broadcast` static methods in the `Dispatchable` trait to accept variadic arguments, enabling support for named arguments when instantiating event classes. [[1]](diffhunk://#diff-777eef7c13ac16da29618b4f0aefeb7505b73d1708b9957f6734113a257af328R10-R15) [[2]](diffhunk://#diff-777eef7c13ac16da29618b4f0aefeb7505b73d1708b9957f6734113a257af328R49-R54)

**Testing improvements:**

* Added new tests in `EventsDispatcherTest.php` and `BroadcastedEventsTest.php` to verify that events can be dispatched and broadcasted using named arguments, ensuring correct instantiation and argument mapping. [[1]](diffhunk://#diff-ed70ba401df8cd02fe16a4269eec104709672d917929c6dd8bdd5b80f64fe838R720-R749) [[2]](diffhunk://#diff-1937745e793ffe7591cfa971f66e0c7c4a37ca7e8c4df269cb91d79f1fa86dfdR147-R178)
* Introduced `DispatchableNamedArgumentsEvent` and `BroadcastableNamedArgumentsEvent` test classes to validate named argument support in event dispatching and broadcasting. [[1]](diffhunk://#diff-ed70ba401df8cd02fe16a4269eec104709672d917929c6dd8bdd5b80f64fe838R901-R911) [[2]](diffhunk://#diff-1937745e793ffe7591cfa971f66e0c7c4a37ca7e8c4df269cb91d79f1fa86dfdR209-R219)
* Included necessary imports for `PendingBroadcast` in the test suite.