### PR TITLE
[12.x] Detect MySQL 2002 lost connections via errorInfo

### DIFF
--- a/src/Illuminate/Database/LostConnectionDetector.php
+++ b/src/Illuminate/Database/LostConnectionDetector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Contracts\Database\LostConnectionDetector as LostConnectionDetectorContract;
 use Illuminate\Support\Str;
+use PDOException;
 use Throwable;
 
 class LostConnectionDetector implements LostConnectionDetectorContract
@@ -16,6 +17,13 @@ class LostConnectionDetector implements LostConnectionDetectorContract
      */
     public function causedByLostConnection(Throwable $e): bool
     {
+        if ($e instanceof PDOException
+            && isset($e->errorInfo[0], $e->errorInfo[1])
+            && $e->errorInfo[0] === 'HY000'
+            && (int) $e->errorInfo[1] === 2002) {
+            return true;
+        }
+
         $message = $e->getMessage();
 
         return Str::contains($message, [

--- a/tests/Database/DatabaseLostConnectionDetectorTest.php
+++ b/tests/Database/DatabaseLostConnectionDetectorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\LostConnectionDetector;
+use Illuminate\Database\QueryException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DatabaseLostConnectionDetectorTest extends TestCase
+{
+    public function testReturnsTrueForMysql2002WithLocalizedMessage()
+    {
+        $detector = new LostConnectionDetector;
+
+        $exception = $this->createPdoExceptionWithErrorInfo(
+            'Connexion terminee par expiration du delai d\'attente',
+            ['HY000', 2002, 'Connexion terminee par expiration du delai d\'attente'],
+        );
+
+        $this->assertTrue($detector->causedByLostConnection($exception));
+    }
+
+    public function testReturnsTrueForQueryExceptionWrapping2002()
+    {
+        $detector = new LostConnectionDetector;
+
+        $previous = $this->createPdoExceptionWithErrorInfo(
+            'Localized mysql socket failure',
+            ['HY000', 2002, 'some text'],
+        );
+
+        $exception = new QueryException('mysql', 'SELECT * FROM users WHERE id = ?', [1], $previous);
+
+        $this->assertTrue($detector->causedByLostConnection($exception));
+    }
+
+    public function testReturnsTrueForExistingMessageFallback()
+    {
+        $detector = new LostConnectionDetector;
+
+        $this->assertTrue($detector->causedByLostConnection(
+            new RuntimeException('server has gone away')
+        ));
+    }
+
+    public function testReturnsFalseForUnrelatedPdoErrorCode()
+    {
+        $detector = new LostConnectionDetector;
+
+        $exception = $this->createPdoExceptionWithErrorInfo(
+            'Authentication failed in locale-specific text',
+            ['HY000', 1045, 'some unrelated error'],
+        );
+
+        $this->assertFalse($detector->causedByLostConnection($exception));
+    }
+
+    public function testReturnsFalseWhenSqlstateDiffers()
+    {
+        $detector = new LostConnectionDetector;
+
+        $exception = $this->createPdoExceptionWithErrorInfo(
+            'Localized transport failure with unmatched SQLSTATE',
+            ['08006', 2002, 'some text'],
+        );
+
+        $this->assertFalse($detector->causedByLostConnection($exception));
+    }
+
+    public function testReturnsTrueForMysql2002WhenDriverCodeIsString()
+    {
+        $detector = new LostConnectionDetector;
+
+        $exception = $this->createPdoExceptionWithErrorInfo(
+            'Unknown locale-specific message',
+            ['HY000', '2002', 'localized text'],
+        );
+
+        $this->assertTrue($detector->causedByLostConnection($exception));
+    }
+
+    private function createPdoExceptionWithErrorInfo(string $message, array $errorInfo): PDOException
+    {
+        $exception = new PDOException($message);
+        $exception->errorInfo = $errorInfo;
+
+        return $exception;
+    }
+}


### PR DESCRIPTION
Fixes #59024

## Summary

This PR fixes MySQL `2002` lost-connection detection when the error message is not in English.
It adds a small `errorInfo` check before the existing message fallback in `LostConnectionDetector`.

## Why

- `#59024` shows this in production with French message text.
- The message text changes by locale, so string matching can miss valid lost-connection errors.
- `PDOException::errorInfo` gives us a stable code-based signal for this path.

This uses `PDOException::errorInfo` (SQLSTATE `HY000` + driver code `2002` / `CR_CONNECTION_ERROR`), which is locale-independent for the reported MySQL connect-failure path, while keeping existing message fallback unchanged.

## Scope

- Adds one conditional in `src/Illuminate/Database/LostConnectionDetector.php`.
- Keeps existing message-based fallback list unchanged.
- Adds focused detector tests in `tests/Database/DatabaseLostConnectionDetectorTest.php`.
- Intentionally does **not** broaden SQLSTATE/message prefix matching (contrast with `#59031`).

## Tests

- `vendor/bin/phpunit tests/Database/DatabaseLostConnectionDetectorTest.php tests/Database/DatabaseQueryExceptionTest.php`
- `vendor/bin/pint --test src/Illuminate/Database/LostConnectionDetector.php tests/Database/DatabaseLostConnectionDetectorTest.php`

## References

- Issue: https://github.com/laravel/framework/issues/59024
- Prior PR (different approach): https://github.com/laravel/framework/pull/59031
- MySQL client error reference (`2002`): https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html
- Technical backing (`mysqlnd`): https://github.com/php/php-src/blob/master/ext/mysqlnd/mysqlnd_vio.c

