### PR TITLE
[12.x] Route Name Aliases

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -47,7 +47,7 @@ class RouteListCommand extends Command
      *
      * @var string[]
      */
-    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
+    protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Aliases', 'Middleware'];
 
     /**
      * The terminal width resolver callback.
@@ -144,6 +144,7 @@ class RouteListCommand extends Command
             'method' => implode('|', $route->methods()),
             'uri' => $route->uri(),
             'name' => $route->getName(),
+            'aliases' =>  $route->getName() ? app('router')->getRouteAliasesFor($route->getName()) : [],
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
             'vendor' => $this->isVendorRoute($route),
@@ -421,13 +422,18 @@ class RouteListCommand extends Command
      */
     protected function formatActionForCli($route)
     {
-        ['action' => $action, 'name' => $name] = $route;
+
+        ['action' => $action, 'name' => $name, 'aliases' => $aliases ]= $route;
+
+        $computed_aliases = $this->option('with-aliases') && sizeof($aliases)>0
+            ?(' ['.implode(', ', $aliases).']')
+            :'';
 
         if ($action === 'Closure' || $action === ViewController::class) {
-            return $name;
+            return $name.$computed_aliases;
         }
 
-        $name = $name ? "$name   " : null;
+        $name = $name ? "$name $computed_aliases  " : null;
 
         $rootControllerNamespace = $this->laravel[UrlGenerator::class]->getRootControllerNamespace()
             ?? ($this->laravel->getNamespace().'Http\\Controllers');
@@ -505,6 +511,7 @@ class RouteListCommand extends Command
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
+            ['with-aliases', 'a', InputOption::VALUE_NONE, 'Show routes with aliases'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware, definition) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
             ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -144,7 +144,7 @@ class RouteListCommand extends Command
             'method' => implode('|', $route->methods()),
             'uri' => $route->uri(),
             'name' => $route->getName(),
-            'aliases' =>  $route->getName() ? app('router')->getRouteAliasesFor($route->getName()) : [],
+            'aliases' => $route->getName() ? app('router')->getRouteAliasesFor($route->getName()) : [],
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
             'vendor' => $this->isVendorRoute($route),
@@ -422,12 +422,11 @@ class RouteListCommand extends Command
      */
     protected function formatActionForCli($route)
     {
+        ['action' => $action, 'name' => $name, 'aliases' => $aliases] = $route;
 
-        ['action' => $action, 'name' => $name, 'aliases' => $aliases ]= $route;
-
-        $computed_aliases = $this->option('with-aliases') && sizeof($aliases)>0
-            ?(' ['.implode(', ', $aliases).']')
-            :'';
+        $computed_aliases = $this->option('with-aliases') && sizeof($aliases) > 0
+            ? (' ['.implode(', ', $aliases).']')
+            : '';
 
         if ($action === 'Closure' || $action === ViewController::class) {
             return $name.$computed_aliases;

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -184,7 +184,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
                 'withTrashed' => $route->allowsTrashedBindings(),
-                'aliases' => app('router')->getRouteAliasesFor($route->getName())?? [],
+                'aliases' => app('router')->getRouteAliasesFor($route->getName()) ?? [],
             ];
         }
 

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -184,6 +184,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
                 'withTrashed' => $route->allowsTrashedBindings(),
+                'aliases' => app('router')->getRouteAliasesFor($route->getName())?? [],
             ];
         }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -299,7 +299,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setBindingFields($attributes['bindingFields'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null)
             ->withTrashed($attributes['withTrashed'] ?? false)
-            ->setAliases($attributes['aliases']??[]);
+            ->setAliases($attributes['aliases'] ?? []);
     }
 
     /**

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -291,6 +291,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
                 )
             ), '/');
         }
+
         return $this->router->newRoute($attributes['methods'], $baseUri === '' ? '/' : $baseUri, $attributes['action'])
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -291,14 +291,14 @@ class CompiledRouteCollection extends AbstractRouteCollection
                 )
             ), '/');
         }
-
         return $this->router->newRoute($attributes['methods'], $baseUri === '' ? '/' : $baseUri, $attributes['action'])
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null)
-            ->withTrashed($attributes['withTrashed'] ?? false);
+            ->withTrashed($attributes['withTrashed'] ?? false)
+            ->setAliases($attributes['aliases']??[]);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -158,7 +158,7 @@ class Route
     protected $bindingFields = [];
 
     /**
-     * TODO: AUR: desc.
+     * List of route aliases.
      *
      * @var array
      */
