### PR TITLE
[13.x] Indicate that raw queries should be literal strings

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -622,7 +622,7 @@ class Connection implements ConnectionInterface
     /**
      * Run a raw, unprepared query against the PDO connection.
      *
-     * @param  string  $query
+     * @param  literal-string  $query
      * @return bool
      */
     public function unprepared($query)
@@ -1111,7 +1111,7 @@ class Connection implements ConnectionInterface
     /**
      * Get a new raw query expression.
      *
-     * @param  mixed  $value
+     * @param  literal-string|int|float  $value
      * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value)

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -18,7 +18,7 @@ interface ConnectionInterface
     /**
      * Get a new raw query expression.
      *
-     * @param  mixed  $value
+     * @param  literal-string|int|float  $value
      * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value);
@@ -115,7 +115,7 @@ interface ConnectionInterface
     /**
      * Run a raw, unprepared query against the PDO connection.
      *
-     * @param  string  $query
+     * @param  literal-string  $query
      * @return bool
      */
     public function unprepared($query);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -335,7 +335,7 @@ class Builder implements BuilderContract
     /**
      * Add a select expression to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $expression
+     * @param  \Illuminate\Contracts\Database\Query\Expression|literal-string  $expression
      * @param  string  $as
      * @return $this
      */
@@ -349,7 +349,7 @@ class Builder implements BuilderContract
     /**
      * Add a new "raw" select expression to the query.
      *
-     * @param  string  $expression
+     * @param  literal-string  $expression
      * @return $this
      */
     public function selectRaw($expression, array $bindings = [])
@@ -382,7 +382,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "from" clause to the query.
      *
-     * @param  string  $expression
+     * @param  literal-string  $expression
      * @param  mixed  $bindings
      * @return $this
      */
@@ -1275,7 +1275,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "where" clause to the query.
      *
-     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $sql
+     * @param  \Illuminate\Contracts\Database\Query\Expression|literal-string  $sql
      * @param  mixed  $bindings
      * @param  string  $boolean
      * @return $this
@@ -1292,7 +1292,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "or where" clause to the query.
      *
-     * @param  string  $sql
+     * @param  literal-string  $sql
      * @param  mixed  $bindings
      * @return $this
      */
@@ -2642,7 +2642,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "groupBy" clause to the query.
      *
-     * @param  string  $sql
+     * @param  literal-string  $sql
      * @return $this
      */
     public function groupByRaw($sql, array $bindings = [])
@@ -2895,7 +2895,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "having" clause to the query.
      *
-     * @param  string  $sql
+     * @param  literal-string  $sql
      * @param  string  $boolean
      * @return $this
      */
@@ -2913,7 +2913,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "or having" clause to the query.
      *
-     * @param  string  $sql
+     * @param  literal-string  $sql
      * @return $this
      */
     public function orHavingRaw($sql, array $bindings = [])
@@ -3034,7 +3034,7 @@ class Builder implements BuilderContract
     /**
      * Add a raw "order by" clause to the query.
      *
-     * @param  string  $sql
+     * @param  literal-string  $sql
      * @param  array  $bindings
      * @return $this
      */
@@ -3438,6 +3438,7 @@ class Builder implements BuilderContract
     /**
      * Get a single expression value from the first result of a query.
      *
+     * @param  literal-string  $expression
      * @return mixed
      */
     public function rawValue(string $expression, array $bindings = [])
@@ -4492,7 +4493,7 @@ class Builder implements BuilderContract
     /**
      * Create a raw database expression.
      *
-     * @param  mixed  $value
+     * @param  literal-string|int|float  $value
      * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value)

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Database\Grammar;
 
 /**
- * @template TValue of string|int|float
+ * @template TValue of literal-string|int|float
  */
 class Expression implements ExpressionContract
 {


### PR DESCRIPTION
This PR changes the types of all raw query parts (that I could find) to `literal-string`. PHPStan defines a `literal-string` as:

> Security-focused literal-string is inspired by the [is_literal() RFC](https://wiki.php.net/rfc/is_literal). In short, it means a string that is either written by a developer or composed only of developer-written strings.
> -- https://phpstan.org/writing-php-code/phpdoc-types

As raw queries are not escaped by the framework, developers should take extra care that user input is always passed through bindings. Even when this is not possible, care should still be taken to validate user input, for example by checking if the string is in a list of expected values.

With this PR:

```php
$input = request()->input('age');

if (is_string($input)) {
    $count = User::query()->whereRaw("age >= $input")->count(); // ❌ 

    if ($input === '30') {
        $count = User::query()->whereRaw("age >= $input")->count(); // ✅ 
    }

    if (in_array($input, ['10', '20', '30'])) {
        $count = User::query()->whereRaw("age >= $input")->count(); // ✅ 
    }

    $count = User::query()->whereRaw('age >= ?', [$input])->count();  // ✅
}

```

This PR does not contain any breaking changes, it would only affect developers using PHPStan and/or Psalm. But because of that I felt it made sense to send this to 13.

Links:

- Psalm documentation on this: https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#literal-string
- Official PHPStan extension for Doctrine that adds this for a similar use-case: https://github.com/phpstan/phpstan-doctrine?tab=readme-ov-file#literal-strings