### PR TITLE
[12.x] Optional prevention for legacy getFooAttribute() mutators

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -182,6 +182,13 @@ trait HasAttributes
     protected static $setAttributeMutatorCache = [];
 
     /**
+     * The cache of the legacy magic get mutators for each class.
+     *
+     * @var array
+     */
+    protected static $legacyGetMutatorCache = [];
+
+    /**
      * The cache of the converted cast types.
      *
      * @var array
@@ -519,6 +526,21 @@ trait HasAttributes
     }
 
     /**
+     * Handle a magic mutator violation.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    protected function handleMagicMutatorViolation($key)
+    {
+        throw new RuntimeException(sprintf(
+            'Model [%s] uses legacy magic mutator [get%sAttribute()]. Use the Attribute return type or call the model method explicitly.',
+            get_class($this),
+            Str::studly($key)
+        ));
+    }
+
+    /**
      * Get a plain attribute (not a relationship).
      *
      * @param  string  $key
@@ -647,7 +669,15 @@ trait HasAttributes
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.Str::studly($key).'Attribute');
+        $class = get_class($this);
+
+        if (isset(static::$legacyGetMutatorCache[$class][$key])) {
+            return static::$legacyGetMutatorCache[$class][$key];
+        }
+
+        return static::$legacyGetMutatorCache[$class][$key] = method_exists(
+            $this, 'get'.Str::studly($key).'Attribute'
+        );
     }
 
     /**
@@ -712,6 +742,10 @@ trait HasAttributes
      */
     protected function mutateAttribute($key, $value)
     {
+        if (static::preventsMagicMutators()) {
+            $this->handleMagicMutatorViolation($key);
+        }
+
         $this->mergeAttributesFromCachedCasts();
 
         return $this->{'get'.Str::studly($key).'Attribute'}($value);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -234,6 +234,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $missingAttributeViolationCallback;
 
     /**
+     * Indicates whether magic mutators should be prevented.
+     *
+     * @var bool
+     */
+    protected static $modelsShouldPreventMagicMutators = false;
+
+    /**
      * Indicates if broadcasting is currently enabled.
      *
      * @var bool
@@ -576,6 +583,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function handleMissingAttributeViolationUsing(?callable $callback)
     {
         static::$missingAttributeViolationCallback = $callback;
+    }
+
+    /**
+     * Prevent models from using legacy magic mutators.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventMagicMutators($value = true)
+    {
+        static::$modelsShouldPreventMagicMutators = $value;
     }
 
     /**
@@ -2390,6 +2408,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventsAccessingMissingAttributes()
     {
         return static::$modelsShouldPreventAccessingMissingAttributes;
+    }
+
+    /**
+     * Determine if magic mutators are being prevented.
+     *
+     * @return bool
+     */
+    public static function preventsMagicMutators()
+    {
+        return static::$modelsShouldPreventMagicMutators;
     }
 
     /**

--- a/tests/Database/EloquentMagicMutatorTest.php
+++ b/tests/Database/EloquentMagicMutatorTest.php
@@ -62,7 +62,6 @@ class EloquentMagicMutatorTest extends TestCase
 
         $this->assertSame('TAYLOR', $model->name);
     }
-
 }
 
 class EloquentMagicMutatorTestModelWithLegacy extends Model

--- a/tests/Database/EloquentMagicMutatorTest.php
+++ b/tests/Database/EloquentMagicMutatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class EloquentMagicMutatorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Model::preventMagicMutators(false);
+
+        parent::tearDown();
+    }
+
+    public function testLegacyGetMutatorWorksWhenToggleIsOff()
+    {
+        $model = new EloquentMagicMutatorTestModelWithLegacy;
+        $model->name = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->name);
+    }
+
+    public function testLegacySetMutatorWorksWhenToggleIsOff()
+    {
+        $model = new EloquentMagicMutatorTestModelWithLegacy;
+        $model->name = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->getAttributes()['name']);
+    }
+
+    public function testExceptionIsThrownForLegacyGetMutator()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('legacy magic mutator [getNameAttribute()]');
+
+        Model::preventMagicMutators();
+
+        $model = new EloquentMagicMutatorTestModelWithLegacy;
+        $model->name;
+    }
+
+    public function testLegacySetMutatorStillWorksWhenToggleIsOn()
+    {
+        Model::preventMagicMutators();
+
+        $model = new EloquentMagicMutatorTestModelWithLegacy;
+        $model->name = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->getAttributes()['name']);
+    }
+
+    public function testModernAttributeAccessorWorksWhenToggleIsOn()
+    {
+        Model::preventMagicMutators();
+
+        $model = new EloquentMagicMutatorTestModelWithModern;
+        $model->name = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->name);
+    }
+
+}
+
+class EloquentMagicMutatorTestModelWithLegacy extends Model
+{
+    protected $guarded = [];
+
+    public function getNameAttribute($value)
+    {
+        return strtoupper($value);
+    }
+
+    public function setNameAttribute($value)
+    {
+        $this->attributes['name'] = strtoupper($value);
+    }
+}
+
+class EloquentMagicMutatorTestModelWithModern extends Model
+{
+    protected $guarded = [];
+
+    protected function name(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => strtoupper($value),
+            set: fn ($value) => strtoupper($value),
+        );
+    }
+}


### PR DESCRIPTION
Legacy getFooAttribute() access via $model->foo can hide the model behaviour at the call site, which makes code harder to reason about and less discoverable in tooling. 

This PR adds an opt-in guard so teams can prevent or at least debug legacy magic getter mutators during local development or testing, without deprecating the feature globally in Laravel which would be a major breaking change for older code bases. It goes in the family of "local tooling" model helpers such as Model::preventAccessingMissingAttributes() and would normally be used by adding Model:: preventMagicMutators() to the AppServiceProvider (behind an environment check).

This is important because once agents or humans see the getFooAttribute() syntax in a code base, they are tempted to use $model->foo and there is currently no elegant way to enforce the correct modern approach of model attributes or explicit calls to model methods.

## Summary
- Add Model::preventMagicMutators() as an opt-in guard for legacy get mutators.
- Enforces at getter invocation call site (no side effects in hasGetMutator checks).
- Add focused tests for opt-in behavior and modern Attribute compatibility.

## Notes
- Not added to the shouldBeStrict() family in this first pass. Could be good once 13 brings more attributes and mutator calls become less common. 
- No callback API in this first pass. Could be good if someone wants custom errors.
- No setter (setFooAttribute) enforcement in this pass (that pattern was much less common and should probably be manually moved to modern code style).