### PR TITLE
[13.x] Сonfig typed getters

### DIFF
--- a/src/Illuminate/Config/ConfigIntType.php
+++ b/src/Illuminate/Config/ConfigIntType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Config;
+
+enum ConfigIntType: string
+{
+    case DEFAULT = 'default';
+    case POSITIVE = 'positive';
+    case NEGATIVE = 'negative';
+    case NON_POSITIVE = 'nonPositive';
+    case NON_NEGATIVE = 'nonNegative';
+    case NON_ZERO = 'nonZero';
+}

--- a/src/Illuminate/Config/ConfigStringType.php
+++ b/src/Illuminate/Config/ConfigStringType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Config;
+
+enum ConfigStringType: string
+{
+    case DEFAULT = 'default';
+    case NON_EMPTY = 'nonEmpty';
+    case NON_FALSY = 'nonFalsy';
+    case LOWERCASE = 'lowercase';
+    case UPPERCASE = 'uppercase';
+}

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -79,15 +79,19 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
-     * Get the specified string configuration value.
+     * Get the specified string configuration value with optional type validation.
      *
-     * @param  string  $key
      * @param  (\Closure():(string|null))|string|null  $default
-     * @return string
+     * @return (
+     *     $type is ConfigStringType::DEFAULT ? string :
+     *     ($type is ConfigStringType::NON_EMPTY ? non-empty-string :
+     *     ($type is ConfigStringType::NON_FALSY ? non-falsy-string :
+     *     ($type is ConfigStringType::LOWERCASE ? lowercase-string : uppercase-string)))
+     * )
      *
      * @throws \InvalidArgumentException
      */
-    public function string(string $key, $default = null): string
+    public function string(string $key, $default = null, ConfigStringType $type = ConfigStringType::DEFAULT): string
     {
         $value = $this->get($key, $default);
 
@@ -97,19 +101,64 @@ class Repository implements ArrayAccess, ConfigContract
             );
         }
 