@@ -1410,7 +1410,7 @@ class Route
     }
 
     /**
-     * TODO: AUR: desc.
+     * Add an alise for the route.
      *
      * @return void
      */
@@ -1420,7 +1420,7 @@ class Route
     }
 
     /**
-     * TODO: AUR: desc.
+     * Set the aliases for the route.
      *
      * @param  array<string>  $aliases
      * @return $this
@@ -1433,7 +1433,7 @@ class Route
     }
 
     /**
-     * TODO: AUR: desc.
+     * Get the aliases for the route.
      */
     public function getAliases(): array
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -158,6 +158,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * TODO: AUR: desc.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -1400,6 +1407,37 @@ class Route
         $this->compileRoute();
 
         unset($this->router, $this->container);
+    }
+
+    /**
+     * TODO: AUR: desc.
+     *
+     * @return void
+     */
+    public function addAlias(string $alias)
+    {
+        $this->aliases[] = $alias;
+    }
+
+    /**
+     * TODO: AUR: desc.
+     *
+     * @param  array<string>  $aliases
+     * @return $this
+     */
+    public function setAliases(array $aliases)
+    {
+        $this->aliases = $aliases;
+
+        return $this;
+    }
+
+    /**
+     * TODO: AUR: desc.
+     */
+    public function getAliases(): array
+    {
+        return $this->aliases;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -122,7 +122,7 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $groupStack = [];
 
     /**
-     * TODO: AUR: COMMENTS.
+     * Store of all registered route aliases.
      *
      * @var array
      */
@@ -1516,10 +1516,10 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * TODO: AUR: desc.
+     * Register route aliases.
      *
-     * @param  string  $aliasName
      * @param  string  $originalName
+     * @param  string|array  $aliasNames
      * @return void
      */
     public function alias(string $originalName, string|array $aliasNames): void
@@ -1532,7 +1532,7 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * TODO: AUR: desc.
+     * Get all the registered route aliases.
      *
      * @return array
      */
@@ -1542,16 +1542,23 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * TODO: AUR: desc.
+     * Resolve alias returning the original name.
      *
      * @param  string  $name
-     * @return string
+     * @return string|null
      */
     public function resolveAlias(string $name): string|null
     {
         return $this->routeAliases[$name] ?? null;
     }
 
+
+    /**
+     * Get all aliases for a given route name.
+     *
+     * @param string $originalName
+     * @return array
+     */
     public function getRouteAliasesFor(string $originalName): array
     {
         return array_keys(

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1468,6 +1468,15 @@ class Router implements BindingRegistrar, RegistrarContract
             ->setContainer($this->container);
 
         $this->container->instance('routes', $this->routes);
+
+        foreach ($this->routes as $route) {
+            $aliases = $route->getAliases();
+            if ($name = $route->getName()) {
+                if ( sizeof($aliases) > 0) {
+                    $this->alias($name, $aliases);
+                }
+            }
+        }
     }
 
     /**
@@ -1541,6 +1550,13 @@ class Router implements BindingRegistrar, RegistrarContract
     public function resolveAlias(string $name): string|null
     {
         return $this->routeAliases[$name] ?? null;
+    }
+
+    public function getRouteAliasesFor(string $originalName): array
+    {
+        return array_keys(
+            array_filter($this->routeAliases, fn($original) => $original === $originalName)
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -122,6 +122,13 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $groupStack = [];
 
     /**
+     * TODO: AUR: COMMENTS.
+     *
+     * @var array
+     */
+    protected $routeAliases = [];
+
+    /**
      * The registered custom implicit binding callback.
      *
      * @var array
@@ -1497,6 +1504,43 @@ class Router implements BindingRegistrar, RegistrarContract
         $this->container = $container;
 
         return $this;
+    }
+
+    /**
+     * TODO: AUR: desc.
+     *
+     * @param  string  $aliasName
+     * @param  string  $originalName
+     * @return void
+     */
+    public function alias(string $originalName, string|array $aliasNames): void
+    {
+        $aliasNames = is_array($aliasNames) ? $aliasNames : [$aliasNames];
+
+        foreach ($aliasNames as $aliasName) {
+            $this->routeAliases[$aliasName] = $originalName;
+        }
+    }
+
+    /**
+     * TODO: AUR: desc.
+     *
+     * @return array
+     */
+    public function getRouteAliases(): array
+    {
+        return $this->routeAliases;
+    }
+
+    /**
+     * TODO: AUR: desc.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function resolveAlias(string $name): string|null
+    {
+        return $this->routeAliases[$name] ?? null;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1472,7 +1472,7 @@ class Router implements BindingRegistrar, RegistrarContract
         foreach ($this->routes as $route) {
             $aliases = $route->getAliases();
             if ($name = $route->getName()) {
-                if ( sizeof($aliases) > 0) {
+                if (sizeof($aliases) > 0) {
                     $this->alias($name, $aliases);
                 }
             }
@@ -1547,22 +1547,21 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  string  $name
      * @return string|null
      */
-    public function resolveAlias(string $name): string|null
+    public function resolveAlias(string $name): ?string
     {
         return $this->routeAliases[$name] ?? null;
     }
 
-
     /**
      * Get all aliases for a given route name.
      *
-     * @param string $originalName
+     * @param  string  $originalName
      * @return array
      */
     public function getRouteAliasesFor(string $originalName): array
     {
         return array_keys(
-            array_filter($this->routeAliases, fn($original) => $original === $originalName)
+            array_filter($this->routeAliases, fn ($original) => $original === $originalName)
         );
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -516,6 +516,10 @@ class UrlGenerator implements UrlGeneratorContract
             throw new InvalidArgumentException('Attribute [name] expects a string backed enum.');
         }
 
+        if ($resolved = app('router')->resolveAlias($name)) {
+            $name = $resolved;
+        }
+
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
@@ -526,6 +530,19 @@ class UrlGenerator implements UrlGeneratorContract
         }
 
         throw new RouteNotFoundException("Route [{$name}] not defined.");
+    }
+
+    /**
+     * TODO: AUR: desc.
+     */
+    public function getAliasesFor(string $originalName): array
+    {
+        return array_keys(
+            array_filter(
+                app('router')->getRouteAliases(),
+                fn ($original) => $original === $originalName
+            )
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -516,7 +516,7 @@ class UrlGenerator implements UrlGeneratorContract
             throw new InvalidArgumentException('Attribute [name] expects a string backed enum.');
         }
 
-        if (is_null($this->routes->getByName($name))){
+        if (is_null($this->routes->getByName($name))) {
             if ($resolved = app('router')->resolveAlias($name)) {
                 $name = $resolved;
             }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -533,19 +533,6 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * TODO: AUR: desc.
-     */
-    public function getAliasesFor(string $originalName): array
-    {
-        return array_keys(
-            array_filter(
-                app('router')->getRouteAliases(),
-                fn ($original) => $original === $originalName
-            )
-        );
-    }
-
-    /**
      * Get the URL for a given route instance.
      *
      * @param  \Illuminate\Routing\Route  $route

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -516,8 +516,10 @@ class UrlGenerator implements UrlGeneratorContract
             throw new InvalidArgumentException('Attribute [name] expects a string backed enum.');
         }
 
-        if ($resolved = app('router')->resolveAlias($name)) {
-            $name = $resolved;
+        if (is_null($this->routes->getByName($name))){
+            if ($resolved = app('router')->resolveAlias($name)) {
+                $name = $resolved;
+            }
         }
 
         if (! is_null($route = $this->routes->getByName($name))) {

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -81,6 +81,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  * @method static mixed macroCall(string $method, array $parameters)
+ * @method static void alias(string $originalName, string|array $aliasNames)
  * @method static \Illuminate\Support\HigherOrderTapProxy|\Illuminate\Routing\Router tap(callable|null $callback = null)
  * @method static \Illuminate\Routing\RouteRegistrar attribute(string $key, mixed $value)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlpha(array|string $parameters)

--- a/tests/Foundation/Console/RouteListCommandTest.php
+++ b/tests/Foundation/Console/RouteListCommandTest.php
@@ -77,7 +77,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["web","auth"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
@@ -87,7 +87,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'domain,uri', '--reverse' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $expectedOrder = '[{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["web","auth"]},{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
@@ -97,7 +97,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}, {"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["web","auth"]}, {"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
@@ -107,7 +107,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '--sort' => 'definition']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}, {"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]}, {"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["web","auth"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
@@ -181,7 +181,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-vv' => true]);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","middleware":["exampleMiddleware"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]},{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["Middleware 5","Middleware 1","Middleware 4","Middleware 2","Middleware 3"]},{"domain":"sub","method":"GET|HEAD","uri":"sub-example","name":null,"action":"Closure","aliases": [],"middleware":["exampleMiddleware"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }
@@ -191,7 +191,7 @@ class RouteListCommandTest extends TestCase
         $this->app->call('route:list', ['--json' => true, '-v' => true, '--middleware' => 'auth']);
         $output = $this->app->output();
 
-        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","middleware":["web","auth"]}]';
+        $expectedOrder = '[{"domain":null,"method":"GET|HEAD","uri":"example-group","name":null,"action":"Closure","aliases": [],"middleware":["web","auth"]}]';
 
         $this->assertJsonStringEqualsJsonString($expectedOrder, $output);
     }

--- a/tests/Routing/RoutingAliasTest.php
+++ b/tests/Routing/RoutingAliasTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Routing\CallableDispatcher;
+use Illuminate\Routing\Contracts\CallableDispatcher as CallableDispatcherContract;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\ControllerDispatcher;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\Router;
+use Illuminate\Routing\UrlGenerator;
+use PHPUnit\Framework\TestCase;
+
+class RoutingAliasTest extends TestCase
+{
+
+
+    public function testRegisterSingleAlias()
+    {
+        $router = $this->getRouter();
+
+        $router->get('users', function () {
+            return 'users';
+        })->name('users.index');
+
+        $router->alias('users.index', 'members.index');
+
+        $this->assertSame('users.index', $router->resolveAlias('members.index'));
+    }
+
+    public function testRegisterMultipleAliases()
+    {
+        $router = $this->getRouter();
+
+        $router->get('users', function () {
+            return 'users';
+        })->name('users.index');
+
+        $router->alias('users.index', ['members.index', 'people.index']);
+
+        $this->assertSame('users.index', $router->resolveAlias('members.index'));
+        $this->assertSame('users.index', $router->resolveAlias('people.index'));
+    }
+
+    public function testResolveAliasReturnsNullForUnknownAlias()
+    {
+        $router = $this->getRouter();
+
+        $this->assertNull($router->resolveAlias('nonexistent.alias'));
+    }
+
+    public function testCompiledRoutesRestoreAliases()
+    {
+        [$container, $router] = $this->getRouterWithApp();
+
+        $router->get('users', function () {
+            return 'users';
+        })->name('users.index');
+
+        $router->alias('users.index', ['members.index', 'people.index']);
+
+        $compiled = $router->getRoutes()->compile();
+        $newRouter = $this->getRouter($container);
+        $container->instance('router', $newRouter);
+        $container->instance(Registrar::class, $newRouter);
+        $newRouter->setCompiledRoutes($compiled);
+
+        $this->assertSame('users.index', $newRouter->resolveAlias('members.index'));
+        $this->assertSame('users.index', $newRouter->resolveAlias('people.index'));
+    }
+
+    public function testPreventOverrideAliases()
+    {
+
+        [$container, $router] = $this->getRouterWithApp();
+
+        $router->get('dashboard', function () {
+            return 'dashboard';
+        })->name('dashboard');
+
+        $router->get('app', function () {
+            return 'app';
+        })->name('app');
+
+        $router->alias('dashboard', ['app', 'home']);
+
+        $routes = $router->getRoutes();
+        $routes->refreshNameLookups();
+
+        $container->instance('url', new UrlGenerator($routes, Request::create('http://www.foo.com/')));
+
+        $this->assertSame('http://www.foo.com/app', route('app'));
+        $this->assertSame(route('dashboard'), route('home'));
+        $this->assertNotSame(route('dashboard'), route('app'));
+    }
+
+    protected function getRouter($container = null)
+    {
+        $container ??= new Container;
+
+        $router = new Router($container->make(Dispatcher::class), $container);
+
+        $container->instance(Registrar::class, $router);
+
+        $container->bind(ControllerDispatcherContract::class, fn($app) => new ControllerDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
+
+        return $router;
+    }
+
+    protected function getRouterWithApp(): array
+    {
+        $container = new Container;
+
+
+        Container::setInstance($container);
+
+        $router = $this->getRouter($container);
+        $container->instance('router', $router);
+
+        return [$container, $router];
+    }
+}

--- a/tests/Routing/RoutingAliasTest.php
+++ b/tests/Routing/RoutingAliasTest.php
@@ -10,16 +10,12 @@ use Illuminate\Routing\CallableDispatcher;
 use Illuminate\Routing\Contracts\CallableDispatcher as CallableDispatcherContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Routing\ControllerDispatcher;
-use Illuminate\Routing\Route;
-use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use PHPUnit\Framework\TestCase;
 
 class RoutingAliasTest extends TestCase
 {
-
-
     public function testRegisterSingleAlias()
     {
         $router = $this->getRouter();
@@ -76,7 +72,6 @@ class RoutingAliasTest extends TestCase
 
     public function testPreventOverrideAliases()
     {
-
         [$container, $router] = $this->getRouterWithApp();
 
         $router->get('dashboard', function () {
@@ -107,8 +102,8 @@ class RoutingAliasTest extends TestCase
 
         $container->instance(Registrar::class, $router);
 
-        $container->bind(ControllerDispatcherContract::class, fn($app) => new ControllerDispatcher($app));
-        $container->bind(CallableDispatcherContract::class, fn($app) => new CallableDispatcher($app));
+        $container->bind(ControllerDispatcherContract::class, fn ($app) => new ControllerDispatcher($app));
+        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
 
         return $router;
     }
@@ -116,7 +111,6 @@ class RoutingAliasTest extends TestCase
     protected function getRouterWithApp(): array
     {
         $container = new Container;
-
 
         Container::setInstance($container);
 


### PR DESCRIPTION
### Summary

This PR introduces a first-class concept of **route name aliases** — the ability to assign one or more alternative names to an already-named route, without duplicating the route registration itself.

```php
Route::get('/', HomeController::class)->name('home');

Route::alias('home', ['app', 'saas.team-selector']);
```

`route('app')` and `route('saas.team-selector')` will now resolve to the exact same URL as `route('home')`, with no duplicate entries in the route collection.

---

### Motivation

The need for this feature emerges naturally in **modular Laravel applications**, where multiple independent packages contribute routes and expect to navigate between each other using well-known route names.

A concrete example: consider an application composed of two packages:
- A **core package** that defines the application entry point as `GET /` with the name `home`.
- A **SaaS/team package** that needs to navigate to a route named `saas.team-selector`.
- The **host application** that registers its own entry point under the name `app`.

All three names refer to the same route. Today, the only workarounds are:
1. **Registering duplicate routes** — same URI and action, different names. This pollutes the route collection and `route:list` output.
2. **Using config values** to share route names across packages — which introduces coupling, requires publish steps, and arguably adds more overhead than a simple alias map.

---

### Approach

This implementation takes a deliberate design decision: **aliases live on the name, not on the route**.

Rather than creating new `Route` instances, aliases are stored as a simple map of `alias → original name` directly inside the `Router`. The `UrlGenerator` resolves aliases transparently at call time, so `route('alias')` behaves identically to `route('original')`.

This keeps the route collection clean and avoids any runtime overhead from duplicate route matching.

#### Key design choices

- **`Router::addAlias(string $aliasName, string $originalName)`** — stores the alias map inside the Router itself, so it is serialized as part of `bootstrap/cache/routes-v7.php` with no additional cache file needed.
- **`UrlGenerator::route()`** — resolves aliases transparently before delegating to the original implementation.
- **`route:list --with-aliases` (or `-a`)** — a new flag has been added to the `route:list` command. By default aliases are hidden to keep the output clean; passing `-a` reveals them inline next to the original route name:
  ```
  GET|HEAD  /   home [app, saas.team-selector]  › HomeController
  ```
- **`Route::alias()`** — provides a clean, expressive API at the route definition level.
- **Alias name collision protection** — rather than adding explicit checks or throwing exceptions at registration time, the protection is handled at the root level inside `UrlGenerator::route()`. The resolution order is strict: **real route names always take priority over aliases**. If a route named `app` exists in the route collection, it will be resolved directly and the alias map is never consulted. The alias lookup only kicks in when no real route matches the given name. This means a real route can never be silently shadowed by an alias, with no extra validation logic needed anywhere else.

---

### Open questions

- Should `route:list -a` show aliases as a separate column, or inline as in the current implementation?
- Should `->alias('other-name')` be supported as a chainable alternative to `Route::alias()`?
- Should there be a way to explicitly allow overriding an existing name (opt-in), or should the collision check always be strict?
- Would it also be useful to add a dedicated command to list all registered aliases, something like `route:alias`?