### PR TITLE
[13.x] Connect seeder `run()` params to CLI via `--with` on seed-enabled commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -122,6 +122,7 @@ class FreshCommand extends Command
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
             '--force' => true,
+            '--with' => $this->option('with'),
         ]));
     }
 
@@ -142,6 +143,7 @@ class FreshCommand extends Command
             ['schema-path', null, InputOption::VALUE_OPTIONAL, 'The path to a schema dump file'],
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
+            ['with', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Values passed into the seeder'],
             ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],
         ];
     }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -35,6 +35,7 @@ class MigrateCommand extends BaseCommand implements Isolatable
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
                 {--seeder= : The class name of the root seeder}
+                {--with=* : Values passed into the seeder}
                 {--step : Force the migrations to be run so they can be rolled back individually}
                 {--graceful : Return a successful exit code even if an error occurs}';
 
@@ -124,10 +125,11 @@ class MigrateCommand extends BaseCommand implements Isolatable
             // seed task to re-populate the database, which is convenient when adding
             // a migration and a seed at the same time, as it is only this command.
             if ($this->option('seed') && ! $this->option('pretend')) {
-                $this->call('db:seed', [
+                $this->call('db:seed', array_filter([
                     '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
                     '--force' => true,
-                ]);
+                    '--with' => $this->option('with'),
+                ]));
             }
         });
     }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -140,6 +140,7 @@ class RefreshCommand extends Command
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
             '--force' => true,
+            '--with' => $this->option('with'),
         ]));
     }
 
@@ -157,6 +158,7 @@ class RefreshCommand extends Command
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
+            ['with', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Values passed into the seeder'],
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted & re-run'],
         ];
     }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 use InvalidArgumentException;
+use JsonException;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -173,9 +174,42 @@ class SeedCommand extends Command
             'float' => $this->castFloatSeederParameter($seeder, $parameter, $value),
             'bool' => $this->castBooleanSeederParameter($seeder, $parameter, $value),
             'string' => $value,
-            'array' => [$value],
+            'array' => $this->castArraySeederParameter($seeder, $parameter, $value),
             default => $value,
         };
+    }
+
+    /**
+     * Cast a seeder parameter value to array.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  \ReflectionParameter  $parameter
+     * @param  string  $value
+     * @return array
+     */
+    protected function castArraySeederParameter(Seeder $seeder, ReflectionParameter $parameter, string $value): array
+    {
+        $trimmed = trim($value);
+
+        if ($trimmed !== '' && str_starts_with($trimmed, '[')) {
+            try {
+                $parsed = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                throw new InvalidArgumentException(
+                    "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid JSON array.'
+                );
+            }
+
+            if (! is_array($parsed)) {
+                throw new InvalidArgumentException(
+                    "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid JSON array.'
+                );
+            }
+
+            return $parsed;
+        }
+
+        return [$value];
     }
 
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -7,6 +7,11 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\Prohibitable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
+use InvalidArgumentException;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -67,8 +72,12 @@ class SeedCommand extends Command
 
         $this->resolver->setDefaultConnection($this->getDatabase());
 
