### PR TITLE
 [12.x] Add typed getters for strings and integers to Config Repository 

### DIFF
--- a/src/Illuminate/Config/ConfigIntType.php
+++ b/src/Illuminate/Config/ConfigIntType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Config;
+
+enum ConfigIntType: string
+{
+    case DEFAULT = 'default';
+    case POSITIVE = 'positive';
+    case NEGATIVE = 'negative';
+    case NON_POSITIVE = 'nonPositive';
+    case NON_NEGATIVE = 'nonNegative';
+    case NON_ZERO = 'nonZero';
+}

--- a/src/Illuminate/Config/ConfigStringType.php
+++ b/src/Illuminate/Config/ConfigStringType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Config;
+
+enum ConfigStringType: string
+{
+    case DEFAULT = 'default';
+    case NON_EMPTY = 'nonEmpty';
+    case NON_FALSY = 'nonFalsy';
+    case LOWERCASE = 'lowercase';
+    case UPPERCASE = 'uppercase';
+}

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -22,8 +22,6 @@ class Repository implements ArrayAccess, ConfigContract
 
     /**
      * Create a new configuration repository.
-     *
-     * @param  array  $items
      */
     public function __construct(array $items = [])
     {
@@ -81,9 +79,7 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get the specified string configuration value.
      *
-     * @param  string  $key
      * @param  (\Closure():(string|null))|string|null  $default
-     * @return string
      *
      * @throws \InvalidArgumentException
      */
@@ -101,11 +97,93 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified string configuration value.
+     *
+     * @param  (\Closure():(string|null))|string|null  $default
+     * @return non-empty-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nonEmptyString(string $key, $default = null): string
+    {
+        $value = $this->string($key, $default);
+
+        if (trim($value) === '') {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a non empty string, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified string configuration value.
+     *
+     * @param  (\Closure():(string|null))|string|null  $default
+     * @return non-falsy-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nonFalsyString(string $key, $default = null): string
+    {
+        $value = $this->string($key, $default);
+
+        if (! (bool) $value) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a non falsy string, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified string configuration value.
+     *
+     * @param  (\Closure():(string|null))|string|null  $default
+     * @return lowercase-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function lowerCaseString(string $key, $default = null): string
+    {
+        $value = $this->string($key, $default);
+
+        if (strtolower($value) !== $value) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a lower case string, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified string configuration value.
+     *
+     * @param  (\Closure():(string|null))|string|null  $default
+     * @return uppercase-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function upperCaseString(string $key, $default = null): string
+    {
+        $value = $this->string($key, $default);
+
+        if (strtoupper($value) !== $value) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be a upper case string, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the specified integer configuration value.
      *
-     * @param  string  $key
      * @param  (\Closure():(int|null))|int|null  $default
-     * @return int
      *
      * @throws \InvalidArgumentException
      */
@@ -123,11 +201,114 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified integer configuration value.
+     *
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return positive-int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function positiveInteger(string $key, $default = null): int
+    {
+        $value = $this->integer($key, $default);
+
+        if ($value <= 0) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an positive integer, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer configuration value.
+     *
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return negative-int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function negativeInteger(string $key, $default = null): int
+    {
+        $value = $this->integer($key, $default);
+
+        if ($value >= 0) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an negative integer, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer configuration value.
+     *
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return non-positive-int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nonPositiveInteger(string $key, $default = null): int
+    {
+        $value = $this->integer($key, $default);
+
+        if ($value > 0) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an non positive integer, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer configuration value.
+     *
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return non-negative-int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nonNegativeInteger(string $key, $default = null): int
+    {
+        $value = $this->integer($key, $default);
+
+        if ($value < 0) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an non negative integer, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the specified integer configuration value.
+     *
+     * @param  (\Closure():(int|null))|int|null  $default
+     * @return non-zero-int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nonZeroInteger(string $key, $default = null): int
+    {
+        $value = $this->integer($key, $default);
+
+        if ($value === 0) {
+            throw new InvalidArgumentException(
+                sprintf('Configuration value for key [%s] must be an non zero integer, %s given.', $key, $value)
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the specified float configuration value.
      *
-     * @param  string  $key
      * @param  (\Closure():(float|null))|float|null  $default
-     * @return float
      *
      * @throws \InvalidArgumentException
      */
@@ -147,9 +328,7 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get the specified boolean configuration value.
      *
-     * @param  string  $key
      * @param  (\Closure():(bool|null))|bool|null  $default
-     * @return bool
      *
      * @throws \InvalidArgumentException
      */
@@ -169,7 +348,6 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get the specified array configuration value.
      *
-     * @param  string  $key
      * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
      * @return array<array-key, mixed>
      *
@@ -191,7 +369,6 @@ class Repository implements ArrayAccess, ConfigContract
     /**
      * Get the specified array configuration value as a collection.
      *
-     * @param  string  $key
      * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
      * @return Collection<array-key, mixed>
      */
@@ -262,7 +439,6 @@ class Repository implements ArrayAccess, ConfigContract
      * Determine if the given configuration option exists.
      *
      * @param  string  $key
-     * @return bool
      */
     public function offsetExists($key): bool
     {
@@ -273,7 +449,6 @@ class Repository implements ArrayAccess, ConfigContract
      * Get a configuration option.
      *
      * @param  string  $key
-     * @return mixed
      */
     public function offsetGet($key): mixed
     {
@@ -285,7 +460,6 @@ class Repository implements ArrayAccess, ConfigContract
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
      */
     public function offsetSet($key, $value): void
     {
@@ -296,7 +470,6 @@ class Repository implements ArrayAccess, ConfigContract
      * Unset a configuration option.
      *
      * @param  string  $key
-     * @return void
      */
     public function offsetUnset($key): void
     {

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -110,7 +110,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if (trim($value) === '') {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non empty string, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a non-empty string, %s given.', $key, $value)
             );
         }
 
@@ -131,7 +131,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if (! (bool) $value) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non falsy string, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a non-falsy string, %s given.', $key, $value)
             );
         }
 
@@ -152,7 +152,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if (strtolower($value) !== $value) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a lower case string, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a lowercase string, %s given.', $key, $value)
             );
         }
 
@@ -173,7 +173,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if (strtoupper($value) !== $value) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a upper case string, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be an uppercase string, %s given.', $key, $value)
             );
         }
 
@@ -214,7 +214,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if ($value <= 0) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an positive integer, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a positive integer, %s given.', $key, $value)
             );
         }
 
@@ -235,7 +235,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if ($value >= 0) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an negative integer, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a negative integer, %s given.', $key, $value)
             );
         }
 
@@ -256,7 +256,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if ($value > 0) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an non positive integer, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a non-positive integer, %s given.', $key, $value)
             );
         }
 
@@ -277,7 +277,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if ($value < 0) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an non negative integer, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a non-negative integer, %s given.', $key, $value)
             );
         }
 
@@ -298,7 +298,7 @@ class Repository implements ArrayAccess, ConfigContract
 
         if ($value === 0) {
             throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an non zero integer, %s given.', $key, $value)
+                sprintf('Configuration value for key [%s] must be a non-zero integer, %s given.', $key, $value)
             );
         }
 

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -77,13 +77,19 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
-     * Get the specified string configuration value.
+     * Get the specified string configuration value with optional type validation.
      *
      * @param  (\Closure():(string|null))|string|null  $default
+     * @return (
+     *     $type is ConfigStringType::DEFAULT ? string :
+     *     ($type is ConfigStringType::NON_EMPTY ? non-empty-string :
+     *     ($type is ConfigStringType::NON_FALSY ? non-falsy-string :
+     *     ($type is ConfigStringType::LOWERCASE ? lowercase-string : uppercase-string)))
+     * )
      *
      * @throws \InvalidArgumentException
      */
-    public function string(string $key, $default = null): string
+    public function string(string $key, $default = null, ConfigStringType $type = ConfigStringType::DEFAULT): string
     {
         $value = $this->get($key, $default);
 
@@ -93,101 +99,64 @@ class Repository implements ArrayAccess, ConfigContract
             );
         }
 
