### PR TITLE
[12.x] Suppress chmod in Filesystem::replace() for non-POSIX filesystems

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -221,11 +221,12 @@ class Filesystem
 
         $tempPath = tempnam(dirname($path), basename($path));
 
-        // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600...
+        // Fix permissions of tempPath because `tempnam()` creates it with permissions set to 0600.
+        // chmod is suppressed because it may fail on non-POSIX filesystems (e.g. Azure File SMB)...
         if (! is_null($mode)) {
-            chmod($tempPath, $mode);
+            @chmod($tempPath, $mode);
         } else {
-            chmod($tempPath, 0777 - umask());
+            @chmod($tempPath, 0777 - umask());
         }
 
         file_put_contents($tempPath, $content);


### PR DESCRIPTION
Fixes #59076

The `chmod()` call inside `Filesystem::replace()` was throwing an `ErrorException` on filesystems that don't support POSIX permissions — like Azure File shares mounted via SMB/CIFS in Kubernetes.

This was introduced when `BladeCompiler::compile()` switched from `put()` to `replace()` in PR #58812 to fix a race condition. The chmod there is just a best-effort fix for `tempnam()` defaulting to `0600` — it shouldn't be fatal if the filesystem doesn't support it.

This PR simply suppresses the error with `@chmod()`, which is a common pattern in PHP for non-critical permission operations. If chmod works, great. If not, life goes on.