### PR TITLE
[13.x] fix: MorphToMany morphClass type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -23,9 +23,9 @@ abstract class MorphOneOrMany extends HasOneOrMany
     protected $morphType;
 
     /**
-     * The class name of the parent model.
+     * The morph class of the parent model.
      *
-     * @var class-string<TRelatedModel>
+     * @var class-string<TDeclaringModel>|string
      */
     protected $morphClass;
 
@@ -156,9 +156,9 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Get the class name of the parent model.
+     * Get the morph class of the parent model.
      *
-     * @return class-string<TRelatedModel>
+     * @return class-string<TDeclaringModel>|string
      */
     public function getMorphClass()
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -18,7 +18,7 @@ class MorphPivot extends Pivot
      *
      * Explicitly define this so it's not included in saved attributes.
      *
-     * @var class-string
+     * @var class-string|string
      */
     protected $morphClass;
 
@@ -100,7 +100,7 @@ class MorphPivot extends Pivot
     /**
      * Set the morph class for the pivot.
      *
-     * @param  class-string  $morphClass
+     * @param  class-string|string  $morphClass
      * @return \Illuminate\Database\Eloquent\Relations\MorphPivot
      */
     public function setMorphClass($morphClass)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -25,9 +25,9 @@ class MorphToMany extends BelongsToMany
     protected $morphType;
 
     /**
-     * The class name of the morph type constraint.
+     * The morph class of the morph type constraint.
      *
-     * @var class-string<TRelatedModel>
+     * @var class-string|string
      */
     protected $morphClass;
 
@@ -214,7 +214,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Get the class name of the parent model.
      *
-     * @return class-string<TRelatedModel>
+     * @return class-string|string
      */
     public function getMorphClass()
     {


### PR DESCRIPTION
Hello!

This just fixes the `MorphToMany::morphClass` property type and description (and other related classes):
- the morph class is not for the *related* model, but rather the **declaring** model
- the morph class is not guaranteed to be a class string---it could be an alias.

Thanks!