-        Model::unguarded(function () {
-            $this->getSeeder()->__invoke();
+        $seeder = $this->getSeeder();
+
+        $parameters = $this->resolveSeederParameters($seeder, $this->parseParameters());
+
+        Model::unguarded(function () use ($seeder, $parameters) {
+            $seeder->__invoke($parameters);
         });
 
         if ($previousConnection) {
@@ -76,6 +85,166 @@ class SeedCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Parse the parameters passed to the command using the --with option.
+     *
+     * @return array<string, string>
+     */
+    protected function parseParameters(): array
+    {
+        $parameters = [];
+
+        foreach ($this->option('with') ?? [] as $parameter) {
+            if (! is_string($parameter) || ! str_contains($parameter, '=')) {
+                throw new InvalidArgumentException('The --with option expects values in key=value format.');
+            }
+
+            [$key, $value] = explode('=', $parameter, 2);
+
+            $key = trim($key);
+
+            if ($key === '') {
+                throw new InvalidArgumentException('The --with option expects non-empty keys.');
+            }
+
+            $parameters[$key] = trim($value);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Resolve and cast parameters for the given seeder run method.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  array<string, string>  $parameters
+     * @return array<string, mixed>
+     */
+    protected function resolveSeederParameters(Seeder $seeder, array $parameters): array
+    {
+        if ($parameters === []) {
+            return [];
+        }
+
+        $method = new ReflectionMethod($seeder, 'run');
+        $signature = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            $signature[$parameter->getName()] = $parameter;
+        }
+
+        foreach ($parameters as $name => $value) {
+            if (! array_key_exists($name, $signature)) {
+                throw new InvalidArgumentException("Unknown seeder parameter [{$name}] for [".get_class($seeder).'].');
+            }
+
+            $parameters[$name] = $this->castSeederParameterValue($seeder, $signature[$name], $value);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Cast a seeder parameter value based on the run method signature.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  \ReflectionParameter  $parameter
+     * @param  string  $value
+     * @return mixed
+     */
+    protected function castSeederParameterValue(Seeder $seeder, ReflectionParameter $parameter, string $value)
+    {
+        $type = $parameter->getType();
+
+        if ($type === null) {
+            return $value;
+        }
+
+        if (! $type instanceof ReflectionNamedType || ! $type->isBuiltin()) {
+            throw new InvalidArgumentException(
+                "Unable to pass [{$parameter->getName()}] to [".get_class($seeder).'] via --with because only single built-in scalar parameter types are supported.'
+            );
+        }
+
+        return match ($type->getName()) {
+            'int' => $this->castIntegerSeederParameter($seeder, $parameter, $value),
+            'float' => $this->castFloatSeederParameter($seeder, $parameter, $value),
+            'bool' => $this->castBooleanSeederParameter($seeder, $parameter, $value),
+            'string' => $value,
+            'array' => [$value],
+            default => $value,
+        };
+    }
+
+    /**
+     * Cast a seeder parameter value to integer.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  \ReflectionParameter  $parameter
+     * @param  string  $value
+     * @return int
+     */
+    protected function castIntegerSeederParameter(Seeder $seeder, ReflectionParameter $parameter, string $value): int
+    {
+        $parsed = filter_var($value, FILTER_VALIDATE_INT);
+
+        if ($parsed === false) {
+            throw new InvalidArgumentException(
+                "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid integer.'
+            );
+        }
+
+        return (int) $parsed;
+    }
+
+    /**
+     * Cast a seeder parameter value to float.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  \ReflectionParameter  $parameter
+     * @param  string  $value
+     * @return float
+     */
+    protected function castFloatSeederParameter(Seeder $seeder, ReflectionParameter $parameter, string $value): float
+    {
+        $parsed = filter_var($value, FILTER_VALIDATE_FLOAT);
+
+        if ($parsed === false) {
+            throw new InvalidArgumentException(
+                "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid float.'
+            );
+        }
+
+        return (float) $parsed;
+    }
+
+    /**
+     * Cast a seeder parameter value to boolean.
+     *
+     * @param  \Illuminate\Database\Seeder  $seeder
+     * @param  \ReflectionParameter  $parameter
+     * @param  string  $value
+     * @return bool
+     */
+    protected function castBooleanSeederParameter(Seeder $seeder, ReflectionParameter $parameter, string $value): bool
+    {
+        if ($value === '') {
+            throw new InvalidArgumentException(
+                "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid boolean.'
+            );
+        }
+
+        $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($parsed === null) {
+            throw new InvalidArgumentException(
+                "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid boolean.'
+            );
+        }
+
+        return $parsed;
     }
 
     /**
@@ -136,6 +305,7 @@ class SeedCommand extends Command
             ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+            ['with', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Values passed into the seeder'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -129,6 +129,10 @@ class SeedCommand extends Command
             return [];
         }
 
+        if (! method_exists($seeder, 'run')) {
+            throw new InvalidArgumentException('Method [run] missing from '.get_class($seeder));
+        }
+
         $method = new ReflectionMethod($seeder, 'run');
         $signature = [];
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -158,15 +158,14 @@ class SeedCommand extends Command
     protected function castSeederParameterValue(Seeder $seeder, ReflectionParameter $parameter, string $value)
     {
         $type = $parameter->getType();
+        $unsupportedTypeMessage = "Unable to pass [{$parameter->getName()}] to [".get_class($seeder).'] via --with because only int, float, bool, string, and array types are supported.';
 
         if ($type === null) {
             return $value;
         }
 
-        if (! $type instanceof ReflectionNamedType || ! $type->isBuiltin()) {
-            throw new InvalidArgumentException(
-                "Unable to pass [{$parameter->getName()}] to [".get_class($seeder).'] via --with because only single built-in scalar parameter types are supported.'
-            );
+        if (! $type instanceof ReflectionNamedType) {
+            throw new InvalidArgumentException($unsupportedTypeMessage);
         }
 
         return match ($type->getName()) {
@@ -175,7 +174,7 @@ class SeedCommand extends Command
             'bool' => $this->castBooleanSeederParameter($seeder, $parameter, $value),
             'string' => $value,
             'array' => $this->castArraySeederParameter($seeder, $parameter, $value),
-            default => $value,
+            default => throw new InvalidArgumentException($unsupportedTypeMessage),
         };
     }
 

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -194,25 +194,23 @@ class SeedCommand extends Command
     {
         $trimmed = trim($value);
 
-        if ($trimmed !== '' && str_starts_with($trimmed, '[')) {
-            try {
-                $parsed = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
-            } catch (JsonException) {
-                throw new InvalidArgumentException(
-                    "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid JSON array.'
-                );
-            }
-
-            if (! is_array($parsed)) {
-                throw new InvalidArgumentException(
-                    "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid JSON array.'
-                );
-            }
-
-            return $parsed;
+        if ($trimmed === '' || ! str_starts_with($trimmed, '[')) {
+            return [$value];
         }
 
-        return [$value];
+        $invalidJsonArrayMessage = "The [{$parameter->getName()}] parameter for [".get_class($seeder).'] must be a valid JSON array.';
+
+        try {
+            $parsed = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new InvalidArgumentException($invalidJsonArrayMessage);
+        }
+
+        if (! is_array($parsed)) {
+            throw new InvalidArgumentException($invalidJsonArrayMessage);
+        }
+
+        return $parsed;
     }
 
     /**

--- a/tests/Database/DatabaseMigrationFreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationFreshCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Closure;
+use Illuminate\Database\Console\Migrations\FreshCommand;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class DatabaseMigrationFreshCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        FreshCommand::prohibit(false);
+
+        parent::tearDown();
+    }
+
+    public function testFreshCommandMayForwardWithOptionsToSeeder()
+    {
+        $params = [$migrator = m::mock(Migrator::class)];
+        $command = $this->getMockBuilder(FreshCommand::class)->onlyMethods(['call', 'callSilent'])->setConstructorArgs($params)->getMock();
+        $app = new ApplicationDatabaseFreshStub(['path.database' => __DIR__]);
+        $command->setLaravel($app);
+
+        $migrator->shouldReceive('usingConnection')->once()->with(null, m::type(Closure::class))->andReturnUsing(function ($connection, $callback) {
+            $callback();
+        });
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
+
+        $calls = [];
+
+        $command->method('call')->willReturnCallback(function ($commandName, array $arguments = []) use (&$calls) {
+            $calls[$commandName][] = $arguments;
+
+            return 0;
+        });
+        $command->expects($this->never())->method('callSilent');
+
+        $this->runCommand($command, ['--seed' => true, '--with' => ['count=10', 'active=true']]);
+
+        $this->assertSame([
+            '--class' => 'Database\\Seeders\\DatabaseSeeder',
+            '--force' => true,
+            '--with' => ['count=10', 'active=true'],
+        ], $calls['db:seed'][0] ?? null);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseFreshStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment(...$environments)
+    {
+        return 'development';
+    }
+}

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -135,6 +135,32 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $this->runCommand($command, ['--step' => true]);
     }
 
+    public function testWithOptionMayBeForwardedToSeeder()
+    {
+        $params = [$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)];
+        $command = $this->getMockBuilder(MigrateCommand::class)->onlyMethods(['call'])->setConstructorArgs($params)->getMock();
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $command->expects($this->once())->method('call')->with($this->equalTo('db:seed'), $this->equalTo([
+            '--class' => 'Database\\Seeders\\DatabaseSeeder',
+            '--force' => true,
+            '--with' => ['count=10', 'active=true'],
+        ]));
+
+        $this->runCommand($command, ['--seed' => true, '--with' => ['count=10', 'active=true']]);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new ArrayInput($input), new NullOutput);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -74,6 +74,44 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $this->runCommand($command, ['--step' => 2]);
     }
 
+    public function testRefreshCommandMayForwardWithOptionsToSeeder()
+    {
+        $command = new RefreshCommand;
+
+        $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
+        $command->setLaravel($app);
+        $command->setApplication($console);
+
+        $resetCommand = m::mock(ResetCommand::class);
+        $migrateCommand = m::mock(MigrateCommand::class);
+        $seedCommand = m::mock(\Illuminate\Database\Console\Seeds\SeedCommand::class);
+
+        $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
+        $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $console->shouldReceive('find')->with('db:seed')->andReturn($seedCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
+
+        $quote = DIRECTORY_SEPARATOR === '\\' ? '"' : "'";
+        $resetCommand->shouldReceive('run')->with(new InputMatcher("--force=1 {$quote}migrate:reset{$quote}"), m::any());
+        $migrateCommand->shouldReceive('run')->with(new InputMatcher('--force=1 migrate'), m::any());
+        $seedCommand->shouldReceive('run')->withArgs(function ($input, $output) {
+            $serializedInput = (string) $input;
+
+            return str_contains($serializedInput, 'db:seed')
+                && str_contains($serializedInput, '--class=')
+                && str_contains($serializedInput, 'Database\\Seeders\\DatabaseSeeder')
+                && str_contains($serializedInput, '--force=1')
+                && str_contains($serializedInput, '--with=')
+                && str_contains($serializedInput, 'count=10')
+                && str_contains($serializedInput, 'active=true');
+        });
+
+        $this->runCommand($command, ['--seed' => true, '--with' => ['count=10', 'active=true']]);
+    }
+
     public function testRefreshCommandExitsWhenProhibited()
     {
         $command = new RefreshCommand;

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -309,6 +309,48 @@ class SeedCommandTest extends TestCase
         $command->handle();
     }
 
+    public function testHandleThrowsExceptionForUnsupportedBuiltInSeederParameterType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to pass [items]');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandUnsupportedBuiltInParameterSeeder::class,
+            '--with' => ['items=value'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandUnsupportedBuiltInParameterSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandUnsupportedBuiltInParameterSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
     public function testHandleThrowsExceptionForInvalidIntegerParameter()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -689,6 +731,14 @@ class SeedCommandNonScalarParameterSeeder extends Seeder
 class SeedCommandArrayParameterSeeder extends Seeder
 {
     public function run(array $tags = [])
+    {
+        //
+    }
+}
+
+class SeedCommandUnsupportedBuiltInParameterSeeder extends Seeder
+{
+    public function run(iterable $items)
     {
         //
     }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -87,6 +87,64 @@ class SeedCommandTest extends TestCase
         ], SeedCommandExecutedWithDependencySeeder::$calledWith);
     }
 
+    public function testHandleExecutesSeederRunWithJsonArrayWithParameters()
+    {
+        SeedCommandExecutedArraySeeder::$calledWith = null;
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandExecutedArraySeeder::class,
+            '--with' => ['tags=["admin","staff"]'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn(null);
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = new SeedCommandTestApplication;
+        $container->instance(OutputStyle::class, $outputStyle);
+        $container->instance(Factory::class, new Factory($outputStyle));
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        $this->assertSame(['admin', 'staff'], SeedCommandExecutedArraySeeder::$calledWith);
+    }
+
+    public function testHandleExecutesSeederRunWithScalarArrayParameterFallback()
+    {
+        SeedCommandExecutedArraySeeder::$calledWith = null;
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandExecutedArraySeeder::class,
+            '--with' => ['tags=admin'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn(null);
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = new SeedCommandTestApplication;
+        $container->instance(OutputStyle::class, $outputStyle);
+        $container->instance(Factory::class, new Factory($outputStyle));
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        $this->assertSame(['admin'], SeedCommandExecutedArraySeeder::$calledWith);
+    }
+
     public function testHandle()
     {
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
@@ -335,6 +393,49 @@ class SeedCommandTest extends TestCase
         $command->handle();
     }
 
+    public function testHandleThrowsExceptionForInvalidJsonArrayParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [tags] parameter');
+        $this->expectExceptionMessage('must be a valid JSON array');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandArrayParameterSeeder::class,
+            '--with' => ['tags=[invalid'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandArrayParameterSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandArrayParameterSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
     public function testWithoutModelEvents()
     {
         $input = new ArrayInput([
@@ -549,6 +650,7 @@ class SeedCommandTest extends TestCase
     {
         SeedCommandExecutedSeeder::$calledWith = null;
         SeedCommandExecutedWithDependencySeeder::$calledWith = null;
+        SeedCommandExecutedArraySeeder::$calledWith = null;
 
         SeedCommand::prohibit(false);
 
@@ -584,6 +686,14 @@ class SeedCommandNonScalarParameterSeeder extends Seeder
     }
 }
 
+class SeedCommandArrayParameterSeeder extends Seeder
+{
+    public function run(array $tags = [])
+    {
+        //
+    }
+}
+
 class SeedCommandExecutedSeeder extends Seeder
 {
     public static ?array $calledWith = null;
@@ -608,6 +718,16 @@ class SeedCommandExecutedWithDependencySeeder extends Seeder
             'dependency' => get_class($dependency),
             'count' => $count,
         ];
+    }
+}
+
+class SeedCommandExecutedArraySeeder extends Seeder
+{
+    public static ?array $calledWith = null;
+
+    public function run(array $tags = [])
+    {
+        static::$calledWith = $tags;
     }
 }
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -15,12 +15,78 @@ use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Testing\Assert;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 class SeedCommandTest extends TestCase
 {
+    public function testHandleExecutesSeederRunWithCastedWithParameters()
+    {
+        SeedCommandExecutedSeeder::$calledWith = null;
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandExecutedSeeder::class,
+            '--with' => ['count=10', 'active=true', 'name=TestUser'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn(null);
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = new SeedCommandTestApplication;
+        $container->instance(OutputStyle::class, $outputStyle);
+        $container->instance(Factory::class, new Factory($outputStyle));
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        $this->assertSame([
+            'count' => 10,
+            'active' => true,
+            'name' => 'TestUser',
+        ], SeedCommandExecutedSeeder::$calledWith);
+    }
+
+    public function testHandleExecutesSeederRunWithContainerDependencyAndWithParameters()
+    {
+        SeedCommandExecutedWithDependencySeeder::$calledWith = null;
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandExecutedWithDependencySeeder::class,
+            '--with' => ['count=10'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once()->andReturn(null);
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = new SeedCommandTestApplication;
+        $container->instance(OutputStyle::class, $outputStyle);
+        $container->instance(Factory::class, new Factory($outputStyle));
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+
+        $this->assertSame([
+            'dependency' => SeedCommandDependency::class,
+            'count' => 10,
+        ], SeedCommandExecutedWithDependencySeeder::$calledWith);
+    }
+
     public function testHandle()
     {
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
@@ -56,6 +122,217 @@ class SeedCommandTest extends TestCase
         $command->handle();
 
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
+    }
+
+    public function testHandlePassesWithParametersToSeeder()
+    {
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandTypedParametersSeeder::class,
+            '--with' => ['count=10', 'active=true', 'name=TestUser'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandTypedParametersSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldReceive('__invoke')->once()->with([
+            'count' => 10,
+            'active' => true,
+            'name' => 'TestUser',
+        ]);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandTypedParametersSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
+    public function testHandleThrowsExceptionForUnknownSeederParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown seeder parameter [unknown]');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandTypedParametersSeeder::class,
+            '--with' => ['unknown=value'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandTypedParametersSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandTypedParametersSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
+    public function testHandleThrowsExceptionForNonScalarSeederParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to pass [date]');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandNonScalarParameterSeeder::class,
+            '--with' => ['date=2024-01-01'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandNonScalarParameterSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandNonScalarParameterSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
+    public function testHandleThrowsExceptionForInvalidIntegerParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [count] parameter');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandTypedParametersSeeder::class,
+            '--with' => ['count=abc'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandTypedParametersSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandTypedParametersSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
+    public function testHandleThrowsExceptionForInvalidBooleanParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [active] parameter');
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandTypedParametersSeeder::class,
+            '--with' => ['active=maybe'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $seeder = m::mock(new SeedCommandTypedParametersSeeder);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+        $seeder->shouldNotReceive('__invoke');
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandTypedParametersSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
     }
 
     public function testWithoutModelEvents()
@@ -133,8 +410,146 @@ class SeedCommandTest extends TestCase
         Assert::assertSame(Command::FAILURE, $command->handle());
     }
 
+    #[DataProvider('parseParametersProvider')]
+    public function testParseParameters($input, $expected)
+    {
+        $arrayInput = new ArrayInput(['--with' => $input]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($arrayInput, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldIgnoreMissing();
+
+        $container = m::mock(Container::class);
+        $container->shouldIgnoreMissing();
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn($outputStyle);
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+        $command->run($arrayInput, $output);
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('parseParameters');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($command);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testParseParametersThrowsExceptionForInvalidFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The --with option expects values in key=value format.');
+
+        $arrayInput = new ArrayInput(['--with' => ['invalidparam']]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($arrayInput, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldIgnoreMissing();
+
+        $container = m::mock(Container::class);
+        $container->shouldIgnoreMissing();
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn($outputStyle);
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+        $command->run($arrayInput, $output);
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('parseParameters');
+        $method->setAccessible(true);
+        $method->invoke($command);
+    }
+
+    public function testParseParametersThrowsExceptionForEmptyKeys()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The --with option expects non-empty keys.');
+
+        $arrayInput = new ArrayInput(['--with' => ['=orphaned-value']]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($arrayInput, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldIgnoreMissing();
+
+        $container = m::mock(Container::class);
+        $container->shouldIgnoreMissing();
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn($outputStyle);
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+        $command->run($arrayInput, $output);
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('parseParameters');
+        $method->setAccessible(true);
+        $method->invoke($command);
+    }
+
+    public static function parseParametersProvider()
+    {
+        return [
+            'multiple with options' => [
+                ['count=10', 'active=true', 'name=TestUser'],
+                ['count' => '10', 'active' => 'true', 'name' => 'TestUser'],
+            ],
+
+            'comma separated with options' => [
+                ['count=10,active=true,name=TestUser'],
+                ['count' => '10,active=true,name=TestUser'],
+            ],
+
+            'multiple values for the same key' => [
+                ['count=10', 'count=20'],
+                ['count' => '20'],
+            ],
+
+            'single with option' => [
+                ['count=10'],
+                ['count' => '10'],
+            ],
+
+            'spaces around equals' => [
+                ['count = 10', ' active = true '],
+                ['count' => '10', 'active' => 'true'],
+            ],
+
+            'value with equals' => [
+                ['url=https://example.com?param=value', 'query=SELECT * FROM users WHERE id=1'],
+                ['url' => 'https://example.com?param=value', 'query' => 'SELECT * FROM users WHERE id=1'],
+            ],
+
+            'empty values' => [
+                ['key=', 'another='],
+                ['key' => '', 'another' => ''],
+            ],
+
+            'no parameters' => [
+                [],
+                [],
+            ],
+
+            'complex values' => [
+                ['json={"key":"value","nested":{"prop":"val"}}', 'csv=val1,val2,val3', 'path=/var/www/html'],
+                ['json' => '{"key":"value","nested":{"prop":"val"}}', 'csv' => 'val1,val2,val3', 'path' => '/var/www/html'],
+            ],
+        ];
+    }
+
     protected function tearDown(): void
     {
+        SeedCommandExecutedSeeder::$calledWith = null;
+        SeedCommandExecutedWithDependencySeeder::$calledWith = null;
+
         SeedCommand::prohibit(false);
 
         Model::unsetEventDispatcher();
@@ -150,5 +565,66 @@ class UserWithoutModelEventsSeeder extends Seeder
     public function run()
     {
         Assert::assertInstanceOf(NullDispatcher::class, Model::getEventDispatcher());
+    }
+}
+
+class SeedCommandTypedParametersSeeder extends Seeder
+{
+    public function run(int $count = 0, bool $active = false, string $name = '')
+    {
+        //
+    }
+}
+
+class SeedCommandNonScalarParameterSeeder extends Seeder
+{
+    public function run(\DateTime $date)
+    {
+        //
+    }
+}
+
+class SeedCommandExecutedSeeder extends Seeder
+{
+    public static ?array $calledWith = null;
+
+    public function run(int $count = 0, bool $active = false, string $name = '')
+    {
+        static::$calledWith = [
+            'count' => $count,
+            'active' => $active,
+            'name' => $name,
+        ];
+    }
+}
+
+class SeedCommandExecutedWithDependencySeeder extends Seeder
+{
+    public static ?array $calledWith = null;
+
+    public function run(SeedCommandDependency $dependency, int $count = 0)
+    {
+        static::$calledWith = [
+            'dependency' => get_class($dependency),
+            'count' => $count,
+        ];
+    }
+}
+
+class SeedCommandDependency
+{
+    //
+}
+
+class SeedCommandTestApplication extends Container
+{
+    public function environment(...$environments)
+    {
+        return 'testing';
+    }
+
+    public function runningUnitTests()
+    {
+        return true;
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -351,6 +351,45 @@ class SeedCommandTest extends TestCase
         $command->handle();
     }
 
+    public function testHandleThrowsExceptionWhenRunMethodIsMissingAndWithParametersAreProvided()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Method [run] missing from '.SeedCommandMissingRunMethodSeeder::class);
+
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => SeedCommandMissingRunMethodSeeder::class,
+            '--with' => ['count=10'],
+        ]);
+        $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('runningUnitTests')->andReturn('true');
+        $container->shouldReceive('make')->with(SeedCommandMissingRunMethodSeeder::class)->andReturn(
+            new SeedCommandMissingRunMethodSeeder
+        );
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+    }
+
     public function testHandleThrowsExceptionForInvalidIntegerParameter()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -739,6 +778,11 @@ class SeedCommandUnsupportedBuiltInParameterSeeder extends Seeder
     {
         //
     }
+}
+
+class SeedCommandMissingRunMethodSeeder extends Seeder
+{
+    //
 }
 
 class SeedCommandExecutedSeeder extends Seeder

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -575,7 +575,6 @@ class SeedCommandTest extends TestCase
 
         $reflection = new \ReflectionClass($command);
         $method = $reflection->getMethod('parseParameters');
-        $method->setAccessible(true);
 
         $result = $method->invoke($command);
 
@@ -606,7 +605,6 @@ class SeedCommandTest extends TestCase
 
         $reflection = new \ReflectionClass($command);
         $method = $reflection->getMethod('parseParameters');
-        $method->setAccessible(true);
         $method->invoke($command);
     }
 
@@ -634,7 +632,6 @@ class SeedCommandTest extends TestCase
 
         $reflection = new \ReflectionClass($command);
         $method = $reflection->getMethod('parseParameters');
-        $method->setAccessible(true);
         $method->invoke($command);
     }
 


### PR DESCRIPTION
## Summary

`Seeder` has long supported receiving parameters internally, but there has never been a first-class console implementation for passing and resolving those values from `artisan` commands.  
This PR fills that gap by introducing an elegant `--with` flow for seeding, with safe casting to supported parameter types: `int`, `float`, `bool`, `string`, and `array`.

## Why This Is Needed

In our case, we needed to generate different seeded datasets quickly to validate chart behavior (small, medium, large, skewed, etc.) without rewriting seeders each time. This PR makes that workflow fast and repeatable from the CLI.

## What This PR Adds

- Adds repeatable `--with` support to seeding commands using `key=value` pairs.
- Resolves parameters against the target seeder `run()` signature.
- Casts values based on supported built-in parameter types:
- `int`, `float`, `bool`, `string` & `array`
- Supports arrays via JSON array input, with scalar fallback to single-item arrays.
- Forwards `--with` to seeding when using:
- `migrate --seed`
- `migrate:fresh --seed`
- `migrate:refresh --seed`

## Validation Behaviour

- Fails fast on malformed `--with` input.
- Fails on unknown parameter names.
- Fails on invalid scalar casts (invalid int/float/bool).
- Fails when non-supported parameter types are targeted.
- Fails on invalid JSON when an array parameter is provided as JSON.
- Fails when unsupported parameter types are targeted.

## Examples

```bash
php artisan db:seed --class=DynamicUserSeeder \
  --with count=10 \
  --with active=false \
  --with role=admin \
  --with credits=42.75 \
  --with 'tags=["admin","staff"]'
```