### PR TITLE
[13.x] Ensure insertOrIgnoreReturning only marks records as modified when rows are inserted

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4152,11 +4152,13 @@ class Builder implements BuilderContract
 
         $sql = $this->grammar->compileInsertOrIgnoreReturning($this, $values, (array) $uniqueBy, $returning);
 
-        $this->connection->recordsHaveBeenModified();
-
-        return new Collection(
+        $result = new Collection(
             $this->connection->selectFromWriteConnection($sql, $this->cleanBindings(Arr::flatten($values, 1)))
         );
+
+        $this->connection->recordsHaveBeenModified($result->isNotEmpty());
+
+        return $result;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4146,6 +4146,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', []);
     }
 
+    public function testInsertOrIgnoreReturningDoesNotMarkRecordsModifiedWhenNoRowsWereInserted()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(false);
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert into "users" ("email") values (?) on conflict ("email") do nothing returning *',
+            ['foo']
+        )->andReturn([]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertTrue($result->isEmpty());
+    }
+
     public function testInsertOrIgnoreUsingMethod()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4149,11 +4149,11 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreReturningDoesNotMarkRecordsModifiedWhenNoRowsWereInserted()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(false);
         $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
             'insert into "users" ("email") values (?) on conflict ("email") do nothing returning *',
             ['foo']
         )->andReturn([]);
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once()->with(false);
         $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());


### PR DESCRIPTION
If all the rows conflict, nothing is inserted.

I noticed `$this->connection->recordsHaveBeenModified();` was being called regardless - which means if you use a sticky connection subsequent reads hit the write server unnecessarily.

This aligns the behavior with `insertOrIgnore`, which only marks the connection as modified when rows are actually affected. 

13.x cause thats where insertOrIgnoreReturning is.. :)