### PR TITLE
[12.x] Introduce `php artisan db:open` command

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\ConfigurationUrlParser;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
@@ -19,7 +20,8 @@ class DbCommand extends Command
      */
     protected $signature = 'db {connection? : The database connection that should be used}
                {--read : Connect to the read connection}
-               {--write : Connect to the write connection}';
+               {--write : Connect to the write connection}
+               {--open : Open the connection URL in a GUI client}';
 
     /**
      * The console command description.
@@ -43,6 +45,10 @@ class DbCommand extends Command
             $this->newLine();
 
             return Command::FAILURE;
+        }
+
+        if ($this->option('open')) {
+            return $this->openDatabaseUrl($connection);
         }
 
         try {
@@ -253,5 +259,149 @@ class DbCommand extends Command
         return array_values(array_filter($args, function ($key) use ($connection) {
             return ! empty($connection[$key]);
         }, ARRAY_FILTER_USE_KEY));
+    }
+
+    /**
+     * Open the database connection URL in a GUI client.
+     *
+     * @param  array  $connection
+     * @return int
+     */
+    protected function openDatabaseUrl(array $connection)
+    {
+        $url = $this->buildDatabaseUrl($connection);
+
+        $this->open($url);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Build the database connection URL.
+     *
+     * @param  array  $connection
+     * @return string
+     */
+    protected function buildDatabaseUrl(array $connection)
+    {
+        $driver = $this->getDriverScheme($connection['driver']);
+
+        if ($connection['driver'] === 'sqlite') {
+            $path = $connection['database'];
+
+            return str_starts_with($path, '/')
+                ? "{$driver}://{$path}"
+                : "{$driver}:///{$path}";
+        }
+
+        $url = "{$driver}://";
+
+        if (! empty($connection['username'])) {
+            $url .= urlencode($connection['username']);
+
+            if (! empty($connection['password'])) {
+                $url .= ':'.urlencode($connection['password']);
+            }
+
+            $url .= '@';
+        }
+
+        $url .= $connection['host'];
+
+        if (! empty($connection['port'])) {
+            $url .= ":{$connection['port']}";
+        }
+
+        if (! empty($connection['database'])) {
+            $url .= '/'.urlencode($connection['database']);
+        }
+
+        $queryParams = $this->getQueryParameters($connection);
+        if (! empty($queryParams)) {
+            $url .= '?'.http_build_query($queryParams);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Get the URL scheme for the database driver.
+     *
+     * @param  string  $driver
+     * @return string
+     */
+    protected function getDriverScheme($driver)
+    {
+        return match ($driver) {
+            'mysql', 'mariadb' => 'mysql',
+            'pgsql' => 'postgresql',
+            'sqlite' => 'sqlite',
+            'sqlsrv' => 'sqlserver',
+            default => $driver,
+        };
+    }
+
+    /**
+     * Get additional query parameters for the URL.
+     *
+     * @param  array  $connection
+     * @return array
+     */
+    protected function getQueryParameters(array $connection)
+    {
+        $params = [];
+
+        // Add SSL/TLS parameters if configured
+        if (! empty($connection['sslmode'])) {
+            $params['sslmode'] = $connection['sslmode'];
+        }
+
+        if (! empty($connection['options'])) {
+            // For PostgreSQL SSL mode
+            if (isset($connection['options'][\PDO::MYSQL_ATTR_SSL_CA])) {
+                $params['ssl'] = 'true';
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * Open the database URL.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function open($url)
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $process = Process::fromShellCommandline(escapeshellcmd("start {$url}"));
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            return;
+        }
+
+        $binary = collect(match (PHP_OS_FAMILY) {
+            'Darwin' => ['open'],
+            'Linux' => ['xdg-open', 'wslview'],
+        })->first(fn ($binary) => (new ExecutableFinder)->find($binary) !== null);
+
+        if ($binary === null) {
+            $this->components->warn('Unable to open the URL on your system. You will need to open it yourself.');
+            $this->components->info("Database URL: {$url}");
+
+            return;
+        }
+
+        $process = Process::fromShellCommandline(escapeshellcmd("{$binary} {$url}"));
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
     }
 }

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\ConfigurationUrlParser;
+use Illuminate\Support\Uri;
 use PDO;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -289,34 +290,17 @@ class DbCommand extends Command
             return $connection['database'];
         }
 
-        $url = "{$driver}://";
-
-        if (! empty($connection['username'])) {
-            $url .= urlencode($connection['username']);
-
-            if (! empty($connection['password'])) {
-                $url .= ':'.urlencode($connection['password']);
-            }
-
-            $url .= '@';
-        }
-
-        $url .= $connection['host'];
-
-        if (! empty($connection['port'])) {
-            $url .= ":{$connection['port']}";
-        }
-
-        if (! empty($connection['database'])) {
-            $url .= '/'.urlencode($connection['database']);
-        }
-
-        $queryParams = $this->getQueryParameters($connection);
-        if (! empty($queryParams)) {
-            $url .= '?'.http_build_query($queryParams);
-        }
-
-        return $url;
+        return (new Uri)
+            ->withScheme($driver)
+            ->withHost($connection['host'])
+            ->withUser(
+                $connection['username'] ?? null,
+                ! empty($connection['password']) ? $connection['password'] : null,
+            )
+            ->when(! empty($connection['port']), fn (Uri $uri) => $uri->withPort((int) $connection['port']))
+            ->when(! empty($connection['database']), fn (Uri $uri) => $uri->withPath($connection['database']))
+            ->when(! empty($this->getQueryParameters($connection)), fn (Uri $uri) => $uri->withQuery($this->getQueryParameters($connection)))
+            ->value();
     }
 
     /**

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -269,9 +269,7 @@ class DbCommand extends Command
      */
     protected function openDatabaseUrl(array $connection)
     {
-        $url = $this->buildDatabaseUrl($connection);
-
-        $this->open($url);
+        $this->open($this->buildDatabaseUrl($connection));
 
         return Command::SUCCESS;
     }
@@ -287,11 +285,7 @@ class DbCommand extends Command
         $driver = $this->getDriverScheme($connection['driver']);
 
         if ($connection['driver'] === 'sqlite') {
-            $path = $connection['database'];
-
-            return str_starts_with($path, '/')
-                ? "{$driver}://{$path}"
-                : "{$driver}:///{$path}";
+            return $connection['database'];
         }
 
         $url = "{$driver}://";

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -4,12 +4,12 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\ConfigurationUrlParser;
+use PDO;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
-use PDO;
 
 #[AsCommand(name: 'db')]
 class DbCommand extends Command

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
+use PDO;
 
 #[AsCommand(name: 'db')]
 class DbCommand extends Command
@@ -352,7 +353,7 @@ class DbCommand extends Command
 
         if (! empty($connection['options'])) {
             // For PostgreSQL SSL mode
-            if (isset($connection['options'][\PDO::MYSQL_ATTR_SSL_CA])) {
+            if (isset($connection['options'][PDO::MYSQL_ATTR_SSL_CA])) {
                 $params['ssl'] = 'true';
             }
         }

--- a/src/Illuminate/Database/Console/DbOpenCommand.php
+++ b/src/Illuminate/Database/Console/DbOpenCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'db:open')]
+class DbOpenCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:open {connection? : The database connection that should be used}
+               {--read : Connect to the read connection}
+               {--write : Connect to the write connection}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Open the database connection in a GUI client';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // This is an alias for 'db --open'
+        $arguments = array_filter([
+            'connection' => $this->argument('connection'),
+            '--read' => $this->option('read'),
+            '--write' => $this->option('write'),
+            '--open' => true,
+        ]);
+
+        return $this->call('db', $arguments);
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Console\Signals;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
+use Illuminate\Database\Console\DbOpenCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
@@ -129,6 +130,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigClear' => ConfigClearCommand::class,
         'ConfigShow' => ConfigShowCommand::class,
         'Db' => DbCommand::class,
