### PR TITLE
[13.x] Update brick/math constraint and rounding mode constant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-session": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2.2",
-        "brick/math": "^0.12 || ^0.13 || ^0.14",
+        "brick/math": "^0.14.2 || ^0.15",
         "doctrine/inflector": "^2.0.5",
         "dragonmantank/cron-expression": "^3.4",
         "egulias/email-validator": "^4.0",

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1535,7 +1535,7 @@ trait HasAttributes
     protected function asDecimal($value, $decimals)
     {
         try {
-            return (string) BigDecimal::of((string) $value)->toScale($decimals, RoundingMode::HALF_UP);
+            return (string) BigDecimal::of((string) $value)->toScale($decimals, RoundingMode::HalfUp);
         } catch (BrickMathException $e) {
             throw new MathException('Unable to cast value to a decimal.', previous: $e);
         }

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "ext-pdo": "*",
-        "brick/math": "^0.12 || ^0.13 || ^0.14",
+        "brick/math": "^0.14.2 || ^0.15",
         "illuminate/collections": "^13.0",
         "illuminate/container": "^13.0",
         "illuminate/contracts": "^13.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.3",
         "ext-filter": "*",
         "ext-mbstring": "*",
-        "brick/math": "^0.12 || ^0.13 || ^0.14",
+        "brick/math": "^0.14.2 || ^0.15",
         "egulias/email-validator": "^4.0",
         "illuminate/collections": "^13.0",
         "illuminate/container": "^13.0",


### PR DESCRIPTION
Updates `brick/math` constraints to allow `^0.15` and switches to `RoundingMode::HalfUp`, since `HALF_UP` was deprecated in `0.14.2` and removed in `0.15`.