### PR TITLE
[12.x] Fix migrate:fresh failing when database does not exist

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Events\DatabaseRefreshed;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 #[AsCommand(name: 'migrate:fresh')]
 class FreshCommand extends Command
@@ -64,7 +65,13 @@ class FreshCommand extends Command
         $database = $this->input->getOption('database');
 
         $this->migrator->usingConnection($database, function () use ($database) {
-            if ($this->migrator->repositoryExists()) {
+            try {
+                $repositoryExists = $this->migrator->repositoryExists();
+            } catch (Throwable) {
+                $repositoryExists = false;
+            }
+
+            if ($repositoryExists) {
                 $this->newLine();
 
                 $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([


### PR DESCRIPTION
## Summary
- When running `migrate:fresh` against a non-existent database, `repositoryExists()` throws a `QueryException` instead of gracefully handling the missing database
- The `migrate` command already handles this by prompting the user to create the database, but `migrate:fresh` crashes before reaching that point
- This wraps the `repositoryExists()` call in a try-catch so the wipe step is skipped and the subsequent `migrate` call handles database creation with its existing prompt

## Example

**Before (migrate:fresh crashes):**
```
$ php artisan migrate:fresh --seed

   Illuminate\Database\QueryException

  SQLSTATE[HY000] [1049] Unknown database 'backend23'
```

**After (falls through to migrate's database creation prompt):**
```
$ php artisan migrate:fresh --seed

   WARN  The database 'backend23' does not exist on the 'mysql' connection.

 ┌ Would you like to create it? ────────────────────────────────┐
 │ ● Yes / ○ No                                                 │
 └──────────────────────────────────────────────────────────────┘
```

**While `migrate` already handles this correctly:**
```
$ php artisan migrate

   WARN  The database 'backend23' does not exist on the 'mysql' connection.

 ┌ Would you like to create it? ────────────────────────────────┐
 │ ● Yes / ○ No                                                 │
 └──────────────────────────────────────────────────────────────┘
```