### PR TITLE
[13.x] Support enums for route and group middleware registration

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1084,7 +1084,7 @@ class Route
         }
 
         foreach ($middleware as $index => $value) {
-            $middleware[$index] = (string) $value;
+            $middleware[$index] = (string) enum_value($value);
         }
 
         $this->action['middleware'] = array_merge(

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @method \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|null $action = null)
@@ -124,7 +126,7 @@ class RouteRegistrar
             $value = array_filter(Arr::wrap($value));
 
             foreach ($value as $index => $middleware) {
-                $value[$index] = (string) $middleware;
+                $value[$index] = (string) enum_value($middleware);
             }
         }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -104,6 +104,15 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame(['one'], $this->getRoute()->middleware());
     }
 
+    public function testMiddlewareAsEnumsOnRouteInstance()
+    {
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware([CategoryEnum::People, CategoryBackedEnum::People, IntegerEnum::One]);
+
+        $this->assertSame(['People', 'people', '1'], $this->getRoute()->middleware());
+    }
+
     public function testMiddlewareAsArrayWithStringables()
     {
         $one = new class implements Stringable
@@ -344,6 +353,17 @@ class RouteRegistrarTest extends TestCase
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->seeMiddleware('one');
+    }
+
+    public function testCanRegisterGroupWithBackedEnumMiddleware()
+    {
+        $this->router->middleware(CategoryBackedEnum::People)->group(function ($router) {
+            $router->get('users', function () {
+                return 'all-users';
+            });
+        });
+
+        $this->seeMiddleware('people');
     }
 
     public function testCanRegisterGroupWithNamespace()


### PR DESCRIPTION
## Summary
- replace direct `(string)` casts with enum-safe normalization via `enum_value()` in route middleware registration
- apply the same fix for registrar/group middleware attributes
- add tests covering route instance and route group middleware with enums

## Before
Passing an enum to `Route::middleware(...)` or `$router->middleware(...)->group(...)` raised an error when casting objects to string.

## After
```php
<?php

enum RouteMiddleware: string
{
    case Auth = 'auth';
    case Verified = 'verified';
}

// Route directe
Route::get('/dashboard', fn () => 'ok')
    ->middleware(RouteMiddleware::Auth);

// Groupe
Route::middleware(RouteMiddleware::Verified)->group(function () {
    Route::get('/profile', fn () => 'profile');
});
```