+        if ($type === ConfigStringType::NON_EMPTY) {
+            if (trim($value) === '') {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-empty string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigStringType::NON_FALSY) {
+            if (! (bool) $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-falsy string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigStringType::LOWERCASE) {
+            if (strtolower($value) !== $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a lowercase string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigStringType::UPPERCASE) {
+            if (strtoupper($value) !== $value) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be an uppercase string, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
         return $value;
     }
 
     /**
-     * Get the specified integer configuration value.
+     * Get the specified integer configuration value with optional type validation.
      *
-     * @param  string  $key
      * @param  (\Closure():(int|null))|int|null  $default
-     * @return int
+     * @return (
+     *     $type is ConfigIntType::DEFAULT ? int :
+     *     ($type is ConfigIntType::POSITIVE ? positive-int :
+     *     ($type is ConfigIntType::NEGATIVE ? negative-int :
+     *     ($type is ConfigIntType::NON_POSITIVE ? non-positive-int :
+     *     ($type is ConfigIntType::NON_NEGATIVE ? non-negative-int : non-zero-int))))
+     * )
      *
      * @throws \InvalidArgumentException
      */
-    public function integer(string $key, $default = null): int
+    public function integer(string $key, $default = null, ConfigIntType $type = ConfigIntType::DEFAULT): int
     {
         $value = $this->get($key, $default);
 
@@ -117,6 +166,56 @@ class Repository implements ArrayAccess, ConfigContract
             throw new InvalidArgumentException(
                 sprintf('Configuration value for key [%s] must be an integer, %s given.', $key, gettype($value))
             );
+        }
+
+        if ($type === ConfigIntType::POSITIVE) {
+            if ($value <= 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a positive integer, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigIntType::NEGATIVE) {
+            if ($value >= 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a negative integer, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigIntType::NON_POSITIVE) {
+            if ($value > 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-positive integer, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigIntType::NON_NEGATIVE) {
+            if ($value < 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-negative integer, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
+        }
+
+        if ($type === ConfigIntType::NON_ZERO) {
+            if ($value === 0) {
+                throw new InvalidArgumentException(
+                    sprintf('Configuration value for key [%s] must be a non-zero integer, %s given.', $key, $value)
+                );
+            }
+
+            return $value;
         }
 
         return $value;

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Config;
 
+use Illuminate\Config\ConfigIntType;
+use Illuminate\Config\ConfigStringType;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
@@ -29,6 +31,13 @@ class RepositoryTest extends TestCase
             'boolean' => true,
             'integer' => 1,
             'float' => 1.1,
+            'empty_string' => '',
+            'falsy_string' => '0',
+            'lowercase_string' => 'bar',
+            'mixedcase_string' => 'Bar',
+            'uppercase_string' => 'BAR',
+            'zero_integer' => 0,
+            'negative_integer' => -1,
             'associate' => [
                 'x' => 'xxx',
                 'y' => 'yyy',
@@ -281,7 +290,7 @@ class RepositoryTest extends TestCase
         $this->assertNull($this->repository->get('associate'));
     }
 
-    public function testItIsMacroable()
+    public function testItIsMacroable(): void
     {
         $this->repository->macro('foo', function () {
             return 'macroable';
@@ -292,9 +301,8 @@ class RepositoryTest extends TestCase
 
     public function testItGetsAsString(): void
     {
-        $this->assertSame(
-            'c', $this->repository->string('a.b')
-        );
+        $this->assertSame('c', $this->repository->string('a.b'));
+        $this->assertSame('c', $this->repository->string('a.b', null, ConfigStringType::DEFAULT));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonStringValueAsString(): void
@@ -345,9 +353,8 @@ class RepositoryTest extends TestCase
 
     public function testItGetsAsInteger(): void
     {
-        $this->assertSame(
-            $this->repository->integer('integer'), 1
-        );
+        $this->assertSame(1, $this->repository->integer('integer'));
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::DEFAULT));
     }
 
     public function testItThrowsAnExceptionWhenTryingToGetNonIntegerValueAsInteger(): void
@@ -356,6 +363,125 @@ class RepositoryTest extends TestCase
         $this->expectExceptionMessageMatches('#Configuration value for key \[a.b\] must be an integer, (.*) given.#');
 
         $this->repository->integer('a.b');
+    }
+
+    public function testItGetsAsNonEmptyString(): void
+    {
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::NON_EMPTY));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetEmptyStringAsNonEmptyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[empty_string\] must be a non-empty string, (.*) given.#');
+
+        $this->repository->string('empty_string', null, ConfigStringType::NON_EMPTY);
+    }
+
+    public function testItGetsAsNonFalsyString(): void
+    {
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::NON_FALSY));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetFalsyStringAsNonFalsyString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[falsy_string\] must be a non-falsy string, (.*) given.#');
+
+        $this->repository->string('falsy_string', null, ConfigStringType::NON_FALSY);
+    }
+
+    public function testItGetsAsLowerCaseString(): void
+    {
+        $this->assertSame('bar', $this->repository->string('foo', null, ConfigStringType::LOWERCASE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonLowerCaseStringAsLowerCaseString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[mixedcase_string\] must be a lowercase string, (.*) given.#');
+
+        $this->repository->string('mixedcase_string', null, ConfigStringType::LOWERCASE);
+    }
+
+    public function testItGetsAsUpperCaseString(): void
+    {
+        $this->assertSame('BAR', $this->repository->string('uppercase_string', null, ConfigStringType::UPPERCASE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonUpperCaseStringAsUpperCaseString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[foo\] must be an uppercase string, (.*) given.#');
+
+        $this->repository->string('foo', null, ConfigStringType::UPPERCASE);
+    }
+
+    public function testItGetsAsPositiveInteger(): void
+    {
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::POSITIVE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonPositiveIntegerAsPositiveInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a positive integer, (.*) given.#');
+
+        $this->repository->integer('zero_integer', null, ConfigIntType::POSITIVE);
+    }
+
+    public function testItGetsAsNegativeInteger(): void
+    {
+        $this->assertSame(-1, $this->repository->integer('negative_integer', null, ConfigIntType::NEGATIVE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNonNegativeIntegerAsNegativeInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a negative integer, (.*) given.#');
+
+        $this->repository->integer('integer', null, ConfigIntType::NEGATIVE);
+    }
+
+    public function testItGetsAsNonPositiveInteger(): void
+    {
+        $this->assertSame(0, $this->repository->integer('zero_integer', null, ConfigIntType::NON_POSITIVE));
+        $this->assertSame(-1, $this->repository->integer('negative_integer', null, ConfigIntType::NON_POSITIVE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetPositiveIntegerAsNonPositiveInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[integer\] must be a non-positive integer, (.*) given.#');
+
+        $this->repository->integer('integer', null, ConfigIntType::NON_POSITIVE);
+    }
+
+    public function testItGetsAsNonNegativeInteger(): void
+    {
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::NON_NEGATIVE));
+        $this->assertSame(0, $this->repository->integer('zero_integer', null, ConfigIntType::NON_NEGATIVE));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetNegativeIntegerAsNonNegativeInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[negative_integer\] must be a non-negative integer, (.*) given.#');
+
+        $this->repository->integer('negative_integer', null, ConfigIntType::NON_NEGATIVE);
+    }
+
+    public function testItGetsAsNonZeroInteger(): void
+    {
+        $this->assertSame(1, $this->repository->integer('integer', null, ConfigIntType::NON_ZERO));
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToGetZeroAsNonZeroInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#^Configuration value for key \[zero_integer\] must be a non-zero integer, (.*) given.#');
+
+        $this->repository->integer('zero_integer', null, ConfigIntType::NON_ZERO);
     }
 
     public function testItGetsAsFloat(): void


### PR DESCRIPTION
### Problem
When using static analysers (PHPStan, Psalm) with Laravel config, you often need narrowed types (non-empty-string, positive-int, lowercase-string, etc.) for type-safe code. Today that usually means:
- Manual checks after config()->get() or config()->string().
- Repetitive validation and custom helpers in every project.
- Either ignoring analyser warnings or adding many @var / assertions.

Example of the current friction:
```php
$apiKey = config()->string('services.api.key');

// PHPStan: $apiKey is `string`. Your method requires `non-empty-string`.
if ($apiKey === '') {
    throw new InvalidArgumentException('API key is required');
}

$this->callExternalApi($apiKey); // still need @var or assert for analyser

/**
 * @param non-empty-string $apiKey
 */
private function callExternalApi(string $apiKey): void { ... }
```

### What this PR adds
- string($key, $default, ConfigStringType $type) and integer($key, $default, ConfigIntType $type) with validation and conditional return types (PHPStan 1.6+).
- Enums ConfigStringType and ConfigIntType instead of string flags (clear API, IDE support, no typos).
- Single place for validation and PHPDoc: no duplicated checks, consistent error messages.

So the same use case becomes:
```php
$apiKey = config()->string('services.api.key', type: ConfigStringType::NON_EMPTY);
$this->callExternalApi($apiKey); // PHPStan knows $apiKey is non-empty-string

/** @param non-empty-string $apiKey */
private function callExternalApi(string $apiKey): void { ... }
```

### Benefits
1. Less boilerplate and fewer bugs
- No repeated “if empty / invalid, throw” blocks around config access.
- Validation lives in the framework; call sites stay short and readable.
- Stricter types (non-empty-string, positive-int, etc.) make invalid data impossible at the type level when analysers are used.

2. First-class support for static analysis
- Return type depends on the type argument (e.g. ConfigStringType::NON_EMPTY → non-empty-string).
- Analysers understand the type without extra @var or assertions.
- Fewer suppressions and safer refactors when config types change.

3. Clear, discoverable API
- Enum cases document allowed options: NON_EMPTY, LOWERCASE, POSITIVE, NON_ZERO, etc.
- IDE autocomplete and “wrong type” errors at call site instead of string typos.

4. Backward compatible
- New parameter has defaults: string($key, $default) and integer($key, $default) behave as before.
- Existing code keeps working; new code can adopt the typed API gradually.

**Examples**
Non-empty config value (e.g. API key, app URL):
```php
use Illuminate\Config\ConfigStringType;

$apiKey = config()->string('services.api.key', type: ConfigStringType::NON_EMPTY);
$baseUrl = config()->string('app.url', type: ConfigStringType::NON_FALSY);
// Analyser knows both are non-empty / non-falsy; no manual checks or @var needed.
```
Environment / normalized string (e.g. production, utf-8):
```php
$env = config()->string('app.env', type: ConfigStringType::LOWERCASE);
$encoding = config()->string('app.encoding', default: 'utf-8', type: ConfigStringType::LOWERCASE);
// Type: lowercase-string; no need to validate or cast for case-sensitive logic.
```
Numeric config (ports, limits, timeouts):
```php
use Illuminate\Config\ConfigIntType;

$port = config()->integer('app.port', default: 8080, type: ConfigIntType::POSITIVE);
$timeout = config()->integer('http.timeout', type: ConfigIntType::NON_NEGATIVE);
$batchSize = config()->integer('queue.batch_size', type: ConfigIntType::NON_ZERO);
// positive-int / non-negative-int / non-zero-int; analysers and code stay consistent.
```
Typed helper without extra checks or assertions:
```php
$value = config()->string('test.non_empty_value', type: ConfigStringType::NON_EMPTY);
$this->acceptNonEmptyString($value);

/**
 * @param  non-empty-string  $value
 * @return non-empty-string
 */
private function acceptNonEmptyString(string $value): string
{
    return $value;
}
```

### What will we get in the end?
- For users of PHPStan/Psalm: Config can return precise types; less manual narrowing and fewer suppressions.
- For code quality: One place for validation and errors; shorter, safer config usage.
- For the framework: Modern API (enums, optional named args), no breaking changes, aligned with Laravel’s existing typed helpers.

