### PR TITLE
[13.x] Support array values for Middleware attribute

### DIFF
--- a/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Attributes/Controllers/Middleware.php
@@ -9,11 +9,12 @@ use Closure;
 class Middleware
 {
     /**
+     * @param  array<int, \Closure|string>|\Closure|string  $value
      * @param  array<string>|null  $only
      * @param  array<string>|null  $except
      */
     public function __construct(
-        public Closure|string $value,
+        public array|Closure|string $value,
         public ?array $only = null,
         public ?array $except = null,
     ) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1196,6 +1196,7 @@ class Route
             ) ? null : $instance->value;
         })
             ->filter()
+            ->flatten()
             ->values()
             ->all();
     }

--- a/tests/Integration/Routing/MiddlewareAttributeTest.php
+++ b/tests/Integration/Routing/MiddlewareAttributeTest.php
@@ -23,6 +23,25 @@ class MiddlewareAttributeTest extends TestCase
             'except-index',
         ], $route->controllerMiddleware());
     }
+
+    public function test_attribute_middleware_supports_arrays(): void
+    {
+        $route = Route::get('/', [MiddlewareArrayAttributeController::class, 'index']);
+        $this->assertEquals([
+            'all',
+            'all-array-one',
+            'all-array-two',
+            'also-index-array-one',
+            'also-index-array-two',
+        ], $route->controllerMiddleware());
+
+        $route = Route::get('/', [MiddlewareArrayAttributeController::class, 'show']);
+        $this->assertEquals([
+            'all',
+            'all-array-one',
+            'all-array-two',
+        ], $route->controllerMiddleware());
+    }
 }
 
 #[Middleware('all')]
@@ -31,6 +50,22 @@ class MiddlewareAttributeTest extends TestCase
 class MiddlewareAttributeController
 {
     #[Middleware('also-index')]
+    public function index(): void
+    {
+        // ...
+    }
+
+    public function show(): void
+    {
+        // ...
+    }
+}
+
+#[Middleware('all')]
+#[Middleware(['all-array-one', 'all-array-two'])]
+class MiddlewareArrayAttributeController
+{
+    #[Middleware(['also-index-array-one', 'also-index-array-two'], only: ['index'])]
     public function index(): void
     {
         // ...


### PR DESCRIPTION
- allow `#[Middleware([...])]` by accepting arrays in the middleware attribute value
- flatten controller middleware values from attributes so array payloads are merged into a flat middleware list
- add integration coverage for class-level and method-level middleware arrays

## Before
`#[Middleware]` only accepted `Closure|string`. Passing an array of middleware values was not supported.

## After
`#[Middleware]` now accepts `array|Closure|string`, and route controller middleware resolution correctly handles and flattens array values.
