### PR TITLE
[12.x] Support brick/math 0.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.11|^0.12|^0.13|^0.14",
+        "brick/math": "^0.11|^0.12|^0.13|^0.14|^0.15",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^3.2.1|^4.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2",
         "ext-pdo": "*",
-        "brick/math": "^0.11|^0.12|^0.13|^0.14",
+        "brick/math": "^0.11|^0.12|^0.13|^0.14|^0.15",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.11|^0.12|^0.13|^0.14",
+        "brick/math": "^0.11|^0.12|^0.13|^0.14|^0.15",
         "egulias/email-validator": "^3.2.5|^4.0",
         "illuminate/collections": "^12.0",
         "illuminate/container": "^12.0",


### PR DESCRIPTION
This PR allows [brick/math 0.15](https://github.com/brick/math/releases/tag/0.15.0)