### PR TITLE
Add composite index to jobs table migration for improved queue polling

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -14,12 +14,13 @@ return new class extends Migration
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue');
-            $table->index(['queue', 'reserved_at', 'available_at']);
             $table->longText('payload');
             $table->unsignedTinyInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
+
+            $table->index(['queue', 'reserved_at', 'available_at']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('queue')->index();
+            $table->string('queue');
+            $table->index(['queue', 'reserved_at', 'available_at']);
             $table->longText('payload');
             $table->unsignedTinyInteger('attempts');
             $table->unsignedInteger('reserved_at')->nullable();


### PR DESCRIPTION
## Summary

Laravel's database queue driver polls for jobs using a query that filters on `queue`, `reserved_at`, and `available_at`:

```sql
SELECT * FROM jobs
WHERE queue = ?
  AND ((reserved_at IS NULL AND available_at <= ?) OR reserved_at <= ?)
ORDER BY id ASC
LIMIT 1
FOR UPDATE SKIP LOCKED
```

The current `jobs` migration stub only creates a single-column index on `queue`. This means the database must scan all rows for a given queue to evaluate the `reserved_at` and `available_at` conditions on every poll cycle, which becomes expensive on busy systems with large job tables.

This PR replaces the single-column `queue` index with a composite index on `(queue, reserved_at, available_at)`. The composite index allows the database to use the index for both the equality filter on `queue` and the range/null checks on `reserved_at` and `available_at`, avoiding unnecessary row scans.

The standalone `queue` index is no longer needed since `queue` is the leftmost column of the composite index, meaning any query that previously used the single-column index can use the composite index instead.