### PR TITLE
[13.x] Use constructor property promotion

### DIFF
--- a/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushFailed.php
@@ -5,19 +5,11 @@ namespace Illuminate\Cache\Events;
 class CacheLocksFlushFailed
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public ?string $storeName;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      */
-    public function __construct(?string $storeName)
-    {
-        $this->storeName = $storeName;
-    }
+    public function __construct(
+        public ?string $storeName,
+    ) {}
 }

--- a/src/Illuminate/Cache/Events/CacheLocksFlushed.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushed.php
@@ -5,19 +5,11 @@ namespace Illuminate\Cache\Events;
 class CacheLocksFlushed
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public ?string $storeName;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      */
-    public function __construct(?string $storeName)
-    {
-        $this->storeName = $storeName;
-    }
+    public function __construct(
+        public ?string $storeName,
+    ) {}
 }

--- a/src/Illuminate/Cache/Events/CacheLocksFlushing.php
+++ b/src/Illuminate/Cache/Events/CacheLocksFlushing.php
@@ -5,19 +5,11 @@ namespace Illuminate\Cache\Events;
 class CacheLocksFlushing
 {
     /**
-     * The name of the cache store.
-     *
-     * @var string|null
-     */
-    public ?string $storeName;
-
-    /**
      * Create a new event instance.
      *
      * @param  string|null  $storeName
      */
-    public function __construct(?string $storeName)
-    {
-        $this->storeName = $storeName;
-    }
+    public function __construct(
+        public ?string $storeName,
+    ) {}
 }


### PR DESCRIPTION
Following #59006 and #59098, it would be beneficial to also include the `constructor property promotion` in the cache lock events.