### PR TITLE
[13.x] Add MariaDB support for insertOrIgnoreReturning

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MariaDbGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinLateralClause;
+use Illuminate\Support\Str;
 use RuntimeException;
 
 class MariaDbGrammar extends MySqlGrammar
@@ -20,6 +21,21 @@ class MariaDbGrammar extends MySqlGrammar
     public function compileJoinLateral(JoinLateralClause $join, string $expression): string
     {
         throw new RuntimeException('This database engine does not support lateral joins.');
+    }
+
+    /**
+     * Compile an insert ignore statement with returning into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $returning
+     * @return string
+     */
+    public function compileInsertOrIgnoreReturning(Builder $query, array $values, array $uniqueBy, array $returning)
+    {
+        return Str::replaceFirst('insert', 'insert ignore', $this->compileInsert($query, $values))
+            .' returning '.$this->columnize($returning);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4028,6 +4028,49 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email');
     }
 
+    public function testMariaDbInsertOrIgnoreReturningMethod()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert ignore into `users` (`email`) values (?) returning `id`',
+            ['foo']
+        )->andReturn([['id' => 1]]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo'], 'email', ['id']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1]], $result->all());
+    }
+
+    public function testMariaDbInsertOrIgnoreReturningMethodWithMultipleUniqueByColumns()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert ignore into `users` (`email`, `name`) values (?, ?) returning *',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo', 'name' => 'bar']]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(['email' => 'foo', 'name' => 'bar'], ['email', 'name']);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo', 'name' => 'bar']], $result->all());
+    }
+
+    public function testMariaDbInsertOrIgnoreReturningMethodWithMultipleRecords()
+    {
+        $builder = $this->getMariaDbBuilder();
+        $builder->getConnection()->shouldReceive('recordsHaveBeenModified')->once();
+        $builder->getConnection()->shouldReceive('selectFromWriteConnection')->once()->with(
+            'insert ignore into `users` (`email`) values (?), (?) returning `id`, `email`',
+            ['foo', 'bar']
+        )->andReturn([['id' => 1, 'email' => 'foo']]);
+        $result = $builder->from('users')->insertOrIgnoreReturning(
+            [['email' => 'foo'], ['email' => 'bar']],
+            'email',
+            ['id', 'email']
+        );
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals([['id' => 1, 'email' => 'foo']], $result->all());
+    }
+
     public function testPostgresInsertOrIgnoreReturningMethod()
     {
         $builder = $this->getPostgresBuilder();


### PR DESCRIPTION
Follow-up to #59025.

PR #59025 added `insertOrIgnoreReturning()` with support for PostgreSQL and SQLite, but MariaDB was left out — it falls through to the base grammar and throws a RuntimeException.

MariaDB 10.5+ supports the `RETURNING` clause natively, so this adds `compileInsertOrIgnoreReturning()` to `MariaDbGrammar` using MariaDB's `INSERT IGNORE INTO ... RETURNING` syntax. This also means `saveOrIgnore()` from #59026 now works on MariaDB.

Added tests for single insert, multiple unique-by columns, and multiple records — all following the same patterns as the existing Postgres and SQLite tests.