### PR TITLE
[13.x] Add opt-in Artisan command input validation

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -22,6 +22,7 @@ class Command extends SymfonyCommand
         Concerns\InteractsWithIO,
         Concerns\InteractsWithSignals,
         Concerns\PromptsForMissingInput,
+        Concerns\ValidatesInput,
         Macroable;
 
     /**
@@ -236,6 +237,12 @@ class Command extends SymfonyCommand
             return (int) (is_numeric($this->option('isolated'))
                 ? $this->option('isolated')
                 : $this->isolatedExitCode);
+        }
+
+        if (! is_null($validator = $this->getFailedCommandInputValidator())) {
+            $this->displayValidationErrors($validator);
+
+            return static::FAILURE;
         }
 
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -239,15 +239,15 @@ class Command extends SymfonyCommand
                 : $this->isolatedExitCode);
         }
 
-        if (! is_null($validator = $this->getFailedCommandInputValidator())) {
-            $this->displayValidationErrors($validator);
-
-            return static::FAILURE;
-        }
-
-        $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
-
         try {
+            if (! is_null($validator = $this->getFailedCommandInputValidator())) {
+                $this->displayValidationErrors($validator);
+
+                return static::FAILURE;
+            }
+
+            $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
+
             return (int) $this->laravel->call([$this, $method]);
         } catch (ManuallyFailedException $e) {
             $this->components->error($e->getMessage());

--- a/src/Illuminate/Console/Concerns/ValidatesInput.php
+++ b/src/Illuminate/Console/Concerns/ValidatesInput.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+
+trait ValidatesInput
+{
+    /**
+     * Determine if the command has validation rules.
+     */
+    protected function hasCommandValidationRules(): bool
+    {
+        return ! empty($this->rules());
+    }
+
+    /**
+     * Get the validator instance for the command input.
+     */
+    protected function getCommandInputValidator(): ValidatorContract
+    {
+        return $this->laravel->make(ValidationFactory::class)->make(
+            $this->validationData(),
+            $this->rules(),
+            $this->messages(),
+            $this->attributes(),
+        );
+    }
+
+    /**
+     * Get the validator instance when command input is invalid.
+     */
+    protected function getFailedCommandInputValidator(): ?ValidatorContract
+    {
+        if (! $this->hasCommandValidationRules()) {
+            return null;
+        }
+
+        $validator = $this->getCommandInputValidator();
+
+        return $validator->fails() ? $validator : null;
+    }
+
+    /**
+     * Display failed validation messages for the given validator.
+     */
+    protected function displayValidationErrors(ValidatorContract $validator): void
+    {
+        foreach ($validator->errors()->all() as $error) {
+            $this->components->error($error);
+        }
+    }
+
+    /**
+     * Get the command input data used for validation.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validationData(): array
+    {
+        $arguments = $this->arguments();
+        $options = $this->options();
+
+        unset($arguments['command']);
+
+        $prefixedOptions = [];
+
+        foreach ($options as $key => $value) {
+            $prefixedOptions["--{$key}"] = $value;
+        }
+
+        return array_merge(
+            $arguments,
+            $options,
+            $prefixedOptions,
+            [
+                'arguments' => $arguments,
+                'options' => array_merge($options, $prefixedOptions),
+            ],
+        );
+    }
+
+    /**
+     * Get the validation rules that apply to the command input.
+     *
+     * @return array<string, mixed>
+     */
+    protected function rules(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get custom validation messages for command input validation.
+     *
+     * @return array<string, string>
+     */
+    protected function messages(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get custom validation attributes for command input validation.
+     *
+     * @return array<string, string>
+     */
+    protected function attributes(): array
+    {
+        return [];
+    }
+}

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Contracts\Console\Isolatable;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Foundation\Application;
 use Mockery as m;
 use Orchestra\Testbench\Concerns\InteractsWithMockery;
@@ -101,6 +103,50 @@ class CommandMutexTest extends TestCase
         $this->runCommand(false);
 
         $this->assertEquals(1, $this->command->ran);
+    }
+
+    public function testReleasesIsolationMutexWhenCommandValidationFails()
+    {
+        $command = new class extends Command implements Isolatable
+        {
+            public $ran = 0;
+
+            protected $signature = 'command:name {name?}';
+
+            protected function rules(): array
+            {
+                return ['name' => 'required'];
+            }
+
+            public function __invoke()
+            {
+                $this->ran++;
+            }
+        };
+
+        $command->setLaravel($this->command->getLaravel());
+
+        $validator = m::mock(ValidatorContract::class);
+        $validator->shouldReceive('fails')->once()->andReturn(true);
+        $validator->shouldReceive('errors->all')->once()->andReturn(['The name field is required.']);
+
+        $validationFactory = m::mock(ValidationFactory::class);
+        $validationFactory->shouldReceive('make')->once()->andReturn($validator);
+
+        $command->getLaravel()->instance(ValidationFactory::class, $validationFactory);
+
+        $this->commandMutex->shouldReceive('create')
+            ->andReturn(true)
+            ->once();
+        $this->commandMutex->shouldReceive('forget')
+            ->andReturn(true)
+            ->once();
+
+        $input = new ArrayInput(['--isolated' => true]);
+        $output = new NullOutput;
+
+        $this->assertSame(Command::FAILURE, $command->run($input, $output));
+        $this->assertSame(0, $command->ran);
     }
 
     protected function runCommand($withIsolated = true)

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -5,8 +5,12 @@ namespace Illuminate\Tests\Console;
 use Composer\Autoload\ClassLoader;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application as FoundationApplication;
