### PR TITLE
[13.x] Support enum models in Authorize middleware attribute

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Authorize.php
@@ -7,19 +7,24 @@ use Illuminate\Auth\Middleware\Authorize as AuthorizeMiddleware;
 use Illuminate\Support\Arr;
 use UnitEnum;
 
+use function Illuminate\Support\enum_value;
+
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Authorize extends Middleware
 {
     /**
-     * @param  array<string>|string|null  $models
+     * @param  array<int, \UnitEnum|string>|\UnitEnum|string|null  $models
      */
     public function __construct(
         UnitEnum|string $ability,
-        array|string|null $models = null,
+        array|UnitEnum|string|null $models = null,
         ?array $only = null,
         ?array $except = null,
     ) {
-        $middleware = AuthorizeMiddleware::using($ability, ...Arr::wrap($models));
+        $middleware = AuthorizeMiddleware::using(
+            $ability,
+            ...array_map(fn ($model) => (string) enum_value($model), Arr::wrap($models)),
+        );
 
         parent::__construct($middleware, $only, $except);
     }

--- a/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/AuthorizeMiddlewareAttributeTest.php
@@ -23,6 +23,15 @@ class AuthorizeMiddlewareAttributeTest extends TestCase
             'Illuminate\Auth\Middleware\Authorize:except-index,a,b',
         ], $route->controllerMiddleware());
     }
+
+    public function test_attribute_supports_enums_for_models(): void
+    {
+        $route = Route::get('/', [AuthorizeMiddlewareEnumModelsController::class, 'index']);
+        $this->assertEquals([
+            'Illuminate\Auth\Middleware\Authorize:view,user',
+            'Illuminate\Auth\Middleware\Authorize:update,post,Account,1',
+        ], $route->controllerMiddleware());
+    }
 }
 
 #[Authorize('all')]
@@ -40,4 +49,30 @@ class AuthorizeMiddlewareAttributeController
     {
         // ...
     }
+}
+
+#[Authorize('view', models: AuthorizeModelBackedEnum::User)]
+#[Authorize('update', models: [AuthorizeModelBackedEnum::Post, AuthorizeModelUnitEnum::Account, AuthorizeModelIntegerEnum::One])]
+class AuthorizeMiddlewareEnumModelsController
+{
+    public function index(): void
+    {
+        // ...
+    }
+}
+
+enum AuthorizeModelBackedEnum: string
+{
+    case User = 'user';
+    case Post = 'post';
+}
+
+enum AuthorizeModelUnitEnum
+{
+    case Account;
+}
+
+enum AuthorizeModelIntegerEnum: int
+{
+    case One = 1;
 }


### PR DESCRIPTION
## Summary
- add enum support for the `models` argument in `#[Authorize(...)]`
- normalize `models` values with `enum_value()` before building the middleware string
- expand integration coverage for backed enum, unit enum, and int-backed enum models

`#[Authorize(..., models: ...)]` accepted `string|array|null`, but enum values in `models` could break when the middleware string was assembled.

