### PR TITLE
[13.x] Use constructor promotion and typed properties in cache flush events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheFlushFailed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushFailed.php
@@ -5,29 +5,15 @@ namespace Illuminate\Cache\Events;
 class CacheFlushFailed
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
-    /**
-     * The tags that were assigned to the key.
-     *
-     * @var array
-     */
-    public $tags;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      * @param  array  $tags
      */
-    public function __construct($storeName, array $tags = [])
-    {
-        $this->storeName = $storeName;
-        $this->tags = $tags;
+    public function __construct(
+        public ?string $storeName,
+        public array $tags = [],
+    ) {
     }
 
     /**
@@ -36,7 +22,7 @@ class CacheFlushFailed
      * @param  array  $tags
      * @return $this
      */
-    public function setTags($tags)
+    public function setTags(array $tags)
     {
         $this->tags = $tags;
 

--- a/src/Illuminate/Cache/Events/CacheFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheFlushed.php
@@ -5,29 +5,15 @@ namespace Illuminate\Cache\Events;
 class CacheFlushed
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
-    /**
-     * The tags that were assigned to the key.
-     *
-     * @var array
-     */
-    public $tags;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      * @param  array  $tags
      */
-    public function __construct($storeName, array $tags = [])
-    {
-        $this->storeName = $storeName;
-        $this->tags = $tags;
+    public function __construct(
+        public ?string $storeName,
+        public array $tags = [],
+    ) {
     }
 
     /**
@@ -36,7 +22,7 @@ class CacheFlushed
      * @param  array  $tags
      * @return $this
      */
-    public function setTags($tags)
+    public function setTags(array $tags)
     {
         $this->tags = $tags;
 

--- a/src/Illuminate/Cache/Events/CacheFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheFlushing.php
@@ -5,29 +5,15 @@ namespace Illuminate\Cache\Events;
 class CacheFlushing
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public $storeName;
-
-    /**
-     * The tags that were assigned to the key.
-     *
-     * @var array
-     */
-    public $tags;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      * @param  array  $tags
      */
-    public function __construct($storeName, array $tags = [])
-    {
-        $this->storeName = $storeName;
-        $this->tags = $tags;
+    public function __construct(
+        public ?string $storeName,
+        public array $tags = [],
+    ) {
     }
 
     /**
@@ -36,7 +22,7 @@ class CacheFlushing
      * @param  array  $tags
      * @return $this
      */
-    public function setTags($tags)
+    public function setTags(array $tags)
     {
         $this->tags = $tags;
 


### PR DESCRIPTION
The newly added cache lock events (CacheLocksFlushed, CacheLocksFlushing, CacheLocksFlushFailed) use typed properties and a clean style. However, the older cache flush events (CacheFlushed, CacheFlushing, CacheFlushFailed) still follow the previous pattern with untyped properties, manual assignment, and `@var` docblocks.

This change brings the older events in line with the newer ones by using constructor promotion and typed properties for a consistent style. No behavior change.