### PR TITLE
[12.x] Initialize $result in Container::call() for PHP 8.5 compatibility

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -796,6 +796,8 @@ class Container implements ArrayAccess, ContainerContract
             $pushedToBuildStack = true;
         }
 
+        $result = null;
+
         $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
 
         if ($pushedToBuildStack) {


### PR DESCRIPTION
Fixes #59002

On PHP 8.5, `Container::call()` can throw an `ErrorException: Undefined variable $result` during application termination. PHP 8.5 promotes undefined variable access to an error, and there seems to be an edge case where `$result` isn't assigned before the return statement is reached.

This just initializes `$result = null` before the `BoundMethod::call()` line. Simple defensive fix — no behavior change for existing code, just stops the noise on PHP 8.5.