### PR TITLE
[12.x] Fix Pluralizer uppercase acronym suffix (CD → CDs not CDS)

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -91,6 +91,10 @@ class Pluralizer
 
         foreach ($functions as $function) {
             if ($function($comparison) === $comparison) {
+                if ($function === 'mb_strtoupper' && str_starts_with($value, $comparison)) {
+                    return $comparison.mb_substr($value, mb_strlen($comparison));
+                }
+
                 return $function($value);
             }
         }

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -35,6 +35,14 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('children', Str::plural('cHiLd'));
     }
 
+    public function testPluralAcronyms()
+    {
+        $this->assertSame('CDs', Str::plural('CD'));
+        $this->assertSame('DVDs', Str::plural('DVD'));
+        $this->assertSame('URLs', Str::plural('URL'));
+        $this->assertSame('APIs', Str::plural('API'));
+    }
+
     public function testIfEndOfWordPlural()
     {
         $this->assertSame('VortexFields', Str::plural('VortexField'));


### PR DESCRIPTION
Fixes #56932

Right now `Str::plural('CD')` gives you `"CDS"` instead of `"CDs"`. Same thing happens with DVD, URL, API, etc. The Doctrine inflector actually returns the correct `"CDs"` — but then `matchCase()` sees the input was all uppercase and runs `mb_strtoupper()` on the whole thing, wiping out the lowercase suffix.

The fix is small: in `matchCase()`, when the input is all uppercase and the inflector preserved the original word exactly (just appended a suffix), we keep the original uppercase portion and leave the appended suffix alone. This way "CD" + "s" stays "CDs" instead of becoming "CDS".

Words that actually change form (like CHILD → CHILDREN, PERSON → PEOPLE) still get fully uppercased as before since the inflector doesn't preserve the original stem in those cases.

Added tests for CD, DVD, URL, and API.