+        'DbOpen' => DbOpenCommand::class,
         'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,

--- a/tests/Database/DbCommandTest.php
+++ b/tests/Database/DbCommandTest.php
@@ -81,7 +81,7 @@ class DbCommandTest extends TestCase
 
         $url = $command->buildDatabaseUrl($connection);
 
-        $this->assertSame('sqlserver://sa:Password123%21@localhost:1433/master', $url);
+        $this->assertSame('sqlserver://sa:Password123!@localhost:1433/master', $url);
     }
 
     public function testBuildDatabaseUrlWithSpecialCharactersInPassword()
@@ -99,7 +99,7 @@ class DbCommandTest extends TestCase
 
         $url = $command->buildDatabaseUrl($connection);
 
-        $this->assertSame('mysql://root:p%40ss%3Aword%21%23%24@localhost:3306/forge', $url);
+        $this->assertSame('mysql://root:p%40ss:word!%23$@localhost:3306/forge', $url);
     }
 
     public function testBuildDatabaseUrlWithoutPassword()

--- a/tests/Database/DbCommandTest.php
+++ b/tests/Database/DbCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Console\DbCommand;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DbCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testBuildDatabaseUrlForMysql()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'database' => 'forge',
+            'username' => 'root',
+            'password' => 'secret',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('mysql://root:secret@localhost:3306/forge', $url);
+    }
+
+    public function testBuildDatabaseUrlForPostgresql()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'pgsql',
+            'host' => 'ep-falling-heart-a5luqcqc.aws-us-east-2.pg.laravel.cloud',
+            'port' => 5432,
+            'database' => 'main',
+            'username' => 'laravel',
+            'password' => 'npg_G7UguAkROK4l',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame(
+            'postgresql://laravel:npg_G7UguAkROK4l@ep-falling-heart-a5luqcqc.aws-us-east-2.pg.laravel.cloud:5432/main',
+            $url
+        );
+    }
+
+    public function testBuildDatabaseUrlForSqlite()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'sqlite',
+            'database' => '/path/to/database.sqlite',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('sqlite:///path/to/database.sqlite', $url);
+    }
+
+    public function testBuildDatabaseUrlForSqlServer()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'sqlsrv',
+            'host' => 'localhost',
+            'port' => 1433,
+            'database' => 'master',
+            'username' => 'sa',
+            'password' => 'Password123!',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('sqlserver://sa:Password123%21@localhost:1433/master', $url);
+    }
+
+    public function testBuildDatabaseUrlWithSpecialCharactersInPassword()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'database' => 'forge',
+            'username' => 'root',
+            'password' => 'p@ss:word!#$',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('mysql://root:p%40ss%3Aword%21%23%24@localhost:3306/forge', $url);
+    }
+
+    public function testBuildDatabaseUrlWithoutPassword()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'database' => 'forge',
+            'username' => 'root',
+            'password' => '',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('mysql://root@localhost:3306/forge', $url);
+    }
+
+    public function testBuildDatabaseUrlWithoutPort()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'mysql',
+            'host' => 'localhost',
+            'database' => 'forge',
+            'username' => 'root',
+            'password' => 'secret',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('mysql://root:secret@localhost/forge', $url);
+    }
+
+    public function testBuildDatabaseUrlWithSslMode()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'pgsql',
+            'host' => 'localhost',
+            'port' => 5432,
+            'database' => 'forge',
+            'username' => 'postgres',
+            'password' => 'secret',
+            'sslmode' => 'require',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        $this->assertSame('postgresql://postgres:secret@localhost:5432/forge?sslmode=require', $url);
+    }
+
+    public function testGetDriverScheme()
+    {
+        $command = new DbCommandTestStub();
+
+        $this->assertSame('mysql', $command->getDriverScheme('mysql'));
+        $this->assertSame('mysql', $command->getDriverScheme('mariadb'));
+        $this->assertSame('postgresql', $command->getDriverScheme('pgsql'));
+        $this->assertSame('sqlite', $command->getDriverScheme('sqlite'));
+        $this->assertSame('sqlserver', $command->getDriverScheme('sqlsrv'));
+    }
+
+    public function testBuildDatabaseUrlForMariaDb()
+    {
+        $command = new DbCommandTestStub();
+
+        $connection = [
+            'driver' => 'mariadb',
+            'host' => 'localhost',
+            'port' => 3306,
+            'database' => 'myapp',
+            'username' => 'root',
+            'password' => 'password',
+        ];
+
+        $url = $command->buildDatabaseUrl($connection);
+
+        // MariaDB uses the same mysql:// scheme
+        $this->assertSame('mysql://root:password@localhost:3306/myapp', $url);
+    }
+}
+
+class DbCommandTestStub extends DbCommand
+{
+    public function buildDatabaseUrl(array $connection)
+    {
+        return parent::buildDatabaseUrl($connection);
+    }
+
+    public function getDriverScheme($driver)
+    {
+        return parent::getDriverScheme($driver);
+    }
+}

--- a/tests/Database/DbCommandTest.php
+++ b/tests/Database/DbCommandTest.php
@@ -63,7 +63,7 @@ class DbCommandTest extends TestCase
 
         $url = $command->buildDatabaseUrl($connection);
 
-        $this->assertSame('sqlite:///path/to/database.sqlite', $url);
+        $this->assertSame('/path/to/database.sqlite', $url);
     }
 
     public function testBuildDatabaseUrlForSqlServer()


### PR DESCRIPTION
This PR adds db:open (alias to `php artisan db --open`) which opens your database connection in your default GUI client (e.g., TablePlus, DBeaver).