### PR TITLE
[12.x] Fix previousPath() returning full URL for external referrers

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -182,9 +182,9 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function previousPath($fallback = false)
     {
-        $previousPath = str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
+        $previousPath = parse_url($this->previous($fallback), PHP_URL_PATH);
 
-        return $previousPath === '' ? '/' : $previousPath;
+        return $previousPath && $previousPath !== '/' ? rtrim($previousPath, '/') : '/';
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -731,6 +731,12 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/', $url->previousPath());
 
         $this->assertSame('/bar', $url->previousPath('/bar'));
+
+        $url->getRequest()->headers->set('referer', 'http://www.google.com/search?q=laravel');
+        $this->assertSame('/search', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.external.com/some/path');
+        $this->assertSame('/some/path', $url->previousPath());
     }
 
     public function testRouteNotDefinedException()


### PR DESCRIPTION
Fixes #57456

`url()->previousPath()` was using `str_replace` to strip the app's base URL from the referrer. But when the referrer comes from an external domain (which is totally possible since clients control the `Referer` header), the app URL doesn't match and the full URL gets returned as-is.

So instead of getting `/search` you'd get `http://www.google.com/search` — which isn't a path at all, and could lead to open redirect issues if developers trust it.

Switched to `parse_url($url, PHP_URL_PATH)` which always reliably extracts just the path portion, regardless of where the URL points to.

Added tests for external referrer URLs.