-        return $value;
-    }
+        if ($type === ConfigStringType::NON_EMPTY) {
+            if (trim($value) === '') {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-empty string, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified string configuration value.
-     *
-     * @param  (\Closure():(string|null))|string|null  $default
-     * @return non-empty-string
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function nonEmptyString(string $key, $default = null): string
-    {
-        $value = $this->string($key, $default);
+            return $value;
+        }
 
-        if (trim($value) === '') {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non-empty string, %s given.', $key, $value)
-            );
+        if ($type === ConfigStringType::NON_FALSY) {
+            if (! (bool) $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-falsy string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigStringType::LOWERCASE) {
+            if (strtolower($value) !== $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a lowercase string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigStringType::UPPERCASE) {
+            if (strtoupper($value) !== $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be an uppercase string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
         }
 
         return $value;
     }
 
     /**
-     * Get the specified string configuration value.
-     *
-     * @param  (\Closure():(string|null))|string|null  $default
-     * @return non-falsy-string
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function nonFalsyString(string $key, $default = null): string
-    {
-        $value = $this->string($key, $default);
-
-        if (! (bool) $value) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non-falsy string, %s given.', $key, $value)
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified string configuration value.
-     *
-     * @param  (\Closure():(string|null))|string|null  $default
-     * @return lowercase-string
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function lowerCaseString(string $key, $default = null): string
-    {
-        $value = $this->string($key, $default);
-
-        if (strtolower($value) !== $value) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a lowercase string, %s given.', $key, $value)
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified string configuration value.
-     *
-     * @param  (\Closure():(string|null))|string|null  $default
-     * @return uppercase-string
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function upperCaseString(string $key, $default = null): string
-    {
-        $value = $this->string($key, $default);
-
-        if (strtoupper($value) !== $value) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be an uppercase string, %s given.', $key, $value)
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get the specified integer configuration value.
+     * Get the specified integer configuration value with optional type validation.
      *
      * @param  (\Closure():(int|null))|int|null  $default
+     * @return (
+     *     $type is ConfigIntType::DEFAULT ? int :
+     *     ($type is ConfigIntType::POSITIVE ? positive-int :
+     *     ($type is ConfigIntType::NEGATIVE ? negative-int :
+     *     ($type is ConfigIntType::NON_POSITIVE ? non-positive-int :
+     *     ($type is ConfigIntType::NON_NEGATIVE ? non-negative-int : non-zero-int))))
+     * )
      *
      * @throws \InvalidArgumentException
      */
-    public function integer(string $key, $default = null): int
+    public function integer(string $key, $default = null, ConfigIntType $type = ConfigIntType::DEFAULT): int
     {
         $value = $this->get($key, $default);
 
@@ -197,109 +166,54 @@ class Repository implements ArrayAccess, ConfigContract
             );
         }
 
-        return $value;
-    }
+        if ($type === ConfigIntType::POSITIVE) {
+            if ($value <= 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a positive integer, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified integer configuration value.
-     *
-     * @param  (\Closure():(int|null))|int|null  $default
-     * @return positive-int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function positiveInteger(string $key, $default = null): int
-    {
-        $value = $this->integer($key, $default);
-
-        if ($value <= 0) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a positive integer, %s given.', $key, $value)
-            );
+            return $value;
         }
 
-        return $value;
-    }
+        if ($type === ConfigIntType::NEGATIVE) {
+            if ($value >= 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a negative integer, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified integer configuration value.
-     *
-     * @param  (\Closure():(int|null))|int|null  $default
-     * @return negative-int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function negativeInteger(string $key, $default = null): int
-    {
-        $value = $this->integer($key, $default);
-
-        if ($value >= 0) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a negative integer, %s given.', $key, $value)
-            );
+            return $value;
         }
 
-        return $value;
-    }
+        if ($type === ConfigIntType::NON_POSITIVE) {
+            if ($value > 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-positive integer, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified integer configuration value.
-     *
-     * @param  (\Closure():(int|null))|int|null  $default
-     * @return non-positive-int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function nonPositiveInteger(string $key, $default = null): int
-    {
-        $value = $this->integer($key, $default);
-
-        if ($value > 0) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non-positive integer, %s given.', $key, $value)
-            );
+            return $value;
         }
 
-        return $value;
-    }
+        if ($type === ConfigIntType::NON_NEGATIVE) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-negative integer, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified integer configuration value.
-     *
-     * @param  (\Closure():(int|null))|int|null  $default
-     * @return non-negative-int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function nonNegativeInteger(string $key, $default = null): int
-    {
-        $value = $this->integer($key, $default);
-
-        if ($value < 0) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non-negative integer, %s given.', $key, $value)
-            );
+            return $value;
         }
 
-        return $value;
-    }
+        if ($type === ConfigIntType::NON_ZERO) {
+            if ($value === 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-zero integer, %s given.', $key, $value)
+                );
+            }
 
