### PR TITLE
[12.x] Wrap flags in `int-mask-of` annotation

### DIFF
--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -42,7 +42,7 @@ trait HasParameters
      *
      * @return (InputArgument|array{
      *    0: non-empty-string,
-     *    1?: InputArgument::REQUIRED|InputArgument::OPTIONAL|InputArgument::IS_ARRAY,
+     *    1?: int-mask-of<InputArgument::REQUIRED|InputArgument::OPTIONAL|InputArgument::IS_ARRAY>,
      *    2?: string,
      *    3?: mixed,
      *    4?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>
@@ -59,7 +59,7 @@ trait HasParameters
      * @return (InputOption|array{
      *    0: non-empty-string,
      *    1?: string|non-empty-array<string>,
-     *    2?: InputOption::VALUE_*,
+     *    2?: int-mask-of<InputOption::VALUE_*>,
      *    3?: string,
      *    4?: mixed,
      *    5?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/pull/58771#discussion_r2826655975

Caused by #58771 and #58565

Reported by @stefanfisk

# Problem
Right now, only `InputArgument::REQUIRED`/`InputArgument::OPTIONAL` *OR* `InputArgument::IS_ARRAY` could be used but not together

# Alternative solutions
```diff
- InputArgument::REQUIRED|InputArgument::OPTIONAL|InputArgument::IS_ARRAY
+ int-mask-of<InputArgument::REQUIRED|InputArgument::IS_ARRAY>|int-mask-of<InputArgument::OPTIONAL|InputArgument::IS_ARRAY>
```
This would avoid using `InputArgument::REQUIRED` in conjunction with `InputArgument::OPTIONAL` but might overcomplicate the already somewhat complex type. Technically, it is _possible_ to pass these two in together.