### PR TITLE
[13.x] Add ability to set channel name via Log contextual attribute

### DIFF
--- a/src/Illuminate/Container/Attributes/Log.php
+++ b/src/Illuminate/Container/Attributes/Log.php
@@ -32,6 +32,7 @@ class Log implements ContextualAttribute
     public static function resolve(self $attribute, Container $container)
     {
         $logger = $container->make('log')->channel(enum_value($attribute->channel));
+
         if ($attribute->name !== null) {
             $logger = $logger->withName(enum_value($attribute->name));
         }

--- a/src/Illuminate/Container/Attributes/Log.php
+++ b/src/Illuminate/Container/Attributes/Log.php
@@ -11,9 +11,13 @@ class Log implements ContextualAttribute
 {
     /**
      * Create a new class instance.
+     * @param  string|null  $channel  The log configuration's channel name.
+     * @param  string|null  $name  The name to prefix all logs with. Only to be used with Monolog drivers.
      */
-    public function __construct(public ?string $channel = null)
-    {
+    public function __construct(
+        public ?string $channel = null,
+        public ?string $name = null,
+    ) {
     }
 
     /**
@@ -25,6 +29,11 @@ class Log implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container)
     {
-        return $container->make('log')->channel($attribute->channel);
+        $logger = $container->make('log')->channel($attribute->channel);
+        if ($attribute->name !== null) {
+            $logger = $logger->withName($attribute->name);
+        }
+
+        return $logger;
     }
 }

--- a/src/Illuminate/Container/Attributes/Log.php
+++ b/src/Illuminate/Container/Attributes/Log.php
@@ -13,12 +13,12 @@ class Log implements ContextualAttribute
 {
     /**
      * Create a new class instance.
-     * @param  string|UnitEnum|null  $channel  The log configuration's channel name.
-     * @param  string|UnitEnum|null  $name  The name to prefix all logs with. Only to be used with Monolog drivers.
+     * @param  UnitEnum|string|null  $channel  The log configuration's channel name.
+     * @param  UnitEnum|string|null  $name  The name to prefix all logs with. Only to be used with Monolog drivers.
      */
     public function __construct(
-        public string|UnitEnum|null $channel = null,
-        public string|UnitEnum|null $name = null,
+        public UnitEnum|string|null $channel = null,
+        public UnitEnum|string|null $name = null,
     ) {
     }
 

--- a/src/Illuminate/Container/Attributes/Log.php
+++ b/src/Illuminate/Container/Attributes/Log.php
@@ -5,18 +5,20 @@ namespace Illuminate\Container\Attributes;
 use Attribute;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
+use UnitEnum;
+use function Illuminate\Support\enum_value;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Log implements ContextualAttribute
 {
     /**
      * Create a new class instance.
-     * @param  string|null  $channel  The log configuration's channel name.
-     * @param  string|null  $name  The name to prefix all logs with. Only to be used with Monolog drivers.
+     * @param  string|UnitEnum|null  $channel  The log configuration's channel name.
+     * @param  string|UnitEnum|null  $name  The name to prefix all logs with. Only to be used with Monolog drivers.
      */
     public function __construct(
-        public ?string $channel = null,
-        public ?string $name = null,
+        public string|UnitEnum|null $channel = null,
+        public string|UnitEnum|null $name = null,
     ) {
     }
 
@@ -29,9 +31,9 @@ class Log implements ContextualAttribute
      */
     public static function resolve(self $attribute, Container $container)
     {
-        $logger = $container->make('log')->channel($attribute->channel);
+        $logger = $container->make('log')->channel(enum_value($attribute->channel));
         if ($attribute->name !== null) {
-            $logger = $logger->withName($attribute->name);
+            $logger = $logger->withName(enum_value($attribute->name));
         }
 
         return $logger;

--- a/tests/Integration/Container/ContextualAttributesBindingIntegrationTest.php
+++ b/tests/Integration/Container/ContextualAttributesBindingIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Container;
+
+use Illuminate\Container\Attributes\Log;
+use Illuminate\Support\Collection;
+use Monolog\Handler\TestHandler;
+use Monolog\LogRecord;
+use Orchestra\Testbench\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ContextualAttributesBindingIntegrationTest extends TestCase
+{
+    public function testLogAttributeCanSetName()
+    {
+        config(['logging.default' => 'testing']);
+        config(['logging.channels' => [
+            'testing' => [
+                'driver' => 'monolog',
+                'handler' => TestHandler::class,
+            ],
+        ]]);
+
+        /** @var TestHandler $testHandler */
+        $testHandler = resolve('log')->driver()->getLogger()->getHandlers()[0];
+
+        $tester = resolve(LogAttributeTester::class);
+        $tester->log('hello');
+        $tester->logWithName('bye');
+
+        $records = new Collection($testHandler->getRecords());
+
+        $this->assertCount(2, $records);
+        $this->assertEquals('hello', $records->firstWhere(function (LogRecord $record) {
+            return $record->channel === 'testing';
+        })->message);
+        $this->assertEquals('bye', $records->firstWhere(function (LogRecord $record) {
+            return $record->channel === 'look-ma-a-channel-name';
+        })->message);
+    }
+}
+
+class LogAttributeTester
+{
+    public function __construct(
+        #[Log('testing')]
+        public LoggerInterface $logger,
+        #[Log('testing', 'look-ma-a-channel-name')]
+        public LoggerInterface $loggerWithName
+    ) {
+    }
+
+    public function log(string $line)
+    {
+        $this->logger->info($line);
+    }
+
+    public function logWithName(string $line)
+    {
+        $this->loggerWithName->info($line);
+    }
+}


### PR DESCRIPTION
Channel names in logs is massively underrated.

### Why I Use Channel Names
It's much easier to query DataDog by channel name than just a string. It keeps all of those logs grouped together for easier contextual understanding. I would even wager a guess this makes it easier for AI to grep logs, but citation needed on that.

If you aren't using channel names, then you might be writing log line with something like `ProcessPayment - payment created` and then querying by the `ProcessPayment` prefix 😢 It's also irritating to remember to add these. 

### But can't you just...
Monolog's `Logger` is immutable, so when you call `Logger::withName()` you actually create a new instance.

```php
class ProcessPayment
{
    private readonly LoggerInterface $logger;

    public function __construct(
        #[Log] LoggerInterface $logger
    ) {
        $this->logger = $logger->withName('ProcessPayment');
    }

    public function __invoke()
    {
        $this->logger->debug('Validating payment');
        // ...
    }
}
```

That's kind of ugly and tedious.

With this PR, we could just write:

```php
class ProcessPayment
{
    private readonly LoggerInterface $logger;

    public function __construct(
        #[Log(name: 'ProcessPayment')]
        private readonly LoggerInterface $logger
    ) {
    }
}
```