-    /**
-     * Get the specified integer configuration value.
-     *
-     * @param  (\Closure():(int|null))|int|null  $default
-     * @return non-zero-int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function nonZeroInteger(string $key, $default = null): int
-    {
-        $value = $this->integer($key, $default);
-
-        if ($value === 0) {
-            throw new InvalidArgumentException(
-                sprintf('Configuration value for key [%s] must be a non-zero integer, %s given.', $key, $value)
-            );
+            return $value;
         }
 
         return $value;

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -29,6 +29,13 @@ class RepositoryTest extends TestCase
             'boolean' => true,
             'integer' => 1,
             'float' => 1.1,
+            'empty_string' => '',
+            'falsy_string' => '0',
+            'lowercase_string' => 'bar',
+            'mixedcase_string' => 'Bar',
+            'uppercase_string' => 'BAR',
+            'zero_integer' => 0,
+            'negative_integer' => -1,
             'associate' => [
                 'x' => 'xxx',
                 'y' => 'yyy',
@@ -371,5 +378,124 @@ class RepositoryTest extends TestCase
         $this->expectExceptionMessageMatches('#^Configuration value for key \[a.b\] must be a float, (.*) given.#');
 
         $this->repository->float('a.b');
+    }
+
+    public function testItGetsAsNonEmptyString(): void
+    {
+        $this->assertSame('bar', $this->repository->nonEmptyString('foo'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetEmptyStringAsNonEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[empty_string\] must be a non-empty string, (.*) given.#');
+
+        $this->repository->nonEmptyString('empty_string');
+    }
+
+    public function testItGetsAsNonFalsyString(): void
+    {
+        $this->assertSame('bar', $this->repository->nonFalsyString('foo'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetFalsyStringAsNonFalsyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[falsy_string\] must be a non-falsy string, (.*) given.#');
+
+        $this->repository->nonFalsyString('falsy_string');
+    }
+
+    public function testItGetsAsLowerCaseString(): void
+    {
+        $this->assertSame('bar', $this->repository->lowerCaseString('foo'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonLowerCaseStringAsLowerCaseString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[mixedcase_string\] must be a lowercase string, (.*) given.#');
+
+        $this->repository->lowerCaseString('mixedcase_string');
+    }
+
+    public function testItGetsAsUpperCaseString(): void
+    {
+        $this->assertSame('BAR', $this->repository->upperCaseString('uppercase_string'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonUpperCaseStringAsUpperCaseString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[foo\] must be an uppercase string, (.*) given.#');
+
+        $this->repository->upperCaseString('foo');
+    }
+
+    public function testItGetsAsPositiveInteger(): void
+    {
+        $this->assertSame(1, $this->repository->positiveInteger('integer'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonPositiveIntegerAsPositiveInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a positive integer, (.*) given.#');
+
+        $this->repository->positiveInteger('zero_integer');
+    }
+
+    public function testItGetsAsNegativeInteger(): void
+    {
+        $this->assertSame(-1, $this->repository->negativeInteger('negative_integer'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonNegativeIntegerAsNegativeInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a negative integer, (.*) given.#');
+
+        $this->repository->negativeInteger('integer');
+    }
+
+    public function testItGetsAsNonPositiveInteger(): void
+    {
+        $this->assertSame(0, $this->repository->nonPositiveInteger('zero_integer'));
+        $this->assertSame(-1, $this->repository->nonPositiveInteger('negative_integer'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetPositiveIntegerAsNonPositiveInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a non-positive integer, (.*) given.#');
+
+        $this->repository->nonPositiveInteger('integer');
+    }
+
+    public function testItGetsAsNonNegativeInteger(): void
+    {
+        $this->assertSame(1, $this->repository->nonNegativeInteger('integer'));
+        $this->assertSame(0, $this->repository->nonNegativeInteger('zero_integer'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNegativeIntegerAsNonNegativeInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[negative_integer\] must be a non-negative integer, (.*) given.#');
+
+        $this->repository->nonNegativeInteger('negative_integer');
+    }
+
+    public function testItGetsAsNonZeroInteger(): void
+    {
+        $this->assertSame(1, $this->repository->nonZeroInteger('integer'));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetZeroAsNonZeroInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a non-zero integer, (.*) given.#');
+
+        $this->repository->nonZeroInteger('zero_integer');
     }
 }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Config;
 
+use Illuminate\Config\ConfigIntType;
+use Illuminate\Config\ConfigStringType;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
@@ -299,9 +301,8 @@ class RepositoryTest extends TestCase
 
     public function testItGetsAsString(): void
     {
-        $this->assertSame(
-            'c', $this->repository->string('a.b')
-        );
+        $this->assertSame('c', $this->repository->string('a.b'));
+        $this->assertSame('c', $this->repository->string('a.b', null, ConfigStringType::DEFAULT));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
@@ -352,9 +353,8 @@ class RepositoryTest extends TestCase
 
     public function testItGetsAsInteger(): void
     {
-        $this->assertSame(
-            $this->repository->integer('integer'), 1
-        );
+        $this->assertSame(1, $this->repository->integer('integer'));
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::DEFAULT));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonIntegerValueAsInteger(): void
@@ -382,7 +382,7 @@ class RepositoryTest extends TestCase
 
     public function testItGetsAsNonEmptyString(): void
     {
-        $this->assertSame('bar', $this->repository->nonEmptyString('foo'));
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::NON_EMPTY));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetEmptyStringAsNonEmptyString(): void
@@ -390,12 +390,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[empty_string\] must be a non-empty string, (.*) given.#');
 
-        $this->repository->nonEmptyString('empty_string');
+        $this->repository->string('empty_string', null, ConfigStringType::NON_EMPTY);
     }
 
     public function testItGetsAsNonFalsyString(): void
     {
-        $this->assertSame('bar', $this->repository->nonFalsyString('foo'));
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::NON_FALSY));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetFalsyStringAsNonFalsyString(): void
@@ -403,12 +403,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[falsy_string\] must be a non-falsy string, (.*) given.#');
 
-        $this->repository->nonFalsyString('falsy_string');
+        $this->repository->string('falsy_string', null, ConfigStringType::NON_FALSY);
     }
 
     public function testItGetsAsLowerCaseString(): void
     {
-        $this->assertSame('bar', $this->repository->lowerCaseString('foo'));
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::LOWERCASE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonLowerCaseStringAsLowerCaseString(): void
@@ -416,12 +416,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[mixedcase_string\] must be a lowercase string, (.*) given.#');
 
-        $this->repository->lowerCaseString('mixedcase_string');
+        $this->repository->string('mixedcase_string', null, ConfigStringType::LOWERCASE);
     }
 
     public function testItGetsAsUpperCaseString(): void
     {
-        $this->assertSame('BAR', $this->repository->upperCaseString('uppercase_string'));
+        $this->assertSame('BAR', $this->repository->string('uppercase_string', null, ConfigStringType::UPPERCASE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonUpperCaseStringAsUpperCaseString(): void
@@ -429,12 +429,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[foo\] must be an uppercase string, (.*) given.#');
 
-        $this->repository->upperCaseString('foo');
+        $this->repository->string('foo', null, ConfigStringType::UPPERCASE);
     }
 
     public function testItGetsAsPositiveInteger(): void
     {
-        $this->assertSame(1, $this->repository->positiveInteger('integer'));
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::POSITIVE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonPositiveIntegerAsPositiveInteger(): void
@@ -442,12 +442,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a positive integer, (.*) given.#');
 
-        $this->repository->positiveInteger('zero_integer');
+        $this->repository->integer('zero_integer', null, ConfigIntType::POSITIVE);
     }
 
     public function testItGetsAsNegativeInteger(): void
     {
-        $this->assertSame(-1, $this->repository->negativeInteger('negative_integer'));
+        $this->assertSame(-1, $this->repository->integer('negative_integer', null, ConfigIntType::NEGATIVE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonNegativeIntegerAsNegativeInteger(): void
@@ -455,13 +455,13 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a negative integer, (.*) given.#');
 
-        $this->repository->negativeInteger('integer');
+        $this->repository->integer('integer', null, ConfigIntType::NEGATIVE);
     }
 
     public function testItGetsAsNonPositiveInteger(): void
     {
-        $this->assertSame(0, $this->repository->nonPositiveInteger('zero_integer'));
-        $this->assertSame(-1, $this->repository->nonPositiveInteger('negative_integer'));
+        $this->assertSame(0, $this->repository->integer('zero_integer', null, ConfigIntType::NON_POSITIVE));
+        $this->assertSame(-1, $this->repository->integer('negative_integer', null, ConfigIntType::NON_POSITIVE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetPositiveIntegerAsNonPositiveInteger(): void
@@ -469,13 +469,13 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a non-positive integer, (.*) given.#');
 
-        $this->repository->nonPositiveInteger('integer');
+        $this->repository->integer('integer', null, ConfigIntType::NON_POSITIVE);
     }
 
     public function testItGetsAsNonNegativeInteger(): void
     {
-        $this->assertSame(1, $this->repository->nonNegativeInteger('integer'));
-        $this->assertSame(0, $this->repository->nonNegativeInteger('zero_integer'));
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::NON_NEGATIVE));
+        $this->assertSame(0, $this->repository->integer('zero_integer', null, ConfigIntType::NON_NEGATIVE));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNegativeIntegerAsNonNegativeInteger(): void
@@ -483,12 +483,12 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[negative_integer\] must be a non-negative integer, (.*) given.#');
 
-        $this->repository->nonNegativeInteger('negative_integer');
+        $this->repository->integer('negative_integer', null, ConfigIntType::NON_NEGATIVE);
     }
 
     public function testItGetsAsNonZeroInteger(): void
     {
-        $this->assertSame(1, $this->repository->nonZeroInteger('integer'));
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::NON_ZERO));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetZeroAsNonZeroInteger(): void
@@ -496,6 +496,6 @@ class RepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a non-zero integer, (.*) given.#');
 
-        $this->repository->nonZeroInteger('zero_integer');
+        $this->repository->integer('zero_integer', null, ConfigIntType::NON_ZERO);
     }
 }


### PR DESCRIPTION
These changes are mainly useful for people using static analysers (PHPStan, Psalm, and similar).

Many libraries expose APIs that require you to narrow types first: checking that strings are non-empty, and so on. That’s cumbersome and repetitive.

Stricter types also help reduce the chance of bugs.

**Example:**
There’s no need to manually check whether a string is empty. Static analysers stop reporting errors and warnings:

```php
$nonEmptyStringValue = config()->nonEmptyString('test.non_empty_value');
$this->nonEmptyStringCheck($nonEmptyStringValue);

/**
 * @param  non-empty-string  $value
 * @return non-empty-string
 */
private function nonEmptyStringCheck(string $value): string
{
    return $value;
}
```