@@ -21,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Throwable;
 
 use function Illuminate\Filesystem\join_paths;
@@ -157,6 +163,41 @@ class ConsoleApplicationTest extends TestCase
 
         $this->assertSame($codeOfCallingArrayInput, $codeOfCallingStringInput);
         $this->assertSame($outputOfCallingArrayInput, $outputOfCallingStringInput);
+    }
+
+    public function testCommandInputValidationThrowsWhenValidatorBindingIsMissing()
+    {
+        $command = new class extends Command
+        {
+            protected $signature = 'validation:test {name?}';
+
+            protected function rules(): array
+            {
+                return ['name' => 'required'];
+            }
+
+            public function handle(): int
+            {
+                return self::SUCCESS;
+            }
+        };
+
+        $app = m::mock(ApplicationContract::class);
+        $command->setLaravel($app);
+
+        $input = new ArrayInput(['name' => 'Taylor']);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $app->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn($outputStyle);
+        $app->shouldReceive('make')->with(Factory::class, ['output' => $outputStyle])->andReturn(new Factory($outputStyle));
+        $app->shouldReceive('runningUnitTests')->andReturn(true);
+        $app->shouldReceive('make')->with(ValidationFactory::class)->andThrow(new BindingResolutionException('Target class [validator] does not exist.'));
+
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target class [validator] does not exist.');
+
+        $command->run($input, $output);
     }
 
     public function testCommandInputPromptsWhenRequiredArgumentIsMissing()

