### PR TITLE
[13.x] Fix ArrayStore::touch numeric key duplication

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -183,7 +183,7 @@ class ArrayStore extends TaggableStore implements CanFlushLocks, LockProvider
 
         $item['expiresAt'] = $this->calculateExpiration($seconds);
 
-        $this->storage = array_merge($this->storage, [$key => $item]);
+        $this->storage[$key] = $item;
 
         return true;
     }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -86,6 +86,22 @@ class CacheArrayStoreTest extends TestCase
         $this->assertSame($value, $store->get($key));
     }
 
+    public function testTouchDoesNotDuplicateNumericKeys(): void
+    {
+        $store = new ArrayStore;
+
+        $store->put('0', 'value', 30);
+
+        $this->assertTrue($store->touch('0', 60));
+        $this->assertSame('value', $store->get('0'));
+
+        $all = $store->all();
+
+        $this->assertCount(1, $all);
+        $this->assertArrayHasKey(0, $all);
+        $this->assertArrayNotHasKey(1, $all);
+    }
+
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();


### PR DESCRIPTION
## Summary
- replace `array_merge` with direct assignment in `ArrayStore::touch()`
- prevent numeric cache keys from being re-indexed and duplicated during `touch()`
- add a regression test for key "0"