--- a/tests/Integration/Console/CommandInputValidationTest.php
+++ b/tests/Integration/Console/CommandInputValidationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Command;
+use Orchestra\Testbench\TestCase;
+
+class CommandInputValidationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Artisan::starting(function ($artisan) {
+            $artisan->resolveCommands([
+                BasicCommandInputValidationStub::class,
+                ArgumentsScopedValidationStub::class,
+                OptionsScopedValidationStub::class,
+                DashedOptionValidationStub::class,
+                PlainKeyCollisionValidationStub::class,
+                CustomMessagesAndAttributesValidationStub::class,
+            ]);
+        });
+
+        BasicCommandInputValidationStub::$handled = false;
+        PlainKeyCollisionValidationStub::$handled = false;
+
+        parent::setUp();
+    }
+
+    public function testItFailsValidationForInvalidArgumentInputAndSkipsHandler(): void
+    {
+        $this->artisan('validation:basic')
+            ->expectsOutputToContain('The name field is required.')
+            ->assertExitCode(1);
+
+        $this->assertFalse(BasicCommandInputValidationStub::$handled);
+    }
+
+    public function testItPassesValidationAndExecutesHandlerForValidInput(): void
+    {
+        $this->artisan('validation:basic', ['name' => 'Taylor'])
+            ->assertSuccessful();
+
+        $this->assertTrue(BasicCommandInputValidationStub::$handled);
+    }
+
+    public function testItValidatesUsingArgumentsNamespacedRules(): void
+    {
+        $this->artisan('validation:arguments')
+            ->expectsOutputToContain('Argument scoped rule failed.')
+            ->assertExitCode(1);
+    }
+
+    public function testItValidatesUsingOptionsNamespacedRules(): void
+    {
+        $this->artisan('validation:options')
+            ->expectsOutputToContain('Option scoped rule failed.')
+            ->assertExitCode(1);
+    }
+
+    public function testItValidatesUsingDashedOptionAliasRules(): void
+    {
+        $this->artisan('validation:dashed-option', ['--color' => 'green'])
+            ->assertSuccessful();
+    }
+
+    public function testPlainKeyValidationUsesOptionValueWhenArgumentAndOptionShareAName(): void
+    {
+        $this->artisan('validation:collision', [
+            'name' => 'argument-value',
+            '--name' => 'option-value',
+        ])->assertSuccessful();
+
+        $this->assertTrue(PlainKeyCollisionValidationStub::$handled);
+    }
+
+    public function testItUsesCustomValidationMessagesAndAttributes(): void
+    {
+        $this->artisan('validation:custom', ['--count' => 1])
+            ->expectsOutputToContain('Need at least 2 for record count.')
+            ->assertExitCode(1);
+    }
+}
+
+class BasicCommandInputValidationStub extends Command
+{
+    public static bool $handled = false;
+
+    protected $signature = 'validation:basic {name?}';
+
+    protected function rules(): array
+    {
+        return ['name' => 'required'];
+    }
+
+    public function handle(): int
+    {
+        static::$handled = true;
+
+        return static::SUCCESS;
+    }
+}
+
+class ArgumentsScopedValidationStub extends Command
+{
+    protected $signature = 'validation:arguments {name?}';
+
+    protected function rules(): array
+    {
+        return ['arguments.name' => 'required'];
+    }
+
+    protected function messages(): array
+    {
+        return ['arguments.name.required' => 'Argument scoped rule failed.'];
+    }
+
+    public function handle(): int
+    {
+        return static::SUCCESS;
+    }
+}
+
+class OptionsScopedValidationStub extends Command
+{
+    protected $signature = 'validation:options {--color=}';
+
+    protected function rules(): array
+    {
+        return ['options.color' => 'required|in:green'];
+    }
+
+    protected function messages(): array
+    {
+        return ['options.color.required' => 'Option scoped rule failed.'];
+    }
+
+    public function handle(): int
+    {
+        return static::SUCCESS;
+    }
+}
+
+class DashedOptionValidationStub extends Command
+{
+    protected $signature = 'validation:dashed-option {--color=}';
+
+    protected function rules(): array
+    {
+        return ['--color' => 'required|in:green'];
+    }
+
+    public function handle(): int
+    {
+        return static::SUCCESS;
+    }
+}
+
+class PlainKeyCollisionValidationStub extends Command
+{
+    public static bool $handled = false;
+
+    protected $signature = 'validation:collision {name?} {--name=}';
+
+    protected function rules(): array
+    {
+        return ['name' => 'in:option-value'];
+    }
+
+    public function handle(): int
+    {
+        static::$handled = true;
+
+        return static::SUCCESS;
+    }
+}
+
+class CustomMessagesAndAttributesValidationStub extends Command
+{
+    protected $signature = 'validation:custom {--count=}';
+
+    protected function rules(): array
+    {
+        return ['options.count' => 'required|integer|min:2'];
+    }
+
+    protected function messages(): array
+    {
+        return ['options.count.min' => 'Need at least :min for :attribute.'];
+    }
+
+    protected function attributes(): array
+    {
+        return ['options.count' => 'record count'];
+    }
+
+    public function handle(): int
+    {
+        return static::SUCCESS;
+    }
+}


### PR DESCRIPTION

This change introduces opt-in input validation for Artisan commands on Laravel 13, so command authors can validate arguments and options using Laravel validation rules before command logic runs.

### Usage

```php
class SendReport extends Command
{
    protected $signature = 'report:send {email?} {--queue=}';

    protected function rules(): array
    {
        return [
            'email' => 'required|email',
            'arguments.email' => 'required|email',
            'options.queue' => 'in:default,high',
            '--queue' => 'in:default,high',
        ];
    }
}
```

If validation fails, Artisan prints validation errors and exits with code `1`, without executing the command handler.

### Approach

- Added an opt-in validation lifecycle for commands that define rules.
- Added command hooks for `rules`, `messages`, `attributes`, and `validationData`.
- Validation data supports plain keys, `arguments.*`, `options.*`, and `--option` aliases.
- Kept behavior unchanged for commands that do not define rules.
- Added tests for invalid and valid paths, namespaced keys, dashed option aliases, key collisions, custom messages/attributes, and missing validator binding behavior.

### How this accounts for prior attempt feedback

- No new console validation contract/interface was added; this is trait-based and minimal.
- Behavior is consistent for CLI and `Artisan::call()` (validation errors are surfaced and command fails).
- Option key semantics from previous discussion are handled by supporting both plain option keys and `--option` aliases.
- Argument/option name collisions are addressed via namespaced keys (`arguments.*`, `options.*`) plus deterministic merged behavior.
- No silent fallback when validation services are unavailable; missing validator binding is surfaced explicitly.
- Commands without rules are unaffected (fully backward-compatible default path).

No breaking changes expected.
